### PR TITLE
cli: respect `$VISUAL`, overriding `$EDITOR`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `$JJ_CONFIG` environment variable can now point to a directory. If it
   does, all files in the directory will be read, in alphabetical order.
 
-* You can now override the `$EDITOR` environment variable by setting the
-  `ui.editor` config. There is also a new `$JJ_EDITOR` environment variable,
-  which has even higher priority than the config.
+* The `$VISUAL` environment is now respected and overrides `$EDITOR`. The new
+  `ui.editor` config has higher priority than both of them. There is also a new
+  `$JJ_EDITOR` environment variable, which has even higher priority than the
+  config.
 
 * You can now use `-` and `+` in revset symbols. You used to have to quote
   branch names like `my-feature` in nested quotes (outer layer for your shell)

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,9 @@ fn config_path() -> Result<Option<PathBuf>, ConfigError> {
 /// Environment variables that should be overridden by config values
 fn env_base() -> config::Config {
     let mut builder = config::Config::builder();
-    if let Ok(value) = env::var("EDITOR") {
+    if let Ok(value) = env::var("VISUAL") {
+        builder = builder.set_override("ui.editor", value).unwrap();
+    } else if let Ok(value) = env::var("EDITOR") {
         builder = builder.set_override("ui.editor", value).unwrap();
     }
     builder.build().unwrap()

--- a/tests/test_describe_command.rs
+++ b/tests/test_describe_command.rs
@@ -69,15 +69,23 @@ fn test_describe() {
         .failure();
     assert!(get_stderr_string(&assert).contains("Failed to run"));
 
-    // `ui.editor` config overrides `$EDITOR`
-    std::fs::write(&edit_script, "").unwrap();
+    // `$VISUAL` overrides `$EDITOR`
+    let assert = test_env
+        .jj_cmd(&repo_path, &["describe"])
+        .env("VISUAL", "bad-editor-from-visual-env")
+        .env("EDITOR", "bad-editor-from-editor-env")
+        .assert()
+        .failure();
+    assert!(get_stderr_string(&assert).contains("bad-editor-from-visual-env"));
+
+    // `ui.editor` config overrides `$VISUAL`
     test_env.add_config(
         br#"[ui]
     editor = "bad-editor-from-config""#,
     );
     let assert = test_env
         .jj_cmd(&repo_path, &["describe"])
-        .env("EDITOR", "bad-editor-from-env")
+        .env("VISUAL", "bad-editor-from-visual-env")
         .assert()
         .failure();
     assert!(get_stderr_string(&assert).contains("bad-editor-from-config"));
@@ -85,8 +93,8 @@ fn test_describe() {
     // `$JJ_EDITOR` overrides `ui.editor` config
     let assert = test_env
         .jj_cmd(&repo_path, &["describe"])
-        .env("JJ_EDITOR", "bad-jj-editor-from-env")
+        .env("JJ_EDITOR", "bad-jj-editor-from-jj-editor-env")
         .assert()
         .failure();
-    assert!(get_stderr_string(&assert).contains("bad-jj-editor-from-env"));
+    assert!(get_stderr_string(&assert).contains("bad-jj-editor-from-jj-editor-env"));
 }


### PR DESCRIPTION
With this patch, the order is this:

`$JJ_EDITOR` environement variable
`ui.editor` config
`$VISUAL` environement variable
`$EDITOR` environement variable
`pico`

That matches git, except that git falls back to an editor determined
at compile time (usually `vi`) instead of using `pico`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch).
-->

# Checklist

- [x] I have made relevant updates to `CHANGELOG.md`
