### PR TITLE
git: use type-safe RefName enum extensively in import_some_refs()

### DIFF
--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -22,7 +22,7 @@ use crate::op_store;
 use crate::op_store::{BranchTarget, RefTarget, WorkspaceId};
 use crate::refs::merge_ref_targets;
 
-#[derive(PartialEq, Eq, Clone, Hash, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Debug)]
 pub enum RefName {
     LocalBranch(String),
     RemoteBranch { branch: String, remote: String },


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
