### PR TITLE
cli: pass change IDs to ui.editor where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository.
   [#2011](https://github.com/martinvonz/jj/issues/2011)
 
+### Other changes
+
+* `jj describe` and `jj commit` will now pass an environment variable named
+  `JJ_CHANGE_ID` to the configured `ui.editor` when modifying the commit
+  message. This is useful for scripted tools and aliases that set custom
+  `ui.editor` values before invoking another editor.
+
 ## [0.8.0] - 2023-07-09
 
 ### Breaking changes


### PR DESCRIPTION
Summary: It's useful to overload `jj describe` to use a different editor, which can format or alter commit messages before passing things off to the real editor. However, in such a context, the `ui.editor` program has no idea what original change ID it was invoked on.

This means that any script which wants to know the change identifier it was invoked on has no way to obtain it.

This doesn't work in every case, but for now, fix it when using `jj describe` and `jj commit`, at least.

Change-Id: Id66a0cb0bc745dc8381cbb122cf83b14

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (src/config-schema.json)
- [ ] I have added tests to cover my changes
