### PR TITLE
Signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Commit templates now support `immutable` keyword.
 
+* Add templater support for rendering commit signatures and added new builtin templates which
+  show commit signatures.
+
 ### Fixed bugs
 
 ## [0.15.1] - 2024-03-06

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -17,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::env::{self, ArgsOs, VarError};
 use std::ffi::OsString;
 use std::fmt::Debug;
-use std::io::{self, Write as _};
+use std::io::{self, Write};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -47,8 +47,8 @@ use jj_lib::op_store::{OpStoreError, OperationId, WorkspaceId};
 use jj_lib::op_walk::OpsetEvaluationError;
 use jj_lib::operation::Operation;
 use jj_lib::repo::{
-    CheckOutCommitError, EditCommitError, MutableRepo, ReadonlyRepo, Repo, RepoLoader,
-    StoreFactories, StoreLoadError,
+    CheckOutCommitError, EditCommitError, MutableRepo, ReadonlyRepo, RebaseCounts, Repo,
+    RepoLoader, StoreFactories, StoreLoadError,
 };
 use jj_lib::repo_path::{FsPathParseError, RepoPath, RepoPathBuf};
 use jj_lib::revset::{
@@ -322,7 +322,8 @@ impl CommandHelper {
                         start_repo_transaction(&base_repo, &self.settings, &self.string_args);
                     for other_op_head in op_heads.into_iter().skip(1) {
                         tx.merge_operation(other_op_head)?;
-                        let num_rebased = tx.mut_repo().rebase_descendants(&self.settings)?;
+                        let rebase_counts = tx.mut_repo().rebase_descendants(&self.settings)?;
+                        let num_rebased = rebase_counts.rebased;
                         if num_rebased > 0 {
                             writeln!(
                                 ui.stderr(),
@@ -330,6 +331,7 @@ impl CommandHelper {
                                  by other operation"
                             )?;
                         }
+                        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
                     }
                     Ok(tx
                         .write("resolve concurrent operations")
@@ -553,13 +555,15 @@ impl WorkspaceCommandHelper {
         print_git_import_stats(ui, tx.repo(), &stats, false)?;
         let mut tx = tx.into_inner();
         // Rebase here to show slightly different status message.
-        let num_rebased = tx.mut_repo().rebase_descendants(&self.settings)?;
+        let rebase_counts = tx.mut_repo().rebase_descendants(&self.settings)?;
+        let num_rebased = rebase_counts.rebased;
         if num_rebased > 0 {
             writeln!(
                 ui.stderr(),
                 "Rebased {num_rebased} descendant commits off of commits rewritten from git"
             )?;
         }
+        print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
         self.finish_transaction(ui, tx, "import git refs")?;
         writeln!(
             ui.stderr(),
@@ -1040,13 +1044,15 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             mut_repo.set_wc_commit(workspace_id, commit.id().clone())?;
 
             // Rebase descendants
-            let num_rebased = mut_repo.rebase_descendants(&self.settings)?;
+            let rebase_counts = mut_repo.rebase_descendants(&self.settings)?;
+            let num_rebased = rebase_counts.rebased;
             if num_rebased > 0 {
                 writeln!(
                     ui.stderr(),
                     "Rebased {num_rebased} descendant commits onto updated working copy"
                 )?;
             }
+            print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
 
             if self.working_copy_shared_with_git {
                 let failed_branches = git::export_refs(mut_repo)?;
@@ -1074,6 +1080,17 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
         )?;
         if Some(new_commit) != maybe_old_commit {
             let mut formatter = ui.stderr_formatter();
+
+            if let Some(old_commit) = maybe_old_commit {
+                if old_commit.is_signed() && !new_commit.is_signed() {
+                    writeln!(
+                        formatter,
+                        "Working copy was signed, but that signature was dropped. You should \
+                         probably configure signing"
+                    )?;
+                }
+            }
+
             let template = self.commit_summary_template();
             write!(formatter, "Working copy now at: ")?;
             formatter.with_label("working_copy", |fmt| template.format(new_commit, fmt))?;
@@ -1106,10 +1123,8 @@ See https://github.com/martinvonz/jj/blob/main/docs/working-copy.md#stale-workin
             writeln!(ui.stderr(), "Nothing changed.")?;
             return Ok(());
         }
-        let num_rebased = tx.mut_repo().rebase_descendants(&self.settings)?;
-        if num_rebased > 0 {
-            writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
-        }
+        let rebase_counts = tx.mut_repo().rebase_descendants(&self.settings)?;
+        print_rebase_info(ui, &rebase_counts)?;
 
         let old_repo = tx.base_repo().clone();
 
@@ -1576,6 +1591,32 @@ pub fn print_trackable_remote_branches(ui: &Ui, view: &View) -> io::Result<()> {
         names = remote_branch_names.join(" "),
     )?;
     Ok(())
+}
+
+pub fn check_dropped_signature(
+    ui: &Ui,
+    old_commit: &Commit,
+    rewritten: &Commit,
+) -> Result<(), std::io::Error> {
+    if old_commit.is_signed() && !rewritten.is_signed() {
+        writeln!(ui.warning(), "Dropped a commit signature")?;
+    }
+    Ok(())
+}
+
+pub fn print_dropped_signatures(ui: &Ui, num_dropped: usize) -> Result<(), std::io::Error> {
+    if num_dropped > 0 {
+        writeln!(ui.warning(), "Dropped {num_dropped} commit signatures")?;
+    }
+    Ok(())
+}
+
+pub fn print_rebase_info(ui: &Ui, rebase_counts: &RebaseCounts) -> Result<(), std::io::Error> {
+    let num_rebased = rebase_counts.rebased;
+    if num_rebased > 0 {
+        writeln!(ui.warning(), "Rebased {num_rebased} descendant commits")?;
+    }
+    print_dropped_signatures(ui, rebase_counts.dropped_signatures)
 }
 
 pub fn parse_string_pattern(src: &str) -> Result<StringPattern, StringPatternParseError> {

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -17,7 +17,9 @@ use std::io::Write;
 use jj_lib::object_id::ObjectId;
 use tracing::instrument;
 
-use crate::cli_util::{resolve_multiple_nonempty_revsets, CommandHelper, RevisionArg};
+use crate::cli_util::{
+    print_dropped_signatures, resolve_multiple_nonempty_revsets, CommandHelper, RevisionArg,
+};
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -55,7 +57,8 @@ pub(crate) fn cmd_abandon(
     for commit in &to_abandon {
         tx.mut_repo().record_abandoned_commit(commit.id().clone());
     }
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+    let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = rebase_counts.rebased;
 
     if to_abandon.len() == 1 {
         write!(ui.stderr(), "Abandoned commit ")?;
@@ -89,6 +92,7 @@ pub(crate) fn cmd_abandon(
             to_abandon.len() - 1
         )
     };
+    print_dropped_signatures(ui, rebase_counts.dropped_signatures)?;
     tx.finish(ui, transaction_description)?;
     Ok(())
 }

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -17,7 +17,7 @@ use std::io::{self, Read, Write};
 use jj_lib::object_id::ObjectId;
 use tracing::instrument;
 
-use crate::cli_util::{CommandHelper, RevisionArg};
+use crate::cli_util::{check_dropped_signature, CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
 use crate::description_util::{
     description_template_for_describe, edit_description, join_message_paragraphs,
@@ -94,7 +94,8 @@ pub(crate) fn cmd_describe(
             let new_author = commit_builder.committer().clone();
             commit_builder = commit_builder.set_author(new_author);
         }
-        commit_builder.write()?;
+        let rewritten = commit_builder.write()?;
+        check_dropped_signature(ui, &commit, &rewritten)?;
         tx.finish(ui, format!("describe commit {}", commit.id().hex()))?;
     }
     Ok(())

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -19,7 +19,7 @@ use jj_lib::object_id::ObjectId;
 use jj_lib::rewrite::merge_commit_trees;
 use tracing::instrument;
 
-use crate::cli_util::{CommandHelper, RevisionArg};
+use crate::cli_util::{print_rebase_info, CommandHelper, RevisionArg};
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -106,13 +106,11 @@ don't make any changes, then the operation will be aborted.",
             .write()?;
         // rebase_descendants early; otherwise `new_commit` would always have
         // a conflicted change id at this point.
-        let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+        let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
         write!(ui.stderr(), "Created ")?;
         tx.write_commit_summary(ui.stderr_formatter().as_mut(), &new_commit)?;
         writeln!(ui.stderr())?;
-        if num_rebased > 0 {
-            writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
-        }
+        print_rebase_info(ui, &rebase_counts)?;
         tx.finish(ui, format!("edit commit {}", target_commit.id().hex()))?;
     }
     Ok(())

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -24,13 +24,15 @@ use jj_lib::commit::Commit;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::{ReadonlyRepo, Repo};
 use jj_lib::revset::{RevsetExpression, RevsetIteratorExt};
-use jj_lib::rewrite::{rebase_commit, rebase_commit_with_options, EmptyBehaviour, RebaseOptions};
+use jj_lib::rewrite::{
+    rebase_commit, rebase_commit_with_options, EmptyBehaviour, RebaseOptions, RebasedCommit,
+};
 use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
 use crate::cli_util::{
-    self, resolve_multiple_nonempty_revsets_default_single, short_commit_hash, CommandHelper,
-    RevisionArg, WorkspaceCommandHelper,
+    self, print_dropped_signatures, resolve_multiple_nonempty_revsets_default_single,
+    short_commit_hash, CommandHelper, RevisionArg, WorkspaceCommandHelper,
 };
 use crate::command_error::{user_error, CommandError};
 use crate::ui::Ui;
@@ -296,18 +298,28 @@ fn rebase_descendants(
     let mut tx = workspace_command.start_transaction();
     // `rebase_descendants` takes care of sorting in reverse topological order, so
     // no need to do it here.
+    let mut dropped_signatures = 0;
     for old_commit in old_commits {
-        rebase_commit_with_options(
+        let rebased = rebase_commit_with_options(
             settings,
             tx.mut_repo(),
             old_commit,
             new_parents,
             &rebase_options,
         )?;
+        let is_signed = match rebased {
+            RebasedCommit::Rewritten(commit) => Some(commit.is_signed()),
+            _ => None,
+        };
+        if old_commit.is_signed() && is_signed == Some(false) {
+            dropped_signatures += 1;
+        }
     }
-    let num_rebased = old_commits.len()
-        + tx.mut_repo()
-            .rebase_descendants_with_options(settings, rebase_options)?;
+    let counts = tx
+        .mut_repo()
+        .rebase_descendants_with_options(settings, rebase_options)?;
+    dropped_signatures += counts.dropped_signatures;
+    let num_rebased = old_commits.len() + counts.rebased;
     writeln!(ui.stderr(), "Rebased {num_rebased} commits")?;
     let tx_message = if old_commits.len() == 1 {
         format!(
@@ -317,6 +329,7 @@ fn rebase_descendants(
     } else {
         format!("rebase {} commits and their descendants", old_commits.len())
     };
+    print_dropped_signatures(ui, dropped_signatures)?;
     tx.finish(ui, tx_message)?;
     Ok(())
 }
@@ -393,6 +406,7 @@ fn rebase_revision(
     // Now, rebase the descendants of the children.
     // TODO(ilyagr): Consider making it possible for these descendants to become
     // emptied, like --skip_empty. This would require writing careful tests.
+
     rebased_commit_ids.extend(tx.mut_repo().rebase_descendants_return_map(settings)?);
     let num_rebased_descendants = rebased_commit_ids.len();
 
@@ -436,7 +450,7 @@ fn rebase_revision(
     // have any children; they have all been rebased and the originals have been
     // abandoned.
     rebase_commit(settings, tx.mut_repo(), &old_commit, &new_parents)?;
-    debug_assert_eq!(tx.mut_repo().rebase_descendants(settings)?, 0);
+    debug_assert_eq!(tx.mut_repo().rebase_descendants(settings)?.rebased, 0);
 
     if num_rebased_descendants > 0 {
         writeln!(

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -150,7 +150,8 @@ don't make any changes, then the operation will be aborted.
     // descendants.
     tx.mut_repo()
         .set_rewritten_commit(commit.id().clone(), [second_commit.id().clone()]);
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
+    let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
+    let num_rebased = rebase_counts.rebased;
     if num_rebased > 0 {
         writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
     }

--- a/cli/src/commands/untrack.rs
+++ b/cli/src/commands/untrack.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Write;
-
 use itertools::Itertools;
 use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTreeBuilder;
@@ -21,7 +19,7 @@ use jj_lib::repo::Repo;
 use jj_lib::working_copy::SnapshotOptions;
 use tracing::instrument;
 
-use crate::cli_util::CommandHelper;
+use crate::cli_util::{print_rebase_info, CommandHelper};
 use crate::command_error::{user_error_with_hint, CommandError};
 use crate::ui::Ui;
 
@@ -98,10 +96,8 @@ Make sure they're ignored, then try again.",
             locked_ws.locked_wc().reset(&new_commit)?;
         }
     }
-    let num_rebased = tx.mut_repo().rebase_descendants(command.settings())?;
-    if num_rebased > 0 {
-        writeln!(ui.stderr(), "Rebased {num_rebased} descendant commits")?;
-    }
+    let rebase_counts = tx.mut_repo().rebase_descendants(command.settings())?;
+    print_rebase_info(ui, &rebase_counts)?;
     let repo = tx.commit("untrack paths");
     locked_ws.finish(repo.op_id().clone())?;
     Ok(())

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -82,3 +82,9 @@
 "op_log current_operation id" = "bright blue"
 "op_log current_operation user" = "yellow"                    # No bright yellow, see comment above
 "op_log current_operation time" = "bright cyan"
+"signature good" = "green"
+"signature unknown" = "bright black"
+"signature bad" = "red"
+"signature invalid" = "yellow"
+"signature key" = "blue"
+"signature display" = "yellow"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -161,11 +161,69 @@ commit_summary_separator = 'label("separator", " | ")'
 # commit id to refer to a hidden revision regardless.
 builtin_change_id_with_hidden_and_divergent_info = '''
 if(hidden,
-  label("hidden", 
+  label("hidden",
     format_short_change_id(change_id) ++ " hidden"
   ),
   label(if(divergent, "divergent"),
     format_short_change_id(change_id) ++ if(divergent,"??")
+  )
+)
+'''
+
+'builtin_log_detailed_with_sig' = '''
+concat(
+  "Commit ID: " ++ commit_id ++ "\n",
+  "Change ID: " ++ change_id ++ "\n",
+  surround("Branches: ", "\n", separate(" ", local_branches, remote_branches)),
+  surround("Tags: ", "\n", tags),
+  "Author: " ++ format_detailed_signature(author) ++ "\n",
+  "Committer: " ++ format_detailed_signature(committer)  ++ "\n",
+  builtin_sig_detailed,
+  "\n",
+  indent("    ", if(description, description, description_placeholder ++ "\n")),
+  "\n",
+)
+'''
+
+builtin_sig_status = '''
+if(signature.present(),
+  label("signature",
+    concat(
+      "[",
+      label("status",
+        if(signature.good(), label("good", "✓︎"),
+          if(signature.unknown(), label("unknown", "?"),
+            if(signature.bad(), label("bad", "x"),
+              if(signature.invalid(), label("invalid", "x"))
+            )
+          )
+        )
+      ),
+      "]"
+    )
+  )
+)
+'''
+
+builtin_sig_detailed = '''
+if(signature.present(),
+  concat(
+    "Signature: ",
+    label("signature",
+      if(signature.good(), label("good", "Good"),
+        if(signature.unknown(), label("unknown", "Unknown"),
+          if(signature.bad(), label("bad", "Bad"),
+            if(signature.invalid(), label("invalid", "Invalid"))
+          )
+        )
+      )
+    ),
+    if(signature.backend(), " " ++ label("backend", signature.backend()) ++ " signature"),
+    if(signature.display(),
+      ". By " ++ label("display", signature.display()) ++ if(signature.key(), " (key " ++ label("key", signature.key()) ++ ")"),
+      if(signature.key(), ". Key " ++ label("key", signature.key()))
+    ),
+    "\n"
   )
 )
 '''

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -53,6 +53,7 @@ mod test_revset_output;
 mod test_root;
 mod test_shell_completion;
 mod test_show_command;
+mod test_signature_templates;
 mod test_sparse_command;
 mod test_split_command;
 mod test_squash_command;

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -44,9 +44,12 @@ fn test_log_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_detailed_with_sig
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_sig_detailed
+    - builtin_sig_status
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_obslog_command.rs
+++ b/cli/tests/test_obslog_command.rs
@@ -252,9 +252,12 @@ fn test_obslog_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_detailed_with_sig
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_sig_detailed
+    - builtin_sig_status
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -109,9 +109,12 @@ fn test_op_log_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_detailed_with_sig
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_sig_detailed
+    - builtin_sig_status
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -64,9 +64,12 @@ fn test_show_with_no_template() {
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_detailed
+    - builtin_log_detailed_with_sig
     - builtin_log_oneline
     - builtin_op_log_comfortable
     - builtin_op_log_compact
+    - builtin_sig_detailed
+    - builtin_sig_status
     - commit_summary_separator
     - description_placeholder
     - email_placeholder

--- a/cli/tests/test_signature_templates.rs
+++ b/cli/tests/test_signature_templates.rs
@@ -1,0 +1,55 @@
+// Copyright 2022 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+#[test]
+fn test_signature_templates() {
+    let test_env = TestEnvironment::default();
+
+    test_env.add_config(r#"signing.sign-all = true"#);
+    test_env.add_config(r#"signing.backend = "mock""#);
+
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-Tbuiltin_log_detailed_with_sig"]);
+    insta::assert_snapshot!(stdout, @r###"
+    @  Commit ID: ab2be60e0fe849f40d8bcce25f93ec4216e9c488
+    │  Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    │  Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    │  Signature: Good mock signature
+    │
+    │      (no description set)
+    │
+    ◉  Commit ID: 0000000000000000000000000000000000000000
+       Change ID: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+       Author: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+       Committer: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+    
+           (no description set)
+    "###);
+
+    let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-Tbuiltin_log_detailed_with_sig"]);
+    insta::assert_snapshot!(stdout, @r###"
+    Commit ID: ab2be60e0fe849f40d8bcce25f93ec4216e9c488
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Signature: Good mock signature
+    
+        (no description set)
+    "###);
+}

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -103,7 +103,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword "builtin" doesn't exist
-    Hint: Did you mean "builtin_change_id_with_hidden_and_divergent_info", "builtin_log_comfortable", "builtin_log_compact", "builtin_log_detailed", "builtin_log_oneline", "builtin_op_log_comfortable", "builtin_op_log_compact"?
+    Hint: Did you mean "builtin_change_id_with_hidden_and_divergent_info", "builtin_log_comfortable", "builtin_log_compact", "builtin_log_detailed", "builtin_log_detailed_with_sig", "builtin_log_oneline", "builtin_op_log_comfortable", "builtin_op_log_compact", "builtin_sig_detailed", "builtin_sig_status"?
     "###);
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -522,6 +522,8 @@ the conflict is done, `jj` assumes that the conflict was only partially resolved
 and parses the conflict markers to get the new state of the conflict. The
 conflict is considered fully resolved when there are no conflict markers left.
 
+<<<<<<<
++++++++
 ## Commit Signing
 
 `jj` can be configured to sign and verify the commits it creates using either 
@@ -581,6 +583,21 @@ as follows:
 
 ```toml
 signing.backends.ssh.allowed-signers = "/path/to/allowed-signers"
+```
+
+## Commit Signature Verification
+
+Commit verification uses the configured [signing backends](#commit-signing) to attempt to verify
+any signatures found on commits when displaying them with `jj log` or `jj show`.
+
+By default signature verification and display is **disabled** as it incurs a performance cost when
+rendering medium to large change logs.
+
+To verify signatures you can either pass the `--show-signature` CLI flag or to have signatures always 
+shown you can configure the `show-signatures` config option:
+
+```toml
+signing.show-signatures = true
 ```
 
 ## Git settings

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -18,6 +18,32 @@ In `jj log`/`jj obslog` templates, all 0-argument methods of [the `Commit`
 type](#commit-type) are available as keywords. For example, `commit_id` is
 equivalent to `self.commit_id()`.
 
+ * `description: String`
+ * `change_id: ChangeId`
+ * `commit_id: CommitId`
+ * `parents: List<Commit>`
+ * `author: Signature`
+ * `committer: Signature`
+ * `signature: CommitSignature`: The information about a cryptographic signature of the commit.
+ * `working_copies: String`: For multi-workspace repository, indicate
+   working-copy commit as `<workspace name>@`.
+ * `current_working_copy: Boolean`: True for the working-copy commit of the
+   current workspace.
+ * `branches: List<RefName>`: Local and remote branches pointing to the commit.
+   A tracking remote branch will be included only if its target is different
+   from the local one.
+ * `local_branches: List<RefName>`: All local branches pointing to the commit.
+ * `remote_branches: List<RefName>`: All remote branches pointing to the commit.
+ * `tags: List<RefName>`
+ * `git_refs: List<RefName>`
+ * `git_head: List<RefName>`
+ * `divergent: Boolean`: True if the commit's change id corresponds to multiple
+   visible commits.
+ * `hidden: Boolean`: True if the commit is not visible (a.k.a. abandoned).
+ * `conflict: Boolean`: True if the commit contains merge conflicts.
+ * `empty: Boolean`: True if the commit modifies no files.
+ * `root: Boolean`: True if the commit is the root commit.
+ 
 ### Operation keywords
 
 In `jj op log` templates, all 0-argument methods of [the `Operation`
@@ -161,6 +187,18 @@ The following methods are defined.
 * `.email() -> String`
 * `.username() -> String`
 * `.timestamp() -> Timestamp`
+
+### CommitSignature type
+
+The following methods are defined.
+
+* `.present() -> Boolean`: True if the commit has a cryptographic signature.
+* `.good() -> Boolean`: True if the signature matches the commit data.
+* `.unknown() -> Boolean`: True if the signing backend cannot verify the signature (e.g. due to a missing public key), or if there's no backend implemented that can verify the signature.
+* `.bad() -> Boolean`: True if the signature does not match the commit data.
+* `.invalid() -> Boolean`: True if the signature is detected to be made with a signing backend (e.g. has a PGP prefix) but is otherwise invalid.
+* `.key() -> String`: Signing backend specific key id. For GPG, it's a long key ID, present for all non-invalid signatures.
+* `.display() -> String`: Signing backend specific display string. For GPG, it's a formatted primary user ID, only present if the public key is known (only for good/bad signatures).
 
 ### String type
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -54,6 +54,7 @@ pub mod lock;
 pub mod matchers;
 pub mod merge;
 pub mod merged_tree;
+pub mod mock_signing;
 pub mod object_id;
 pub mod op_heads_store;
 pub mod op_store;

--- a/lib/src/mock_signing.rs
+++ b/lib/src/mock_signing.rs
@@ -1,15 +1,33 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic APIs to work with cryptographic signatures created and verified by
+//! various backends.
+
 use hex::ToHex;
 use jj_lib::content_hash::blake2b_hash;
 use jj_lib::signing::{SigStatus, SignError, SignResult, SigningBackend, Verification};
 
 #[derive(Debug)]
-pub struct TestSigningBackend;
+#[allow(missing_docs)]
+pub struct MockSigningBackend;
 
-const PREFIX: &str = "--- JJ-TEST-SIGNATURE ---\nKEY: ";
+const PREFIX: &str = "--- JJ-MOCK-SIGNATURE ---\nKEY: ";
 
-impl SigningBackend for TestSigningBackend {
+impl SigningBackend for MockSigningBackend {
     fn name(&self) -> &str {
-        "test"
+        "mock"
     }
 
     fn can_read(&self, signature: &[u8]) -> bool {
@@ -37,18 +55,11 @@ impl SigningBackend for TestSigningBackend {
         let key = (!key.is_empty()).then_some(std::str::from_utf8(key).unwrap().to_owned());
 
         let sig = self.sign(data, key.as_deref())?;
-        if sig == signature {
-            Ok(Verification {
-                status: SigStatus::Good,
-                key,
-                display: None,
-            })
+        let status = if sig == signature {
+            SigStatus::Good
         } else {
-            Ok(Verification {
-                status: SigStatus::Bad,
-                key,
-                display: None,
-            })
-        }
+            SigStatus::Bad
+        };
+        Ok(Verification::new(status, key, None))
     }
 }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -905,10 +905,17 @@ impl MutableRepo {
         &mut self,
         settings: &UserSettings,
         options: RebaseOptions,
-    ) -> Result<usize, TreeMergeError> {
+    ) -> Result<RebaseCounts, TreeMergeError> {
         let result = self
             .rebase_descendants_return_rebaser(settings, options)?
-            .map_or(0, |rebaser| rebaser.into_map().len());
+            .map(|rebaser| {
+                let dropped_signatures_len = rebaser.dropped_signatures().len();
+                RebaseCounts {
+                    rebased: rebaser.into_map().len(),
+                    dropped_signatures: dropped_signatures_len,
+                }
+            })
+            .unwrap_or_default();
         self.clear_descendant_rebaser_plans();
         Ok(result)
     }
@@ -941,7 +948,10 @@ impl MutableRepo {
         result
     }
 
-    pub fn rebase_descendants(&mut self, settings: &UserSettings) -> Result<usize, TreeMergeError> {
+    pub fn rebase_descendants(
+        &mut self,
+        settings: &UserSettings,
+    ) -> Result<RebaseCounts, TreeMergeError> {
         self.rebase_descendants_with_options(settings, Default::default())
     }
 
@@ -1390,6 +1400,23 @@ impl Repo for MutableRepo {
     fn shortest_unique_change_id_prefix_len(&self, target_id: &ChangeId) -> usize {
         let change_id_index = self.index.change_id_index(&mut self.view().heads().iter());
         change_id_index.shortest_unique_prefix_len(target_id)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct RebaseCounts {
+    /// Number of commits that were rebased.
+    pub rebased: usize,
+    /// Number of commits that had their cryptographic signatures dropped.
+    pub dropped_signatures: usize,
+}
+
+impl RebaseCounts {
+    pub fn new(rebased: usize, dropped_signatures: usize) -> Self {
+        Self {
+            rebased,
+            dropped_signatures,
+        }
     }
 }
 

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -273,6 +273,7 @@ pub(crate) struct DescendantRebaser<'settings, 'repo> {
     abandoned: HashSet<CommitId>,
     new_commits: HashSet<CommitId>,
     rebased: HashMap<CommitId, CommitId>,
+    dropped_signatures: HashSet<CommitId>,
     // Names of branches where local target includes the commit id in the key.
     branches: HashMap<CommitId, HashSet<String>>,
     // Parents of rebased/abandoned commit that should become new heads once their descendants
@@ -380,6 +381,7 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
             abandoned,
             new_commits,
             rebased: Default::default(),
+            dropped_signatures: Default::default(),
             branches,
             heads_to_add,
             heads_to_remove: Default::default(),
@@ -397,6 +399,12 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
     /// `rebase_descendants`.
     pub fn into_map(self) -> HashMap<CommitId, CommitId> {
         self.rebased
+    }
+
+    /// Returns a set of commits whose cryptographic signatures were dropped
+    /// during the rebase.
+    pub fn dropped_signatures(&self) -> &HashSet<CommitId> {
+        &self.dropped_signatures
     }
 
     /// Panics if `parent_mapping` contains cycles
@@ -590,6 +598,9 @@ impl<'settings, 'repo> DescendantRebaser<'settings, 'repo> {
                 parent
             }
         };
+        if old_commit.is_signed() && !new_commit.is_signed() {
+            self.dropped_signatures.insert(old_commit_id.clone());
+        }
         let previous_rebased_value = self
             .rebased
             .insert(old_commit_id.clone(), new_commit.id().clone());

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1070,7 +1070,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten.
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 and feature4 should still be the heads, and all three branches
@@ -1087,7 +1090,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 and feature4 should still be the heads, and both branches
@@ -1103,7 +1109,10 @@ fn test_import_some_refs() {
     })
     .unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.mut_repo().rebase_descendants(&settings).unwrap(), 0);
+    assert_eq!(
+        tx.mut_repo().rebase_descendants(&settings).unwrap().rebased,
+        0
+    );
     let repo = tx.commit("test");
 
     // feature2 should now be the only head and only branch.

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -140,6 +140,7 @@ fn gpg_signing_roundtrip_explicit_key() {
         display: Some(
             "Someone Else (jj test signing key) <someone-else@example.com>",
         ),
+        backend: None,
     }
     "###);
     assert_debug_snapshot!(backend.verify(b"so so bad", &signature).unwrap(), @r###"
@@ -151,6 +152,7 @@ fn gpg_signing_roundtrip_explicit_key() {
         display: Some(
             "Someone Else (jj test signing key) <someone-else@example.com>",
         ),
+        backend: None,
     }
     "###);
 }
@@ -176,6 +178,7 @@ fn unknown_key() {
             "071FE3E324DD7333",
         ),
         display: None,
+        backend: None,
     }
     "###);
     assert_debug_snapshot!(backend.verify(b"so bad", signature).unwrap(), @r###"
@@ -185,6 +188,7 @@ fn unknown_key() {
             "071FE3E324DD7333",
         ),
         display: None,
+        backend: None,
     }
     "###);
 }

--- a/lib/tests/test_signing.rs
+++ b/lib/tests/test_signing.rs
@@ -1,9 +1,9 @@
 use jj_lib::backend::{MillisSinceEpoch, Signature, Timestamp};
+use jj_lib::mock_signing::MockSigningBackend;
 use jj_lib::repo::Repo;
 use jj_lib::settings::UserSettings;
 use jj_lib::signing::{SigStatus, SignBehavior, Signer, Verification};
 use test_case::test_case;
-use testutils::test_signing_backend::TestSigningBackend;
 use testutils::{create_random_commit, write_random_commit, TestRepoBackend, TestWorkspace};
 
 fn user_settings(sign_all: bool) -> UserSettings {
@@ -46,7 +46,7 @@ fn good_verification() -> Option<Verification> {
 fn manual(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -76,7 +76,7 @@ fn manual(backend: TestRepoBackend) {
 fn keep_on_rewrite(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -102,7 +102,7 @@ fn keep_on_rewrite(backend: TestRepoBackend) {
 fn manual_drop_on_rewrite(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -132,7 +132,7 @@ fn manual_drop_on_rewrite(backend: TestRepoBackend) {
 fn forced(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -155,7 +155,7 @@ fn forced(backend: TestRepoBackend) {
 fn configured(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;

--- a/lib/tests/test_ssh_signing.rs
+++ b/lib/tests/test_ssh_signing.rs
@@ -35,14 +35,14 @@ y2yxhhHnagH52avUqw5hAAAAAAECAwQF
 static PUBLIC_KEY: &str =
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52avUqw5h";
 
-struct SshEnvironment {
+pub struct SshEnvironment {
     _keys: tempfile::TempDir,
-    private_key_path: PathBuf,
-    allowed_signers: Option<tempfile::TempPath>,
+    pub private_key_path: PathBuf,
+    pub allowed_signers: Option<tempfile::TempPath>,
 }
 
 impl SshEnvironment {
-    fn new() -> Result<Self, std::process::Output> {
+    pub fn new() -> Result<Self, std::process::Output> {
         let keys_dir = tempfile::Builder::new()
             .prefix("jj-test-signing-keys-")
             .tempdir()

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -45,7 +45,6 @@ use tempfile::TempDir;
 use crate::test_backend::TestBackend;
 
 pub mod test_backend;
-pub mod test_signing_backend;
 
 pub fn hermetic_libgit2() {
     // libgit2 respects init.defaultBranch (and possibly other config


### PR DESCRIPTION
This is a continuation from #3007 and #2728 which adds in the templater changes for verifying and displaying commit signatures.

---

There were some outstanding comments on #3007 which I am listing below:

- [x] https://github.com/martinvonz/jj/pull/3007#discussion_r1492197725
- [ ] https://github.com/martinvonz/jj/pull/3007#discussion_r1492225610 - I understand the conclusion to be that this could be addressed later.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
