### PR TITLE
Add `jj sign` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Added a new `jj sign` command to explicitly sign a commit using the new signing
+  backend implementation.
+
 * Added support for commit signing and verification. This comes with 
   out-of-the-box support for the following backends:
   * GnuPG

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -46,6 +46,7 @@ mod restore;
 mod root;
 mod run;
 mod show;
+mod sign;
 mod sparse;
 mod split;
 mod squash;
@@ -127,6 +128,7 @@ enum Command {
     // TODO: Flesh out.
     Run(run::RunArgs),
     Show(show::ShowArgs),
+    Sign(sign::SignArgs),
     #[command(subcommand)]
     Sparse(sparse::SparseArgs),
     Split(split::SplitArgs),
@@ -169,6 +171,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Cat(sub_args) => cat::cmd_cat(ui, command_helper, sub_args),
         Command::Diff(sub_args) => diff::cmd_diff(ui, command_helper, sub_args),
         Command::Show(sub_args) => show::cmd_show(ui, command_helper, sub_args),
+        Command::Sign(sub_args) => sign::cmd_sign(ui, command_helper, sub_args),
         Command::Status(sub_args) => status::cmd_status(ui, command_helper, sub_args),
         Command::Log(sub_args) => log::cmd_log(ui, command_helper, sub_args),
         Command::Interdiff(sub_args) => interdiff::cmd_interdiff(ui, command_helper, sub_args),

--- a/cli/src/commands/sign.rs
+++ b/cli/src/commands/sign.rs
@@ -1,0 +1,85 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use jj_lib::object_id::ObjectId;
+use jj_lib::signing::SignBehavior;
+
+use crate::cli_util::{user_error, CommandError, CommandHelper, RevisionArg};
+use crate::ui::Ui;
+
+/// Cryptographically sign a revision
+#[derive(clap::Args, Clone, Debug)]
+pub struct SignArgs {
+    /// What key to use, depends on the configured signing backend.
+    #[arg()]
+    key: Option<String>,
+    /// What revision to sign
+    #[arg(long, short, default_value = "@")]
+    revision: RevisionArg,
+    /// Sign a commit that is not authored by you or was already signed.
+    #[arg(long, short)]
+    force: bool,
+    /// Drop the signature, explicitly "un-signing" the commit.
+    #[arg(long, short = 'D', conflicts_with = "force")]
+    drop: bool,
+}
+
+pub fn cmd_sign(ui: &mut Ui, command: &CommandHelper, args: &SignArgs) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    workspace_command.check_rewritable([&commit])?;
+
+    if !args.force {
+        if !args.drop && commit.is_signed() {
+            return Err(user_error(
+                "Commit is already signed, use --force to sign anyway",
+            ));
+        }
+        if commit.author().email != command.settings().user_email() {
+            return Err(user_error(
+                "Commit is not authored by you, use --force to sign anyway",
+            ));
+        }
+    }
+
+    let mut tx = workspace_command.start_transaction();
+
+    let behavior = if args.drop {
+        SignBehavior::Drop
+    } else if args.force {
+        SignBehavior::Force
+    } else {
+        SignBehavior::Own
+    };
+    let rewritten = tx
+        .mut_repo()
+        .rewrite_commit(command.settings(), &commit)
+        .override_sign_key(args.key.clone())
+        .set_sign_behavior(behavior)
+        .write()?;
+
+    tx.finish(ui, format!("sign commit {}", commit.id().hex()))?;
+
+    let summary = workspace_command.format_commit_summary(&rewritten);
+    if args.drop {
+        writeln!(ui.stderr(), "Signature was dropped: {summary}")?;
+    } else {
+        writeln!(ui.stderr(), "Commit was signed: {summary}")?;
+    }
+
+    Ok(())
+}

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -67,6 +67,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj restore`↴](#jj-restore)
 * [`jj root`↴](#jj-root)
 * [`jj show`↴](#jj-show)
+* [`jj sign`↴](#jj-sign)
 * [`jj sparse`↴](#jj-sparse)
 * [`jj sparse list`↴](#jj-sparse-list)
 * [`jj sparse set`↴](#jj-sparse-set)
@@ -131,6 +132,7 @@ repository.
 * `restore` — Restore paths from another revision
 * `root` — Show the current workspace root directory
 * `show` — Show commit description and changes in a revision
+* `sign` — Cryptographically sign a revision
 * `sparse` — Manage which paths from the working-copy commit are present in the working copy
 * `split` — Split a revision in two
 * `squash` — Move changes from a revision into its parent
@@ -1577,6 +1579,32 @@ Show commit description and changes in a revision
   Possible values: `true`, `false`
 
 * `--tool <TOOL>` — Generate diff by external command
+
+
+
+## `jj sign`
+
+Cryptographically sign a revision
+
+**Usage:** `jj sign [OPTIONS] [KEY]`
+
+###### **Arguments:**
+
+* `<KEY>` — What key to use, depends on the configured signing backend
+
+###### **Options:**
+
+* `-r`, `--revision <REVISION>` — What revision to sign
+
+  Default value: `@`
+* `-f`, `--force` — Sign a commit that is not authored by you or was already signed
+
+  Possible values: `true`, `false`
+
+* `-D`, `--drop` — Drop the signature, explicitly "un-signing" the commit
+
+  Possible values: `true`, `false`
+
 
 
 

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -53,6 +53,7 @@ mod test_revset_output;
 mod test_root;
 mod test_shell_completion;
 mod test_show_command;
+mod test_sign_command;
 mod test_sparse_command;
 mod test_split_command;
 mod test_squash_command;

--- a/cli/tests/test_sign_command.rs
+++ b/cli/tests/test_sign_command.rs
@@ -1,0 +1,117 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+#[test]
+fn test_sign() {
+    let test_env = TestEnvironment::default();
+
+    test_env.add_config(
+        r#"
+[signing]
+show-signatures = true
+sign-all = false
+backend = "mock"
+"#,
+    );
+
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "init"]);
+
+    let show_no_sig = test_env.jj_cmd_success(&repo_path, &["show", "-r", "@-"]);
+
+    insta::assert_snapshot!(show_no_sig, @r###"
+    Commit ID: 9f2e994e4ee015d1b91f6676bc2de9531efb98fd
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:08.000 +07:00)
+
+        init
+    "###);
+
+    let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["sign", "-r", "@-"]);
+    insta::assert_snapshot!(stderr, @r###"
+    Rebased 1 descendant commits
+    Working copy now at: rlvkpnrz b162855d (empty) (no description set)
+    Parent commit      : qpvuntsm [✓︎] 5aab9df2 (empty) init
+    Commit was signed: qpvuntsm [✓︎] 5aab9df2 (empty) init
+    "###);
+
+    let show_with_sig = test_env.jj_cmd_success(&repo_path, &["show", "-r", "@-"]);
+
+    insta::assert_snapshot!(show_with_sig, @r###"
+    Commit ID: 5aab9df27eb838f225ae554edd56a11b3ecd13df
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:10.000 +07:00)
+    Signature: Good mock signature
+
+        init
+    "###);
+}
+
+#[test]
+fn test_sig_drop() {
+    let test_env = TestEnvironment::default();
+
+    test_env.add_config(
+        r#"
+[signing]
+show-signatures = true
+sign-all = false
+backend = "mock"
+"#,
+    );
+
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "init"]);
+
+    let show_no_sig = test_env.jj_cmd_success(&repo_path, &["show", "-r", "@-"]);
+    insta::assert_snapshot!(show_no_sig, @r###"
+    Commit ID: 9f2e994e4ee015d1b91f6676bc2de9531efb98fd
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:08.000 +07:00)
+
+        init
+    "###);
+
+    test_env.jj_cmd_ok(&repo_path, &["sign", "-r", "@-"]);
+
+    let show_with_sig = test_env.jj_cmd_success(&repo_path, &["show", "-r", "@-"]);
+    insta::assert_snapshot!(show_with_sig, @r###"
+    Commit ID: 5aab9df27eb838f225ae554edd56a11b3ecd13df
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:10.000 +07:00)
+    Signature: Good mock signature
+
+        init
+    "###);
+
+    test_env.jj_cmd_ok(&repo_path, &["sign", "-r", "@-", "--drop"]);
+
+    let show_with_sig = test_env.jj_cmd_success(&repo_path, &["show", "-r", "@-"]);
+    insta::assert_snapshot!(show_with_sig, @r###"
+    Commit ID: a37490e69293173538209a45786d10c63c8960d7
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author: Test User <test.user@example.com> (2001-02-03 04:05:07.000 +07:00)
+    Committer: Test User <test.user@example.com> (2001-02-03 04:05:12.000 +07:00)
+
+        init
+    "###);
+}

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -172,8 +172,8 @@ impl CommitBuilder<'_> {
         self
     }
 
-    pub fn set_sign_key(mut self, sign_key: Option<String>) -> Self {
-        self.sign_settings.key = sign_key;
+    pub fn override_sign_key(mut self, sign_key: Option<String>) -> Self {
+        self.sign_settings.key = sign_key.or(self.sign_settings.key);
         self
     }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -53,6 +53,7 @@ pub mod lock;
 pub mod matchers;
 pub mod merge;
 pub mod merged_tree;
+pub mod mock_signing;
 pub mod object_id;
 pub mod op_heads_store;
 pub mod op_store;

--- a/lib/src/mock_signing.rs
+++ b/lib/src/mock_signing.rs
@@ -1,15 +1,33 @@
+// Copyright 2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic APIs to work with cryptographic signatures created and verified by
+//! various backends.
+
 use hex::ToHex;
 use jj_lib::content_hash::blake2b_hash;
 use jj_lib::signing::{SigStatus, SignError, SignResult, SigningBackend, Verification};
 
 #[derive(Debug)]
-pub struct TestSigningBackend;
+#[allow(missing_docs)]
+pub struct MockSigningBackend;
 
-const PREFIX: &str = "--- JJ-TEST-SIGNATURE ---\nKEY: ";
+const PREFIX: &str = "--- JJ-MOCK-SIGNATURE ---\nKEY: ";
 
-impl SigningBackend for TestSigningBackend {
+impl SigningBackend for MockSigningBackend {
     fn name(&self) -> &str {
-        "test"
+        "mock"
     }
 
     fn can_read(&self, signature: &[u8]) -> bool {
@@ -37,18 +55,11 @@ impl SigningBackend for TestSigningBackend {
         let key = (!key.is_empty()).then_some(std::str::from_utf8(key).unwrap().to_owned());
 
         let sig = self.sign(data, key.as_deref())?;
-        if sig == signature {
-            Ok(Verification {
-                status: SigStatus::Good,
-                key,
-                display: None,
-            })
+        let status = if sig == signature {
+            SigStatus::Good
         } else {
-            Ok(Verification {
-                status: SigStatus::Bad,
-                key,
-                display: None,
-            })
-        }
+            SigStatus::Good
+        };
+        Ok(Verification::new(status, key, None))
     }
 }

--- a/lib/tests/test_signing.rs
+++ b/lib/tests/test_signing.rs
@@ -1,9 +1,9 @@
 use jj_lib::backend::{MillisSinceEpoch, Signature, Timestamp};
+use jj_lib::mock_signing::MockSigningBackend;
 use jj_lib::repo::Repo;
 use jj_lib::settings::UserSettings;
 use jj_lib::signing::{SigStatus, SignBehavior, Signer, Verification};
 use test_case::test_case;
-use testutils::test_signing_backend::TestSigningBackend;
 use testutils::{create_random_commit, write_random_commit, TestRepoBackend, TestWorkspace};
 
 fn user_settings(sign_all: bool) -> UserSettings {
@@ -46,7 +46,7 @@ fn good_verification() -> Option<Verification> {
 fn manual(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -76,7 +76,7 @@ fn manual(backend: TestRepoBackend) {
 fn keep_on_rewrite(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -102,7 +102,7 @@ fn keep_on_rewrite(backend: TestRepoBackend) {
 fn manual_drop_on_rewrite(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -132,7 +132,7 @@ fn manual_drop_on_rewrite(backend: TestRepoBackend) {
 fn forced(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;
@@ -155,7 +155,7 @@ fn forced(backend: TestRepoBackend) {
 fn configured(backend: TestRepoBackend) {
     let settings = user_settings(true);
 
-    let signer = Signer::new(Some(Box::new(TestSigningBackend)), vec![]);
+    let signer = Signer::new(Some(Box::new(MockSigningBackend)), vec![]);
     let test_workspace = TestWorkspace::init_with_backend_and_signer(&settings, backend, signer);
 
     let repo = &test_workspace.repo;

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -45,7 +45,6 @@ use tempfile::TempDir;
 use crate::test_backend::TestBackend;
 
 pub mod test_backend;
-pub mod test_signing_backend;
 
 pub fn hermetic_libgit2() {
     // libgit2 respects init.defaultBranch (and possibly other config


### PR DESCRIPTION
This is a continuation from #3007 and #2728 which adds in the `jj sign` command that was split out of the original PR.

---

Some outstanding comments I am carrying over from #3007:

- [ ] https://github.com/martinvonz/jj/pull/3007#discussion_r1492155652
- [ ] https://github.com/martinvonz/jj/pull/3007#discussion_r1492161844
- [ ] https://github.com/martinvonz/jj/pull/3007#discussion_r1492180855

# Checklist

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes