### PR TITLE
Add ui.diff-formatter to replace ui.diff.tool and ui.diff.format (and address #3327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecations
 
+* `ui.diff.format` and `ui.diff.tool` were deprecated in favor of `ui.diff-viewer`
+
 ### Breaking changes
 
 * The default template alias `builtin_op_log_root(op_id: OperationId)` was replaced by `format_root_operation(root: Operation)`.
@@ -72,6 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `jj log` command no longer uses the default revset when a path is specified.
 
 ### New features
+
+* Add `ui.diff-viewer` combining the both `ui.diff.format` and `ui.diff.tool` into a single setting. Built-in formats previously set via `ui.diff.format` can now be specified prefixed with `:`. Having a single option allows a repository level built-in format to override a global tool format.
+
+  * `"ui.diff-viewer" = ":color-words"`
+  * `"ui.diff-viewer" = ["difft", "--color=always", "$left", "$right"]`
 
 * Config now supports rgb hex colors (in the form `#rrggbb`) wherever existing color names are supported.
 

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -95,6 +95,19 @@
                     "description": "Pager to use for displaying command output",
                     "default": "less -FRX"
                 },
+                "diff-viewer": {
+                  "description": "Format or tool used to show diffs",
+                  "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }]
+                },
                 "diff": {
                     "type": "object",
                     "description": "Options for how diffs are displayed",

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -152,6 +152,21 @@ fn diff_formats_from_args(
     Ok(formats)
 }
 
+fn builtin_diff_format(name: &str, num_context_lines: Option<usize>) -> Option<DiffFormat> {
+    match name.as_ref() {
+        "summary" => Some(DiffFormat::Summary),
+        "types" => Some(DiffFormat::Types),
+        "git" => Some(DiffFormat::Git {
+            context: num_context_lines.unwrap_or(DEFAULT_CONTEXT_LINES),
+        }),
+        "color-words" => Some(DiffFormat::ColorWords {
+            context: num_context_lines.unwrap_or(DEFAULT_CONTEXT_LINES),
+        }),
+        "stat" => Some(DiffFormat::Stat),
+        _ => None,
+    }
+}
+
 fn default_diff_format(
     settings: &UserSettings,
     num_context_lines: Option<usize>,
@@ -174,20 +189,8 @@ fn default_diff_format(
     } else {
         "color-words".to_owned()
     };
-    match name.as_ref() {
-        "summary" => Ok(DiffFormat::Summary),
-        "types" => Ok(DiffFormat::Types),
-        "git" => Ok(DiffFormat::Git {
-            context: num_context_lines.unwrap_or(DEFAULT_CONTEXT_LINES),
-        }),
-        "color-words" => Ok(DiffFormat::ColorWords {
-            context: num_context_lines.unwrap_or(DEFAULT_CONTEXT_LINES),
-        }),
-        "stat" => Ok(DiffFormat::Stat),
-        _ => Err(config::ConfigError::Message(format!(
-            "invalid diff format: {name}"
-        ))),
-    }
+    builtin_diff_format(&name, num_context_lines)
+        .ok_or_else(|| config::ConfigError::Message(format!("invalid diff format: {name}")))
 }
 
 pub fn show_diff(

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -768,6 +768,93 @@ fn test_diff_skipped_context_nondefault() {
 }
 
 #[test]
+fn test_diff_formatter_setting() {
+    let mut test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':summary'"]), @r###"
+    A file1
+    "###);
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':types'"]), @r###"
+    -F file1
+    "###);
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':git'"]), @r###"
+    diff --git a/file1 b/file1
+    new file mode 100644
+    index 0000000000..257cc5642c
+    --- /dev/null
+    +++ b/file1
+    @@ -1,0 +1,1 @@
+    +foo
+    "###);
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':color-words'"]), @r###"
+    Added regular file file1:
+            1: foo
+    "###);
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':stat'"]), @r###"
+    file1 | 1 +
+    1 file changed, 1 insertion(+), 0 deletions(-)
+    "###);
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_failure(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':unknown'"]), @r###"
+    Config error: Unknown format setting for 'ui.diff-viewer', built-in formats are ':summary', ':types', ':git', ':color-words', and ':stat', or use an external tool
+    For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
+    "###);
+
+    let edit_script = test_env.set_up_fake_diff_editor();
+    std::fs::write(
+        edit_script,
+        "print-files-before\0print --\0print-files-after",
+    )
+    .unwrap();
+
+    let command = escaped_fake_diff_editor_path();
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='fake-diff-editor'"]), @r###"
+    --
+    file1
+    "###);
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_success(&repo_path, &["diff", &format!(r#"--config-toml=ui.diff-viewer=["{command}"]"#)]), @r###"
+    --
+    file1
+    "###);
+
+    if cfg!(windows) {
+        insta::assert_snapshot!(
+      test_env.jj_cmd_failure(&repo_path, &["diff", r#"--config-toml=ui.diff-viewer=["unknown-diff-binary"]"#]), @r###"
+    Error: Failed to generate diff
+    Caused by:
+    1: Error executing 'unknown-diff-binary' (run with --debug to see the exact invocation)
+    2: program not found
+    "###);
+    } else {
+        insta::assert_snapshot!(
+      test_env.jj_cmd_failure(&repo_path, &["diff", r#"--config-toml=ui.diff-viewer=["unknown-diff-binary"]"#]), @r###"
+    Error: Failed to generate diff
+    Caused by:
+    1: Error executing 'unknown-diff-binary' (run with --debug to see the exact invocation)
+    2: No such file or directory (os error 2)
+    "###);
+    }
+}
+
+#[test]
 fn test_diff_external_tool() {
     let mut test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
@@ -839,7 +926,7 @@ fn test_diff_external_tool() {
     "###);
 
     // Enabled by default, looks up the merge-tools table
-    let config = "--config-toml=ui.diff.tool='fake-diff-editor'";
+    let config = "--config-toml=ui.diff-viewer='fake-diff-editor'";
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", config]), @r###"
     file1
     file2
@@ -850,7 +937,7 @@ fn test_diff_external_tool() {
 
     // Inlined command arguments
     let command = escaped_fake_diff_editor_path();
-    let config = format!(r#"--config-toml=ui.diff.tool=["{command}", "$right", "$left"]"#);
+    let config = format!(r#"--config-toml=ui.diff-viewer=["{command}", "$right", "$left"]"#);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", &config]), @r###"
     file2
     file3

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -776,17 +776,17 @@ fn test_diff_formatter_setting() {
     std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
 
     insta::assert_snapshot!(
-      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':summary'"]), @r###"
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='summary'"]), @r###"
     A file1
     "###);
 
     insta::assert_snapshot!(
-      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':types'"]), @r###"
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='types'"]), @r###"
     -F file1
     "###);
 
     insta::assert_snapshot!(
-      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':git'"]), @r###"
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='git'"]), @r###"
     diff --git a/file1 b/file1
     new file mode 100644
     index 0000000000..257cc5642c
@@ -797,19 +797,19 @@ fn test_diff_formatter_setting() {
     "###);
 
     insta::assert_snapshot!(
-      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':color-words'"]), @r###"
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='color-words'"]), @r###"
     Added regular file file1:
             1: foo
     "###);
 
     insta::assert_snapshot!(
-      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':stat'"]), @r###"
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='stat'"]), @r###"
     file1 | 1 +
     1 file changed, 1 insertion(+), 0 deletions(-)
     "###);
 
     insta::assert_snapshot!(
-      test_env.jj_cmd_failure(&repo_path, &["diff", "--config-toml=ui.diff-viewer=':unknown'"]), @r###"
+      test_env.jj_cmd_failure(&repo_path, &["diff", "--config-toml=ui.diff-viewer='unknown'"]), @r###"
     Config error: Unknown format setting for 'ui.diff-viewer', built-in formats are ':summary', ':types', ':git', ':color-words', and ':stat', or use an external tool
     For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
     "###);
@@ -824,9 +824,15 @@ fn test_diff_formatter_setting() {
     let command = escaped_fake_diff_editor_path();
 
     insta::assert_snapshot!(
-      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='fake-diff-editor'"]), @r###"
+      test_env.jj_cmd_success(&repo_path, &["diff", "--config-toml=ui.diff-viewer='tool:fake-diff-editor'"]), @r###"
     --
     file1
+    "###);
+
+    insta::assert_snapshot!(
+      test_env.jj_cmd_failure(&repo_path, &["diff", "--config-toml=ui.diff-viewer='tool:unknown-diff-tool'"]), @r###"
+    Config error: Unknown external tool 'unknown-diff-tool'
+    For help, see https://github.com/martinvonz/jj/blob/main/docs/config.md.
     "###);
 
     insta::assert_snapshot!(
@@ -926,7 +932,7 @@ fn test_diff_external_tool() {
     "###);
 
     // Enabled by default, looks up the merge-tools table
-    let config = "--config-toml=ui.diff-viewer='fake-diff-editor'";
+    let config = "--config-toml=ui.diff-viewer='tool:fake-diff-editor'";
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", config]), @r###"
     file1
     file2

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -138,7 +138,7 @@ fn test_log_with_or_without_diff() {
             "description",
             "-p",
             "-s",
-            "--config-toml=ui.diff.format='summary'",
+            "--config-toml=ui.diff-viewer=':summary'",
         ],
     );
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -138,7 +138,7 @@ fn test_log_with_or_without_diff() {
             "description",
             "-p",
             "-s",
-            "--config-toml=ui.diff-viewer=':summary'",
+            "--config-toml=ui.diff-viewer='summary'",
         ],
     );
     insta::assert_snapshot!(stdout, @r###"

--- a/docs/config.md
+++ b/docs/config.md
@@ -165,24 +165,23 @@ useful reminder to fill in things like BUG=, TESTED= etc.
 ui.default-description = "\n\nTESTED=TODO"
 ```
 
-### Diff format
+### Generating diffs with built-in and external formatters
+
+Different diff formatters can be chosen with the `ui.diff-viewer` setting. `jj` provides three built-in formatters, `:color-words` (the default), `:git`, and `:summary`.
 
 ```toml
-# Possible values: "color-words" (default), "git", "summary"
-ui.diff.format = "git"
+[ui]
+diff-viewer = ":git"
 ```
 
-### Generating diffs by external command
-
-If `ui.diff.tool` is set, the specified diff command will be called instead of
-the internal diff function.
+An external diff command can be used instead of a built-in formatter, specifying the command and its arguments.
 
 ```toml
 [ui]
 # Use Difftastic by default
-diff.tool = ["difft", "--color=always", "$left", "$right"]
+diff-viewer = ["difft", "--color=always", "$left", "$right"]
 # Use tool named "<name>" (see below)
-diff.tool = "<name>"
+diff-viewer = "<name>"
 ```
 
 The external diff tool can also be enabled by `diff --tool <name>` argument.


### PR DESCRIPTION
This is to address #3327 

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
