### PR TITLE
config: also use XDG_CONFIG_HOME on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * You can check whether Watchman fsmonitor is enabled or installed with the new
   `jj debug watchman status` command.
 
+* On MacOS, jj will now look for its config in `$XDG_CONFIG_HOME` in addition
+  to  `~/Library/Application Support/jj/`
+
 ### Fixed bugs
 
 * Revsets now support `\`-escapes in string literal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,27 +673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +720,17 @@ checksum = "3a1840969ab8be31e186bb6d2f672d586dcd203dd4019a80dc1277a14686eca9"
 dependencies = [
  "bitflags 1.3.2",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1680,8 +1670,8 @@ dependencies = [
  "config",
  "criterion",
  "crossterm",
- "dirs",
  "esl01-renderdag",
+ "etcetera",
  "futures 0.3.30",
  "git2",
  "gix",
@@ -1835,17 +1825,6 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
-dependencies = [
- "bitflags 2.5.0",
- "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -2085,12 +2064,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"
@@ -2456,17 +2429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ config = { version = "0.13.4", default-features = false, features = ["toml"] }
 criterion = "0.5.1"
 crossterm = { version = "0.27", default-features = false }
 digest = "0.10.7"
-dirs = "5.0.1"
 either = "1.11.0"
+etcetera = "0.8"
 esl01-renderdag = "0.3.0"
 futures = "0.3.30"
 git2 = "0.18.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,8 +55,8 @@ clap_mangen = { workspace = true }
 config = { workspace = true }
 criterion = { workspace = true, optional = true }
 crossterm = { workspace = true }
-dirs = { workspace = true }
 esl01-renderdag = { workspace = true }
+etcetera = { workspace = true }
 futures = { workspace = true }
 git2 = { workspace = true }
 gix = { workspace = true }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -83,7 +83,7 @@ use crate::command_error::{
 };
 use crate::commit_templater::{CommitTemplateLanguage, CommitTemplateLanguageExtension};
 use crate::config::{
-    new_config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
+    new_or_existing_config_path, AnnotatedValue, CommandNameAndArgs, ConfigSource, LayeredConfigs,
 };
 use crate::formatter::{FormatRecorder, Formatter, PlainTextFormatter};
 use crate::git_util::{
@@ -1984,9 +1984,8 @@ pub fn get_new_config_file_path(
 ) -> Result<PathBuf, CommandError> {
     let edit_path = match config_source {
         // TODO(#531): Special-case for editors that can't handle viewing directories?
-        ConfigSource::User => {
-            new_config_path()?.ok_or_else(|| user_error("No repo config path found to edit"))?
-        }
+        ConfigSource::User => new_or_existing_config_path()?
+            .ok_or_else(|| user_error("No repo config path found to edit"))?,
         ConfigSource::Repo => command.workspace_loader()?.repo_path().join("config.toml"),
         _ => {
             return Err(user_error(format!(

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -121,7 +121,7 @@ fn pinentry_get_pw(url: &str) -> Option<String> {
 #[tracing::instrument]
 fn get_ssh_keys(_username: &str) -> Vec<PathBuf> {
     let mut paths = vec![];
-    if let Some(home_dir) = dirs::home_dir() {
+    if let Ok(home_dir) = etcetera::home_dir() {
         let ssh_dir = Path::new(&home_dir).join(".ssh");
         for filename in ["id_ed25519_sk", "id_ed25519", "id_rsa"] {
             let key_path = ssh_dir.join(filename);

--- a/docs/config.md
+++ b/docs/config.md
@@ -734,7 +734,7 @@ using `jj debug watchman status`.
 
 ### User config file
 
-An easy way to find the user config file is:
+An easy way to find the user config file (if one exists) is:
 
 ```bash
 jj config path --user
@@ -742,17 +742,18 @@ jj config path --user
 
 The rest of this section covers the details of where this file can be located.
 
-On all platforms, the user's global `jj` configuration file is located at either
-`~/.jjconfig.toml` (where `~` represents `$HOME` on Unix-likes, or
-`%USERPROFILE%` on Windows) or in a platform-specific directory. The
-platform-specific location is recommended for better integration with platform
-services. It is an error for both of these files to exist.
+On all platforms, the user's global `jj` configuration file is located at
+either `~/.jjconfig.toml` (where `~` represents `$HOME` on Unix-likes, or
+`%USERPROFILE%` on Windows), in a platform-specific directory, or
+`$XDG_CONFIG_HOME` (if different from the platform-specific directory, like on
+MacOS). The platform-specific location is recommended for better integration
+with platform services. It is an error for more than one of these files to exist.
 
-| Platform | Value                                              | Example                                                   |
-| :------- | :------------------------------------------------- | :-------------------------------------------------------- |
-| Linux    | `$XDG_CONFIG_HOME/jj/config.toml`                  | `/home/alice/.config/jj/config.toml`                      |
-| macOS    | `$HOME/Library/Application Support/jj/config.toml` | `/Users/Alice/Library/Application Support/jj/config.toml` |
-| Windows  | `{FOLDERID_RoamingAppData}\jj\config.toml`         | `C:\Users\Alice\AppData\Roaming\jj\config.toml`           |
+| Platform | Value                                    | Example                                       |
+| :------- | ---------------------------------------- | --------------------------------------------- |
+| Linux    | `$XDG_CONFIG_HOME/jj/config.toml`          | `/home/alice/.config/jj/config.toml`            |
+| macOS    | `~/Library/Application Support/jj/config.toml` or `$XDG_CONFIG_HOME/jj/config.toml`          | `/Users/alice/Library/Application Support/jj/config.toml` or `/Users/Alice/.config/jj/config.toml`           |
+| Windows  | `{FOLDERID_RoamingAppData}\jj\config.toml` | `C:\Users\Alice\AppData\Roaming\jj\config.toml` |
 
 The location of the `jj` config file can also be overridden with the
 `JJ_CONFIG` environment variable. If it is not empty, it should contain the path


### PR DESCRIPTION
This replaces the `dirs` crate with the more lightweight and flexible `etcetera` crate, which also lets us use XDG config on MacOS.


Fixes #3434.

~~I'm not entirely sure how do prevent the line break in the doc table between "Application" and "Support" 😅 ...~~

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
