### PR TITLE
cli: Add 'dup' alias to 'duplicate' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * A new global flag `--ignore-immutable` lets you rewrite immutable commits.
 
+* `jj duplicate` now has a shortened alias `jj dup`. 
+
 ### Fixed bugs
 
 * Revsets now support `\`-escapes in string literal.

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -26,6 +26,7 @@ use crate::ui::Ui;
 
 /// Create a new change with the same content as an existing one
 #[derive(clap::Args, Clone, Debug)]
+#[command(visible_aliases = &["dup"])]
 pub(crate) struct DuplicateArgs {
     /// The revision(s) to duplicate
     #[arg(default_value = "@")]


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes


I found myself using the duplicate command often when splitting massive branches into smaller PRs. This alias could save me valuable milliseconds in the future :smile: 