### PR TITLE
prototype implementation for topics #3402

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -52,6 +52,7 @@ mod split;
 mod squash;
 mod status;
 mod tag;
+mod topic;
 mod unsquash;
 mod untrack;
 mod util;
@@ -138,6 +139,8 @@ enum Command {
     #[command(subcommand)]
     Tag(tag::TagCommand),
     #[command(subcommand)]
+    Topic(topic::TopicCommand),
+    #[command(subcommand)]
     Util(util::UtilCommand),
     /// Undo an operation (shortcut for `jj op undo`)
     Undo(operation::OperationUndoArgs),
@@ -206,6 +209,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Workspace(sub_args) => workspace::cmd_workspace(ui, command_helper, sub_args),
         Command::Sparse(sub_args) => sparse::cmd_sparse(ui, command_helper, sub_args),
         Command::Tag(sub_args) => tag::cmd_tag(ui, command_helper, sub_args),
+        Command::Topic(sub_args) => topic::cmd_topic(ui, command_helper, sub_args),
         Command::Chmod(sub_args) => chmod::cmd_chmod(ui, command_helper, sub_args),
         Command::Git(sub_args) => git::cmd_git(ui, command_helper, sub_args),
         Command::Util(sub_args) => util::cmd_util(ui, command_helper, sub_args),

--- a/cli/src/commands/operation.rs
+++ b/cli/src/commands/operation.rs
@@ -247,6 +247,7 @@ fn view_with_desired_portions_restored(
         head_ids: repo_source.head_ids.clone(),
         local_branches: repo_source.local_branches.clone(),
         tags: repo_source.tags.clone(),
+        topics: repo_source.topics.clone(),
         remote_views: remote_source.remote_views.clone(),
         git_refs: current_view.git_refs.clone(),
         git_head: current_view.git_head.clone(),

--- a/cli/src/commands/topic.rs
+++ b/cli/src/commands/topic.rs
@@ -1,0 +1,379 @@
+// Copyright 2020-2023 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::io::Write as _;
+use std::rc::Rc;
+
+use itertools::Itertools;
+use jj_lib::backend::{BackendResult, CommitId};
+use jj_lib::revset::{self, RevsetExpression};
+use jj_lib::str_util::StringPattern;
+
+use crate::cli_util::{CommandHelper, RevisionArg};
+use crate::command_error::{user_error, CommandError};
+use crate::ui::Ui;
+
+/// Manage branches.
+///
+/// For information about branches, see
+/// https://github.com/martinvonz/jj/blob/main/docs/branches.md.
+#[derive(clap::Subcommand, Clone, Debug)]
+pub enum TopicCommand {
+    #[command(visible_alias("d"))]
+    Delete(TopicDeleteArgs),
+    #[command(visible_alias("l"))]
+    List(TopicListArgs),
+    #[command(visible_alias("r"))]
+    Rename(TopicRenameArgs),
+    #[command(visible_alias("s"))]
+    Set(TopicSetArgs),
+    #[command(visible_alias("u"))]
+    Unset(TopicUnsetArgs),
+}
+
+/// Delete an existing topic and unset it from all associated commits
+#[derive(clap::Args, Clone, Debug)]
+pub struct TopicDeleteArgs {
+    /// The topic to delete
+    ///
+    /// By default, the specified name matches exactly. Use `glob:` prefix to
+    /// select topics by wildcard pattern. For details, see
+    /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
+    #[arg(required = true, value_parser = StringPattern::parse)]
+    pub names: Vec<StringPattern>,
+}
+
+/// List topics
+///
+/// For information about topics, see
+/// https://github.com/martinvonz/jj/blob/main/docs/topics.md.
+#[derive(clap::Args, Clone, Debug)]
+pub struct TopicListArgs {
+    /// Show topics whose name matches
+    ///
+    /// By default, the specified name matches exactly. Use `glob:` prefix to
+    /// select topics by wildcard pattern. For details, see
+    /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
+    #[arg(value_parser = StringPattern::parse)]
+    pub names: Vec<StringPattern>,
+
+    /// Show topics associated with any of the given revisions.
+    #[arg(long, short)]
+    pub revisions: Vec<RevisionArg>,
+}
+
+/// Rename `old` topic name to `new` topic name.
+///
+/// The new topic name is associated with the same commits as the old
+/// topic name.
+#[derive(clap::Args, Clone, Debug)]
+pub struct TopicRenameArgs {
+    /// The old name of the topic.
+    pub old: String,
+
+    /// The new name of the topic.
+    pub new: String,
+}
+
+/// Updates the given revision(s) to be associated with the given topic(s).
+///
+/// Unless `--keep` is passed, this will replace previously associated topics.
+#[derive(clap::Args, Clone, Debug)]
+pub struct TopicSetArgs {
+    /// The revisions to associate with the topics, defaults to @.
+    #[arg(long, short)]
+    pub revisions: Vec<RevisionArg>,
+
+    /// The topics to add.
+    #[arg(required = true)]
+    pub names: Vec<String>,
+
+    /// Whether to keep other topics on the revisions
+    #[arg(long)]
+    pub exclusive_topics: bool,
+
+    /// Whether to disassociate the topics from other revisions
+    #[arg(long)]
+    pub exclusive_commits: bool,
+}
+
+/// Updates the given revision(s) to no longer be associated with the given
+/// topic(s).
+#[derive(clap::Args, Clone, Debug)]
+pub struct TopicUnsetArgs {
+    /// The revisions to disassociate with the topics, defaults to @.
+    #[arg(long, short)]
+    pub revisions: Vec<RevisionArg>,
+
+    /// The topic to unset
+    ///
+    /// By default, the specified name matches exactly. Use `glob:` prefix to
+    /// select topics by wildcard pattern. For details, see
+    /// https://github.com/martinvonz/jj/blob/main/docs/revsets.md#string-patterns.
+    #[arg(value_parser = StringPattern::parse)]
+    pub names: Vec<StringPattern>,
+}
+
+pub fn cmd_topic(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    subcommand: &TopicCommand,
+) -> Result<(), CommandError> {
+    match subcommand {
+        TopicCommand::Rename(sub_args) => cmd_topic_rename(ui, command, sub_args),
+        TopicCommand::Set(sub_args) => cmd_topic_set(ui, command, sub_args),
+        TopicCommand::Unset(sub_args) => cmd_topic_unset(ui, command, sub_args),
+        TopicCommand::Delete(sub_args) => cmd_topic_delete(ui, command, sub_args),
+        TopicCommand::List(sub_args) => cmd_topic_list(ui, command, sub_args),
+    }
+}
+
+fn cmd_topic_rename(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &TopicRenameArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let mut tx = workspace_command.start_transaction();
+    let repo = tx.mut_repo();
+    let base_repo = repo.base_repo().clone();
+
+    let Some(commits) = base_repo.view().get_topic_commits(&args.old) else {
+        return Err(user_error(format!("No such topic {}", args.old)));
+    };
+
+    let mut stats = repo.set_topic_commits(
+        HashSet::from_iter([args.new.clone()]),
+        commits,
+        false,
+        false,
+    );
+    stats += repo.remove_topics(vec![StringPattern::exact(args.old.to_string())]);
+
+    tx.finish(
+        ui,
+        format!("rename topic {} to {} commits", args.old, args.new),
+    )?;
+    if !stats.is_empty() {
+        let summary = stats
+            .iter()
+            .map(|(topic, stats)| {
+                format!(
+                    "{topic}: {} added, {} removed",
+                    stats.added().len(),
+                    stats.removed().len()
+                )
+            })
+            .join("\n");
+        writeln!(
+            ui.stdout_formatter(),
+            "The following topics were updated:\n{}",
+            summary
+        )?;
+    }
+
+    Ok(())
+}
+
+fn cmd_topic_set(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &TopicSetArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let commit_ids = if args.revisions.is_empty() {
+        workspace_command.attach_revset_evaluator(RevsetExpression::working_copy(
+            workspace_command.workspace_id().clone(),
+        ))?
+    } else {
+        workspace_command.parse_union_revsets(&args.revisions)?
+    }
+    .evaluate_to_commit_ids()?
+    .collect();
+
+    let mut tx = workspace_command.start_transaction();
+    let repo = tx.mut_repo();
+
+    let stats = repo.set_topic_commits(
+        HashSet::from_iter(args.names.clone()),
+        &commit_ids,
+        args.exclusive_topics,
+        args.exclusive_commits,
+    );
+
+    tx.finish(
+        ui,
+        format!(
+            "update topics {} on {} commits",
+            stats.keys().join(", "),
+            stats.affected().len()
+        ),
+    )?;
+    if !stats.is_empty() {
+        let summary = stats
+            .iter()
+            .map(|(topic, stats)| {
+                format!(
+                    "{topic}: {} added, {} removed",
+                    stats.added().len(),
+                    stats.removed().len()
+                )
+            })
+            .join("\n");
+        writeln!(
+            ui.stdout_formatter(),
+            "The following topics were updated:\n{}",
+            summary
+        )?;
+    }
+
+    Ok(())
+}
+
+fn cmd_topic_unset(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &TopicUnsetArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let expression = if args.revisions.is_empty() {
+        workspace_command.attach_revset_evaluator(RevsetExpression::working_copy(
+            workspace_command.workspace_id().clone(),
+        ))?
+    } else {
+        workspace_command.parse_union_revsets(&args.revisions)?
+    };
+    let commit_ids = expression.evaluate_to_commit_ids()?.collect();
+
+    let mut tx = workspace_command.start_transaction();
+    let repo = tx.mut_repo();
+
+    let stats = repo.disassociate_topics_from_commits(
+        if args.names.is_empty() {
+            vec![StringPattern::everything()]
+        } else {
+            args.names.clone()
+        },
+        &commit_ids,
+    );
+
+    tx.finish(
+        ui,
+        format!(
+            "disassociate topics {} from {} commits",
+            stats.keys().join(", "),
+            stats.affected().len()
+        ),
+    )?;
+    if !stats.is_empty() {
+        let summary = stats
+            .iter()
+            .map(|(topic, stats)| format!("{topic}: {} removed", stats.removed().len()))
+            .join("\n");
+        writeln!(
+            ui.stdout_formatter(),
+            "The following topics were updated:\n{}",
+            summary
+        )?;
+    }
+
+    Ok(())
+}
+
+fn cmd_topic_delete(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &TopicDeleteArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let mut tx = workspace_command.start_transaction();
+    let repo = tx.mut_repo();
+
+    let stats = repo.remove_topics(args.names.clone());
+
+    tx.finish(ui, format!("delete topics {}", stats.keys().join(", "),))?;
+    if !stats.is_empty() {
+        let summary = stats
+            .iter()
+            .map(|(topic, stats)| format!("{topic}: {} commits", stats.removed().len()))
+            .join("\n");
+        writeln!(
+            ui.stdout_formatter(),
+            "The following topics were removed:\n{}",
+            summary
+        )?;
+    }
+
+    Ok(())
+}
+
+fn cmd_topic_list(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &TopicListArgs,
+) -> Result<(), CommandError> {
+    let workspace_command = command.workspace_helper(ui)?;
+    let repo = workspace_command.repo();
+
+    let topic_names_to_list = {
+        let mut expression = if args.revisions.is_empty() {
+            workspace_command.attach_revset_evaluator(RevsetExpression::all())?
+        } else {
+            workspace_command.parse_union_revsets(&args.revisions)?
+        };
+        for pattern in args.names.clone() {
+            expression.intersect_with(&Rc::new(RevsetExpression::CommitRef(
+                revset::RevsetCommitRef::Topics(pattern),
+            )))
+        }
+        let res = expression.evaluate()?;
+        let mut topics = res.iter().try_fold(
+            HashMap::new(),
+            |mut topics, id| -> BackendResult<HashMap<String, Vec<CommitId>>> {
+                for topic in repo.view().topics_containing_commit(&id) {
+                    match topics.entry(topic.to_string()) {
+                        std::collections::hash_map::Entry::Occupied(mut entry) => {
+                            entry.get_mut().push(id.clone());
+                        }
+                        std::collections::hash_map::Entry::Vacant(entry) => {
+                            entry.insert(vec![id.clone()]);
+                        }
+                    }
+                }
+                Ok(topics)
+            },
+        )?;
+
+        if !args.names.is_empty() {
+            topics.retain(|name, _| args.names.iter().any(|pattern| pattern.matches(name)))
+        }
+        topics
+    };
+
+    ui.request_pager();
+    let mut formatter = ui.stdout_formatter();
+    let formatter = formatter.as_mut();
+
+    for (topic, commits) in topic_names_to_list {
+        write!(formatter.labeled("topics"), "{topic}")?;
+        writeln!(formatter, ": {}", commits.len())?;
+    }
+
+    Ok(())
+}

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -261,6 +261,7 @@ pub struct View {
     pub head_ids: HashSet<CommitId>,
     pub local_branches: BTreeMap<String, RefTarget>,
     pub tags: BTreeMap<String, RefTarget>,
+    pub topics: BTreeMap<String, HashSet<CommitId>>,
     pub remote_views: BTreeMap<String, RemoteView>,
     pub git_refs: BTreeMap<String, RefTarget>,
     /// The commit the Git HEAD points to.

--- a/lib/src/protos/op_store.proto
+++ b/lib/src/protos/op_store.proto
@@ -75,6 +75,11 @@ message Tag {
   RefTarget target = 2;
 }
 
+message Topic {
+  string name = 1;
+  repeated bytes commit_ids = 2;
+}
+
 message View {
   repeated bytes head_ids = 1;
   reserved 4;
@@ -82,6 +87,7 @@ message View {
   map<string, bytes> wc_commit_ids = 8;
   repeated Branch branches = 5;
   repeated Tag tags = 6;
+  repeated Topic topics = 11;
   // Only a subset of the refs. For example, does not include refs/notes/.
   repeated GitRef git_refs = 3;
   // This field is just for historical reasons (before we had the RefTarget

--- a/lib/src/protos/op_store.rs
+++ b/lib/src/protos/op_store.rs
@@ -96,6 +96,14 @@ pub struct Tag {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Topic {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub commit_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct View {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub head_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
@@ -111,6 +119,8 @@ pub struct View {
     pub branches: ::prost::alloc::vec::Vec<Branch>,
     #[prost(message, repeated, tag = "6")]
     pub tags: ::prost::alloc::vec::Vec<Tag>,
+    #[prost(message, repeated, tag = "11")]
+    pub topics: ::prost::alloc::vec::Vec<Topic>,
     /// Only a subset of the refs. For example, does not include refs/notes/.
     #[prost(message, repeated, tag = "3")]
     pub git_refs: ::prost::alloc::vec::Vec<GitRef>,

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -318,6 +318,7 @@ pub enum RevsetCommitRef {
         remote_pattern: StringPattern,
     },
     Tags,
+    Topics(StringPattern),
     GitRefs,
     GitHead,
 }
@@ -450,6 +451,12 @@ impl RevsetExpression {
 
     pub fn tags() -> Rc<RevsetExpression> {
         Rc::new(RevsetExpression::CommitRef(RevsetCommitRef::Tags))
+    }
+
+    pub fn topics(pattern: StringPattern) -> Rc<RevsetExpression> {
+        Rc::new(RevsetExpression::CommitRef(RevsetCommitRef::Topics(
+            pattern,
+        )))
     }
 
     pub fn git_refs() -> Rc<RevsetExpression> {
@@ -1270,6 +1277,15 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
     map.insert("tags", |name, arguments_pair, _state| {
         expect_no_arguments(name, arguments_pair)?;
         Ok(RevsetExpression::tags())
+    });
+    map.insert("topics", |name, arguments_pair, state| {
+        let ([], [opt_arg]) = expect_arguments(name, arguments_pair)?;
+        let pattern = if let Some(arg) = opt_arg {
+            parse_function_argument_to_string_pattern(name, arg, state)?
+        } else {
+            StringPattern::everything()
+        };
+        Ok(RevsetExpression::topics(pattern))
     });
     map.insert("git_refs", |name, arguments_pair, _state| {
         expect_no_arguments(name, arguments_pair)?;
@@ -2111,6 +2127,21 @@ impl PartialSymbolResolver for TagResolver {
     }
 }
 
+struct TopicResolver;
+
+impl PartialSymbolResolver for TopicResolver {
+    fn resolve_symbol(
+        &self,
+        repo: &dyn Repo,
+        symbol: &str,
+    ) -> Result<Option<Vec<CommitId>>, RevsetResolutionError> {
+        Ok(repo
+            .view()
+            .get_topic_commits(symbol)
+            .map(|set| set.iter().cloned().collect_vec()))
+    }
+}
+
 struct BranchResolver;
 
 impl PartialSymbolResolver for BranchResolver {
@@ -2146,8 +2177,12 @@ impl PartialSymbolResolver for GitRefResolver {
     }
 }
 
-const DEFAULT_RESOLVERS: &[&'static dyn PartialSymbolResolver] =
-    &[&TagResolver, &BranchResolver, &GitRefResolver];
+const DEFAULT_RESOLVERS: &[&'static dyn PartialSymbolResolver] = &[
+    &TagResolver,
+    &BranchResolver,
+    &TopicResolver,
+    &GitRefResolver,
+];
 
 #[derive(Default)]
 struct CommitPrefixResolver<'a> {
@@ -2329,6 +2364,15 @@ fn resolve_commit_ref(
             for ref_target in repo.view().tags().values() {
                 commit_ids.extend(ref_target.added_ids().cloned());
             }
+            Ok(commit_ids)
+        }
+        RevsetCommitRef::Topics(pattern) => {
+            let commit_ids = repo
+                .view()
+                .topics_matching(pattern)
+                .flat_map(|(_, ids)| ids)
+                .cloned()
+                .collect();
             Ok(commit_ids)
         }
         RevsetCommitRef::GitRefs => {

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -344,6 +344,7 @@ impl View {
             head_ids,
             local_branches,
             tags,
+            topics,
             remote_views,
             git_refs,
             git_head,
@@ -352,6 +353,7 @@ impl View {
         itertools::chain!(
             head_ids,
             local_branches.values().flat_map(ref_target_ids),
+            topics.values().flatten(),
             tags.values().flat_map(ref_target_ids),
             remote_views.values().flat_map(|remote_view| {
                 let op_store::RemoteView { branches } = remote_view;


### PR DESCRIPTION
This is still a very rough draft, but I think it's at least at a point where it can be played around with to move the discussion further along.

Any feedback is welcome, there's probably some unused code in there from various attempts at keeping commit and view metadata in sync.

First basic implementation of #3402 adding basic crud, revset and commit template integration. There's still a lot to be done though.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
