### PR TITLE
add prompt: revset modifier 

### DIFF
--- a/cli/examples/custom-command/main.rs
+++ b/cli/examples/custom-command/main.rs
@@ -39,7 +39,7 @@ fn run_custom_command(
     match command {
         CustomCommand::Frobnicate(args) => {
             let mut workspace_command = command_helper.workspace_helper(ui)?;
-            let commit = workspace_command.resolve_single_rev(&args.revision)?;
+            let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
             let mut tx = workspace_command.start_transaction();
             let new_commit = tx
                 .mut_repo()

--- a/cli/src/commands/backout.rs
+++ b/cli/src/commands/backout.rs
@@ -40,10 +40,10 @@ pub(crate) fn cmd_backout(
     args: &BackoutArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit_to_back_out = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit_to_back_out = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let mut parents = vec![];
     for revision_str in &args.destination {
-        let destination = workspace_command.resolve_single_rev(revision_str)?;
+        let destination = workspace_command.resolve_single_rev(ui, revision_str)?;
         parents.push(destination);
     }
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/bench.rs
+++ b/cli/src/commands/bench.rs
@@ -135,8 +135,8 @@ pub(crate) fn cmd_bench(
     match subcommand {
         BenchCommand::CommonAncestors(args) => {
             let workspace_command = command.workspace_helper(ui)?;
-            let commit1 = workspace_command.resolve_single_rev(&args.revision1)?;
-            let commit2 = workspace_command.resolve_single_rev(&args.revision2)?;
+            let commit1 = workspace_command.resolve_single_rev(ui, &args.revision1)?;
+            let commit2 = workspace_command.resolve_single_rev(ui, &args.revision2)?;
             let index = workspace_command.repo().index();
             let routine =
                 || index.common_ancestors(&[commit1.id().clone()], &[commit2.id().clone()]);
@@ -149,8 +149,8 @@ pub(crate) fn cmd_bench(
         }
         BenchCommand::IsAncestor(args) => {
             let workspace_command = command.workspace_helper(ui)?;
-            let ancestor_commit = workspace_command.resolve_single_rev(&args.ancestor)?;
-            let descendant_commit = workspace_command.resolve_single_rev(&args.descendant)?;
+            let ancestor_commit = workspace_command.resolve_single_rev(ui, &args.ancestor)?;
+            let descendant_commit = workspace_command.resolve_single_rev(ui, &args.descendant)?;
             let index = workspace_command.repo().index();
             let routine = || index.is_ancestor(ancestor_commit.id(), descendant_commit.id());
             run_bench(

--- a/cli/src/commands/branch.rs
+++ b/cli/src/commands/branch.rs
@@ -247,8 +247,8 @@ fn cmd_branch_create(
     args: &BranchCreateArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let target_commit =
-        workspace_command.resolve_single_rev(args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
+    let target_commit = workspace_command
+        .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
     let view = workspace_command.repo().view();
     let branch_names = &args.names;
     if let Some(branch_name) = branch_names
@@ -348,8 +348,8 @@ fn cmd_branch_set(
     args: &BranchSetArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let target_commit =
-        workspace_command.resolve_single_rev(args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
+    let target_commit = workspace_command
+        .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
     let repo = workspace_command.repo().as_ref();
     let is_fast_forward = |old_target: &RefTarget| {
         // Strictly speaking, "all" old targets should be ancestors, but we allow

--- a/cli/src/commands/cat.rs
+++ b/cli/src/commands/cat.rs
@@ -50,7 +50,7 @@ pub(crate) fn cmd_cat(
     args: &CatArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let tree = commit.tree()?;
     // TODO: No need to add special case for empty paths when switching to
     // parse_union_filesets(). paths = [] should be "none()" if supported.

--- a/cli/src/commands/checkout.rs
+++ b/cli/src/commands/checkout.rs
@@ -51,7 +51,7 @@ pub(crate) fn cmd_checkout(
         "`jj checkout` will be removed in a future version, and this will be a hard error"
     )?;
     let mut workspace_command = command.workspace_helper(ui)?;
-    let target = workspace_command.resolve_single_rev(&args.revision)?;
+    let target = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let mut tx = workspace_command.start_transaction();
     let commit_builder = tx
         .mut_repo()

--- a/cli/src/commands/chmod.rs
+++ b/cli/src/commands/chmod.rs
@@ -59,7 +59,7 @@ pub(crate) fn cmd_chmod(
     };
 
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     workspace_command.check_rewritable([commit.id()])?;
     let tree = commit.tree()?;
     // TODO: No need to add special case for empty paths when switching to

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -347,7 +347,7 @@ fn cmd_debug_tree(
         MergedTree::resolved(tree)
     } else {
         let commit = workspace_command
-            .resolve_single_rev(args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
+            .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
         commit.tree()?
     };
     let matcher = workspace_command

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -67,7 +67,7 @@ pub(crate) fn cmd_describe(
     args: &DescribeArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     workspace_command.check_rewritable([commit.id()])?;
     let description = if args.stdin {
         let mut buffer = String::new();

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -62,15 +62,15 @@ pub(crate) fn cmd_diff(
     let from_tree;
     let to_tree;
     if args.from.is_some() || args.to.is_some() {
-        let from =
-            workspace_command.resolve_single_rev(args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
+        let from = workspace_command
+            .resolve_single_rev(ui, args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
         from_tree = from.tree()?;
-        let to =
-            workspace_command.resolve_single_rev(args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
+        let to = workspace_command
+            .resolve_single_rev(ui, args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
         to_tree = to.tree()?;
     } else {
         let commit = workspace_command
-            .resolve_single_rev(args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
+            .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
         from_tree = commit.parent_tree(workspace_command.repo().as_ref())?;
         to_tree = commit.tree()?
     }

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -70,18 +70,17 @@ pub(crate) fn cmd_diffedit(
 
     let (target_commit, base_commits, diff_description);
     if args.from.is_some() || args.to.is_some() {
-        target_commit =
-            workspace_command.resolve_single_rev(args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
-        base_commits =
-            vec![workspace_command
-                .resolve_single_rev(args.from.as_ref().unwrap_or(&RevisionArg::AT))?];
+        target_commit = workspace_command
+            .resolve_single_rev(ui, args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
+        base_commits = vec![workspace_command
+            .resolve_single_rev(ui, args.from.as_ref().unwrap_or(&RevisionArg::AT))?];
         diff_description = format!(
             "The diff initially shows the commit's changes relative to:\n{}",
             workspace_command.format_commit_summary(&base_commits[0])
         );
     } else {
         target_commit = workspace_command
-            .resolve_single_rev(args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
+            .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
         base_commits = target_commit.parents().try_collect()?;
         diff_description = "The diff initially shows the commit's changes.".to_string();
     };

--- a/cli/src/commands/edit.rs
+++ b/cli/src/commands/edit.rs
@@ -43,7 +43,7 @@ pub(crate) fn cmd_edit(
     args: &EditArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let new_commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let new_commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     workspace_command.check_rewritable([new_commit.id()])?;
     if workspace_command.get_wc_commit_id() == Some(new_commit.id()) {
         writeln!(ui.status(), "Already editing that commit")?;

--- a/cli/src/commands/files.rs
+++ b/cli/src/commands/files.rs
@@ -38,7 +38,7 @@ pub(crate) fn cmd_files(
     args: &FilesArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let tree = commit.tree()?;
     let matcher = workspace_command
         .parse_file_patterns(&args.paths)?

--- a/cli/src/commands/git.rs
+++ b/cli/src/commands/git.rs
@@ -1103,7 +1103,7 @@ fn classify_branch_update(
 
 /// Creates or moves branches based on the change IDs.
 fn update_change_branches(
-    ui: &Ui,
+    ui: &mut Ui,
     tx: &mut WorkspaceCommandTransaction,
     changes: &[RevisionArg],
     branch_prefix: &str,
@@ -1111,7 +1111,7 @@ fn update_change_branches(
     let mut branch_names = Vec::new();
     for change_arg in changes {
         let workspace_command = tx.base_workspace_helper();
-        let commit = workspace_command.resolve_single_rev(change_arg)?;
+        let commit = workspace_command.resolve_single_rev(ui, change_arg)?;
         let mut branch_name = format!("{branch_prefix}{}", commit.change_id().hex());
         let view = tx.base_repo().view();
         if view.get_local_branch(&branch_name).is_absent() {
@@ -1119,7 +1119,7 @@ fn update_change_branches(
             // short ID if it's not ambiguous (which it shouldn't be most of the time).
             let short_change_id = short_change_hash(commit.change_id());
             if workspace_command
-                .resolve_single_rev(&RevisionArg::from(short_change_id.clone()))
+                .resolve_single_rev(ui, &RevisionArg::from(short_change_id.clone()))
                 .is_ok()
             {
                 // Short change ID is not ambiguous, so update the branch name to use it.
@@ -1259,7 +1259,7 @@ fn cmd_git_submodule_print_gitmodules(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();
-    let commit = workspace_command.resolve_single_rev(&args.revisions)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revisions)?;
     let tree = commit.tree()?;
     let gitmodules_path = RepoPath::from_internal_string(".gitmodules");
     let mut gitmodules_file = match tree.path_value(gitmodules_path).into_resolved() {

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -50,8 +50,9 @@ pub(crate) fn cmd_interdiff(
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
     let from =
-        workspace_command.resolve_single_rev(args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
-    let to = workspace_command.resolve_single_rev(args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
+        workspace_command.resolve_single_rev(ui, args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
+    let to =
+        workspace_command.resolve_single_rev(ui, args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
 
     let from_tree = rebase_to_dest_parent(workspace_command.repo().as_ref(), &from, &to)?;
     let to_tree = to.tree()?;

--- a/cli/src/commands/move.rs
+++ b/cli/src/commands/move.rs
@@ -72,9 +72,9 @@ pub(crate) fn cmd_move(
     )?;
     let mut workspace_command = command.workspace_helper(ui)?;
     let source =
-        workspace_command.resolve_single_rev(args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
+        workspace_command.resolve_single_rev(ui, args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
     let destination =
-        workspace_command.resolve_single_rev(args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
+        workspace_command.resolve_single_rev(ui, args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
     if source.id() == destination.id() {
         return Err(user_error("Source and destination cannot be the same."));
     }

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -95,7 +95,7 @@ Please use `jj new 'all:x|y'` instead of `jj new --allow-large-revsets x y`.",
     }
     let mut workspace_command = command.workspace_helper(ui)?;
     let target_commits = workspace_command
-        .resolve_some_revsets_default_single(&args.revisions)?
+        .resolve_some_revsets_default_single(ui, &args.revisions)?
         .into_iter()
         .collect_vec();
     let target_ids = target_commits.iter().ids().cloned().collect_vec();

--- a/cli/src/commands/obslog.rs
+++ b/cli/src/commands/obslog.rs
@@ -69,7 +69,7 @@ pub(crate) fn cmd_obslog(
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo().as_ref();
 
-    let start_commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let start_commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
 
     let diff_renderer = workspace_command.diff_renderer_for_log(&args.diff_format, args.patch)?;
     let with_content_format = LogContentFormat::new(ui, command.settings())?;

--- a/cli/src/commands/prev.rs
+++ b/cli/src/commands/prev.rs
@@ -16,9 +16,8 @@ use itertools::Itertools;
 use jj_lib::repo::Repo;
 use jj_lib::revset::{RevsetExpression, RevsetIteratorExt};
 
-use crate::cli_util::{short_commit_hash, CommandHelper};
+use crate::cli_util::{choose_commit, short_commit_hash, CommandHelper};
 use crate::command_error::{user_error, CommandError};
-use crate::commands::next::choose_commit;
 use crate::ui::Ui;
 /// Change the working copy revision relative to the parent revision
 ///
@@ -99,7 +98,12 @@ pub(crate) fn cmd_prev(
                 if args.offset > 1 { "s" } else { "" }
             )))
         }
-        commits => choose_commit(ui, &workspace_command, "prev", commits)?,
+        commits => choose_commit(
+            ui,
+            &workspace_command,
+            "ambiguous prev commit, choose one to target",
+            commits,
+        )?,
     };
 
     // Generate a short commit hash, to make it readable in the op log.

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -243,9 +243,9 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
             .try_collect()?; // in reverse topological order
         if !args.insert_after.is_empty() && !args.insert_before.is_empty() {
             let after_commits =
-                workspace_command.resolve_some_revsets_default_single(&args.insert_after)?;
+                workspace_command.resolve_some_revsets_default_single(ui, &args.insert_after)?;
             let before_commits =
-                workspace_command.resolve_some_revsets_default_single(&args.insert_before)?;
+                workspace_command.resolve_some_revsets_default_single(ui, &args.insert_before)?;
             rebase_revisions_after_before(
                 ui,
                 command.settings(),
@@ -256,7 +256,7 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
             )?;
         } else if !args.insert_after.is_empty() {
             let after_commits =
-                workspace_command.resolve_some_revsets_default_single(&args.insert_after)?;
+                workspace_command.resolve_some_revsets_default_single(ui, &args.insert_after)?;
             rebase_revisions_after(
                 ui,
                 command.settings(),
@@ -266,7 +266,7 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
             )?;
         } else if !args.insert_before.is_empty() {
             let before_commits =
-                workspace_command.resolve_some_revsets_default_single(&args.insert_before)?;
+                workspace_command.resolve_some_revsets_default_single(ui, &args.insert_before)?;
             rebase_revisions_before(
                 ui,
                 command.settings(),
@@ -276,7 +276,7 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
             )?;
         } else {
             let new_parents = workspace_command
-                .resolve_some_revsets_default_single(&args.destination)?
+                .resolve_some_revsets_default_single(ui, &args.destination)?
                 .into_iter()
                 .collect_vec();
             rebase_revisions(
@@ -289,10 +289,11 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
         }
     } else if !args.source.is_empty() {
         let new_parents = workspace_command
-            .resolve_some_revsets_default_single(&args.destination)?
+            .resolve_some_revsets_default_single(ui, &args.destination)?
             .into_iter()
             .collect_vec();
-        let source_commits = workspace_command.resolve_some_revsets_default_single(&args.source)?;
+        let source_commits =
+            workspace_command.resolve_some_revsets_default_single(ui, &args.source)?;
         rebase_descendants_transaction(
             ui,
             command.settings(),
@@ -303,13 +304,13 @@ Please use `jj rebase -d 'all:x|y'` instead of `jj rebase --allow-large-revsets 
         )?;
     } else {
         let new_parents = workspace_command
-            .resolve_some_revsets_default_single(&args.destination)?
+            .resolve_some_revsets_default_single(ui, &args.destination)?
             .into_iter()
             .collect_vec();
         let branch_commits = if args.branch.is_empty() {
-            IndexSet::from([workspace_command.resolve_single_rev(&RevisionArg::AT)?])
+            IndexSet::from([workspace_command.resolve_single_rev(ui, &RevisionArg::AT)?])
         } else {
-            workspace_command.resolve_some_revsets_default_single(&args.branch)?
+            workspace_command.resolve_some_revsets_default_single(ui, &args.branch)?
         };
         rebase_branch(
             ui,

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -67,7 +67,7 @@ pub(crate) fn cmd_resolve(
     let matcher = workspace_command
         .parse_file_patterns(&args.paths)?
         .to_matcher();
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let tree = commit.tree()?;
     let conflicts = tree
         .conflicts()

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -86,14 +86,14 @@ pub(crate) fn cmd_restore(
         ));
     }
     if args.from.is_some() || args.to.is_some() {
-        to_commit =
-            workspace_command.resolve_single_rev(args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
+        to_commit = workspace_command
+            .resolve_single_rev(ui, args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
         from_tree = workspace_command
-            .resolve_single_rev(args.from.as_ref().unwrap_or(&RevisionArg::AT))?
+            .resolve_single_rev(ui, args.from.as_ref().unwrap_or(&RevisionArg::AT))?
             .tree()?;
     } else {
         to_commit = workspace_command
-            .resolve_single_rev(args.changes_in.as_ref().unwrap_or(&RevisionArg::AT))?;
+            .resolve_single_rev(ui, args.changes_in.as_ref().unwrap_or(&RevisionArg::AT))?;
         from_tree = to_commit.parent_tree(workspace_command.repo().as_ref())?;
     }
     workspace_command.check_rewritable([to_commit.id()])?;

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -45,7 +45,7 @@ pub(crate) fn cmd_show(
     args: &ShowArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let template_string = match &args.template {
         Some(value) => value.to_string(),
         None => command.settings().config().get_string("templates.show")?,

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -66,7 +66,7 @@ pub(crate) fn cmd_split(
     args: &SplitArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     if commit.is_empty(workspace_command.repo().as_ref())? {
         return Err(user_error_with_hint(
             format!("Refusing to split empty commit {}.", commit.id().hex()),

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -94,8 +94,8 @@ pub(crate) fn cmd_squash(
         }
         .evaluate_to_commits()?
         .try_collect()?;
-        destination =
-            workspace_command.resolve_single_rev(args.into.as_ref().unwrap_or(&RevisionArg::AT))?;
+        destination = workspace_command
+            .resolve_single_rev(ui, args.into.as_ref().unwrap_or(&RevisionArg::AT))?;
         if sources.iter().any(|source| source.id() == destination.id()) {
             return Err(user_error("Source and destination cannot be the same"));
         }
@@ -105,7 +105,7 @@ pub(crate) fn cmd_squash(
         sources.reverse();
     } else {
         let source = workspace_command
-            .resolve_single_rev(args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
+            .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
         let mut parents: Vec<_> = source.parents().try_collect()?;
         if parents.len() != 1 {
             return Err(user_error("Cannot squash merge commits"));

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -55,7 +55,7 @@ pub(crate) fn cmd_unsquash(
     args: &UnsquashArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(&args.revision)?;
+    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     workspace_command.check_rewritable([commit.id()])?;
     if commit.parent_ids().len() > 1 {
         return Err(user_error("Cannot unsquash merge commits"));

--- a/cli/src/commands/workspace.rs
+++ b/cli/src/commands/workspace.rs
@@ -208,7 +208,7 @@ fn cmd_workspace_add(
         }
     } else {
         old_workspace_command
-            .resolve_some_revsets_default_single(&args.revision)?
+            .resolve_some_revsets_default_single(ui, &args.revision)?
             .into_iter()
             .collect_vec()
     };

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -95,6 +95,7 @@ pub enum RevsetModifier {
     /// Expression can be evaluated to multiple revisions even if a single
     /// revision is expected by default.
     All,
+    Prompt,
 }
 
 /// Symbol or function to be resolved to `CommitId`s.

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -272,6 +272,7 @@ pub(super) fn parse_program_with_modifier(
             assert_eq!(rhs.as_rule(), Rule::expression);
             let modififer = match lhs.as_str() {
                 "all" => RevsetModifier::All,
+                "prompt" => RevsetModifier::Prompt,
                 name => {
                     return Err(RevsetParseError::with_span(
                         RevsetParseErrorKind::NoSuchModifier(name.to_owned()),


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->
# Use Case
Instead of failing when a revset is ambiguous we can allow picking from the possible options when the `prompt:` modifier is provided. In that case the behavior is similar to `jj next` / `jj prev` when there is more than one next/prev commit and you're able to choose one of them.

This also allows using `jj new` / `jj edit` instead of `jj next` / `jj prev`
`jj new 'prompt:@-+ & ~@'` = `jj next`
`jj edit 'prompt:@+'` = `jj next --edit`
`jj new 'prompt:@--` = `jj prev`
`jj edit 'prompt:@-` = `jj prev --edit`

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
