### PR TITLE
improve error message when missing ops head

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -22,7 +22,7 @@ use jj_lib::backend::BackendError;
 use jj_lib::fileset::{FilePatternParseError, FilesetParseError, FilesetParseErrorKind};
 use jj_lib::git::{GitConfigParseError, GitExportError, GitImportError, GitRemoteManagementError};
 use jj_lib::gitignore::GitIgnoreError;
-use jj_lib::op_heads_store::OpHeadResolutionError;
+use jj_lib::op_heads_store::{OpHeadResolutionError, OpHeadStoreError};
 use jj_lib::op_store::OpStoreError;
 use jj_lib::op_walk::OpsetEvaluationError;
 use jj_lib::repo::{CheckOutCommitError, EditCommitError, RepoLoaderError, RewriteRootCommit};
@@ -288,7 +288,14 @@ impl From<OpsetEvaluationError> for CommandError {
             OpsetEvaluationError::OpsetResolution(err) => user_error(err),
             OpsetEvaluationError::OpHeadResolution(err) => err.into(),
             OpsetEvaluationError::OpStore(err) => err.into(),
+            OpsetEvaluationError::OpHeadsStore(err) => err.into(),
         }
+    }
+}
+
+impl From<OpHeadStoreError> for CommandError {
+    fn from(err: OpHeadStoreError) -> Self {
+        internal_error_with_message("Failed to load the set of operation heads", err)
     }
 }
 

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -28,6 +28,7 @@ use crate::backend::{CommitId, MillisSinceEpoch, Timestamp};
 use crate::content_hash::ContentHash;
 use crate::merge::Merge;
 use crate::object_id::{id_type, HexPrefix, ObjectId, PrefixResolution};
+use crate::op_heads_store::OpHeadStoreError;
 
 #[derive(ContentHash, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct WorkspaceId(String);
@@ -416,6 +417,12 @@ pub enum OpStoreError {
 }
 
 pub type OpStoreResult<T> = Result<T, OpStoreError>;
+
+impl From<OpHeadStoreError> for OpStoreError {
+    fn from(err: OpHeadStoreError) -> Self {
+        OpStoreError::Other(err.into())
+    }
+}
 
 pub trait OpStore: Send + Sync + Debug {
     fn as_any(&self) -> &dyn Any;

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -40,7 +40,7 @@ use crate::file_util::{IoResultExt as _, PathError};
 use crate::index::{ChangeIdIndex, Index, IndexStore, MutableIndex, ReadonlyIndex};
 use crate::local_backend::LocalBackend;
 use crate::object_id::{HexPrefix, ObjectId, PrefixResolution};
-use crate::op_heads_store::{self, OpHeadResolutionError, OpHeadsStore};
+use crate::op_heads_store::{self, OpHeadResolutionError, OpHeadStoreError, OpHeadsStore};
 use crate::op_store::{
     OpStore, OpStoreError, OperationId, RefTarget, RemoteRef, RemoteRefState, WorkspaceId,
 };
@@ -590,6 +590,8 @@ pub enum RepoLoaderError {
     Backend(#[from] BackendError),
     #[error(transparent)]
     OpHeadResolution(#[from] OpHeadResolutionError),
+    #[error(transparent)]
+    OpHeadStore(#[from] OpHeadStoreError),
     #[error(transparent)]
     OpStore(#[from] OpStoreError),
 }


### PR DESCRIPTION
When reading the operation head directory fails, the thread panics and does not return a useful error message to the user. Create OpHeadStoreError to prevent thread panic and print a more useful error message