### PR TITLE
Fix a few issues with invoking the builtin diff editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,8 +2814,7 @@ dependencies = [
 [[package]]
 name = "scm-record"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bf431016c7a34038f440696c672f0fee1a15d6aea31fe100df6974a35bf5f"
+source = "git+https://github.com/30350n/scm-record.git?branch=fix-jj-split#13ae26bc26bb95469bc26f9a112ff30227310ac0"
 dependencies = [
  "cassowary",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ ref-cast = "1.0.23"
 regex = "1.10.5"
 rpassword = "7.3.1"
 rustix = { version = "0.38.34", features = ["fs"] }
-scm-record = "0.3.0"
+scm-record = { git = "https://github.com/30350n/scm-record.git", branch = "fix-jj-split" } #"0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.120"
 slab = "0.4.9"

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -851,6 +851,80 @@ mod tests {
     }
 
     #[test]
+    fn test_edit_diff_builtin_add_executable_file() {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+
+        let added_executable_file_path = RepoPath::from_internal_string("executable_file");
+        let left_tree = testutils::create_tree(&test_repo.repo, &[]);
+        let right_tree = {
+            let store = test_repo.repo.store();
+            let mut tree_builder = store.tree_builder(store.empty_tree_id().clone());
+            testutils::write_executable_file(
+                &mut tree_builder,
+                added_executable_file_path,
+                "executable",
+            );
+            let id = tree_builder.write_tree().unwrap();
+            MergedTree::Legacy(store.get_tree(RepoPath::root(), &id).unwrap())
+        };
+
+        let changed_files = vec![added_executable_file_path.to_owned()];
+        let files = make_diff_files(store, &left_tree, &right_tree, &changed_files).unwrap();
+        insta::assert_debug_snapshot!(files, @r###"
+        [
+            File {
+                old_path: None,
+                path: "executable_file",
+                file_mode: Some(
+                    FileMode(
+                        0,
+                    ),
+                ),
+                sections: [
+                    Changed {
+                        lines: [
+                            SectionChangedLine {
+                                is_checked: false,
+                                change_type: Added,
+                                line: "executable",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+        "###);
+        let no_changes_tree_id = apply_diff_builtin(
+            store,
+            &left_tree,
+            &right_tree,
+            changed_files.clone(),
+            &files,
+        )
+        .unwrap();
+        let no_changes_tree = store.get_root_tree(&no_changes_tree_id).unwrap();
+        assert_eq!(
+            no_changes_tree.id(),
+            left_tree.id(),
+            "no-changes tree was different",
+        );
+
+        let mut files = files;
+        for file in files.iter_mut() {
+            file.toggle_all();
+        }
+        let all_changes_tree_id =
+            apply_diff_builtin(store, &left_tree, &right_tree, changed_files, &files).unwrap();
+        let all_changes_tree = store.get_root_tree(&all_changes_tree_id).unwrap();
+        assert_eq!(
+            all_changes_tree.id(),
+            right_tree.id(),
+            "all-changes tree was different",
+        );
+    }
+
+    #[test]
     fn test_edit_diff_builtin_delete_empty_file() {
         let test_repo = TestRepo::init();
         let store = test_repo.repo.store();

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -454,7 +454,7 @@ pub fn apply_diff_builtin(
                     }),
                     Some(Some(TreeValue::Symlink(_))) => Some(scm_record::FileMode(mode::SYMLINK)),
                     Some(None) => {
-                        if contents == "" {
+                        if contents.is_empty() {
                             None
                         } else {
                             file.get_file_mode()


### PR DESCRIPTION
Proof of Concept to fix #3702 and #3846.

Relies on [scm-record #62](https://github.com/arxanas/scm-record/pull/62).

This is pretty ugly, especially the `unreachable!()` stuff, but it seems to mostly work fine. Fixing this properly would require rewriting large parts of [`scm-record`](https://github.com/arxanas/scm-record).

### Checklist

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
