### PR TITLE
fixes for paths on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "maplit",
  "minus",
  "once_cell",
+ "path-slash",
  "pest",
  "pest_derive",
  "pollster",
@@ -2340,6 +2341,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "maplit",
  "num_cpus",
  "once_cell",
+ "path-slash",
  "pest",
  "pest_derive",
  "pollster",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ maplit = "1.0.2"
 minus = { version = "5.6.1", features = ["dynamic_output", "search"] }
 num_cpus = "1.16.0"
 once_cell = "1.19.0"
+path-slash = "0.2.1"
 pest = "2.7.11"
 pest_derive = "2.7.11"
 pollster = "0.3.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,6 +74,7 @@ jj-lib = { workspace = true }
 maplit = { workspace = true }
 minus = { workspace = true }
 once_cell = { workspace = true }
+path-slash = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }
 pollster = { workspace = true }

--- a/cli/src/commands/git/remote/add.rs
+++ b/cli/src/commands/git/remote/add.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use jj_lib::git;
+use jj_lib::git::{self, sanitize_git_url_if_path};
 use jj_lib::repo::Repo;
 
 use crate::cli_util::CommandHelper;
@@ -37,6 +37,10 @@ pub fn cmd_git_remote_add(
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();
     let git_repo = get_git_repo(repo.store())?;
-    git::add_remote(&git_repo, &args.remote, &args.url)?;
+    git::add_remote(
+        &git_repo,
+        &args.remote,
+        &sanitize_git_url_if_path(command.cwd(), &args.url),
+    )?;
     Ok(())
 }

--- a/cli/src/commands/git/remote/set_url.rs
+++ b/cli/src/commands/git/remote/set_url.rs
@@ -37,6 +37,6 @@ pub fn cmd_git_remote_set_url(
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();
     let git_repo = get_git_repo(repo.store())?;
-    git::set_remote_url(&git_repo, &args.remote, &args.url)?;
+    git::set_remote_url(&git_repo, &args.remote, &args.url, command.cwd())?;
     Ok(())
 }

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools as _;
+use path_slash::PathBufExt;
 use regex::{Captures, Regex};
 use tempfile::TempDir;
 
@@ -320,13 +321,14 @@ impl TestEnvironment {
     pub fn normalize_output(&self, text: &str) -> String {
         let text = text.replace("jj.exe", "jj");
         let regex = Regex::new(&format!(
-            r"{}(\S+)",
-            regex::escape(&self.env_root.display().to_string())
+            r"({}|{})(\S+)",
+            regex::escape(&self.env_root.display().to_string()),
+            regex::escape(&self.env_root.to_slash_lossy())
         ))
         .unwrap();
         regex
             .replace_all(&text, |caps: &Captures| {
-                format!("$TEST_ENV{}", caps[1].replace('\\', "/"))
+                format!("$TEST_ENV{}", caps[2].replace('\\', "/"))
             })
             .to_string()
     }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -52,6 +52,7 @@ itertools = { workspace = true }
 jj-lib-proc-macros = { workspace = true }
 maplit = { workspace = true }
 once_cell = { workspace = true }
+path-slash = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }
 pollster = { workspace = true }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1165,6 +1165,7 @@ pub fn sanitize_git_url_if_path(cwd: &Path, source: &str) -> String {
         // TODO: This won't work for Windows UNC path or (less importantly) if the
         // original source is a non-UTF Windows path. For Windows UNC paths, we
         // could use dunce, though see also https://gitlab.com/kornelski/dunce/-/issues/7
+        // TODO: double-check about UNC paths; what does Git do?
         cwd.join(source).to_slash().map_or_else(
             // It's less likely that cwd isn't utf-8, so just fall back to original source.
             || source.to_owned(),

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1180,6 +1180,7 @@ pub fn set_remote_url(
     git_repo: &git2::Repository,
     remote_name: &str,
     new_remote_url: &str,
+    cwd: &Path,
 ) -> Result<(), GitRemoteManagementError> {
     if remote_name == REMOTE_NAME_FOR_LOCAL_GIT_REPO {
         return Err(GitRemoteManagementError::RemoteReservedForLocalGitRepo);
@@ -1197,7 +1198,7 @@ pub fn set_remote_url(
     })?;
 
     git_repo
-        .remote_set_url(remote_name, new_remote_url)
+        .remote_set_url(remote_name, &sanitize_git_url_if_path(cwd, new_remote_url))
         .map_err(GitRemoteManagementError::InternalGitError)?;
     Ok(())
 }


### PR DESCRIPTION
This is my attempt to replace #4184 with something more principled. It is, however, not so principled as to replace `fs::canonicalize` with `dunce::canonicalize` everywhere.

I tried to improve (what used to be) `absolute_git_source` in general, but I may have introduced some bugs.

It feels a bit like whack-a-mole. I couldn't find rules on what kind of Windows paths Git or libgit2 accept in clone URLs so far. I'm also introducing more and more ways the same path can look in a test.

I'm still looking into it, but I am running out of patience (though perhaps I'll get some better ideas later). Advice is welcome. Do you think using `dunce` everywhere would help, for example? Also, my Windows setup is awkward; I'm running it in a VM and it's not very fast and runs out of memory or causes the main system to run out of memory occasionally. Perhaps because of that, or perhaps it's on a USB drive, it also freezes occasionally.

At the moment, it fails a *different* test when merged with `git2` upgrade that #4080 does, see https://github.com/martinvonz/jj/pull/4183. (There are also more trivial but annoying test failures with TEST_ENV)