### PR TITLE
editor: initialize `.vscode` settings directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true
+}


### PR DESCRIPTION
People have brought this up before that we might want some vscode settings, so let's try adding a few basic ones?

These options are basically always useful in vscode; turn them on. Note that there is an editorconfig plugin for vscode and we do have a `.editorconfig` file but these options aren't set due to an old intellj-rust bug. Maybe we could get rid of it?