### PR TITLE
fix: Add `enabled` config for fix tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `git.sign-on-push` config option to automatically sign commits which are being
   pushed to a Git remote.
 
+* New `fix.tools.TOOL.enabled` config option to enable/disable tools. This is
+  useful for defining disabled tools in user configuration that can be enabled
+  in individual repositories with one config setting.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -617,6 +617,11 @@
                                     "type": "string"
                                 },
                                 "description": "Filesets that will be affected by this tool"
+                            },
+                            "enabled": {
+                                "type": "boolean",
+                                "description": "Disables this tool if set to false",
+                                "default": true
                             }
                         }
                     },

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -986,6 +986,9 @@ the values have the following properties:
    empty, no files will be affected by the tool. If there are multiple
    patterns, the tool is applied only once to each file in the union of the
    patterns.
+ - `enabled`: Enables or disables the tool. If omitted, the tool is enabled.
+   This is useful for defining disabled tools in user configuration that can
+   be enabled in individual repositories with one config setting.
 
 For example, the following configuration defines how two code formatters
 (`clang-format` and `black`) will apply to three different file extensions

--- a/docs/config.md
+++ b/docs/config.md
@@ -960,6 +960,27 @@ command = ["head", "-n", "10"]
 patterns = ["numbers.txt"]
 ```
 
+### Disabling and enabling tools
+
+Tools can be disabled and enabled with the optional `enabled` config. This
+allows you to define tools globally but enable them only for specific
+repositories.
+
+In the user configuration, define a disabled tool for running rustfmt:
+
+```toml
+[fix.tools.rustfmt]
+enabled = false
+command = ["rustfmt", "--emit", "stdout"]
+patterns = ["glob:'**/*.rs'"]
+```
+
+Then to use the tool in a specific repository, set the `enabled` config:
+
+```shell
+$ jj config set --repo fix.tools.rustfmt.enabled true
+```
+
 ## Commit Signing
 
 `jj` can be configured to sign and verify the commits it creates using either


### PR DESCRIPTION
As inspired by @ilyagr: https://discord.com/channels/968932220549103686/969291218347524238/1276278608729608243

Adds an optional `fix.tools.TOOL.enabled` config that disables use of a fix tool (if omitted, the tool is enabled). This is useful for defining tools in the user's configuration without enabling them for all repositories:

```toml
# ~/.jjconfig.toml
[fix.tools.rustfmt]
enabled = false
command = ["rustfmt", "--emit", "stdout"]
patterns = ["glob:'**/*.rs'"]
```

Then to enable it in a repository:

```shell
$ jj config set --repo fix.tools.rustfmt.enabled true
```

This also allows Jujutsu to ship some built-in tool configurations that are disabled by default.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the branch rather than adding commits on top. Use force-push when
pushing the updated branch (`jj git push` does that automatically when you
rewrite a branch). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
