### PR TITLE
Colocated workspaces, minimal

### DIFF
--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -60,7 +60,13 @@ fn create_store_factories() -> StoreFactories {
     // must match `Backend::name()`.
     store_factories.add_backend(
         "jit",
-        Box::new(|settings, store_path| Ok(Box::new(JitBackend::load(settings, store_path)?))),
+        Box::new(|settings, store_path, workspace_root| {
+            Ok(Box::new(JitBackend::load(
+                settings,
+                store_path,
+                workspace_root,
+            )?))
+        }),
     );
     store_factories
 }
@@ -105,8 +111,12 @@ impl JitBackend {
         Ok(JitBackend { inner })
     }
 
-    fn load(settings: &UserSettings, store_path: &Path) -> Result<Self, BackendLoadError> {
-        let inner = GitBackend::load(settings, store_path)?;
+    fn load(
+        settings: &UserSettings,
+        store_path: &Path,
+        workspace_root: Option<&Path>,
+    ) -> Result<Self, BackendLoadError> {
+        let inner = GitBackend::load(settings, store_path, workspace_root)?;
         Ok(JitBackend { inner })
     }
 }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -835,7 +835,7 @@ impl WorkspaceCommandHelper {
         let op_summary_template_text = settings.config().get_string("templates.op_summary")?;
         let may_update_working_copy =
             loaded_at_head && !env.command.global_args().ignore_working_copy;
-        let working_copy_shared_with_git = is_colocated_git_workspace(&workspace, &repo);
+        let working_copy_shared_with_git = is_colocated_git_workspace(Some(ui), &workspace, &repo);
         let helper = Self {
             workspace,
             user_repo: ReadonlyUserRepo::new(repo),
@@ -878,7 +878,7 @@ impl WorkspaceCommandHelper {
     }
 
     /// Snapshot the working copy if allowed, and import Git refs if the working
-    /// copy is collocated with Git.
+    /// copy is colocated with Git.
     #[instrument(skip_all)]
     pub fn maybe_snapshot(&mut self, ui: &Ui) -> Result<(), CommandError> {
         if self.may_update_working_copy {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -386,6 +386,10 @@ impl CommandHelper {
         WorkspaceCommandHelper::new(ui, workspace, repo, env, self.is_at_head_operation())
     }
 
+    pub fn get_store_factories(&self) -> &StoreFactories {
+        &self.data.store_factories
+    }
+
     pub fn get_working_copy_factory(&self) -> Result<&dyn WorkingCopyFactory, CommandError> {
         let loader = self.workspace_loader()?;
 

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -304,6 +304,7 @@ impl From<WorkspaceInitError> for CommandError {
             }
             WorkspaceInitError::SignInit(err @ SignInitError::UnknownBackend(_)) => user_error(err),
             WorkspaceInitError::SignInit(err) => internal_error(err),
+            WorkspaceInitError::LoadNewlyCreated(err) => internal_error(err),
         }
     }
 }

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -167,7 +167,9 @@ pub fn do_init(
                 Workspace::init_external_git(command.settings(), workspace_root, git_repo_path)?;
             // Import refs first so all the reachable commits are indexed in
             // chronological order.
-            let colocated = is_colocated_git_workspace(&workspace, &repo);
+            // No UI, because we're about to call this function again in the workspace
+            // command helper, and warnings can be shown then.
+            let colocated = is_colocated_git_workspace(None, &workspace, &repo);
             let repo = init_git_refs(ui, command, repo, colocated)?;
             let mut workspace_command = command.for_workable_repo(ui, workspace, repo)?;
             maybe_add_gitignore(&workspace_command)?;

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -114,6 +114,7 @@ pub fn cmd_workspace_add(
         repo_path,
         repo,
         working_copy_factory,
+        command.get_store_factories(),
         workspace_id,
     )?;
     writeln!(

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -73,22 +73,12 @@ pub fn get_git_repo(store: &Store) -> Result<git2::Repository, CommandError> {
     }
 }
 
-pub fn is_colocated_git_workspace(workspace: &Workspace, repo: &ReadonlyRepo) -> bool {
+pub fn is_colocated_git_workspace(_workspace: &Workspace, repo: &ReadonlyRepo) -> bool {
     let Some(git_backend) = repo.store().backend_impl().downcast_ref::<GitBackend>() else {
         return false;
     };
-    let Some(git_workdir) = git_backend.git_workdir() else {
-        return false; // Bare repository
-    };
-    if git_workdir == workspace.workspace_root() {
-        return true;
-    }
-    // Colocated workspace should have ".git" directory, file, or symlink. Compare
-    // its parent as the git_workdir might be resolved from the real ".git" path.
-    let Ok(dot_git_path) = workspace.workspace_root().join(".git").canonicalize() else {
-        return false;
-    };
-    git_workdir.canonicalize().ok().as_deref() == dot_git_path.parent()
+
+    git_backend.is_colocated()
 }
 
 fn terminal_get_username(ui: &Ui, url: &str) -> Option<String> {

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -791,6 +791,7 @@ fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
       commit_id,
       bookmarks,
       if(git_head, "git_head()"),
+      working_copies,
       description,
     )
     "#;
@@ -806,6 +807,7 @@ fn get_log_output_with_stderr(
       commit_id,
       bookmarks,
       if(git_head, "git_head()"),
+      working_copies,
       description,
     )
     "#;
@@ -887,4 +889,35 @@ fn test_git_colocated_unreachable_commits() {
 fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
     // --quiet to suppress deleted bookmarks hint
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes", "--quiet"])
+}
+
+#[test]
+fn test_git_colocated_create_workspace_moving_wc() {
+    let test_env = TestEnvironment::default();
+    let repo_path = test_env.env_root().join("repo");
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "--colocate", "repo"]);
+    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second_wc_parent"]);
+    let second_wc_parent =
+        test_env.jj_cmd_success(&repo_path, &["log", "-Tcommit_id", "-r@-", "--no-graph"]);
+    test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "should be git head"]);
+    test_env.jj_cmd_ok(
+        &repo_path,
+        &["workspace", "add", "../second", "-r", &second_wc_parent],
+    );
+
+    // The second workspace is not colocated. So creating it should not
+    // move git_head(). This tests whether we managed to reload the workspace
+    // command effectively in the middle of `jj workspace add`; if we did not,
+    // it will still think it's colocated in the default workspace.
+    //
+    // This test should survive switching to multi-git-head views, where each
+    // workspace gets its own git_head().
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
+    ○  3ee64208816f8264850a1cfcb99ac75e878c207a second@
+    │ @  076d128fc75cb291f908b77ffe9ff24c80de4fd7 default@
+    │ ○  005cf6c5b5e5fd032b804d98d11212a5317b4f3a git_head() should be git head
+    ├─╯
+    ○  ad5ff99a9ee8726ffe511430e4569f1d57bd550e second_wc_parent
+    ◆  0000000000000000000000000000000000000000
+    ");
 }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use std::path::Path;
+use std::process::Command;
 
+use assert_cmd::assert::OutputAssertExt;
 use git2::Oid;
 
 use crate::common::TestEnvironment;
@@ -920,4 +922,56 @@ fn test_git_colocated_create_workspace_moving_wc() {
     ○  ad5ff99a9ee8726ffe511430e4569f1d57bd550e second_wc_parent
     ◆  0000000000000000000000000000000000000000
     ");
+}
+
+/// Substitute for `jj workspace add --colocate` or similar using git CLI,
+/// please replace with the real thing when it lands.
+fn stopgap_workspace_colocate(
+    test_env: &TestEnvironment,
+    repo_path: &Path,
+    original_colocated: bool,
+    dst: &str,
+    initial_head: &str,
+) {
+    // Can't use gix/git2, as neither can repair the broken worktree we're about to
+    // create.
+    let repo_relative_path = if original_colocated {
+        dst.to_owned()
+    } else {
+        format!("../../../../{dst}")
+    };
+    Command::new("git")
+        .args(["worktree", "add", &repo_relative_path])
+        .arg(initial_head)
+        .current_dir(if original_colocated {
+            repo_path.to_path_buf()
+        } else {
+            repo_path.join(".jj/repo/store/git")
+        })
+        .assert()
+        .success()
+        .stderr(format!(
+            "Preparing worktree (detached HEAD {})\n",
+            &initial_head[..7]
+        ));
+    let dst_path = repo_path.join(dst);
+    let tmp_path = test_env.env_root().join("__tmp_worktree__");
+    if tmp_path.exists() {
+        std::fs::remove_dir_all(&tmp_path).unwrap();
+    }
+    std::fs::rename(&dst_path, &tmp_path).unwrap();
+    test_env.jj_cmd_ok(repo_path, &["workspace", "add", dst]);
+    std::fs::rename(tmp_path.join(".git"), dst_path.join(".git")).unwrap();
+    std::fs::write(dst_path.join(".jj/.gitignore"), "*\n").unwrap();
+    Command::new("git")
+        .args(["worktree", "repair"])
+        .current_dir(&dst_path)
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("checkout")
+        .arg(initial_head)
+        .current_dir(&dst_path)
+        .assert()
+        .success();
 }

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -731,6 +731,237 @@ fn test_git_init_external_but_git_dir_exists() {
     "###);
 }
 
+fn create_commit(git_repo: &git2::Repository, msg: &str, parents: &[&git2::Commit]) -> git2::Oid {
+    let author = git2::Signature::new("JJ test", "jj@example.com", &git2::Time::new(0, 0)).unwrap();
+    let empty_tree = git_repo.treebuilder(None).unwrap().write().unwrap();
+    let oid = git_repo
+        .commit(
+            Some("HEAD"),
+            &author,
+            &author,
+            msg,
+            &git_repo.find_tree(empty_tree).unwrap(),
+            parents,
+        )
+        .unwrap();
+    oid
+}
+
+#[test]
+fn test_git_init_external_pointing_at_worktree_from_outside() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let worktree_path = test_env.env_root().join("worktree");
+    let workspace_root = test_env.env_root().join("repo");
+    let git_repo = git2::Repository::init(&git_repo_path).unwrap();
+    // Must create a commit so we can create a worktree
+    let initial_commit = create_commit(&git_repo, "initial commit", &[]);
+    let _worktree = git_repo
+        .worktree("jj-worktree", &worktree_path, None)
+        .unwrap();
+
+    // now commit in the worktree, so we know where we are importing from
+    let worktree_repo = git2::Repository::open(&worktree_path).unwrap();
+    let _initial_commit = create_commit(
+        &worktree_repo,
+        "second commit",
+        &[&worktree_repo.find_commit(initial_commit).unwrap()],
+    )
+    .to_string();
+
+    std::fs::create_dir(&workspace_root).unwrap();
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &workspace_root,
+        &["git", "init", "--git-repo", worktree_path.to_str().unwrap()],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r#"
+    Done importing changes from the underlying Git repo.
+    Working copy now at: sqpuoqvx 58a55009 (empty) (no description set)
+    Parent commit      : kyuukqus 49c63010 jj-worktree | (empty) second commit
+    Initialized repo in "."
+    "#);
+
+    assert_eq!(
+        PathBuf::from(read_git_target(&workspace_root))
+            .canonicalize()
+            .unwrap(),
+        worktree_path.join(".git")
+    );
+
+    // This is similar to a normal `jj git init --git-repo=` -- we import the
+    // commits, but in this case our HEAD@git comes from the worktree.
+    let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
+    insta::assert_snapshot!(stdout, @r#"
+    @  58a55009f1c1
+    ○  49c630103a76 jj-worktree git_head() second commit
+    ○  70618e4d103f master initial commit
+    ◆  000000000000
+    "#);
+    insta::assert_snapshot!(stderr, @"");
+
+    // The git HEAD should not advance, because this is not colocated
+    test_env.jj_cmd_ok(&workspace_root, &["new"]);
+    let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
+    insta::assert_snapshot!(stdout, @r#"
+    @  f133c02dde73
+    ○  58a55009f1c1
+    ○  49c630103a76 jj-worktree git_head() second commit
+    ○  70618e4d103f master initial commit
+    ◆  000000000000
+    "#);
+    insta::assert_snapshot!(stderr, @"");
+}
+
+#[test]
+fn test_git_init_external_in_worktree_pointing_worktree() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let workspace_root = test_env.env_root().join("repo");
+    let git_repo = git2::Repository::init(&git_repo_path).unwrap();
+    // Must create a commit so we can create a worktree
+    let initial_commit = create_commit(&git_repo, "initial commit", &[]);
+    let _worktree = git_repo
+        .worktree("jj-worktree", &workspace_root, None)
+        .unwrap();
+    assert!(workspace_root.join(".git").is_file());
+
+    // now commit in the worktree, so we know where we are importing from
+    let worktree_repo = git2::Repository::open(&workspace_root).unwrap();
+    let _initial_commit = create_commit(
+        &worktree_repo,
+        "second commit",
+        &[&worktree_repo.find_commit(initial_commit).unwrap()],
+    )
+    .to_string();
+
+    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r#"
+    Done importing changes from the underlying Git repo.
+    Initialized repo in "."
+    "#);
+
+    assert_eq!(read_git_target(&workspace_root), "../../../.git");
+
+    // The local ".git" repository is related, so commits should be imported
+    let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
+    insta::assert_snapshot!(stdout, @r#"
+    @  58a55009f1c1
+    ○  49c630103a76 jj-worktree git_head() second commit
+    ○  70618e4d103f master initial commit
+    ◆  000000000000
+    "#);
+    insta::assert_snapshot!(stderr, @"");
+
+    // Check that Git HEAD is advanced because this is colocated
+    test_env.jj_cmd_ok(&workspace_root, &["new"]);
+    let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
+    insta::assert_snapshot!(stdout, @r#"
+    @  f133c02dde73
+    ○  58a55009f1c1 git_head()
+    ○  49c630103a76 jj-worktree second commit
+    ○  70618e4d103f master initial commit
+    ◆  000000000000
+    "#);
+    insta::assert_snapshot!(stderr, @"");
+
+    let stdout = test_env.jj_cmd_success(&workspace_root, OP_LOG_COMPACT);
+    insta::assert_snapshot!(stdout, @r#"
+    @  0c47efd49cba new empty commit
+    │  args: jj new
+    ○  5fd008dad5b5 import git head
+    │  args: jj git init --git-repo .
+    ○  ec635623258d import git refs
+    │  args: jj git init --git-repo .
+    ○  eac759b9ab75 add workspace 'default'
+    ○  000000000000
+    "#);
+}
+
+const OP_LOG_COMPACT: &[&str] = &[
+    "op",
+    "log",
+    "-Tself.id().short() ++ ' ' ++ separate(\"\\n\", self.description().first_line(), self.tags())",
+];
+
+/// This one is a bit weird, but technically you can do it. Should be roughly
+/// equivalent to the --git-repo=. case, but with a different git_target file.
+#[test]
+fn test_git_init_external_in_worktree_pointing_commondir() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let workspace_root = test_env.env_root().join("repo");
+    let git_repo = git2::Repository::init(&git_repo_path).unwrap();
+    // Must create a commit so we can create a worktree
+    let initial_commit = create_commit(&git_repo, "initial commit", &[]);
+    let _worktree = git_repo
+        .worktree("jj-worktree", &workspace_root, None)
+        .unwrap();
+    assert!(workspace_root.join(".git").is_file());
+
+    // now commit in the worktree, so we know where we are importing from
+    let worktree_repo = git2::Repository::open(&workspace_root).unwrap();
+    let _initial_commit = create_commit(
+        &worktree_repo,
+        "second commit",
+        &[&worktree_repo.find_commit(initial_commit).unwrap()],
+    )
+    .to_string();
+
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &workspace_root,
+        &["git", "init", "--git-repo", "../git-repo"],
+    );
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r#"
+    Done importing changes from the underlying Git repo.
+    Initialized repo in "."
+    "#);
+
+    assert_eq!(
+        PathBuf::from(read_git_target(&workspace_root))
+            .canonicalize()
+            .unwrap(),
+        git_repo_path.join(".git")
+    );
+
+    // The local ".git" repository is related, so commits should be imported,
+    // specifically from the worktree, not the original repo.
+    let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
+    insta::assert_snapshot!(stdout, @r#"
+    @  58a55009f1c1
+    ○  49c630103a76 jj-worktree git_head() second commit
+    ○  70618e4d103f master initial commit
+    ◆  000000000000
+    "#);
+    insta::assert_snapshot!(stderr, @"");
+
+    // Check that Git HEAD is advanced because this is colocated
+    test_env.jj_cmd_ok(&workspace_root, &["new"]);
+    let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
+    insta::assert_snapshot!(stdout, @r#"
+    @  f133c02dde73
+    ○  58a55009f1c1 git_head()
+    ○  49c630103a76 jj-worktree second commit
+    ○  70618e4d103f master initial commit
+    ◆  000000000000
+    "#);
+    insta::assert_snapshot!(stderr, @"");
+
+    let stdout = test_env.jj_cmd_success(&workspace_root, OP_LOG_COMPACT);
+    insta::assert_snapshot!(stdout, @r#"
+    @  79619167098b new empty commit
+    │  args: jj new
+    ○  db043dbad297 import git head
+    │  args: jj git init --git-repo ../git-repo
+    ○  7296ad45aee9 import git refs
+    │  args: jj git init --git-repo ../git-repo
+    ○  eac759b9ab75 add workspace 'default'
+    ○  000000000000
+    "#);
+}
+
 #[test]
 fn test_git_init_colocated_via_flag_git_dir_exists() {
     let test_env = TestEnvironment::default();

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -470,26 +470,33 @@ fn test_init_git_external_but_git_dir_exists() {
         &["init", "--git-repo", git_repo_path.to_str().unwrap()],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: Workspace has a .git directory that is not managed by JJ
     Warning: `--git` and `--git-repo` are deprecated.
     Use `jj git init` instead
     Initialized repo in "."
-    "###);
+    "#);
 
     // The local ".git" repository is unrelated, so no commits should be imported
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
     ◆  zzzzzzzz root() 00000000
     "###);
+    insta::assert_snapshot!(stderr, @"
+    Warning: Workspace has a .git directory that is not managed by JJ
+    ");
 
     // Check that Git HEAD is not set because this isn't a colocated repo
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "@-"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @r###"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
     "###);
+    insta::assert_snapshot!(stderr, @"
+    Warning: Workspace has a .git directory that is not managed by JJ
+    ");
 }
 
 #[test]

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -99,7 +99,7 @@ pub enum GitBackendInitError {
     #[error("Failed to initialize git repository")]
     InitRepository(#[source] gix::init::Error),
     #[error("Failed to open git repository")]
-    OpenRepository(#[source] gix::open::Error),
+    OpenRepository(#[source] Box<gix::open::Error>),
     #[error(transparent)]
     Path(PathError),
 }
@@ -113,7 +113,7 @@ impl From<Box<GitBackendInitError>> for BackendInitError {
 #[derive(Debug, Error)]
 pub enum GitBackendLoadError {
     #[error("Failed to open git repository")]
-    OpenRepository(#[source] gix::open::Error),
+    OpenRepository(#[source] Box<gix::open::Error>),
     #[error(transparent)]
     Path(PathError),
 }
@@ -237,6 +237,7 @@ impl GitBackend {
             canonical_git_repo_path,
             gix_open_opts_from_settings(settings),
         )
+        .map_err(Box::new)
         .map_err(GitBackendInitError::OpenRepository)?;
         Self::init_with_repo(store_path, git_repo_path, git_repo)
     }
@@ -293,6 +294,7 @@ impl GitBackend {
             git_repo_path,
             gix_open_opts_from_settings(settings),
         )
+        .map_err(Box::new)
         .map_err(GitBackendLoadError::OpenRepository)?;
         let extra_metadata_store = TableStore::load(store_path.join("extra"), HASH_LENGTH);
         Ok(GitBackend::new(repo, extra_metadata_store))

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -277,6 +277,7 @@ impl GitBackend {
     pub fn load(
         settings: &UserSettings,
         store_path: &Path,
+        _workspace_root: Option<&Path>,
     ) -> Result<Self, Box<GitBackendLoadError>> {
         let git_repo_path = {
             let target_path = store_path.join("git_target");

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -71,6 +71,7 @@ use crate::backend::TreeId;
 use crate::backend::TreeValue;
 use crate::file_util::IoResultExt as _;
 use crate::file_util::PathError;
+use crate::git::MaybeColocatedGitRepo;
 use crate::index::Index;
 use crate::lock::FileLock;
 use crate::merge::Merge;
@@ -159,6 +160,7 @@ pub struct GitBackend {
     empty_tree_id: TreeId,
     extra_metadata_store: TableStore,
     cached_extra_metadata: Mutex<Option<Arc<ReadonlyTable>>>,
+    colocated: bool,
 }
 
 impl GitBackend {
@@ -166,7 +168,11 @@ impl GitBackend {
         "git"
     }
 
-    fn new(base_repo: gix::ThreadSafeRepository, extra_metadata_store: TableStore) -> Self {
+    fn new(base_repo: MaybeColocatedGitRepo, extra_metadata_store: TableStore) -> Self {
+        let MaybeColocatedGitRepo {
+            git_repo: base_repo,
+            colocated,
+        } = base_repo;
         let repo = Mutex::new(base_repo.to_thread_local());
         let root_commit_id = CommitId::from_bytes(&[0; HASH_LENGTH]);
         let root_change_id = ChangeId::from_bytes(&[0; CHANGE_ID_LENGTH]);
@@ -179,6 +185,7 @@ impl GitBackend {
             empty_tree_id,
             extra_metadata_store,
             cached_extra_metadata: Mutex::new(None),
+            colocated,
         }
     }
 
@@ -194,7 +201,14 @@ impl GitBackend {
             gix_open_opts_from_settings(settings),
         )
         .map_err(GitBackendInitError::InitRepository)?;
-        Self::init_with_repo(store_path, git_repo_path, git_repo)
+        Self::init_with_repo(
+            store_path,
+            git_repo_path,
+            MaybeColocatedGitRepo {
+                git_repo,
+                colocated: false,
+            },
+        )
     }
 
     /// Initializes backend by creating a new Git repo at the specified
@@ -218,7 +232,14 @@ impl GitBackend {
         )
         .map_err(GitBackendInitError::InitRepository)?;
         let git_repo_path = workspace_root.join(".git");
-        Self::init_with_repo(store_path, &git_repo_path, git_repo)
+        Self::init_with_repo(
+            store_path,
+            &git_repo_path,
+            MaybeColocatedGitRepo {
+                git_repo,
+                colocated: true,
+            },
+        )
     }
 
     /// Initializes backend with an existing Git repo at the specified path.
@@ -226,6 +247,7 @@ impl GitBackend {
         settings: &UserSettings,
         store_path: &Path,
         git_repo_path: &Path,
+        workspace_root: Option<&Path>,
     ) -> Result<Self, Box<GitBackendInitError>> {
         let canonical_git_repo_path = {
             let path = store_path.join(git_repo_path);
@@ -233,11 +255,11 @@ impl GitBackend {
                 .context(&path)
                 .map_err(GitBackendInitError::Path)?
         };
-        let git_repo = gix::ThreadSafeRepository::open_opts(
-            canonical_git_repo_path,
+        let git_repo = MaybeColocatedGitRepo::open_automatic(
+            &canonical_git_repo_path,
+            workspace_root,
             gix_open_opts_from_settings(settings),
         )
-        .map_err(Box::new)
         .map_err(GitBackendInitError::OpenRepository)?;
         Self::init_with_repo(store_path, git_repo_path, git_repo)
     }
@@ -245,7 +267,7 @@ impl GitBackend {
     fn init_with_repo(
         store_path: &Path,
         git_repo_path: &Path,
-        git_repo: gix::ThreadSafeRepository,
+        git_repo: MaybeColocatedGitRepo,
     ) -> Result<Self, Box<GitBackendInitError>> {
         let extra_path = store_path.join("extra");
         fs::create_dir(&extra_path)
@@ -278,7 +300,7 @@ impl GitBackend {
     pub fn load(
         settings: &UserSettings,
         store_path: &Path,
-        _workspace_root: Option<&Path>,
+        workspace_root: Option<&Path>,
     ) -> Result<Self, Box<GitBackendLoadError>> {
         let git_repo_path = {
             let target_path = store_path.join("git_target");
@@ -290,11 +312,11 @@ impl GitBackend {
                 .context(&git_repo_path)
                 .map_err(GitBackendLoadError::Path)?
         };
-        let repo = gix::ThreadSafeRepository::open_opts(
-            git_repo_path,
+        let repo = MaybeColocatedGitRepo::open_automatic(
+            &git_repo_path,
+            workspace_root,
             gix_open_opts_from_settings(settings),
         )
-        .map_err(Box::new)
         .map_err(GitBackendLoadError::OpenRepository)?;
         let extra_metadata_store = TableStore::load(store_path.join("extra"), HASH_LENGTH);
         Ok(GitBackend::new(repo, extra_metadata_store))
@@ -322,6 +344,12 @@ impl GitBackend {
     /// Path to the working directory if the repository isn't bare.
     pub fn git_workdir(&self) -> Option<&Path> {
         self.base_repo.work_dir()
+    }
+
+    /// Whether the git repo is colocated and we can therefore import/export
+    /// HEAD
+    pub fn is_colocated(&self) -> bool {
+        self.colocated
     }
 
     fn cached_extra_metadata_table(&self) -> BackendResult<Arc<ReadonlyTable>> {
@@ -1608,7 +1636,8 @@ mod tests {
             .unwrap();
         let commit_id2 = CommitId::from_bytes(git_commit_id2.as_bytes());
 
-        let backend = GitBackend::init_external(&settings, store_path, git_repo.path()).unwrap();
+        let backend =
+            GitBackend::init_external(&settings, store_path, git_repo.path(), None).unwrap();
 
         // Import the head commit and its ancestors
         backend
@@ -1730,7 +1759,8 @@ mod tests {
             )
             .unwrap();
 
-        let backend = GitBackend::init_external(&settings, store_path, git_repo.path()).unwrap();
+        let backend =
+            GitBackend::init_external(&settings, store_path, git_repo.path(), None).unwrap();
 
         // read_commit() without import_head_commits() works as of now. This might be
         // changed later.
@@ -1779,7 +1809,8 @@ mod tests {
             .commit_signed(commit_buf, secure_sig, None)
             .unwrap();
 
-        let backend = GitBackend::init_external(&settings, store_path, git_repo.path()).unwrap();
+        let backend =
+            GitBackend::init_external(&settings, store_path, git_repo.path(), None).unwrap();
 
         let commit = backend
             .read_commit(&CommitId::from_bytes(git_commit_id.as_bytes()))
@@ -1848,7 +1879,8 @@ mod tests {
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(git_repo_path).unwrap();
 
-        let backend = GitBackend::init_external(&settings, store_path, git_repo.path()).unwrap();
+        let backend =
+            GitBackend::init_external(&settings, store_path, git_repo.path(), None).unwrap();
         let mut commit = Commit {
             parents: vec![],
             predecessors: vec![],
@@ -1917,7 +1949,8 @@ mod tests {
         let git_repo_path = temp_dir.path().join("git");
         let git_repo = git2::Repository::init(git_repo_path).unwrap();
 
-        let backend = GitBackend::init_external(&settings, store_path, git_repo.path()).unwrap();
+        let backend =
+            GitBackend::init_external(&settings, store_path, git_repo.path(), None).unwrap();
         let create_tree = |i| {
             let blob_id = git_repo.blob(b"content {i}").unwrap();
             let mut tree_builder = git_repo.treebuilder(None).unwrap();

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -64,8 +64,12 @@ impl SecretBackend {
     }
 
     /// Loads the backend from the given path.
-    pub fn load(settings: &UserSettings, store_path: &Path) -> Result<Self, BackendLoadError> {
-        let inner = GitBackend::load(settings, store_path)?;
+    pub fn load(
+        settings: &UserSettings,
+        store_path: &Path,
+        workspace_root: Option<&Path>,
+    ) -> Result<Self, BackendLoadError> {
+        let inner = GitBackend::load(settings, store_path, workspace_root)?;
         Ok(SecretBackend { inner })
     }
 

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -592,8 +592,12 @@ impl WorkspaceLoader for DefaultWorkspaceLoader {
         store_factories: &StoreFactories,
         working_copy_factories: &WorkingCopyFactories,
     ) -> Result<Workspace, WorkspaceLoadError> {
-        let repo_loader =
-            RepoLoader::init_from_file_system(user_settings, &self.repo_path, store_factories)?;
+        let repo_loader = RepoLoader::init_from_file_system(
+            user_settings,
+            &self.repo_path,
+            store_factories,
+            Some(self.workspace_root()),
+        )?;
         let working_copy_factory = get_working_copy_factory(self, working_copy_factories)?;
         let working_copy = self.load_working_copy(repo_loader.store(), working_copy_factory)?;
         let workspace = Workspace::new(

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -283,6 +283,7 @@ impl Workspace {
                 settings,
                 store_path,
                 &store_relative_git_repo_path,
+                Some(workspace_root),
             )?;
             Ok(Box::new(backend))
         };

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1334,6 +1334,7 @@ impl GitRepoData {
                     settings,
                     store_path,
                     git_repo.path(),
+                    Some(&jj_repo_dir),
                 )?))
             },
             Signer::from_settings(&settings).unwrap(),
@@ -2242,6 +2243,7 @@ fn test_init() {
                 settings,
                 store_path,
                 git_repo.path(),
+                Some(&jj_repo_dir),
             )?))
         },
         Signer::from_settings(&settings).unwrap(),
@@ -2601,6 +2603,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
                 settings,
                 store_path,
                 clone_repo.path(),
+                Some(&jj_repo_dir),
             )?))
         },
         Signer::from_settings(settings).unwrap(),

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -36,6 +36,7 @@ fn test_load_at_operation() {
         &settings,
         test_repo.repo_path(),
         &test_repo.env.default_store_factories(),
+        None,
     )
     .unwrap();
     let head_repo = loader.load_at_head(&settings).unwrap();
@@ -47,6 +48,7 @@ fn test_load_at_operation() {
         &settings,
         test_repo.repo_path(),
         &test_repo.env.default_store_factories(),
+        None,
     )
     .unwrap();
     let old_repo = loader.load_at(repo.operation()).unwrap();

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -57,6 +57,7 @@ fn test_init_additional_workspace() {
         test_workspace.repo_path(),
         &test_workspace.repo,
         &*default_working_copy_factory(),
+        &test_workspace.env.default_store_factories(),
         ws2_id.clone(),
     )
     .unwrap();

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -141,12 +141,18 @@ impl TestEnvironment {
         let mut factories = StoreFactories::default();
         factories.add_backend("test", {
             let factory = self.test_backend_factory.clone();
-            Box::new(move |_settings, store_path| Ok(Box::new(factory.load(store_path))))
+            Box::new(move |_settings, store_path, _workspace_root| {
+                Ok(Box::new(factory.load(store_path)))
+            })
         });
         factories.add_backend(
             SecretBackend::name(),
-            Box::new(|settings, store_path| {
-                Ok(Box::new(SecretBackend::load(settings, store_path)?))
+            Box::new(|settings, store_path, workspace_root| {
+                Ok(Box::new(SecretBackend::load(
+                    settings,
+                    store_path,
+                    workspace_root,
+                )?))
             }),
         );
         factories
@@ -157,10 +163,15 @@ impl TestEnvironment {
         settings: &UserSettings,
         repo_path: &Path,
     ) -> Arc<ReadonlyRepo> {
-        RepoLoader::init_from_file_system(settings, repo_path, &self.default_store_factories())
-            .unwrap()
-            .load_at_head(settings)
-            .unwrap()
+        RepoLoader::init_from_file_system(
+            settings,
+            repo_path,
+            &self.default_store_factories(),
+            None,
+        )
+        .unwrap()
+        .load_at_head(settings)
+        .unwrap()
     }
 }
 


### PR DESCRIPTION
Only the worktree recognition and HEAD reading/writing parts of #4588.

In other PRs:
- The CLI changes: create/destroy git worktrees during `jj workspace add`/`forget`
- The view changes to track multiple git heads and make the `git_head()` revset work correctly

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
