### PR TITLE
templates: add `.email_domain()` method to `Signature`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Timestamp objects in templates now have `after(date) -> Boolean` and
   `before(date) -> Boolean` methods for comparing timestamps to other dates.
 
+* Signature objects in templates now have a `email_domain() -> String` method.
+
 * New template functions `pad_start()`, `pad_end()`, `truncate_start()`, and
   `truncate_end()` are added.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -210,6 +210,8 @@ The following methods are defined.
 * `.name() -> String`
 * `.email() -> String`
 * `.username() -> String`
+* `.email_domain() -> String`: The part of the email after the `@`. May be empty
+  and may contain `@` for abnormal emails.
 * `.timestamp() -> Timestamp`
 
 ### SizeHint type


### PR DESCRIPTION
This is slightly less pretty than making an Email type, but I think is much easier.

I would use instead of the last argument of:

```
  concat(
    label("email", signature.username()),
    "@",
    label("email",
      signature.email().remove_prefix(
        signature.username()
      ).remove_prefix("@")
    )
  )
```

(Aside for more motivation: I initially had a bug above by using `.remove_prefix(signature.username() ++ "@")`. This is wrong since an email might not contain an `@`, as I discovered while looking at the code. The bug is now fixed, but `signature.email_domain()` would avoid the problem)

The effect I was going for (though I'm still not sure whether and how many characters I want to trim to):

<img width="644" alt="image" src="https://github.com/user-attachments/assets/5b40710b-88c8-4a43-9d8e-45565da028da">


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- n/a I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
