### PR TITLE
templates: respect format_short_signature() in builtin_log_oneline

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -73,7 +73,7 @@ if(root,
     concat(
       separate(" ",
         format_short_change_id_with_hidden_and_divergent_info(self),
-        if(author.email(), author.username(), email_placeholder),
+        format_short_signature(author),
         format_timestamp(committer.timestamp()),
         bookmarks,
         tags,


### PR DESCRIPTION
I noticed that `jj log -T builtin_log_oneline` wasn't respecting my `format_short_signature()` settings.

This is a slightly breaking change -- people's `oneline` logs will become longer if they use the default `format_short_signature()`. Perhaps there should be a new override, eg. `format_tiny_signature()`?

# Checklist

*not updating tests/changelog yet since idk if the PR will be merged*

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
