### PR TITLE
markdown cleanup (bookmarks.md, contributing.md)

### DIFF
--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -31,24 +31,24 @@ does not provide a way to manually edit these recorded positions.
 
 A remote bookmark can be associated with a local bookmark of the same name. This
 is called a **tracked remote bookmark** (which maps to a Git remote branch when
-using the Git backend). When you pull a tracked bookmark from a remote, any
+using the Git backend). When you fetch a tracked bookmark from a remote, any
 changes compared to the current record of the remote's state will be propagated
 to the corresponding local bookmark, which will be created if it doesn't exist
 already.
 
-!!! note "Details: how `fetch` pulls bookmarks"
-
-    Let's say you run `jj git fetch --remote origin` and, during the fetch, `jj`
-    determines that the remote's `main` bookmark has been moved so that its target is
-    now ahead of the local record in `main@origin`.
-
-    `jj` will then update `main@origin` to the new target. If `main@origin` is
-    **tracked**, `jj` will also apply the change to the local bookmark `main`. If the
-    local target has also been moved compared to `main@origin` (probably because you
-    ran `jj bookmark set main`), then the two updates will be merged. If one is ahead
-    of the other, then that target will become the new target. Otherwise, the local
-    bookmark will become conflicted (see the ["Conflicts" section](#conflicts) below
-    for details).
+> #### Note on how `jj git fetch` propagates bookmarks
+> 
+> Let's say you run `jj git fetch --remote origin` and, during the fetch, `jj`
+> determines that the remote's `main` bookmark has been moved so that its target is
+> now ahead of the local record in `main@origin`.
+> 
+> `jj` will then update `main@origin` to the new target. If `main@origin` is
+> **tracked**, `jj` will also apply the change to the local bookmark `main`. If the
+> local target has also been moved compared to `main@origin` (probably because you
+> ran `jj bookmark set main`), then the two updates will be merged. If one is ahead
+> of the other, then that target will become the new target. Otherwise, the local
+> bookmark will become conflicted (see the ["Conflicts" section](#conflicts) below
+> for details).
 
 Most commands don't show the tracked remote bookmark if it has the same target as
 the local bookmark. The local bookmark (without `@<remote name>`) is considered the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -284,40 +284,40 @@ version and the dependencies needed to build the docs. Install it like so:
 
 [uv]: https://docs.astral.sh/uv/
 
-=== "macOS/Linux"
+#### macOS/Linux
 
-    ``` { .shell .copy }
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    ```
+``` { .shell .copy }
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
 
-    !!! note
-        If you don't have `~/.local/bin` in your `PATH`, the installer will
-        modify your shell profile. To avoid it:
+> [!TIP]
+> If you don't have `~/.local/bin` in your `PATH`, the installer will
+> modify your shell profile. To avoid it:
+>
+> ``` { .shell .copy }
+> curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh
+> ```
 
-        ``` { .shell .copy }
-        curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh
-        ```
-
-=== "Windows"
+#### Windows
 
     ``` { .shell .copy }
     powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
 
-=== "Homebrew"
+#### Homebrew
 
     ``` { .shell .copy }
     brew install uv
     ```
 
-=== "Cargo"
+#### Cargo
 
     ``` { .shell .copy }
     # This might take a while
     cargo install --git https://github.com/astral-sh/uv uv
     ```
 
-=== "Other options"
+#### Other options
 
     * Directly download the binaries from GitHub: [uv releases](https://github.com/astral-sh/uv/releases).
     * Even more options: [Installing uv](https://docs.astral.sh/uv/getting-started/installation/).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -300,27 +300,27 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 #### Windows
 
-    ``` { .shell .copy }
-    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-    ```
+``` { .shell .copy }
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
 
 #### Homebrew
 
-    ``` { .shell .copy }
-    brew install uv
-    ```
+``` { .shell .copy }
+brew install uv
+```
 
 #### Cargo
 
-    ``` { .shell .copy }
-    # This might take a while
-    cargo install --git https://github.com/astral-sh/uv uv
-    ```
+``` { .shell .copy }
+# This might take a while
+cargo install --git https://github.com/astral-sh/uv uv
+```
 
 #### Other options
 
-    * Directly download the binaries from GitHub: [uv releases](https://github.com/astral-sh/uv/releases).
-    * Even more options: [Installing uv](https://docs.astral.sh/uv/getting-started/installation/).
+* Directly download the binaries from GitHub: [uv releases](https://github.com/astral-sh/uv/releases).
+* Even more options: [Installing uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ### Build the docs
 
@@ -333,21 +333,19 @@ uv run mkdocs serve
 Open <http://127.0.0.1:8000> in your browser to see the docs.
 
 As you edit the `.md` files in `docs/`, the website should be rebuilt and
-reloaded in your browser automatically.
-
-!!! note "If the docs are not updating"
-    Check the terminal from which you ran `uv run mkdocs serve` for any build
-    errors or warnings. Warnings about `"GET /versions.json HTTP/1.1" code 404`
-    are expected and harmless.
+reloaded in your browser automatically. If the docs are not updating, check
+the terminal from which you ran `uv run mkdocs serve` for any build errors
+or warnings. Warnings about `"GET /versions.json HTTP/1.1" code 404` are
+expected and harmless.
 
 ## Building the entire website
 
-!!! tip
-    Building the entire website is not usually necessary. If you are editing
-    documentation, the previous section is enough.
-
-    These instructions are relevant if you are working on the versioning of the
-    documentation that we currently do with `mike`.
+> [!TIP]
+> Building the entire website is not usually necessary. If you are editing
+> documentation, the previous section is enough.
+> 
+> These instructions are relevant if you are working on the versioning of the
+> documentation that we currently do with `mike`.
 
 The full `jj` website includes the documentation for several `jj` versions
 (`prerelease`, latest release, and the older releases). The top-level


### PR DESCRIPTION
Previous markdown did not produce any appealing effect on github.com renderer.
Change markdown to the style supported by github.com.

The notes were of varying importance. Using a quotation-style note where the distraction is not warranted.

Use "[!TIP]" formatting per [Github formatting recommendation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).