### PR TITLE
bookmark: Make `bookmark {create, set, move}` unhide hidden commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj bookmark create`, `jj bookmark set` and `jj bookmark move` onto a hidden
+   commit make it visible.
+
 * `jj undo` now shows a hint when undoing an undo operation that the user may
    be looking for `jj op restore` instead.
 

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -984,10 +984,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
         |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let repo = language.repo;
-            let out_property = self_property.map(|commit| {
-                let maybe_entries = repo.resolve_change_id(commit.change_id());
-                maybe_entries.map_or(true, |entries| !entries.contains(commit.id()))
-            });
+            let out_property = self_property.map(|commit| commit.is_hidden(repo));
             Ok(L::wrap_boolean(out_property))
         },
     );

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1079,9 +1079,9 @@ fn test_bookmark_track_conflict() {
     insta::assert_snapshot!(stderr, @r###"
     Started tracking 1 remote bookmarks.
     main (conflicted):
-      + qpvuntsm e802c4f8 (empty) b
-      + qpvuntsm hidden 427890ea (empty) a
-      @origin (behind by 1 commits): qpvuntsm hidden 427890ea (empty) a
+      + qpvuntsm?? e802c4f8 (empty) b
+      + qpvuntsm?? 427890ea (empty) a
+      @origin (behind by 1 commits): qpvuntsm?? 427890ea (empty) a
     "###);
 }
 

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -157,6 +157,12 @@ impl Commit {
         &self.data.committer
     }
 
+    ///  A commit is hidden if its commit id is not in the change id index.
+    pub fn is_hidden(&self, repo: &dyn Repo) -> bool {
+        let maybe_entries = repo.resolve_change_id(self.change_id());
+        maybe_entries.map_or(true, |entries| !entries.contains(&self.id))
+    }
+
     /// A commit is discardable if it has no change from its parent, and an
     /// empty description.
     pub fn is_discardable(&self, repo: &dyn Repo) -> BackendResult<bool> {

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -877,6 +877,7 @@ impl MutableRepo {
     }
 
     pub fn has_changes(&self) -> bool {
+        self.view.ensure_clean(|v| self.enforce_view_invariants(v));
         !(self.parent_mapping.is_empty() && self.view() == &self.base_repo.view)
     }
 
@@ -1521,7 +1522,11 @@ impl MutableRepo {
     }
 
     pub fn set_local_bookmark_target(&mut self, name: &str, target: RefTarget) {
-        self.view_mut().set_local_bookmark_target(name, target);
+        let view = self.view_mut();
+        for id in target.added_ids() {
+            view.add_head(id);
+        }
+        view.set_local_bookmark_target(name, target);
     }
 
     pub fn merge_local_bookmark(
@@ -1534,7 +1539,7 @@ impl MutableRepo {
         let index = self.index.as_index();
         let self_target = view.get_local_bookmark(name);
         let new_target = merge_ref_targets(index, self_target, base_target, other_target);
-        view.set_local_bookmark_target(name, new_target);
+        self.set_local_bookmark_target(name, new_target);
     }
 
     pub fn get_remote_bookmark(&self, name: &str, remote_name: &str) -> RemoteRef {


### PR DESCRIPTION
This was [discussed in Discord][dc] a while ago,  and this is the logical and consistent
conclusion. Implementing it as such makes it consistent with both `jj edit` and `jj new`
which unhide any predecessor.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes

[dc]: https://discord.com/channels/968932220549103686/968932220549103689/1298729954670022676