### PR TITLE
ci: check Rust documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,26 @@ jobs:
           components: rustfmt
       - run: cargo +nightly fmt --all -- --check
 
+  check-doctests:
+    name: Run doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8
+        with:
+          toolchain: 1.76
+      # NOTE: We need to run `cargo test --doc` separately from normal tests:
+      # - `cargo build --all-targets` specifies: "Build all targets"
+      # - `cargo test --all-targets` specifies: "Test all targets (does not include doctests)"
+      - name: Run doctests
+        run: cargo test --workspace --doc
+        env:
+          RUST_BACKTRACE: 1
+      - name: Check `cargo doc` for lint issues
+        env:
+          RUSTDOCFLAGS: "--deny warnings"
+        run: cargo doc --workspace --no-deps
+
   mkdocs:
     name: Check that MkDocs can build the docs
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
       with:
-        toolchain:  1.76
+        toolchain: 1.76
     - name: Build
       run: cargo build --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
     - name: Test
@@ -89,7 +89,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
       with:
-        toolchain:  1.76
+        toolchain: 1.76
     - name: Build
       run: cargo build -p jj-lib --no-default-features --verbose
 

--- a/lib/src/time_util.rs
+++ b/lib/src/time_util.rs
@@ -89,7 +89,7 @@ impl DatePattern {
     /// * `kind` must be either "after" or "before". This determines whether the
     ///   pattern will match dates after or before the parsed date.
     ///
-    /// * `now` is the user's current time. This is a DateTime<Tz> because
+    /// * `now` is the user's current time. This is a [`DateTime<Tz>`] because
     ///   knowledge of offset changes is needed to correctly process relative
     ///   times like "today". For example, California entered DST on March 10,
     ///   2024, shifting clocks from UTC-8 to UTC-7 at 2:00 AM. If the pattern

--- a/lib/src/union_find.rs
+++ b/lib/src/union_find.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This module implements a UnionFind<T> type which can be used to
+//! This module implements a [`UnionFind<T>`] type which can be used to
 //! efficiently calculate disjoint sets for any data type.
 
 use std::collections::HashMap;
@@ -25,7 +25,7 @@ struct Node<T> {
 }
 
 /// Implementation of the union-find algorithm:
-/// https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+/// <https://en.wikipedia.org/wiki/Disjoint-set_data_structure>
 ///
 /// Joins disjoint sets by size to amortize cost.
 #[derive(Clone)]


### PR DESCRIPTION
Follow-up from https://github.com/martinvonz/jj/pull/5052. This isn't critical, so we can drop this PR if we think it's not important or not worth resolving the outstanding questions for now.

Questions:

- What is our policy/strategy for new top-level checks vs embedding steps into existing checks?
  - I chose to make new top-level checks since I figured the feedback loop would be faster that way:
    - When a problem occurs, it's obvious at the top-level display that it's not a "real" test failure, just a rustdoc issue.
    - When you're fixing the problem, you don't have to wait the entire test suite.
  - However, it probably induces additional overall load to compile/process the codebase again?
- What is our policy for setting the Rust toolchain for the new checks?
  - I chose MSRV for the doctests themselves, since I imagined that they could demonstrate the API boundary, which needs to adhere to MSRV.
    - See below: we don't have any "real" doctests right now. So it's mostly immaterial for now.
  - I chose `stable` for `cargo doc` in case new lints get added.
    - It could be annoying to have to resolve lints that don't appear unless you have the latest `stable` toolchain.
    - We're already doing this for `cargo clippy`, so I don't think it should be much worse than the status quo?

Notes:

- These checks are mostly unrelated to the doc website generation.
  - Feel free to suggest any naming changes to the jobs/steps/etc. that make it clearer.
  - The exception is that website might process the same information from the CLI doc-comments, similarly to the original issue in #5052, but this is incidental.
- We don't actually have any doctests at present.
  - So this mainly just detects "breaking the doctest build".
  - We might add some in the future to demonstrate how to use the library?
  - I confirmed that `cargo test --doc` catches the issue in #5052.
- I fixed the few existing rustdoc issues.
- I highly recommend linking symbols in docs when possible (with square brackets, like <code>[\`Foo\`]</code>):
  - It makes the docs easier to navigate (both in the IDE and the crate documentation website).
  - With this PR, we can check validity of those references automatically to ensure the docs are up-to-date (via `rustdoc::broken_intra_doc_links`).
- In the current setup, I added new non-required top-level checks.
  - They're not "required" checks unless/until somebody goes into the GitHub repo configuration and adds them.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
