### PR TITLE
feat(cli): add buzz command

### DIFF
--- a/cli/src/commands/buzz.rs
+++ b/cli/src/commands/buzz.rs
@@ -1,0 +1,35 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Display version information
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct BuzzArgs {}
+
+#[instrument(skip_all)]
+pub(crate) fn cmd_buzz(
+    ui: &mut Ui,
+    _command: &CommandHelper,
+    _args: &BuzzArgs,
+) -> Result<(), CommandError> {
+    write!(ui.stdout(), "\x07")?; // https://www.ascii-code.com/7
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ mod backout;
 #[cfg(feature = "bench")]
 mod bench;
 mod bookmark;
+mod buzz;
 mod commit;
 mod config;
 mod debug;
@@ -87,6 +88,7 @@ enum Command {
     // TODO: Remove in jj 0.28+
     #[command(subcommand, hide = true)]
     Branch(bookmark::BookmarkCommand),
+    Buzz(buzz::BuzzArgs),
     #[command(alias = "print", hide = true)]
     Cat(file::show::FileShowArgs),
     // TODO: Delete `chmod` in jj 0.25+
@@ -185,6 +187,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
             let cmd = renamed_cmd("branch", "bookmark", bookmark::cmd_bookmark);
             cmd(ui, command_helper, args)
         }
+        Command::Buzz(args) => buzz::cmd_buzz(ui, command_helper, args),
         Command::Cat(args) => {
             let cmd = renamed_cmd("cat", "file show", file::show::cmd_file_show);
             cmd(ui, command_helper, args)


### PR DESCRIPTION
`jj buzz` is an easter egg command that sends a bell character to the terminal. Running `jj buzz` is expected to make a bell sound

The code was adapted from the simplest subcommand, `jj version`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/martinvonz/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

https://discord.com/channels/968932220549103686/1167230861448581167/1317610036733673684

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes

<hr/>

NOTE: not a serious proposal
