### PR TITLE
show untracked files in jj status

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2578,26 +2578,38 @@ pub fn print_snapshot_stats(
     stats: &SnapshotStats,
     path_converter: &RepoPathUiConverter,
 ) -> io::Result<()> {
-    // It might make sense to add files excluded by snapshot.auto-track to the
-    // untracked_paths, but they shouldn't be warned every time we do snapshot.
-    // These paths will have to be printed by "jj status" instead.
-    if !stats.untracked_paths.is_empty() {
-        writeln!(ui.warning_default(), "Refused to snapshot some files:")?;
-        let mut formatter = ui.stderr_formatter();
-        for (path, reason) in &stats.untracked_paths {
-            let ui_path = path_converter.format_file_path(path);
-            let message = match reason {
+    // Paths with UntrackedReason::FileNotAutoTracked shouldn't be warned about
+    // every time we make a snapshot. These paths will be printed by
+    // "jj status" instead.
+
+    let mut untracked_paths = stats
+        .untracked_paths
+        .iter()
+        .filter_map(|(path, reason)| {
+            match reason {
                 UntrackedReason::FileTooLarge { size, max_size } => {
                     // Show both exact and human bytes sizes to avoid something
                     // like '1.0MiB, maximum size allowed is ~1.0MiB'
                     let size_approx = HumanByteSize(*size);
                     let max_size_approx = HumanByteSize(*max_size);
-                    format!(
-                        "{size_approx} ({size} bytes); the maximum size allowed is \
-                         {max_size_approx} ({max_size} bytes)",
-                    )
+                    Some((
+                        path,
+                        format!(
+                            "{size_approx} ({size} bytes); the maximum size allowed is \
+                             {max_size_approx} ({max_size} bytes)",
+                        ),
+                    ))
                 }
-            };
+                UntrackedReason::FileNotAutoTracked => None,
+            }
+        })
+        .peekable();
+
+    if untracked_paths.peek().is_some() {
+        writeln!(ui.warning_default(), "Refused to snapshot some files:")?;
+        let mut formatter = ui.stderr_formatter();
+        for (path, message) in untracked_paths {
+            let ui_path = path_converter.format_file_path(path);
             writeln!(formatter, "  {ui_path}: {message}")?;
         }
     }
@@ -2605,8 +2617,9 @@ pub fn print_snapshot_stats(
     if let Some(size) = stats
         .untracked_paths
         .values()
-        .map(|reason| match reason {
-            UntrackedReason::FileTooLarge { size, .. } => *size,
+        .filter_map(|reason| match reason {
+            UntrackedReason::FileTooLarge { size, .. } => Some(*size),
+            UntrackedReason::FileNotAutoTracked => None,
         })
         .max()
     {

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -47,7 +47,7 @@ pub(crate) fn cmd_status(
     command: &CommandHelper,
     args: &StatusArgs,
 ) -> Result<(), CommandError> {
-    let workspace_command = command.workspace_helper(ui)?;
+    let (workspace_command, _snapshot_stats) = command.workspace_helper_with_stats(ui)?;
     let repo = workspace_command.repo();
     let maybe_wc_commit = workspace_command
         .get_wc_commit_id()

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io;
+
 use itertools::Itertools;
 use jj_lib::copies::CopyRecords;
 use jj_lib::repo::Repo;
@@ -47,7 +49,7 @@ pub(crate) fn cmd_status(
     command: &CommandHelper,
     args: &StatusArgs,
 ) -> Result<(), CommandError> {
-    let (workspace_command, _snapshot_stats) = command.workspace_helper_with_stats(ui)?;
+    let (workspace_command, snapshot_stats) = command.workspace_helper_with_stats(ui)?;
     let repo = workspace_command.repo();
     let maybe_wc_commit = workspace_command
         .get_wc_commit_id()
@@ -63,26 +65,44 @@ pub(crate) fn cmd_status(
     if let Some(wc_commit) = &maybe_wc_commit {
         let parent_tree = wc_commit.parent_tree(repo.as_ref())?;
         let tree = wc_commit.tree()?;
-        if tree.id() == parent_tree.id() {
+
+        let wc_has_changes = tree.id() != parent_tree.id();
+        let wc_has_untracked = !snapshot_stats.untracked_paths.is_empty();
+        if !wc_has_changes && !wc_has_untracked {
             writeln!(formatter, "The working copy is clean")?;
         } else {
-            writeln!(formatter, "Working copy changes:")?;
-            let mut copy_records = CopyRecords::default();
-            for parent in wc_commit.parent_ids() {
-                let records = get_copy_records(repo.store(), parent, wc_commit.id(), &matcher)?;
-                copy_records.add_records(records)?;
+            if wc_has_changes {
+                writeln!(formatter, "Working copy changes:")?;
+                let mut copy_records = CopyRecords::default();
+                for parent in wc_commit.parent_ids() {
+                    let records = get_copy_records(repo.store(), parent, wc_commit.id(), &matcher)?;
+                    copy_records.add_records(records)?;
+                }
+                let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
+                let width = ui.term_width();
+                diff_renderer.show_diff(
+                    ui,
+                    formatter,
+                    &parent_tree,
+                    &tree,
+                    &matcher,
+                    &copy_records,
+                    width,
+                )?;
             }
-            let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
-            let width = ui.term_width();
-            diff_renderer.show_diff(
-                ui,
-                formatter,
-                &parent_tree,
-                &tree,
-                &matcher,
-                &copy_records,
-                width,
-            )?;
+
+            if wc_has_untracked {
+                // TODO: make sure this always display all untracked non-ignored files, even
+                // when using watchman. See https://github.com/jj-vcs/jj/commit/168c7979feab40d58f49fe19683975697a7bc089 for details.
+                writeln!(formatter, "Untracked paths:")?;
+                formatter.with_label("diff", |formatter| {
+                    for path in snapshot_stats.untracked_paths.keys() {
+                        let ui_path = workspace_command.path_converter().format_file_path(path);
+                        writeln!(formatter.labeled("untracked"), "? {ui_path}")?;
+                    }
+                    io::Result::Ok(())
+                })?;
+            }
         }
 
         // TODO: Conflicts should also be filtered by the `matcher`. See the related

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -93,6 +93,7 @@
 "diff added" = { fg = "green" }
 "diff token" = { underline = true }
 "diff modified" = "cyan"
+"diff untracked" = "magenta"
 "diff renamed" = "cyan"
 "diff copied" = "green"
 "diff access-denied" = { bg = "red" }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1272,7 +1272,9 @@ impl FileSnapshotter<'_> {
                 && !self.start_tracking_matcher.matches(&path)
             {
                 // Leave the file untracked
-                // TODO: Report this path to the caller
+                self.untracked_paths_tx
+                    .send((path, UntrackedReason::FileNotAutoTracked))
+                    .ok();
                 Ok(None)
             } else {
                 let metadata = entry.metadata().map_err(|err| SnapshotError::Other {

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -257,6 +257,8 @@ pub enum UntrackedReason {
         /// Maximum allowed size.
         max_size: u64,
     },
+    /// File does not match the fileset specified in snapshot.auto-track.
+    FileNotAutoTracked,
 }
 
 /// Options used when checking out a tree in the working copy.


### PR DESCRIPTION
This adds the plumbing to get the untracked files from the snapshot to the status command and displays them similar to mercurial. I am not sure if this is the right way to do this.

This might be the last thing to fix https://github.com/jj-vcs/jj/issues/323.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
