### PR TITLE
config: Add `commit_timestamp(commit)` template alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A new Email template type is added. `Signature.email()` now returns an Email
   template type instead of a String.
 
+* Adds a new template alias `commit_timestamp(commit)` which defaults to the
+  committer date.
+
 ### Fixed bugs
 
 * The `$NO_COLOR` environment variable must now be non-empty to be respected.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -18,7 +18,7 @@ annotate_commit_summary = '''
 separate(" ",
   change_id.shortest(8),
   pad_end(8, truncate_end(8, author.email().local())),
-  committer.timestamp().local().format('%Y-%m-%d %H:%M:%S'),
+  commit_timestamp(self).local().format('%Y-%m-%d %H:%M:%S'),
 )
 '''
 
@@ -73,7 +73,7 @@ if(root,
       separate(" ",
         format_short_change_id_with_hidden_and_divergent_info(self),
         if(author.email(), author.email().local(), email_placeholder),
-        format_timestamp(committer.timestamp()),
+        format_timestamp(commit_timestamp(self)),
         bookmarks,
         tags,
         working_copies,
@@ -160,6 +160,7 @@ name_placeholder = 'label("name placeholder", "(no name set)")'
 commit_summary_separator = 'label("separator", " | ")'
 
 # Hook points for users to customize the default templates:
+'commit_timestamp(commit)' = 'commit.committer().timestamp()'
 'format_short_id(id)' = 'id.shortest(8)'
 'format_short_change_id(id)' = 'format_short_id(id)'
 'format_short_commit_id(id)' = 'format_short_id(id)'
@@ -256,7 +257,7 @@ if(commit.hidden(),
 separate(" ",
         format_short_change_id_with_hidden_and_divergent_info(commit),
         format_short_signature(commit.author()),
-        format_timestamp(commit.committer().timestamp()),
+        format_timestamp(commit_timestamp(commit)),
         commit.bookmarks(),
         commit.tags(),
         commit.working_copies(),

--- a/docs/config.md
+++ b/docs/config.md
@@ -484,6 +484,20 @@ Can be customized by the `format_short_signature()` template alias.
 'format_short_signature(signature)' = 'signature.username()'
 ```
 
+### Commit timestamp
+
+Commits have both an "author timestamp" and "committer timestamp". By default,
+jj displays the committer timestamp, but can be changed to show the author
+timestamp instead.
+
+The function must return a timestamp because the return value will likely be
+formatted with `format_timestamp()`.
+
+```toml
+[template-aliases]
+'commit_timestamp(commit)' = 'commit.author().timestamp()'
+```
+
 ### Allow "large" revsets by default
 
 Certain commands (such as `jj rebase`) can take multiple revset arguments, but


### PR DESCRIPTION
Adds an extension point for changing which date is displayed in log formats. The function should return a timestamp, not a formatted string.

Fixes: #5132 
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
