### PR TITLE
tests: use toml_edit::Value to escape string and array

### DIFF
--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -254,11 +254,11 @@ impl TestEnvironment {
             .join(format!("config{config_file_number:04}.toml"))
     }
 
-    pub fn set_config_path(&mut self, config_path: PathBuf) {
-        self.config_path = config_path;
+    pub fn set_config_path(&mut self, config_path: impl Into<PathBuf>) {
+        self.config_path = config_path.into();
     }
 
-    pub fn add_config(&self, content: &str) {
+    pub fn add_config(&self, content: impl AsRef<[u8]>) {
         if self.config_path.is_file() {
             panic!("add_config not supported when config_path is a file");
         }
@@ -275,8 +275,8 @@ impl TestEnvironment {
         .unwrap();
     }
 
-    pub fn add_env_var(&mut self, key: &str, val: &str) {
-        self.env_vars.insert(key.to_string(), val.to_string());
+    pub fn add_env_var(&mut self, key: impl Into<String>, val: impl Into<String>) {
+        self.env_vars.insert(key.into(), val.into());
     }
 
     pub fn current_operation_id(&self, repo_path: &Path) -> String {
@@ -294,7 +294,7 @@ impl TestEnvironment {
         // in it
         let escaped_editor_path = editor_path.to_str().unwrap().replace('\\', r"\\");
         self.add_env_var("EDITOR", &escaped_editor_path);
-        self.add_config(&format!(
+        self.add_config(format!(
             r###"
                     [ui]
                     merge-editor = "fake-editor"
@@ -314,7 +314,7 @@ impl TestEnvironment {
     /// path
     pub fn set_up_fake_diff_editor(&mut self) -> PathBuf {
         let escaped_diff_editor_path = escaped_fake_diff_editor_path();
-        self.add_config(&format!(
+        self.add_config(format!(
             r###"
             ui.diff-editor = "fake-diff-editor"
             merge-tools.fake-diff-editor.program = "{escaped_diff_editor_path}"

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use regex::Regex;
 
 use crate::common::fake_editor_path;
+use crate::common::to_toml_value;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -270,7 +271,10 @@ fn test_config_layer_override_default() {
     "###);
 
     // User
-    test_env.add_config(format!("{config_key} = {value:?}\n", value = "user"));
+    test_env.add_config(format!(
+        "{config_key} = {value}\n",
+        value = to_toml_value("user")
+    ));
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
     insta::assert_snapshot!(stdout, @r###"
     merge-tools.vimdiff.program = "user"
@@ -279,7 +283,7 @@ fn test_config_layer_override_default() {
     // Repo
     std::fs::write(
         repo_path.join(".jj/repo/config.toml"),
-        format!("{config_key} = {value:?}\n", value = "repo"),
+        format!("{config_key} = {value}\n", value = to_toml_value("repo")),
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
@@ -295,7 +299,7 @@ fn test_config_layer_override_default() {
             "list",
             config_key,
             "--config",
-            &format!("{config_key}={value:?}", value = "command-arg"),
+            &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
@@ -311,7 +315,7 @@ fn test_config_layer_override_default() {
             config_key,
             "--include-overridden",
             "--config",
-            &format!("{config_key}={value:?}", value = "command-arg"),
+            &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
@@ -351,7 +355,10 @@ fn test_config_layer_override_env() {
     "###);
 
     // User
-    test_env.add_config(format!("{config_key} = {value:?}\n", value = "user"));
+    test_env.add_config(format!(
+        "{config_key} = {value}\n",
+        value = to_toml_value("user")
+    ));
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
     insta::assert_snapshot!(stdout, @r###"
     ui.editor = "user"
@@ -360,7 +367,7 @@ fn test_config_layer_override_env() {
     // Repo
     std::fs::write(
         repo_path.join(".jj/repo/config.toml"),
-        format!("{config_key} = {value:?}\n", value = "repo"),
+        format!("{config_key} = {value}\n", value = to_toml_value("repo")),
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
@@ -383,7 +390,7 @@ fn test_config_layer_override_env() {
             "list",
             config_key,
             "--config",
-            &format!("{config_key}={value:?}", value = "command-arg"),
+            &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
@@ -399,7 +406,7 @@ fn test_config_layer_override_env() {
             config_key,
             "--include-overridden",
             "--config",
-            &format!("{config_key}={value:?}", value = "command-arg"),
+            &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
     insta::assert_snapshot!(stdout, @r###"
@@ -429,7 +436,10 @@ fn test_config_layer_workspace() {
     // Repo
     std::fs::write(
         main_path.join(".jj/repo/config.toml"),
-        format!("{config_key} = {value:?}\n", value = "main-repo"),
+        format!(
+            "{config_key} = {value}\n",
+            value = to_toml_value("main-repo")
+        ),
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&main_path, &["config", "list", config_key]);
@@ -1139,7 +1149,7 @@ fn test_config_conditional_without_home_dir() {
                 --when.repositories = [{repo_path}]
                 foo = 'repo'
             "},
-            repo_path = toml_edit::Value::from(repo_path.to_str().unwrap())
+            repo_path = to_toml_value(repo_path.to_str().unwrap())
         ),
     )
     .unwrap();

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -203,7 +203,7 @@ fn test_config_list_layer() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     // Test with fresh new config file
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
     let repo_path = test_env.env_root().join("repo");
 
     // User
@@ -269,7 +269,7 @@ fn test_config_layer_override_default() {
     "###);
 
     // User
-    test_env.add_config(&format!("{config_key} = {value:?}\n", value = "user"));
+    test_env.add_config(format!("{config_key} = {value:?}\n", value = "user"));
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
     insta::assert_snapshot!(stdout, @r###"
     merge-tools.vimdiff.program = "user"
@@ -350,7 +350,7 @@ fn test_config_layer_override_env() {
     "###);
 
     // User
-    test_env.add_config(&format!("{config_key} = {value:?}\n", value = "user"));
+    test_env.add_config(format!("{config_key} = {value:?}\n", value = "user"));
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
     insta::assert_snapshot!(stdout, @r###"
     ui.editor = "user"
@@ -492,7 +492,7 @@ fn test_config_set_for_user() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     // Test with fresh new config file
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
     let repo_path = test_env.env_root().join("repo");
 
     test_env.jj_cmd_ok(
@@ -586,7 +586,7 @@ fn test_config_set_toml_types() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     // Test with fresh new config file
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
     let repo_path = test_env.env_root().join("repo");
 
     let set_value = |key, value| {
@@ -700,7 +700,7 @@ fn test_config_unset_table_like() {
     let mut test_env = TestEnvironment::default();
     // Test with fresh new config file
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
 
     std::fs::write(
         &user_config_path,
@@ -740,7 +740,7 @@ fn test_config_unset_for_user() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     // Test with fresh new config file
     let user_config_path = test_env.config_path().join("config.toml");
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
     let repo_path = test_env.env_root().join("repo");
 
     test_env.jj_cmd_ok(&repo_path, &["config", "set", "--user", "foo", "true"]);
@@ -820,7 +820,7 @@ fn test_config_edit_user_new_file() {
     let mut test_env = TestEnvironment::default();
     let user_config_path = test_env.config_path().join("config").join("file.toml");
     test_env.set_up_fake_editor(); // set $EDITOR, but added configuration is ignored
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
     assert!(!user_config_path.exists());
 
     test_env.jj_cmd_ok(test_env.env_root(), &["config", "edit", "--user"]);
@@ -856,7 +856,7 @@ fn test_config_path() {
 
     let user_config_path = test_env.env_root().join("config.toml");
     let repo_config_path = repo_path.join(PathBuf::from_iter([".jj", "repo", "config.toml"]));
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["config", "path", "--user"]),
@@ -1057,7 +1057,7 @@ fn test_config_conditional() {
     let repo2_path = test_env.home_dir().join("repo2");
     // Test with fresh new config file
     let user_config_path = test_env.env_root().join("config.toml");
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
     std::fs::write(
         &user_config_path,
         indoc! {"
@@ -1127,7 +1127,7 @@ fn test_config_conditional_without_home_dir() {
     let repo_path = test_env.env_root().join("repo");
     // Test with fresh new config file
     let user_config_path = test_env.env_root().join("config.toml");
-    test_env.set_config_path(user_config_path.clone());
+    test_env.set_config_path(&user_config_path);
     std::fs::write(
         &user_config_path,
         format!(

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -18,6 +18,7 @@ use indoc::indoc;
 use itertools::Itertools;
 use regex::Regex;
 
+use crate::common::fake_editor_path;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -819,7 +820,8 @@ fn test_config_edit_user() {
 fn test_config_edit_user_new_file() {
     let mut test_env = TestEnvironment::default();
     let user_config_path = test_env.config_path().join("config").join("file.toml");
-    test_env.set_up_fake_editor(); // set $EDITOR, but added configuration is ignored
+    test_env.set_up_fake_editor(); // set $EDIT_SCRIPT, but added configuration is ignored
+    test_env.add_env_var("EDITOR", fake_editor_path());
     test_env.set_config_path(&user_config_path);
     assert!(!user_config_path.exists());
 

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -140,9 +140,15 @@ fn test_describe() {
     std::fs::write(&edit_script, "fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe"]);
     assert!(stderr.contains("exited with an error"));
+}
+
+#[test]
+fn test_describe_editor_env() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo", "--git"]);
+    let repo_path = test_env.env_root().join("repo");
 
     // Fails if the editor doesn't exist
-    std::fs::write(&edit_script, "").unwrap();
     let assert = test_env
         .jj_cmd(&repo_path, &["describe"])
         .env("EDITOR", "this-editor-does-not-exist")

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -15,8 +15,9 @@
 use indoc::indoc;
 use itertools::Itertools;
 
-use crate::common::escaped_fake_diff_editor_path;
+use crate::common::fake_diff_editor_path;
 use crate::common::strip_last_line;
+use crate::common::to_toml_value;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -2109,8 +2110,8 @@ fn test_diff_external_tool() {
     "###);
 
     // Inlined command arguments
-    let command = escaped_fake_diff_editor_path();
-    let config = format!(r#"--config=ui.diff.tool=["{command}", "$right", "$left"]"#);
+    let command_toml = to_toml_value(fake_diff_editor_path());
+    let config = format!("--config=ui.diff.tool=[{command_toml}, '$right', '$left']");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", &config]), @r###"
     file2
     file3

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -34,7 +34,7 @@ fn init_with_fake_formatter(args: &[&str]) -> (TestEnvironment, PathBuf, impl Fn
     // make a meaningful difference in coverage. Otherwise, we would have to add
     // dedicated test coverage for the deprecated syntax until it is removed. We use
     // single quotes here to avoid escaping issues when running the test on Windows.
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r#"fix.tool-command = ['{}']"#,
         [formatter_path.to_str().unwrap()]
             .iter()
@@ -77,7 +77,7 @@ fn test_config_both_legacy_and_table_tools() {
     let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
     assert!(formatter_path.is_file());
     let escaped_formatter_path = formatter_path.to_str().unwrap().replace('\\', r"\\");
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix]
         tool-command = ["{formatter}", "--append", "legacy change"]
@@ -115,7 +115,7 @@ fn test_config_multiple_tools() {
     let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
     assert!(formatter_path.is_file());
     let escaped_formatter_path = formatter_path.to_str().unwrap().replace('\\', r"\\");
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.tool-1]
         command = ["{formatter}", "--uppercase"]
@@ -153,7 +153,7 @@ fn test_config_multiple_tools_with_same_name() {
 
     // Multiple definitions with the same `name` are not allowed, because it is
     // likely to be a mistake, and mistakes are risky when they rewrite files.
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.my-tool]
         command = ["{formatter}", "--uppercase"]
@@ -183,7 +183,7 @@ fn test_config_multiple_tools_with_same_name() {
     For help, see https://jj-vcs.github.io/jj/latest/config/.
     ");
 
-    test_env.set_config_path("/dev/null".into());
+    test_env.set_config_path("/dev/null");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
     insta::assert_snapshot!(content, @"Foo\n");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
@@ -199,7 +199,7 @@ fn test_config_tables_overlapping_patterns() {
     assert!(formatter_path.is_file());
     let escaped_formatter_path = formatter_path.to_str().unwrap().replace('\\', r"\\");
 
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.tool-1]
         command = ["{formatter}", "--append", "tool-1"]
@@ -274,7 +274,7 @@ fn test_config_tables_some_commands_missing() {
     let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
     assert!(formatter_path.is_file());
     let escaped_formatter_path = formatter_path.to_str().unwrap().replace('\\', r"\\");
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.tool-1]
         command = ["{formatter}", "--uppercase"]
@@ -309,7 +309,7 @@ fn test_config_tables_empty_patterns_list() {
     let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
     assert!(formatter_path.is_file());
     let escaped_formatter_path = formatter_path.to_str().unwrap().replace('\\', r"\\");
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.my-tool-empty-patterns]
         command = ["{formatter}", "--uppercase"]
@@ -339,7 +339,7 @@ fn test_config_filesets() {
     let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
     assert!(formatter_path.is_file());
     let escaped_formatter_path = formatter_path.to_str().unwrap().replace('\\', r"\\");
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.my-tool-match-one]
         command = ["{formatter}", "--uppercase"]
@@ -378,7 +378,7 @@ fn test_relative_paths() {
     let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
     assert!(formatter_path.is_file());
     let escaped_formatter_path = formatter_path.to_str().unwrap().replace('\\', r"\\");
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.tool]
         command = ["{formatter}", "--stdout", "Fixed!"]
@@ -1145,7 +1145,7 @@ fn test_all_files() {
     // File D: NOT in patterns,     changed in child
     // Some files will be in subdirectories to make sure we're covering that aspect
     // of matching.
-    test_env.add_config(&format!(
+    test_env.add_config(format!(
         r###"
         [fix.tools.tool]
         command = ["{formatter}", "--append", "fixed"]


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
