### PR TITLE
describe: add ignore-rest directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `$marker_length` variable to allow merge tools to support longer conflict
   markers (equivalent to "%L" for Git merge drivers).
 
+* `jj describe` now accepts a `JJ: ignore-rest` line that ignores everything
+  below it, similar to a "scissor line" in git. When editing multiple commits,
+  only ignore until the next `JJ: describe` line.
+
 ### Fixed bugs
 
 * The `$NO_COLOR` environment variable must now be non-empty to be respected.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -29,8 +29,6 @@ if(overridden,
 ) ++ "\n"
 '''
 
-# TODO: Provide hook point for diff customization (#1946)? We might want a
-# syntax to comment out full text diffs without using the "JJ:" prefix.
 draft_commit_description = '''
 concat(
   description,

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use bstr::ByteVec as _;
 use indexmap::IndexMap;
 use indoc::indoc;
+use itertools::FoldWhile;
 use itertools::Itertools;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
@@ -28,8 +29,17 @@ where
 {
     let description = lines
         .into_iter()
-        .filter(|line| !line.as_ref().starts_with("JJ:"))
-        .fold(String::new(), |acc, line| acc + line.as_ref() + "\n");
+        .fold_while(String::new(), |acc, line| {
+            let line = line.as_ref();
+            if line.strip_prefix("JJ: ignore-rest").is_some() {
+                FoldWhile::Done(acc)
+            } else if line.starts_with("JJ:") {
+                FoldWhile::Continue(acc)
+            } else {
+                FoldWhile::Continue(acc + line + "\n")
+            }
+        })
+        .into_inner();
     text_util::complete_newline(description.trim_matches('\n'))
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -185,6 +185,8 @@ concat(
     "\nJJ: This commit contains the following changes:\n", "",
     indent("JJ:     ", diff.stat(72)),
   ),
+  "\nJJ: ignore-rest\n",
+  diff.git(),
 )
 '''
 ```


### PR DESCRIPTION
Implements #4210

~~Instead of a scissor _line_, this implements a scissor _section_. Everything between a pair of scissor lines is ignored. This allows it to work with #3828, as long as you put the ending line. Currently the beginning and ending lines are the same, so only one alias is required. Could easily be separated.~~

Implements a single scissor line, since `JJ: describe` lines are parsed first. Everything after a scissor line, before a `JJ: describe` line is ignored.

Open to other ideas on the style of the scissor lines. Additionally, the `scissor` template alias does *not* insert the "Do not modify or remove the line above." line from git --- should it? I lean softly towards no, since the user would have to seek out the alias to end up with it.

# Example usage
```toml
[templates]
draft_commit_description = '''
concat(
  description,
  "\n",
  scissors,
  diff.stat(72),
  diff.git(),
  scissors,
)
'''
```

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
