### PR TITLE
cli: git push: allow signing commits on push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New template function `config(name)` to access to configuration variable from
   template.
 
+* New `git.sign-on-push` config option to automatically sign commits which are being
+  pushed to a Git remote.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -362,6 +362,11 @@
                     "type": "string",
                     "description": "The remote to which commits are pushed",
                     "default": "origin"
+                },
+                "sign-on-push": {
+                    "type": "boolean",
+                    "description": "Whether jj should sign commits before pushing",
+                    "default": "false"
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -15,6 +15,7 @@ context = 3
 
 [git]
 push-bookmark-prefix = "push-"
+sign-on-push = false
 
 [ui]
 # TODO: delete ui.allow-filesets in jj 0.26+

--- a/docs/config.md
+++ b/docs/config.md
@@ -1027,6 +1027,26 @@ as follows:
 backends.ssh.allowed-signers = "/path/to/allowed-signers"
 ```
 
+### Sign commits only on `jj git push`
+
+Instead of signing all commits during creation when `signing.sign-all` is
+set to `true`, the `git.sign-on-push` configuration can be used to sign
+commits only upon running `jj git push`. All mutable unsigned commits
+being pushed will be signed prior to pushing. This might be preferred if the
+signing backend requires user interaction or is slow, so that signing is
+performed in a single batch operation.
+
+```toml
+# Configure signing backend as before, without setting `signing.sign-all`
+[signing]
+backend = "ssh"
+key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52avUqw5h"
+
+[git]
+sign-on-push = true
+```
+
+
 ## Commit Signature Verification
 
 By default signature verification and display is **disabled** as it incurs a


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->


This adds the `git.sign-on-push` configuration which can be used to
automatically sign unsigned commits before pushing to a Git remote.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [X] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
