### PR TITLE
lib: fix various typos

### DIFF
--- a/lib/src/dag_walk.rs
+++ b/lib/src/dag_walk.rs
@@ -277,7 +277,7 @@ impl<T: Ord, ID: Hash + Eq + Clone, E> TopoOrderReverseLazyInner<T, ID, E> {
     }
 }
 
-/// Splits DAG at single fork point, and extracts bookmarky part as sub graph.
+/// Splits DAG at single fork point, and extracts branchy part as sub graph.
 ///
 /// ```text
 ///  o | C
@@ -1067,7 +1067,7 @@ mod tests {
     }
 
     #[test]
-    fn test_topo_order_reverse_cycle_to_bookmarky_sub_graph() {
+    fn test_topo_order_reverse_cycle_to_branchy_sub_graph() {
         // This graph:
         //  o D
         //  |\

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -283,7 +283,7 @@ fn test_reparent_range_linear() {
 }
 
 #[test]
-fn test_reparent_range_bookmarky() {
+fn test_reparent_range_branchy() {
     let settings = testutils::user_settings();
     let test_repo = TestRepo::init();
     let repo_0 = test_repo.repo;
@@ -297,7 +297,7 @@ fn test_reparent_range_bookmarky() {
         parents.try_into().unwrap()
     }
 
-    // Set up bookmarky operation graph:
+    // Set up branchy operation graph:
     // G
     // |\
     // | F

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -264,7 +264,7 @@ fn test_rebase_descendants_backward() {
 }
 
 #[test]
-fn test_rebase_descendants_chain_becomes_bookmarky() {
+fn test_rebase_descendants_chain_becomes_branchy() {
     let settings = testutils::user_settings();
     let test_repo = TestRepo::init();
     let repo = &test_repo.repo;


### PR DESCRIPTION
This commit fixes typos unintentionally introduced in d9c68e08, when renaming `jj branch` to `jj bookmark`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
