### PR TITLE
merge_tools: add `"$marker_length"` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conflicts to be materialized and parsed correctly in files which already
   contain lines that look like conflict markers.
 
+* New `$marker_length` variable to allow merge tools to support longer conflict
+  markers (equivalent to "%L" for Git merge drivers).
+
 ### Fixed bugs
 
 * The `$NO_COLOR` environment variable must now be non-empty to be respected.

--- a/cli/testing/fake-editor.rs
+++ b/cli/testing/fake-editor.rs
@@ -27,6 +27,8 @@ use itertools::Itertools;
 struct Args {
     /// Path to the file to edit
     file: PathBuf,
+    /// Other arguments to the editor
+    other_args: Vec<String>,
 }
 
 fn main() {
@@ -60,6 +62,20 @@ fn main() {
                 let actual = String::from_utf8(fs::read(&args.file).unwrap()).unwrap();
                 if actual != payload {
                     eprintln!("fake-editor: Unexpected content.\n");
+                    eprintln!("EXPECTED: <{payload}>\nRECEIVED: <{actual}>");
+                    exit(1)
+                }
+            }
+            ["expect-arg", index] => {
+                let index = index.parse::<usize>().unwrap();
+                let Some(actual) = args.other_args.get(index) else {
+                    eprintln!("fake-editor: Missing argument at index {index}.\n");
+                    eprintln!("EXPECTED: <{payload}>");
+                    exit(1)
+                };
+
+                if actual != payload {
+                    eprintln!("fake-editor: Unexpected argument at index {index}.\n");
                     eprintln!("EXPECTED: <{payload}>\nRECEIVED: <{actual}>");
                     exit(1)
                 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -860,6 +860,11 @@ merge-tool-edits-conflict-markers = true    # See below for an explanation
 - `$base` is replaced with the path to a file containing the contents of the
   conflicted file in the last common ancestor of the two sides of the conflict.
 
+- `$marker_length` is replaced with the length of the conflict markers which
+  should be used for the file. This can be useful if the merge tool parses
+  and/or generates conflict markers. Usually, `jj` uses conflict markers of
+  length 7, but they can be longer if necessary to make parsing unambiguous.
+
 ### Editing conflict markers with a tool or a text editor
 
 By default, the merge tool starts with an empty output file. If the tool puts


### PR DESCRIPTION
Discussed previously here: https://github.com/jj-vcs/jj/pull/4969#discussion_r1859088488

Git supports passing the conflict marker length to merge drivers using "%L". It would be useful if we also had a way to pass the marker length to merge tools, since it would allow Git merge drivers to be used with `jj resolve` in more cases. Without this variable, any merge tool that parses or generates conflict markers could fail on files which require conflict markers longer than 7 characters.

https://git-scm.com/docs/gitattributes#_defining_a_custom_merge_driver

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
