### PR TITLE
cli: push new non-tracking bookmarks by default, rename --allow-new flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj absorb` now abandons the source commit if it becomes empty and has no
   description.
 
+* `jj git push` now pushes new non-tracking bookmarks by default. The
+  `--allow-new` flag (introduced by 0.24.0) and relates changes are reverted.
+  New `--allow-new-tracking` flag is required in order to push tracking
+  bookmarks to other remotes. [#5094](https://github.com/jj-vcs/jj/issues/5094)
+
 ### Deprecations
 
 * `--config-toml=TOML` is deprecated in favor of `--config=NAME=VALUE` and

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1154,7 +1154,7 @@ Create a new Git backed repo
 
 Push to a Git remote
 
-By default, pushes tracking bookmarks pointing to `remote_bookmarks(remote=<remote>)..@`. Use `--bookmark` to push specific bookmarks. Use `--all` to push all bookmarks. Use `--change` to generate bookmark names based on the change IDs of specific commits.
+By default, pushes new non-tracking and existing tracking bookmarks pointing to `remote_bookmarks(remote=<remote>)..@`. Use `--bookmark` to push specific bookmarks. Use `--all` to push all bookmarks. Use `--change` to generate bookmark names based on the change IDs of specific commits.
 
 Unlike in Git, the remote to push to is not derived from the tracked remote bookmarks. Use `--remote` to select the remote Git repository by name. There is no option to push to multiple remotes.
 
@@ -1181,7 +1181,7 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 * `--deleted` — Push all deleted bookmarks
 
    Only tracked bookmarks can be successfully deleted on the remote. A warning will be printed if any untracked bookmarks on the remote correspond to missing local bookmarks.
-* `-N`, `--allow-new` — Allow pushing new bookmarks
+* `-N`, `--allow-new-tracking` — Allow pushing tracking bookmarks to new remote
 
    Newly-created remote bookmarks will be tracked automatically.
 * `--allow-empty-description` — Allow pushing commits with empty descriptions

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -196,7 +196,7 @@ fn test_bookmark_move() {
 
     // Delete bookmark locally, but is still tracking remote
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-mcommit"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new", "-r@-"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push", "-r@-"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo"]);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     foo (deleted)
@@ -441,7 +441,7 @@ fn test_bookmark_rename() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-2"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bremote"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new", "-b=bremote"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push", "-b=bremote"]);
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "rename", "bremote", "bremote2"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -1081,7 +1081,7 @@ fn test_bookmark_track_conflict() {
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "a"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new", "-b", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push", "-b", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "main@origin"]);
     test_env.jj_cmd_ok(
         &repo_path,
@@ -1757,11 +1757,9 @@ fn test_bookmark_list_tracked() {
         &[
             "git",
             "push",
-            "--allow-new",
-            "--remote",
-            "upstream",
-            "--bookmark",
-            "remote-unsync",
+            "--allow-new-tracking",
+            "--remote=upstream",
+            "--bookmark=remote-unsync",
         ],
     );
     test_env.jj_cmd_ok(

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -49,10 +49,7 @@ fn test_bookmark_names() {
     test_env.jj_cmd_ok(&repo_path, &["desc", "-r", "aaa-tracked", "-m", "x"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bbb-tracked"]);
     test_env.jj_cmd_ok(&repo_path, &["desc", "-r", "bbb-tracked", "-m", "x"]);
-    test_env.jj_cmd_ok(
-        &repo_path,
-        &["git", "push", "--allow-new", "--bookmark", "glob:*-tracked"],
-    );
+    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--bookmark", "glob:*-tracked"]);
 
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "aaa-untracked"]);
     test_env.jj_cmd_ok(&origin_path, &["desc", "-r", "aaa-untracked", "-m", "x"]);

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -70,7 +70,7 @@ fn set_up_remote_at_main(test_env: &TestEnvironment, workspace_root: &Path, remo
         &[
             "git",
             "push",
-            "--allow-new",
+            "--allow-new-tracking",
             "--remote",
             remote_name,
             "-b=main",
@@ -166,10 +166,7 @@ fn test_git_private_commits_not_directly_in_line_block_pushing() {
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "bookmark1"]);
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
-    let stderr = test_env.jj_cmd_failure(
-        &workspace_root,
-        &["git", "push", "--allow-new", "-b=bookmark1"],
-    );
+    let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "-b=bookmark1"]);
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit f1253a9b1ea9 since it is private
     Hint: Rejected commit: yqosqzyt f1253a9b (empty) private 1
@@ -208,10 +205,8 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "-m=private 1"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m=public 3"]);
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main"]);
-    let (_, stderr) = test_env.jj_cmd_ok(
-        &workspace_root,
-        &["git", "push", "--allow-new", "-b=main", "-b=bookmark1"],
-    );
+    let (_, stderr) =
+        test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-b=main", "-b=bookmark1"]);
     insta::assert_snapshot!(stderr, @r#"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to fbb352762352
@@ -241,10 +236,7 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &["new", "description('private 1')", "-m=public 4"],
     );
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "bookmark2"]);
-    let (_, stderr) = test_env.jj_cmd_ok(
-        &workspace_root,
-        &["git", "push", "--allow-new", "-b=bookmark2"],
-    );
+    let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-b=bookmark2"]);
     insta::assert_snapshot!(stderr, @r#"
     Changes to push to origin:
       Add bookmark bookmark2 to ee5b808b0b95

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -58,7 +58,7 @@ fn test_git_push_undo() {
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
     //   Refs at this point look as follows (-- means no ref)
@@ -131,7 +131,7 @@ fn test_git_push_undo_with_import() {
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
     //   Refs at this point look as follows (-- means no ref)
@@ -211,7 +211,7 @@ fn test_git_push_undo_colocated() {
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
     //   Refs at this point look as follows (-- means no ref)
@@ -291,7 +291,7 @@ fn test_git_push_undo_repo_only() {
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     main: qpvuntsm 2080bdb8 (empty) AA
       @origin: qpvuntsm 2080bdb8 (empty) AA
@@ -335,7 +335,7 @@ fn test_bookmark_track_untrack_undo() {
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-mcommit"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "feature1", "feature2"]);
-    test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
+    test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "feature2"]);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     feature1: qpvuntsm 8da1cfc8 (empty) commit

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -194,8 +194,8 @@ makes several safety checks.
 
 3. If the remote bookmark already exists on the remote, it must be
    [tracked](#remotes-and-tracked-bookmarks). If the bookmark does not already
-   exist on the remote, there is no problem; `jj git push --allow-new` will
-   create the remote bookmark and mark it as tracked.
+   exist on the remote, there is no problem; `jj git push` will create the
+   remote bookmark and mark it as tracked.
 
 [^known-issue]: See "A general note on safety" in
     <https://git-scm.com/docs/git-push#Documentation/git-push.txt---no-force-with-lease>

--- a/docs/github.md
+++ b/docs/github.md
@@ -48,7 +48,7 @@ $ jj commit -m 'feat(bar): add support for bar'
 # on the working-copy commit's *parent* because the working copy itself is empty.
 $ jj bookmark create bar -r @- # `bar` now contains the previous two commits.
 # Push the bookmark to GitHub (pushes only `bar`)
-$ jj git push --allow-new
+$ jj git push
 ```
 
 While it's possible to create a bookmark in advance and commit on top of it in a
@@ -80,7 +80,7 @@ $ # Do some more work.
 $ jj commit -m "Update tutorial"
 # Create a bookmark on the working-copy commit's parent
 $ jj bookmark create doc-update -r @-
-$ jj git push --allow-new
+$ jj git push
 ```
 
 ## Working in a Jujutsu repository


### PR DESCRIPTION
#5094

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
