### PR TITLE
conflicts: allow missing newlines at end of file (based on `[noeol]` marker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `[diff.<format>]` configuration now applies to `.diff().<format>()` commit
   template methods.
 
+* Conflicts at the end of files which don't end with a newline character are
+  now materialized in a way that can be parsed correctly.
+  [#3968](https://github.com/jj-vcs/jj/issues/3968)
+
 ## [0.25.0] - 2025-01-01
 
 ### Release highlights

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -184,3 +184,33 @@ New Heading
 ===========
 >>>>>>>>>>>>>>> Conflict 1 of 1 ends
 ```
+
+## Conflict with no newline at end of file
+
+On POSIX systems, text files are generally assumed to be a series of lines, with
+each line terminated by a newline character. However, some files may not end
+with a newline character, and it's important that `jj` doesn't lose any
+information about the contents of a file when materializing conflicts.
+
+Therefore, when `jj` encounters a conflict involving a missing terminating
+newline character, it will add a `[noeol]` marker to the start of the conflict
+to indicate that there was a missing End-Of-Line (EOL) character, and it will
+automatically add a newline character after every base and side of the conflict.
+
+For instance, if a file originally contained "grape" as its last line with no
+terminating newline character, and one person changed "grape" to "grapefruit",
+while another person added the missing newline character, the resulting conflict
+would look like this:
+
+```
+<<<<<<< Conflict 1 of 1 [noeol]
++++++++ Contents of side #1
+grapefruit
+%%%%%%% Changes from base to side #2
+ grape
++
+>>>>>>> Conflict 1 of 1 ends
+```
+
+The correct resolution of this conflict would be "grapefruit" followed by a
+terminating newline character.


### PR DESCRIPTION
Fixes #3968 (this is an alternative to #4088). This is a rough draft of one possible solution. It's similar to what @yuja proposed with adding the "noeol" indicator to the comment part of the conflict marker, but I only added it to the `<<<<<<<` start marker. I think this makes the materialization and parsing easier since we don't need to handle adding markers for both the removes and adds in `%%%%%%%` diff sections, but I'm open to comments and other approaches.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
