### PR TITLE
conflicts: allow missing newlines at end of file (based on previous content)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [streampager](https://github.com/markbt/streampager/). It can handle large
   inputs better.
 
+* Conflicts materialized in the working copy before `jj 0.19.0` may no longer
+  be parsed correctly. If you are using version 0.18.0 or earlier, check out a
+  non-conflicted commit before upgrading to prevent issues.
+
 ### Deprecations
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `[diff.<format>]` configuration now applies to `.diff().<format>()` commit
   template methods.
 
+* Conflicts at the end of files which don't end with a newline character are
+  now materialized in a way that can be parsed correctly.
+  [#3968](https://github.com/jj-vcs/jj/issues/3968)
+
 ## [0.25.0] - 2025-01-01
 
 ### Release highlights

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -629,9 +629,9 @@ fn test_materialize_conflict_no_newlines_at_eof() {
     insta::assert_snapshot!(materialized,
         @r###"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    %%%%%%% Changes from base to side #1 [-noeol]
     -base
-    +++++++ Contents of side #2
+    +++++++ Contents of side #2 [noeol]
     right
     >>>>>>> Conflict 1 of 1 ends
     "###
@@ -2057,7 +2057,7 @@ fn test_update_conflict_from_content_no_eol() {
     +++++++ Contents of side #1
     base
     left
-    %%%%%%% Changes from base to side #2
+    %%%%%%% Changes from base to side #2 [noeol]
     -base
     +right
     >>>>>>> Conflict 2 of 2 ends
@@ -2096,9 +2096,9 @@ fn test_update_conflict_from_content_no_eol() {
     +++++++ Contents of side #1
     base
     left
-    ------- Contents of base
+    ------- Contents of base [noeol]
     base
-    +++++++ Contents of side #2
+    +++++++ Contents of side #2 [noeol]
     right
     >>>>>>> Conflict 2 of 2 ends
     "##
@@ -2134,11 +2134,11 @@ fn test_update_conflict_from_content_no_eol() {
     <<<<<<< Side #1 (Conflict 2 of 2)
     base
     left
-    ||||||| Base
+    ||||||| Base [noeol]
     base
     =======
     right
-    >>>>>>> Side #2 (Conflict 2 of 2 ends)
+    >>>>>>> Side #2 [noeol] (Conflict 2 of 2 ends)
     "##
     );
     // Parse with "diff" markers to ensure the file is actually parsed
@@ -2197,15 +2197,15 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     side
-    %%%%%%% Changes from base #1 to side #2
+    %%%%%%% Changes from base #1 to side #2 [-noeol]
      add newline
     -line
     +line
-    %%%%%%% Changes from base #2 to side #3
+    %%%%%%% Changes from base #2 to side #3 [+noeol]
      remove newline
     -line
     +line
-    %%%%%%% Changes from base #3 to side #4
+    %%%%%%% Changes from base #3 to side #4 [noeol]
      no newline
     -line 1
     +line 2
@@ -2253,7 +2253,7 @@ fn test_update_conflict_from_content_only_no_eol_change() {
         @r##"
     line 1
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    %%%%%%% Changes from base to side #1 [+noeol]
     +line 2
     +++++++ Contents of side #2
     line 2


### PR DESCRIPTION
Fixes #3968. Alternative to #5181 and #4088.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
