### PR TITLE
git: use merged parent tree for git index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The deprecated `--siblings` options for `jj split` has been removed.
   `jj split --parallel` can be used instead.
 
+* In colocated repos, the Git index now contains the changes from all parents
+  of the working copy instead of just the first parent (`HEAD`). 2-sided
+  conflicts from the merged parents are now added to the Git index as conflicts
+  as well.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2011,9 +2011,8 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
             .transpose()?;
 
         if self.working_copy_shared_with_git {
-            let git_repo = self.git_backend().unwrap().open_git_repo()?;
             if let Some(wc_commit) = &maybe_new_wc_commit {
-                git::reset_head(tx.repo_mut(), &git_repo, wc_commit)?;
+                git::reset_head(tx.repo_mut(), wc_commit)?;
             }
             let refs = git::export_refs(tx.repo_mut())?;
             print_failed_git_export(ui, &refs)?;

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -899,12 +899,15 @@ fn test_git_colocated_update_index_merge_conflict() {
     ◆  0000000000000000000000000000000000000000
     "#);
 
-    // The index should contain the tree of the Git HEAD. The stat for base.txt
-    // should not change.
+    // Conflict should be added in index with correct blob IDs. The stat for
+    // base.txt should not change.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Ours         Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Theirs       Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
+    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
     "#);
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -920,21 +923,14 @@ fn test_git_colocated_update_index_merge_conflict() {
     ◆  0000000000000000000000000000000000000000
     "#);
 
-    // The Git HEAD now contains ".jjconflict" files instead of the real contents.
+    // Index should be the same after `jj new`.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/base.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/conflict.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/left.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/right.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/base.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/conflict.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/left.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/right.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/base.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/conflict.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/left.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/right.txt
-    Unconflicted Mode(FILE) 5dc38902e68e ctime=0:0 mtime=0:0 size=0 README
+    Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
+    Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Ours         Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Theirs       Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
+    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
     "#);
 }
 
@@ -992,8 +988,8 @@ fn test_git_colocated_update_index_rebase_conflict() {
     ◆  0000000000000000000000000000000000000000
     "#);
 
-    // The index should contain the tree of the Git HEAD. The stat for base.txt
-    // should not change.
+    // Index should contain files from parent commit, so there should be no conflict
+    // in conflict.txt yet. The stat for base.txt should not change.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
@@ -1010,21 +1006,15 @@ fn test_git_colocated_update_index_rebase_conflict() {
     ◆  0000000000000000000000000000000000000000
     "#);
 
-    // The Git HEAD now contains ".jjconflict" files instead of the real contents.
+    // Now the working copy commit's parent is conflicted, so the index should have
+    // a conflict with correct blob IDs.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/base.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/conflict.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/left.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/right.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/base.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/conflict.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/left.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/right.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/base.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/conflict.txt
-    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/left.txt
-    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/right.txt
-    Unconflicted Mode(FILE) 5dc38902e68e ctime=0:0 mtime=0:0 size=0 README
+    Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
+    Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Ours         Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Theirs       Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
+    Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
     "#);
 }
 
@@ -1082,12 +1072,14 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ◆  0000000000000000000000000000000000000000
     "#);
 
-    // The index should contain the tree of the Git HEAD. The stat for base.txt
-    // should not change.
+    // We can't add conflicts with more than 2 sides to the index, so they should
+    // show as unconflicted. The stat for base.txt should not change.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
+    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
+    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
     "#);
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -1105,34 +1097,13 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ◆  0000000000000000000000000000000000000000
     "#);
 
-    // The Git HEAD now contains ".jjconflict" files instead of the real contents.
+    // Index should be the same after `jj new`.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/base.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/conflict.txt
-    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/side-1.txt
-    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/side-2.txt
-    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-0/side-3.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-1/base.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-1/conflict.txt
-    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-1/side-1.txt
-    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-1/side-2.txt
-    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 .jjconflict-base-1/side-3.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/base.txt
-    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/conflict.txt
-    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/side-1.txt
-    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/side-2.txt
-    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-0/side-3.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/base.txt
-    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/conflict.txt
-    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/side-1.txt
-    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/side-2.txt
-    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-1/side-3.txt
-    Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-2/base.txt
-    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-2/conflict.txt
-    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-2/side-1.txt
-    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-2/side-2.txt
-    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 .jjconflict-side-2/side-3.txt
-    Unconflicted Mode(FILE) 5dc38902e68e ctime=0:0 mtime=0:0 size=0 README
+    Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
+    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
+    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
+    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
     "#);
 }
 

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1072,9 +1072,10 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ◆  0000000000000000000000000000000000000000
     "#);
 
-    // We can't add conflicts with more than 2 sides to the index, so they should
-    // show as unconflicted. The stat for base.txt should not change.
+    // We can't add conflicts with more than 2 sides to the index, so we add a dummy
+    // conflict instead. The stat for base.txt should not change.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    Ours         Mode(FILE) eb8299123d2a ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
@@ -1099,6 +1100,20 @@ fn test_git_colocated_update_index_3_sided_conflict() {
 
     // Index should be the same after `jj new`.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    Ours         Mode(FILE) eb8299123d2a ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
+    Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
+    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
+    Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
+    Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
+    Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
+    "#);
+
+    // If we add a file named ".jj-do-not-resolve-this-conflict", it should take
+    // precedence over the dummy conflict.
+    std::fs::write(repo_path.join(".jj-do-not-resolve-this-conflict"), "file\n").unwrap();
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    Unconflicted Mode(FILE) f73f3093ff86 ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -703,7 +703,11 @@ pub fn export_some_refs(
                 current_oid.as_ref()
             };
             if new_oid != current_oid.as_ref() {
-                update_git_head(&git_repo, old_target, current_oid)?;
+                update_git_head(
+                    &git_repo,
+                    gix::refs::transaction::PreviousValue::MustExistAndMatch(old_target),
+                    current_oid,
+                )?;
             }
         }
     }
@@ -942,7 +946,7 @@ fn update_git_ref(
 /// is `None` (meaning absent), dummy placeholder ref will be set.
 fn update_git_head(
     git_repo: &gix::Repository,
-    old_target: gix::refs::Target,
+    expected_ref: gix::refs::transaction::PreviousValue,
     new_oid: Option<gix::ObjectId>,
 ) -> Result<(), GitExportError> {
     let mut ref_edits = Vec::new();
@@ -969,7 +973,7 @@ fn update_git_head(
                 message: "export from jj".into(),
                 ..Default::default()
             },
-            expected: gix::refs::transaction::PreviousValue::MustExistAndMatch(old_target),
+            expected: expected_ref,
             new: new_target,
         },
         name: "HEAD".try_into().unwrap(),

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2129,7 +2129,7 @@ fn test_reset_head_to_root() {
         .unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &git_repo, &commit2).unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).unwrap();
     assert!(git_repo.head().is_ok());
     assert_eq!(
         tx.repo_mut().git_head(),
@@ -2137,7 +2137,7 @@ fn test_reset_head_to_root() {
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &git_repo, &commit1).unwrap();
+    git::reset_head(tx.repo_mut(), &commit1).unwrap();
     assert!(git_repo.head().is_err());
     assert!(tx.repo_mut().git_head().is_absent());
 
@@ -2145,7 +2145,7 @@ fn test_reset_head_to_root() {
     git_repo
         .reference("refs/jj/root", git_id(&commit1), false, "")
         .unwrap();
-    git::reset_head(tx.repo_mut(), &git_repo, &commit2).unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).unwrap();
     assert!(git_repo.head().is_ok());
     assert_eq!(
         tx.repo_mut().git_head(),
@@ -2154,7 +2154,7 @@ fn test_reset_head_to_root() {
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &git_repo, &commit1).unwrap();
+    git::reset_head(tx.repo_mut(), &commit1).unwrap();
     assert!(git_repo.head().is_err());
     assert!(tx.repo_mut().git_head().is_absent());
     // The placeholder ref should be deleted
@@ -2204,7 +2204,7 @@ fn test_reset_head_with_index() {
         .unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &git_repo, &commit2).unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 
     // Add "staged changes" to the Git index
@@ -2221,7 +2221,7 @@ fn test_reset_head_with_index() {
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Unconflicted file.txt Mode(FILE)");
 
     // Reset head and the Git index
-    git::reset_head(tx.repo_mut(), &git_repo, &commit2).unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 }
 
@@ -2276,12 +2276,7 @@ fn test_reset_head_with_index_no_conflict() {
         .unwrap();
 
     // Reset head to working copy commit
-    git::reset_head(
-        mut_repo,
-        &git2::Repository::open(&workspace_root).unwrap(),
-        &wc_commit,
-    )
-    .unwrap();
+    git::reset_head(mut_repo, &wc_commit).unwrap();
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -2411,12 +2406,7 @@ fn test_reset_head_with_index_merge_conflict() {
         .unwrap();
 
     // Reset head to working copy commit with merge conflict
-    git::reset_head(
-        mut_repo,
-        &git2::Repository::open(&workspace_root).unwrap(),
-        &wc_commit,
-    )
-    .unwrap();
+    git::reset_head(mut_repo, &wc_commit).unwrap();
 
     // Files from left commit (HEAD) should be added to index as "Unconflicted".
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.


### PR DESCRIPTION
I had some free time over the holidays, so I thought I'd take a shot at #3979. I think this matches what was agreed upon as the best "step 1" in the issue discussion.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes