### PR TITLE
templates: add `tail` argument to truncate_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* `truncate_start` and `truncate_end` now accept an optional `tail` named
+  argument, to indicate when truncation has occurred.
+
 ### Release highlights
 
 ### Breaking changes

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -55,10 +55,14 @@ The following functions are defined.
 * `pad_end(width: Integer, content: Template[, fill_char: Template])`: Pad (or
   left-justify) content by adding trailing fill characters. The `content`
   shouldn't have newline character.
-* `truncate_start(width: Integer, content: Template)`: Truncate `content` by
-  removing leading characters. The `content` shouldn't have newline character.
-* `truncate_end(width: Integer, content: Template)`: Truncate `content` by
-  removing trailing characters. The `content` shouldn't have newline character.
+* `truncate_start(width: Integer, content: Template[, tail: Template])`:
+  Truncate `content` by removing leading characters. The `content` shouldn't
+  have newline character. If the content is truncated and `tail` was provided,
+  `tail` will be placed before `content`.
+* `truncate_end(width: Integer, content: Template[, tail: Template])`: Truncate
+  `content` by removing trailing characters. The `content` shouldn't have
+  newline character. If the content is truncated and `tail` was provided, `tail`
+  will be place after `content`.
 * `label(label: Template, content: Template) -> Template`: Apply label to
   the content. The `label` is evaluated as a space-separated string.
 * `raw_escape_sequence(content: Template) -> Template`: Preserves any escape


### PR DESCRIPTION
#5085 

The way this is implemented, the tail length is *not* taken into account when finding the truncation position. That means that `truncate_end(2, "abcdef", tail="...")` will result in `"ab..."`, a 5 character string.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have added tests to cover my changes
