### PR TITLE
nix: add name to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,7 @@
       });
 
       devShells.default = pkgs.mkShell {
+        name = "jujutsu";
         packages = with pkgs; [
           # NOTE (aseipp): explicitly add rust-src to the rustc compiler only in
           # devShell. this in turn causes a dependency on the rust compiler src,


### PR DESCRIPTION
This changes the `$name` environment variable from `nix-shell-env` to `jujutsu-env` when inside the nix-provided devshell.

Looks nicer / more descriptive if you use it as part of your prompt.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
