### PR TITLE
nix: use dynamic completions in installPhase

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,9 +127,9 @@
             installManPage ./jj.1
 
             installShellCompletion --cmd jj \
-              --bash <($out/bin/jj util completion bash) \
-              --fish <($out/bin/jj util completion fish) \
-              --zsh <($out/bin/jj util completion zsh)
+              --bash <(COMPLETE=bash $out/bin/jj) \
+              --fish <(COMPLETE=fish $out/bin/jj) \
+              --zsh <(COMPLETE=zsh $out/bin/jj)
           '';
 
           meta = {


### PR DESCRIPTION
Have been used in nixpkgs since the update to 0.24. This makes dynamic completions the default for those who use jj directly from the jj repo as well.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
