### PR TITLE
git: spawn a separate git process for network operations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,9 +86,20 @@ jobs:
         tool: nextest
     - name: Build
       run: cargo build --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
-    - name: Test
+    - name: Test [non-windows]
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: |
+        cargo nextest run --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
+      env:
+        RUST_BACKTRACE: 1
+        CARGO_TERM_COLOR: always
+    - name: Test [windows]
+      if: ${{ matrix.os == 'windows-latest' }}
       run: cargo nextest run --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
       env:
+        # tests clear the PATH variable (but is only felt on windows),
+        # so we need to set the git executable
+        TEST_GIT_EXECUTABLE_PATH: 'C:\Program Files\Git\bin\git.exe'
         RUST_BACKTRACE: 1
         CARGO_TERM_COLOR: always
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj git {push,clone,fetch}` can now spawn an external `git` subprocess, via
+   the `git.subprocess = true` config knob. This provides an alternative that,
+   when turned on, fixes SSH bugs when interacting with Git remotes due to
+   `libgit2`s limitations [#4979](https://github.com/jj-vcs/jj/issues/4979).
+
 * `jj describe` now accepts `--edit`.
 
 * `jj evolog` and `jj op log` now accept `--reversed`.

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -204,8 +204,7 @@ fn fetch_new_remote(
     )?;
     let git_settings = workspace_command.settings().git_settings()?;
     let mut fetch_tx = workspace_command.start_transaction();
-
-    let stats = with_remote_git_callbacks(ui, None, |cb| {
+    let stats = with_remote_git_callbacks(ui, None, &git_settings, |cb| {
         git::fetch(
             fetch_tx.repo_mut(),
             &git_repo,
@@ -222,6 +221,7 @@ fn fetch_new_remote(
         }
         GitFetchError::GitImportError(err) => CommandError::from(err),
         GitFetchError::InternalGitError(err) => map_git_error(err),
+        GitFetchError::Subprocess(err) => user_error(err),
         GitFetchError::InvalidBranchPattern => {
             unreachable!("we didn't provide any globs")
         }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -380,6 +380,16 @@
                     "type": "boolean",
                     "description": "Whether jj should sign commits before pushing",
                     "default": "false"
+                },
+                "subprocess": {
+                    "type": "boolean",
+                    "description": "Whether jj spawns a git subprocess for network operations (push/fetch/clone)",
+                    "default": false
+                },
+                "executable-path": {
+                    "type": "string",
+                    "description": "Path to the git executable",
+                    "default": "git"
                 }
             }
         },

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -41,6 +41,7 @@ use jj_lib::op_store::RefTarget;
 use jj_lib::op_store::RemoteRef;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
+use jj_lib::settings::GitSettings;
 use jj_lib::store::Store;
 use jj_lib::str_util::StringPattern;
 use jj_lib::workspace::Workspace;
@@ -286,29 +287,40 @@ type SidebandProgressCallback<'a> = &'a mut dyn FnMut(&[u8]);
 pub fn with_remote_git_callbacks<T>(
     ui: &Ui,
     sideband_progress_callback: Option<SidebandProgressCallback<'_>>,
+    git_settings: &GitSettings,
     f: impl FnOnce(git::RemoteCallbacks<'_>) -> T,
 ) -> T {
-    let mut callbacks = git::RemoteCallbacks::default();
-    let mut progress_callback = None;
-    if let Some(mut output) = ui.progress_output() {
-        let mut progress = Progress::new(Instant::now());
-        progress_callback = Some(move |x: &git::Progress| {
-            _ = progress.update(Instant::now(), x, &mut output);
-        });
+    if git_settings.subprocess {
+        // TODO: with git2, we are able to display progress from the data that is given
+        // With the git processes themselves, this is significantly harder, as it
+        // requires parsing the output directly
+        //
+        // In any case, this would be the place to add that funcionalty
+        f(git::RemoteCallbacks::default())
+    } else {
+        let mut callbacks = git::RemoteCallbacks::default();
+        let mut progress_callback = None;
+        if let Some(mut output) = ui.progress_output() {
+            let mut progress = Progress::new(Instant::now());
+            progress_callback = Some(move |x: &git::Progress| {
+                _ = progress.update(Instant::now(), x, &mut output);
+            });
+        }
+        callbacks.progress = progress_callback
+            .as_mut()
+            .map(|x| x as &mut dyn FnMut(&git::Progress));
+        callbacks.sideband_progress =
+            sideband_progress_callback.map(|x| x as &mut dyn FnMut(&[u8]));
+        let mut get_ssh_keys = get_ssh_keys; // Coerce to unit fn type
+        callbacks.get_ssh_keys = Some(&mut get_ssh_keys);
+        let mut get_pw =
+            |url: &str, _username: &str| pinentry_get_pw(url).or_else(|| terminal_get_pw(ui, url));
+        callbacks.get_password = Some(&mut get_pw);
+        let mut get_user_pw =
+            |url: &str| Some((terminal_get_username(ui, url)?, terminal_get_pw(ui, url)?));
+        callbacks.get_username_password = Some(&mut get_user_pw);
+        f(callbacks)
     }
-    callbacks.progress = progress_callback
-        .as_mut()
-        .map(|x| x as &mut dyn FnMut(&git::Progress));
-    callbacks.sideband_progress = sideband_progress_callback.map(|x| x as &mut dyn FnMut(&[u8]));
-    let mut get_ssh_keys = get_ssh_keys; // Coerce to unit fn type
-    callbacks.get_ssh_keys = Some(&mut get_ssh_keys);
-    let mut get_pw =
-        |url: &str, _username: &str| pinentry_get_pw(url).or_else(|| terminal_get_pw(ui, url));
-    callbacks.get_password = Some(&mut get_pw);
-    let mut get_user_pw =
-        |url: &str| Some((terminal_get_username(ui, url)?, terminal_get_pw(ui, url)?));
-    callbacks.get_username_password = Some(&mut get_user_pw);
-    f(callbacks)
 }
 
 pub fn print_git_import_stats(
@@ -639,7 +651,7 @@ pub fn git_fetch(
     let git_settings = tx.settings().git_settings()?;
 
     for remote in remotes {
-        let stats = with_remote_git_callbacks(ui, None, |cb| {
+        let stats = with_remote_git_callbacks(ui, None, &git_settings, |cb| {
             git::fetch(
                 tx.repo_mut(),
                 git_repo,

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -80,6 +80,7 @@ impl Default for TestEnvironment {
 'format_time_range(time_range)' = 'time_range.start() ++ " - " ++ time_range.end()'
         "#,
         );
+
         env
     }
 }
@@ -278,6 +279,18 @@ impl TestEnvironment {
 
     pub fn add_env_var(&mut self, key: impl Into<String>, val: impl Into<String>) {
         self.env_vars.insert(key.into(), val.into());
+    }
+
+    pub fn set_up_git_subprocessing(&self) {
+        self.add_config("git.subprocess = true");
+
+        // add a git path from env: this is only used if git.subprocess = true
+        if let Ok(git_executable_path) = std::env::var("TEST_GIT_EXECUTABLE_PATH") {
+            self.add_config(format!(
+                "git.executable-path = {}",
+                to_toml_value(git_executable_path)
+            ));
+        }
     }
 
     pub fn current_operation_id(&self, repo_path: &Path) -> String {

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -799,6 +799,7 @@ fn test_git_fetch_bookmarks_some_missing() {
     add_git_remote(&test_env, &repo_path, "origin");
     add_git_remote(&test_env, &repo_path, "rem1");
     add_git_remote(&test_env, &repo_path, "rem2");
+    add_git_remote(&test_env, &repo_path, "rem3");
 
     // single missing bookmark, implicit remotes (@origin)
     let (_stdout, stderr) =
@@ -838,22 +839,25 @@ fn test_git_fetch_bookmarks_some_missing() {
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &[
-            "git", "fetch", "--branch", "rem1", "--branch", "rem2", "--remote", "rem1", "--remote",
-            "rem2",
+            "git", "fetch", "--branch", "rem1", "--branch", "rem2", "--branch", "rem3", "--remote",
+            "rem1", "--remote", "rem2", "--remote", "rem3",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: rem1@rem1 [new] tracked
     bookmark: rem2@rem2 [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    bookmark: rem3@rem3 [new] tracked
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    rem3: lvsrtwwm 4ffdff2b message
+      @rem3: lvsrtwwm 4ffdff2b message
+    ");
 
     // multiple bookmarks, one exists, one doesn't
     let (_stdout, stderr) = test_env.jj_cmd_ok(
@@ -866,14 +870,16 @@ fn test_git_fetch_bookmarks_some_missing() {
     Warning: No branch matching `notexist` found on any specified/configured remote
     Nothing changed.
     "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    rem3: lvsrtwwm 4ffdff2b message
+      @rem3: lvsrtwwm 4ffdff2b message
+    ");
 }
 
 // See `test_undo_restore_commands.rs` for fetch-undo-push and fetch-undo-fetch

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 use std::path::Path;
 
+use test_case::test_case;
+
 use crate::common::TestEnvironment;
 
 /// Creates a remote Git repo containing a bookmark with the same name
@@ -72,56 +74,80 @@ fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
     test_env.jj_cmd_success(workspace_root, &["log", "-T", template, "-r", "all()"])
 }
 
-#[test]
-fn test_git_fetch_with_default_config() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_with_default_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin@origin: oputwtnw ffecd2d6 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_default_remote() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_default_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_single_remote() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_single_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "rem1");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Hint: Fetching from the only existing remote: rem1
     bookmark: rem1@rem1 [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_single_remote_all_remotes_flag() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -131,30 +157,42 @@ fn test_git_fetch_single_remote_all_remotes_flag() {
         .jj_cmd(&repo_path, &["git", "fetch", "--all-remotes"])
         .assert()
         .success();
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_single_remote_from_arg() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "rem1");
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote", "rem1"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_single_remote_from_config() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -162,15 +200,21 @@ fn test_git_fetch_single_remote_from_config() {
     test_env.add_config(r#"git.fetch = "rem1""#);
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_multiple_remotes() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_multiple_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -181,17 +225,23 @@ fn test_git_fetch_multiple_remotes() {
         &repo_path,
         &["git", "fetch", "--remote", "rem1", "--remote", "rem2"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_all_remotes() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_all_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -199,17 +249,23 @@ fn test_git_fetch_all_remotes() {
     add_git_remote(&test_env, &repo_path, "rem2");
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--all-remotes"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_multiple_remotes_from_config() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -218,17 +274,23 @@ fn test_git_fetch_multiple_remotes_from_config() {
     test_env.add_config(r#"git.fetch = ["rem1", "rem2"]"#);
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_nonexistent_remote() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "rem1");
@@ -237,37 +299,52 @@ fn test_git_fetch_nonexistent_remote() {
         &repo_path,
         &["git", "fetch", "--remote", "rem1", "--remote", "rem2"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: rem1@rem1 [new] untracked
     Error: No git remote named 'rem2'
     "###);
+    }
+    insta::allow_duplicates! {
     // No remote should have been fetched as part of the failing transaction
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
+    }
 }
 
-#[test]
-fn test_git_fetch_nonexistent_remote_from_config() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "rem1");
     test_env.add_config(r#"git.fetch = ["rem1", "rem2"]"#);
 
     let stderr = &test_env.jj_cmd_failure(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: rem1@rem1 [new] untracked
     Error: No git remote named 'rem2'
     "###);
     // No remote should have been fetched as part of the failing transaction
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
+    }
 }
 
-#[test]
-fn test_git_fetch_from_remote_named_git() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     let repo_path = test_env.env_root().join("repo");
     init_git_remote(&test_env, "git");
+
     let git_repo = git2::Repository::init(&repo_path).unwrap();
     git_repo.remote("git", "../git").unwrap();
 
@@ -276,15 +353,20 @@ fn test_git_fetch_from_remote_named_git() {
 
     // Try fetching from the remote named 'git'.
     let stderr = &test_env.jj_cmd_failure(&repo_path, &["git", "fetch", "--remote=git"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Error: Failed to import refs from underlying Git repo
     Caused by: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give different name.
     "###);
+    }
 
     // Implicit import shouldn't fail because of the remote ref.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "--all-remotes"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @"");
 
     // Explicit import is an error.
@@ -294,32 +376,43 @@ fn test_git_fetch_from_remote_named_git() {
     Caused by: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give different name.
     "###);
+    }
 
     // The remote can be renamed, and the ref can be imported.
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "git", "bar"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "--all-remotes"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @r###"
     git: mrylzrtu 76fc7466 message
       @bar: mrylzrtu 76fc7466 message
       @git: mrylzrtu 76fc7466 message
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Done importing changes from the underlying Git repo.
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_prune_before_updating_tips() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
     "###);
+    }
 
     // Remove origin bookmark in git repo and create origin/subname
     let git_repo = git2::Repository::open(test_env.env_root().join("origin")).unwrap();
@@ -330,15 +423,21 @@ fn test_git_fetch_prune_before_updating_tips() {
         .unwrap();
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin/subname: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_conflicting_bookmarks() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -347,41 +446,53 @@ fn test_git_fetch_conflicting_bookmarks() {
     // Create a rem1 bookmark locally
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "rem1"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: kkmpptxz fcdbbd73 (empty) (no description set)
     "###);
+    }
 
     test_env.jj_cmd_ok(
         &repo_path,
         &["git", "fetch", "--remote", "rem1", "--branch", "glob:*"],
     );
     // This should result in a CONFLICTED bookmark
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1 (conflicted):
       + kkmpptxz fcdbbd73 (empty) (no description set)
       + qxosxrvv 6a211027 message
       @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_conflicting_bookmarks_colocated() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     let repo_path = test_env.env_root().join("repo");
     let _git_repo = git2::Repository::init(&repo_path).unwrap();
     // create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "init", "--git-repo", "."]);
     add_git_remote(&test_env, &repo_path, "rem1");
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
+    }
 
     // Create a rem1 bookmark locally
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "rem1"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: zsuskuln f652c321 (empty) (no description set)
       @git: zsuskuln f652c321 (empty) (no description set)
     "###);
+    }
 
     test_env.jj_cmd_ok(
         &repo_path,
@@ -389,6 +500,7 @@ fn test_git_fetch_conflicting_bookmarks_colocated() {
     );
     // This should result in a CONFLICTED bookmark
     // See https://github.com/jj-vcs/jj/pull/1146#discussion_r1112372340 for the bug this tests for.
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1 (conflicted):
       + zsuskuln f652c321 (empty) (no description set)
@@ -396,6 +508,7 @@ fn test_git_fetch_conflicting_bookmarks_colocated() {
       @git (behind by 1 commits): zsuskuln f652c321 (empty) (no description set)
       @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
     "###);
+    }
 }
 
 // Helper functions to test obtaining multiple bookmarks at once and changed
@@ -427,9 +540,13 @@ fn create_trunk2_and_rebase_bookmarks(test_env: &TestEnvironment, repo_path: &Pa
     )
 }
 
-#[test]
-fn test_git_fetch_all() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_all(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let source_git_repo_path = test_env.env_root().join("source");
@@ -438,15 +555,20 @@ fn test_git_fetch_all() {
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     "###);
+    }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
@@ -457,21 +579,31 @@ fn test_git_fetch_all() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
 
     // Nothing in our repo before the fetch
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
     ◆  000000000000
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @"");
+    }
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+        }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
     "###);
+        }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
     a1: nknoxmzm 359a9a02 descr_for_a1
       @origin: nknoxmzm 359a9a02 descr_for_a1
@@ -482,6 +614,8 @@ fn test_git_fetch_all() {
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
       @origin: zowqyktl ff36dc55 descr_for_trunk1
     "###);
+        }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
@@ -493,10 +627,12 @@ fn test_git_fetch_all() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     ○  babc49226c14 descr_for_b b
@@ -508,6 +644,7 @@ fn test_git_fetch_all() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
         &target_jj_repo_path,
@@ -515,6 +652,7 @@ fn test_git_fetch_all() {
     );
 
     // Our repo before and after fetch
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  061eddbb43ab new_descr_for_b_to_create_conflict b*
@@ -526,6 +664,8 @@ fn test_git_fetch_all() {
     ├─╯
     ◆  000000000000
     "#);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
     a1: nknoxmzm 359a9a02 descr_for_a1
       @origin: nknoxmzm 359a9a02 descr_for_a1
@@ -536,8 +676,12 @@ fn test_git_fetch_all() {
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
       @origin: zowqyktl ff36dc55 descr_for_trunk1
     "###);
+    }
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin     [updated] tracked
     bookmark: a2@origin     [updated] tracked
@@ -545,6 +689,8 @@ fn test_git_fetch_all() {
     bookmark: trunk2@origin [new] tracked
     Abandoned 2 commits that are no longer reachable.
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
     a1: quxllqov 0424f6df descr_for_a1
       @origin: quxllqov 0424f6df descr_for_a1
@@ -560,6 +706,8 @@ fn test_git_fetch_all() {
     trunk2: umznmzko 8f1f14fb descr_for_trunk2
       @origin: umznmzko 8f1f14fb descr_for_trunk2
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  babc49226c14 descr_for_b b?? b@origin
@@ -574,11 +722,16 @@ fn test_git_fetch_all() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 }
 
-#[test]
-fn test_git_fetch_some_of_many_bookmarks() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let source_git_repo_path = test_env.env_root().join("source");
@@ -587,15 +740,20 @@ fn test_git_fetch_some_of_many_bookmarks() {
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     "###);
+    }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
@@ -606,31 +764,43 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
 
     // Test an error message
     let stderr = test_env.jj_cmd_failure(
         &target_jj_repo_path,
         &["git", "fetch", "--branch", "glob:^:a*"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @"Error: Invalid branch pattern provided. When fetching, branch names and globs may not contain the characters `:`, `^`, `?`, `[`, `]`");
+    }
     let stderr = test_env.jj_cmd_failure(&target_jj_repo_path, &["git", "fetch", "--branch", "a*"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r"
     Error: Branch names may not include `*`.
     Hint: Prefix the pattern with `glob:` to expand `*` as a glob
     ");
+    }
 
     // Nothing in our repo before the fetch
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
     @  230dd059e1b0
     ◆  000000000000
     "###);
+    }
     // Fetch one bookmark...
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch", "--branch", "b"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: b@origin [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
@@ -638,21 +808,29 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ├─╯
     ◆  000000000000
     "#);
+    }
     // ...check what the intermediate state looks like...
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
     b: vpupmnsl c7d4bdcb descr_for_b
       @origin: vpupmnsl c7d4bdcb descr_for_b
     "###);
+    }
     // ...then fetch two others with a glob.
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
         &["git", "fetch", "--branch", "glob:a*"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin [new] tracked
     bookmark: a2@origin [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -664,10 +842,14 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ├─╯
     ◆  000000000000
     "#);
+    }
     // Fetching the same bookmark again
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch", "--branch", "a1"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Nothing changed.
     "###);
@@ -682,10 +864,12 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     ○  01d115196c39 descr_for_b b
@@ -697,6 +881,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
         &target_jj_repo_path,
@@ -704,6 +889,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     );
 
     // Our repo before and after fetch of two bookmarks
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b*
@@ -715,16 +901,22 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ├─╯
     ◆  000000000000
     "#);
+    }
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
         &["git", "fetch", "--branch", "b", "--branch", "a1"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
     Abandoned 1 commits that are no longer reachable.
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  01d115196c39 descr_for_b b?? b@origin
@@ -739,8 +931,10 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 
     // We left a2 where it was before, let's see how `jj bookmark list` sees this.
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
     a1: ypowunwp 6df2d34c descr_for_a1
       @origin: ypowunwp 6df2d34c descr_for_a1
@@ -752,17 +946,23 @@ fn test_git_fetch_some_of_many_bookmarks() {
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
     "###);
+    }
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
     // anything.
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
         &["git", "fetch", "--branch", "b", "--branch", "glob:a*"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a2@origin [updated] tracked
     Abandoned 1 commits that are no longer reachable.
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  31c7d94b1f29 descr_for_a2 a2
@@ -777,6 +977,8 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ├─╯
     ◆  000000000000
     "#);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
     a1: ypowunwp 6df2d34c descr_for_a1
       @origin: ypowunwp 6df2d34c descr_for_a1
@@ -788,11 +990,16 @@ fn test_git_fetch_some_of_many_bookmarks() {
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_bookmarks_some_missing() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -804,11 +1011,15 @@ fn test_git_fetch_bookmarks_some_missing() {
     // single missing bookmark, implicit remotes (@origin)
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--branch", "noexist"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Warning: No branch matching `noexist` found on any specified/configured remote
     Nothing changed.
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
+    }
 
     // multiple missing bookmarks, implicit remotes (@origin)
     let (_stdout, stderr) = test_env.jj_cmd_ok(
@@ -817,22 +1028,30 @@ fn test_git_fetch_bookmarks_some_missing() {
             "git", "fetch", "--branch", "noexist1", "--branch", "noexist2",
         ],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Warning: No branch matching `noexist1` found on any specified/configured remote
     Warning: No branch matching `noexist2` found on any specified/configured remote
     Nothing changed.
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
+    }
 
     // single existing bookmark, implicit remotes (@origin)
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--branch", "origin"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: origin@origin [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
     "###);
+    }
 
     // multiple existing bookmark, explicit remotes, each bookmark is only in one
     // remote.
@@ -843,12 +1062,15 @@ fn test_git_fetch_bookmarks_some_missing() {
             "rem1", "--remote", "rem2", "--remote", "rem3",
         ],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r"
     bookmark: rem1@rem1 [new] tracked
     bookmark: rem2@rem2 [new] tracked
     bookmark: rem3@rem3 [new] tracked
     ");
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
+    }
+    insta::allow_duplicates! {
+     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
     rem1: qxosxrvv 6a211027 message
@@ -858,6 +1080,7 @@ fn test_git_fetch_bookmarks_some_missing() {
     rem3: lvsrtwwm 4ffdff2b message
       @rem3: lvsrtwwm 4ffdff2b message
     ");
+    }
 
     // multiple bookmarks, one exists, one doesn't
     let (_stdout, stderr) = test_env.jj_cmd_ok(
@@ -866,10 +1089,13 @@ fn test_git_fetch_bookmarks_some_missing() {
             "git", "fetch", "--branch", "rem1", "--branch", "notexist", "--remote", "rem1",
         ],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Warning: No branch matching `notexist` found on any specified/configured remote
     Nothing changed.
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
@@ -880,13 +1106,18 @@ fn test_git_fetch_bookmarks_some_missing() {
     rem3: lvsrtwwm 4ffdff2b message
       @rem3: lvsrtwwm 4ffdff2b message
     ");
+    }
 }
 
 // See `test_undo_restore_commands.rs` for fetch-undo-push and fetch-undo-fetch
 // of the same bookmarks for various kinds of undo.
-#[test]
-fn test_git_fetch_undo() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_undo(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
     let _git_repo = git2::Repository::init(source_git_repo_path.clone()).unwrap();
@@ -894,15 +1125,20 @@ fn test_git_fetch_undo() {
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     "###);
+    }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
@@ -913,13 +1149,17 @@ fn test_git_fetch_undo() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
 
     // Fetch 2 bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
         &["git", "fetch", "--branch", "b", "--branch", "a1"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin [new] tracked
     bookmark: b@origin  [new] tracked
@@ -933,8 +1173,12 @@ fn test_git_fetch_undo() {
     ├─╯
     ◆  000000000000
     "#);
+    }
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["undo"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r#"
     Undid operation: eb2029853b02 (2001-02-03 08:05:18) fetch from git remote(s) origin
     "#);
@@ -943,10 +1187,14 @@ fn test_git_fetch_undo() {
     @  230dd059e1b0
     ◆  000000000000
     "###);
+    }
     // Now try to fetch just one bookmark
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch", "--branch", "b"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: b@origin [new] tracked
     "###);
@@ -957,13 +1205,18 @@ fn test_git_fetch_undo() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 }
 
 // Compare to `test_git_import_undo` in test_git_import_export
 // TODO: Explain why these behaviors are useful
-#[test]
-fn test_fetch_undo_what() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_fetch_undo_what(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
     let _git_repo = git2::Repository::init(source_git_repo_path.clone()).unwrap();
@@ -971,15 +1224,20 @@ fn test_fetch_undo_what() {
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     "###);
+    }
     let repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
@@ -990,18 +1248,26 @@ fn test_fetch_undo_what() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
 
     // Initial state we will try to return to after `op restore`. There are no
     // bookmarks.
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
+    }
     let base_operation_id = test_env.current_operation_id(&repo_path);
 
     // Fetch a bookmark
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--branch", "b"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: b@origin [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
@@ -1009,10 +1275,13 @@ fn test_fetch_undo_what() {
     ├─╯
     ◆  000000000000
     "#);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     b: vpupmnsl c7d4bdcb descr_for_b
       @origin: vpupmnsl c7d4bdcb descr_for_b
     "###);
+    }
 
     // We can undo the change in the repo without moving the remote-tracking
     // bookmark
@@ -1020,23 +1289,31 @@ fn test_fetch_undo_what() {
         &repo_path,
         &["op", "restore", "--what", "repo", &base_operation_id],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r#"
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     "#);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     b (deleted)
       @origin: vpupmnsl hidden c7d4bdcb descr_for_b
     "###);
+    }
 
     // Now, let's demo restoring just the remote-tracking bookmark. First, let's
     // change our local repo state...
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "newbookmark"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     b (deleted)
       @origin: vpupmnsl hidden c7d4bdcb descr_for_b
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)
     "###);
+    }
     // Restoring just the remote-tracking state will not affect `newbookmark`, but
     // will eliminate `b@origin`.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1049,103 +1326,143 @@ fn test_fetch_undo_what() {
             &base_operation_id,
         ],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r#"
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     "#);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_remove_fetch() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_remove_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "origin"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin: qpvuntsm 230dd059 (empty) (no description set)
     "###);
+    }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
+    }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "remove", "origin"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
     "###);
+    }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "add", "origin", "../origin"]);
 
     // Check that origin@origin is properly recreated
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: origin@origin [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_rename_fetch() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_rename_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "origin"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin: qpvuntsm 230dd059 (empty) (no description set)
     "###);
+    }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
+    }
 
     test_env.jj_cmd_ok(
         &repo_path,
         &["git", "remote", "rename", "origin", "upstream"],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @upstream (behind by 1 commits): oputwtnw ffecd2d6 message
     "###);
+    }
 
     // Check that jj indicates that nothing has changed
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote", "upstream"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Nothing changed.
     "###);
+    }
 }
 
-#[test]
-fn test_git_fetch_removed_bookmark() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_removed_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
     let _git_repo = git2::Repository::init(source_git_repo_path.clone()).unwrap();
@@ -1153,15 +1470,20 @@ fn test_git_fetch_removed_bookmark() {
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     "###);
+    }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
@@ -1172,16 +1494,22 @@ fn test_git_fetch_removed_bookmark() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
 
     // Fetch all bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
@@ -1193,6 +1521,7 @@ fn test_git_fetch_removed_bookmark() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 
     // Remove a2 bookmark in origin
     test_env.jj_cmd_ok(&source_git_repo_path, &["bookmark", "forget", "a2"]);
@@ -1200,10 +1529,15 @@ fn test_git_fetch_removed_bookmark() {
     // Fetch bookmark a1 from origin and check that a2 is still there
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch", "--branch", "a1"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Nothing changed.
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
@@ -1215,11 +1549,15 @@ fn test_git_fetch_removed_bookmark() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 
     // Fetch bookmarks a2 from origin, and check that it has been removed locally
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch", "--branch", "a2"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a2@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
@@ -1233,11 +1571,16 @@ fn test_git_fetch_removed_bookmark() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 }
 
-#[test]
-fn test_git_fetch_removed_parent_bookmark() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
     let _git_repo = git2::Repository::init(source_git_repo_path.clone()).unwrap();
@@ -1245,15 +1588,20 @@ fn test_git_fetch_removed_parent_bookmark() {
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "target"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     "###);
+    }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r###"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
@@ -1264,16 +1612,22 @@ fn test_git_fetch_removed_parent_bookmark() {
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
     "###);
+    }
 
     // Fetch all bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
@@ -1285,6 +1639,7 @@ fn test_git_fetch_removed_parent_bookmark() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 
     // Remove all bookmarks in origin.
     test_env.jj_cmd_ok(&source_git_repo_path, &["bookmark", "forget", "glob:*"]);
@@ -1298,13 +1653,18 @@ fn test_git_fetch_removed_parent_bookmark() {
             "git", "fetch", "--branch", "master", "--branch", "trunk1", "--branch", "a1",
         ],
     );
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin     [deleted] untracked
     bookmark: trunk1@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
     Warning: No branch matching `master` found on any specified/configured remote
     "###);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
@@ -1314,11 +1674,16 @@ fn test_git_fetch_removed_parent_bookmark() {
     ├─╯
     ◆  000000000000
     "#);
+    }
 }
 
-#[test]
-fn test_git_fetch_remote_only_bookmark() {
+#[test_case(false; "use git2 for remote calls")]
+#[test_case(true; "spawn a git subprocess for remote calls")]
+fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
+    if subprocess {
+        test_env.set_up_git_subprocessing();
+    }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
@@ -1353,10 +1718,12 @@ fn test_git_fetch_remote_only_bookmark() {
     // Fetch using git.auto_local_bookmark = true
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
     "###);
+    }
 
     git_repo
         .commit(
@@ -1372,15 +1739,19 @@ fn test_git_fetch_remote_only_bookmark() {
     // Fetch using git.auto_local_bookmark = false
     test_env.add_config("git.auto-local-bookmark = false");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     @  230dd059e1b0
     │ ◆  9f01a0e04879 message feature1 feature2@origin
     ├─╯
     ◆  000000000000
     "#);
+    }
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
     feature2@origin: mzyxwzks 9f01a0e0 message
     "###);
+    }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1210,6 +1210,28 @@ from the private set.
 Private commits prevent their descendants from being pushed, since doing so
 would require pushing the private commit as well.
 
+### Git subprocessing behaviour
+
+By default, Git remote interactions are handled by [`libgit2`](https://github.com/libgit2/libgit2).
+This sometimes causes [SSH problems](https://github.com/jj-vcs/jj/issues/4979) that
+cannot be solved by `jj` directly.
+
+To sidestep this, there is an option to spawn a `git` subprocess to handle those
+remote interactions:
+
+```toml
+[git]
+subprocess = true
+```
+
+Additionally, if `git` is not on your OS path, or you want to specify a
+particular binary, you can:
+
+```toml
+[git]
+executable-path = "/path/to/git"
+```
+
 ## Filesystem monitor
 
 In large repositories, it may be beneficial to use a "filesystem monitor" to

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,9 @@
         # for signing tests
         gnupg
         openssh
+
+        # for git subprocess test
+        git
       ];
 
       env = {
@@ -111,6 +114,7 @@
               RUSTFLAGS = pkgs.lib.optionalString pkgs.stdenv.isLinux "-C link-arg=-fuse-ld=mold";
               NIX_JJ_GIT_HASH = self.rev or "";
               CARGO_INCREMENTAL = "0";
+              TEST_GIT_EXECUTABLE_PATH = pkgs.lib.getExe pkgs.git;
             };
 
           postInstall = ''

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -12,6 +12,8 @@ register_snapshot_trigger = false
 [git]
 abandon-unreachable-commits = true
 auto-local-bookmark = false
+subprocess = false
+executable-path = "git"
 
 [operation]
 hostname = ""

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -1,0 +1,593 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+use std::num::NonZeroU32;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Output;
+use std::process::Stdio;
+
+use bstr::ByteSlice;
+use thiserror::Error;
+
+use crate::git::RefSpec;
+use crate::git::RefToPush;
+
+/// Error originating by a Git subprocess
+#[derive(Error, Debug)]
+pub enum GitSubprocessError {
+    #[error("Could not find repository at '{0}'")]
+    NoSuchRepository(String),
+    #[error("Could not execute the git process, found in the OS path '{path}'")]
+    SpawnInPath {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
+    #[error("Could not execute git process at specified path '{path}'")]
+    Spawn {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
+    #[error("Failed to wait for the git process")]
+    Wait(std::io::Error),
+    #[error("Git process failed: {0}")]
+    External(String),
+}
+
+/// Context for creating Git subprocesses
+pub(crate) struct GitSubprocessContext<'a> {
+    git_dir: PathBuf,
+    git_executable_path: &'a Path,
+}
+
+impl<'a> GitSubprocessContext<'a> {
+    pub(crate) fn new(git_dir: impl Into<PathBuf>, git_executable_path: &'a Path) -> Self {
+        GitSubprocessContext {
+            git_dir: git_dir.into(),
+            git_executable_path,
+        }
+    }
+
+    pub(crate) fn from_git2(git_repo: &git2::Repository, git_executable_path: &'a Path) -> Self {
+        Self::new(git_repo.path(), git_executable_path)
+    }
+
+    /// Create the Git command
+    fn create_command(&self) -> Command {
+        let mut git_cmd = Command::new(self.git_executable_path);
+        // TODO: here we are passing the full path to the git_dir, which can lead to UNC
+        // bugs in Windows. The ideal way to do this is to pass the workspace
+        // root to Command::current_dir and then pass a relative path to the git
+        // dir
+        git_cmd
+            .arg("--bare")
+            .arg("--git-dir")
+            .arg(&self.git_dir)
+            .stdin(Stdio::null())
+            .stderr(Stdio::piped());
+
+        git_cmd
+    }
+
+    /// Spawn the git command
+    fn spawn_cmd(&self, mut git_cmd: Command) -> Result<Output, GitSubprocessError> {
+        tracing::debug!(cmd = ?git_cmd, "spawning a git subprocess");
+        let child_git = git_cmd.spawn().map_err(|error| {
+            if self.git_executable_path.is_absolute() {
+                GitSubprocessError::Spawn {
+                    path: self.git_executable_path.to_path_buf(),
+                    error,
+                }
+            } else {
+                GitSubprocessError::SpawnInPath {
+                    path: self.git_executable_path.to_path_buf(),
+                    error,
+                }
+            }
+        })?;
+
+        child_git
+            .wait_with_output()
+            .map_err(GitSubprocessError::Wait)
+    }
+
+    /// Perform a git fetch
+    ///
+    /// This returns a fully qualified ref that wasn't fetched successfully
+    /// Note that git only returns one failed ref at a time
+    pub(crate) fn spawn_fetch(
+        &self,
+        remote_name: &str,
+        depth: Option<NonZeroU32>,
+        refspecs: &[RefSpec],
+    ) -> Result<Option<String>, GitSubprocessError> {
+        if refspecs.is_empty() {
+            return Ok(None);
+        }
+        let mut command = self.create_command();
+        command.stdout(Stdio::piped());
+        command
+            .arg("fetch")
+            // attempt to prune stale refs
+            .arg("--prune");
+        if let Some(d) = depth {
+            command.arg(format!("--depth={d}"));
+        }
+        command.arg("--").arg(remote_name);
+        command.args(refspecs.iter().map(|x| x.to_git_format()));
+
+        let output = self.spawn_cmd(command)?;
+
+        parse_git_fetch_output(output)
+    }
+
+    /// Prune particular branches
+    pub(crate) fn spawn_branch_prune(
+        &self,
+        branches_to_prune: &[String],
+    ) -> Result<(), GitSubprocessError> {
+        if branches_to_prune.is_empty() {
+            return Ok(());
+        }
+        let mut command = self.create_command();
+        command.stdout(Stdio::null());
+        command.args(["branch", "--remotes", "--delete", "--"]);
+        command.args(branches_to_prune);
+
+        let output = self.spawn_cmd(command)?;
+
+        // we name the type to make sure that it is not meant to be used
+        let () = parse_git_branch_prune_output(output)?;
+
+        Ok(())
+    }
+
+    /// How we retrieve the remote's default branch:
+    ///
+    /// `git remote show <remote_name>`
+    ///
+    /// dumps a lot of information about the remote, with a line such as:
+    /// `  HEAD branch: <default_branch>`
+    pub(crate) fn spawn_remote_show(
+        &self,
+        remote_name: &str,
+    ) -> Result<Option<String>, GitSubprocessError> {
+        let mut command = self.create_command();
+        command.stdout(Stdio::piped());
+        command.args(["remote", "show", "--", remote_name]);
+        let output = self.spawn_cmd(command)?;
+
+        let output = parse_git_remote_show_output(output)?;
+
+        // find the HEAD branch line in the output
+        parse_git_remote_show_default_branch(&output.stdout)
+    }
+
+    /// Push references to git
+    ///
+    /// All pushes are forced, using --force-with-lease to perform a test&set
+    /// operation on the remote repository
+    ///
+    /// Return tuple with
+    ///     1. refs that failed to push
+    ///     2. refs that succeeded to push
+    pub(crate) fn spawn_push(
+        &self,
+        remote_name: &str,
+        references: &[RefToPush],
+    ) -> Result<(Vec<String>, Vec<String>), GitSubprocessError> {
+        let mut command = self.create_command();
+        command.stdout(Stdio::piped());
+        command.args(["push", "--porcelain"]);
+        command.args(
+            references
+                .iter()
+                .map(|reference| format!("--force-with-lease={}", reference.to_git_lease())),
+        );
+        command.args(["--", remote_name]);
+        // with --force-with-lease we cannot have the forced refspec,
+        // as it ignores the lease
+        command.args(
+            references
+                .iter()
+                .map(|r| r.refspec.to_git_format_not_forced()),
+        );
+
+        let output = self.spawn_cmd(command)?;
+
+        parse_git_push_output(output)
+    }
+}
+
+/// Generate a GitSubprocessError::ExternalGitError if the stderr output was not
+/// recognizable
+fn external_git_error(stderr: &[u8]) -> GitSubprocessError {
+    GitSubprocessError::External(format!(
+        "External git program failed:\n{}",
+        stderr.to_str_lossy()
+    ))
+}
+
+/// Parse no such remote errors output from git
+///
+/// Returns the remote that wasn't found
+///
+/// To say this, git prints out a lot of things, but the first line is of the
+/// form:
+/// `fatal: '<remote>' does not appear to be a git repository`
+/// or
+/// `fatal: '<remote>': Could not resolve host: invalid-remote
+fn parse_no_such_remote(stderr: &[u8]) -> Option<String> {
+    let first_line = stderr.lines().next()?;
+    let suffix = first_line
+        .strip_prefix(b"fatal: '")
+        .or_else(|| first_line.strip_prefix(b"fatal: unable to access '"))?;
+
+    suffix
+        .strip_suffix(b"' does not appear to be a git repository")
+        .or_else(|| suffix.strip_suffix(b"': Could not resolve host: invalid-remote"))
+        .map(|remote| remote.to_str_lossy().into_owned())
+}
+
+/// Parse error from refspec not present on the remote
+///
+/// This returns
+///     Some(local_ref) that wasn't found by the remote
+///     None if this wasn't the error
+///
+/// On git fetch even though --prune is specified, if a particular
+/// refspec is asked for but not present in the remote, git will error out.
+///
+/// Git only reports one of these errors at a time, so we only look at the first
+/// line
+///
+/// The first line is of the form:
+/// `fatal: couldn't find remote ref refs/heads/<ref>`
+fn parse_no_remote_ref(stderr: &[u8]) -> Option<String> {
+    let first_line = stderr.lines().next()?;
+    first_line
+        .strip_prefix(b"fatal: couldn't find remote ref ")
+        .map(|refname| refname.to_str_lossy().into_owned())
+}
+
+/// Parse remote tracking branch not found
+///
+/// This returns true if the error was detected
+///
+/// if a branch is asked for but is not present, jj will detect it post-hoc
+/// so, we want to ignore these particular errors with git
+///
+/// The first line is of the form:
+/// `error: remote-tracking branch '<branch>' not found`
+fn parse_no_remote_tracking_branch(stderr: &[u8]) -> Option<String> {
+    let first_line = stderr.lines().next()?;
+
+    let suffix = first_line.strip_prefix(b"error: remote-tracking branch '")?;
+
+    suffix
+        .strip_suffix(b"' not found.")
+        .or_else(|| suffix.strip_suffix(b"' not found"))
+        .map(|branch| branch.to_str_lossy().into_owned())
+}
+
+// return the fully qualified ref that failed to fetch
+//
+// note that git fetch only returns one error at a time
+fn parse_git_fetch_output(output: Output) -> Result<Option<String>, GitSubprocessError> {
+    if output.status.success() {
+        return Ok(None);
+    }
+
+    // There are some git errors we want to parse out
+    if let Some(remote) = parse_no_such_remote(&output.stderr) {
+        return Err(GitSubprocessError::NoSuchRepository(remote));
+    }
+
+    if let Some(refspec) = parse_no_remote_ref(&output.stderr) {
+        return Ok(Some(refspec));
+    }
+
+    if parse_no_remote_tracking_branch(&output.stderr).is_some() {
+        return Ok(None);
+    }
+
+    Err(external_git_error(&output.stderr))
+}
+
+fn parse_git_branch_prune_output(output: Output) -> Result<(), GitSubprocessError> {
+    if output.status.success() {
+        return Ok(());
+    }
+
+    // There are some git errors we want to parse out
+    if parse_no_remote_tracking_branch(&output.stderr).is_some() {
+        return Ok(());
+    }
+
+    Err(external_git_error(&output.stderr))
+}
+
+fn parse_git_remote_show_output(output: Output) -> Result<Output, GitSubprocessError> {
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    // There are some git errors we want to parse out
+    if let Some(remote) = parse_no_such_remote(&output.stderr) {
+        return Err(GitSubprocessError::NoSuchRepository(remote));
+    }
+
+    Err(external_git_error(&output.stderr))
+}
+
+fn parse_git_remote_show_default_branch(
+    stdout: &[u8],
+) -> Result<Option<String>, GitSubprocessError> {
+    stdout
+        .lines()
+        .map(|x| x.trim())
+        .find(|x| x.starts_with_str("HEAD branch:"))
+        .and_then(|x| x.split_str(" ").last().map(|y| y.trim()))
+        .filter(|branch_name| branch_name != b"(unknown)")
+        .map(|branch_name| branch_name.to_str())
+        .transpose()
+        .map_err(|e| GitSubprocessError::External(format!("git remote output is not utf-8: {e:?}")))
+        .map(|b| b.map(|x| x.to_string()))
+}
+
+// git-push porcelain has the following format (per line)
+// `<flag>\t<from>:<to>\t<summary>\t(<reason>)`
+//
+// <flag> is one of:
+//     ' ' for a successfully pushed fast-forward;
+//      + for a successful forced update
+//      - for a successfully deleted ref
+//      * for a successfully pushed new ref
+//      !  for a ref that was rejected or failed to push; and
+//      =  for a ref that was up to date and did not need pushing.
+//
+// <from>:<to> is the refspec
+//
+// <summary> is extra info (commit ranges or reason for rejected)
+// at times the summary is omitted
+//
+// <reason> is a human-readable explanation
+fn parse_ref_pushes(stdout: &[u8]) -> Result<(Vec<String>, Vec<String>), GitSubprocessError> {
+    if !stdout.starts_with(b"To ") {
+        return Err(GitSubprocessError::External(format!(
+            "Git push output unfamiliar:\n{}",
+            stdout.to_str_lossy()
+        )));
+    }
+
+    let mut pushed_refs = Vec::new();
+    let mut rejected_refs = Vec::new();
+    for (idx, line) in stdout
+        .lines()
+        .skip(1)
+        .take_while(|line| line != b"Done")
+        .enumerate()
+    {
+        // format:
+        // <flag>\t<ref>\t<summary>\t<comment>
+        // sometimes the summary is omitted
+        let create_error = || {
+            GitSubprocessError::External(format!(
+                "Line #{idx} of git-push has unknown format: {}",
+                line.to_str_lossy()
+            ))
+        };
+        let mut it = line.split_str("\t").fuse();
+        let flag = it.next().ok_or_else(create_error)?;
+        let reference = it.next().ok_or_else(create_error)?;
+        // we capture the remaining elements to ensure the line is well formed
+        let _summary_or_comment = it.next().ok_or_else(create_error)?;
+        let _comment_opt = it.next();
+        if it.next().is_some() {
+            return Err(create_error());
+        }
+
+        let full_refspec = reference
+            .to_str()
+            .map_err(|e| {
+                format!(
+                    "Line #{} of git-push has non-utf8 refspec {}: {}",
+                    idx,
+                    reference.to_str_lossy(),
+                    e
+                )
+            })
+            .map_err(GitSubprocessError::External)?;
+
+        let reference = full_refspec
+            .split_once(":")
+            .map(|(_refname, reference)| reference.to_string())
+            .ok_or_else(|| {
+                GitSubprocessError::External(format!(
+                    "Line #{idx} of git-push has full refspec without named ref: {full_refspec}"
+                ))
+            })?;
+
+        match flag {
+            // ' ' for a successfully pushed fast-forward;
+            //  + for a successful forced update
+            //  - for a successfully deleted ref
+            //  * for a successfully pushed new ref
+            //  =  for a ref that was up to date and did not need pushing.
+            b"+" | b"-" | b"*" | b"=" | b" " => {
+                pushed_refs.push(reference);
+            }
+            // ! for a ref that was rejected or failed to push; and
+            b"!" => {
+                rejected_refs.push(reference);
+            }
+            unknown => {
+                return Err(GitSubprocessError::External(format!(
+                    "Line #{} of git-push starts with an unknown flag '{}': '{}'",
+                    idx,
+                    unknown.to_str_lossy(),
+                    line.to_str_lossy()
+                )));
+            }
+        }
+    }
+
+    Ok((rejected_refs, pushed_refs))
+}
+
+// on Ok, return a tuple with
+//  1. list of failed references from test and set
+//  2. list of successful references pushed
+fn parse_git_push_output(output: Output) -> Result<(Vec<String>, Vec<String>), GitSubprocessError> {
+    if output.status.success() {
+        // TODO: figure out how to report `remote: ` logging nicely
+        // In sum, git apparently supports the remote repo sending a message to the
+        // local, which we should probably forward nicely
+        //
+        // If we support this, we can be a bit more strict, and say that messages other
+        // than these constitute an error
+        let ref_pushes = parse_ref_pushes(&output.stdout)?;
+        return Ok(ref_pushes);
+    }
+
+    if let Some(remote) = parse_no_such_remote(&output.stderr) {
+        return Err(GitSubprocessError::NoSuchRepository(remote));
+    }
+
+    if output
+        .stderr
+        .starts_with_str("error: failed to push some refs to ")
+    {
+        parse_ref_pushes(&output.stdout)
+    } else {
+        Err(external_git_error(&output.stderr))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const SAMPLE_NO_SUCH_REPOSITORY_ERROR: &[u8] =
+        br###"fatal: unable to access 'origin': Could not resolve host: invalid-remote
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists. "###;
+    const SAMPLE_NO_SUCH_REMOTE_ERROR: &[u8] =
+        br###"fatal: 'origin' does not appear to be a git repository
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists. "###;
+    const SAMPLE_NO_REMOTE_REF_ERROR: &[u8] = b"fatal: couldn't find remote ref refs/heads/noexist";
+    const SAMPLE_NO_REMOTE_TRACKING_BRANCH_ERROR: &[u8] =
+        b"error: remote-tracking branch 'bookmark' not found";
+    const SAMPLE_PUSH_REFS_PORCELAIN_OUTPUT: &[u8] = b"To origin
+*\tdeadbeef:refs/heads/bookmark1\tdeadbeef\t[new branch]
++\tdeadbeef:refs/heads/bookmark2\tdeadbeef\t[new branch]
+-\tdeadbeef:refs/heads/bookmark3\tdeadbeef\t[new branch]
+ \tdeadbeef:refs/heads/bookmark4\tdeadbeef\t[new branch]
+=\tdeadbeef:refs/heads/bookmark5\tdeadbeef\t[new branch]
+!\tdeadbeef:refs/heads/bookmark6\tdeadbeef\t[new branch]
+Done";
+    const SAMPLE_OK_STDERR: &[u8] = b"";
+
+    #[test]
+    fn test_parse_no_such_remote() {
+        assert_eq!(
+            parse_no_such_remote(SAMPLE_NO_SUCH_REPOSITORY_ERROR),
+            Some("origin".to_string())
+        );
+        assert_eq!(
+            parse_no_such_remote(SAMPLE_NO_SUCH_REMOTE_ERROR),
+            Some("origin".to_string())
+        );
+        assert_eq!(parse_no_such_remote(SAMPLE_NO_REMOTE_REF_ERROR), None);
+        assert_eq!(
+            parse_no_such_remote(SAMPLE_NO_REMOTE_TRACKING_BRANCH_ERROR),
+            None
+        );
+        assert_eq!(
+            parse_no_such_remote(SAMPLE_PUSH_REFS_PORCELAIN_OUTPUT),
+            None
+        );
+        assert_eq!(parse_no_such_remote(SAMPLE_OK_STDERR), None);
+    }
+
+    #[test]
+    fn test_parse_no_remote_ref() {
+        assert_eq!(parse_no_remote_ref(SAMPLE_NO_SUCH_REPOSITORY_ERROR), None);
+        assert_eq!(parse_no_remote_ref(SAMPLE_NO_SUCH_REMOTE_ERROR), None);
+        assert_eq!(
+            parse_no_remote_ref(SAMPLE_NO_REMOTE_REF_ERROR),
+            Some("refs/heads/noexist".to_string())
+        );
+        assert_eq!(
+            parse_no_remote_ref(SAMPLE_NO_REMOTE_TRACKING_BRANCH_ERROR),
+            None
+        );
+        assert_eq!(parse_no_remote_ref(SAMPLE_PUSH_REFS_PORCELAIN_OUTPUT), None);
+        assert_eq!(parse_no_remote_ref(SAMPLE_OK_STDERR), None);
+    }
+
+    #[test]
+    fn test_parse_no_remote_tracking_branch() {
+        assert_eq!(
+            parse_no_remote_tracking_branch(SAMPLE_NO_SUCH_REPOSITORY_ERROR),
+            None
+        );
+        assert_eq!(
+            parse_no_remote_tracking_branch(SAMPLE_NO_SUCH_REMOTE_ERROR),
+            None
+        );
+        assert_eq!(
+            parse_no_remote_tracking_branch(SAMPLE_NO_REMOTE_REF_ERROR),
+            None
+        );
+        assert_eq!(
+            parse_no_remote_tracking_branch(SAMPLE_NO_REMOTE_TRACKING_BRANCH_ERROR),
+            Some("bookmark".to_string())
+        );
+        assert_eq!(
+            parse_no_remote_tracking_branch(SAMPLE_PUSH_REFS_PORCELAIN_OUTPUT),
+            None
+        );
+        assert_eq!(parse_no_remote_tracking_branch(SAMPLE_OK_STDERR), None);
+    }
+
+    #[test]
+    fn test_parse_ref_pushes() {
+        assert!(parse_ref_pushes(SAMPLE_NO_SUCH_REPOSITORY_ERROR).is_err());
+        assert!(parse_ref_pushes(SAMPLE_NO_SUCH_REMOTE_ERROR).is_err());
+        assert!(parse_ref_pushes(SAMPLE_NO_REMOTE_REF_ERROR).is_err());
+        assert!(parse_ref_pushes(SAMPLE_NO_REMOTE_TRACKING_BRANCH_ERROR).is_err());
+        let (failed, success) = parse_ref_pushes(SAMPLE_PUSH_REFS_PORCELAIN_OUTPUT).unwrap();
+        assert_eq!(failed, vec!["refs/heads/bookmark6".to_string()]);
+        assert_eq!(
+            success,
+            vec![
+                "refs/heads/bookmark1".to_string(),
+                "refs/heads/bookmark2".to_string(),
+                "refs/heads/bookmark3".to_string(),
+                "refs/heads/bookmark4".to_string(),
+                "refs/heads/bookmark5".to_string(),
+            ]
+        );
+        assert!(parse_ref_pushes(SAMPLE_OK_STDERR).is_err());
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -65,6 +65,8 @@ pub mod git {
 }
 #[cfg(feature = "git")]
 pub mod git_backend;
+#[cfg(feature = "git")]
+mod git_subprocess;
 pub mod gitignore;
 pub mod gpg_signing;
 pub mod graph;

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -14,6 +14,7 @@
 
 #![allow(missing_docs)]
 
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -58,6 +59,8 @@ struct UserSettingsData {
 pub struct GitSettings {
     pub auto_local_bookmark: bool,
     pub abandon_unreachable_commits: bool,
+    pub subprocess: bool,
+    pub executable_path: PathBuf,
 }
 
 impl GitSettings {
@@ -65,6 +68,8 @@ impl GitSettings {
         Ok(GitSettings {
             auto_local_bookmark: settings.get_bool("git.auto-local-bookmark")?,
             abandon_unreachable_commits: settings.get_bool("git.abandon-unreachable-commits")?,
+            subprocess: settings.get_bool("git.subprocess")?,
+            executable_path: settings.get("git.executable-path")?,
         })
     }
 }
@@ -74,6 +79,8 @@ impl Default for GitSettings {
         GitSettings {
             auto_local_bookmark: false,
             abandon_unreachable_commits: true,
+            subprocess: false,
+            executable_path: PathBuf::from("git"),
         }
     }
 }


### PR DESCRIPTION
# Reasoning:

`jj` fails to push/fetch over ssh depending on the system.
Issue #4979 lists over 20 related issues on this and proposes spawning
a `git` subprocess for tasks related to the network (in fact, just push/fetch
are enough).

This PR implements this.
Users can either enable shelling out to git in a config file:

```toml
[git]
subprocess = true
```

# Implementation Details:

This PR implements shelling out to `git` via `std::process::Command`.
There are 2 sharp edges with the patch:
 - it relies on having to parse out git errors to match the error codes
   (and parsing git2's errors in one particular instance to match the
   error behaviour). This seems mostly unavoidable

 - to ensure matching behaviour with git2, the tests are maintained across the
   two implementations. This is done using test_case, as with the rest
   of the codebase

# Testing:

Run the rust tests:
```
$ cargo test
```

# Build:
```
$ cargo build
```

# Clone a private repo:
```
$ path/to/jj git clone --config='git.subprocess=true' <REPO_SSH_URL>
```

# Create new commit and push
```
$ echo "TEST" > this_is_a_test_file.txt
$ path/to/jj describe -m 'test commit'
$ path/to/jj git push --config='git.subprocess=true' -b <branch>
```


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Issues Closed

With a grain of salt, but most of these problems should be fixed (or at least checked if they are fixed). They are the ones listed in #4979 .

SSH:
- https://github.com/martinvonz/jj/issues/63
- https://github.com/martinvonz/jj/issues/440
- https://github.com/martinvonz/jj/issues/1455
- https://github.com/martinvonz/jj/issues/1507
- https://github.com/martinvonz/jj/issues/2931
- https://github.com/martinvonz/jj/issues/2958
- https://github.com/martinvonz/jj/issues/3322
- https://github.com/martinvonz/jj/issues/4101
- https://github.com/martinvonz/jj/issues/4333
- https://github.com/martinvonz/jj/issues/4386
- https://github.com/martinvonz/jj/issues/4488
- https://github.com/martinvonz/jj/issues/4591
- https://github.com/martinvonz/jj/issues/4802
- https://github.com/martinvonz/jj/issues/4870
- https://github.com/martinvonz/jj/issues/4937
- https://github.com/martinvonz/jj/issues/4978
- https://github.com/jj-vcs/jj/issues/5120
- https://github.com/jj-vcs/jj/issues/5166

Clone/fetch/push/pull:
- https://github.com/martinvonz/jj/issues/360 
- https://github.com/martinvonz/jj/issues/1278
- https://github.com/martinvonz/jj/issues/1957
- https://github.com/martinvonz/jj/issues/2295
- https://github.com/martinvonz/jj/issues/3851
- https://github.com/martinvonz/jj/issues/4177
- https://github.com/martinvonz/jj/issues/4682
- https://github.com/martinvonz/jj/issues/4719
- https://github.com/martinvonz/jj/issues/4889
- https://github.com/jj-vcs/jj/discussions/5147
- https://github.com/jj-vcs/jj/issues/5238

Notable Holdouts:
 - Interactive HTTP authentication (https://github.com/martinvonz/jj/issues/401, https://github.com/martinvonz/jj/issues/469)
 - libssh2-sys dependency on windows problem (can only be removed if/when we get rid of libgit2): https://github.com/martinvonz/jj/issues/3984 

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
