### PR TITLE
cli: add "ui.editor" type that captures configuration

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2836,26 +2836,6 @@ impl LogContentFormat {
     }
 }
 
-pub fn run_ui_editor(settings: &UserSettings, edit_path: &Path) -> Result<(), CommandError> {
-    let editor = TextEditor::from_settings(settings)?;
-    editor.edit_file(edit_path)?;
-    Ok(())
-}
-
-pub fn edit_temp_file(
-    error_name: &str,
-    tempfile_suffix: &str,
-    dir: &Path,
-    content: &str,
-    settings: &UserSettings,
-) -> Result<String, CommandError> {
-    let editor = TextEditor::from_settings(settings)?.with_temp_dir(dir);
-    let edited = editor
-        .edit_str(content, Some(tempfile_suffix))
-        .map_err(|err| err.with_name(error_name))?;
-    Ok(edited)
-}
-
 pub fn short_commit_hash(commit_id: &CommitId) -> String {
     format!("{commit_id:.12}")
 }

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -62,6 +62,8 @@ use thiserror::Error;
 use crate::cli_util::short_operation_hash;
 use crate::config::ConfigEnvError;
 use crate::description_util::ParseBulkEditMessageError;
+use crate::description_util::TempTextEditError;
+use crate::description_util::TextEditError;
 use crate::diff_util::DiffRenderError;
 use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
@@ -440,6 +442,24 @@ impl From<MergeToolConfigError> for CommandError {
             }
             _ => user_error_with_message("Failed to load tool configuration", err),
         }
+    }
+}
+
+impl From<TextEditError> for CommandError {
+    fn from(err: TextEditError) -> Self {
+        user_error(err)
+    }
+}
+
+impl From<TempTextEditError> for CommandError {
+    fn from(err: TempTextEditError) -> Self {
+        let hint = err.path.as_ref().map(|path| {
+            let name = err.name.as_deref().unwrap_or("file");
+            format!("Edited {name} is left in {path}", path = path.display())
+        });
+        let mut cmd_err = user_error(err);
+        cmd_err.extend_hints(hint);
+        cmd_err
     }
 }
 

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -87,6 +87,7 @@ pub(crate) fn cmd_commit(
     let advanceable_bookmarks = workspace_command.get_advanceable_bookmarks(commit.parent_ids())?;
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
+    let text_editor = workspace_command.text_editor()?;
     let mut tx = workspace_command.start_transaction();
     let base_tree = commit.parent_tree(tx.repo())?;
     let format_instructions = || {
@@ -138,11 +139,7 @@ new working-copy commit.
         }
         let temp_commit = commit_builder.write_hidden()?;
         let template = description_template(ui, &tx, "", &temp_commit)?;
-        edit_description(
-            tx.base_workspace_helper().repo_path(),
-            &template,
-            command.settings(),
-        )?
+        edit_description(&text_editor, &template)?
     };
     commit_builder.set_description(description);
     let new_commit = commit_builder.write(tx.repo_mut())?;

--- a/cli/src/commands/config/edit.rs
+++ b/cli/src/commands/config/edit.rs
@@ -15,7 +15,6 @@
 use tracing::instrument;
 
 use super::ConfigLevelArgs;
-use crate::cli_util::run_ui_editor;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
@@ -36,9 +35,11 @@ pub fn cmd_config_edit(
     command: &CommandHelper,
     args: &ConfigEditArgs,
 ) -> Result<(), CommandError> {
+    let editor = command.text_editor()?;
     let file = args.level.edit_config_file(command)?;
     if !file.path().exists() {
         file.save()?;
     }
-    run_ui_editor(command.settings(), file.path())
+    editor.edit_file(file.path())?;
+    Ok(())
 }

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -110,6 +110,7 @@ pub(crate) fn cmd_describe(
         return Ok(());
     }
     workspace_command.check_rewritable(commits.iter().ids())?;
+    let text_editor = workspace_command.text_editor()?;
 
     let mut tx = workspace_command.start_transaction();
     let tx_description = if commits.len() == 1 {
@@ -172,12 +173,7 @@ pub(crate) fn cmd_describe(
 
         if let [(_, temp_commit)] = &*temp_commits {
             let template = description_template(ui, &tx, "", temp_commit)?;
-            let description = edit_description(
-                tx.base_workspace_helper().repo_path(),
-                &template,
-                command.settings(),
-            )?;
-
+            let description = edit_description(&text_editor, &template)?;
             vec![(&commits[0], description)]
         } else {
             let ParsedBulkEditMessage {
@@ -185,7 +181,7 @@ pub(crate) fn cmd_describe(
                 missing,
                 duplicates,
                 unexpected,
-            } = edit_multiple_descriptions(ui, &tx, &temp_commits, command.settings())?;
+            } = edit_multiple_descriptions(ui, &text_editor, &tx, &temp_commits)?;
             if !missing.is_empty() {
                 return Err(user_error(format!(
                     "The description for the following commits were not found in the edited \

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -101,6 +101,7 @@ pub(crate) fn cmd_split(
         args.tool.as_deref(),
         args.interactive || args.paths.is_empty(),
     )?;
+    let text_editor = workspace_command.text_editor()?;
     let mut tx = workspace_command.start_transaction();
     let end_tree = commit.tree()?;
     let base_tree = commit.parent_tree(tx.repo())?;
@@ -151,11 +152,7 @@ The remainder will be in the second commit.
             "Enter a description for the first commit.",
             &temp_commit,
         )?;
-        let description = edit_description(
-            tx.base_workspace_helper().repo_path(),
-            &template,
-            command.settings(),
-        )?;
+        let description = edit_description(&text_editor, &template)?;
         commit_builder.set_description(description);
         commit_builder.write(tx.repo_mut())?
     };
@@ -195,11 +192,7 @@ The remainder will be in the second commit.
                 "Enter a description for the second commit.",
                 &temp_commit,
             )?;
-            edit_description(
-                tx.base_workspace_helper().repo_path(),
-                &template,
-                command.settings(),
-            )?
+            edit_description(&text_editor, &template)?
         };
         commit_builder.set_description(description);
         commit_builder.write(tx.repo_mut())?

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -78,6 +78,7 @@ pub(crate) fn cmd_unsquash(
     } else {
         None
     };
+    let text_editor = workspace_command.text_editor()?;
     let mut tx = workspace_command.start_transaction();
     let parent_base_tree = parent.parent_tree(tx.repo())?;
     let new_parent_tree_id;
@@ -116,12 +117,7 @@ aborted.
     // case).
     if new_parent_tree_id == parent_base_tree.id() {
         tx.repo_mut().record_abandoned_commit(parent.id().clone());
-        let description = combine_messages(
-            tx.base_workspace_helper().repo_path(),
-            &[&parent],
-            &commit,
-            command.settings(),
-        )?;
+        let description = combine_messages(&text_editor, &[&parent], &commit)?;
         // Commit the new child on top of the parent's parents.
         tx.repo_mut()
             .rewrite_commit(&commit)

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -140,9 +140,17 @@ fn test_describe() {
     std::fs::write(&edit_script, "fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe"]);
     insta::with_settings!({
-        filters => [(r"\bEditor '[^']*'", "Editor '<redacted>'")],
+        filters => [
+            (r"\bEditor '[^']*'", "Editor '<redacted>'"),
+            (r"\b(editor-)[^.]*(\.jjdescription)\b", "$1<redacted>$2"),
+            ("exit code", "exit status"), // Windows
+        ],
     }, {
-        insta::assert_snapshot!(stderr, @"Error: Editor '<redacted>' exited with an error");
+        insta::assert_snapshot!(stderr, @r"
+        Error: Failed to edit description
+        Caused by: Editor '<redacted>' exited with exit status: 1
+        Hint: Edited description is left in $TEST_ENV/repo/.jj/repo/editor-<redacted>.jjdescription
+        ");
     });
 
     // ignore everything after the first ignore-rest line
@@ -417,9 +425,17 @@ fn test_describe_multiple_commits() {
     std::fs::write(&edit_script, "fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
     insta::with_settings!({
-        filters => [(r"\bEditor '[^']*'", "Editor '<redacted>'")],
+        filters => [
+            (r"\bEditor '[^']*'", "Editor '<redacted>'"),
+            (r"\b(editor-)[^.]*(\.jjdescription)\b", "$1<redacted>$2"),
+            ("exit code", "exit status"), // Windows
+        ],
     }, {
-        insta::assert_snapshot!(stderr, @"Error: Editor '<redacted>' exited with an error");
+        insta::assert_snapshot!(stderr, @r"
+        Error: Failed to edit description
+        Caused by: Editor '<redacted>' exited with exit status: 1
+        Hint: Edited description is left in $TEST_ENV/repo/.jj/repo/editor-<redacted>.jjdescription
+        ");
     });
 
     // describe lines should take priority over ignore-rest

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -139,7 +139,11 @@ fn test_describe() {
     // Fails if the editor fails
     std::fs::write(&edit_script, "fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe"]);
-    assert!(stderr.contains("exited with an error"));
+    insta::with_settings!({
+        filters => [(r"\bEditor '[^']*'", "Editor '<redacted>'")],
+    }, {
+        insta::assert_snapshot!(stderr, @"Error: Editor '<redacted>' exited with an error");
+    });
 
     // ignore everything after the first ignore-rest line
     std::fs::write(
@@ -412,7 +416,11 @@ fn test_describe_multiple_commits() {
     // Fails if the editor fails
     std::fs::write(&edit_script, "fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    assert!(stderr.contains("exited with an error"));
+    insta::with_settings!({
+        filters => [(r"\bEditor '[^']*'", "Editor '<redacted>'")],
+    }, {
+        insta::assert_snapshot!(stderr, @"Error: Editor '<redacted>' exited with an error");
+    });
 
     // describe lines should take priority over ignore-rest
     std::fs::write(


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
