### PR TITLE
Enable `useless_conversion` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ implicit_clone = "warn"
 needless_for_each = "warn"
 semicolon_if_nothing_returned = "warn"
 uninlined_format_args = "warn"
+useless_conversion = "warn"
 
 # Insta suggests compiling these packages in opt mode for faster testing.
 # See https://docs.rs/insta/latest/insta/#optional-faster-runs.

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -887,9 +887,7 @@ fn diff_content(
             is_binary: false,
             contents: format!("Access denied: {err}").into_bytes(),
         }),
-        MaterializedTreeValue::File { mut reader, .. } => {
-            file_content_for_diff(&mut reader).map_err(Into::into)
-        }
+        MaterializedTreeValue::File { mut reader, .. } => file_content_for_diff(&mut reader),
         MaterializedTreeValue::Symlink { id: _, target } => Ok(FileContent {
             // Unix file paths can't contain null bytes.
             is_binary: false,


### PR DESCRIPTION
The code is already clean, except for one occurrence of a useless call to `Into::into()`.