### PR TITLE
perf: use `.next_back()` to get the last component

### DIFF
--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -212,7 +212,7 @@ pub fn run_mergetool_external(
     };
 
     let temp_dir = new_utf8_temp_dir("jj-resolve-").map_err(ExternalToolError::SetUpDir)?;
-    let suffix = if let Some(filename) = repo_path.components().last() {
+    let suffix = if let Some(filename) = repo_path.components().next_back() {
         let name = filename
             .to_fs_name()
             .map_err(|err| err.with_path(repo_path))?;


### PR DESCRIPTION
Using `.last()` needs to go through all components first instead of splitting only the last one.

