### PR TITLE
add builtin_op_log_oneline template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `merge-tools.<TOOL>.diff-expected-exit-codes` config option to suppress
   warnings from tools exiting with non-zero exit codes.
 
+* Add a new template alias `builtin_op_log_oneline` along with `format_operation_oneline` and `format_snapshot_operation_oneline`
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -151,6 +151,15 @@ label(if(current_operation, "current_operation"),
 )
 '''
 builtin_op_log_comfortable = 'builtin_op_log_compact ++ "\n"'
+builtin_op_log_oneline = '''
+label(if(current_operation, "current_operation"),
+  coalesce(
+    if(snapshot, format_snapshot_operation_oneline(self)),
+    if(root, format_root_operation(self)),
+    format_operation_oneline(self),
+  )
+)
+'''
 
 description_placeholder = 'label("description placeholder", "(no description set)")'
 email_placeholder = 'label("email placeholder", "(no email set)")'
@@ -236,6 +245,16 @@ if(ref.tracking_present(), surround("(", ")", separate(", ",
 '''
 'format_snapshot_operation(op)' = 'format_operation(op)'
 'format_root_operation(root)' = 'separate(" ", root.id().short(), label("root", "root()")) ++ "\n"'
+
+
+'format_operation_oneline(op)' = '''
+  separate(" ",
+    op.id().short(), op.user(), format_time_range(op.time()),
+    op.description().first_line(), 
+    if(op.tags(), op.tags()),
+  ) ++ "\n"
+'''
+'format_snapshot_operation_oneline(op)' = 'format_operation_oneline(op)'
 
 # We have "hidden" override "divergent", since a hidden revision does not cause
 # change id conflicts and is not affected by such conflicts; you have to use the

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -326,7 +326,7 @@ fn test_evolog_with_no_template() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["evolog", "-T"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--template <TEMPLATE>' but none was supplied
 
     For more information, try '--help'.
@@ -342,11 +342,12 @@ fn test_evolog_with_no_template() {
     - builtin_op_log_compact
     - builtin_op_log_node
     - builtin_op_log_node_ascii
+    - builtin_op_log_oneline
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
     - name_placeholder
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -36,7 +36,7 @@ fn test_log_with_no_template() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["log", "-T"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--template <TEMPLATE>' but none was supplied
 
     For more information, try '--help'.
@@ -52,11 +52,12 @@ fn test_log_with_no_template() {
     - builtin_op_log_compact
     - builtin_op_log_node
     - builtin_op_log_node_ascii
+    - builtin_op_log_oneline
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
     - name_placeholder
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -141,7 +141,7 @@ fn test_op_log_with_no_template() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["op", "log", "-T"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--template <TEMPLATE>' but none was supplied
 
     For more information, try '--help'.
@@ -157,11 +157,12 @@ fn test_op_log_with_no_template() {
     - builtin_op_log_compact
     - builtin_op_log_node
     - builtin_op_log_node_ascii
+    - builtin_op_log_oneline
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
     - name_placeholder
-    "#);
+    ");
 }
 
 #[test]
@@ -299,6 +300,13 @@ fn test_op_log_builtin_templates() {
 
     [EOF]
     "#);
+
+    insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @r"
+    d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22 args: jj describe -m 'description 0'
+    eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    000000000000 root()
+    [EOF]
+    ");
 }
 
 #[test]

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -250,7 +250,7 @@ fn test_show_with_no_template() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["show", "-T"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--template <TEMPLATE>' but none was supplied
 
     For more information, try '--help'.
@@ -266,11 +266,12 @@ fn test_show_with_no_template() {
     - builtin_op_log_compact
     - builtin_op_log_node
     - builtin_op_log_node_ascii
+    - builtin_op_log_oneline
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
     - name_placeholder
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -113,7 +113,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword "builtin" doesn't exist
-    Hint: Did you mean "builtin_log_comfortable", "builtin_log_compact", "builtin_log_compact_full_description", "builtin_log_detailed", "builtin_log_node", "builtin_log_node_ascii", "builtin_log_oneline", "builtin_op_log_comfortable", "builtin_op_log_compact", "builtin_op_log_node", "builtin_op_log_node_ascii"?
+    Hint: Did you mean "builtin_log_comfortable", "builtin_log_compact", "builtin_log_compact_full_description", "builtin_log_detailed", "builtin_log_node", "builtin_log_node_ascii", "builtin_log_oneline", "builtin_op_log_comfortable", "builtin_op_log_compact", "builtin_op_log_node", "builtin_op_log_node_ascii", "builtin_op_log_oneline"?
     "#);
 }
 


### PR DESCRIPTION
I find one-line logs a *lot* more readable, so I really appreciate `jj log -T builtin_log_oneline` and would like to have the same available for `jj op log`:
![image](https://github.com/user-attachments/assets/a95fc896-0e30-46ab-85ae-b254f7f7c5b3)

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
  - I don't think this needs a special mention, as `builtin_log_oneline` doesn't have one either
- [x] I have updated the config schema (cli/src/config-schema.json): not applicable
- [x] I have added tests to cover my changes

# Option questions

Occasionally the single line won't be enough to display all the information
![image](https://github.com/user-attachments/assets/ad05d178-53c6-4e0b-9e20-8bfdcfcdb054)

In that case I think I would prefer to have `lasted t milliseconds -> lasted 5ms` and maybe shorten the commit id in the message, but that's something for another PR / personal configuration.