### PR TITLE
diff: add `merge-tools.*.diff-expected-exit-codes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj status` now shows untracked files when they reside directly under a tracked directory.
 
+* New `merge-tools.<TOOL>.diff-expected-exit-codes` config option to suppress
+  warnings from tools exiting with non-zero exit codes.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -380,6 +380,14 @@
                             "type": "string"
                         }
                     },
+                    "diff-expected-exit-codes": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Array of exit codes that do not indicate tool failure, i.e. [0, 1] for unix diff.",
+                        "default": [0]
+                    },
                     "diff-invocation-mode": {
                       "description": "Invoke the tool with directories or individual files",
                       "enum": [

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -393,13 +393,16 @@ mod tests {
         insta::assert_debug_snapshot!(get(":builtin", "").unwrap(), @"Builtin");
 
         // Just program name, edit_args are filled by default
-        insta::assert_debug_snapshot!(get("my diff", "").unwrap(), @r###"
+        insta::assert_debug_snapshot!(get("my diff", "").unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "my diff",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -412,7 +415,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // Pick from merge-tools
         insta::assert_debug_snapshot!(get(
@@ -420,13 +423,16 @@ mod tests {
         [merge-tools."foo bar"]
         edit-args = ["--edit", "args", "$left", "$right"]
         "#,
-        ).unwrap(), @r###"
+        ).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "foo bar",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -441,7 +447,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -463,13 +469,16 @@ mod tests {
         insta::assert_debug_snapshot!(get("").unwrap(), @"Builtin");
 
         // Just program name, edit_args are filled by default
-        insta::assert_debug_snapshot!(get(r#"ui.diff-editor = "my-diff""#).unwrap(), @r###"
+        insta::assert_debug_snapshot!(get(r#"ui.diff-editor = "my-diff""#).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "my-diff",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -482,17 +491,20 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // String args (with interpolation variables)
         insta::assert_debug_snapshot!(
-            get(r#"ui.diff-editor = "my-diff -l $left -r $right""#).unwrap(), @r###"
+            get(r#"ui.diff-editor = "my-diff -l $left -r $right""#).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "my-diff",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -507,17 +519,20 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // List args (with interpolation variables)
         insta::assert_debug_snapshot!(
-            get(r#"ui.diff-editor = ["my-diff", "--diff", "$left", "$right"]"#).unwrap(), @r###"
+            get(r#"ui.diff-editor = ["my-diff", "--diff", "$left", "$right"]"#).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "my-diff",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -531,7 +546,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // Pick from merge-tools
         insta::assert_debug_snapshot!(get(
@@ -540,13 +555,16 @@ mod tests {
         [merge-tools."foo bar"]
         edit-args = ["--edit", "args", "$left", "$right"]
         "#,
-        ).unwrap(), @r###"
+        ).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "foo bar",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -561,7 +579,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // Pick from merge-tools, but no edit-args specified
         insta::assert_debug_snapshot!(get(
@@ -570,7 +588,7 @@ mod tests {
         [merge-tools.my-diff]
         program = "MyDiff"
         "#,
-        ).unwrap(), @r###"
+        ).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "MyDiff",
@@ -578,6 +596,9 @@ mod tests {
                     "$left",
                     "$right",
                 ],
+                diff_expected_exit_codes: [
+                    0,
+                ],
                 diff_invocation_mode: Dir,
                 edit_args: [
                     "$left",
@@ -589,10 +610,10 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // List args should never be a merge-tools key, edit_args are filled by default
-        insta::assert_debug_snapshot!(get(r#"ui.diff-editor = ["meld"]"#).unwrap(), @r###"
+        insta::assert_debug_snapshot!(get(r#"ui.diff-editor = ["meld"]"#).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "meld",
@@ -600,6 +621,9 @@ mod tests {
                     "$left",
                     "$right",
                 ],
+                diff_expected_exit_codes: [
+                    0,
+                ],
                 diff_invocation_mode: Dir,
                 edit_args: [
                     "$left",
@@ -611,7 +635,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // Invalid type
         assert!(get(r#"ui.diff-editor.k = 0"#).is_err());
@@ -641,13 +665,16 @@ mod tests {
         [merge-tools."foo bar"]
         merge-args = ["$base", "$left", "$right", "$output"]
         "#,
-        ).unwrap(), @r###"
+        ).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "foo bar",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -665,7 +692,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -690,13 +717,16 @@ mod tests {
 
         // String args
         insta::assert_debug_snapshot!(
-            get(r#"ui.merge-editor = "my-merge $left $base $right $output""#).unwrap(), @r###"
+            get(r#"ui.merge-editor = "my-merge $left $base $right $output""#).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "my-merge",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -714,19 +744,22 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // List args
         insta::assert_debug_snapshot!(
             get(
                 r#"ui.merge-editor = ["my-merge", "$left", "$base", "$right", "$output"]"#,
-            ).unwrap(), @r###"
+            ).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "my-merge",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -744,7 +777,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // Pick from merge-tools
         insta::assert_debug_snapshot!(get(
@@ -753,13 +786,16 @@ mod tests {
         [merge-tools."foo bar"]
         merge-args = ["$base", "$left", "$right", "$output"]
         "#,
-        ).unwrap(), @r###"
+        ).unwrap(), @r#"
         External(
             ExternalMergeTool {
                 program: "foo bar",
                 diff_args: [
                     "$left",
                     "$right",
+                ],
+                diff_expected_exit_codes: [
+                    0,
                 ],
                 diff_invocation_mode: Dir,
                 edit_args: [
@@ -777,7 +813,7 @@ mod tests {
                 conflict_marker_style: None,
             },
         )
-        "###);
+        "#);
 
         // List args should never be a merge-tools key
         insta::assert_debug_snapshot!(

--- a/docs/config.md
+++ b/docs/config.md
@@ -295,6 +295,15 @@ diff.tool = "vimdiff"
 diff-invocation-mode = "file-by-file"
 ```
 
+By default `jj` will display a warning when the command exits with a non-success
+error code. The `diff-expected-exit-codes` config can suppress this warning
+message for specific exit codes:
+
+```toml
+[merge-tools.delta]
+diff-expected-exit-codes = [0, 1]
+```
+
 ### Conflict marker style
 
 You can configure which style of conflict markers to use when materializing


### PR DESCRIPTION
#5250

Certain tools (`diff`, `delta`) exit with code 1 to indicate there was
a difference. This allows selectively suppressing the "Tool exited with
... status" warning from jj when generating a diff.

example:
```toml
[merge.tools.delta]
diff-expected-exit-codes = [1]
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
