### PR TITLE
cli: make git support optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         RUST_BACKTRACE: 1
 
   build-no-git:
-    name: Build jj-lib without Git support
+    name: Build without Git support
     runs-on: ubuntu-24.04
 
     steps:
@@ -91,7 +91,7 @@ jobs:
       with:
         toolchain: 1.76
     - name: Build
-      run: cargo build -p jj-lib --no-default-features --verbose
+      run: cargo build -p jj-cli --no-default-features --verbose
 
   check-protos:
     name: Check protos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,6 @@ dependencies = [
  "version_check",
  "watchman_client",
  "winreg",
- "zstd",
 ]
 
 [[package]]
@@ -4078,33 +4077,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,6 @@ version_check = "0.9.5"
 watchman_client = { version = "0.9.0" }
 whoami = "1.5.2"
 winreg = "0.52"
-zstd = "0.12.4"
 
 # put all inter-workspace libraries, i.e. those that use 'path = ...' here in
 # their own (alphabetically sorted) block

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ winreg = "0.52"
 # put all inter-workspace libraries, i.e. those that use 'path = ...' here in
 # their own (alphabetically sorted) block
 
-jj-lib = { path = "lib", version = "0.25.0" }
+jj-lib = { path = "lib", version = "0.25.0", default-features = false }
 jj-lib-proc-macros = { path = "lib/proc-macros", version = "0.25.0" }
 testutils = { path = "lib/testutils" }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ include = [
     "/tests/",
     "!*.pending-snap",
     "!*.snap*",
-    "/tests/cli-reference@.md.snap"
+    "/tests/cli-reference@.md.snap",
 ]
 
 [[bin]]
@@ -61,8 +61,8 @@ crossterm = { workspace = true }
 dirs = { workspace = true }
 dunce = { workspace = true }
 futures = { workspace = true }
-git2 = { workspace = true }
-gix = { workspace = true }
+git2 = { workspace = true, optional = true }
+gix = { workspace = true, optional = true }
 glob = { workspace = true }
 indexmap = { workspace = true }
 indoc = { workspace = true }
@@ -109,8 +109,9 @@ testutils = { workspace = true }
 jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 
 [features]
-default = ["watchman"]
+default = ["watchman", "git"]
 bench = ["dep:criterion"]
+git = ["jj-lib/git", "dep:git2", "dep:gix"]
 gix-max-performance = ["jj-lib/gix-max-performance"]
 packaging = ["gix-max-performance"]
 test-fakes = ["jj-lib/testing"]

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -16,7 +16,6 @@ use std::collections::HashSet;
 
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools;
-use jj_lib::git;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::str_util::StringPattern;
 
@@ -174,8 +173,7 @@ pub fn cmd_bookmark_list(
             .partition::<Vec<_>, _>(|&(_, remote_ref)| remote_ref.is_tracking());
 
         if args.tracked {
-            tracking_remote_refs
-                .retain(|&(remote, _)| remote != git::REMOTE_NAME_FOR_LOCAL_GIT_REPO);
+            tracking_remote_refs.retain(|&(remote, _)| !jj_lib::git::is_special_git_remote(remote));
         } else if !args.all_remotes && args.remotes.is_none() {
             tracking_remote_refs.retain(|&(_, remote_ref)| remote_ref.target != *local_target);
         }
@@ -199,7 +197,7 @@ pub fn cmd_bookmark_list(
             found_deleted_local_bookmark = true;
             found_deleted_tracking_local_bookmark |= tracking_remote_refs
                 .iter()
-                .any(|&(remote, _)| remote != git::REMOTE_NAME_FOR_LOCAL_GIT_REPO);
+                .any(|&(remote, _)| !jj_lib::git::is_special_git_remote(remote));
         }
 
         if !args.tracked && (args.all_remotes || args.remotes.is_some()) {

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -24,7 +24,6 @@ mod untrack;
 
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
-use jj_lib::git;
 use jj_lib::op_store::RefTarget;
 use jj_lib::op_store::RemoteRef;
 use jj_lib::repo::Repo;
@@ -186,7 +185,7 @@ fn has_tracked_remote_bookmarks(view: &View, bookmark: &str) -> bool {
         &StringPattern::exact(bookmark),
         &StringPattern::everything(),
     )
-    .filter(|&((_, remote_name), _)| remote_name != git::REMOTE_NAME_FOR_LOCAL_GIT_REPO)
+    .filter(|&((_, remote_name), _)| !jj_lib::git::is_special_git_remote(remote_name))
     .any(|(_, remote_ref)| remote_ref.is_tracking())
 }
 

--- a/cli/src/commands/bookmark/untrack.rs
+++ b/cli/src/commands/bookmark/untrack.rs
@@ -14,7 +14,6 @@
 
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
-use jj_lib::git;
 
 use super::find_remote_bookmarks;
 use crate::cli_util::CommandHelper;
@@ -53,7 +52,7 @@ pub fn cmd_bookmark_untrack(
     let view = workspace_command.repo().view();
     let mut names = Vec::new();
     for (name, remote_ref) in find_remote_bookmarks(view, &args.names)? {
-        if name.remote == git::REMOTE_NAME_FOR_LOCAL_GIT_REPO {
+        if jj_lib::git::is_special_git_remote(&name.remote) {
             // This restriction can be lifted if we want to support untracked @git
             // bookmarks.
             writeln!(

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -29,6 +29,7 @@ mod edit;
 mod evolog;
 mod file;
 mod fix;
+#[cfg(feature = "git")]
 mod git;
 mod help;
 mod init;
@@ -102,6 +103,7 @@ enum Command {
     #[command(subcommand)]
     File(file::FileCommand),
     Fix(fix::FixArgs),
+    #[cfg(feature = "git")]
     #[command(subcommand)]
     Git(git::GitCommand),
     Help(help::HelpArgs),
@@ -186,6 +188,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Edit(args) => edit::cmd_edit(ui, command_helper, args),
         Command::File(args) => file::cmd_file(ui, command_helper, args),
         Command::Fix(args) => fix::cmd_fix(ui, command_helper, args),
+        #[cfg(feature = "git")]
         Command::Git(args) => git::cmd_git(ui, command_helper, args),
         Command::Help(args) => help::cmd_help(ui, command_helper, args),
         Command::Init(args) => init::cmd_init(ui, command_helper, args),

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -23,7 +23,6 @@ use jj_lib::backend::ChangeId;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
 use jj_lib::dag_walk;
-use jj_lib::git::REMOTE_NAME_FOR_LOCAL_GIT_REPO;
 use jj_lib::graph::GraphEdge;
 use jj_lib::graph::TopoGroupedGraphIterator;
 use jj_lib::matchers::EverythingMatcher;
@@ -354,7 +353,7 @@ pub fn show_op_diff(
     )
     // Skip updates to the local git repo, since they should typically be covered in
     // local branches.
-    .filter(|((_, remote_name), _)| *remote_name != REMOTE_NAME_FOR_LOCAL_GIT_REPO)
+    .filter(|((_, remote_name), _)| !jj_lib::git::is_special_git_remote(remote_name))
     .collect_vec();
     if !changed_remote_bookmarks.is_empty() {
         writeln!(formatter)?;

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -15,15 +15,20 @@
 //! Git utilities shared by various commands.
 
 use std::error;
+use std::io;
 use std::io::Read;
 use std::io::Write;
 use std::iter;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::time::Duration;
 use std::time::Instant;
 
+use crossterm::terminal::Clear;
+use crossterm::terminal::ClearType;
 use itertools::Itertools;
+use jj_lib::fmt_util::binary_prefix;
 use jj_lib::git;
 use jj_lib::git::FailedRefExport;
 use jj_lib::git::FailedRefExportReason;
@@ -40,12 +45,13 @@ use jj_lib::str_util::StringPattern;
 use jj_lib::workspace::Workspace;
 use unicode_width::UnicodeWidthStr;
 
+use crate::cleanup_guard::CleanupGuard;
 use crate::cli_util::WorkspaceCommandTransaction;
 use crate::command_error::user_error;
 use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::formatter::Formatter;
-use crate::progress::Progress;
+use crate::ui::ProgressOutput;
 use crate::ui::Ui;
 
 pub fn map_git_error(err: git2::Error) -> CommandError {
@@ -326,6 +332,150 @@ pub fn print_git_import_stats(
     Ok(())
 }
 
+pub struct Progress {
+    next_print: Instant,
+    rate: RateEstimate,
+    buffer: String,
+    guard: Option<CleanupGuard>,
+}
+
+impl Progress {
+    pub fn new(now: Instant) -> Self {
+        Self {
+            next_print: now + crate::progress::INITIAL_DELAY,
+            rate: RateEstimate::new(),
+            buffer: String::new(),
+            guard: None,
+        }
+    }
+
+    pub fn update<W: std::io::Write>(
+        &mut self,
+        now: Instant,
+        progress: &git::Progress,
+        output: &mut ProgressOutput<W>,
+    ) -> io::Result<()> {
+        use std::fmt::Write as _;
+
+        if progress.overall == 1.0 {
+            write!(output, "\r{}", Clear(ClearType::CurrentLine))?;
+            output.flush()?;
+            return Ok(());
+        }
+
+        let rate = progress
+            .bytes_downloaded
+            .and_then(|x| self.rate.update(now, x));
+        if now < self.next_print {
+            return Ok(());
+        }
+        self.next_print = now + Duration::from_secs(1) / crate::progress::UPDATE_HZ;
+        if self.guard.is_none() {
+            let guard = output.output_guard(crossterm::cursor::Show.to_string());
+            let guard = CleanupGuard::new(move || {
+                drop(guard);
+            });
+            _ = write!(output, "{}", crossterm::cursor::Hide);
+            self.guard = Some(guard);
+        }
+
+        self.buffer.clear();
+        write!(self.buffer, "\r").unwrap();
+        let control_chars = self.buffer.len();
+        write!(self.buffer, "{: >3.0}% ", 100.0 * progress.overall).unwrap();
+        if let Some(total) = progress.bytes_downloaded {
+            let (scaled, prefix) = binary_prefix(total as f32);
+            write!(self.buffer, "{scaled: >5.1} {prefix}B ").unwrap();
+        }
+        if let Some(estimate) = rate {
+            let (scaled, prefix) = binary_prefix(estimate);
+            write!(self.buffer, "at {scaled: >5.1} {prefix}B/s ").unwrap();
+        }
+
+        let bar_width = output
+            .term_width()
+            .map(usize::from)
+            .unwrap_or(0)
+            .saturating_sub(self.buffer.len() - control_chars + 2);
+        self.buffer.push('[');
+        draw_progress(progress.overall, &mut self.buffer, bar_width);
+        self.buffer.push(']');
+
+        write!(self.buffer, "{}", Clear(ClearType::UntilNewLine)).unwrap();
+        write!(output, "{}", self.buffer)?;
+        output.flush()?;
+        Ok(())
+    }
+}
+
+fn draw_progress(progress: f32, buffer: &mut String, width: usize) {
+    const CHARS: [char; 9] = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];
+    const RESOLUTION: usize = CHARS.len() - 1;
+    let ticks = (width as f32 * progress.clamp(0.0, 1.0) * RESOLUTION as f32).round() as usize;
+    let whole = ticks / RESOLUTION;
+    for _ in 0..whole {
+        buffer.push(CHARS[CHARS.len() - 1]);
+    }
+    if whole < width {
+        let fraction = ticks % RESOLUTION;
+        buffer.push(CHARS[fraction]);
+    }
+    for _ in (whole + 1)..width {
+        buffer.push(CHARS[0]);
+    }
+}
+
+struct RateEstimate {
+    state: Option<RateEstimateState>,
+}
+
+impl RateEstimate {
+    pub fn new() -> Self {
+        RateEstimate { state: None }
+    }
+
+    /// Compute smoothed rate from an update
+    pub fn update(&mut self, now: Instant, total: u64) -> Option<f32> {
+        if let Some(ref mut state) = self.state {
+            return Some(state.update(now, total));
+        }
+
+        self.state = Some(RateEstimateState {
+            total,
+            avg_rate: None,
+            last_sample: now,
+        });
+        None
+    }
+}
+
+struct RateEstimateState {
+    total: u64,
+    avg_rate: Option<f32>,
+    last_sample: Instant,
+}
+
+impl RateEstimateState {
+    fn update(&mut self, now: Instant, total: u64) -> f32 {
+        let delta = total - self.total;
+        self.total = total;
+        let dt = now - self.last_sample;
+        self.last_sample = now;
+        let sample = delta as f32 / dt.as_secs_f32();
+        match self.avg_rate {
+            None => *self.avg_rate.insert(sample),
+            Some(ref mut avg_rate) => {
+                // From Algorithms for Unevenly Spaced Time Series: Moving
+                // Averages and Other Rolling Operators (Andreas Eckner, 2019)
+                const TIME_WINDOW: f32 = 2.0;
+                let alpha = 1.0 - (-dt.as_secs_f32() / TIME_WINDOW).exp();
+                *avg_rate += alpha * (sample - *avg_rate);
+                *avg_rate
+            }
+        }
+    }
+}
+
 struct RefStatus {
     ref_kind: RefKind,
     ref_name: String,
@@ -534,4 +684,63 @@ fn warn_if_branches_not_found(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    #[test]
+    fn test_bar() {
+        let mut buf = String::new();
+        draw_progress(0.0, &mut buf, 10);
+        assert_eq!(buf, "          ");
+        buf.clear();
+        draw_progress(1.0, &mut buf, 10);
+        assert_eq!(buf, "██████████");
+        buf.clear();
+        draw_progress(0.5, &mut buf, 10);
+        assert_eq!(buf, "█████     ");
+        buf.clear();
+        draw_progress(0.54, &mut buf, 10);
+        assert_eq!(buf, "█████▍    ");
+        buf.clear();
+    }
+
+    #[test]
+    fn test_update() {
+        let start = Instant::now();
+        let mut progress = Progress::new(start);
+        let mut current_time = start;
+        let mut update = |duration, overall| -> String {
+            current_time += duration;
+            let mut buf = vec![];
+            let mut output = ProgressOutput::for_test(&mut buf, 25);
+            progress
+                .update(
+                    current_time,
+                    &jj_lib::git::Progress {
+                        bytes_downloaded: None,
+                        overall,
+                    },
+                    &mut output,
+                )
+                .unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+        // First output is after the initial delay
+        assert_snapshot!(update(crate::progress::INITIAL_DELAY - Duration::from_millis(1), 0.1), @"");
+        assert_snapshot!(update(Duration::from_millis(1), 0.10), @"[?25l\r 10% [█▊                ][K");
+        // No updates for the next 30 milliseconds
+        assert_snapshot!(update(Duration::from_millis(10), 0.11), @"");
+        assert_snapshot!(update(Duration::from_millis(10), 0.12), @"");
+        assert_snapshot!(update(Duration::from_millis(10), 0.13), @"");
+        // We get an update now that we go over the threshold
+        assert_snapshot!(update(Duration::from_millis(100), 0.30), @" 30% [█████▍            ][K");
+        // Even though we went over by quite a bit, the new threshold is relative to the
+        // previous output, so we don't get an update here
+        assert_snapshot!(update(Duration::from_millis(30), 0.40), @"");
+    }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -25,7 +25,19 @@ pub mod description_util;
 pub mod diff_util;
 pub mod formatter;
 pub mod generic_templater;
+#[cfg(feature = "git")]
 pub mod git_util;
+#[cfg(not(feature = "git"))]
+/// A stub module that provides a no-op implementation of some of the functions
+/// in the `git` module.
+pub mod git_util {
+    use jj_lib::repo::ReadonlyRepo;
+    use jj_lib::workspace::Workspace;
+
+    pub fn is_colocated_git_workspace(_workspace: &Workspace, _repo: &ReadonlyRepo) -> bool {
+        false
+    }
+}
 pub mod graphlog;
 pub mod merge_tools;
 pub mod movement_util;

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -6,162 +5,15 @@ use std::time::Instant;
 
 use crossterm::terminal::Clear;
 use crossterm::terminal::ClearType;
-use jj_lib::fmt_util::binary_prefix;
-use jj_lib::git;
 use jj_lib::repo_path::RepoPath;
 
-use crate::cleanup_guard::CleanupGuard;
 use crate::text_util;
 use crate::ui::OutputGuard;
 use crate::ui::ProgressOutput;
 use crate::ui::Ui;
 
-pub struct Progress {
-    next_print: Instant,
-    rate: RateEstimate,
-    buffer: String,
-    guard: Option<CleanupGuard>,
-}
-
-impl Progress {
-    pub fn new(now: Instant) -> Self {
-        Self {
-            next_print: now + INITIAL_DELAY,
-            rate: RateEstimate::new(),
-            buffer: String::new(),
-            guard: None,
-        }
-    }
-
-    pub fn update<W: std::io::Write>(
-        &mut self,
-        now: Instant,
-        progress: &git::Progress,
-        output: &mut ProgressOutput<W>,
-    ) -> io::Result<()> {
-        use std::fmt::Write as _;
-
-        if progress.overall == 1.0 {
-            write!(output, "\r{}", Clear(ClearType::CurrentLine))?;
-            output.flush()?;
-            return Ok(());
-        }
-
-        let rate = progress
-            .bytes_downloaded
-            .and_then(|x| self.rate.update(now, x));
-        if now < self.next_print {
-            return Ok(());
-        }
-        self.next_print = now + Duration::from_secs(1) / UPDATE_HZ;
-        if self.guard.is_none() {
-            let guard = output.output_guard(crossterm::cursor::Show.to_string());
-            let guard = CleanupGuard::new(move || {
-                drop(guard);
-            });
-            _ = write!(output, "{}", crossterm::cursor::Hide);
-            self.guard = Some(guard);
-        }
-
-        self.buffer.clear();
-        write!(self.buffer, "\r").unwrap();
-        let control_chars = self.buffer.len();
-        write!(self.buffer, "{: >3.0}% ", 100.0 * progress.overall).unwrap();
-        if let Some(total) = progress.bytes_downloaded {
-            let (scaled, prefix) = binary_prefix(total as f32);
-            write!(self.buffer, "{scaled: >5.1} {prefix}B ").unwrap();
-        }
-        if let Some(estimate) = rate {
-            let (scaled, prefix) = binary_prefix(estimate);
-            write!(self.buffer, "at {scaled: >5.1} {prefix}B/s ").unwrap();
-        }
-
-        let bar_width = output
-            .term_width()
-            .map(usize::from)
-            .unwrap_or(0)
-            .saturating_sub(self.buffer.len() - control_chars + 2);
-        self.buffer.push('[');
-        draw_progress(progress.overall, &mut self.buffer, bar_width);
-        self.buffer.push(']');
-
-        write!(self.buffer, "{}", Clear(ClearType::UntilNewLine)).unwrap();
-        write!(output, "{}", self.buffer)?;
-        output.flush()?;
-        Ok(())
-    }
-}
-
-fn draw_progress(progress: f32, buffer: &mut String, width: usize) {
-    const CHARS: [char; 9] = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];
-    const RESOLUTION: usize = CHARS.len() - 1;
-    let ticks = (width as f32 * progress.clamp(0.0, 1.0) * RESOLUTION as f32).round() as usize;
-    let whole = ticks / RESOLUTION;
-    for _ in 0..whole {
-        buffer.push(CHARS[CHARS.len() - 1]);
-    }
-    if whole < width {
-        let fraction = ticks % RESOLUTION;
-        buffer.push(CHARS[fraction]);
-    }
-    for _ in (whole + 1)..width {
-        buffer.push(CHARS[0]);
-    }
-}
-
-const UPDATE_HZ: u32 = 30;
-const INITIAL_DELAY: Duration = Duration::from_millis(250);
-
-struct RateEstimate {
-    state: Option<RateEstimateState>,
-}
-
-impl RateEstimate {
-    fn new() -> Self {
-        RateEstimate { state: None }
-    }
-
-    /// Compute smoothed rate from an update
-    fn update(&mut self, now: Instant, total: u64) -> Option<f32> {
-        if let Some(ref mut state) = self.state {
-            return Some(state.update(now, total));
-        }
-
-        self.state = Some(RateEstimateState {
-            total,
-            avg_rate: None,
-            last_sample: now,
-        });
-        None
-    }
-}
-
-struct RateEstimateState {
-    total: u64,
-    avg_rate: Option<f32>,
-    last_sample: Instant,
-}
-
-impl RateEstimateState {
-    fn update(&mut self, now: Instant, total: u64) -> f32 {
-        let delta = total - self.total;
-        self.total = total;
-        let dt = now - self.last_sample;
-        self.last_sample = now;
-        let sample = delta as f32 / dt.as_secs_f32();
-        match self.avg_rate {
-            None => *self.avg_rate.insert(sample),
-            Some(ref mut avg_rate) => {
-                // From Algorithms for Unevenly Spaced Time Series: Moving
-                // Averages and Other Rolling Operators (Andreas Eckner, 2019)
-                const TIME_WINDOW: f32 = 2.0;
-                let alpha = 1.0 - (-dt.as_secs_f32() / TIME_WINDOW).exp();
-                *avg_rate += alpha * (sample - *avg_rate);
-                *avg_rate
-            }
-        }
-    }
-}
+pub const UPDATE_HZ: u32 = 30;
+pub const INITIAL_DELAY: Duration = Duration::from_millis(250);
 
 pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + '_> {
     struct State {
@@ -211,63 +63,4 @@ pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + '_> {
         );
         _ = state.output.flush();
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use insta::assert_snapshot;
-
-    use super::*;
-
-    #[test]
-    fn test_bar() {
-        let mut buf = String::new();
-        draw_progress(0.0, &mut buf, 10);
-        assert_eq!(buf, "          ");
-        buf.clear();
-        draw_progress(1.0, &mut buf, 10);
-        assert_eq!(buf, "██████████");
-        buf.clear();
-        draw_progress(0.5, &mut buf, 10);
-        assert_eq!(buf, "█████     ");
-        buf.clear();
-        draw_progress(0.54, &mut buf, 10);
-        assert_eq!(buf, "█████▍    ");
-        buf.clear();
-    }
-
-    #[test]
-    fn test_update() {
-        let start = Instant::now();
-        let mut progress = Progress::new(start);
-        let mut current_time = start;
-        let mut update = |duration, overall| -> String {
-            current_time += duration;
-            let mut buf = vec![];
-            let mut output = ProgressOutput::for_test(&mut buf, 25);
-            progress
-                .update(
-                    current_time,
-                    &jj_lib::git::Progress {
-                        bytes_downloaded: None,
-                        overall,
-                    },
-                    &mut output,
-                )
-                .unwrap();
-            String::from_utf8(buf).unwrap()
-        };
-        // First output is after the initial delay
-        assert_snapshot!(update(INITIAL_DELAY - Duration::from_millis(1), 0.1), @"");
-        assert_snapshot!(update(Duration::from_millis(1), 0.10), @"[?25l\r 10% [█▊                ][K");
-        // No updates for the next 30 milliseconds
-        assert_snapshot!(update(Duration::from_millis(10), 0.11), @"");
-        assert_snapshot!(update(Duration::from_millis(10), 0.12), @"");
-        assert_snapshot!(update(Duration::from_millis(10), 0.13), @"");
-        // We get an update now that we go over the threshold
-        assert_snapshot!(update(Duration::from_millis(100), 0.30), @" 30% [█████▍            ][K");
-        // Even though we went over by quite a bit, the new threshold is relative to the
-        // previous output, so we don't get an update here
-        assert_snapshot!(update(Duration::from_millis(30), 0.40), @"");
-    }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -109,10 +109,9 @@
             openssh
           ] ++ linuxNativeDeps;
           buildInputs = with pkgs; [
-            openssl zstd libgit2 libssh2
+            openssl libgit2 libssh2
           ] ++ darwinDeps;
 
-          ZSTD_SYS_USE_PKG_CONFIG = "1";
           LIBSSH2_SYS_USE_PKG_CONFIG = "1";
           RUSTFLAGS = pkgs.lib.optionalString pkgs.stdenv.isLinux "-C link-arg=-fuse-ld=mold";
           NIX_JJ_GIT_HASH = self.rev or "";
@@ -175,7 +174,7 @@
           })
 
           # Foreign dependencies
-          openssl zstd libgit2 libssh2
+          openssl libgit2 libssh2
           pkg-config
 
           # Additional tools recommended by contributing.md
@@ -204,7 +203,6 @@
 
         shellHook = ''
           export RUST_BACKTRACE=1
-          export ZSTD_SYS_USE_PKG_CONFIG=1
           export LIBSSH2_SYS_USE_PKG_CONFIG=1
 
           export RUSTFLAGS="-Zthreads=0 ${rustLinkFlagsString}"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -74,7 +74,6 @@ tokio = { workspace = true, optional = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
 watchman_client = { workspace = true, optional = true }
-zstd = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1222,6 +1222,14 @@ fn is_remote_exists_err(err: &git2::Error) -> bool {
     )
 }
 
+/// Determine, by its name, if a remote refers to the special local-only "git"
+/// remote that is used in the Git backend.
+///
+/// This function always returns false if the "git" feature is not enabled.
+pub fn is_special_git_remote(remote: &str) -> bool {
+    remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
+}
+
 pub fn add_remote(
     git_repo: &git2::Repository,
     remote_name: &str,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -51,6 +51,18 @@ pub mod fmt_util;
 pub mod fsmonitor;
 #[cfg(feature = "git")]
 pub mod git;
+#[cfg(not(feature = "git"))]
+/// A stub module that provides a no-op implementation of some of the functions
+/// in the `git` module.
+pub mod git {
+    /// Determine, by its name, if a remote refers to the special local-only
+    /// "git" remote that is used in the Git backend.
+    ///
+    /// This function always returns false if the "git" feature is not enabled.
+    pub fn is_special_git_remote(_remote: &str) -> bool {
+        false
+    }
+}
 #[cfg(feature = "git")]
 pub mod git_backend;
 pub mod gitignore;

--- a/lib/src/protos/op_store.proto
+++ b/lib/src/protos/op_store.proto
@@ -89,8 +89,7 @@ message View {
   // TODO: Delete support for the old format.
   bytes git_head_legacy = 7 [deprecated = true];
   RefTarget git_head = 9;
-  // Whether "@git" bookmark have been migrated to remote_targets.
-  bool has_git_refs_migrated_to_remote = 10;
+  reserved 10;
 }
 
 message Operation {

--- a/lib/src/protos/op_store.rs
+++ b/lib/src/protos/op_store.rs
@@ -122,9 +122,6 @@ pub struct View {
     pub git_head_legacy: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "9")]
     pub git_head: ::core::option::Option<RefTarget>,
-    /// Whether "@git" bookmark have been migrated to remote_targets.
-    #[prost(bool, tag = "10")]
-    pub has_git_refs_migrated_to_remote: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2161,17 +2161,7 @@ fn resolve_commit_ref(
                 .filter(|(_, remote_ref)| {
                     remote_ref_state.map_or(true, |state| remote_ref.state == state)
                 })
-                .filter(|&((_, remote_name), _)| {
-                    #[cfg(feature = "git")]
-                    {
-                        remote_name != crate::git::REMOTE_NAME_FOR_LOCAL_GIT_REPO
-                    }
-                    #[cfg(not(feature = "git"))]
-                    {
-                        let _ = remote_name;
-                        true
-                    }
-                })
+                .filter(|&((_, remote_name), _)| !crate::git::is_special_git_remote(remote_name))
                 .flat_map(|(_, remote_ref)| remote_ref.target.added_ids())
                 .cloned()
                 .collect();

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -553,11 +553,8 @@ fn bookmark_views_from_proto_legacy(
                 // bookmark. Alternatively, we could read
                 // git.auto-local-bookmark setting here, but that wouldn't always work since the
                 // setting could be toggled after the bookmark got merged.
-                #[cfg(feature = "git")]
                 let is_git_tracking =
-                    remote_bookmark.remote_name == crate::git::REMOTE_NAME_FOR_LOCAL_GIT_REPO;
-                #[cfg(not(feature = "git"))]
-                let is_git_tracking = false;
+                    crate::git::is_special_git_remote(&remote_bookmark.remote_name);
                 let default_state = if is_git_tracking || local_target.is_present() {
                     RemoteRefState::Tracking
                 } else {


### PR DESCRIPTION
There are some experiments to try and compile `jj` to WebAssembly, so that we might be able to do things like interactive web tutorials. One step for that is making `git` support in `jj-cli` optional, because we can stub it out for something more appropriate and it's otherwise a lot of porting annoyance for both gitoxide and libgit2.

(On top of that, it might be a useful build configuration for other experiments of mine where removing the need for the large libgit2 depchain is useful.)

As part of this, we need to mark `jj-lib` as having `default-features = false` in the workspace dependency configuration; otherwise, the default behavior for Cargo is to compile with all its default features, i.e. with git support enabled, ignoring the `jj-cli` features clauses.

Other than that, it is fairly straightforward junk; it largely just sprinkles some `#[cfg]` around liberally in order to make things work. It also adjusts the CI pipeline so this is tested there, too, so we can progressively clean it up.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
