### PR TITLE
added changelog entry for showing untracked files in `jj status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Add templater support for rendering commit signatures.
 
+* `jj status` now shows untracked files when they reside directly under a tracked directory.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.


### PR DESCRIPTION
I am not sure this belongs in breaking changes or new features. I have it as breaking right now because it changes the output of the status command.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
