### PR TITLE
Draft: Attempt to fix submodules being marked as removed in subdirs

### DIFF
--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1330,7 +1330,16 @@ impl FileSnapshotter<'_> {
                     new_file_state,
                 )?;
             } else {
-                self.deleted_files_tx.send(tracked_path.to_owned()).ok();
+                let was_submodule = self
+                    .current_tree
+                    .path_value(tracked_path)?
+                    .resolve_trivial()
+                    .map(|t| matches!(t, Some(TreeValue::GitSubmodule(_))))
+                    .unwrap_or(false);
+
+                if was_submodule {
+                    self.deleted_files_tx.send(tracked_path.to_owned()).ok();
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
This appears to fix #5246 but I'm very unsure if it is the correct way to solve the problem. I figured it is better to open a PR than not though.

This seems to be the correct place to put the fix since the other place that filters for submodule deletion is also done prior to pushing into `deleted_files_tx` at line 1404 of `local_working_copy.rs`

I suppose this also needs tests etc. and I could use some guidance on how to do that.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
