### PR TITLE
Roll back 9d4a973 (resolve intermediate parent tree when rebasing merge commits)

### DIFF
--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -247,16 +247,8 @@ impl<'repo> CommitRewriter<'repo> {
                 self.old_commit.tree_id().clone(),
             )
         } else {
-            let old_base_tree = merge_commit_trees_no_resolve_without_repo(
-                self.mut_repo.store(),
-                self.mut_repo.index(),
-                &old_parents,
-            )?;
-            let new_base_tree = merge_commit_trees_no_resolve_without_repo(
-                self.mut_repo.store(),
-                self.mut_repo.index(),
-                &new_parents,
-            )?;
+            let old_base_tree = merge_commit_trees(self.mut_repo, &old_parents)?;
+            let new_base_tree = merge_commit_trees(self.mut_repo, &new_parents)?;
             let old_tree = self.old_commit.tree()?;
             (
                 old_base_tree.id() == *self.old_commit.tree_id(),


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
