### PR TITLE
cli: add `ui.signed-off-by` to configure sign offs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* A `Signed-off-by:` footer can automatically be added to new draft
+  commit messages by enabling the setting `ui.signed-off-by=true`.
+  Note that overriding `draft_commit_message` on your own might undo
+  this; it is configured purely in the template language (for now).
+  [#5290](https://github.com/jj-vcs/jj/pull/5290)
+
 ### Fixed bugs
 
 * `jj status` now shows untracked files under untracked directories.

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -37,6 +37,7 @@ log-synthetic-elided-nodes = true
 conflict-marker-style = "diff"
 # signature verification is slow, disable by default
 show-cryptographic-signatures = false
+signed-off-by = false
 
 [ui.movement]
 edit = false

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -32,6 +32,10 @@ if(overridden,
 draft_commit_description = '''
 concat(
   description,
+  if(
+    config("ui.signed-off-by").as_boolean() && !description.contains("Signed-off-by: " ++ author.name()),
+    "\nSigned-off-by: " ++ author,
+  ),
   surround(
     "\nJJ: This commit contains the following changes:\n", "",
     indent("JJ:     ", diff.summary()),


### PR DESCRIPTION
Many of the desired features of the default commit template can be solved with a simple pattern:

1. Write a `template-aliases` function `should_do_something() = 'false'` to your global config

2. Inside `template-aliases.draft_commit_message`, use the following:

       if(should_do_something() && !description.contains("..."), ...)`

3. Set `should_do_something() = 'true'` in repos where you want it enabled.

This patch uses this idea to configure a new, built-in `signed_off_by()` template alias, which defaults to `false`. With this, a user only has to configure this to `true` in order to get `Signed-off-by` lines included in their repositories.

While `Signed-off-by:` is a git mechanism, it is a common one and this makes it easier to use jj OOTB with repositories that might require those, without adding any more real surface area to the Rust codebase. This general idea can be configured by the user though, e.g. for `BUG=123` templates, or Gerrit `Change-Id`s, or other various things.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
