### PR TITLE
github: install and use nextest for GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,16 @@ jobs:
       uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
       with:
         toolchain: 1.76
+    - uses: taiki-e/install-action@08d473f7b2bf2e092f4c5bd3812b23ed7253f2c9
+      with:
+        tool: nextest
     - name: Build
       run: cargo build --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
     - name: Test
-      run: cargo test --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
+      run: cargo nextest run --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
       env:
         RUST_BACKTRACE: 1
+        CARGO_TERM_COLOR: always
 
   build-no-git:
     name: Build jj-lib without Git support


### PR DESCRIPTION
This seems to have no impact on the CI runners (I thought it might, but oh well.) It's at least more consistent with how we run the test ourselves, and I think the output looks nicer, so I consider it a win anyway.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
