### PR TITLE
github: don't run build workflows twice on push to `main`

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -3,7 +3,8 @@ name: nix
 on:
   push:
     branches:
-      - main
+      - '**'
+      - '!main' # Don't build on main, because merge_group will do that already.
   pull_request:
   merge_group:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: build
 
 on:
   push:
+    branches:
+      - '**'
+      - '!main' # Don't build on main, because merge_group will do that already.
   pull_request:
   merge_group:
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,9 +1,6 @@
 name: Codespell
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 


### PR DESCRIPTION
The new `merge_group` event will already attach all the CI events from the various workflows where it applies. If the merge queue is drained and merges to `main`, having `push` on these workflows will cause them to be run again, doubling the number of CI checks. We don't need `push` anymore, basically.

Also, because checks can be cancelled now, the current double running can probably lead to an awkward setup like:

- Merge Queue merges A to main, starts `push` workflows
- Merge Queue then merges B and C to main, starts `push` workflows
- `A`'s workflows get cancelled if it's not yet done
- This makes it look like `A` has failing tests somehow, but it doesn't

Therefore, just removing the double builds is the first step to cut down on the CI times for our repo.

We also run the build workflows on all pushes to NOT main, because that will help people who want to run CI before opening an actual PR.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
