### PR TITLE
templates: add cryptographic_signature display to default formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inline errors, and more. Please [see the documentation](/docs/config.md#json-schema-support)
   for more on this.
 
+* Add a config option `ui.show-cryptographic-signatures`. When set to `"true"`, the
+  builtin templates will show signataure information if available. The signature display
+  can be customized using `format_detailed_cryptographic_signature(signature)` and
+  `format_short_cryptographic_signature(signature)`.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -173,6 +173,11 @@
                 },
                 "conflict-marker-style": {
                     "$ref": "#/properties/ui/definitions/conflict-marker-style"
+                },
+                "show-cryptographic-signatures": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether the built-in templates should show cryptographic signature information"
                 }
             }
         },

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -111,3 +111,10 @@
 "node current_operation" = { fg = "green", bold = true }
 "node immutable" = { fg = "bright cyan", bold = true }
 "node conflict" = { fg = "red", bold = true }
+
+"signature display" = "yellow"
+"signature key" = "cyan"
+"signature status good" = "green"
+"signature status unknown" = "yellow"
+"signature status bad" = "red"
+"signature status invalid" = "red"

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -33,6 +33,8 @@ quiet = false
 log-word-wrap = false
 log-synthetic-elided-nodes = true
 conflict-marker-style = "diff"
+# signature verification is slow, disable by default
+show-cryptographic-signatures = false
 
 [ui.movement]
 edit = false

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -78,6 +78,8 @@ if(root,
         if(git_head, label("git_head", "git_head()")),
         format_short_commit_id(commit_id),
         if(conflict, label("conflict", "conflict")),
+        if(config("ui.show-cryptographic-signatures").as_boolean(),
+          format_short_cryptographic_signature(signature)),
         if(empty, label("empty", "(empty)")),
         if(description,
           description.first_line(),
@@ -134,6 +136,8 @@ concat(
   surround("Tags     : ", "\n", tags),
   "Author   : " ++ format_detailed_signature(author) ++ "\n",
   "Committer: " ++ format_detailed_signature(committer)  ++ "\n",
+  if(config("ui.show-cryptographic-signatures").as_boolean(),
+    "Signature: " ++ format_detailed_cryptographic_signature(signature) ++ "\n"),
   "\n",
   indent("    ",
     coalesce(description, label(if(empty, "empty"), description_placeholder) ++ "\n")),
@@ -281,7 +285,34 @@ separate(" ",
         if(commit.git_head(), label("git_head", "git_head()")),
         format_short_commit_id(commit.commit_id()),
         if(commit.conflict(), label("conflict", "conflict")),
+        if(config("ui.show-cryptographic-signatures").as_boolean(),
+          format_short_cryptographic_signature(commit.signature())),
       )
+'''
+
+'format_detailed_cryptographic_signature(signature)' = '''
+if(signature,
+  separate(" ",
+    label("signature status " ++ signature.status(), signature.status()),
+    "signature by",
+    coalesce(signature.display(), "(unknown)"),
+    signature.key(),
+  ),
+  "(no signature)",
+)
+'''
+'format_short_cryptographic_signature(signature)' = '''
+if(signature,
+  label("signature status", concat(
+    "[",
+    label(signature.status(), coalesce(
+      if(signature.status() == "good", "✓︎"),
+      if(signature.status() == "unknown", "?"),
+      "x",
+    )),
+    "]",
+  ))
+)
 '''
 
 builtin_log_node = '''

--- a/docs/config.md
+++ b/docs/config.md
@@ -505,7 +505,32 @@ formatted with `format_timestamp()`.
 'commit_timestamp(commit)' = 'commit.author().timestamp()'
 ```
 
-### Allow "large" revsets by default
+### Signature format
+
+Can be enabled with `ui.show-cryptographic-signatures`, and
+customized with `format_short_cryptographic_signature(sig)` and
+`format_detailed_cryptographic_signature(sig)`.
+
+Note that the formatting functions take an `Option<CryptographicSignature>`.
+This allows you to emit a custom message if a signature is not present, but
+will raise an error if you try to access methods on a signature that is not
+available.
+
+```toml
+[ui]
+# default is false
+show-cryptographic-signatures = true
+
+[template-aliases]
+'format_short_cryptographic_signature(sig)' = '''
+  if(sig,
+    sig.status(),
+    "(no sig)",
+  )
+'''
+```
+
+## Allow "large" revsets by default
 
 Certain commands (such as `jj rebase`) can take multiple revset arguments, but
 default to requiring each of those revsets to expand to a *single* revision.


### PR DESCRIPTION
Cryptographic signature support in templates was added in c99c97c6467fee3f3269d2934c10c758e041f834, but has to be manually configured. This adds some defaults to the built-in config.

Instead of having separate `builtin_log_*_with_sig` aliases, this adds to the aliases that actually format commits. Since signature verification is slow, this is disabled by default. To enable it, override the `should_show_cryptographic_signature()` template alias like so:

    [template-aliases]
    'should_show_cryptographic_signature()' = 'true'
    'format_short_cryptographic_signature(signature)' = ...
    'format_detailed_cryptographic_signature(signature)' = ...

Note that the two formatting functions take `Option<Signature>`, not `Signature`. This allows you to display a custom message if a signature is not found, but will emit an error if you do not check for signature presence.

    [template-aliases]
    'format_detailed_cryptographic_signature(signature)' = '''
      if(signature,
        "message if present",
        "message if missing",
      )
    '''

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
