### PR TITLE
contributing: recommend bacon over cargo-watch

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -134,15 +134,13 @@ One-time setup:
 
     rustup toolchain add nightly  # wanted for 'rustfmt'
     rustup toolchain add 1.76     # also specified in Cargo.toml
-    cargo install cargo-insta
-    cargo install cargo-watch
-    cargo install cargo-nextest
+    cargo install --locked bacon
+    cargo install --locked cargo-insta
+    cargo install --locked cargo-nextest
 
 During development (adapt according to your preference):
 
-    cargo watch --ignore '.jj/**' -s \
-      'cargo clippy --workspace --all-targets \
-       && cargo +1.76 check --workspace --all-targets'
+    bacon clippy-all
     cargo +nightly fmt # Occasionally
     cargo nextest run --workspace # Occasionally
     cargo insta test --workspace --test-runner nextest # Occasionally
@@ -178,9 +176,8 @@ These are listed roughly in order of decreasing importance.
 4. Your code needs to pass `cargo clippy`. You can also
    use `cargo +nightly clippy` if you wish to see more warnings.
 
-5. You may also want to install and use `cargo-watch`. In this case, you should
-   exclude `.jj`. directory from the filesystem watcher, as it gets updated on
-   every `jj log`.
+5. You may also want to install and use [`bacon`](https://dystroy.org/bacon/),
+   to automatically build, check, and / or run tests.
 
 6. To run tests more quickly, use `cargo nextest run --workspace`. To
    use `nextest` with `insta`, use `cargo insta test --workspace

--- a/flake.nix
+++ b/flake.nix
@@ -178,10 +178,10 @@
           pkg-config
 
           # Additional tools recommended by contributing.md
+          bacon
           cargo-deny
           cargo-insta
           cargo-nextest
-          cargo-watch
 
           # Miscellaneous tools
           watchman


### PR DESCRIPTION
As of https://github.com/watchexec/cargo-watch/commit/9f27bc1c96d93ff85347619ec4a2bf72fc90fe68, `cargo-watch` is on minimal development and officially recommends `bacon` as a successor.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
