### PR TITLE
config: add `--when.commands` scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `subject(pattern)` revset function that matches first line of commit
   descriptions.
 
+* Conditional configuration now supports `--when.command` to change configuration
+  based on subcommand.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -263,6 +263,7 @@ pub struct ConfigEnv {
     repo_path: Option<PathBuf>,
     user_config_path: ConfigPath,
     repo_config_path: ConfigPath,
+    command: Option<String>,
 }
 
 impl ConfigEnv {
@@ -281,7 +282,12 @@ impl ConfigEnv {
             repo_path: None,
             user_config_path: env.resolve()?,
             repo_config_path: ConfigPath::Unavailable,
+            command: None,
         })
+    }
+
+    pub fn set_command_name(&mut self, command: String) {
+        self.command = Some(command);
     }
 
     /// Returns a path to the user-specific config file or directory.
@@ -398,6 +404,7 @@ impl ConfigEnv {
         let context = ConfigResolutionContext {
             home_dir: self.home_dir.as_deref(),
             repo_path: self.repo_path.as_deref(),
+            command: self.command.as_deref(),
         };
         jj_lib::config::resolve(config.as_ref(), &context)
     }
@@ -1369,6 +1376,7 @@ mod tests {
                 repo_path: None,
                 user_config_path: env.resolve()?,
                 repo_config_path: ConfigPath::Unavailable,
+                command: None,
             })
         }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1371,6 +1371,9 @@ You can conditionally enable config variables by using `--when` and
 `[[--scope]]` tables. Variables defined in `[[--scope]]` tables are expanded to
 the root table. `--when` specifies the condition to enable the scope table.
 
+If no conditions are specified, table is always enabled. If multiple conditions
+are specified, the intersection is used.
+
 ```toml
 [user]
 name = "YOUR NAME"
@@ -1381,19 +1384,38 @@ email = "YOUR_DEFAULT_EMAIL@example.com"
 --when.repositories = ["~/oss"]
 [--scope.user]
 email = "YOUR_OSS_EMAIL@example.org"
+
+# disable pagination for `jj status`, use `delta` for `jj diff` and `jj show`
+[[--scope]]
+--when.commands = ["status"]
+[--scope.ui]
+paginate = "never"
+[[--scope]]
+--when.commands = ["diff", "show"]
+[--scope.ui]
+pager = "delta"
 ```
 
 Condition keys:
 
 * `--when.repositories`: List of paths to match the repository path prefix.
 
-Paths should be absolute. Each path component (directory or file name, drive
-letter, etc.) is compared case-sensitively on all platforms. A path starting
-with `~` is expanded to the home directory. On Windows, directory separator may
-be either `\` or `/`. (Beware that `\` needs escape in double-quoted strings.)
+  Paths should be absolute. Each path component (directory or file name, drive
+  letter, etc.) is compared case-sensitively on all platforms. A path starting
+  with `~` is expanded to the home directory. On Windows, directory separator may
+  be either `\` or `/`. (Beware that `\` needs escape in double-quoted strings.)
 
-Use `jj root` to see the workspace root directory. Note that the repository path
-is in the main workspace if you're using multiple workspaces with `jj
-workspace`.
+  Use `jj root` to see the workspace root directory. Note that the repository path
+  is in the main workspace if you're using multiple workspaces with `jj
+  workspace`.
 
-If no conditions are specified, table is always enabled.
+
+* `--when.command`: List of subcommands to match.
+
+  Subcommands are space-separated and matched by prefix.
+
+  ```toml
+  --when.command = ["file"]        # matches `jj file show`, `jj file list`, etc
+  --when.command = ["file show"]   # matches `jj file show` but *NOT* `jj file list`
+  --when.command = ["file", "log"] # matches `jj file` *OR* `jj log` (or subcommand of either)
+  ```


### PR DESCRIPTION
Closes #5217 

Adds a new config scope resolution `--when.commands`. This is a list of space-separated commands:
```toml
--when.command = ["file"]        # matches `jj file show`, `jj file list`, etc
--when.command = ["file show"]   # matches `jj file show`, but *NOT* `jj file list`
--when.command = ["file", "log"] # matches `jj file` *OR* `jj log` (or subcommand of either)
```

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
