### PR TITLE
github: don't run `dependabot` or `gh-readonly-queue` builds twice

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches:
       - '**'
-      - '!main' # Don't build on main, because merge_group will do that already.
+      # Disable builds on these branches, because they will become a pull
+      # request, and be handled by merge_group below.
+      - '!dependabot/**'
+      # `main` and `gh-readonly-queue` are handled by merge_group specifically.
+      - '!gh-readonly-queue/**'
+      - '!main'
   pull_request:
   merge_group:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches:
       - '**'
-      - '!main' # Don't build on main, because merge_group will do that already.
+      # Disable builds on these branches, because they will become a pull
+      # request, and be handled by merge_group below.
+      - '!dependabot/**'
+      # `main` and `gh-readonly-queue` are handled by merge_group specifically.
+      - '!gh-readonly-queue/**'
+      - '!main'
   pull_request:
   merge_group:
 


### PR DESCRIPTION
Like `main`, we don't want to double build these branches since they will be handled by `merge_group` already.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
