### PR TITLE
cli: remove handling of deprecated fix.tool-command config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The deprecated `--siblings` options for `jj split` has been removed.
   `jj split --parallel` can be used instead.
 
+* The deprecated `fix.tool-command` config option has been removed.
+
 * In colocated repos, the Git index now contains the changes from all parents
   of the working copy instead of just the first parent (`HEAD`). 2-sided
   conflicts from the merged parents are now added to the Git index as conflicts

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -593,13 +593,6 @@
             "type": "object",
             "description": "Settings for jj fix",
             "properties": {
-                "tool-command": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Shell command that takes file content on stdin and returns fixed file content on stdout (deprecated)"
-                },
                 "tools": {
                     "type": "object",
                     "additionalProperties": {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1007,20 +1007,6 @@ currently unspecified, and may change between releases. If two tools affect
 the same file, the second tool to run will receive its input from the
 output of the first tool.
 
-There is also a deprecated configuration schema that defines a single
-command that will affect all changed files in the specified revisions. For
-example, the following configuration would apply the Rust formatter to all
-changed files (whether they are Rust files or not):
-
-```toml
-[fix]
-tool-command = ["rustfmt", "--emit", "stdout"]
-```
-
-The tool defined by `tool-command` acts as if it was the first entry in
-`fix.tools`, and uses `pattern = "all()"``. Support for `tool-command`
-will be removed in a future version.
-
 **Usage:** `jj fix [OPTIONS] [FILESETS]...`
 
 ###### **Arguments:**


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
