### PR TITLE
cli: autocomplete: complete `--config` with possible configuration keys

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3122,7 +3122,7 @@ pub struct EarlyArgs {
     /// The name should be specified as TOML dotted keys. The value should be
     /// specified as a TOML expression. If string value doesn't contain any TOML
     /// constructs (such as array notation), quotes can be omitted.
-    #[arg(long, value_name = "NAME=VALUE", global = true)]
+    #[arg(long, value_name = "NAME=VALUE", global = true, add = ArgValueCandidates::new(complete::leaf_config_keys_eq))]
     pub config: Vec<String>,
     /// Additional configuration options (can be repeated) (DEPRECATED)
     // TODO: delete --config-toml in jj 0.31+

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -533,6 +533,12 @@ fn test_config() {
     core.watchman
     core.watchman.register_snapshot_trigger	Whether to use triggers to monitor for changes in the background.
     ");
+
+    let stdout = test_env.jj_cmd_success(dir, &["--", "jj", "log", "--config", "c"]);
+    insta::assert_snapshot!(stdout, @r"
+    core.fsmonitor=	Whether to use an external filesystem monitor, useful for large repos
+    core.watchman.register_snapshot_trigger=	Whether to use triggers to monitor for changes in the background.
+    ");
 }
 
 fn create_commit(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2ac6a34e-806c-4b2d-95b0-e2ed3233d1d4)


If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
