### PR TITLE
workflows: fix the pre-release docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   prerelease-docs-build-deploy:
-    if: github.repository_owner == 'martinvonz' # Stops this job from running on forks
+    if: github.repository_owner == 'jj-vcs' # Stops this job from running on forks
     strategy:
       matrix:
         os: [ubuntu-24.04]


### PR DESCRIPTION
It contained a check for `repo_owner == 'martinvonz'` which meant that it hasn't run in 4 weeks. This is another great example showing why current CI systems suck, as it always was "successful" in doing nothing with no warning whatsoever.

I also only noticed it because I wanted to check my latest doc change on the prerelease site.

cc @thoughtpolice 