### PR TITLE
cli: complete: fix stderr during autocomplete of revsets

### DIFF
--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -472,6 +472,7 @@ fn all_files_from_rev(rev: String, current: &std::ffi::OsStr) -> Vec<CompletionC
             .arg("--config=ui.allow-filesets=true")
             .arg(current_prefix_to_fileset(current))
             .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
             .spawn()
             .map_err(user_error)?;
         let stdout = child.stdout.take().unwrap();

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -819,4 +819,8 @@ fn test_files() {
     f_not_yet_renamed
     f_unchanged
     ");
+
+    let outside_repo = test_env.env_root();
+    let stdout = test_env.jj_cmd_success(outside_repo, &["--", "jj", "log", "f_"]);
+    insta::assert_snapshot!(stdout, @r"");
 }


### PR DESCRIPTION
When running `cmd.spawn()` rust will by default inherit the stderr of the parent, so `jj log test<TAB>`, would print `There is no jj repo in "."` into the prompt if you aren't in a repository.