### PR TITLE
lib: dag_walk: fix doc comment typos

### DIFF
--- a/lib/src/dag_walk.rs
+++ b/lib/src/dag_walk.rs
@@ -171,7 +171,7 @@ where
 /// For example, topological order of chronological data should respect
 /// timestamp (except a few outliers caused by clock skew.)
 ///
-/// Use `topo_order_reverse()` if the DAG is heavily bookmarked. This can
+/// Use `topo_order_reverse()` if the DAG is heavily branched. This can
 /// only process linear part lazily.
 pub fn topo_order_reverse_lazy<T, ID, II, NI>(
     start: II,
@@ -286,9 +286,9 @@ impl<T: Ord, ID: Hash + Eq + Clone, E> TopoOrderReverseLazyInner<T, ID, E> {
 ///  o A
 /// ```
 ///
-/// If a bookmark reached to root (empty neighbors), the graph can't be split
-/// anymore because the other bookmark may be connected to a descendant of
-/// the rooted bookmark.
+/// If a branch reached to root (empty neighbors), the graph can't be split
+/// anymore because the other branch may be connected to a descendant of
+/// the rooted branch.
 ///
 /// ```text
 ///  o | C
@@ -809,7 +809,7 @@ mod tests {
         assert_eq!(common, vec!['E', 'D', 'C', 'B', 'a']);
 
         // The root node 'a' is visited before 'C'. If the graph were split there,
-        // the bookmark 'C->B->a' would be orphaned.
+        // the branch 'C->B->a' would be orphaned.
         let common = topo_order_reverse_lazy(vec!['E'], id_fn, neighbors_fn).collect_vec();
         assert_eq!(common, vec!['E', 'D', 'C', 'B', 'a']);
 


### PR DESCRIPTION
This commit fixes more typos unintentionally introduced in d9c68e08, when renaming `jj branch` to `jj bookmark`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
