### PR TITLE
docs: Expose `config-schema.json` in the docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   useful for defining disabled tools in user configuration that can be enabled
   in individual repositories with one config setting.
 
+* The Jujutsu documentation site now publishes a schema for the official
+  configuration file, which can be integrated into your editor for autocomplete,
+  inline errors, and more. Please [see the documentation](/docs/config.md#json-schema-support)
+  for more on this.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -1,0 +1,1 @@
+../cli/src/config-schema.json

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,12 +23,17 @@ These are listed in the order they are loaded; the settings from earlier items
 in the list are overridden by the settings from later items if they disagree.
 Every type of config except for the built-in settings is optional.
 
+You can enable JSON Schema validation in your editor by adding a `$schema`
+reference at the top of your TOML config files. See [JSON Schema
+Support] for details.
+
 See the [TOML site] and the [syntax guide] for a detailed description of the
 syntax. We cover some of the basics below.
 
 [the user config file]: #user-config-file
 [TOML site]: https://toml.io/en/
 [syntax guide]: https://toml.io/en/v1.0.0
+[JSON Schema Support]: #json-schema-support
 
 The first thing to remember is that the value of a setting (the part to the
 right of the `=` sign) should be surrounded in quotes if it's a string.
@@ -1271,6 +1276,41 @@ default locations. For example,
 ```shell
 env JJ_CONFIG=/dev/null jj log       # Ignores any settings specified in the config file.
 ```
+
+### JSON Schema Support
+
+Many popular editors support TOML file syntax highlighting and validation. To
+enable schema validation in your editor, add this line at the top of your TOML
+config files:
+
+```toml
+"$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
+```
+
+This enables features like:
+
+- Autocomplete for config keys
+- Type checking of values
+- Documentation on hover
+- Validation of settings
+
+Here are some popular editors with TOML schema validation support:
+
+- VS Code
+  - Install [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)
+
+- Neovim/Vim
+  - Use with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) and [taplo](https://github.com/tamasfe/taplo)
+
+- JetBrains IDEs (IntelliJ, PyCharm, etc)
+  - Install [TOML](https://plugins.jetbrains.com/plugin/8195-toml) plugin
+
+- Sublime Text
+  - Install [LSP](https://packagecontrol.io/packages/LSP) and [LSP-taplo](https://packagecontrol.io/packages/LSP-taplo)
+
+- Emacs
+  - Install [lsp-mode](https://github.com/emacs-lsp/lsp-mode) and [toml-mode](https://github.com/dryman/toml-mode.el)
+  - Configure [taplo](https://github.com/tamasfe/taplo) as the LSP server
 
 ### Specifying config on the command-line
 


### PR DESCRIPTION
When landed and published, this will expose the config file as:

https://jj-vcs.github.io/jj/latest/config-schema.json

Exposing the schema like that will allow users to reference in their `~/.config/jj/config.toml` like:

```toml
"$schema" = 'https://jj-vcs.github.io/jj/latest/config-schema.json'
```

At which point any user with a configured LSP for TOML files will get inline documentation, suggestions on valid keys, &c.

### Examples

Some example screenshots of this working in my local NeoVim setup (using a local `mkdocs serve` of these changes), but the same works in any editor with an LSP setup for TOML files.

<img width="480" alt="Screenshot 2025-01-11 at 10 04 32 PM" src="https://github.com/user-attachments/assets/df30aaf4-f2bf-4d39-975e-6bee1a6a35e1" />
<img width="498" alt="Screenshot 2025-01-11 at 10 06 41 PM" src="https://github.com/user-attachments/assets/f8db60f7-6246-406d-a81d-60f74dafcef6" />
<img width="481" alt="Screenshot 2025-01-11 at 10 05 32 PM" src="https://github.com/user-attachments/assets/e5eb8638-71c7-43e0-95f0-8009f359d479" />


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
