### PR TITLE
cli: autocomplete: complete config values in addition to keys

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -46,6 +46,7 @@ use clap::ArgMatches;
 use clap::Command;
 use clap::FromArgMatches;
 use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use indoc::writedoc;
@@ -3122,7 +3123,7 @@ pub struct EarlyArgs {
     /// The name should be specified as TOML dotted keys. The value should be
     /// specified as a TOML expression. If string value doesn't contain any TOML
     /// constructs (such as array notation), quotes can be omitted.
-    #[arg(long, value_name = "NAME=VALUE", global = true, add = ArgValueCandidates::new(complete::leaf_config_keys_eq))]
+    #[arg(long, value_name = "NAME=VALUE", global = true, add = ArgValueCompleter::new(complete::leaf_config_key_value))]
     pub config: Vec<String>,
     /// Additional configuration options (can be repeated) (DEPRECATED)
     // TODO: delete --config-toml in jj 0.31+

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -539,6 +539,28 @@ fn test_config() {
     core.fsmonitor=	Whether to use an external filesystem monitor, useful for large repos
     core.watchman.register_snapshot_trigger=	Whether to use triggers to monitor for changes in the background.
     ");
+
+    let stdout = test_env.jj_cmd_success(
+        dir,
+        &["--", "jj", "log", "--config", "ui.conflict-marker-style="],
+    );
+    insta::assert_snapshot!(stdout, @r"
+    ui.conflict-marker-style=diff
+    ui.conflict-marker-style=snapshot
+    ui.conflict-marker-style=git
+    ");
+    let stdout = test_env.jj_cmd_success(
+        dir,
+        &["--", "jj", "log", "--config", "ui.conflict-marker-style=g"],
+    );
+    insta::assert_snapshot!(stdout, @"ui.conflict-marker-style=git");
+
+    let stdout =
+        test_env.jj_cmd_success(dir, &["--", "jj", "log", "--config", "signing.sign-all="]);
+    insta::assert_snapshot!(stdout, @r"
+    signing.sign-all=false
+    signing.sign-all=true
+    ");
 }
 
 fn create_commit(


### PR DESCRIPTION
Now `jj --config ui.con<TAB><TAB>` will autocomplete

```
ui.conflict-marker-style=diff
ui.conflict-marker-style=snapshot
ui.conflict-marker-style=git
```

Booleans are completed as `false`, `true`, the remaining types are left without completions.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- ~[ ] I have updated `CHANGELOG.md`~
- ~[ ] I have updated the documentation (README.md, docs/, demos/)~
- ~[ ] I have updated the config schema (cli/src/config-schema.json)~
- [x] I have added tests to cover my changes
