### PR TITLE
cli: add "git.push-new-bookmarks" config knob to enable --allow-new by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `git.sign-on-push` config option to automatically sign commits which are being
   pushed to a Git remote.
 
+* New `git.push-new-bookmarks` config option to push new bookmarks without
+  `--allow-new`.
+
 * New `fix.tools.TOOL.enabled` config option to enable/disable tools. This is
   useful for defining disabled tools in user configuration that can be enabled
   in individual repositories with one config setting.

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -125,6 +125,9 @@ pub struct GitPushArgs {
     /// Allow pushing new bookmarks
     ///
     /// Newly-created remote bookmarks will be tracked automatically.
+    ///
+    /// This can also be turned on by the `git.push-new-bookmarks` setting. If
+    /// it's set to `true`, `--allow-new` is no-op.
     #[arg(long, short = 'N', conflicts_with = "what")]
     allow_new: bool,
     /// Allow pushing commits with empty descriptions
@@ -249,12 +252,13 @@ pub fn cmd_git_push(
             }
         }
 
+        let allow_new = args.allow_new || tx.settings().get("git.push-new-bookmarks")?;
         let bookmarks_by_name = find_bookmarks_to_push(view, &args.bookmark, &remote)?;
         for &(bookmark_name, targets) in &bookmarks_by_name {
             if !seen_bookmarks.insert(bookmark_name) {
                 continue;
             }
-            match classify_bookmark_update(bookmark_name, &remote, targets, args.allow_new) {
+            match classify_bookmark_update(bookmark_name, &remote, targets, allow_new) {
                 Ok(Some(update)) => bookmark_updates.push((bookmark_name.to_owned(), update)),
                 Ok(None) => writeln!(
                     ui.status(),
@@ -277,7 +281,7 @@ pub fn cmd_git_push(
             if !seen_bookmarks.insert(bookmark_name) {
                 continue;
             }
-            match classify_bookmark_update(bookmark_name, &remote, targets, args.allow_new) {
+            match classify_bookmark_update(bookmark_name, &remote, targets, allow_new) {
                 Ok(Some(update)) => bookmark_updates.push((bookmark_name.to_owned(), update)),
                 Ok(None) => {}
                 Err(reason) => reason.print(ui)?,

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -343,6 +343,11 @@
                     "description": "Prefix used when pushing a bookmark based on a change ID",
                     "default": "push-"
                 },
+                "push-new-bookmarks": {
+                    "type": "boolean",
+                    "description": "Allow pushing new bookmarks without --allow-new",
+                    "default": false
+                },
                 "fetch": {
                     "description": "The remote(s) from which commits are fetched",
                     "default": "origin",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -15,6 +15,7 @@ context = 3
 
 [git]
 push-bookmark-prefix = "push-"
+push-new-bookmarks = false
 sign-on-push = false
 
 [ui]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1171,6 +1171,8 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 * `-N`, `--allow-new` — Allow pushing new bookmarks
 
    Newly-created remote bookmarks will be tracked automatically.
+
+   This can also be turned on by the `git.push-new-bookmarks` setting. If it's set to `true`, `--allow-new` is no-op.
 * `--allow-empty-description` — Allow pushing commits with empty descriptions
 * `--allow-private` — Allow pushing commits that are private
 * `-r`, `--revisions <REVSETS>` — Push bookmarks pointing to these commits (can be repeated)

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -446,7 +446,20 @@ fn test_git_push_locally_created_and_rewritten() {
     Hint: Use --allow-new to push new bookmark. Use --remote to specify the remote to push to.
     Nothing changed.
     ");
-    let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--allow-new"]);
+    // Either --allow-new or git.push-new-bookmarks=true should work
+    let (_stdout, stderr) = test_env.jj_cmd_ok(
+        &workspace_root,
+        &["git", "push", "--allow-new", "--dry-run"],
+    );
+    insta::assert_snapshot!(stderr, @r"
+    Changes to push to origin:
+      Add bookmark my to fcc999921ce9
+    Dry-run requested, not pushing.
+    ");
+    let (_stdout, stderr) = test_env.jj_cmd_ok(
+        &workspace_root,
+        &["git", "push", "--config=git.push-new-bookmarks=true"],
+    );
     insta::assert_snapshot!(stderr, @r#"
     Changes to push to origin:
       Add bookmark my to fcc999921ce9
@@ -460,13 +473,13 @@ fn test_git_push_locally_created_and_rewritten() {
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    my: vruxwmqv eaf7a52c (empty) local 2
+    my: vruxwmqv 423bb660 (empty) local 2
       @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv hidden fcc99992 (empty) local 1
     ");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
-      Move sideways bookmark my from fcc999921ce9 to eaf7a52c8906
+      Move sideways bookmark my from fcc999921ce9 to 423bb66069e7
     ");
 }
 


### PR DESCRIPTION
#5094

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
