### PR TITLE
revset: parse unicode XID_CONTINUE characters as symbol

### DIFF
--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -454,16 +454,16 @@ fn test_log_bad_short_prefixes() {
     test_env.add_config(r#"revsets.short-prefixes = "!nval!d""#);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["status"]);
     insta::assert_snapshot!(stderr,
-        @r###"
+        @r"
     Config error: Invalid `revsets.short-prefixes`
     Caused by:  --> 1:1
       |
     1 | !nval!d
       | ^---
       |
-      = expected <identifier> or <expression>
+      = expected <strict_identifier> or <expression>
     For help, see https://jj-vcs.github.io/jj/latest/config/.
-    "###);
+    ");
 
     // Warn on resolution of short prefixes
     test_env.add_config("revsets.short-prefixes = 'missing'");

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -266,15 +266,15 @@ fn test_bad_function_call() {
     "###);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_bookmarks(=foo)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Syntax error
     Caused by:  --> 1:18
       |
     1 | remote_bookmarks(=foo)
       |                  ^---
       |
-      = expected <identifier> or <expression>
-    "###);
+      = expected <strict_identifier> or <expression>
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_bookmarks(remote=)"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -601,20 +601,20 @@ fn test_bad_alias_decl() {
     insta::assert_snapshot!(stdout, @r###"
     ◆  zzzzzzzz root() 00000000
     "###);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Warning: Failed to load "revset-aliases."bad"":  --> 1:1
       |
     1 | "bad"
       | ^---
       |
-      = expected <identifier> or <function_name>
+      = expected <strict_identifier> or <function_name>
     Warning: Failed to load "revset-aliases.badfn(a, a)":  --> 1:7
       |
     1 | badfn(a, a)
       |       ^--^
       |
       = Redefinition of function parameter
-    "###);
+    "#);
 }
 
 #[test]

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -18,6 +18,12 @@ identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }
 identifier = @{
   identifier_part ~ (("." | "-" | "+") ~ identifier_part)*
 }
+// TODO: remove "/", ".", "+" for consistency with fileset?
+strict_identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }
+strict_identifier = @{
+  strict_identifier_part ~ (("." | "-" | "+") ~ strict_identifier_part)*
+}
+
 symbol = _{
   identifier
   | string_literal
@@ -68,19 +74,19 @@ infix_op = _{ union_op | intersection_op | difference_op | compat_add_op | compa
 
 function = { function_name ~ "(" ~ whitespace* ~ function_arguments ~ whitespace* ~ ")" }
 function_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
-keyword_argument = { identifier ~ whitespace* ~ "=" ~ whitespace* ~ expression }
+keyword_argument = { strict_identifier ~ whitespace* ~ "=" ~ whitespace* ~ expression }
 argument = _{ keyword_argument | expression }
 function_arguments = {
   argument ~ (whitespace* ~ "," ~ whitespace* ~ argument)* ~ (whitespace* ~ ",")?
   | ""
 }
 formal_parameters = {
-  identifier ~ (whitespace* ~ "," ~ whitespace* ~ identifier)* ~ (whitespace* ~ ",")?
+  strict_identifier ~ (whitespace* ~ "," ~ whitespace* ~ strict_identifier)* ~ (whitespace* ~ ",")?
   | ""
 }
 
 // TODO: change rhs to string_literal to require quoting? #2101
-string_pattern = { identifier ~ pattern_kind_op ~ symbol }
+string_pattern = { strict_identifier ~ pattern_kind_op ~ symbol }
 
 primary = {
   "(" ~ whitespace* ~ expression ~ whitespace* ~ ")"
@@ -108,7 +114,7 @@ expression = {
   ~ (whitespace* ~ infix_op ~ whitespace* ~ (negate_op ~ whitespace*)* ~ range_expression)*
 }
 
-program_modifier = { identifier ~ pattern_kind_op ~ !":" }
+program_modifier = { strict_identifier ~ pattern_kind_op ~ !":" }
 program = _{
   SOI ~ whitespace* ~ (program_modifier ~ whitespace*)? ~ expression ~ whitespace* ~ EOI
 }
@@ -117,5 +123,5 @@ function_alias_declaration = {
   function_name ~ "(" ~ whitespace* ~ formal_parameters ~ whitespace* ~ ")"
 }
 alias_declaration = _{
-  SOI ~ (function_alias_declaration | identifier) ~ EOI
+  SOI ~ (function_alias_declaration | strict_identifier) ~ EOI
 }

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -14,7 +14,10 @@
 
 whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 
-identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }
+// XID_CONTINUE: https://www.unicode.org/reports/tr31/#Default_Identifier_Syntax
+// +, -, .: often included in tag/bookmark name or version number
+// /: sometimes used as a tag/bookmark namespace separator
+identifier_part = @{ (XID_CONTINUE | "_" | "/")+ }
 identifier = @{
   identifier_part ~ (("." | "-" | "+") ~ identifier_part)*
 }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
