### PR TITLE
absorb: print status if source commit still contains diffs

### DIFF
--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -480,6 +480,8 @@ fn test_absorb_file_mode() {
     Rebased 1 descendant commits.
     Working copy now at: zsuskuln 77de368e (no description set)
     Parent commit      : qpvuntsm 991365da 1
+    Remaining changes:
+    M file1
     ");
 
     insta::assert_snapshot!(get_diffs(&test_env, &repo_path, "mutable()"), @r"
@@ -521,6 +523,8 @@ fn test_absorb_from_into() {
     Rebased 1 descendant commits.
     Working copy now at: zsuskuln d5424357 (no description set)
     Parent commit      : kkmpptxz 91df4543 2
+    Remaining changes:
+    M file1
     ");
 
     insta::assert_snapshot!(get_diffs(&test_env, &repo_path, "@-::"), @r"
@@ -623,6 +627,8 @@ fn test_absorb_paths() {
     Rebased 1 descendant commits.
     Working copy now at: kkmpptxz c6f31836 (no description set)
     Parent commit      : qpvuntsm ae044adb 1
+    Remaining changes:
+    M file2
     ");
 
     insta::assert_snapshot!(get_diffs(&test_env, &repo_path, "mutable()"), @r"
@@ -677,6 +683,8 @@ fn test_absorb_immutable() {
     Rebased 1 descendant commits.
     Working copy now at: mzvwutvl 3021153d (no description set)
     Parent commit      : kkmpptxz d80e3c2a 2
+    Remaining changes:
+    M file1
     ");
 
     // Immutable revisions shouldn't be rewritten

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -439,6 +439,25 @@ fn test_absorb_conflict() {
 }
 
 #[test]
+fn test_absorb_deleted_file() {
+    let test_env = TestEnvironment::default();
+    test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.jj_cmd_ok(&repo_path, &["describe", "-m1"]);
+    std::fs::write(repo_path.join("file1"), "1a\n").unwrap();
+
+    test_env.jj_cmd_ok(&repo_path, &["new"]);
+    std::fs::remove_file(repo_path.join("file1")).unwrap();
+
+    let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["absorb"]);
+    insta::assert_snapshot!(stderr, @r"
+    Warning: Skipping file1: Deleted file
+    Nothing changed.
+    ");
+}
+
+#[test]
 fn test_absorb_file_mode() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);


### PR DESCRIPTION
#5362

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
