### PR TITLE
style/cleanup: remove a bunch of Default implementations

### DIFF
--- a/cli/src/commands/debug/watchman.rs
+++ b/cli/src/commands/debug/watchman.rs
@@ -50,6 +50,10 @@ pub fn cmd_debug_watchman(
 
     let mut workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo().clone();
+    let watchman_config = WatchmanConfig {
+        // The value is likely irrelevant here. TODO(ilyagr): confirm
+        register_trigger: false,
+    };
     match subcommand {
         DebugWatchmanCommand::Status => {
             // TODO(ilyagr): It would be nice to add colors here
@@ -76,7 +80,7 @@ pub fn cmd_debug_watchman(
                         ui.stdout(),
                         "Attempting to contact the `watchman` CLI regardless..."
                     )?;
-                    WatchmanConfig::default()
+                    watchman_config
                 }
                 other_fsmonitor => {
                     return Err(user_error(format!(
@@ -102,12 +106,12 @@ pub fn cmd_debug_watchman(
         }
         DebugWatchmanCommand::QueryClock => {
             let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;
-            let (clock, _changed_files) = wc.query_watchman(&WatchmanConfig::default())?;
+            let (clock, _changed_files) = wc.query_watchman(&watchman_config)?;
             writeln!(ui.stdout(), "Clock: {clock:?}")?;
         }
         DebugWatchmanCommand::QueryChangedFiles => {
             let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;
-            let (_clock, changed_files) = wc.query_watchman(&WatchmanConfig::default())?;
+            let (_clock, changed_files) = wc.query_watchman(&watchman_config)?;
             writeln!(ui.stdout(), "Changed files: {changed_files:?}")?;
         }
         DebugWatchmanCommand::ResetClock => {

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -206,13 +206,12 @@ pub struct Ui {
     output: UiOutput,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ColorChoice {
     Always,
     Never,
     Debug,
-    #[default]
     Auto,
 }
 
@@ -261,11 +260,10 @@ fn prepare_formatter_factory(
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub enum PaginationChoice {
     Never,
-    #[default]
     Auto,
 }
 

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -156,7 +156,7 @@ pub struct ConflictTerm {
     pub value: TreeValue,
 }
 
-#[derive(ContentHash, Default, Debug, PartialEq, Eq, Clone)]
+#[derive(ContentHash, Debug, PartialEq, Eq, Clone)]
 pub struct Conflict {
     // A conflict is represented by a list of positive and negative states that need to be applied.
     // In a simple 3-way merge of B and C with merge base A, the conflict will be { add: [B, C],

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -28,7 +28,7 @@ use crate::config::ConfigGetError;
 use crate::settings::UserSettings;
 
 /// Config for Watchman filesystem monitor (<https://facebook.github.io/watchman/>).
-#[derive(Default, Eq, PartialEq, Clone, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct WatchmanConfig {
     /// Whether to use triggers to monitor for changes in the background.
     pub register_trigger: bool,

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -511,14 +511,17 @@ fn conflict_to_proto(conflict: &Conflict) -> crate::protos::local_store::Conflic
 }
 
 fn conflict_from_proto(proto: crate::protos::local_store::Conflict) -> Conflict {
-    let mut conflict = Conflict::default();
-    for term in proto.removes {
-        conflict.removes.push(conflict_term_from_proto(term));
-    }
-    for term in proto.adds {
-        conflict.adds.push(conflict_term_from_proto(term));
-    }
-    conflict
+    let removes = proto
+        .removes
+        .into_iter()
+        .map(conflict_term_from_proto)
+        .collect();
+    let adds = proto
+        .adds
+        .into_iter()
+        .map(conflict_term_from_proto)
+        .collect();
+    Conflict { removes, adds }
 }
 
 fn conflict_term_from_proto(proto: crate::protos::local_store::conflict::Term) -> ConflictTerm {

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -79,7 +79,7 @@ impl Default for GitSettings {
 }
 
 /// Commit signing settings, describes how to and if to sign commits.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SignSettings {
     /// What to actually do, see [SignBehavior].
     pub behavior: SignBehavior,

--- a/lib/src/signing.rs
+++ b/lib/src/signing.rs
@@ -141,12 +141,11 @@ pub enum SignInitError {
 }
 
 /// A enum that describes if a created/rewritten commit should be signed or not.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SignBehavior {
     /// Drop existing signatures.
     /// This is what jj did before signing support or does now when a signing
     /// backend is not configured.
-    #[default]
     Drop,
     /// Only sign commits that were authored by self and already signed,
     /// "preserving" the signature across rewrites.


### PR DESCRIPTION
I noticed that some config structures do not use their "Default" implementation, and have their default specified in a TOML file. I think specifying defaults in TOML is great, and it'd be good to delete those Default implementations, so that it does not diverge from the default in the TOML file.

I then kept going with a few more structures that seem better off without Default implemented.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
