### PR TITLE
diffedit: start the builtin ui with all boxes checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [streampager](https://github.com/markbt/streampager/). It can handle large
   inputs better.
 
+* The terminal UI of `jj diffedit` now starts with the whole diff checked, meaning
+  you need to uncheck what you want to discard, instead of checking what you want to
+  preserve.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -164,6 +164,7 @@ use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
 use crate::formatter::PlainTextFormatter;
 use crate::merge_tools::DiffEditor;
+use crate::merge_tools::InitialSelection;
 use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
 use crate::operation_templater::OperationTemplateLanguage;
@@ -2950,7 +2951,13 @@ impl DiffSelector {
                 // whereas we want to update the left tree. Unmatched paths
                 // shouldn't be based off the right tree.
                 let right_tree = right_tree.store().get_root_tree(&selected_tree_id)?;
-                Ok(editor.edit(left_tree, &right_tree, matcher, format_instructions)?)
+                Ok(editor.edit(
+                    left_tree,
+                    &right_tree,
+                    matcher,
+                    format_instructions,
+                    InitialSelection::None,
+                )?)
             }
         }
     }

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -25,6 +25,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
 use crate::complete;
+use crate::merge_tools::InitialSelection;
 use crate::ui::Ui;
 
 /// Touch up the content changes in a revision with a diff editor
@@ -132,7 +133,13 @@ don't make any changes, then the operation will be aborted.",
     };
     let base_tree = merge_commit_trees(tx.repo(), base_commits.as_slice())?;
     let tree = target_commit.tree()?;
-    let tree_id = diff_editor.edit(&base_tree, &tree, &EverythingMatcher, format_instructions)?;
+    let tree_id = diff_editor.edit(
+        &base_tree,
+        &tree,
+        &EverythingMatcher,
+        format_instructions,
+        InitialSelection::All,
+    )?;
     if tree_id == *target_commit.tree_id() {
         writeln!(ui.status(), "Nothing changed.")?;
     } else {

--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -21,6 +21,7 @@ use crate::cli_util::RevisionArg;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::description_util::combine_messages;
+use crate::merge_tools::InitialSelection;
 use crate::ui::Ui;
 
 /// Move changes from a revision's parent into the revision
@@ -106,6 +107,7 @@ aborted.
             &parent_tree,
             &EverythingMatcher,
             format_instructions,
+            InitialSelection::None,
         )?;
         if new_parent_tree_id == parent_base_tree.id() {
             return Err(user_error("No changes selected"));

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -44,6 +44,7 @@ use thiserror::Error;
 use self::builtin::edit_diff_builtin;
 use self::builtin::edit_merge_builtin;
 use self::builtin::BuiltinToolError;
+pub use self::builtin::InitialSelection;
 pub(crate) use self::diff_working_copies::new_utf8_temp_dir;
 use self::diff_working_copies::DiffCheckoutError;
 use self::external::edit_diff_external;
@@ -255,14 +256,17 @@ impl DiffEditor {
         right_tree: &MergedTree,
         matcher: &dyn Matcher,
         format_instructions: impl FnOnce() -> String,
+        initial_selection: InitialSelection,
     ) -> Result<MergedTreeId, DiffEditError> {
         match &self.tool {
-            MergeTool::Builtin => {
-                Ok(
-                    edit_diff_builtin(left_tree, right_tree, matcher, self.conflict_marker_style)
-                        .map_err(Box::new)?,
-                )
-            }
+            MergeTool::Builtin => Ok(edit_diff_builtin(
+                left_tree,
+                right_tree,
+                matcher,
+                self.conflict_marker_style,
+                initial_selection,
+            )
+            .map_err(Box::new)?),
             MergeTool::External(editor) => {
                 let instructions = self.use_instructions.then(format_instructions);
                 edit_diff_external(


### PR DESCRIPTION
(fixes #5390)

Currently, there is a blocker: when quitting the ui with 'q' after making no changes, you get prompted with 'you have modified N files, are you sure?', which seems like a bug in the scm_record library.

Separately, I tested this manually but I'm unsure whether and how I should add automated tests. The problem is that this change only affects the builtin UI, which I don't know how to test automatically. If I make external tools support this new `InitialSelection` parameter, I could test that `diffedit` receives `InitialSelection::All`, but not the bulk of the change.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209241374115279