### PR TITLE
make `jj bookmark *` aliases non-visible

### DIFF
--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -80,6 +80,7 @@ pub enum BookmarkCommand {
     Set(BookmarkSetArgs),
     #[command(alias("t"))]
     Track(BookmarkTrackArgs),
+    #[command(alias("u"))]
     Untrack(BookmarkUntrackArgs),
 }
 

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -64,21 +64,21 @@ use crate::ui::Ui;
 /// https://jj-vcs.github.io/jj/latest/bookmarks.
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum BookmarkCommand {
-    #[command(visible_alias("c"))]
+    #[command(alias("c"))]
     Create(BookmarkCreateArgs),
-    #[command(visible_alias("d"))]
+    #[command(alias("d"))]
     Delete(BookmarkDeleteArgs),
-    #[command(visible_alias("f"))]
+    #[command(alias("f"))]
     Forget(BookmarkForgetArgs),
-    #[command(visible_alias("l"))]
+    #[command(alias("l"))]
     List(BookmarkListArgs),
-    #[command(visible_alias("m"))]
+    #[command(alias("m"))]
     Move(BookmarkMoveArgs),
-    #[command(visible_alias("r"))]
+    #[command(alias("r"))]
     Rename(BookmarkRenameArgs),
-    #[command(visible_alias("s"))]
+    #[command(alias("s"))]
     Set(BookmarkSetArgs),
-    #[command(visible_alias("t"))]
+    #[command(alias("t"))]
     Track(BookmarkTrackArgs),
     Untrack(BookmarkUntrackArgs),
 }


### PR DESCRIPTION
This goes makes completions go from
```
c                                                               (Create a new bookmark)
d  (Delete an existing bookmark and propagate the deletion to remotes on the next push)
f          (Forget everything about a bookmark, including its local and remote targets)
l                                                    (List bookmarks and their targets)
m                                          (Move existing bookmarks to target revision)
r                                   (Rename `old` bookmark name to `new` bookmark name)
s                            (Create or update a bookmark to point to a certain commit)
t                                               (Start tracking given remote bookmarks)
untrack                                          (Stop tracking given remote bookmarks)
```

To
```
create                                                               (Create a new bookmark)
delete  (Delete an existing bookmark and propagate the deletion to remotes on the next push)
forget          (Forget everything about a bookmark, including its local and remote targets)
list                                                      (List bookmarks and their targets)
move                                            (Move existing bookmarks to target revision)
rename                                   (Rename `old` bookmark name to `new` bookmark name)
set                               (Create or update a bookmark to point to a certain commit)
track                                                (Start tracking given remote bookmarks)
untrack                                               (Stop tracking given remote bookmarks)
```
which is much more readable.

I think this is worth more than the discoverability of these short aliases.
The bookmark commands also all start with distinct characters, so `jj
bookmark c<TAB>` etc. all work.


I also added a `u = untrack` alias for consistency, it was the only subcommand that didn't have any.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
