### PR TITLE
cli: handle remote configuration error on "git clone"

### DIFF
--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -196,12 +196,12 @@ fn fetch_new_remote(
     depth: Option<NonZeroU32>,
 ) -> Result<GitFetchStats, CommandError> {
     let git_repo = get_git_repo(workspace_command.repo().store())?;
+    git::add_remote(&git_repo, remote_name, source)?;
     writeln!(
         ui.status(),
         r#"Fetching into new repo in "{}""#,
         workspace_command.workspace_root().display()
     )?;
-    git_repo.remote(remote_name, source).unwrap();
     let git_settings = workspace_command.settings().git_settings()?;
     let mut fetch_tx = workspace_command.start_transaction();
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -548,6 +548,19 @@ fn test_git_clone_with_remote_name() {
 }
 
 #[test]
+fn test_git_clone_with_remote_named_git() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("source");
+    git2::Repository::init(git_repo_path).unwrap();
+
+    let stderr = test_env.jj_cmd_failure(
+        test_env.env_root(),
+        &["git", "clone", "--remote=git", "source", "dest"],
+    );
+    insta::assert_snapshot!(stderr, @"Error: Git remote named 'git' is reserved for local Git repository");
+}
+
+#[test]
 fn test_git_clone_trunk_deleted() {
     let test_env = TestEnvironment::default();
     let git_repo_path = test_env.env_root().join("source");


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
