### PR TITLE
revset: split author()/committer() into _name()/email() predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Italic text is now supported. You can set e.g. `color.error = { fg = "red", italic = true }`
   in your config.
 
+* New `author_name`/`author_email`/`committer_name`/`committer_email(pattern)`
+  revset functions to match either name or email field explicitly.
+
 ### Fixed bugs
 
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -378,7 +378,7 @@ fn test_function_name_hint() {
     "###);
 
     // Both builtin function and function alias should be suggested
-    insta::assert_snapshot!(evaluate_err("author_()"), @r###"
+    insta::assert_snapshot!(evaluate_err("author_()"), @r#"
     Error: Failed to parse revset: Function "author_" doesn't exist
     Caused by:  --> 1:1
       |
@@ -386,8 +386,8 @@ fn test_function_name_hint() {
       | ^-----^
       |
       = Function "author_" doesn't exist
-    Hint: Did you mean "author", "author_date", "my_author"?
-    "###);
+    Hint: Did you mean "author", "author_date", "author_email", "author_name", "my_author"?
+    "#);
 
     insta::assert_snapshot!(evaluate_err("my_bookmarks"), @r#"
     Error: Failed to parse revset: In alias "my_bookmarks"

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -268,16 +268,30 @@ revsets (expressions) as arguments.
   [string pattern](#string-patterns).
 
 * `author(pattern)`: Commits with the author's name or email matching the given
+  [string pattern](#string-patterns). Equivalent to `author_name(pattern) |
+  author_email(pattern)`.
+
+* `author_name(pattern)`: Commits with the author's name matching the given
   [string pattern](#string-patterns).
 
-* `mine()`: Commits where the author's email matches the email of the current
-  user.
-
-* `committer(pattern)`: Commits with the committer's  name or email matching the
-given [string pattern](#string-patterns).
+* `author_email(pattern)`: Commits with the author's email matching the given
+  [string pattern](#string-patterns).
 
 * `author_date(pattern)`: Commits with author dates matching the specified [date
   pattern](#date-patterns).
+
+* `mine()`: Commits where the author's email matches the email of the current
+  user. Equivalent to `author_email(exact-i:<user-email>)`
+
+* `committer(pattern)`: Commits with the committer's name or email matching the
+  given [string pattern](#string-patterns). Equivalent to
+  `committer_name(pattern) | committer_email(pattern)`.
+
+* `committer_name(pattern)`: Commits with the committer's name matching the
+  given [string pattern](#string-patterns).
+
+* `committer_email(pattern)`: Commits with the committer's email matching the
+  given [string pattern](#string-patterns).
 
 * `committer_date(pattern)`: Commits with committer dates matching the specified
   [date pattern](#date-patterns).

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1163,8 +1163,6 @@ fn build_predicate_fn(
         }
         RevsetFilterPredicate::Author(pattern) => {
             let pattern = pattern.clone();
-            // TODO: Make these functions that take a needle to search for accept some
-            // syntax for specifying whether it's a regex.
             box_pure_predicate_fn(move |index, pos| {
                 let entry = index.entry_by_pos(pos);
                 let commit = store.get_commit(&entry.commit_id())?;

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1161,22 +1161,20 @@ fn build_predicate_fn(
                 Ok(pattern.matches(commit.description()))
             })
         }
-        RevsetFilterPredicate::Author(pattern) => {
+        RevsetFilterPredicate::AuthorName(pattern) => {
             let pattern = pattern.clone();
             box_pure_predicate_fn(move |index, pos| {
                 let entry = index.entry_by_pos(pos);
                 let commit = store.get_commit(&entry.commit_id())?;
-                Ok(pattern.matches(&commit.author().name)
-                    || pattern.matches(&commit.author().email))
+                Ok(pattern.matches(&commit.author().name))
             })
         }
-        RevsetFilterPredicate::Committer(pattern) => {
+        RevsetFilterPredicate::AuthorEmail(pattern) => {
             let pattern = pattern.clone();
             box_pure_predicate_fn(move |index, pos| {
                 let entry = index.entry_by_pos(pos);
                 let commit = store.get_commit(&entry.commit_id())?;
-                Ok(pattern.matches(&commit.committer().name)
-                    || pattern.matches(&commit.committer().email))
+                Ok(pattern.matches(&commit.author().email))
             })
         }
         RevsetFilterPredicate::AuthorDate(expression) => {
@@ -1186,6 +1184,22 @@ fn build_predicate_fn(
                 let commit = store.get_commit(&entry.commit_id())?;
                 let author_date = &commit.author().timestamp;
                 Ok(expression.matches(author_date))
+            })
+        }
+        RevsetFilterPredicate::CommitterName(pattern) => {
+            let pattern = pattern.clone();
+            box_pure_predicate_fn(move |index, pos| {
+                let entry = index.entry_by_pos(pos);
+                let commit = store.get_commit(&entry.commit_id())?;
+                Ok(pattern.matches(&commit.committer().name))
+            })
+        }
+        RevsetFilterPredicate::CommitterEmail(pattern) => {
+            let pattern = pattern.clone();
+            box_pure_predicate_fn(move |index, pos| {
+                let entry = index.entry_by_pos(pos);
+                let commit = store.get_commit(&entry.commit_id())?;
+                Ok(pattern.matches(&commit.committer().email))
             })
         }
         RevsetFilterPredicate::CommitterDate(expression) => {

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2755,6 +2755,25 @@ fn test_evaluate_expression_author() {
             commit1.id().clone(),
         ]
     );
+
+    // Can match name or email explicitly
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "author_name('name2')"),
+        vec![commit2.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "author_email('name2')"),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "author_name('email2')"),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "author_email('email2')"),
+        vec![commit2.id().clone()]
+    );
+
     // Searches only among candidates if specified
     assert_eq!(
         resolve_commit_ids(mut_repo, "visible_heads() & author(\"name2\")"),
@@ -2921,7 +2940,8 @@ fn test_evaluate_expression_mine() {
     };
     let commit1 = create_random_commit(mut_repo)
         .set_author(Signature {
-            name: "name1".to_string(),
+            // Test that the name field doesn't match
+            name: settings.user_email().to_owned(),
             email: "email1".to_string(),
             timestamp,
         })
@@ -3038,6 +3058,25 @@ fn test_evaluate_expression_committer() {
             commit1.id().clone(),
         ]
     );
+
+    // Can match name or email explicitly
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "committer_name('name2')"),
+        vec![commit2.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "committer_email('name2')"),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "committer_name('email2')"),
+        vec![]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "committer_email('email2')"),
+        vec![commit2.id().clone()]
+    );
+
     // Searches only among candidates if specified
     assert_eq!(
         resolve_commit_ids(mut_repo, "visible_heads() & committer(\"name2\")"),


### PR DESCRIPTION

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
