### PR TITLE
Allow signing commits by other authors when rewriting them

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -565,6 +565,11 @@
                     "description": "Whether to sign all commits by default. Overridden by global `--no-sign` option",
                     "default": false
                 },
+                "sign-foreign": {
+                    "type": "boolean",
+                    "description": "Whether to sign commits of other authors with your own key when rewriting them. Only applicable with `sign-all = true`.",
+                    "default": false
+                },
                 "backends": {
                     "type": "object",
                     "description": "Tables of options to pass to specific signing backends",

--- a/docs/config.md
+++ b/docs/config.md
@@ -1095,6 +1095,22 @@ key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52
 sign-on-push = true
 ```
 
+### Sign foreign commits
+
+The `signing.sign-all` setting by default only applies to commits authored by
+yourself, based on the author email. Signatures by different authors cannot
+be recreated, due to missing their private key material. However, it is
+possible to sign those commits with your own key by setting the additional
+configuration variable `signing.sign-foreign`:
+
+```toml
+[signing]
+sign-all = true
+sign-foreign = true
+```
+
+Note that `sign-foreign` does not have any effect if `sign-all` is set to
+false.
 
 ## Commit Signature Verification
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -94,11 +94,12 @@ impl SignSettings {
     /// Load the signing settings from the config.
     pub fn from_settings(settings: &UserSettings) -> Self {
         let sign_all = settings.get_bool("signing.sign-all").unwrap_or(false);
+        let sign_foreign = settings.get_bool("signing.sign-foreign").unwrap_or(false);
         Self {
-            behavior: if sign_all {
-                SignBehavior::Own
-            } else {
-                SignBehavior::Keep
+            behavior: match (sign_all, sign_foreign) {
+                (true, true) => SignBehavior::Force,
+                (true, false) => SignBehavior::Own,
+                (false, _) => SignBehavior::Keep,
             },
             user_email: settings.user_email().to_owned(),
             key: settings.get_string("signing.key").ok(),


### PR DESCRIPTION
Hi! I want to try and get the ball rolling on a fix for #4561, so here's a first shot at it. This simply adds another boolean flag `sign-foreign`, which upgrades `SignBehavior::Own` to `Force`. As such, it's a very non-invasive change.

The code in this PR is working fine for me locally, but I haven't really looked into automated tests yet.

[One proposed alternative](https://github.com/jj-vcs/jj/issues/4561#issuecomment-2559422465) is to change it to a `sign` variable that takes one of these behavior names. This would require migration or deprecation of the previous `sign-all` flag, which I haven't figured out how it works yet :)

Please let me know what you think about this. I'm also happy to change to a different approach (although it might take me a while, as I'm new to this codebase).

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
