### PR TITLE
builtin pager: add configuration options, change default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * The builtin pager is switched to
   [streampager](https://github.com/markbt/streampager/). It can handle large
-  inputs better.
+  inputs better and can be configured.
 
 * Conflicts materialized in the working copy before `jj 0.19.0` may no longer
   be parsed correctly. If you are using version 0.18.0 or earlier, check out a

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -107,6 +107,30 @@
                     "description": "Pager to use for displaying command output",
                     "default": "less -FRX"
                 },
+                "streampager": {
+                    "type": "object",
+                    "description": "':builtin' (streampager-based) pager configuration",
+                    "properties": {
+                        "interface": {
+                            "description": "Whether to quit automatically, whether to clear screen on startup/exit",
+                            "enum": [
+                                "quit-if-one-page",
+                                "full-screen-clear-output",
+                                "quit-quickly-or-clear-output"
+                            ],
+                            "default": "never"
+                        },
+                        "wrapping": {
+                            "description": "Whether to wrap long lines",
+                            "enum": [
+                                "anywhere",
+                                "word",
+                                "none"
+                            ],
+                            "default": "anywhere"
+                        }
+                    }
+                },
                 "diff": {
                     "type": "object",
                     "description": "Options for how diffs are displayed",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -41,6 +41,10 @@ show-cryptographic-signatures = false
 [ui.movement]
 edit = false
 
+[ui.streampager]
+interface = "quit-if-one-page"
+wrapping = "anywhere"
+
 [snapshot]
 max-new-file-size = "1MiB"
 auto-track = "all()"

--- a/docs/config.md
+++ b/docs/config.md
@@ -604,7 +604,23 @@ Our builtin pager is based on
 [`streampager`](https://github.com/markbt/streampager/) but is configured within
 `jj`'s config. It is configured via the `ui.streampager` table.
 
-#### Wrapping
+#### Key bindings
+
+The built-in pager supports both navigation via arrows and Vim-style navigation.
+Beyond that, here are some useful keybindings for the pager:
+
+| Key             | Action                |
+| :-------------- | :-------------------- |
+| `Ctrl-c` or `q` | Quit                  |
+| `h` or `F1`     | Show all key bindings |
+| `Esc`           | Close help or prompt  |
+| `\`             | Toggle line wrapping  |
+| `#`             | Toggle line numbers   |
+| `Ctrl-r`        | Toggle the ruler      |
+
+The built-in pager does not support mouse input.
+
+#### Wrapping config
 
 Wrapping performed by the pager happens *in addition to* any
 wrapping that `jj` itself does.

--- a/docs/config.md
+++ b/docs/config.md
@@ -575,8 +575,8 @@ a `$`):
 `less -FRX` is the default pager in the absence of any other setting, except
 on Windows where it is `:builtin`.
 
-The special value `:builtin` enables usage of the [integrated pager called
-`streampager`](https://github.com/markbt/streampager/).
+The special value `:builtin` enables usage of the [integrated
+pager](#builtin-pager).
 
 If you are using a standard Linux distro, your system likely already has
 `$PAGER` set and that will be preferred over the built-in. To use the built-in:
@@ -597,6 +597,45 @@ paginate = "auto"
 # Disable all pagination, equivalent to using --no-pager
 paginate = "never"
 ```
+
+### Builtin pager
+
+Our builtin pager is based on
+[`streampager`](https://github.com/markbt/streampager/) but is configured within
+`jj`'s config. It is configured via the `ui.streampager` table.
+
+#### Wrapping
+
+Wrapping performed by the pager happens *in addition to* any
+wrapping that `jj` itself does.
+
+```toml
+[ui.streampager]
+wrapping = "anywhere"  # wrap at screen edge (default)
+wrapping = "word"      # wrap on word boundaries
+wrapping = "none"      # strip long lines, allow scrolling
+                       # left and right like `less -S`
+```
+
+#### Auto-exit, clearing the screen on startup or exit
+
+You can configure whether the pager clears the screen on startup or exit, and
+whether it quits automatically on short inputs. When the pager auto-quits,
+features like word-wrapping are disabled.
+
+```toml
+[ui.streampager]
+# Do not clear screen on exit. Use a full-screen interface for long
+# output only. Like `less -FX`.
+interface = "quit-if-one-page"  # (default).
+# Always use a full-screen interface, ask the terminal to clear the
+# screen on exit. Like `less -+FX`.
+interface = "full-screen-clear-output"
+# Use the alternate screen if the input is either long or takes more
+# than 2 seconds to finish. Similar but not identical to `less -F -+X`.
+interface = "quit-quickly-or-clear-output"
+```
+
 
 ### Processing contents to be paged
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

I've been going back and forth on naming of the `alternate-screen` option. It has many subtle effects that seem hard to describe without thinking of the alternate screen (e.g. if we call it `clear-screen`), at least if we want to allow the `if-long-or-slow` behavior. If we are OK with forbidding it, we could have a simple `quit-if-one-page` boolean, but I think it might just be useful enough to keep.

Streampager's naming of the corresponding [`interface_mode` option](https://github.com/facebook/sapling/blob/0280ed4ab533abbaa4836abc0854b66ac13a10fa/eden/scm/lib/third-party/streampager/src/config.rs#L14) seems more confusing to me: the Direct mode seems useless, there are two hybrid modes (one of which is called Hybrid) that are hard to distinguish unless you think in terms of the alternate screen terminal mode.

# TODOs

- [x] Describe streampager keybindings (here or another PR)
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] (not planned) I have added tests to cover my changes
