### PR TITLE
Add a --edit flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj describe` now accepts `--edit`.
+
 * `jj evolog` and `jj op log` now accept `--reversed`.
 
 * `jj restore` now supports `-i`/`--interactive` selection.

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -55,7 +55,12 @@ pub(crate) struct DescribeArgs {
     ///
     /// If multiple revisions are specified, the same description will be used
     /// for all of them.
-    #[arg(long = "message", short, value_name = "MESSAGE")]
+    #[arg(
+        long = "message",
+        short,
+        value_name = "MESSAGE",
+        conflicts_with = "stdin"
+    )]
     message_paragraphs: Vec<String>,
     /// Read the change description from stdin
     ///

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -66,8 +66,14 @@ pub(crate) struct DescribeArgs {
     /// Don't open an editor
     ///
     /// This is mainly useful in combination with e.g. `--reset-author`.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "edit")]
     no_edit: bool,
+    /// Open an editor
+    ///
+    /// Forces an editor to open when using `--stdin` or `--message` to
+    /// allow the message to be edited afterwards.
+    #[arg(long)]
+    edit: bool,
     /// Reset the author to the configured user
     ///
     /// This resets the author name, email, and timestamp.
@@ -133,7 +139,12 @@ pub(crate) fn cmd_describe(
         None
     };
 
-    let commit_descriptions: Vec<(_, _)> = if args.no_edit || shared_description.is_some() {
+    // edit and no_edit are conflicting arguments and therefore it should not
+    // be possible for both to be true at the same time.
+    assert!(!(args.edit && args.no_edit));
+    let use_editor = args.edit || (shared_description.is_none() && !args.no_edit);
+
+    let commit_descriptions: Vec<(_, _)> = if !use_editor {
         commits
             .iter()
             .map(|commit| {
@@ -150,7 +161,9 @@ pub(crate) fn cmd_describe(
             .rev()
             .map(|commit| -> Result<_, CommandError> {
                 let mut commit_builder = tx.repo_mut().rewrite_commit(commit).detach();
-                if commit_builder.description().is_empty() {
+                if let Some(description) = &shared_description {
+                    commit_builder.set_description(description);
+                } else if commit_builder.description().is_empty() {
                     commit_builder
                         .set_description(tx.settings().get_string("ui.default-description")?);
                 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -665,6 +665,9 @@ Starts an editor to let you edit the description of changes. The editor will be 
 * `--no-edit` — Don't open an editor
 
    This is mainly useful in combination with e.g. `--reset-author`.
+* `--edit` — Open an editor
+
+   Forces an editor to open when using `--stdin` or `--message` to allow the message to be edited afterwards.
 * `--reset-author` — Reset the author to the configured user
 
    This resets the author name, email, and timestamp.


### PR DESCRIPTION
The --edit flag forces the editor to be shown, even if it would have been hidden due to the --no-edit flag or another flag that implies it (such as --message or --stdin).

This fixes #5379  

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
