### PR TITLE
cli: warn user if they try to `jj bookmark set bookmark@remote`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * New `subject(pattern)` revset function that matches first line of commit
   descriptions.
+* Warn user if they try to use `jj boookmark set branch@remote`
 
 ### Fixed bugs
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -97,6 +97,7 @@ use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::repo_path::UiPathParseError;
 use jj_lib::revset;
+use jj_lib::revset::ExpressionNode;
 use jj_lib::revset::ResolvedRevsetExpression;
 use jj_lib::revset::RevsetAliasesMap;
 use jj_lib::revset::RevsetDiagnostics;
@@ -1601,6 +1602,19 @@ to the current parents may contain changes from multiple commits.
             revset::parse_with_modifier(&mut diagnostics, revision_arg.as_ref(), &context)?;
         print_parse_diagnostics(ui, "In revset expression", &diagnostics)?;
         Ok((self.attach_revset_evaluator(expression), modifier))
+    }
+
+    pub fn parse_revset_expression<'a, 'b>(
+        &'b self,
+        revision_arg: &'a str,
+    ) -> Result<ExpressionNode<'a>, CommandError>
+    where
+        'b: 'a,
+    {
+        let context = self.revset_parse_context();
+        let expression = revset::parse_expr_with_expansion(revision_arg, &context)?;
+
+        Ok(expression)
     }
 
     /// Parses the given revset expressions and concatenates them all.

--- a/cli/src/commands/bookmark/create.rs
+++ b/cli/src/commands/bookmark/create.rs
@@ -55,6 +55,9 @@ pub fn cmd_bookmark_create(
         .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
     let view = workspace_command.repo().view();
     let bookmark_names = &args.names;
+
+    super::validate_bookmark_names(command, ui, bookmark_names, "create")?;
+
     for name in bookmark_names {
         if view.get_local_bookmark(name).is_present() {
             return Err(user_error_with_hint(

--- a/cli/src/commands/bookmark/set.rs
+++ b/cli/src/commands/bookmark/set.rs
@@ -61,6 +61,9 @@ pub fn cmd_bookmark_set(
         .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
     let repo = workspace_command.repo().as_ref();
     let bookmark_names = &args.names;
+
+    super::validate_bookmark_names(command, ui, bookmark_names, "set")?;
+
     let mut new_bookmark_count = 0;
     let mut moved_bookmark_count = 0;
     for name in bookmark_names {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1194,8 +1194,7 @@ pub fn parse(
     revset_str: &str,
     context: &RevsetParseContext,
 ) -> Result<Rc<UserRevsetExpression>, RevsetParseError> {
-    let node = revset_parser::parse_program(revset_str)?;
-    let node = dsl_util::expand_aliases(node, context.aliases_map)?;
+    let node = parse_expr_with_expansion(revset_str, context)?;
     lower_expression(diagnostics, &node, context)
         .map_err(|err| err.extend_function_candidates(context.aliases_map.function_names()))
 }
@@ -1205,8 +1204,7 @@ pub fn parse_with_modifier(
     revset_str: &str,
     context: &RevsetParseContext,
 ) -> Result<(Rc<UserRevsetExpression>, Option<RevsetModifier>), RevsetParseError> {
-    let node = revset_parser::parse_program(revset_str)?;
-    let node = dsl_util::expand_aliases(node, context.aliases_map)?;
+    let node = parse_expr_with_expansion(revset_str, context)?;
     revset_parser::expect_program_with(
         diagnostics,
         &node,
@@ -1220,6 +1218,18 @@ pub fn parse_with_modifier(
         },
     )
     .map_err(|err| err.extend_function_candidates(context.aliases_map.function_names()))
+}
+
+pub fn parse_expr_with_expansion<'a, 'b>(
+    revset_str: &'a str,
+    context: &RevsetParseContext<'b>,
+) -> Result<ExpressionNode<'a>, RevsetParseError>
+where
+    'b: 'a,
+{
+    let node = revset_parser::parse_program(revset_str)?;
+    let node = dsl_util::expand_aliases(node, context.aliases_map)?;
+    Ok(node)
 }
 
 /// `Some` for rewritten expression, or `None` to reuse the original expression.


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

I'm not sure, maybe there is a legit use case for having `@` in branch name, but most likely it's a mistake.

It's also not very consistent with other commands.
You can `jj rebase -d br@origin`, but you can't` jj bookmark set br@origin` after rebasing(I was lazy importing bookmark).


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
