### PR TITLE
actions: fix codespell CI failure

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -21,4 +21,4 @@ jobs:
           check_filenames: true
           check_hidden: true
           skip: ./target,./.jj,*.lock
-          ignore_words_list: crate,NotIn,Wirth
+          ignore_words_list: crate,NotIn,Wirth,abd

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -721,7 +721,7 @@ fn test_deduplication() {
     insta::assert_snapshot!(content, @"FOO\n");
 
     // Each new content string only appears once in the log, because all the other
-    // inputs (like file name) were identical, and so the results were re-used. We
+    // inputs (like file name) were identical, and so the results were reused. We
     // sort the log because the order of execution inside `jj fix` is undefined.
     insta::assert_snapshot!(sorted_lines(repo_path.join("file-fixlog")), @"BAR\nFOO\n");
 }


### PR DESCRIPTION
It is having a fit for some reason, see e.g.
https://github.com/jj-vcs/jj/actions/runs/12897590111/job/35963026619?pr=5414

Not sure what changed, but here is a quick fix
