### PR TITLE
git: update jj git clone|fetch to use new GitFetch api directly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj git fetch` with multiple remotes will now fetch from all remotes before
+  importing refs into the jj repo. This fixes a race condition where the
+  treatment of a commit that is found in multiple fetch remotes depended on the
+  order the remotes were specified.
+
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.
   [#5252](https://github.com/jj-vcs/jj/issues/5252)
 

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -19,8 +19,8 @@ use std::num::NonZeroU32;
 use std::path::Path;
 
 use jj_lib::git;
+use jj_lib::git::GitFetch;
 use jj_lib::git::GitFetchError;
-use jj_lib::git::GitFetchStats;
 use jj_lib::repo::Repo;
 use jj_lib::str_util::StringPattern;
 use jj_lib::workspace::Workspace;
@@ -118,8 +118,9 @@ pub fn cmd_git_clone(
 
     let clone_result = (|| -> Result<_, CommandError> {
         let mut workspace_command = init_workspace(ui, command, &canonical_wc_path, args.colocate)?;
-        let stats = fetch_new_remote(ui, &mut workspace_command, remote_name, &source, args.depth)?;
-        Ok((workspace_command, stats))
+        let default_branch =
+            fetch_new_remote(ui, &mut workspace_command, remote_name, &source, args.depth)?;
+        Ok((workspace_command, default_branch))
     })();
     if clone_result.is_err() {
         let clean_up_dirs = || -> io::Result<()> {
@@ -143,8 +144,8 @@ pub fn cmd_git_clone(
         }
     }
 
-    let (mut workspace_command, stats) = clone_result?;
-    if let Some(default_branch) = &stats.default_branch {
+    let (mut workspace_command, default_branch) = clone_result?;
+    if let Some(default_branch) = &default_branch {
         write_repository_level_trunk_alias(
             ui,
             workspace_command.repo_path(),
@@ -194,7 +195,7 @@ fn fetch_new_remote(
     remote_name: &str,
     source: &str,
     depth: Option<NonZeroU32>,
-) -> Result<GitFetchStats, CommandError> {
+) -> Result<Option<String>, CommandError> {
     let git_repo = get_git_repo(workspace_command.repo().store())?;
     git::add_remote(&git_repo, remote_name, source)?;
     writeln!(
@@ -204,29 +205,23 @@ fn fetch_new_remote(
     )?;
     let git_settings = workspace_command.settings().git_settings()?;
     let mut fetch_tx = workspace_command.start_transaction();
-    let stats = with_remote_git_callbacks(ui, None, &git_settings, |cb| {
-        git::fetch(
-            fetch_tx.repo_mut(),
-            &git_repo,
-            remote_name,
-            &[StringPattern::everything()],
-            cb,
-            &git_settings,
-            depth,
-        )
-    })
-    .map_err(|err| match err {
-        GitFetchError::NoSuchRemote(_) => {
-            panic!("shouldn't happen as we just created the git remote")
-        }
-        GitFetchError::GitImportError(err) => CommandError::from(err),
-        GitFetchError::InternalGitError(err) => map_git_error(err),
-        GitFetchError::Subprocess(err) => user_error(err),
-        GitFetchError::InvalidBranchPattern => {
-            unreachable!("we didn't provide any globs")
-        }
+    let mut git_fetch = GitFetch::new(fetch_tx.repo_mut(), &git_repo, &git_settings);
+    let default_branch = with_remote_git_callbacks(ui, None, &git_settings, |cb| {
+        git_fetch
+            .fetch(remote_name, &[StringPattern::everything()], cb, depth)
+            .map_err(|err| match err {
+                GitFetchError::NoSuchRemote(_) => {
+                    panic!("shouldn't happen as we just created the git remote")
+                }
+                GitFetchError::InternalGitError(err) => map_git_error(err),
+                GitFetchError::Subprocess(err) => user_error(err),
+                GitFetchError::InvalidBranchPattern => {
+                    unreachable!("we didn't provide any globs")
+                }
+            })
     })?;
-    print_git_import_stats(ui, fetch_tx.repo(), &stats.import_stats, true)?;
+    let import_stats = git_fetch.import_refs()?;
+    print_git_import_stats(ui, fetch_tx.repo(), &import_stats, true)?;
     fetch_tx.finish(ui, "fetch from git remote into empty repo")?;
-    Ok(stats)
+    Ok(default_branch)
 }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1457,8 +1457,6 @@ pub enum GitFetchError {
         chars = INVALID_REFSPEC_CHARS.iter().join("`, `")
     )]
     InvalidBranchPattern,
-    #[error("Failed to import Git refs")]
-    GitImportError(#[from] GitImportError),
     // TODO: I'm sure there are other errors possible, such as transport-level errors.
     #[error("Unexpected git error when fetching")]
     InternalGitError(#[from] git2::Error),
@@ -1484,36 +1482,29 @@ fn git2_fetch_options(
 }
 
 struct FetchedBranches {
-    branches: Vec<StringPattern>,
     remote: String,
+    branches: Vec<StringPattern>,
 }
 
-struct GitFetch<'a> {
+/// Helper struct to execute multiple `git fetch` operations
+pub struct GitFetch<'a> {
     mut_repo: &'a mut MutableRepo,
     git_repo: &'a git2::Repository,
     git_settings: &'a GitSettings,
-    // for git2 only
-    fetch_options: git2::FetchOptions<'a>,
     fetched: Vec<FetchedBranches>,
-    // for subprocess only
-    depth: Option<NonZeroU32>,
 }
 
 impl<'a> GitFetch<'a> {
-    fn new(
+    pub fn new(
         mut_repo: &'a mut MutableRepo,
         git_repo: &'a git2::Repository,
         git_settings: &'a GitSettings,
-        fetch_options: git2::FetchOptions<'a>,
-        depth: Option<NonZeroU32>,
     ) -> Self {
         GitFetch {
             mut_repo,
             git_repo,
             git_settings,
-            fetch_options,
             fetched: vec![],
-            depth,
         }
     }
 
@@ -1544,8 +1535,10 @@ impl<'a> GitFetch<'a> {
 
     fn git2_fetch(
         &mut self,
-        branch_names: &[StringPattern],
+        callbacks: RemoteCallbacks<'_>,
+        depth: Option<NonZeroU32>,
         remote_name: &str,
+        branch_names: &[StringPattern],
     ) -> Result<Option<String>, GitFetchError> {
         let mut remote = self.git_repo.find_remote(remote_name).map_err(|err| {
             if is_remote_not_found_err(&err) {
@@ -1567,7 +1560,7 @@ impl<'a> GitFetch<'a> {
         }
 
         tracing::debug!("remote.download");
-        remote.download(&refspecs, Some(&mut self.fetch_options))?;
+        remote.download(&refspecs, Some(&mut git2_fetch_options(callbacks, depth)))?;
         tracing::debug!("remote.prune");
         remote.prune(None)?;
         tracing::debug!("remote.update_tips");
@@ -1598,8 +1591,9 @@ impl<'a> GitFetch<'a> {
 
     fn subprocess_fetch(
         &mut self,
-        branch_names: &[StringPattern],
+        depth: Option<NonZeroU32>,
         remote_name: &str,
+        branch_names: &[StringPattern],
     ) -> Result<Option<String>, GitFetchError> {
         let git_ctx =
             GitSubprocessContext::from_git2(self.git_repo, &self.git_settings.executable_path);
@@ -1626,7 +1620,7 @@ impl<'a> GitFetch<'a> {
         // even more unfortunately, git errors out one refspec at a time,
         // meaning that the below cycle runs in O(#failed refspecs)
         while let Some(failing_refspec) =
-            git_ctx.spawn_fetch(remote_name, self.depth, &remaining_refspecs)?
+            git_ctx.spawn_fetch(remote_name, depth, &remaining_refspecs)?
         {
             remaining_refspecs.retain(|r| r.source.as_ref() != Some(&failing_refspec));
 
@@ -1652,20 +1646,23 @@ impl<'a> GitFetch<'a> {
     ///
     /// Keeps track of the {branch_names, remote_name} pair the refs can be
     /// subsequently imported into the `jj` repo by calling `import_refs()`.
-    fn fetch(
+    #[tracing::instrument(skip(self, callbacks))]
+    pub fn fetch(
         &mut self,
-        branch_names: &[StringPattern],
         remote_name: &str,
+        branch_names: &[StringPattern],
+        callbacks: RemoteCallbacks<'_>,
+        depth: Option<NonZeroU32>,
     ) -> Result<Option<String>, GitFetchError> {
         let default_branch = if self.git_settings.subprocess {
-            self.subprocess_fetch(branch_names, remote_name)
+            self.subprocess_fetch(depth, remote_name, branch_names)
         } else {
-            self.git2_fetch(branch_names, remote_name)
+            self.git2_fetch(callbacks, depth, remote_name, branch_names)
         };
 
         self.fetched.push(FetchedBranches {
-            branches: branch_names.to_vec(),
             remote: remote_name.to_string(),
+            branches: branch_names.to_vec(),
         });
 
         default_branch
@@ -1678,6 +1675,7 @@ impl<'a> GitFetch<'a> {
     /// Clears all yet-to-be-imported {branch_names, remote_name} pairs after
     /// the import. If `fetch()` has not been called since the last time
     /// `import_refs()` was called then this will be a no-op.
+    #[tracing::instrument(skip(self))]
     pub fn import_refs(&mut self) -> Result<GitImportStats, GitImportError> {
         tracing::debug!("import_refs");
         let import_stats =
@@ -1706,45 +1704,6 @@ impl<'a> GitFetch<'a> {
 
         Ok(import_stats)
     }
-}
-
-/// Describes successful `fetch()` result.
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
-pub struct GitFetchStats {
-    /// Remote's default branch.
-    pub default_branch: Option<String>,
-    /// Changes made by the import.
-    pub import_stats: GitImportStats,
-}
-
-#[tracing::instrument(skip(mut_repo, git_repo, callbacks))]
-pub fn fetch(
-    mut_repo: &mut MutableRepo,
-    git_repo: &git2::Repository,
-    remote_name: &str,
-    branch_names: &[StringPattern],
-    callbacks: RemoteCallbacks<'_>,
-    git_settings: &GitSettings,
-    depth: Option<NonZeroU32>,
-) -> Result<GitFetchStats, GitFetchError> {
-    let mut git_fetch = GitFetch::new(
-        mut_repo,
-        git_repo,
-        git_settings,
-        if git_settings.subprocess {
-            git2::FetchOptions::default()
-        } else {
-            git2_fetch_options(callbacks, depth)
-        },
-        depth,
-    );
-    let default_branch = git_fetch.fetch(branch_names, remote_name)?;
-    let import_stats = git_fetch.import_refs()?;
-    let stats = GitFetchStats {
-        default_branch,
-        import_stats,
-    };
-    Ok(stats)
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
* Make the new `GitFetch` api public.
* Move `git::fetch` to `lib/tests/test_git.rs` as `git_fetch`, to minimize churn in the tests. Update test call sites to use `git_fetch`
* Delete the `git::fetch` from `lib/src/git.rs`.
* Update `jj git clone` and `git_fetch` in `cli/src/git_utils.rs` to use the new api directly. Removing one redundant layer of indirection.
* This fixes #4920 as it first fetches from all remotes before `import_refs()` is called, so there is no race condition if the same commit is treated differently in different remotes specified in the same command.

Original commit by @essiene #4960 