### PR TITLE
git: externalize the subprocess context

### DIFF
--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -29,6 +29,7 @@ use crate::command_error::CommandError;
 use crate::commands::git::get_single_remote;
 use crate::complete;
 use crate::git_util::get_git_repo;
+use crate::git_util::get_git_subprocess_ctx;
 use crate::git_util::map_git_error;
 use crate::git_util::print_git_import_stats;
 use crate::git_util::with_remote_git_callbacks;
@@ -135,7 +136,8 @@ fn do_git_fetch(
     branch_names: &[StringPattern],
 ) -> Result<(), CommandError> {
     let git_settings = tx.settings().git_settings()?;
-    let mut git_fetch = GitFetch::new(tx.repo_mut(), git_repo, &git_settings);
+    let git_subprocess_ctx = get_git_subprocess_ctx(tx.repo().store(), &git_settings)?;
+    let mut git_fetch = GitFetch::new(tx.repo_mut(), git_repo, &git_settings, &git_subprocess_ctx);
 
     for remote_name in remotes {
         with_remote_git_callbacks(ui, None, &git_settings, |cb| {

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -55,6 +55,7 @@ use crate::commands::git::get_single_remote;
 use crate::complete;
 use crate::formatter::Formatter;
 use crate::git_util::get_git_repo;
+use crate::git_util::get_git_subprocess_ctx;
 use crate::git_util::map_git_error;
 use crate::git_util::with_remote_git_callbacks;
 use crate::git_util::GitSidebandProgressMessageWriter;
@@ -376,6 +377,7 @@ pub fn cmd_git_push(
     };
 
     let git_settings = tx.settings().git_settings()?;
+    let git_subprocess_ctx = get_git_subprocess_ctx(tx.repo().store(), &git_settings)?;
     with_remote_git_callbacks(
         ui,
         Some(&mut sideband_progress_callback),
@@ -385,6 +387,7 @@ pub fn cmd_git_push(
                 tx.repo_mut(),
                 &git_repo,
                 &git_settings,
+                &git_subprocess_ctx,
                 &remote,
                 &targets,
                 cb,

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
+//! Facilities to spawn a Git subprocess and parse their output
+
 use std::collections::HashSet;
 use std::num::NonZeroU32;
 use std::path::Path;
@@ -27,6 +29,7 @@ use crate::git::RefSpec;
 use crate::git::RefToPush;
 
 /// Error originating by a Git subprocess
+#[allow(missing_docs)]
 #[derive(Error, Debug)]
 pub enum GitSubprocessError {
     #[error("Could not find repository at '{0}'")]
@@ -50,21 +53,19 @@ pub enum GitSubprocessError {
 }
 
 /// Context for creating Git subprocesses
-pub(crate) struct GitSubprocessContext<'a> {
+#[derive(Debug)]
+pub struct GitSubprocessContext<'a> {
     git_dir: PathBuf,
     git_executable_path: &'a Path,
 }
 
 impl<'a> GitSubprocessContext<'a> {
-    pub(crate) fn new(git_dir: impl Into<PathBuf>, git_executable_path: &'a Path) -> Self {
+    /// Create a new GitSubprocess context
+    pub fn new(git_dir: impl Into<PathBuf>, git_executable_path: &'a Path) -> Self {
         GitSubprocessContext {
             git_dir: git_dir.into(),
             git_executable_path,
         }
-    }
-
-    pub(crate) fn from_git2(git_repo: &git2::Repository, git_executable_path: &'a Path) -> Self {
-        Self::new(git_repo.path(), git_executable_path)
     }
 
     /// Create the Git command

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -66,7 +66,7 @@ pub mod git {
 #[cfg(feature = "git")]
 pub mod git_backend;
 #[cfg(feature = "git")]
-mod git_subprocess;
+pub mod git_subprocess;
 pub mod gitignore;
 pub mod gpg_signing;
 pub mod graph;


### PR DESCRIPTION
Instead of creating the subprocess context directly in the git functions, pass it as an input.

This is relevant as some bits that go into the subprocess context, namely paths, are known to the caller but inaccessible within the `lib/src/git.rs` functions
