### PR TITLE
git: prevent UNC bugs when subprocessing to git

### DIFF
--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -201,6 +201,7 @@ fn fetch_new_remote(
     let git_settings = workspace_command.settings().git_settings()?;
     let git_subprocess_ctx =
         get_git_subprocess_ctx(workspace_command.repo().store(), &git_settings)?;
+    // TODO(git2): find a way to add remote with gitoxide or git subprocessing
     git::add_remote(&git_repo, remote_name, source)?;
     writeln!(
         ui.status(),

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -199,8 +199,7 @@ fn fetch_new_remote(
 ) -> Result<Option<String>, CommandError> {
     let git_repo = get_git_repo(workspace_command.repo().store())?;
     let git_settings = workspace_command.settings().git_settings()?;
-    let git_subprocess_ctx =
-        get_git_subprocess_ctx(workspace_command.repo().store(), &git_settings)?;
+    let git_subprocess_ctx = get_git_subprocess_ctx(workspace_command, &git_settings)?;
     // TODO(git2): find a way to add remote with gitoxide or git subprocessing
     git::add_remote(&git_repo, remote_name, source)?;
     writeln!(

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -137,7 +137,7 @@ fn do_git_fetch(
     branch_names: &[StringPattern],
 ) -> Result<(), CommandError> {
     let git_settings = tx.settings().git_settings()?;
-    let git_subprocess_ctx = get_git_subprocess_ctx(tx.repo().store(), &git_settings)?;
+    let git_subprocess_ctx = get_git_subprocess_ctx(tx.base_workspace_helper(), &git_settings)?;
     let mut git_fetch = if git_settings.subprocess {
         GitFetch::subprocess(&git_subprocess_ctx, tx.repo_mut(), &git_settings)
     } else {

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -77,6 +77,7 @@ pub fn cmd_git_fetch(
     args: &GitFetchArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
+    // TODO(git2): find remotes without git2
     let git_repo = get_git_repo(workspace_command.repo().store())?;
     let remotes = if args.all_remotes {
         get_all_remotes(&git_repo)?

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -198,6 +198,7 @@ pub fn cmd_git_push(
     let mut workspace_command = command.workspace_helper(ui)?;
     let git_repo = get_git_repo(workspace_command.repo().store())?;
 
+    // TODO(git2): find remote to push without git2
     let remote = if let Some(name) = &args.remote {
         name.clone()
     } else {

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -378,7 +378,7 @@ pub fn cmd_git_push(
     };
 
     let git_settings = tx.settings().git_settings()?;
-    let git_subprocess_ctx = get_git_subprocess_ctx(tx.repo().store(), &git_settings)?;
+    let git_subprocess_ctx = get_git_subprocess_ctx(tx.base_workspace_helper(), &git_settings)?;
     with_remote_git_callbacks(
         ui,
         Some(&mut sideband_progress_callback),


### PR DESCRIPTION
Some programs have trouble dealing with UNC (Universal Naming Convention) on Windows.

`jj` handles it correctly, but it would be better not to rely on external programs (like `git`) to handle UNC correctly. 

This PR safeguards against this in the `GitSubprocessContext`.
The strategy is simple:
 - Pass the path to the workspace root to `Command::current_dir`
 - Pass a relative path to the git dir (from the workspace root) to `git --git-dir X`
 
Since UNC is only a thing for absolute paths, things work