### PR TITLE
Add `git.ssh-key-file` setting

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -390,6 +390,11 @@
                     "type": "string",
                     "description": "Path to the git executable",
                     "default": "git"
+                },
+                "ssh-key-file": {
+                    "type": "string",
+                    "description": "Path to SSH key file to use; by default, uses the following files in ~/.ssh: id_ed25519_sk, id_ed25519, id_rsa",
+                    "default": ""
                 }
             }
         },

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -61,6 +61,7 @@ pub struct GitSettings {
     pub abandon_unreachable_commits: bool,
     pub subprocess: bool,
     pub executable_path: PathBuf,
+    pub ssh_key_file: Option<PathBuf>,
 }
 
 impl GitSettings {
@@ -70,6 +71,17 @@ impl GitSettings {
             abandon_unreachable_commits: settings.get_bool("git.abandon-unreachable-commits")?,
             subprocess: settings.get_bool("git.subprocess")?,
             executable_path: settings.get("git.executable-path")?,
+            ssh_key_file: match settings.get_string("git.ssh-key-file") {
+                Ok(ssh_key_file) => {
+                    let trimmed_ssh_key_file = ssh_key_file.trim();
+                    if trimmed_ssh_key_file.is_empty() {
+                        None
+                    } else {
+                        Some(crate::file_util::expand_home_path(trimmed_ssh_key_file))
+                    }
+                }
+                Err(_) => None,
+            },
         })
     }
 }
@@ -81,6 +93,7 @@ impl Default for GitSettings {
             abandon_unreachable_commits: true,
             subprocess: false,
             executable_path: PathBuf::from("git"),
+            ssh_key_file: None,
         }
     }
 }


### PR DESCRIPTION
This PR addresses a specific problem resulting from `~/.ssh/config` being ignored by jj (https://github.com/jj-vcs/jj/issues/63). Namely, without this PR, jj hardcodes 3 possible ssh key files that it considers: `~/.ssh/id_ed25519_sk`, `~/.ssh/id_ed25519`, and `~/.ssh/id_rsa`: https://github.com/jj-vcs/jj/blob/2a57a6bdd257262059dc62d021e8324a929001c6/cli/src/git_util.rs#L188

Personally, I also have a file called `~/.ssh/id_ed25519_personal` that I use for personal projects, but there is no way to get jj to use it. As a result, my `jj git push` commands always fail with this error:

```
$ jj git push
Changes to push to origin:
  Add bookmark tmp to d2f817604110
Error: failed to authenticate SSH session: Unable to extract public key from private key file: Wrong passphrase or invalid/unrecognized private key file format; class=Ssh (23)
Hint: Jujutsu uses libssh2, which doesn't respect ~/.ssh/config. Does `ssh -F /dev/null` to the host work?
```

With the patch in this PR, I can run this command to tell jj to use the correct ssh key when contacting the git server:

```
jj config set --repo git.ssh-key-file $HOME/.ssh/id_ed25519_personal
```

It may also make sense to add this configuration setting _per remote_, or possibly a different one for _pushing_ and _fetcing_.

Disclaimer: I am a novice rust programmer and this is my first contribution to jj; if this idea is accepted I will also add proper unit testing and changelog entries.