### PR TITLE
github: remove Magic Nix Cache

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -34,5 +34,4 @@ jobs:
         with:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d
-      - uses: DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4
       - run: nix flake check -L --show-trace


### PR DESCRIPTION
Apparently, Magic Nix Cache will stop working on Feb 1st, because the underlying APIs are being sunset by GitHub, and there are no open replacements for it quite yet. Since it's just an optimization, we'll have to live with it.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
