### PR TITLE
github: migrate to GHA aarch64 runners

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -22,10 +22,10 @@ jobs:
           os: ubuntu-24.04
           target: x86_64-unknown-linux-gnu
         - build: linux-aarch64-musl
-          os: ubuntu-24.04
+          os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-musl
         - build: linux-aarch64-gnu
-          os: ubuntu-24.04
+          os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-gnu
         - build: macos-x86_64
           os: macos-13
@@ -54,14 +54,7 @@ jobs:
           target: ${{ matrix.target }}
       - name: Build release binary
         shell: bash
-        run: |
-          CARGO_CMD=cargo
-          if [[ "${{ matrix.target }}" = aarch64-unknown-linux* ]]; then
-            echo "Downloading 'cross' binary for aarch64-linux..."
-            wget -c https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
-            CARGO_CMD=$PWD/cross
-          fi
-          $CARGO_CMD build --target ${{ matrix.target }} --verbose --release --features packaging,vendored-openssl
+        run: cargo build --target ${{ matrix.target }} --verbose --release --features packaging,vendored-openssl
 
       - name: Setup artifact directory
         shell: bash

--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15 # NOTE (aseipp): keep in-sync with the build.yml timeout limit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is x86; macos-14 is ARM
-        os: [ubuntu-24.04, macos-13, macos-14, windows-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
         cargo_flags: [""]
         include:
         - os: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           os: ubuntu-24.04
           target: x86_64-unknown-linux-musl
         - build: linux-aarch64-musl
-          os: ubuntu-24.04
+          os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-musl
         - build: macos-x86_64
           os: macos-13
@@ -48,17 +48,9 @@ jobs:
       with:
         toolchain: stable
         target: ${{ matrix.target }}
-    - name: Download cross-compilation tool (linux-aarch64)
-      if: matrix.target == 'aarch64-unknown-linux-musl'
-      run: wget -c https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
     - name: Build release binary
       shell: bash
-      run: |
-        CARGO_CMD=cargo
-        if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
-          CARGO_CMD=$PWD/cross
-        fi
-        $CARGO_CMD build --target ${{ matrix.target }} --verbose --release --features packaging,vendored-openssl
+      run: cargo build --target ${{ matrix.target }} --verbose --release --features packaging,vendored-openssl
     - name: Build archive
       shell: bash
       run: |


### PR DESCRIPTION
We no longer need to do cross compilation, and these instances seem pretty fast. Enable them everywhere across the board.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
