### PR TITLE
nix: set `TEST_GIT_EXECUTABLE_PATH` in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
       env = {
         LIBSSH2_SYS_USE_PKG_CONFIG = "1";
         RUST_BACKTRACE = 1;
+        TEST_GIT_EXECUTABLE_PATH = pkgs.lib.getExe pkgs.git;
       };
     in {
       formatter = pkgs.alejandra;
@@ -114,7 +115,6 @@
               RUSTFLAGS = pkgs.lib.optionalString pkgs.stdenv.isLinux "-C link-arg=-fuse-ld=mold";
               NIX_JJ_GIT_HASH = self.rev or "";
               CARGO_INCREMENTAL = "0";
-              TEST_GIT_EXECUTABLE_PATH = pkgs.lib.getExe pkgs.git;
             };
 
           postInstall = ''


### PR DESCRIPTION
This environment variable is required for running tests on NixOS for me, otherwise the subprocess tests fail.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
