### PR TITLE
tests: keep user's `$PATH` while running `jj` commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,20 +86,10 @@ jobs:
         tool: nextest
     - name: Build
       run: cargo build --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
-    - name: Test [non-windows]
-      if: ${{ matrix.os != 'windows-latest' }}
+    - name: Test
       run: |
         cargo nextest run --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
       env:
-        RUST_BACKTRACE: 1
-        CARGO_TERM_COLOR: always
-    - name: Test [windows]
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: cargo nextest run --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
-      env:
-        # tests clear the PATH variable (but is only felt on windows),
-        # so we need to set the git executable
-        TEST_GIT_EXECUTABLE_PATH: 'C:\Program Files\Git\bin\git.exe'
         RUST_BACKTRACE: 1
         CARGO_TERM_COLOR: always
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -58,7 +58,7 @@ fn test_git_clone(subprocess: bool) {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -217,7 +217,7 @@ fn test_git_clone(subprocess: bool) {
 fn test_git_clone_bad_source(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["git", "clone", "", "dest"]);
@@ -244,7 +244,7 @@ fn test_git_clone_colocate(subprocess: bool) {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -490,7 +490,7 @@ fn test_git_clone_colocate(subprocess: bool) {
 fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -606,7 +606,7 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
 fn test_git_clone_ignore_working_copy(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -654,7 +654,7 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
 fn test_git_clone_at_operation(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -677,7 +677,7 @@ fn test_git_clone_with_remote_name(subprocess: bool) {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -708,7 +708,7 @@ fn test_git_clone_with_remote_name(subprocess: bool) {
 fn test_git_clone_with_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     git2::Repository::init(git_repo_path).unwrap();
@@ -727,7 +727,7 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
 fn test_git_clone_trunk_deleted(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -888,7 +888,7 @@ fn test_git_clone_with_depth_git2() {
 fn test_git_clone_with_depth_subprocess() {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
-    test_env.set_up_git_subprocessing();
+    test_env.add_config("git.subprocess = true");
     let clone_path = test_env.env_root().join("clone");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -926,7 +926,7 @@ fn test_git_clone_with_depth_subprocess() {
 fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -955,7 +955,7 @@ fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
 fn test_git_clone_malformed(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1013,9 +1013,9 @@ fn test_git_clone_malformed(subprocess: bool) {
 
 #[test]
 fn test_git_clone_no_git_executable() {
-    let mut test_env = TestEnvironment::default();
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.subprocess = true");
-    test_env.add_env_var("PATH", "");
+    test_env.add_config("git.executable-path = 'jj-test-missing-program'");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
     set_up_non_empty_git_repo(&git_repo);
@@ -1023,20 +1023,19 @@ fn test_git_clone_no_git_executable() {
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "clone"]);
     insta::assert_snapshot!(strip_last_line(&stderr), @r#"
     Fetching into new repo in "$TEST_ENV/clone"
-    Error: Could not execute the git process, found in the OS path 'git'
+    Error: Could not execute the git process, found in the OS path 'jj-test-missing-program'
     "#);
 }
 
 #[test]
 fn test_git_clone_no_git_executable_with_path() {
-    let mut test_env = TestEnvironment::default();
+    let test_env = TestEnvironment::default();
     let invalid_git_executable_path = test_env.env_root().join("invalid").join("path");
     test_env.add_config("git.subprocess = true");
     test_env.add_config(format!(
         "git.executable-path = {}",
         to_toml_value(invalid_git_executable_path.to_str().unwrap())
     ));
-    test_env.add_env_var("PATH", "");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
     set_up_non_empty_git_repo(&git_repo);

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -79,7 +79,7 @@ fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
 fn test_git_fetch_with_default_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -98,7 +98,7 @@ fn test_git_fetch_with_default_config(subprocess: bool) {
 fn test_git_fetch_default_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -119,7 +119,7 @@ fn test_git_fetch_default_remote(subprocess: bool) {
 fn test_git_fetch_single_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -146,7 +146,7 @@ fn test_git_fetch_single_remote(subprocess: bool) {
 fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -170,7 +170,7 @@ fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
 fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -191,7 +191,7 @@ fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
 fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -213,7 +213,7 @@ fn test_git_fetch_single_remote_from_config(subprocess: bool) {
 fn test_git_fetch_multiple_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -240,7 +240,7 @@ fn test_git_fetch_multiple_remotes(subprocess: bool) {
 fn test_git_fetch_all_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -264,7 +264,7 @@ fn test_git_fetch_all_remotes(subprocess: bool) {
 fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -289,7 +289,7 @@ fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
 fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -316,7 +316,7 @@ fn test_git_fetch_nonexistent_remote(subprocess: bool) {
 fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -339,7 +339,7 @@ fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
 fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let repo_path = test_env.env_root().join("repo");
@@ -400,7 +400,7 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
 fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -436,7 +436,7 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
 fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -472,7 +472,7 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
 fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let repo_path = test_env.env_root().join("repo");
@@ -545,7 +545,7 @@ fn create_trunk2_and_rebase_bookmarks(test_env: &TestEnvironment, repo_path: &Pa
 fn test_git_fetch_all(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -730,7 +730,7 @@ fn test_git_fetch_all(subprocess: bool) {
 fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -998,7 +998,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
 fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -1116,7 +1116,7 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
 fn test_git_fetch_undo(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1215,7 +1215,7 @@ fn test_git_fetch_undo(subprocess: bool) {
 fn test_fetch_undo_what(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1346,7 +1346,7 @@ fn test_fetch_undo_what(subprocess: bool) {
 fn test_git_fetch_remove_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -1406,7 +1406,7 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
 fn test_git_fetch_rename_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -1461,7 +1461,7 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
 fn test_git_fetch_removed_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1579,7 +1579,7 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
 fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1682,7 +1682,7 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
 fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -54,7 +54,7 @@ fn set_up() -> (TestEnvironment, PathBuf) {
 fn test_git_push_nothing(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
     insta::allow_duplicates! {
@@ -82,7 +82,7 @@ fn test_git_push_nothing(subprocess: bool) {
 fn test_git_push_current_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     // Update some bookmarks. `bookmark1` is not a current bookmark, but
@@ -182,7 +182,7 @@ fn test_git_push_current_bookmark(subprocess: bool) {
 fn test_git_push_parent_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     test_env.jj_cmd_ok(&workspace_root, &["edit", "bookmark1"]);
@@ -209,7 +209,7 @@ fn test_git_push_parent_bookmark(subprocess: bool) {
 fn test_git_push_no_matching_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -229,7 +229,7 @@ fn test_git_push_no_matching_bookmark(subprocess: bool) {
 fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["new", "bookmark1"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -252,7 +252,7 @@ fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
 fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     // Create another remote (but actually the same)
@@ -325,7 +325,7 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
 fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     // Move bookmark1 forward on the remote
@@ -357,7 +357,7 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
 fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     // Move bookmark1 forward on the remote
@@ -409,7 +409,7 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
 fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     // Move bookmark1 forward on the remote
@@ -455,7 +455,7 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
 fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     // Delete bookmark1 forward on the remote
@@ -535,7 +535,7 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
 fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     // Forget bookmark1 locally
@@ -569,7 +569,7 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
 fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     // Ensure that remote bookmarks aren't tracked automatically
     test_env.add_config("git.auto-local-bookmark = false");
@@ -635,7 +635,7 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
 fn test_git_push_multiple(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
     test_env.jj_cmd_ok(
@@ -788,7 +788,7 @@ fn test_git_push_multiple(subprocess: bool) {
 fn test_git_push_changes(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -953,7 +953,7 @@ fn test_git_push_changes(subprocess: bool) {
 fn test_git_push_revisions(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1057,7 +1057,7 @@ fn test_git_push_revisions(subprocess: bool) {
 fn test_git_push_mixed(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1119,7 +1119,7 @@ fn test_git_push_mixed(subprocess: bool) {
 fn test_git_push_existing_long_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1149,7 +1149,7 @@ fn test_git_push_existing_long_bookmark(subprocess: bool) {
 fn test_git_push_unsnapshotted_change(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1163,7 +1163,7 @@ fn test_git_push_unsnapshotted_change(subprocess: bool) {
 fn test_git_push_conflict(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     std::fs::write(workspace_root.join("file"), "first").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["commit", "-m", "first"]);
@@ -1187,7 +1187,7 @@ fn test_git_push_conflict(subprocess: bool) {
 fn test_git_push_no_description(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "my-bookmark"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m="]);
@@ -1219,7 +1219,7 @@ fn test_git_push_no_description(subprocess: bool) {
 fn test_git_push_no_description_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "imm"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m="]);
@@ -1272,7 +1272,7 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
 fn test_git_push_missing_author(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1312,7 +1312,7 @@ fn test_git_push_missing_author(subprocess: bool) {
 fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1373,7 +1373,7 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
 fn test_git_push_missing_committer(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1428,7 +1428,7 @@ fn test_git_push_missing_committer(subprocess: bool) {
 fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1490,7 +1490,7 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
 fn test_git_push_deleted(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
@@ -1532,7 +1532,7 @@ fn test_git_push_deleted(subprocess: bool) {
 fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo = {
@@ -1629,7 +1629,7 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
 fn test_git_push_deleted_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     // Absent local bookmark shouldn't be considered "deleted" compared to
@@ -1658,7 +1658,7 @@ fn test_git_push_deleted_untracked(subprocess: bool) {
 fn test_git_push_tracked_vs_all(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     test_env.jj_cmd_ok(&workspace_root, &["new", "bookmark1", "-mmoved bookmark1"]);
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "bookmark1"]);
@@ -1745,7 +1745,7 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
 fn test_git_push_moved_forward_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "bookmark1", "-mmoved bookmark1"]);
@@ -1769,7 +1769,7 @@ fn test_git_push_moved_forward_untracked(subprocess: bool) {
 fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "root()", "-mmoved bookmark1"]);
@@ -1796,7 +1796,7 @@ fn test_git_push_moved_sideways_untracked(subprocess: bool) {
 fn test_git_push_to_remote_named_git(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
     if subprocess {
-        test_env.set_up_git_subprocessing();
+        test_env.add_config("git.subprocess = true");
     }
     let git_repo = {
         let mut git_repo_path = workspace_root.clone();

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -139,7 +139,7 @@ fn test_util_exec_fail() {
     let test_env = TestEnvironment::default();
     let err = test_env.jj_cmd_failure(
         test_env.env_root(),
-        &["util", "exec", "--", "missing-program"],
+        &["util", "exec", "--", "jj-test-missing-program"],
     );
-    insta::assert_snapshot!(strip_last_line(&err), @"Error: Failed to execute external command 'missing-program'");
+    insta::assert_snapshot!(strip_last_line(&err), @"Error: Failed to execute external command 'jj-test-missing-program'");
 }

--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,6 @@
               RUSTFLAGS = pkgs.lib.optionalString pkgs.stdenv.isLinux "-C link-arg=-fuse-ld=mold";
               NIX_JJ_GIT_HASH = self.rev or "";
               CARGO_INCREMENTAL = "0";
-              TEST_GIT_EXECUTABLE_PATH = pkgs.lib.getExe pkgs.git;
             };
 
           postInstall = ''

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -115,14 +115,8 @@ fn get_git_repo(repo: &Arc<ReadonlyRepo>) -> git2::Repository {
 }
 
 fn get_git_settings(subprocess: bool) -> GitSettings {
-    let executable_path = std::env::var("TEST_GIT_EXECUTABLE_PATH")
-        .as_ref()
-        .map(Path::new)
-        .unwrap_or(Path::new("git"))
-        .to_owned();
     GitSettings {
         subprocess,
-        executable_path,
         ..Default::default()
     }
 }


### PR DESCRIPTION
Currently, the Git subprocess tests only work on Linux due to a default path being used for the `git` executable when `$PATH` is unset. This can break if Git isn't installed at the expected path. Also, I believe it is currently necessary to set the `$TEST_GIT_EXECUTABLE_PATH` environment variable on Windows for tests to pass. Instead, we should use the user's `$PATH` to locate the `git` executable, as well as any other executables that are needed. This also makes `$TEST_GIT_EXECUTABLE_PATH` no longer necessary, so it can be removed.

Discussed in #5463.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
