### PR TITLE
escape bookmark and remote names in `trunk()` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   now materialized in a way that can be parsed correctly.
   [#3968](https://github.com/jj-vcs/jj/issues/3968)
 
+* Bookmark and remote names written by `jj git clone` to
+  `revset-aliases.'trunk()'` are now escaped if necessary.
+  [#5359](https://github.com/jj-vcs/jj/issues/5359)
+
 ## [0.25.0] - 2025-01-01
 
 ### Release highlights

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -28,6 +28,7 @@ use jj_lib::config::ConfigFile;
 use jj_lib::config::ConfigSource;
 use jj_lib::git;
 use jj_lib::git::UnexpectedGitBackendError;
+use jj_lib::revset;
 use jj_lib::store::Store;
 
 use self::clone::cmd_git_clone;
@@ -123,6 +124,8 @@ fn write_repository_level_trunk_alias(
     branch: &str,
 ) -> Result<(), CommandError> {
     let mut file = ConfigFile::load_or_empty(ConfigSource::Repo, repo_path.join("config.toml"))?;
+    let branch = revset::format_symbol(branch);
+    let remote = revset::format_symbol(remote);
     file.set_value(["revset-aliases", "trunk()"], format!("{branch}@{remote}"))
         .expect("initial repo config shouldn't have invalid values");
     file.save()?;

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -582,11 +582,11 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(
-        get_bookmark_output(&test_env, &test_env.env_root().join("clone2")), @r###"
-    feature1@origin: mzyxwzks 9f01a0e0 message
-    main: mzyxwzks 9f01a0e0 message
+        get_bookmark_output(&test_env, &test_env.env_root().join("clone3")), @r"
+    feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    main@origin: mzyxwzks 9f01a0e0 message
+    ");
     }
 
     // "trunk()" alias should be set to new default bookmark "feature1"

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -15,6 +15,7 @@
 //! Domain-specific language helpers.
 
 use std::array;
+use std::ascii;
 use std::collections::HashMap;
 use std::fmt;
 use std::slice;
@@ -427,6 +428,28 @@ impl<R: RuleType> StringLiteralParser<R> {
         }
         result
     }
+}
+
+/// Escape special characters in the input
+pub fn escape_string(unescaped: &str) -> String {
+    let mut escaped = String::with_capacity(unescaped.len());
+    for c in unescaped.chars() {
+        match c {
+            '"' => escaped.push_str(r#"\""#),
+            '\\' => escaped.push_str(r#"\\"#),
+            '\t' => escaped.push_str(r#"\t"#),
+            '\r' => escaped.push_str(r#"\r"#),
+            '\n' => escaped.push_str(r#"\n"#),
+            '\0' => escaped.push_str(r#"\0"#),
+            c if c.is_ascii_control() => {
+                for b in ascii::escape_default(c as u8) {
+                    escaped.push(b as char);
+                }
+            }
+            c => escaped.push(c),
+        }
+    }
+    escaped
 }
 
 /// Helper to parse function call.

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -681,6 +681,14 @@ fn parse_as_string_literal(pair: Pair<Rule>) -> String {
     }
 }
 
+/// Checks if the text is a valid identifier
+pub fn is_identifier(text: &str) -> bool {
+    match RevsetParser::parse(Rule::identifier, text) {
+        Ok(mut pairs) => pairs.next().unwrap().as_span().end() == text.len(),
+        Err(_) => false,
+    }
+}
+
 pub type RevsetAliasesMap = AliasesMap<RevsetAliasParser, String>;
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
