### PR TITLE
Fix a broken link in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Use `--retain-bookmarks` to move bookmarks backwards. If deleted bookmarks
   were tracking remote bookmarks, the associated bookmarks (or branches) will be
   deleted from the remote on `jj git push --all`.
-  [https://github.com/jj-vcs/jj/issues/3505](#3505)
+  [#3505](https://github.com/jj-vcs/jj/issues/3505)
 
 * `jj init --git` and `jj init --git-repo` have been removed. They were
   deprecated in early 2024. Use `jj git init` instead.


### PR DESCRIPTION
Other links in CHANGELOG.md have the issue number as the text, and the full URL as a link. They're swapped here, meaning the link points to a non-existent anchor in the CHANGELOG.md file.