### PR TITLE
Ignore Git LFS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Add support for just ignoring Git LFS files by parsing `.gitattribute` files and automatically
+  adding the relevant files to the internal ignore list
+
 ### Fixed bugs
 
 ## [0.27.0] - 2025-03-05

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -76,9 +76,7 @@ pub(crate) fn cmd_absorb(
         .parse_union_revsets(ui, &args.into)?
         .resolve()?;
 
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
 
     let repo = workspace_command.repo().as_ref();
     let source = AbsorbSource::from_commit(repo, source_commit)?;

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -81,9 +81,7 @@ pub(crate) fn cmd_commit(
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
     let commit = workspace_command.repo().store().get_commit(commit_id)?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let advanceable_bookmarks = workspace_command.get_advanceable_bookmarks(commit.parent_ids())?;
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;

--- a/cli/src/commands/debug/tree.rs
+++ b/cli/src/commands/debug/tree.rs
@@ -62,9 +62,7 @@ pub fn cmd_debug_tree(
             .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
         commit.tree()?
     };
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     for (path, value) in tree.entries_matching(matcher.as_ref()) {
         let ui_path = workspace_command.format_file_path(&path);
         writeln!(ui.stdout(), "{ui_path}: {value:?}")?;

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -94,7 +94,7 @@ pub(crate) fn cmd_diff(
     let workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo();
     let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
-    let matcher = fileset_expression.to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let resolve_revision = |r: &Option<RevisionArg>| {
         workspace_command.resolve_single_rev(ui, r.as_ref().unwrap_or(&RevisionArg::AT))
     };

--- a/cli/src/commands/file/chmod.rs
+++ b/cli/src/commands/file/chmod.rs
@@ -81,7 +81,7 @@ pub(crate) fn cmd_file_chmod(
     // TODO: No need to add special case for empty paths when switching to
     // parse_union_filesets(). paths = [] should be "none()" if supported.
     let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
-    let matcher = fileset_expression.to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
 
     let mut tx = workspace_command.start_transaction();

--- a/cli/src/commands/file/list.rs
+++ b/cli/src/commands/file/list.rs
@@ -63,9 +63,7 @@ pub(crate) fn cmd_file_list(
     let workspace_command = command.workspace_helper(ui)?;
     let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let tree = commit.tree()?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let template = {
         let language = workspace_command.commit_template_language();
         let text = match &args.template {

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -89,7 +89,7 @@ pub(crate) fn cmd_file_show(
         }
     }
 
-    let matcher = fileset_expression.to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     ui.request_pager();
     write_tree_entries(
         ui,

--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -50,9 +50,7 @@ pub(crate) fn cmd_file_track(
     args: &FileTrackArgs,
 ) -> Result<(), CommandError> {
     let (mut workspace_command, auto_stats) = command.workspace_helper_with_stats(ui)?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let options = workspace_command.snapshot_options_with_start_tracking_matcher(&matcher)?;
 
     let mut tx = workspace_command.start_transaction().into_inner();

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -52,9 +52,7 @@ pub(crate) fn cmd_file_untrack(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let store = workspace_command.repo().store().clone();
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let auto_tracking_matcher = workspace_command.auto_tracking_matcher(ui)?;
     let options =
         workspace_command.snapshot_options_with_start_tracking_matcher(&auto_tracking_matcher)?;

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -149,9 +149,7 @@ pub(crate) fn cmd_fix(
     .evaluate_to_commit_ids()?
     .try_collect()?;
     workspace_command.check_rewritable(root_commits.iter())?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
 
     let mut tx = workspace_command.start_transaction();
 

--- a/cli/src/commands/interdiff.rs
+++ b/cli/src/commands/interdiff.rs
@@ -74,9 +74,7 @@ pub(crate) fn cmd_interdiff(
         workspace_command.resolve_single_rev(ui, args.from.as_ref().unwrap_or(&RevisionArg::AT))?;
     let to =
         workspace_command.resolve_single_rev(ui, args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let diff_renderer = workspace_command.diff_renderer_for(&args.format)?;
     ui.request_pager();
     diff_renderer.show_inter_diff(

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -151,7 +151,7 @@ pub(crate) fn cmd_log(
     };
 
     let repo = workspace_command.repo();
-    let matcher = fileset_expression.to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let revset = revset_expression.evaluate()?;
 
     let store = repo.store();

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -78,9 +78,7 @@ pub(crate) fn cmd_resolve(
     args: &ResolveArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
     let tree = commit.tree()?;
     let conflicts = tree

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -134,9 +134,7 @@ pub(crate) fn cmd_restore(
     }
     workspace_command.check_rewritable([to_commit.id()])?;
 
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let to_tree = to_commit.tree()?;

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -95,9 +95,7 @@ pub(crate) fn cmd_split(
     }
 
     workspace_command.check_rewritable([target_commit.id()])?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let diff_selector = workspace_command.diff_selector(
         ui,
         args.tool.as_deref(),

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -155,9 +155,7 @@ pub(crate) fn cmd_squash(
         destination = parents.pop().unwrap();
     }
 
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let text_editor = workspace_command.text_editor()?;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -64,9 +64,7 @@ pub(crate) fn cmd_status(
         .get_wc_commit_id()
         .map(|id| repo.store().get_commit(id))
         .transpose()?;
-    let matcher = workspace_command
-        .parse_file_patterns(ui, &args.paths)?
-        .to_matcher();
+    let matcher = workspace_command.file_matcher(ui, &args.paths)?;
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -419,6 +419,11 @@
                     "type": "string",
                     "description": "Path to the git executable",
                     "default": "git"
+                },
+                "ignore-lfs-files": {
+                    "type": "boolean",
+                    "description": "Whether jj ignores files handled by git lfs or not",
+                    "default": false
                 }
             }
         },

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -299,6 +299,7 @@ diff editing in mind and be a little inaccurate.
             start_tracking_matcher: &EverythingMatcher,
             max_new_file_size: u64::MAX,
             conflict_marker_style,
+            skip_git_lfs_files: false,
         })?;
         Ok(output_tree_state.current_tree_id().clone())
     }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1371,6 +1371,17 @@ subprocess = false
 Note that `libgit2` support will likely be removed in the future, so you are
 encouraged to report any issues you experience with the default configuration.
 
+### Ignore Git LFS Files
+
+By default Git LFS files are **not** handled by `jj`. This will result in `jj` showing
+changes in these files, even if they are unchanged. You can configure `jj` to ignore these
+files by instructing it to parse the relevant `.gitattributes` files
+
+```toml
+[git]
+ignore-lfs-files = true
+```
+
 ## Filesystem monitor
 
 In large repositories, it may be beneficial to use a "filesystem monitor" to

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -63,15 +63,21 @@ pub struct GitSettings {
     pub abandon_unreachable_commits: bool,
     pub subprocess: bool,
     pub executable_path: PathBuf,
+    pub ignore_lfs_files: bool,
 }
 
 impl GitSettings {
     pub fn from_settings(settings: &UserSettings) -> Result<Self, ConfigGetError> {
+        let ignore_lfs_files = settings
+            .get_bool("git.ignore-lfs-files")
+            .optional()?
+            .unwrap_or_default();
         Ok(GitSettings {
             auto_local_bookmark: settings.get_bool("git.auto-local-bookmark")?,
             abandon_unreachable_commits: settings.get_bool("git.abandon-unreachable-commits")?,
             subprocess: settings.get_bool("git.subprocess")?,
             executable_path: settings.get("git.executable-path")?,
+            ignore_lfs_files,
         })
     }
 }
@@ -83,6 +89,7 @@ impl Default for GitSettings {
             abandon_unreachable_commits: true,
             subprocess: true,
             executable_path: PathBuf::from("git"),
+            ignore_lfs_files: false,
         }
     }
 }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -221,6 +221,8 @@ pub struct SnapshotOptions<'a> {
     pub max_new_file_size: u64,
     /// Expected conflict marker style for checking for changed files.
     pub conflict_marker_style: ConflictMarkerStyle,
+    /// skip git lfs files?
+    pub skip_git_lfs_files: bool,
 }
 
 impl SnapshotOptions<'_> {
@@ -233,6 +235,7 @@ impl SnapshotOptions<'_> {
             start_tracking_matcher: &EverythingMatcher,
             max_new_file_size: u64::MAX,
             conflict_marker_style: ConflictMarkerStyle::default(),
+            skip_git_lfs_files: false,
         }
     }
 }


### PR DESCRIPTION
This PR adds support for ignoring files handled by git lfs. `jj` previously detected these files as changed as it expected the original file content before the `git lfs` checkout to be present. With this change it's possible to opt in (via the `git.ignore-lfs-files` setting) into just ignoring this files from `jj`. They then need to be manually handled via e.g. git if they are changed.

From a technical point of view this change parses all `.gitattributes` files in the current repository and constructs a ignore list from that. This ignore list is then applied through all subcommands.

This is still missing tests, as I'm really unsure what to test about and how to write these tests. I likely won't have the capacity to figure that out on my own, so I would appreciate if someone could point to the correct places.

Somewhat addresses #80 

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
