### PR TITLE
Allow deleting files in diffedit and split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,8 +3365,7 @@ checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 [[package]]
 name = "scm-record"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2165c1b15fb2285ed7d1c281501826d451ffa3bf4928de95020a1a103e2c256"
+source = "git+https://github.com/jgilchrist/scm-record?branch=push-usoxskonxnkx#4281f4d86864f89350f7ee0a02bf80624d51be0e"
 dependencies = [
  "cassowary",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ rustix = { version = "0.38.44", features = ["fs"] }
 same-file = "1.0.6"
 sapling-renderdag = "0.1.0"
 sapling-streampager = "0.10.3"
-scm-record = "0.5.0"
+scm-record = { git = "https://github.com/jgilchrist/scm-record", branch = "push-usoxskonxnkx" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.137"
 slab = "0.4.9"


### PR DESCRIPTION
An early proof of concept, extending https://github.com/jj-vcs/jj/pull/4078 but with a slightly different approach based on https://github.com/arxanas/scm-record/pull/62#issuecomment-2241768677.

It relies on changes in https://github.com/arxanas/scm-record/pull/92 to function.

I haven't tested it extensively yet, but wanted to get a pull request up so it's possible to review this in tandem with https://github.com/arxanas/scm-record/pull/92 if it's helpful.

Attempts to fix https://github.com/jj-vcs/jj/issues/3702 and seems to fix https://github.com/jj-vcs/jj/issues/3846 too.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
