### PR TITLE
Allow deleting files in diffedit and split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj log -p --stat` now shows diff stats as well as the default color-words/git
   diff output. [#5986](https://github.com/jj-vcs/jj/issues/5986)
 
+* The built-in diff editor now correctly handles deleted files.
+  [#3702](https://github.com/jj-vcs/jj/issues/3702)
+
+* The built-in diff editor now correctly retains the executable bit on newly
+  added files when splitting. [#3846](https://github.com/jj-vcs/jj/issues/3846)
+
 ## [0.27.0] - 2025-03-05
 
 ### Release highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,9 +3444,9 @@ checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "scm-record"
-version = "0.5.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2165c1b15fb2285ed7d1c281501826d451ffa3bf4928de95020a1a103e2c256"
+checksum = "3262a6cee1ea1663753e7178459c37bd2c5af37ad3371dbefd44607470c6d297"
 dependencies = [
  "cassowary",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ rustix = { version = "1.0.2", features = ["fs"] }
 same-file = "1.0.6"
 sapling-renderdag = "0.1.0"
 sapling-streampager = "0.11.0"
-scm-record = "0.5.0"
+scm-record = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 slab = "0.4.9"


### PR DESCRIPTION
Extends https://github.com/jj-vcs/jj/pull/4078 but with a slightly different approach based on a discussion in Discord: https://discord.com/channels/968932220549103686/1325114717387100201

It relies on changes in https://github.com/arxanas/scm-record/pull/93 to function.

The code in this area gets significantly simpler, since there's no longer any ambiguity to resolve. The `scm-record` changes expect that any mode changes are represented by file mode sections, and adds UI hooks to simplify working with them (e.g. automatically de-selecting a deletion mode change if any lines in the file are de-selected, since the file still needs to exist to hold those lines).

As a result, mode changes always come back from `scm-record` as a `FileModeTransition` and we can handle them explicitly. 'No changes selected' always comes back as `None`, so if we get `None` we can always skip the file entirely and use the previous content/mode.

This also uses code from #4078 to ensure executable bits are respected.

Fixes #3702 
Fixes #3846.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- ~[ ] I have updated the documentation (README.md, docs/, demos/)~
- ~[ ] I have updated the config schema (cli/src/config-schema.json)~
- [x] I have added tests to cover my changes
