### PR TITLE
cli: remove double ": : " on git password prompt

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -126,7 +126,7 @@ fn terminal_get_username(ui: &Ui, url: &str) -> Option<String> {
 }
 
 fn terminal_get_pw(ui: &Ui, url: &str) -> Option<String> {
-    ui.prompt_password(&format!("Passphrase for {url}: ")).ok()
+    ui.prompt_password(&format!("Passphrase for {url}")).ok()
 }
 
 fn pinentry_get_pw(url: &str) -> Option<String> {


### PR DESCRIPTION
`ui.prompt_password()` already adds ": " to the end of the prompt. Remove the extra at the (only) callsite, to keep similarity to the above `terminal_get_pw()`.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
