### PR TITLE
git: update jj git clone|fetch to use new GitFetch api directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj git fetch` with multiple remotes will now fetch from all remotes before
+  importing refs into the jj repo. This fixes a race condition where the
+  treatment of a commit that is found in multiple fetch remotes depended on the
+  order the remotes were specified.
+
 * Fixed diff selection by external tools with `jj split`/`commit -i FILESETS`.
   [#5252](https://github.com/jj-vcs/jj/issues/5252)
 

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -77,6 +77,7 @@ pub fn cmd_git_fetch(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let git_repo = get_git_repo(workspace_command.repo().store())?;
+    // TODO(git2): migrate to gitoxide
     let remotes = if args.all_remotes {
         get_all_remotes(&git_repo)?
     } else if args.remotes.is_empty() {

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -200,6 +200,7 @@ pub fn cmd_git_push(
     let remote = if let Some(name) = &args.remote {
         name.clone()
     } else {
+        // TODO(git2): migrate to gitoxide
         get_default_push_remote(ui, workspace_command.settings(), &git_repo)?
     };
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1320,6 +1320,7 @@ pub fn is_special_git_remote(remote: &str) -> bool {
     remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
 }
 
+// TODO(git2): migrate to gitoxide
 pub fn add_remote(
     git_repo: &git2::Repository,
     remote_name: &str,

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -40,6 +40,7 @@ use jj_lib::commit_builder::CommitBuilder;
 use jj_lib::git;
 use jj_lib::git::FailedRefExportReason;
 use jj_lib::git::GitBranchPushTargets;
+use jj_lib::git::GitFetch;
 use jj_lib::git::GitFetchError;
 use jj_lib::git::GitImportError;
 use jj_lib::git::GitPushError;
@@ -73,6 +74,15 @@ use testutils::create_random_commit;
 use testutils::write_random_commit;
 use testutils::TestRepo;
 use testutils::TestRepoBackend;
+
+/// Describes successful `fetch()` result.
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+struct GitFetchStats {
+    /// Remote's default branch.
+    pub default_branch: Option<String>,
+    /// Changes made by the import.
+    pub import_stats: git::GitImportStats,
+}
 
 fn empty_git_commit<'r>(
     git_repo: &'r git2::Repository,
@@ -119,6 +129,29 @@ fn get_git_settings(subprocess: bool) -> GitSettings {
         subprocess,
         ..Default::default()
     }
+}
+
+fn git_fetch(
+    mut_repo: &mut MutableRepo,
+    git_repo: &git2::Repository,
+    remote_name: &str,
+    branch_names: &[StringPattern],
+    git_settings: &GitSettings,
+) -> Result<GitFetchStats, GitFetchError> {
+    let mut git_fetch = GitFetch::new(mut_repo, git_repo, git_settings);
+    let default_branch = git_fetch.fetch(
+        remote_name,
+        branch_names,
+        git::RemoteCallbacks::default(),
+        None,
+    )?;
+
+    let import_stats = git_fetch.import_refs().unwrap();
+    let stats = GitFetchStats {
+        default_branch,
+        import_stats,
+    };
+    Ok(stats)
 }
 
 #[test]
@@ -2542,14 +2575,12 @@ fn test_fetch_empty_repo(subprocess: bool) {
     let git_settings = get_git_settings(subprocess);
 
     let mut tx = test_data.repo.start_transaction();
-    let stats = git::fetch(
+    let stats = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     // No default bookmark and no refs
@@ -2570,21 +2601,19 @@ fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction();
-    let stats = git::fetch(
+    let stats = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     // No default bookmark because the origin repo's HEAD wasn't set
     assert_eq!(stats.default_branch, None);
     assert!(stats.import_stats.abandoned_commits.is_empty());
     let repo = tx.commit("test").unwrap();
-    // The initial commit is visible after git::fetch().
+    // The initial commit is visible after git_fetch().
     let view = repo.view();
     assert!(view.heads().contains(&jj_id(&initial_git_commit)));
     let initial_commit_target = RefTarget::normal(jj_id(&initial_git_commit));
@@ -2632,14 +2661,12 @@ fn test_fetch_initial_commit_head_is_set(subprocess: bool) {
         .unwrap();
 
     let mut tx = test_data.repo.start_transaction();
-    let stats = git::fetch(
+    let stats = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
 
@@ -2658,14 +2685,12 @@ fn test_fetch_success(subprocess: bool) {
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction();
-    git::fetch(
+    git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     test_data.repo = tx.commit("test").unwrap();
@@ -2682,14 +2707,12 @@ fn test_fetch_success(subprocess: bool) {
         .unwrap();
 
     let mut tx = test_data.repo.start_transaction();
-    let stats = git::fetch(
+    let stats = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     // The default bookmark is "main"
@@ -2741,14 +2764,12 @@ fn test_fetch_prune_deleted_ref(subprocess: bool) {
     let commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction();
-    git::fetch(
+    git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     // Test the setup
@@ -2765,14 +2786,12 @@ fn test_fetch_prune_deleted_ref(subprocess: bool) {
         .delete()
         .unwrap();
     // After re-fetching, the bookmark should be deleted
-    let stats = git::fetch(
+    let stats = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     assert_eq!(stats.import_stats.abandoned_commits, vec![jj_id(&commit)]);
@@ -2794,14 +2813,12 @@ fn test_fetch_no_default_branch(subprocess: bool) {
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     let mut tx = test_data.repo.start_transaction();
-    git::fetch(
+    git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
 
@@ -2818,14 +2835,12 @@ fn test_fetch_no_default_branch(subprocess: bool) {
         .set_head_detached(initial_git_commit.id())
         .unwrap();
 
-    let stats = git::fetch(
+    let stats = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     // There is no default bookmark
@@ -2841,14 +2856,12 @@ fn test_fetch_empty_refspecs(subprocess: bool) {
 
     // Base refspecs shouldn't be respected
     let mut tx = test_data.repo.start_transaction();
-    git::fetch(
+    git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
         &[],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
     assert!(tx
@@ -2869,14 +2882,12 @@ fn test_fetch_no_such_remote(subprocess: bool) {
     let test_data = GitRepoData::create();
     let git_settings = get_git_settings(subprocess);
     let mut tx = test_data.repo.start_transaction();
-    let result = git::fetch(
+    let result = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "invalid-remote",
         &[StringPattern::everything()],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     );
     assert!(matches!(result, Err(GitFetchError::NoSuchRemote(_))));
 }
@@ -2891,7 +2902,7 @@ fn test_fetch_multiple_branches() {
     };
 
     let mut tx = test_data.repo.start_transaction();
-    let fetch_stats = git::fetch(
+    let fetch_stats = git_fetch(
         tx.repo_mut(),
         &test_data.git_repo,
         "origin",
@@ -2900,9 +2911,7 @@ fn test_fetch_multiple_branches() {
             StringPattern::Exact("noexist1".to_string()),
             StringPattern::Exact("noexist2".to_string()),
         ],
-        git::RemoteCallbacks::default(),
         &git_settings,
-        None,
     )
     .unwrap();
 


### PR DESCRIPTION
Make the new GitFetch api public.
   - Move git::fetch to lib/tests/test_git.rs as git_fetch, to minimize churn in the tests. Update test call sites to use git_fetch
   - Delete the git::fetch from lib/src/git.rs.
   - Update jj git clone and git_fetch in cli/src/git_utils.rs to use the new api directly. Removing one redundant layer of indirection.
   - This fixes https://github.com/jj-vcs/jj/issues/4920 as it first fetches from all remotes before import_refs() is called, so there is no race condition if the same commit is treated differently in different remotes specified in the same command.

Original commit by @essiene https://github.com/jj-vcs/jj/pull/4960

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
