### PR TITLE
SECURITY.md: insert an explicit URL

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,10 @@
 To report a security issue, please use the "Report a vulnerability" button on
-this page. Our vulnerability management team will respond within 3 working days
-of your report. If the issue is confirmed as a vulnerability, we will open a
-Security Advisory. This project follows a 90 day disclosure timeline.
+GitHub's Security tab for `jj`'s main repo, under
+[Advisories](https://github.com/jj-vcs/jj/security/advisories).
+
+Our vulnerability management team will respond within 3 working days of your
+report. If the issue is confirmed as a vulnerability, we will open a Security
+Advisory. This project follows a 90 day disclosure timeline.
 
 Feel free to email Jujutsu VCS Security at <jj-security@googlegroups.com> if you
 have questions.


### PR DESCRIPTION
The previous "on this page" statement is wrong more often than not. Unfortunately there is no "Report a vulnerability" button on https://github.com/jj-vcs/jj/security/policy, and looking for such a button from https://github.com/jj-vcs/jj?tab=security-ov-file leads to confusion.

This is not the end of the world, but I don't see much security downside to clarifying it (that is, I don't think *not* having a link protects against phishing in any real way).

