### PR TITLE
Fix typo in templating language example

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -392,7 +392,7 @@ New keywords and functions can be defined as aliases, by using any
 combination of the predefined keywords/functions and other aliases.
 
 Alias functions can be overloaded by the number of parameters. However, builtin
-function will be shadowed by name, and can't co-exist with aliases.
+functions will be shadowed by name, and can't co-exist with aliases.
 
 For example:
 
@@ -401,7 +401,7 @@ For example:
 'commit_change_ids' = '''
 concat(
   format_field("Commit ID", commit_id),
-  format_field("Change ID", commit_id),
+  format_field("Change ID", change_id),
 )
 '''
 'format_field(key, value)' = 'key ++ ": " ++ value ++ "\n"'


### PR DESCRIPTION
I was very confused by the example for a moment before realising that it made sense if `commit_id` became `change_id`.

I also found another typo in the file that I figured I may as well fix while I was there.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
