### PR TITLE
git: forward remote messages to output

### DIFF
--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -227,7 +227,7 @@ fn fetch_new_remote(
     let git_settings = workspace_command.settings().git_settings()?;
     let mut fetch_tx = workspace_command.start_transaction();
     let mut git_fetch = GitFetch::new(fetch_tx.repo_mut(), &git_repo, &git_settings);
-    let default_branch = with_remote_git_callbacks(ui, None, &git_settings, |cb| {
+    let default_branch = with_remote_git_callbacks(ui, None, |cb| {
         git_fetch
             .fetch(remote_name, &[StringPattern::everything()], cb, depth)
             .map_err(|err| match err {

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -139,7 +139,7 @@ fn do_git_fetch(
     let mut git_fetch = GitFetch::new(tx.repo_mut(), git_repo, &git_settings);
 
     for remote_name in remotes {
-        with_remote_git_callbacks(ui, None, &git_settings, |callbacks| {
+        with_remote_git_callbacks(ui, None, |callbacks| {
             git_fetch
                 .fetch(remote_name, branch_names, callbacks, None)
                 .map_err(|err| match err {

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -377,21 +377,16 @@ pub fn cmd_git_push(
     };
 
     let git_settings = tx.settings().git_settings()?;
-    with_remote_git_callbacks(
-        ui,
-        Some(&mut sideband_progress_callback),
-        &git_settings,
-        |cb| {
-            git::push_branches(
-                tx.repo_mut(),
-                &git_repo,
-                &git_settings,
-                &remote,
-                &targets,
-                cb,
-            )
-        },
-    )
+    with_remote_git_callbacks(ui, Some(&mut sideband_progress_callback), |cb| {
+        git::push_branches(
+            tx.repo_mut(),
+            &git_repo,
+            &git_settings,
+            &remote,
+            &targets,
+            cb,
+        )
+    })
     .map_err(|err| match err {
         GitPushError::InternalGitError(err) => map_git_error(err),
         GitPushError::RefInUnexpectedLocation(refs) => user_error_with_hint(


### PR DESCRIPTION
Git remotes can send messages on fetch/push. 
A pressing example is Github, which sends a URL to open a Pull Request when a branch is pushed.

This PR implements forwarding these messages to the UI (via the pre-existing `RemoteCalbacks`) from the `git` subprocess.

# Testing
Since this depends on the remote sending the message, it is hard to test this. The following script is a way to verify that the `remote: ` messages are being reported:

```zsh
USER="bsdinis"
REPO="jj"

cargo build
JJ=$(readlink -f './target/debug/jj')

dir=$(mktemp -d)
pushd $dir

jj git clone git@github.com:${USER}/${REPO} || rm -rf $dir
pushd jj

touch a
$JJ describe -m "x"
$JJ status
$JJ log
$JJ --config="git.subprocess = true" git push -c @ || rm -rf $dir
rm -rf $dir
```