### PR TITLE
conflicts: use clearer wording for missing newline comment

### DIFF
--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -185,19 +185,18 @@ New Heading
 >>>>>>>>>>>>>>> Conflict 1 of 1 ends
 ```
 
-## Conflicts with missing terminating newline (`[noeol]`)
+## Conflicts with missing terminating newline
 
 When materializing conflicts, `jj` outputs them in a line-based format. This
 format is easiest to interpret for text files that consist of a series of lines,
 with each line terminated by a newline character (`\n`). This means that a text
 file should either be empty, or it should end with a newline character.
 
-While most text files follow this convention, some do not. To handle this case,
-when `jj` encounters a missing terminating newline character in a conflict, it
-will add a `[noeol]` comment to the conflict markers to indicate that the
-"end-of-line" (EOL) character was missing. If you don't care about whether your
-file ends with a terminating newline character, you can generally ignore this
-comment and resolve the conflict normally.
+While most text files follow this convention, some do not. When `jj` encounters
+a missing terminating newline character in a conflict, it will add a comment to
+the conflict markers to make the conflict easier to interpret. If you don't care
+about whether your file ends with a terminating newline character, you can
+generally ignore this comment and resolve the conflict normally.
 
 For instance, if a file originally contained `grape` with no terminating newline
 character, and one person changed `grape` to `grapefruit`, while another person
@@ -206,14 +205,13 @@ would look like this:
 
 ```
 <<<<<<< Conflict 1 of 1
-+++++++ Contents of side #1 [noeol]
++++++++ Contents of side #1 (no terminating newline)
 grapefruit
-%%%%%%% Changes from base to side #2 [-noeol]
+%%%%%%% Changes from base to side #2 (adds terminating newline)
 -grape
 +grape
 >>>>>>> Conflict 1 of 1 ends
 ```
 
-The `[-noeol]` comment for the diff section indicates that the base (`-`) was
-missing a terminating newline character. A resolution of this conflict could be
-`grapefruit\n`, with the terminating newline character added.
+Therefore, a resolution of this conflict could be `grapefruit\n`, with the
+terminating newline character added.

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -469,7 +469,7 @@ fn materialize_git_style_conflict(
         output,
         ConflictMarkerLineChar::ConflictStart,
         conflict_marker_len,
-        &format!("Side #1{} ({conflict_info})", maybe_no_eol_comment(left)),
+        &format!("Side #1 ({conflict_info})"),
     )?;
     write_and_ensure_newline(output, left)?;
 
@@ -477,7 +477,7 @@ fn materialize_git_style_conflict(
         output,
         ConflictMarkerLineChar::GitAncestor,
         conflict_marker_len,
-        &format!("Base{}", maybe_no_eol_comment(base)),
+        "Base",
     )?;
     write_and_ensure_newline(output, base)?;
 
@@ -494,10 +494,7 @@ fn materialize_git_style_conflict(
         output,
         ConflictMarkerLineChar::ConflictEnd,
         conflict_marker_len,
-        &format!(
-            "Side #2{} ({conflict_info} ends)",
-            maybe_no_eol_comment(right)
-        ),
+        &format!("Side #2 ({conflict_info} ends)"),
     )?;
 
     Ok(())

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -59,13 +59,13 @@ pub const MIN_CONFLICT_MARKER_LEN: usize = 7;
 const CONFLICT_MARKER_LEN_INCREMENT: usize = 4;
 
 /// Comment for missing terminating newline in a term of a conflict.
-const NO_EOL_COMMENT: &str = " [noeol]";
+const NO_EOL_COMMENT: &str = " (no terminating newline)";
 
 /// Comment for missing terminating newline in the "add" side of a diff.
-const ADD_NO_EOL_COMMENT: &str = " [+noeol]";
+const ADD_NO_EOL_COMMENT: &str = " (removes terminating newline)";
 
 /// Comment for missing terminating newline in the "remove" side of a diff.
-const REMOVE_NO_EOL_COMMENT: &str = " [-noeol]";
+const REMOVE_NO_EOL_COMMENT: &str = " (adds terminating newline)";
 
 fn write_diff_hunks(hunks: &[DiffHunk], file: &mut dyn Write) -> io::Result<()> {
     for hunk in hunks {

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -2134,11 +2134,11 @@ fn test_update_conflict_from_content_no_eol() {
     <<<<<<< Side #1 (Conflict 2 of 2)
     base
     left
-    ||||||| Base [noeol]
+    ||||||| Base
     base
     =======
     right
-    >>>>>>> Side #2 [noeol] (Conflict 2 of 2 ends)
+    >>>>>>> Side #2 (Conflict 2 of 2 ends)
     "##
     );
     // Parse with "diff" markers to ensure the file is actually parsed

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -627,14 +627,14 @@ fn test_materialize_conflict_no_newlines_at_eof() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r###"
+        @r##"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1 [-noeol]
+    %%%%%%% Changes from base to side #1 (adds terminating newline)
     -base
-    +++++++ Contents of side #2 [noeol]
+    +++++++ Contents of side #2 (no terminating newline)
     right
     >>>>>>> Conflict 1 of 1 ends
-    "###
+    "##
     );
     // The conflict markers are parsed with the trailing newline, but it is removed
     // by `update_from_content`
@@ -2057,7 +2057,7 @@ fn test_update_conflict_from_content_no_eol() {
     +++++++ Contents of side #1
     base
     left
-    %%%%%%% Changes from base to side #2 [noeol]
+    %%%%%%% Changes from base to side #2 (no terminating newline)
     -base
     +right
     >>>>>>> Conflict 2 of 2 ends
@@ -2096,9 +2096,9 @@ fn test_update_conflict_from_content_no_eol() {
     +++++++ Contents of side #1
     base
     left
-    ------- Contents of base [noeol]
+    ------- Contents of base (no terminating newline)
     base
-    +++++++ Contents of side #2 [noeol]
+    +++++++ Contents of side #2 (no terminating newline)
     right
     >>>>>>> Conflict 2 of 2 ends
     "##
@@ -2197,15 +2197,15 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     side
-    %%%%%%% Changes from base #1 to side #2 [-noeol]
+    %%%%%%% Changes from base #1 to side #2 (adds terminating newline)
      add newline
     -line
     +line
-    %%%%%%% Changes from base #2 to side #3 [+noeol]
+    %%%%%%% Changes from base #2 to side #3 (removes terminating newline)
      remove newline
     -line
     +line
-    %%%%%%% Changes from base #3 to side #4 [noeol]
+    %%%%%%% Changes from base #3 to side #4 (no terminating newline)
      no newline
     -line 1
     +line 2
@@ -2253,7 +2253,7 @@ fn test_update_conflict_from_content_only_no_eol_change() {
         @r##"
     line 1
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1 [+noeol]
+    %%%%%%% Changes from base to side #1 (removes terminating newline)
     +line 2
     +++++++ Contents of side #2
     line 2


### PR DESCRIPTION
Suggested by @arxanas in https://github.com/jj-vcs/jj/pull/5497#pullrequestreview-2582188101

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
