### PR TITLE
bookmarks: Make target revision a required argument to create/move/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* This release takes the first steps to make target revision required in
+  `bookmark create`, `bookmark move` and `bookmark set`. Those commands will display
+  a warning if the user does not specify target revision  explicitly. In the near
+  future those commands will fail if target revision is not specified.
+
 ### New features
 
 * `jj undo` now shows a hint when undoing an undo operation that the user may

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -54,16 +54,17 @@ pub struct BookmarkMoveArgs {
     )]
     from: Vec<RevisionArg>,
 
+    // TODO(#5374): Make required in jj 0.32+
     /// Move bookmarks to this revision
     // We intentionally do not support the short `-t` for `--to` since we don't
-    // support `-f` for `--from`.
+    // support `-f` for `--from`. Currently this defaults to the working copy, but in the near
+    // future it will be required to explicitly specify it.
     #[arg(
         long,
-        default_value = "@",
         value_name = "REVSET",
         add = ArgValueCandidates::new(complete::all_revisions),
     )]
-    to: RevisionArg,
+    to: Option<RevisionArg>,
 
     /// Allow moving bookmarks backwards or sideways
     #[arg(long, short = 'B')]
@@ -91,8 +92,15 @@ pub fn cmd_bookmark_move(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let repo = workspace_command.repo().clone();
-
-    let target_commit = workspace_command.resolve_single_rev(ui, &args.to)?;
+    if args.to.is_none() {
+        writeln!(
+            ui.warning_default(),
+            "Target revision was not specified, defaulting to the working copy (--to=@). In the \
+             near future it will be required to explicitly specify it."
+        )?;
+    }
+    let target_commit =
+        workspace_command.resolve_single_rev(ui, args.to.as_ref().unwrap_or(&RevisionArg::AT))?;
     let matched_bookmarks = {
         let is_source_ref: Box<dyn Fn(&RefTarget) -> _> = if !args.from.is_empty() {
             let is_source_commit = workspace_command

--- a/cli/src/commands/bookmark/set.rs
+++ b/cli/src/commands/bookmark/set.rs
@@ -29,7 +29,11 @@ use crate::ui::Ui;
 /// Create or update a bookmark to point to a certain commit
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkSetArgs {
+    // TODO(#5374): Make required in jj 0.32+
     /// The bookmark's target revision
+    //
+    // Currently target revision defaults to the working copy if not specified, but in the near
+    // future it will be required to explicitly specify it.
     #[arg(
         long, short,
         visible_alias = "to",
@@ -57,6 +61,13 @@ pub fn cmd_bookmark_set(
     args: &BookmarkSetArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
+    if args.revision.is_none() {
+        writeln!(
+            ui.warning_default(),
+            "Target revision was not specified, defaulting to the working copy (--revision=@). In \
+             the near future it will be required to explicitly specify target revision."
+        )?;
+    }
     let target_commit = workspace_command
         .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
     let repo = workspace_command.repo().as_ref();

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -421,8 +421,6 @@ $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 
 * `--from <REVSETS>` — Move bookmarks from the given revisions
 * `--to <REVSET>` — Move bookmarks to this revision
-
-  Default value: `@`
 * `-B`, `--allow-backwards` — Allow moving bookmarks backwards or sideways
 
 

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -25,7 +25,7 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
         test_env.jj_cmd_ok(repo_path, &args);
     }
     std::fs::write(repo_path.join(name), format!("{name}\n")).unwrap();
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name, "-r", "@"]);
 }
 
 #[test]

--- a/cli/tests/test_advance_bookmarks.rs
+++ b/cli/tests/test_advance_bookmarks.rs
@@ -114,7 +114,10 @@ fn test_advance_bookmarks_at_minus(make_commit: CommitFn) {
     let workspace_path = test_env.env_root().join("repo");
 
     set_advance_bookmarks(&test_env, true);
-    test_env.jj_cmd_ok(&workspace_path, &["bookmark", "create", "test_bookmark"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["bookmark", "create", "test_bookmark", "-r", "@"],
+    );
 
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
@@ -134,7 +137,10 @@ fn test_advance_bookmarks_at_minus(make_commit: CommitFn) {
 
     // Create a second bookmark pointing to @. On the next commit, only the first
     // bookmark, which points to @-, will advance.
-    test_env.jj_cmd_ok(&workspace_path, &["bookmark", "create", "test_bookmark2"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["bookmark", "create", "test_bookmark2", "-r", "@"],
+    );
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -25,7 +25,10 @@ fn test_alias_basic() {
     let repo_path = test_env.env_root().join("repo");
 
     test_env.add_config(r#"aliases.bk = ["log", "-r", "@", "-T", "bookmarks"]"#);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
+    test_env.jj_cmd_ok(
+        &repo_path,
+        &["bookmark", "create", "my-bookmark", "-r", "@"],
+    );
     let stdout = test_env.jj_cmd_success(&repo_path, &["bk"]);
     insta::assert_snapshot!(stdout, @r###"
     @  my-bookmark

--- a/cli/tests/test_backout_command.rs
+++ b/cli/tests/test_backout_command.rs
@@ -33,7 +33,7 @@ fn create_commit(
     for (name, contents) in files {
         std::fs::write(repo_path.join(name), contents).unwrap();
     }
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 #[test]

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -27,9 +27,12 @@ fn set_up(trunk_name: &str) -> (TestEnvironment, PathBuf) {
         .join("git");
 
     test_env.jj_cmd_ok(&origin_path, &["describe", "-m=description 1"]);
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", trunk_name]);
+    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "-r@", trunk_name]);
     test_env.jj_cmd_ok(&origin_path, &["new", "root()", "-m=description 2"]);
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "unrelated_bookmark"]);
+    test_env.jj_cmd_ok(
+        &origin_path,
+        &["bookmark", "create", "-r@", "unrelated_bookmark"],
+    );
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
     test_env.jj_cmd_ok(
@@ -87,7 +90,7 @@ fn test_builtin_alias_trunk_matches_exactly_one_commit() {
     let (test_env, workspace_root) = set_up("main");
     let origin_path = test_env.env_root().join("origin");
     test_env.jj_cmd_ok(&origin_path, &["new", "root()", "-m=description 3"]);
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "master"]);
+    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "-r@", "master"]);
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
     insta::assert_snapshot!(stdout, @r###"

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -237,7 +237,7 @@ fn test_log_default() {
     std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "add a file"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "description 1"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "my-bookmark"]);
 
     // Test default log output format
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
@@ -297,7 +297,7 @@ fn test_log_builtin_templates() {
         &repo_path,
         &["--config=user.email=''", "--config=user.name=''", "new"],
     );
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "my-bookmark"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
     rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark dc315397 (empty) (no description set)
@@ -366,7 +366,7 @@ fn test_log_builtin_templates_colored() {
         &repo_path,
         &["--config=user.email=''", "--config=user.name=''", "new"],
     );
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "my-bookmark"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r#"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
@@ -430,7 +430,7 @@ fn test_log_builtin_templates_colored_debug() {
         &repo_path,
         &["--config=user.email=''", "--config=user.name=''", "new"],
     );
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "my-bookmark"]);
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r#"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy bookmarks name::my-bookmark>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
@@ -565,14 +565,14 @@ fn test_log_bookmarks() {
 
     // Created some bookmarks on the remote
     test_env.jj_cmd_ok(&origin_path, &["describe", "-m=description 1"]);
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "bookmark1"]);
+    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "-r@", "bookmark1"]);
     test_env.jj_cmd_ok(&origin_path, &["new", "root()", "-m=description 2"]);
     test_env.jj_cmd_ok(
         &origin_path,
-        &["bookmark", "create", "bookmark2", "unchanged"],
+        &["bookmark", "create", "-r@", "bookmark2", "unchanged"],
     );
     test_env.jj_cmd_ok(&origin_path, &["new", "root()", "-m=description 3"]);
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "bookmark3"]);
+    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "-r@", "bookmark3"]);
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
     test_env.jj_cmd_ok(
         test_env.env_root(),
@@ -592,8 +592,11 @@ fn test_log_bookmarks() {
         &["describe", "bookmark1", "-m", "modified bookmark1 commit"],
     );
     test_env.jj_cmd_ok(&workspace_root, &["new", "bookmark2"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "bookmark2"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "new-bookmark"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "bookmark2", "--to=@"]);
+    test_env.jj_cmd_ok(
+        &workspace_root,
+        &["bookmark", "create", "-r@", "new-bookmark"],
+    );
     test_env.jj_cmd_ok(&workspace_root, &["describe", "bookmark3", "-m=local"]);
     test_env.jj_cmd_ok(&origin_path, &["describe", "bookmark3", "-m=origin"]);
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
@@ -786,7 +789,7 @@ fn test_log_immutable() {
     let repo_path = test_env.env_root().join("repo");
     test_env.jj_cmd_ok(&repo_path, &["new", "-mA", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mB"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mC"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mD", "root()"]);
 
@@ -847,7 +850,7 @@ fn test_log_contained_in() {
     let repo_path = test_env.env_root().join("repo");
     test_env.jj_cmd_ok(&repo_path, &["new", "-mA", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mB"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mC"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mD", "root()"]);
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -31,8 +31,8 @@ fn test_bookmark_names() {
         .join("store")
         .join("git");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "aaa-local"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bbb-local"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "aaa-local"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bbb-local"]);
 
     // add various remote branches
     test_env.jj_cmd_ok(
@@ -45,18 +45,24 @@ fn test_bookmark_names() {
             origin_git_repo_path.to_str().unwrap(),
         ],
     );
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "aaa-tracked"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "aaa-tracked"]);
     test_env.jj_cmd_ok(&repo_path, &["desc", "-r", "aaa-tracked", "-m", "x"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bbb-tracked"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bbb-tracked"]);
     test_env.jj_cmd_ok(&repo_path, &["desc", "-r", "bbb-tracked", "-m", "x"]);
     test_env.jj_cmd_ok(
         &repo_path,
         &["git", "push", "--allow-new", "--bookmark", "glob:*-tracked"],
     );
 
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "aaa-untracked"]);
+    test_env.jj_cmd_ok(
+        &origin_path,
+        &["bookmark", "create", "-r@", "aaa-untracked"],
+    );
     test_env.jj_cmd_ok(&origin_path, &["desc", "-r", "aaa-untracked", "-m", "x"]);
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "bbb-untracked"]);
+    test_env.jj_cmd_ok(
+        &origin_path,
+        &["bookmark", "create", "-r@", "bbb-untracked"],
+    );
     test_env.jj_cmd_ok(&origin_path, &["desc", "-r", "bbb-untracked", "-m", "x"]);
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
@@ -154,7 +160,7 @@ fn test_global_arg_repository_is_respected() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "aaa"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "aaa"]);
 
     let mut test_env = test_env;
     test_env.add_env_var("COMPLETE", "fish");
@@ -181,7 +187,7 @@ fn test_aliases_are_resolved() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "aaa"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "aaa"]);
 
     // user config alias
     test_env.add_config(r#"aliases.b = ["bookmark"]"#);
@@ -373,12 +379,12 @@ fn test_revisions() {
             origin_git_repo_path.to_str().unwrap(),
         ],
     );
-    test_env.jj_cmd_ok(&origin_path, &["b", "c", "remote_bookmark"]);
+    test_env.jj_cmd_ok(&origin_path, &["b", "c", "-r@", "remote_bookmark"]);
     test_env.jj_cmd_ok(&origin_path, &["commit", "-m", "remote_commit"]);
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
 
-    test_env.jj_cmd_ok(&repo_path, &["b", "c", "immutable_bookmark"]);
+    test_env.jj_cmd_ok(&repo_path, &["b", "c", "-r@", "immutable_bookmark"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "immutable"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "immutable_bookmark""#);
     test_env.add_config(r#"revset-aliases."siblings" = "@-+ ~@""#);
@@ -390,7 +396,7 @@ fn test_revisions() {
     '''"#,
     );
 
-    test_env.jj_cmd_ok(&repo_path, &["b", "c", "mutable_bookmark"]);
+    test_env.jj_cmd_ok(&repo_path, &["b", "c", "-r@", "mutable_bookmark"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "mutable"]);
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "working_copy"]);
@@ -627,7 +633,7 @@ fn create_commit(
             None => std::fs::remove_file(repo_path.join(name)).unwrap(),
         }
     }
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 #[test]

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -544,7 +544,7 @@ fn test_diffedit_merge() {
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     std::fs::write(repo_path.join("file2"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file1"), "b\n").unwrap();
     std::fs::write(repo_path.join("file2"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -25,7 +25,7 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
         test_env.jj_cmd_ok(repo_path, &args);
     }
     std::fs::write(repo_path.join(name), format!("{name}\n")).unwrap();
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 #[test]
@@ -75,9 +75,7 @@ fn test_duplicate() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
-    Undid operation: b5bdbb51ab28 (2001-02-03 08:05:17) duplicate 1 commit(s)
-    "#);
+    insta::assert_snapshot!(stderr, @"Undid operation: 01373b278eae (2001-02-03 08:05:17) duplicate 1 commit(s)");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
@@ -2327,9 +2325,7 @@ fn test_undo_after_duplicate() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
-    Undid operation: e3dbefa46ed5 (2001-02-03 08:05:11) duplicate 1 commit(s)
-    "#);
+    insta::assert_snapshot!(stderr, @"Undid operation: 7e9bd644ad7a (2001-02-03 08:05:11) duplicate 1 commit(s)");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  2443ea76b0b1   a
     ◆  000000000000

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -55,15 +55,15 @@ fn test_annotate_merge() {
 
     std::fs::write(repo_path.join("file.txt"), "line1\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=initial"]);
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "initial"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "initial"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=commit1"]);
     append_to_file(&repo_path.join("file.txt"), "new text from new commit 1");
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "commit1"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "commit1"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=commit2", "initial"]);
     append_to_file(&repo_path.join("file.txt"), "new text from new commit 2");
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "commit2"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "commit2"]);
 
     // create a (conflicted) merge
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=merged", "commit1", "commit2"]);
@@ -90,15 +90,15 @@ fn test_annotate_conflicted() {
 
     std::fs::write(repo_path.join("file.txt"), "line1\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=initial"]);
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "initial"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "initial"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=commit1"]);
     append_to_file(&repo_path.join("file.txt"), "new text from new commit 1");
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "commit1"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "commit1"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=commit2", "initial"]);
     append_to_file(&repo_path.join("file.txt"), "new text from new commit 2");
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "commit2"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "commit2"]);
 
     // create a (conflicted) merge
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=merged", "commit1", "commit2"]);
@@ -124,15 +124,15 @@ fn test_annotate_merge_one_sided_conflict_resolution() {
 
     std::fs::write(repo_path.join("file.txt"), "line1\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=initial"]);
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "initial"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "initial"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=commit1"]);
     append_to_file(&repo_path.join("file.txt"), "new text from new commit 1");
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "commit1"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "commit1"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=commit2", "initial"]);
     append_to_file(&repo_path.join("file.txt"), "new text from new commit 2");
-    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "commit2"]);
+    test_env.jj_cmd_ok(&repo_path, &["branch", "create", "-r@", "commit2"]);
 
     // create a (conflicted) merge
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=merged", "commit1", "commit2"]);

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -33,7 +33,7 @@ fn create_commit(
     for (name, content) in files {
         std::fs::write(repo_path.join(name), content).unwrap();
     }
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -476,13 +476,13 @@ fn test_fix_parent_commit() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     // Using one file name for all commits adds coverage of some possible bugs.
     std::fs::write(repo_path.join("file"), "parent").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "parent"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "parent"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "child1").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "child1"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "child1"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-r", "parent"]);
     std::fs::write(repo_path.join("file"), "child2").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "child2"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "child2"]);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix", "-s", "parent"]);
     insta::assert_snapshot!(stdout, @"");
@@ -504,13 +504,13 @@ fn test_fix_parent_commit() {
 fn test_fix_sibling_commit() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     std::fs::write(repo_path.join("file"), "parent").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "parent"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "parent"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "child1").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "child1"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "child1"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-r", "parent"]);
     std::fs::write(repo_path.join("file"), "child2").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "child2"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "child2"]);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix", "-s", "child1"]);
     insta::assert_snapshot!(stdout, @"");
@@ -527,22 +527,22 @@ fn test_fix_sibling_commit() {
 fn test_default_revset() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     std::fs::write(repo_path.join("file"), "trunk1").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "trunk1"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "trunk1"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "trunk2").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "trunk2"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "trunk2"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "trunk1"]);
     std::fs::write(repo_path.join("file"), "foo").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "trunk1"]);
     std::fs::write(repo_path.join("file"), "bar1").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bar1"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bar1"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "bar2").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bar2"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bar2"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "bar3").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bar3"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bar3"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "bar2"]);
 
     // With no args and no revset configuration, we fix `reachable(@, mutable())`,
@@ -576,10 +576,10 @@ fn test_custom_default_revset() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
 
     std::fs::write(repo_path.join("file"), "foo").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "bar").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bar"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bar"]);
 
     // Check out a different commit so that the schema default `reachable(@,
     // mutable())` would behave differently from our customized default.
@@ -599,10 +599,10 @@ fn test_custom_default_revset() {
 fn test_fix_immutable_commit() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     std::fs::write(repo_path.join("file"), "immutable").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "immutable"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "immutable"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "mutable").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "mutable"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "mutable"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "immutable""#);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["fix", "-s", "immutable"]);
@@ -692,16 +692,16 @@ fn test_deduplication() {
     // There are at least two interesting cases: the content is repeated immediately
     // in the child commit, or later in another descendant.
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "bar\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "bar\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix", "-s", "a"]);
     insta::assert_snapshot!(stdout, @"");
@@ -877,11 +877,11 @@ fn test_fix_trivial_merge_commit() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     std::fs::write(repo_path.join("file_a"), "content a").unwrap();
     std::fs::write(repo_path.join("file_c"), "content c").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
     std::fs::write(repo_path.join("file_b"), "content b").unwrap();
     std::fs::write(repo_path.join("file_c"), "content c").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "a", "b"]);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix", "-s", "@"]);
@@ -905,11 +905,11 @@ fn test_fix_adding_merge_commit() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     std::fs::write(repo_path.join("file_a"), "content a").unwrap();
     std::fs::write(repo_path.join("file_c"), "content c").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
     std::fs::write(repo_path.join("file_b"), "content b").unwrap();
     std::fs::write(repo_path.join("file_c"), "content c").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "a", "b"]);
     std::fs::write(repo_path.join("file_a"), "change a").unwrap();
     std::fs::write(repo_path.join("file_b"), "change b").unwrap();
@@ -939,10 +939,10 @@ fn test_fix_adding_merge_commit() {
 fn test_fix_both_sides_of_conflict() {
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     std::fs::write(repo_path.join("file"), "content a\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
     std::fs::write(repo_path.join("file"), "content b\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "a", "b"]);
 
     // The conflicts are not different from the merged parent, so they would not be
@@ -983,10 +983,10 @@ fn test_fix_resolve_conflict() {
     // will be resolved.
     let (test_env, repo_path) = init_with_fake_formatter(&["--uppercase"]);
     std::fs::write(repo_path.join("file"), "Content\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
     std::fs::write(repo_path.join("file"), "cOnTeNt\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "a", "b"]);
 
     // The conflicts are not different from the merged parent, so they would not be

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -78,7 +78,7 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
         test_env.jj_cmd_ok(repo_path, &args);
     }
     std::fs::write(repo_path.join(name), format!("{name}\n")).unwrap();
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
@@ -484,7 +484,7 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
 
     // Create a rem1 bookmark locally
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "rem1"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "rem1"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: kkmpptxz fcdbbd73 (empty) (no description set)
@@ -525,7 +525,7 @@ fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
 
     // Create a rem1 bookmark locally
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "rem1"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "rem1"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     rem1: zsuskuln f652c321 (empty) (no description set)
@@ -1372,7 +1372,7 @@ fn test_fetch_undo_what(subprocess: bool) {
 
     // Now, let's demo restoring just the remote-tracking bookmark. First, let's
     // change our local repo state...
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "newbookmark"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "newbookmark"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     b (deleted)
@@ -1419,7 +1419,7 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "origin"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "origin"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin: qpvuntsm 230dd059 (empty) (no description set)
@@ -1479,7 +1479,7 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "origin"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "origin"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
     origin: qpvuntsm 230dd059 (empty) (no description set)

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -529,7 +529,7 @@ fn test_git_init_colocated_via_git_repo_path_imported_refs() {
     let remote_path = test_env.env_root().join("remote");
     test_env.jj_cmd_ok(
         &remote_path,
-        &["bookmark", "create", "local-remote", "remote-only"],
+        &["bookmark", "create", "-r@", "local-remote", "remote-only"],
     );
     test_env.jj_cmd_ok(&remote_path, &["new"]);
     test_env.jj_cmd_ok(&remote_path, &["git", "export"]);
@@ -762,7 +762,10 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     "###);
 
     // Create the default bookmark (create both in case we change the default)
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "main", "master"]);
+    test_env.jj_cmd_ok(
+        &workspace_root,
+        &["bookmark", "create", "-r@", "main", "master"],
+    );
 
     // If .git/HEAD pointed to the default bookmark, new working-copy commit would
     // be created on top.

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -29,7 +29,7 @@ fn set_up() -> (TestEnvironment, PathBuf) {
 
     test_env.jj_cmd_ok(&origin_path, &["describe", "-m=public 1"]);
     test_env.jj_cmd_ok(&origin_path, &["new", "-m=public 2"]);
-    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
     test_env.jj_cmd_ok(
@@ -83,7 +83,7 @@ fn test_git_private_commits_block_pushing() {
     let (test_env, workspace_root) = set_up();
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "-m=private 1"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main", "-r@"]);
 
     // Will not push when a pushed commit is contained in git.private-commits
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
@@ -111,7 +111,7 @@ fn test_git_private_commits_can_be_overridden() {
     let (test_env, workspace_root) = set_up();
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "-m=private 1"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main", "-r@"]);
 
     // Will not push when a pushed commit is contained in git.private-commits
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
@@ -141,7 +141,7 @@ fn test_git_private_commits_are_not_checked_if_immutable() {
     let (test_env, workspace_root) = set_up();
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "-m=private 1"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main", "-r@"]);
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "all()""#);
@@ -163,7 +163,7 @@ fn test_git_private_commits_not_directly_in_line_block_pushing() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "root()", "-m=private 1"]);
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "@", "-m=public 3"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "bookmark1"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "bookmark1"]);
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
     let stderr = test_env.jj_cmd_failure(
@@ -182,7 +182,7 @@ fn test_git_private_commits_descending_from_commits_pushed_do_not_block_pushing(
     let (test_env, workspace_root) = set_up();
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "-m=public 3"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "move", "main"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "move", "main", "--to=@"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m=private 1"]);
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
@@ -207,7 +207,7 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     // the remote
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "-m=private 1"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m=public 3"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main", "-r@"]);
     let (_, stderr) = test_env.jj_cmd_ok(
         &workspace_root,
         &["git", "push", "--allow-new", "-b=main", "-b=bookmark1"],
@@ -240,7 +240,7 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &workspace_root,
         &["new", "description('private 1')", "-m=public 4"],
     );
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "bookmark2"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "bookmark2"]);
     let (_, stderr) = test_env.jj_cmd_ok(
         &workspace_root,
         &["git", "push", "--allow-new", "-b=bookmark2"],
@@ -261,7 +261,7 @@ fn test_git_private_commits_are_evaluated_separately_for_each_remote() {
     // the remote
     test_env.jj_cmd_ok(&workspace_root, &["new", "main", "-m=private 1"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m=public 3"]);
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main", "-r@"]);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-b=main"]);
     insta::assert_snapshot!(stderr, @r#"
     Changes to push to origin:

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -217,7 +217,7 @@ fn test_git_remote_named_git() {
         .remote("git", "http://example.com/repo/repo")
         .unwrap();
     test_env.jj_cmd_ok(&repo_path, &["git", "init", "--git-repo=."]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
 
     // The remote can be renamed.
     let (stdout, stderr) =

--- a/cli/tests/test_gitignores.rs
+++ b/cli/tests/test_gitignores.rs
@@ -104,7 +104,7 @@ fn test_gitignores_ignored_file_in_target_commit() {
 
     // Create a commit with file "ignored" in it
     std::fs::write(workspace_root.join("ignored"), "committed contents\n").unwrap();
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "with-file"]);
+    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "with-file"]);
     let target_commit_id = test_env.jj_cmd_success(
         &workspace_root,
         &["log", "--no-graph", "-T=commit_id", "-r=@"],

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -95,9 +95,9 @@ fn test_no_subcommand() {
     assert_eq!(stdout, test_env.jj_cmd_success(&repo_path, &["log"]));
 
     // Command argument that looks like a command name.
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "help"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "log"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "show"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "help"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "log"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "show"]);
     // TODO: test_env.jj_cmd_ok(&repo_path, &["-r", "help"])
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "log"]), @r###"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 help log show 230dd059

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -23,7 +23,7 @@ fn test_rewrite_immutable_generic() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=a"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=b"]);
     std::fs::write(repo_path.join("file"), "b").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "main-", "-m=c"]);
     std::fs::write(repo_path.join("file"), "c").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
@@ -111,10 +111,10 @@ fn test_rewrite_immutable_generic() {
 fn test_new_wc_commit_when_wc_immutable() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init"]);
-    test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "create", "-r@", "main"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     test_env.jj_cmd_ok(test_env.env_root(), &["new", "-m=a"]);
-    let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "set", "main"]);
+    let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "set", "main", "-r@"]);
     insta::assert_snapshot!(stderr, @r###"
     Moved 1 bookmarks to kkmpptxz a164195b main | (empty) a
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
@@ -127,7 +127,7 @@ fn test_new_wc_commit_when_wc_immutable() {
 fn test_immutable_heads_set_to_working_copy() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init"]);
-    test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "create", "-r@", "main"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "@""#);
     let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["new", "-m=a"]);
     insta::assert_snapshot!(stderr, @r###"
@@ -142,13 +142,13 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=a"]);
     test_env.jj_cmd_ok(&repo_path, &["workspace", "add", "../workspace1"]);
     let workspace1_envroot = test_env.env_root().join("workspace1");
     test_env.jj_cmd_ok(&workspace1_envroot, &["edit", "default@"]);
-    let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "main"]);
+    let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "main", "-r@"]);
     insta::assert_snapshot!(stderr, @r###"
     Moved 1 bookmarks to kkmpptxz 7796c4df main | (empty) a
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
@@ -184,7 +184,7 @@ fn test_rewrite_immutable_commands() {
     // Create another file to make sure the merge commit isn't empty (to satisfy `jj
     // split`) and still has a conflict (to satisfy `jj resolve`).
     std::fs::write(repo_path.join("file2"), "merged").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "description(b)"]);
     std::fs::write(repo_path.join("file"), "w").unwrap();
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -23,13 +23,13 @@ fn test_interdiff_basic() {
     std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file2"), "foo\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "left"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "left"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     std::fs::write(repo_path.join("file3"), "foo\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file2"), "foo\nbar\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "right"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "right"]);
 
     // implicit --to
     let stdout = test_env.jj_cmd_success(&repo_path, &["interdiff", "--from", "left"]);
@@ -87,7 +87,7 @@ fn test_interdiff_paths() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file1"), "bar\n").unwrap();
     std::fs::write(repo_path.join("file2"), "bar\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "left"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "left"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
@@ -95,7 +95,7 @@ fn test_interdiff_paths() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file1"), "baz\n").unwrap();
     std::fs::write(repo_path.join("file2"), "baz\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "right"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "right"]);
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -135,13 +135,13 @@ fn test_interdiff_conflicting() {
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "bar\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "left"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "left"]);
 
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     std::fs::write(repo_path.join("file"), "abc\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file"), "def\n").unwrap();
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "right"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "right"]);
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -353,7 +353,7 @@ fn test_log_shortest_accessors() {
 
     std::fs::write(repo_path.join("file"), "original file\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "original"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "original"]);
     insta::assert_snapshot!(
         render("original", r#"format_id(change_id) ++ " " ++ format_id(commit_id)"#),
         @"q[pvuntsmwlqt] e[0e22b9fae75]");
@@ -516,7 +516,7 @@ fn test_log_prefix_highlight_styled() {
 
     std::fs::write(repo_path.join("file"), "original file\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "original"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "original"]);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
         @r###"
@@ -650,7 +650,7 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
 
     std::fs::write(repo_path.join("file"), "original file\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "original"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "original"]);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
         @r###"
@@ -1108,7 +1108,7 @@ fn test_multiple_revsets() {
     let repo_path = test_env.env_root().join("repo");
     for name in ["foo", "bar", "baz"] {
         test_env.jj_cmd_ok(&repo_path, &["new", "-m", name]);
-        test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", name]);
+        test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", name]);
     }
 
     // Default revset should be overridden if one or more -r options are specified.

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -69,7 +69,7 @@ fn test_new_merge() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "add file1"]);
     std::fs::write(repo_path.join("file1"), "a").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "root()", "-m", "add file2"]);
@@ -608,7 +608,7 @@ fn test_new_conflicting_bookmarks() {
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "one"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "two", "@-"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo"]);
     test_env.jj_cmd_ok(
         &repo_path,
         &[
@@ -671,19 +671,19 @@ fn test_new_error_revision_does_not_exist() {
 }
 
 fn setup_before_insertion(test_env: &TestEnvironment, repo_path: &Path) {
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "A"]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", "A"]);
     test_env.jj_cmd_ok(repo_path, &["commit", "-m", "A"]);
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "B"]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", "B"]);
     test_env.jj_cmd_ok(repo_path, &["commit", "-m", "B"]);
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "C"]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", "C"]);
     test_env.jj_cmd_ok(repo_path, &["describe", "-m", "C"]);
     test_env.jj_cmd_ok(repo_path, &["new", "-m", "D", "root()"]);
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "D"]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", "D"]);
     test_env.jj_cmd_ok(repo_path, &["new", "-m", "E", "root()"]);
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "E"]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", "E"]);
     // Any number of -r's is ignored
     test_env.jj_cmd_ok(repo_path, &["new", "-m", "F", "-r", "D", "-r", "E"]);
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "F"]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", "F"]);
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -432,9 +432,9 @@ fn test_prev_on_merge_commit() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     test_env.jj_cmd_ok(&repo_path, &["desc", "-m", "first"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "left"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "left"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "root()", "-m", "second"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "right"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "right"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "left", "right"]);
 
     // Check that the graph looks the way we expect.

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -25,7 +25,7 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
         test_env.jj_cmd_ok(repo_path, &args);
     }
     std::fs::write(repo_path.join(name), format!("{name}\n")).unwrap();
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 #[test]
@@ -648,13 +648,13 @@ fn test_rebase_revision_onto_descendant() {
     // Now, let's rebase onto the descendant merge
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
-    Restored to operation: cc1a7e3419ad (2001-02-03 08:05:15) create bookmark merge pointing to commit b05964d109522cd06e48f1a2661e1a0f58be0984
+    insta::assert_snapshot!(stderr, @r"
+    Restored to operation: 8370ca29327a (2001-02-03 08:05:15) create bookmark merge pointing to commit b05964d109522cd06e48f1a2661e1a0f58be0984
     Working copy now at: vruxwmqv b05964d1 merge | merge
     Parent commit      : royxmykx cea87a87 b | b
     Parent commit      : zsuskuln 2c5b7858 a | a
     Added 1 files, modified 0 files, removed 0 files
-    "#);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "merge"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
@@ -906,7 +906,7 @@ fn test_rebase_error_revision_does_not_exist() {
     let repo_path = test_env.env_root().join("repo");
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "one"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b-one"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b-one"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-r", "@-", "-m", "two"]);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-b", "b-one", "-d", "this"]);
@@ -2645,7 +2645,7 @@ fn test_rebase_skip_emptied_descendants() {
     create_commit(&test_env, &repo_path, "b", &["a"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "a", "-m", "c (will become empty)"]);
     test_env.jj_cmd_ok(&repo_path, &["restore", "--from=b"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "already empty"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "also already empty"]);
 

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -35,7 +35,7 @@ fn create_commit(
     for (name, content) in files {
         std::fs::write(repo_path.join(name), content).unwrap();
     }
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -598,7 +598,7 @@ fn create_commit(
     for (name, content) in files {
         std::fs::write(repo_path.join(name), content).unwrap();
     }
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_simplify_parents_command.rs
+++ b/cli/tests/test_simplify_parents_command.rs
@@ -33,7 +33,7 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
     test_env.jj_cmd_ok(repo_path, &args);
 
     std::fs::write(repo_path.join(name), format!("{name}\n")).unwrap();
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 #[test]

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -228,7 +228,10 @@ fn test_split_with_default_description() {
 
     // Create a bookmark pointing to the commit. It will be moved to the second
     // commit after the split.
-    test_env.jj_cmd_ok(&workspace_path, &["bookmark", "create", "test_bookmark"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["bookmark", "create", "-r@", "test_bookmark"],
+    );
 
     let edit_script = test_env.set_up_fake_editor();
     std::fs::write(
@@ -336,7 +339,10 @@ fn test_split_siblings_no_descendants() {
 
     // Create a bookmark pointing to the commit. It will be moved to the second
     // commit after the split.
-    test_env.jj_cmd_ok(&workspace_path, &["bookmark", "create", "test_bookmark"]);
+    test_env.jj_cmd_ok(
+        &workspace_path,
+        &["bookmark", "create", "-r@", "test_bookmark"],
+    );
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
     @  qpvuntsmwlqt false test_bookmark
     ◆  zzzzzzzzzzzz true

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -23,13 +23,13 @@ fn test_squash() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file1"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -85,10 +85,10 @@ fn test_squash() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "b"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
     std::fs::write(repo_path.join("file2"), "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "c", "d"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "e"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "e"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    41219719ab5f e (empty)
     ├─╮
@@ -137,15 +137,15 @@ fn test_squash_partial() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     std::fs::write(repo_path.join("file2"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file1"), "b\n").unwrap();
     std::fs::write(repo_path.join("file2"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup
@@ -283,13 +283,13 @@ fn test_squash_keep_emptied() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file1"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
 
@@ -337,25 +337,25 @@ fn test_squash_from_to() {
     //
     // When moving changes between e.g. C and F, we should not get unrelated changes
     // from B and D.
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     std::fs::write(repo_path.join("file2"), "a\n").unwrap();
     std::fs::write(repo_path.join("file3"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file3"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["edit", "a"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
     std::fs::write(repo_path.join("file3"), "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "e"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "e"]);
     std::fs::write(repo_path.join("file2"), "e\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "f"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "f"]);
     std::fs::write(repo_path.join("file2"), "f\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -469,20 +469,20 @@ fn test_squash_from_to_partial() {
     // D B
     // |/
     // A
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     std::fs::write(repo_path.join("file2"), "a\n").unwrap();
     std::fs::write(repo_path.join("file3"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file3"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["edit", "a"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
     std::fs::write(repo_path.join("file3"), "d\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -651,22 +651,22 @@ fn test_squash_from_multiple() {
     //  \|/
     //   A
     let file = repo_path.join("file");
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(&file, "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(&file, "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(&file, "c\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
     std::fs::write(&file, "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "all:visible_heads()"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "e"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "e"]);
     std::fs::write(&file, "e\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "f"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "f"]);
     std::fs::write(&file, "f\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -770,27 +770,27 @@ fn test_squash_from_multiple_partial() {
     //   A
     let file1 = repo_path.join("file1");
     let file2 = repo_path.join("file2");
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(&file1, "a\n").unwrap();
     std::fs::write(&file2, "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(&file1, "b\n").unwrap();
     std::fs::write(&file2, "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(&file1, "c\n").unwrap();
     std::fs::write(&file2, "c\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
     std::fs::write(&file1, "d\n").unwrap();
     std::fs::write(&file2, "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "all:visible_heads()"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "e"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "e"]);
     std::fs::write(&file1, "e\n").unwrap();
     std::fs::write(&file2, "e\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "f"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "f"]);
     std::fs::write(&file1, "f\n").unwrap();
     std::fs::write(&file2, "f\n").unwrap();
     // Test the setup

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -33,7 +33,7 @@ fn create_commit(
     for (name, content) in files {
         std::fs::write(repo_path.join(name), content).unwrap();
     }
-    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", name]);
+    test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn test_status_merge() {
 
     std::fs::write(repo_path.join("file"), "base").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=left"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "left"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "left"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@-", "-m=right"]);
     std::fs::write(repo_path.join("file"), "right").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "left", "@"]);

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -38,11 +38,11 @@ fn test_tag_list() {
     };
 
     test_env.jj_cmd_ok(&repo_path, &["new", "root()", "-mcommit1"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bookmark1"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bookmark1"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "root()", "-mcommit2"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bookmark2"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bookmark2"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "root()", "-mcommit3"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bookmark3"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bookmark3"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
 
     copy_ref("refs/heads/bookmark1", "test_tag");

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -57,7 +57,7 @@ fn test_git_push_undo() {
     let repo_path = test_env.env_root().join("repo");
 
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
@@ -130,7 +130,7 @@ fn test_git_push_undo_with_import() {
     let repo_path = test_env.env_root().join("repo");
 
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
@@ -211,7 +211,7 @@ fn test_git_push_undo_colocated() {
     test_env.jj_cmd_ok(&repo_path, &["git", "init", "--git-repo=."]);
 
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
@@ -291,7 +291,7 @@ fn test_git_push_undo_repo_only() {
     let repo_path = test_env.env_root().join("repo");
 
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
@@ -336,7 +336,10 @@ fn test_bookmark_track_untrack_undo() {
     let repo_path = test_env.env_root().join("repo");
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-mcommit"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "feature1", "feature2"]);
+    test_env.jj_cmd_ok(
+        &repo_path,
+        &["bookmark", "create", "-r@", "feature1", "feature2"],
+    );
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "feature2"]);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -23,13 +23,13 @@ fn test_unsquash() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file1"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
@@ -88,10 +88,10 @@ fn test_unsquash() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "b"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
     std::fs::write(repo_path.join("file2"), "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "merge", "c", "d"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "e"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "e"]);
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @    b780e7469252 e
     ├─╮
@@ -143,15 +143,15 @@ fn test_unsquash_partial() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
     std::fs::write(repo_path.join("file1"), "a\n").unwrap();
     std::fs::write(repo_path.join("file2"), "a\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "b"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "b"]);
     std::fs::write(repo_path.join("file1"), "b\n").unwrap();
     std::fs::write(repo_path.join("file2"), "b\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -231,8 +231,8 @@ The use of bookmarks is frequent in some workflows, for example, when
 interacting with Git repositories containing branches. To this end,
 one-letter shortcuts have been implemented, both for the `jj bookmark`
 command itself through an alias (as `jj b`), and for its subcommands.
-For example, `jj bookmark create BOOKMARK-NAME` can be abbreviated as
-`jj b c BOOKMARK-NAME`.
+For example, `jj bookmark create BOOKMARK-NAME -r@` can be abbreviated as
+`jj b c BOOKMARK-NAME -r@`.
 
 [colocated-repos]: git-compatibility.md#co-located-jujutsugit-repos
 [design]: design/tracking-branches.md


### PR DESCRIPTION
This change is not backwards compatible, but it should be very easy to adapt to it.

This fixes
https://github.com/jj-vcs/jj/issues/5374
See also
https://github.com/jj-vcs/jj/discussions/5363

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
