### PR TITLE
cleanup: prefer `MutableRepo::repo()` over `repo_mut()`

### DIFF
--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -407,13 +407,13 @@ fn test_import_refs_reimport_head_removed() {
     tx.repo_mut().rebase_descendants().unwrap();
     let commit_id = jj_id(&commit);
     // Test the setup
-    assert!(tx.repo_mut().view().heads().contains(&commit_id));
+    assert!(tx.repo().view().heads().contains(&commit_id));
 
     // Remove the head and re-import
     tx.repo_mut().remove_head(&commit_id);
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(!tx.repo_mut().view().heads().contains(&commit_id));
+    assert!(!tx.repo().view().heads().contains(&commit_id));
 }
 
 #[test]
@@ -443,7 +443,7 @@ fn test_import_refs_reimport_git_head_does_not_count() {
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(!tx.repo_mut().view().heads().contains(&jj_id(&commit)));
+    assert!(!tx.repo().view().heads().contains(&jj_id(&commit)));
 }
 
 #[test]
@@ -464,8 +464,8 @@ fn test_import_refs_reimport_git_head_without_ref() {
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(tx.repo_mut().view().heads().contains(commit1.id()));
-    assert!(tx.repo_mut().view().heads().contains(commit2.id()));
+    assert!(tx.repo().view().heads().contains(commit1.id()));
+    assert!(tx.repo().view().heads().contains(commit2.id()));
 
     // Move HEAD to commit2 (by e.g. `git checkout` command)
     git_repo.set_head_detached(git_id(&commit2)).unwrap();
@@ -477,8 +477,8 @@ fn test_import_refs_reimport_git_head_without_ref() {
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(tx.repo_mut().view().heads().contains(commit1.id()));
-    assert!(tx.repo_mut().view().heads().contains(commit2.id()));
+    assert!(tx.repo().view().heads().contains(commit1.id()));
+    assert!(tx.repo().view().heads().contains(commit2.id()));
 }
 
 #[test]
@@ -502,8 +502,8 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(tx.repo_mut().view().heads().contains(commit1.id()));
-    assert!(tx.repo_mut().view().heads().contains(commit2.id()));
+    assert!(tx.repo().view().heads().contains(commit1.id()));
+    assert!(tx.repo().view().heads().contains(commit2.id()));
 
     // Move both HEAD and main to commit2 (by e.g. `git commit --amend` command)
     git_repo
@@ -515,14 +515,14 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(!tx.repo_mut().view().heads().contains(commit1.id()));
-    assert!(tx.repo_mut().view().heads().contains(commit2.id()));
+    assert!(!tx.repo().view().heads().contains(commit1.id()));
+    assert!(tx.repo().view().heads().contains(commit2.id()));
     // Reimport HEAD and main, which abandons the old main bookmark.
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(!tx.repo_mut().view().heads().contains(commit1.id()));
-    assert!(tx.repo_mut().view().heads().contains(commit2.id()));
+    assert!(!tx.repo().view().heads().contains(commit1.id()));
+    assert!(tx.repo().view().heads().contains(commit2.id()));
 }
 
 #[test]
@@ -1014,8 +1014,8 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(tx.repo_mut().view().heads().contains(commit1.id()));
-    assert!(tx.repo_mut().view().heads().contains(commit2.id()));
+    assert!(tx.repo().view().heads().contains(commit1.id()));
+    assert!(tx.repo().view().heads().contains(commit2.id()));
 
     // Move only HEAD to commit2 (by e.g. `git checkout` command)
     git_repo.set_head_detached(git_id(&commit2)).unwrap();
@@ -1024,8 +1024,8 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
     git::import_head(tx.repo_mut()).unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(tx.repo_mut().view().heads().contains(commit1.id()));
-    assert!(tx.repo_mut().view().heads().contains(commit2.id()));
+    assert!(tx.repo().view().heads().contains(commit1.id()));
+    assert!(tx.repo().view().heads().contains(commit2.id()));
 }
 
 #[test]
@@ -1042,7 +1042,7 @@ fn test_import_refs_reimport_all_from_root_removed() {
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     // Test the setup
-    assert!(tx.repo_mut().view().heads().contains(&jj_id(&commit)));
+    assert!(tx.repo().view().heads().contains(&jj_id(&commit)));
 
     // Remove all git refs and re-import
     git_repo
@@ -1052,7 +1052,7 @@ fn test_import_refs_reimport_all_from_root_removed() {
         .unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(!tx.repo_mut().view().heads().contains(&jj_id(&commit)));
+    assert!(!tx.repo().view().heads().contains(&jj_id(&commit)));
 }
 
 #[test]
@@ -1072,7 +1072,7 @@ fn test_import_refs_reimport_abandoning_disabled() {
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     // Test the setup
-    assert!(tx.repo_mut().view().heads().contains(&jj_id(&commit2)));
+    assert!(tx.repo().view().heads().contains(&jj_id(&commit2)));
 
     // Remove the `delete-me` bookmark and re-import
     git_repo
@@ -1082,7 +1082,7 @@ fn test_import_refs_reimport_abandoning_disabled() {
         .unwrap();
     git::import_refs(tx.repo_mut(), &git_settings).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    assert!(tx.repo_mut().view().heads().contains(&jj_id(&commit2)));
+    assert!(tx.repo().view().heads().contains(&jj_id(&commit2)));
 }
 
 #[test]
@@ -2176,14 +2176,14 @@ fn test_reset_head_to_root() {
     git::reset_head(tx.repo_mut(), &commit2).unwrap();
     assert!(git_repo.head().is_ok());
     assert_eq!(
-        tx.repo_mut().git_head(),
+        tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
     );
 
     // Set Git HEAD back to root
     git::reset_head(tx.repo_mut(), &commit1).unwrap();
     assert!(git_repo.head().is_err());
-    assert!(tx.repo_mut().git_head().is_absent());
+    assert!(tx.repo().git_head().is_absent());
 
     // Move placeholder ref as if new commit were created by git
     git_repo
@@ -2192,7 +2192,7 @@ fn test_reset_head_to_root() {
     git::reset_head(tx.repo_mut(), &commit2).unwrap();
     assert!(git_repo.head().is_ok());
     assert_eq!(
-        tx.repo_mut().git_head(),
+        tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
     );
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
@@ -2200,7 +2200,7 @@ fn test_reset_head_to_root() {
     // Set Git HEAD back to root
     git::reset_head(tx.repo_mut(), &commit1).unwrap();
     assert!(git_repo.head().is_err());
-    assert!(tx.repo_mut().git_head().is_absent());
+    assert!(tx.repo().git_head().is_absent());
     // The placeholder ref should be deleted
     assert!(git_repo.find_reference("refs/jj/root").is_err());
 }
@@ -2586,8 +2586,8 @@ fn test_fetch_empty_repo(subprocess: bool) {
     // No default bookmark and no refs
     assert_eq!(stats.default_branch, None);
     assert!(stats.import_stats.abandoned_commits.is_empty());
-    assert_eq!(*tx.repo_mut().view().git_refs(), btreemap! {});
-    assert_eq!(tx.repo_mut().view().bookmarks().count(), 0);
+    assert_eq!(*tx.repo().view().git_refs(), btreemap! {});
+    assert_eq!(tx.repo().view().bookmarks().count(), 0);
 }
 
 #[test_case(false; "use git2 for remote calls")]
@@ -2773,11 +2773,8 @@ fn test_fetch_prune_deleted_ref(subprocess: bool) {
     )
     .unwrap();
     // Test the setup
-    assert!(tx.repo_mut().get_local_bookmark("main").is_present());
-    assert!(tx
-        .repo_mut()
-        .get_remote_bookmark("main", "origin")
-        .is_present());
+    assert!(tx.repo().get_local_bookmark("main").is_present());
+    assert!(tx.repo().get_remote_bookmark("main", "origin").is_present());
 
     test_data
         .origin_repo
@@ -2795,7 +2792,7 @@ fn test_fetch_prune_deleted_ref(subprocess: bool) {
     )
     .unwrap();
     assert_eq!(stats.import_stats.abandoned_commits, vec![jj_id(&commit)]);
-    assert!(tx.repo_mut().get_local_bookmark("main").is_absent());
+    assert!(tx.repo().get_local_bookmark("main").is_absent());
     assert!(tx
         .repo_mut()
         .get_remote_bookmark("main", "origin")
@@ -3069,7 +3066,7 @@ fn test_push_bookmarks_success(subprocess: bool) {
     assert_eq!(new_target, Some(new_oid));
 
     // Check that the repo view got updated
-    let view = tx.repo_mut().view();
+    let view = tx.repo().view();
     assert_eq!(
         *view.get_git_ref("refs/remotes/origin/main"),
         RefTarget::normal(setup.child_of_main_commit.id().clone()),
@@ -3086,7 +3083,7 @@ fn test_push_bookmarks_success(subprocess: bool) {
     setup.jj_repo = tx.commit("test").unwrap();
     let mut tx = setup.jj_repo.start_transaction();
     git::import_refs(tx.repo_mut(), &GitSettings::default()).unwrap();
-    assert!(!tx.repo_mut().has_changes());
+    assert!(!tx.repo().has_changes());
 }
 
 #[test_case(false; "use git2 for remote calls")]
@@ -3133,7 +3130,7 @@ fn test_push_bookmarks_deletion(subprocess: bool) {
         .is_err());
 
     // Check that the repo view got updated
-    let view = tx.repo_mut().view();
+    let view = tx.repo().view();
     assert!(view.get_git_ref("refs/remotes/origin/main").is_absent());
     assert!(view.get_remote_bookmark("main", "origin").is_absent());
 
@@ -3141,7 +3138,7 @@ fn test_push_bookmarks_deletion(subprocess: bool) {
     setup.jj_repo = tx.commit("test").unwrap();
     let mut tx = setup.jj_repo.start_transaction();
     git::import_refs(tx.repo_mut(), &GitSettings::default()).unwrap();
-    assert!(!tx.repo_mut().has_changes());
+    assert!(!tx.repo().has_changes());
 }
 
 #[test_case(false; "use git2 for remote calls")]
@@ -3194,7 +3191,7 @@ fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
     assert!(source_repo.find_reference("refs/heads/main").is_err());
 
     // Check that the repo view got updated
-    let view = tx.repo_mut().view();
+    let view = tx.repo().view();
     assert!(view.get_git_ref("refs/remotes/origin/main").is_absent());
     assert!(view.get_remote_bookmark("main", "origin").is_absent());
     assert_eq!(
@@ -3213,7 +3210,7 @@ fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
     setup.jj_repo = tx.commit("test").unwrap();
     let mut tx = setup.jj_repo.start_transaction();
     git::import_refs(tx.repo_mut(), &GitSettings::default()).unwrap();
-    assert!(!tx.repo_mut().has_changes());
+    assert!(!tx.repo().has_changes());
 }
 
 #[test_case(false; "use git2 for remote calls")]
@@ -3788,7 +3785,7 @@ fn test_concurrent_read_write_commit() {
                             }
                         })
                         .collect_vec();
-                    if tx.repo_mut().has_changes() {
+                    if tx.repo().has_changes() {
                         tx.commit(format!("reader {i}")).unwrap();
                     }
                     thread::yield_now();

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -110,7 +110,7 @@ fn test_rebase_descendants_sideways() {
     let new_commit_e = assert_rebased_onto(tx.repo_mut(), &rebase_map, &commit_e, &[commit_f.id()]);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_d.id().clone(),
             new_commit_e.id().clone()
@@ -167,7 +167,7 @@ fn test_rebase_descendants_forward() {
     assert_eq!(rebase_map.len(), 5);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_c.id().clone(),
             new_commit_e.id().clone(),
@@ -216,7 +216,7 @@ fn test_rebase_descendants_reorder() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_i.id().clone(),
         }
@@ -249,7 +249,7 @@ fn test_rebase_descendants_backward() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {new_commit_d.id().clone()}
     );
 }
@@ -290,7 +290,7 @@ fn test_rebase_descendants_chain_becomes_branchy() {
     assert_eq!(rebase_map.len(), 2);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_d.id().clone(),
         }
@@ -336,7 +336,7 @@ fn test_rebase_descendants_internal_merge() {
     assert_eq!(rebase_map.len(), 3);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! { new_commit_e.id().clone() }
     );
 }
@@ -379,7 +379,7 @@ fn test_rebase_descendants_external_merge() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {new_commit_e.id().clone()}
     );
 }
@@ -418,7 +418,7 @@ fn test_rebase_descendants_abandon() {
     assert_eq!(rebase_map.len(), 3);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_c.id().clone(),
             new_commit_f.id().clone()
@@ -449,7 +449,7 @@ fn test_rebase_descendants_abandon_no_descendants() {
     assert_eq!(rebase_map.len(), 0);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             commit_a.id().clone(),
         }
@@ -486,7 +486,7 @@ fn test_rebase_descendants_abandon_and_replace() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! { new_commit_d.id().clone()}
     );
 }
@@ -523,7 +523,7 @@ fn test_rebase_descendants_abandon_degenerate_merge_simplify() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {new_commit_d.id().clone()}
     );
 }
@@ -565,7 +565,7 @@ fn test_rebase_descendants_abandon_degenerate_merge_preserve() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {new_commit_d.id().clone()}
     );
 }
@@ -606,7 +606,7 @@ fn test_rebase_descendants_abandon_widen_merge() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! { new_commit_f.id().clone()}
     );
 }
@@ -644,7 +644,7 @@ fn test_rebase_descendants_multiple_sideways() {
     assert_eq!(rebase_map.len(), 2);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_c.id().clone(),
             new_commit_e.id().clone()
@@ -761,7 +761,7 @@ fn test_rebase_descendants_divergent_rewrite() {
     assert_eq!(rebase_map.len(), 2); // Commit E is not rebased
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_c.id().clone(),
             commit_d2.id().clone(),
@@ -806,7 +806,7 @@ fn test_rebase_descendants_repeated() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             commit_c2.id().clone(),
         }
@@ -830,7 +830,7 @@ fn test_rebase_descendants_repeated() {
     assert_eq!(rebase_map.len(), 1);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             // commit_b.id().clone(),
             commit_c3.id().clone(),
@@ -932,14 +932,11 @@ fn test_rebase_descendants_basic_bookmark_update() {
     let commit_b2 = tx.repo_mut().rewrite_commit(&commit_b).write().unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
+        tx.repo().get_local_bookmark("main"),
         RefTarget::normal(commit_b2.id().clone())
     );
 
-    assert_eq!(
-        *tx.repo_mut().view().heads(),
-        hashset! {commit_b2.id().clone()}
-    );
+    assert_eq!(*tx.repo().view().heads(), hashset! {commit_b2.id().clone()});
 }
 
 #[test]
@@ -980,14 +977,14 @@ fn test_rebase_descendants_bookmark_move_two_steps() {
         .write()
         .unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    let heads = tx.repo_mut().view().heads();
+    let heads = tx.repo().view().heads();
     assert_eq!(heads.len(), 1);
     let c3_id = heads.iter().next().unwrap().clone();
     let commit_c3 = repo.store().get_commit(&c3_id).unwrap();
     assert_ne!(commit_c3.id(), commit_c2.id());
     assert_eq!(commit_c3.parent_ids(), vec![commit_b2.id().clone()]);
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
+        tx.repo().get_local_bookmark("main"),
         RefTarget::normal(commit_c3.id().clone())
     );
 }
@@ -1025,25 +1022,22 @@ fn test_rebase_descendants_basic_bookmark_update_with_non_local_bookmark() {
     let commit_b2 = tx.repo_mut().rewrite_commit(&commit_b).write().unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
+        tx.repo().get_local_bookmark("main"),
         RefTarget::normal(commit_b2.id().clone())
     );
     // The remote bookmark and tag should not get updated
     assert_eq!(
-        tx.repo_mut().get_remote_bookmark("main", "origin"),
-        commit_b_remote_ref,
+        tx.repo().get_remote_bookmark("main", "origin"),
+        commit_b_remote_ref
     );
     assert_eq!(
-        tx.repo_mut().get_tag("v1"),
+        tx.repo().get_tag("v1"),
         RefTarget::normal(commit_b.id().clone())
     );
 
     // Commit B is no longer visible even though the remote bookmark points to it.
     // (The user can still see it using e.g. the `remote_bookmarks()` revset.)
-    assert_eq!(
-        *tx.repo_mut().view().heads(),
-        hashset! {commit_b2.id().clone()}
-    );
+    assert_eq!(*tx.repo().view().heads(), hashset! {commit_b2.id().clone()});
 }
 
 #[test_case(false; "slide down abandoned")]
@@ -1087,7 +1081,7 @@ fn test_rebase_descendants_update_bookmark_after_abandon(delete_abandoned_bookma
     };
     let rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
+        tx.repo().get_local_bookmark("main"),
         if delete_abandoned_bookmarks {
             RefTarget::absent()
         } else {
@@ -1095,16 +1089,16 @@ fn test_rebase_descendants_update_bookmark_after_abandon(delete_abandoned_bookma
         }
     );
     assert_eq!(
-        tx.repo_mut().get_remote_bookmark("main", "origin").target,
+        tx.repo().get_remote_bookmark("main", "origin").target,
         RefTarget::normal(commit_b.id().clone())
     );
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("other"),
+        tx.repo().get_local_bookmark("other"),
         RefTarget::normal(rebase_map[commit_c.id()].clone())
     );
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! { rebase_map[commit_c.id()].clone() }
     );
 }
@@ -1173,7 +1167,7 @@ fn test_rebase_descendants_update_bookmarks_after_divergent_rewrite() {
     );
     tx.repo_mut().rebase_descendants().unwrap();
 
-    let main_target = tx.repo_mut().get_local_bookmark("main");
+    let main_target = tx.repo().get_local_bookmark("main");
     assert!(main_target.has_conflict());
     // If the bookmark were moved at each rewrite point, there would be separate
     // negative terms: { commit_b => 2, commit_b4 => 1 }. Since we flatten
@@ -1192,11 +1186,11 @@ fn test_rebase_descendants_update_bookmarks_after_divergent_rewrite() {
         },
     );
 
-    let other_target = tx.repo_mut().get_local_bookmark("other");
+    let other_target = tx.repo().get_local_bookmark("other");
     assert_eq!(other_target.as_normal(), Some(commit_c.id()));
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             commit_b2.id().clone(),
             commit_b3.id().clone(),
@@ -1256,7 +1250,7 @@ fn test_rebase_descendants_rewrite_updates_bookmark_conflict() {
     );
     tx.repo_mut().rebase_descendants().unwrap();
 
-    let target = tx.repo_mut().get_local_bookmark("main");
+    let target = tx.repo().get_local_bookmark("main");
     assert!(target.has_conflict());
     assert_eq!(
         target.removed_ids().counts(),
@@ -1272,7 +1266,7 @@ fn test_rebase_descendants_rewrite_updates_bookmark_conflict() {
     );
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             commit_a2.id().clone(),
             commit_a3.id().clone(),
@@ -1318,12 +1312,12 @@ fn test_rebase_descendants_rewrite_resolves_bookmark_conflict() {
         .unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
+        tx.repo().get_local_bookmark("main"),
         RefTarget::normal(commit_b2.id().clone())
     );
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! { commit_b2.id().clone()}
     );
 }
@@ -1363,10 +1357,7 @@ fn test_rebase_descendants_bookmark_delete_modify_abandon(delete_abandoned_bookm
         ..Default::default()
     };
     let _rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
-    assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
-        RefTarget::absent()
-    );
+    assert_eq!(tx.repo().get_local_bookmark("main"), RefTarget::absent());
 }
 
 #[test_case(false; "slide down abandoned")]
@@ -1408,7 +1399,7 @@ fn test_rebase_descendants_bookmark_move_forward_abandon(delete_abandoned_bookma
     };
     let _rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
+        tx.repo().get_local_bookmark("main"),
         if delete_abandoned_bookmarks {
             RefTarget::from_merge(Merge::from_vec(vec![
                 None,
@@ -1460,7 +1451,7 @@ fn test_rebase_descendants_bookmark_move_sideways_abandon(delete_abandoned_bookm
     };
     let _rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &options);
     assert_eq!(
-        tx.repo_mut().get_local_bookmark("main"),
+        tx.repo().get_local_bookmark("main"),
         if delete_abandoned_bookmarks {
             RefTarget::from_merge(Merge::from_vec(vec![
                 None,
@@ -1755,7 +1746,7 @@ fn test_empty_commit_option(empty_behavior: EmptyBehaviour) {
     assert_eq!(rebase_map.len(), 6);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_head.id().clone(),
         }
@@ -1833,25 +1824,23 @@ fn test_rebase_abandoning_empty() {
     rebase_commit_with_options(rewriter, &rebase_options).unwrap();
     let rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &rebase_options);
     assert_eq!(rebase_map.len(), 5);
-    let new_commit_c =
-        assert_rebased_onto(tx.repo_mut(), &rebase_map, &commit_c, &[commit_b2.id()]);
-    assert_abandoned_with_parent(tx.repo_mut(), &rebase_map, &commit_d, new_commit_c.id());
-    assert_abandoned_with_parent(tx.repo_mut(), &rebase_map, &commit_e, new_commit_c.id());
-    let new_commit_f =
-        assert_rebased_onto(tx.repo_mut(), &rebase_map, &commit_f, &[new_commit_c.id()]);
-    assert_abandoned_with_parent(tx.repo_mut(), &rebase_map, &commit_g, new_commit_c.id());
+    let new_commit_c = assert_rebased_onto(tx.repo(), &rebase_map, &commit_c, &[commit_b2.id()]);
+    assert_abandoned_with_parent(tx.repo(), &rebase_map, &commit_d, new_commit_c.id());
+    assert_abandoned_with_parent(tx.repo(), &rebase_map, &commit_e, new_commit_c.id());
+    let new_commit_f = assert_rebased_onto(tx.repo(), &rebase_map, &commit_f, &[new_commit_c.id()]);
+    assert_abandoned_with_parent(tx.repo(), &rebase_map, &commit_g, new_commit_c.id());
 
     let new_wc_commit_id = tx
-        .repo_mut()
+        .repo()
         .view()
         .get_wc_commit_id(&workspace)
         .unwrap()
         .clone();
-    let new_wc_commit = tx.repo_mut().store().get_commit(&new_wc_commit_id).unwrap();
+    let new_wc_commit = tx.repo().store().get_commit(&new_wc_commit_id).unwrap();
     assert_eq!(new_wc_commit.parent_ids(), &[new_commit_c.id().clone()]);
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {new_commit_f.id().clone(), new_wc_commit_id.clone()}
     );
 }

--- a/lib/tests/test_rewrite_transform.rs
+++ b/lib/tests/test_rewrite_transform.rs
@@ -66,7 +66,7 @@ fn test_transform_descendants_sync() {
     let new_commit_f = rebased.get(commit_f.id()).unwrap();
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_e.id().clone(),
             new_commit_f.id().clone(),
@@ -112,7 +112,7 @@ fn test_transform_descendants_sync_linearize_merge() {
     let new_commit_c = rebased.get(commit_c.id()).unwrap();
 
     assert_eq!(
-        *tx.repo_mut().view().heads(),
+        *tx.repo().view().heads(),
         hashset! {
             new_commit_c.id().clone(),
         }


### PR DESCRIPTION
When we don't need a mutable reference, we should be using `repo()`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
