### PR TITLE
cli: ability to disable default colorscheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* New `JJ_NO_DEFAULT_COLORS` environment variable disables setting built-in default colors.
+
 * `jj show` now supports `--reversed` flag.
 
 * `jj` now looks for config files in `/etc/jj`.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -768,14 +768,24 @@ pub fn default_config_layers() -> Vec<ConfigLayer> {
     // Syntax error in default config isn't a user error. That's why defaults are
     // loaded by separate builder.
     let parse = |text: &'static str| ConfigLayer::parse(ConfigSource::Default, text).unwrap();
-    let mut layers = vec![
-        parse(include_str!("config/colors.toml")),
-        parse(include_str!("config/hints.toml")),
-        parse(include_str!("config/merge_tools.toml")),
-        parse(include_str!("config/misc.toml")),
-        parse(include_str!("config/revsets.toml")),
-        parse(include_str!("config/templates.toml")),
-    ];
+    let mut layers = {
+        let maybe_colors = if env::var("JJ_NO_DEFAULT_COLORS").is_ok() {
+            vec![]
+        } else {
+            vec![parse(include_str!("config/colors.toml"))]
+        };
+        [
+            maybe_colors,
+            vec![
+                parse(include_str!("config/hints.toml")),
+                parse(include_str!("config/merge_tools.toml")),
+                parse(include_str!("config/misc.toml")),
+                parse(include_str!("config/revsets.toml")),
+                parse(include_str!("config/templates.toml")),
+            ],
+        ]
+        .concat()
+    };
     if cfg!(unix) {
         layers.push(parse(include_str!("config/unix.toml")));
     }


### PR DESCRIPTION
My motivation is mostly to address #5098 , but in a lot of software there's a flag to disable sourcing default configs, which is useful in a lot contexts.

A more granular (or just atlernative/better) approaches would require more design and debate, while this seems simple and immediately useful (at least to some).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
