### PR TITLE
Use null `Ui` in completion to prevent writing warnings into completions

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3714,7 +3714,7 @@ impl CliRunner {
         ui.reset(&config)?;
 
         if env::var_os("COMPLETE").is_some() {
-            return handle_shell_completion(ui, &self.app, &config, &cwd);
+            return handle_shell_completion(&Ui::null(), &self.app, &config, &cwd);
         }
 
         let string_args = expand_args(ui, &self.app, env::args_os(), &config)?;

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -758,7 +758,7 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
     // required.
     let app = crate::commands::default_app();
     let mut raw_config = config_from_environment(default_config_layers());
-    let ui = Ui::with_config(raw_config.as_ref()).expect("default config should be valid");
+    let ui = Ui::null();
     let cwd = std::env::current_dir()
         .and_then(dunce::canonicalize)
         .map_err(user_error)?;


### PR DESCRIPTION
Example of how it looked like in fish when a warning was printed during completion:

![image](https://github.com/user-attachments/assets/602f5c76-8c49-447d-80df-43b4e9baaa27)


# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
