### PR TITLE
cli: complete: complete `-T` template aliases

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2846,7 +2846,7 @@ pub fn update_working_copy(
     Ok(stats)
 }
 
-fn load_template_aliases(
+pub fn load_template_aliases(
     ui: &Ui,
     stacked_config: &StackedConfig,
 ) -> Result<TemplateAliasesMap, CommandError> {

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -102,7 +102,7 @@ pub struct BookmarkListArgs {
     ///
     /// [`RefName` type]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#refname-type
-    #[arg(long, short = 'T')]
+    #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }
 

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -55,7 +55,11 @@ pub struct ConfigListArgs {
     ///
     /// [template expression]:
     ///     https://jj-vcs.github.io/jj/latest/templates/
-    #[arg(long, short = 'T', verbatim_doc_comment)]
+    #[arg(
+        long, short = 'T',
+        verbatim_doc_comment,
+        add = ArgValueCandidates::new(complete::template_aliases)
+    )]
     template: Option<String>,
 }
 

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -76,7 +76,7 @@ pub(crate) struct EvologArgs {
     ///
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
-    #[arg(long, short = 'T')]
+    #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show patch compared to the previous version of this change
     ///

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -109,7 +109,7 @@ pub(crate) struct LogArgs {
     ///     https://jj-vcs.github.io/jj/latest/templates/
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
-    #[arg(long, short = 'T')]
+    #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show patch
     #[arg(long, short = 'p')]

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -14,6 +14,7 @@
 
 use std::slice;
 
+use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
 use jj_lib::config::ConfigGetError;
 use jj_lib::config::ConfigGetResultExt as _;
@@ -32,6 +33,7 @@ use crate::cli_util::LogContentFormat;
 use crate::cli_util::WorkspaceCommandEnvironment;
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitTemplateLanguage;
+use crate::complete;
 use crate::diff_util::diff_formats_for_log;
 use crate::diff_util::DiffFormatArgs;
 use crate::diff_util::DiffRenderer;
@@ -70,7 +72,7 @@ pub struct OperationLogArgs {
     ///
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
-    #[arg(long, short = 'T')]
+    #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show changes to the repository at each operation
     #[arg(long)]

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -46,7 +46,7 @@ pub(crate) struct ShowArgs {
     ///
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
-    #[arg(long, short = 'T')]
+    #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     #[command(flatten)]
     format: DiffFormatArgs,

--- a/cli/src/commands/tag.rs
+++ b/cli/src/commands/tag.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap_complete::ArgValueCandidates;
 use jj_lib::str_util::StringPattern;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitTemplateLanguage;
 use crate::commit_templater::RefName;
+use crate::complete;
 use crate::ui::Ui;
 
 /// Manage tags.
@@ -49,7 +51,7 @@ pub struct TagListArgs {
     ///
     /// [`RefName` type]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#refname-type
-    #[arg(long, short = 'T')]
+    #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }
 

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -25,6 +25,7 @@ use jj_lib::workspace::WorkspaceLoaderFactory as _;
 
 use crate::cli_util::expand_args;
 use crate::cli_util::find_workspace_dir;
+use crate::cli_util::load_template_aliases;
 use crate::cli_util::GlobalArgs;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
@@ -197,6 +198,19 @@ pub fn git_remotes() -> Vec<CompletionCandidate> {
             .lines()
             .filter_map(|line| line.split_once(' ').map(|(name, _url)| name))
             .map(CompletionCandidate::new)
+            .collect())
+    })
+}
+
+pub fn template_aliases() -> Vec<CompletionCandidate> {
+    with_jj(|_, settings| {
+        let Ok(template_aliases) = load_template_aliases(&Ui::null(), settings.config()) else {
+            return Ok(Vec::new());
+        };
+        Ok(template_aliases
+            .symbol_names()
+            .map(CompletionCandidate::new)
+            .sorted()
             .collect())
     })
 }

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -563,6 +563,33 @@ fn test_config() {
     ");
 }
 
+#[test]
+fn test_template_alias() {
+    let mut test_env = TestEnvironment::default();
+    test_env.add_env_var("COMPLETE", "fish");
+    let dir = test_env.env_root();
+
+    let stdout = test_env.jj_cmd_success(dir, &["--", "jj", "log", "-T", ""]);
+    insta::assert_snapshot!(stdout, @r"
+    builtin_log_comfortable
+    builtin_log_compact
+    builtin_log_compact_full_description
+    builtin_log_detailed
+    builtin_log_node
+    builtin_log_node_ascii
+    builtin_log_oneline
+    builtin_op_log_comfortable
+    builtin_op_log_compact
+    builtin_op_log_node
+    builtin_op_log_node_ascii
+    builtin_op_log_oneline
+    commit_summary_separator
+    description_placeholder
+    email_placeholder
+    name_placeholder
+    ");
+}
+
 fn create_commit(
     test_env: &TestEnvironment,
     repo_path: &std::path::Path,


### PR DESCRIPTION
based on #5539 

![image](https://github.com/user-attachments/assets/d490aeec-864c-4b9c-89bb-2912ca1688cd)

It would be nice to filter them down to only applicable ones, but I don't think that type information is present in the toml definitions.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
