### PR TITLE
templater: add pad_center template function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New template function `config(name)` to access to configuration variable from
   template.
 
+* New template function `pad_centered()` to center content within a minimum width.
+
 * Templater now supports `list.filter(|x| ..)` method.
 
 * The `diff` commit template keyword now supports custom formatting via

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -55,6 +55,10 @@ The following functions are defined.
 * `pad_end(width: Integer, content: Template[, fill_char: Template])`: Pad (or
   left-justify) content by adding trailing fill characters. The `content`
   shouldn't have newline character.
+* `pad_centered(width: Integer, content: Template[, fill_char: Template])`: Pad
+  content by adding both leading and trailing fill characters. If an odd number
+  of fill characters are needed, the trailing fill will be one longer than the
+  leading fill. The `content` shouldn't have newline characters.
 * `truncate_start(width: Integer, content: Template)`: Truncate `content` by
   removing leading characters. The `content` shouldn't have newline character.
 * `truncate_end(width: Integer, content: Template)`: Truncate `content` by


### PR DESCRIPTION
I started out trying to implement a `pad_between` function as suggested on the feature request, but got bogged down because all of the template wrapping expects a single content argument. If you think it's still worth pursuing that approach, I can spend Monday working on it, but I thought it might be more useful to get a simpler fix out faster.

Fixes #5066.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
