### PR TITLE
docs: document the ui.movement.edit config option

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -177,6 +177,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Whether the built-in templates should show cryptographic signature information"
+                },
+                "movement": {
+                    "type": "object",
+                    "properties": {
+                        "edit": {
+                            "type": "boolean",
+                            "description": "Whether the next and prev commands should behave as if the --edit flag was passed",
+                            "default": false
+                        }
+                    }
                 }
             }
         },

--- a/docs/config.md
+++ b/docs/config.md
@@ -343,6 +343,22 @@ To prevent rewriting commits authored by other users:
 Ancestors of the configured set are also immutable. The root commit is always
 immutable even if the set is empty.
 
+### Behavior of prev and next commands
+
+If you prefer using an "edit-based" workflow, rather than squashing
+modifications into parent changes, you may find yourself using the `prev` and
+`next` commands with their `--edit` flag often to move between your changes. You
+can avoid having to type the `--edit` flag every time you need it by actually
+making it the default:
+
+```toml
+[ui.movement]
+edit = true
+```
+
+You can pass the `--no-edit` flag to `prev` and `next` if you find yourself
+needing the original behavior.
+
 ## Log
 
 ### Default revisions


### PR DESCRIPTION
This option was introduced in #4283, but was not documented apart from `prev` and `next`'s help text on the --edit/--no-edit flags.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
