### PR TITLE
cli: add `--untrack` option to `bookmark forget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Conditional configuration now supports `--when.commands` to change configuration
   based on subcommand.
 
+* `jj bookmark forget` now accepts a `--untrack` flag to untrack remote
+  bookmarks instead of forgetting them.
+
 ### Fixed bugs
 
 * `jj git fetch` with multiple remotes will now fetch from all remotes before

--- a/cli/src/commands/bookmark/forget.rs
+++ b/cli/src/commands/bookmark/forget.rs
@@ -33,6 +33,10 @@ use crate::ui::Ui;
 /// recreated on future pulls if it still exists in the remote.
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkForgetArgs {
+    /// Untrack remote bookmarks instead of forgetting them
+    #[arg(long, short)]
+    untrack: bool,
+
     /// The bookmarks to forget
     ///
     /// By default, the specified name matches exactly. Use `glob:` prefix to
@@ -61,8 +65,12 @@ pub fn cmd_bookmark_forget(
         tx.repo_mut()
             .set_local_bookmark_target(name, RefTarget::absent());
         for (remote_name, _) in &bookmark_target.remote_refs {
-            tx.repo_mut()
-                .set_remote_bookmark(name, remote_name, RemoteRef::absent());
+            if args.untrack {
+                tx.repo_mut().untrack_remote_bookmark(name, remote_name);
+            } else {
+                tx.repo_mut()
+                    .set_remote_bookmark(name, remote_name, RemoteRef::absent());
+            }
         }
     }
     writeln!(ui.status(), "Forgot {} bookmarks.", matched_bookmarks.len())?;

--- a/cli/src/commands/bookmark/untrack.rs
+++ b/cli/src/commands/bookmark/untrack.rs
@@ -26,6 +26,9 @@ use crate::ui::Ui;
 ///
 /// A non-tracking remote bookmark is just a pointer to the last-fetched remote
 /// bookmark. It won't be imported as a local bookmark on future pulls.
+///
+/// If you want to forget a local bookmark while also untracking the
+/// corresponding remote bookmarks, use `jj bookmark forget --untrack` instead.
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkUntrackArgs {
     /// Remote bookmarks to untrack

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -338,7 +338,7 @@ Forget everything about a bookmark, including its local and remote targets
 
 A forgotten bookmark will not impact remotes on future pushes. It will be recreated on future pulls if it still exists in the remote.
 
-**Usage:** `jj bookmark forget <NAMES>...`
+**Usage:** `jj bookmark forget [OPTIONS] <NAMES>...`
 
 ###### **Arguments:**
 
@@ -347,6 +347,10 @@ A forgotten bookmark will not impact remotes on future pushes. It will be recrea
    By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
 
    [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+
+###### **Options:**
+
+* `-u`, `--untrack` — Untrack remote bookmarks instead of forgetting them
 
 
 
@@ -484,6 +488,8 @@ A tracking remote bookmark will be imported as a local bookmark of the same name
 Stop tracking given remote bookmarks
 
 A non-tracking remote bookmark is just a pointer to the last-fetched remote bookmark. It won't be imported as a local bookmark on future pulls.
+
+If you want to forget a local bookmark while also untracking the corresponding remote bookmarks, use `jj bookmark forget --untrack` instead.
 
 **Usage:** `jj bookmark untrack <BOOKMARK@REMOTE>...`
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -823,6 +823,19 @@ fn test_bookmark_forget_fetched_bookmark() {
     feature1: ooosovrs 38aefb17 (empty) another message
       @origin: ooosovrs 38aefb17 (empty) another message
     "###);
+
+    // TEST 4: If `--untrack` is used, the remote bookmark only be untracked
+    test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "--untrack", "feature1"]);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    feature1@origin: ooosovrs 38aefb17 (empty) another message
+    "###);
+    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
+    insta::assert_snapshot!(stdout, @"");
+    // There should be no output here since the remote bookmark wasn't forgotten
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    feature1@origin: ooosovrs 38aefb17 (empty) another message
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #5524. I went with `--untrack` for the naming because it seemed easier to explain in the help text than `--local`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
