### PR TITLE
git: port remote management to `gix`

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -491,12 +491,6 @@ mod git {
 
     use super::*;
 
-    impl From<git2::Error> for CommandError {
-        fn from(err: git2::Error) -> Self {
-            user_error_with_message("Git operation failed", err)
-        }
-    }
-
     impl From<GitImportError> for CommandError {
         fn from(err: GitImportError) -> Self {
             let hint = match &err {

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -34,7 +34,6 @@ use crate::command_error::user_error_with_message;
 use crate::command_error::CommandError;
 use crate::commands::git::maybe_add_gitignore;
 use crate::git_util::absolute_git_url;
-use crate::git_util::get_git_repo;
 use crate::git_util::print_git_import_stats;
 use crate::git_util::with_remote_git_callbacks;
 use crate::ui::Ui;
@@ -193,8 +192,7 @@ fn configure_remote(
     remote_name: &str,
     source: &str,
 ) -> Result<WorkspaceCommandHelper, CommandError> {
-    let git_repo = get_git_repo(workspace_command.repo().store())?;
-    git::add_remote(&git_repo, remote_name, source)?;
+    git::add_remote(workspace_command.repo().store(), remote_name, source)?;
     // Reload workspace to apply new remote configuration to
     // gix::ThreadSafeRepository behind the store.
     let workspace = command.load_workspace_at(

--- a/cli/src/commands/git/remote/add.rs
+++ b/cli/src/commands/git/remote/add.rs
@@ -18,7 +18,6 @@ use jj_lib::repo::Repo;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::git_util::absolute_git_url;
-use crate::git_util::get_git_repo;
 use crate::ui::Ui;
 
 /// Add a Git remote
@@ -39,9 +38,7 @@ pub fn cmd_git_remote_add(
     args: &GitRemoteAddArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let repo = workspace_command.repo();
-    let git_repo = get_git_repo(repo.store())?;
     let url = absolute_git_url(command.cwd(), &args.url)?;
-    git::add_remote(&git_repo, &args.remote, &url)?;
+    git::add_remote(workspace_command.repo().store(), &args.remote, &url)?;
     Ok(())
 }

--- a/cli/src/commands/git/remote/remove.rs
+++ b/cli/src/commands/git/remote/remove.rs
@@ -14,12 +14,10 @@
 
 use clap_complete::ArgValueCandidates;
 use jj_lib::git;
-use jj_lib::repo::Repo;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::complete;
-use crate::git_util::get_git_repo;
 use crate::ui::Ui;
 
 /// Remove a Git remote and forget its bookmarks
@@ -36,10 +34,8 @@ pub fn cmd_git_remote_remove(
     args: &GitRemoteRemoveArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let repo = workspace_command.repo();
-    let git_repo = get_git_repo(repo.store())?;
     let mut tx = workspace_command.start_transaction();
-    git::remove_remote(tx.repo_mut(), &git_repo, &args.remote)?;
+    git::remove_remote(tx.repo_mut(), &args.remote)?;
     if tx.repo().has_changes() {
         tx.finish(ui, format!("remove git remote {}", &args.remote))
     } else {

--- a/cli/src/commands/git/remote/rename.rs
+++ b/cli/src/commands/git/remote/rename.rs
@@ -14,12 +14,10 @@
 
 use clap_complete::ArgValueCandidates;
 use jj_lib::git;
-use jj_lib::repo::Repo;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::complete;
-use crate::git_util::get_git_repo;
 use crate::ui::Ui;
 
 /// Rename a Git remote
@@ -38,10 +36,8 @@ pub fn cmd_git_remote_rename(
     args: &GitRemoteRenameArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let repo = workspace_command.repo();
-    let git_repo = get_git_repo(repo.store())?;
     let mut tx = workspace_command.start_transaction();
-    git::rename_remote(tx.repo_mut(), &git_repo, &args.old, &args.new)?;
+    git::rename_remote(tx.repo_mut(), &args.old, &args.new)?;
     if tx.repo().has_changes() {
         tx.finish(
             ui,

--- a/cli/src/commands/git/remote/set_url.rs
+++ b/cli/src/commands/git/remote/set_url.rs
@@ -20,7 +20,6 @@ use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::git_util::absolute_git_url;
-use crate::git_util::get_git_repo;
 use crate::ui::Ui;
 
 /// Set the URL of a Git remote
@@ -42,9 +41,7 @@ pub fn cmd_git_remote_set_url(
     args: &GitRemoteSetUrlArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
-    let repo = workspace_command.repo();
-    let git_repo = get_git_repo(repo.store())?;
     let url = absolute_git_url(command.cwd(), &args.url)?;
-    git::set_remote_url(&git_repo, &args.remote, &url)?;
+    git::set_remote_url(workspace_command.repo().store(), &args.remote, &url)?;
     Ok(())
 }

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -39,7 +39,6 @@ use jj_lib::op_store::RefTarget;
 use jj_lib::op_store::RemoteRef;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
-use jj_lib::store::Store;
 use jj_lib::workspace::Workspace;
 use unicode_width::UnicodeWidthStr;
 
@@ -50,11 +49,6 @@ use crate::command_error::CommandError;
 use crate::formatter::Formatter;
 use crate::ui::ProgressOutput;
 use crate::ui::Ui;
-
-// TODO: migrate to gitoxide or subprocess, and remove this function
-pub(crate) fn get_git_repo(store: &Store) -> Result<git2::Repository, CommandError> {
-    Ok(git::get_git_backend(store)?.open_git_repo()?)
-}
 
 pub fn is_colocated_git_workspace(workspace: &Workspace, repo: &ReadonlyRepo) -> bool {
     let Ok(git_backend) = git::get_git_backend(repo.store()) else {

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -85,7 +85,6 @@ fn test_git_remotes() {
     	repositoryformatversion = 0
     	bare = true
     	logallrefupdates = false
-    [remote "foo"]
     [remote "bar"]
     	url = http://example.com/repo/bar
     	fetch = +refs/heads/*:refs/remotes/bar/*
@@ -294,7 +293,6 @@ fn test_git_remote_rename() {
     	repositoryformatversion = 0
     	bare = true
     	logallrefupdates = false
-    [remote "foo"]
     [remote "baz"]
     	url = http://example.com/repo/baz
     	fetch = +refs/heads/*:refs/remotes/baz/*
@@ -332,7 +330,6 @@ fn test_git_remote_named_git() {
     	repositoryformatversion = 0
     	bare = false
     	logallrefupdates = true
-    [remote "git"]
     [remote "bar"]
     	url = http://example.com/repo/repo
     	fetch = +refs/heads/*:refs/remotes/bar/*
@@ -367,7 +364,6 @@ fn test_git_remote_named_git() {
     	bare = false
     	logallrefupdates = true
     [remote "git"]
-    [remote "git"]
     	url = http://example.com/repo/repo
     	fetch = +refs/heads/*:refs/remotes/git/*
     "#);
@@ -382,8 +378,6 @@ fn test_git_remote_named_git() {
     	repositoryformatversion = 0
     	bare = false
     	logallrefupdates = true
-    [remote "git"]
-    [remote "git"]
     "#);
     // @git bookmark shouldn't be removed.
     let output = test_env.run_jj_in(&repo_path, ["log", "-rmain@git", "-Tbookmarks"]);
@@ -512,7 +506,6 @@ fn test_git_remote_with_branch_config() {
     	repositoryformatversion = 0
     	bare = true
     	logallrefupdates = false
-    [remote "foo"]
     [branch "test"]
     	remote = bar
     	merge = refs/heads/test


### PR DESCRIPTION
(Plus one more change to remove the other remaining `git_util::get_git_repo` caller.)

I’m not wholly confident in the first commit here, but the rest should hopefully be good. It feels like there might be awkward race conditions in here but I think Git is just like that.

@Byron 👋 I thought you might be interested in some API UX feedback I came up with while working on this. If you’d like me to open issues/discussions on the `gix` side for any of these please let me know.

* It’s awkward that `gix::Remote::save_to` handles the fussy details of removing the other sections for that remote from the config, but leaves you to reimplement it yourself if you need it in any other context. It would be nice if the removal logic was exposed separately, or perhaps if there was a specific way to tell `gix` that you’re renaming a remote and the old config should go away.

* You can change the name of a `gix::Remote`, and you can set its push URL, but you can’t change its fetch URL. In `set_remote_url` I have to manually copy over all the data from the existing remote to achieve this. Not sure if this is a fundamental constraint of the model or just a missing API.

* It’s a little surprising that there’s a rich representation of parsed refspecs but the remote API expects you to pass in a `BStr` and deal with potentially‐impossible parse errors.

* The borrowing model of configuration and remotes interact awkwardly. In a previous version of this PR where I tried to persist the remote configuration changes to the `gix::Repository`, I had to clone the entire thing so that I could hold a `gix::Remote` and a `gix::config::SnapshotMut` at the same time (otherwise the immutable and mutable borrows conflicted). That felt awkward for a task as simple as adding a remote to the configuration. (In general when using the `gix` API I kind of wish there was less borrowing and more refcounting/cloning, though I realize that there’s a subjective element to the trade‐off here and that you can wrap a borrow‐happy API in a clone‐happy one but not vice versa.)

* Relatedly, there’s this comment in the code:

  ```rust
  // TODO: make it possible to load snapshots with reloading via .config() and write mutated snapshots back to disk which should be the way
  //       to affect all instances of a repo, probably via `config_mut()` and `config_mut_at()`.
  ```

  That would be quite nice for us!

In general there’s more convoluted logic here in the move from `git2` to `gix`, but thankfully most of that is just dealing with lower‐level APIs that don’t bundle configuration changes, ref renames, etc. into one porcelain call. Other than the things listed above, the process went quite smoothly; thanks again for all your work!

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
