### PR TITLE
git: split function that queries remote default branch, call only when needed

### DIFF
--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -224,9 +224,11 @@ fn fetch_new_remote(
     let git_settings = workspace_command.settings().git_settings()?;
     let mut fetch_tx = workspace_command.start_transaction();
     let mut git_fetch = GitFetch::new(fetch_tx.repo_mut(), &git_settings)?;
-    let default_branch = with_remote_git_callbacks(ui, |cb| {
+    with_remote_git_callbacks(ui, |cb| {
         git_fetch.fetch(remote_name, &[StringPattern::everything()], cb, depth)
     })?;
+    let default_branch =
+        with_remote_git_callbacks(ui, |cb| git_fetch.get_default_branch(remote_name, cb))?;
     let import_stats = git_fetch.import_refs()?;
     print_git_import_stats(ui, fetch_tx.repo(), &import_stats, true)?;
     fetch_tx.finish(ui, "fetch from git remote into empty repo")?;

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -138,12 +138,14 @@ fn git_fetch(
     git_settings: &GitSettings,
 ) -> Result<GitFetchStats, GitFetchError> {
     let mut git_fetch = GitFetch::new(mut_repo, git_settings).unwrap();
-    let default_branch = git_fetch.fetch(
+    git_fetch.fetch(
         remote_name,
         branch_names,
         git::RemoteCallbacks::default(),
         None,
     )?;
+    let default_branch =
+        git_fetch.get_default_branch(remote_name, git::RemoteCallbacks::default())?;
 
     let import_stats = git_fetch.import_refs().unwrap();
     let stats = GitFetchStats {


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
