### PR TITLE
tests: run `insta --force-update-snapshots`

### DIFF
--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -857,7 +857,7 @@ mod tests {
         formatter.pop_label().unwrap();
         write!(formatter, " after ").unwrap();
         drop(formatter);
-        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @" before [38;5;2m inside [39m after ");
+        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @" before [38;5;2m inside [39m after");
     }
 
     #[test]
@@ -907,7 +907,7 @@ mod tests {
         formatter.pop_label().unwrap();
         writeln!(formatter).unwrap();
         drop(formatter);
-        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @r###"
+        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @r"
         [38;5;1m fg only [39m
         [48;5;4m bg only [49m
         [1m bold only [0m
@@ -915,7 +915,7 @@ mod tests {
         [4m underlined only [24m
         [1m[3m[4m[38;5;2m[48;5;3m single rule [0m
         [38;5;1m[48;5;4m two rules [39m[49m
-        "###);
+        ");
     }
 
     #[test]
@@ -1005,7 +1005,7 @@ mod tests {
         write!(formatter, " after outer ").unwrap();
         drop(formatter);
         insta::assert_snapshot!(String::from_utf8(output).unwrap(),
-        @" before outer [38;5;4m before inner [38;5;2m inside inner [38;5;4m after inner [39m after outer ");
+        @" before outer [38;5;4m before inner [38;5;2m inside inner [38;5;4m after inner [39m after outer");
     }
 
     #[test]
@@ -1027,7 +1027,7 @@ mod tests {
         formatter.pop_label().unwrap();
         drop(formatter);
         insta::assert_snapshot!(String::from_utf8(output).unwrap(),
-        @" not colored [38;5;2m colored [39m not colored ");
+        @" not colored [38;5;2m colored [39m not colored");
     }
 
     #[test]
@@ -1106,10 +1106,10 @@ mod tests {
         write!(formatter, " and back.").unwrap();
         drop(formatter);
         insta::assert_snapshot!(String::from_utf8(output).unwrap(),
-        @r###"
+        @r"
         [38;5;4m[48;5;3mBlue on yellow, [39m default fg, [38;5;4m and back.[39m[49m
         [38;5;4m[48;5;3mBlue on yellow, [49m default bg, [48;5;3m and back.[39m[49m
-        "###);
+        ");
     }
 
     #[test]
@@ -1149,7 +1149,7 @@ mod tests {
         formatter.pop_label().unwrap();
         formatter.pop_label().unwrap();
         drop(formatter);
-        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @" hello ");
+        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @" hello");
     }
 
     #[test]
@@ -1241,9 +1241,7 @@ mod tests {
         write!(writer, "Message").unwrap();
         writeln!(writer, " continues").unwrap();
         drop(formatter);
-        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @r###"
-        [38;5;1mHeading: [38;5;2mMessage[39m[38;5;2m continues[39m
-        "###);
+        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @"[38;5;1mHeading: [38;5;2mMessage[39m[38;5;2m continues[39m");
     }
 
     #[test]
@@ -1259,7 +1257,7 @@ mod tests {
         write!(writer, "").unwrap();
         write!(writer, "").unwrap();
         drop(formatter);
-        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @"Heading: ");
+        insta::assert_snapshot!(String::from_utf8(output).unwrap(), @"Heading:");
     }
 
     #[test]
@@ -1274,7 +1272,7 @@ mod tests {
 
         insta::assert_snapshot!(
             str::from_utf8(recorder.data()).unwrap(),
-            @" outer1  inner1  inner2  outer2 ");
+            @" outer1  inner1  inner2  outer2");
 
         // Replayed output should be labeled.
         let config = config_from_string(r#" colors.inner = "red" "#);
@@ -1284,7 +1282,7 @@ mod tests {
         drop(formatter);
         insta::assert_snapshot!(
             String::from_utf8(output).unwrap(),
-            @" outer1 [38;5;1m inner1  inner2 [39m outer2 ");
+            @" outer1 [38;5;1m inner1  inner2 [39m outer2");
 
         // Replayed output should be split at push/pop_label() call.
         let mut output: Vec<u8> = vec![];
@@ -1319,7 +1317,7 @@ mod tests {
         recorder.replay(&mut formatter).unwrap();
         drop(formatter);
         insta::assert_snapshot!(
-            String::from_utf8(output).unwrap(), @" outer1 [38;5;1m inner1  inner2 [39m outer2 ");
+            String::from_utf8(output).unwrap(), @" outer1 [38;5;1m inner1  inner2 [39m outer2");
 
         let mut output: Vec<u8> = vec![];
         let mut formatter = ColorFormatter::for_config(&mut output, &config, false).unwrap();
@@ -1333,6 +1331,6 @@ mod tests {
             .unwrap();
         drop(formatter);
         insta::assert_snapshot!(
-            String::from_utf8(output).unwrap(), @" outer1 [38;5;1m inner1  inner2 [39m outer2 ");
+            String::from_utf8(output).unwrap(), @" outer1 [38;5;1m inner1  inner2 [39m outer2");
     }
 }

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -702,7 +702,7 @@ mod tests {
         };
         // First output is after the initial delay
         assert_snapshot!(update(crate::progress::INITIAL_DELAY - Duration::from_millis(1), 0.1), @"");
-        assert_snapshot!(update(Duration::from_millis(1), 0.10), @"[?25l\r 10% [█▊                ][K");
+        assert_snapshot!(update(Duration::from_millis(1), 0.10), @"\u{1b}[?25l\r 10% [█▊                ]\u{1b}[K");
         // No updates for the next 30 milliseconds
         assert_snapshot!(update(Duration::from_millis(10), 0.11), @"");
         assert_snapshot!(update(Duration::from_millis(10), 0.12), @"");

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -733,7 +733,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -821,7 +821,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
 
         let no_changes_tree_id = apply_diff_builtin(
             store,
@@ -870,7 +870,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -893,7 +893,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree_id = apply_diff_builtin(
             store,
             &left_tree,
@@ -941,7 +941,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -964,7 +964,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree_id = apply_diff_builtin(
             store,
             &left_tree,
@@ -1013,7 +1013,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -1036,7 +1036,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree_id = apply_diff_builtin(
             store,
             &left_tree,
@@ -1103,7 +1103,7 @@ mod tests {
             .unwrap();
         let merge_result = files::merge(&content);
         let sections = make_merge_sections(merge_result).unwrap();
-        insta::assert_debug_snapshot!(sections, @r###"
+        insta::assert_debug_snapshot!(sections, @r#"
         [
             Changed {
                 lines: [
@@ -1151,6 +1151,6 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
     }
 }

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -703,11 +703,11 @@ mod tests {
         insta::assert_debug_snapshot!(get(":builtin", "").unwrap(), @"Builtin");
 
         // Just program name
-        insta::assert_debug_snapshot!(get("my diff", "").unwrap_err(), @r###"
+        insta::assert_debug_snapshot!(get("my diff", "").unwrap_err(), @r#"
         MergeArgsNotConfigured {
             tool_name: "my diff",
         }
-        "###);
+        "#);
 
         // Pick from merge-tools
         insta::assert_debug_snapshot!(get(
@@ -763,11 +763,11 @@ mod tests {
         insta::assert_debug_snapshot!(get("").unwrap(), @"Builtin");
 
         // Just program name
-        insta::assert_debug_snapshot!(get(r#"ui.merge-editor = "my-merge""#).unwrap_err(), @r###"
+        insta::assert_debug_snapshot!(get(r#"ui.merge-editor = "my-merge""#).unwrap_err(), @r#"
         MergeArgsNotConfigured {
             tool_name: "my-merge",
         }
-        "###);
+        "#);
 
         // String args
         insta::assert_debug_snapshot!(
@@ -871,11 +871,11 @@ mod tests {
 
         // List args should never be a merge-tools key
         insta::assert_debug_snapshot!(
-            get(r#"ui.merge-editor = ["meld"]"#).unwrap_err(), @r###"
+            get(r#"ui.merge-editor = ["meld"]"#).unwrap_err(), @r#"
         MergeArgsNotConfigured {
             tool_name: "meld",
         }
-        "###);
+        "#);
 
         // Invalid type
         assert!(get(r#"ui.merge-editor.k = 0"#).is_err());

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -2069,14 +2069,14 @@ mod tests {
         env.add_keyword("description", || L::wrap_string(Literal("".to_owned())));
         env.add_keyword("empty", || L::wrap_boolean(Literal(true)));
 
-        insta::assert_snapshot!(env.parse_err(r#"description ()"#), @r#"
+        insta::assert_snapshot!(env.parse_err(r#"description ()"#), @r"
          --> 1:13
           |
         1 | description ()
           |             ^---
           |
           = expected <EOI>, `++`, `||`, `&&`, `==`, `!=`, `>=`, `>`, `<=`, or `<`
-        "#);
+        ");
 
         insta::assert_snapshot!(env.parse_err(r#"foo"#), @r"
          --> 1:1
@@ -2095,14 +2095,14 @@ mod tests {
           |
           = Function `foo` doesn't exist
         ");
-        insta::assert_snapshot!(env.parse_err(r#"false()"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"false()"#), @r"
          --> 1:1
           |
         1 | false()
           | ^---^
           |
           = Expected identifier
-        "###);
+        ");
 
         insta::assert_snapshot!(env.parse_err(r#"!foo"#), @r"
          --> 1:2
@@ -2298,14 +2298,14 @@ mod tests {
           = Expected expression of type `Boolean`, but actual type is `Template`
         "#);
 
-        insta::assert_snapshot!(env.parse_err(r#"|x| description"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"|x| description"#), @r"
          --> 1:1
           |
         1 | |x| description
           | ^-------------^
           |
           = Lambda cannot be defined here
-        "###);
+        ");
     }
 
     #[test]
@@ -2515,31 +2515,31 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().map(identity)"#), @"a b c");
 
         // Not a lambda expression
-        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(empty)"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(empty)"#), @r#"
          --> 1:17
           |
         1 | "a".lines().map(empty)
           |                 ^---^
           |
           = Expected lambda expression
-        "###);
+        "#);
         // Bad lambda parameter count
-        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|| "")"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|| "")"#), @r#"
          --> 1:18
           |
         1 | "a".lines().map(|| "")
           |                  ^
           |
           = Expected 1 lambda parameters
-        "###);
-        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|a, b| "")"#), @r###"
+        "#);
+        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|a, b| "")"#), @r#"
          --> 1:18
           |
         1 | "a".lines().map(|a, b| "")
           |                  ^--^
           |
           = Expected 1 lambda parameters
-        "###);
+        "#);
         // Bad lambda output
         insta::assert_snapshot!(env.parse_err(r#""a".lines().filter(|s| s ++ "\n")"#), @r#"
          --> 1:24
@@ -2817,34 +2817,34 @@ mod tests {
             @"19700101 00:00:00");
 
         // Invalid format string
-        insta::assert_snapshot!(env.parse_err(r#"t0.format("%_")"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"t0.format("%_")"#), @r#"
          --> 1:11
           |
         1 | t0.format("%_")
           |           ^--^
           |
           = Invalid time format
-        "###);
+        "#);
 
         // Invalid type
-        insta::assert_snapshot!(env.parse_err(r#"t0.format(0)"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"t0.format(0)"#), @r"
          --> 1:11
           |
         1 | t0.format(0)
           |           ^
           |
           = Expected string literal
-        "###);
+        ");
 
         // Dynamic string isn't supported yet
-        insta::assert_snapshot!(env.parse_err(r#"t0.format("%Y" ++ "%m")"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"t0.format("%Y" ++ "%m")"#), @r#"
          --> 1:11
           |
         1 | t0.format("%Y" ++ "%m")
           |           ^----------^
           |
           = Expected string literal
-        "###);
+        "#);
 
         // Literal alias expansion
         env.add_alias("time_format", r#""%Y-%m-%d""#);
@@ -2874,17 +2874,17 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok(r#"fill(20, "The quick fox jumps over the " ++
                                   label("error", "lazy") ++ " dog\n")"#),
-            @r###"
+            @r"
         The quick fox jumps
         over the [38;5;1mlazy[39m dog
-        "###);
+        ");
 
         // A low value will not chop words, but can chop a label by words
         insta::assert_snapshot!(
             env.render_ok(r#"fill(9, "Longlonglongword an some short words " ++
                                   label("error", "longlonglongword and short words") ++
                                   " back out\n")"#),
-            @r###"
+            @r"
         Longlonglongword
         an some
         short
@@ -2893,13 +2893,13 @@ mod tests {
         [38;5;1mand short[39m
         [38;5;1mwords[39m
         back out
-        "###);
+        ");
 
         // Filling to 0 means breaking at every word
         insta::assert_snapshot!(
             env.render_ok(r#"fill(0, "The quick fox jumps over the " ++
                                   label("error", "lazy") ++ " dog\n")"#),
-            @r###"
+            @r"
         The
         quick
         fox
@@ -2908,13 +2908,13 @@ mod tests {
         the
         [38;5;1mlazy[39m
         dog
-        "###);
+        ");
 
         // Filling to -0 is the same as 0
         insta::assert_snapshot!(
             env.render_ok(r#"fill(-0, "The quick fox jumps over the " ++
                                   label("error", "lazy") ++ " dog\n")"#),
-            @r###"
+            @r"
         The
         quick
         fox
@@ -2923,7 +2923,7 @@ mod tests {
         the
         [38;5;1mlazy[39m
         dog
-        "###);
+        ");
 
         // Filling to negative width is an error
         insta::assert_snapshot!(
@@ -2936,23 +2936,23 @@ mod tests {
             env.render_ok(r#""START marker to help insta\n" ++
                              indent("    ", fill(20, "The quick fox jumps over the " ++
                                                  label("error", "lazy") ++ " dog\n"))"#),
-            @r###"
+            @r"
         START marker to help insta
             The quick fox jumps
             over the [38;5;1mlazy[39m dog
-        "###);
+        ");
 
         // Word-wrap indented (no special handling for leading spaces)
         insta::assert_snapshot!(
             env.render_ok(r#""START marker to help insta\n" ++
                              fill(20, indent("    ", "The quick fox jumps over the " ++
                                              label("error", "lazy") ++ " dog\n"))"#),
-            @r###"
+            @r"
         START marker to help insta
             The quick fox
         jumps over the [38;5;1mlazy[39m
         dog
-        "###);
+        ");
     }
 
     #[test]
@@ -2971,36 +2971,36 @@ mod tests {
         // "\n" at end of labeled text
         insta::assert_snapshot!(
             env.render_ok(r#"indent("__", label("error", "a\n") ++ label("warning", "b\n"))"#),
-            @r###"
+            @r"
         [38;5;1m__a[39m
         [38;5;3m__b[39m
-        "###);
+        ");
 
         // "\n" in labeled text
         insta::assert_snapshot!(
             env.render_ok(r#"indent("__", label("error", "a") ++ label("warning", "b\nc"))"#),
-            @r###"
+            @r"
         [38;5;1m__a[39m[38;5;3mb[39m
         [38;5;3m__c[39m
-        "###);
+        ");
 
         // Labeled prefix + unlabeled content
         insta::assert_snapshot!(
             env.render_ok(r#"indent(label("error", "XX"), "a\nb\n")"#),
-            @r###"
+            @r"
         [38;5;1mXX[39ma
         [38;5;1mXX[39mb
-        "###);
+        ");
 
         // Nested indent, silly but works
         insta::assert_snapshot!(
             env.render_ok(r#"indent(label("hint", "A"),
                                     label("warning", indent(label("hint", "B"),
                                                             label("error", "x\n") ++ "y")))"#),
-            @r###"
+            @r"
         [38;5;6mAB[38;5;1mx[39m
         [38;5;6mAB[38;5;3my[39m
-        "###);
+        ");
     }
 
     #[test]
@@ -3107,7 +3107,7 @@ mod tests {
                 ++ "\e\\"
                 ++ "Example"
                 ++ "\x1b]8;;\x1B\\""#),
-            @r#"␛]8;;http://example.com␛\Example␛]8;;␛\"#);
+            @r"␛]8;;http://example.com␛\Example␛]8;;␛\");
 
         // Don't sanitize ANSI escape with raw_escape_sequence
         insta::assert_snapshot!(env.render_ok(r#"raw_escape_sequence("\e")"#), @"");
@@ -3119,7 +3119,7 @@ mod tests {
                 ++ "\e\\"
                 ++ "Example"
                 ++ "\x1b]8;;\x1B\\")"#),
-            @r#"]8;;http://example.com\Example]8;;\"#);
+            @r"]8;;http://example.com\Example]8;;\");
     }
 
     #[test]

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -1410,12 +1410,12 @@ mod tests {
         recorder.pop_label().unwrap();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 7)),
-            @r###"
+            @r"
         [38;5;1mfoo bar[39m
         [38;5;1mbaz[39m
         [38;5;1mqux[39m
         [38;5;1mquux[39m
-        "###
+        "
         );
 
         // Multiple label chunks in a line
@@ -1427,12 +1427,12 @@ mod tests {
         }
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 7)),
-            @r###"
+            @r"
         [38;5;1mfoo [39m[38;5;6mbar[39m
         [38;5;1mbaz[39m
         [38;5;6mqux[39m
         [38;5;1mquux[39m
-        "###
+        "
         );
 
         // Empty lines should not cause panic
@@ -1444,13 +1444,13 @@ mod tests {
         }
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
-            @r###"
+            @r"
         [38;5;1m[39m
         [38;5;6mfoo[39m
         [38;5;1m[39m
         [38;5;6mbar baz[39m
         [38;5;1m[39m
-        "###
+        "
         );
 
         // Split at label boundary
@@ -1464,10 +1464,10 @@ mod tests {
         recorder.pop_label().unwrap();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
-            @r###"
+            @r"
         [38;5;1mfoo bar[39m
         [38;5;6mbaz[39m
-        "###
+        "
         );
 
         // Do not split at label boundary "ba|z" (since it's a single word)
@@ -1480,10 +1480,10 @@ mod tests {
         recorder.pop_label().unwrap();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
-            @r###"
+            @r"
         [38;5;1mfoo bar[39m
         [38;5;1mba[39m[38;5;6mz[39m
-        "###
+        "
         );
     }
 

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -40,7 +40,7 @@ fn test_basics() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["a", "d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [znk] e
     ├─╮
     │ ○  [vru] d
@@ -50,19 +50,19 @@ fn test_basics() {
     ○ │  [rlv] a
     ├─╯
     ◆  [zzz]
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "--retain-bookmarks", "d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit vruxwmqv b7c62f28 d | d
     Rebased 1 descendant commits onto parents of abandoned commits
     Working copy now at: znkkpsqq 11a2e10e e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : royxmykx fe2e8e8b c d | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [znk] e
     ├─╮
     │ ○  [roy] c d
@@ -71,7 +71,7 @@ fn test_basics() {
     ○ │  [rlv] a
     ├─╯
     ◆  [zzz]
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -79,14 +79,14 @@ fn test_basics() {
         &["abandon", "--retain-bookmarks"], /* abandons `e` */
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit znkkpsqq 5557ece3 e | e
     Working copy now at: nkmrtpmo d4f8ea73 (empty) (no description set)
     Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Parent commit      : vruxwmqv b7c62f28 d e?? | d
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [nkm]
     ├─╮
     │ ○  [vru] d e??
@@ -96,7 +96,7 @@ fn test_basics() {
     ○ │  [rlv] a e??
     ├─╯
     ◆  [zzz]
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "descendants(d)"]);
@@ -166,9 +166,7 @@ fn test_basics() {
     ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "none()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    No revisions to abandon.
-    "###);
+    insta::assert_snapshot!(stderr, @"No revisions to abandon.");
 }
 
 // This behavior illustrates https://github.com/jj-vcs/jj/issues/2600.
@@ -189,7 +187,7 @@ fn test_bug_2600() {
     create_commit(&test_env, &repo_path, "c", &["b"]);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [znk] c
     ○    [vru] b
     ├─╮
@@ -198,7 +196,7 @@ fn test_bug_2600() {
     ○  [zsu] base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
-    "###);
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -271,7 +269,7 @@ fn test_bug_2600() {
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ========= Reminder of the setup ===========
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [znk] c
     ○    [vru] b
     ├─╮
@@ -280,11 +278,11 @@ fn test_bug_2600() {
     ○  [zsu] base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
-    "###);
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["abandon", "--retain-bookmarks", "a", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned the following commits:
       vruxwmqv 8c0dced0 b | b
       royxmykx 98f3b9ba a | a
@@ -292,19 +290,17 @@ fn test_bug_2600() {
     Working copy now at: znkkpsqq 84fac1f8 c | c
     Parent commit      : zsuskuln 73c929fc a b base | base
     Added 0 files, modified 0 files, removed 2 files
-    "###);
+    ");
     // Commit "c" should have "base" as parent. As when we abandoned "a", it should
     // not have two parent pointers to the same commit.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [znk] c
     ○  [zsu] a b base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
-    "###);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b: zsuskuln 73c929fc base
-    "###);
+    insta::assert_snapshot!(stdout, @"b: zsuskuln 73c929fc base");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -321,7 +317,7 @@ fn test_bug_2600_rootcommit_special_case() {
     create_commit(&test_env, &repo_path, "c", &["b"]);
 
     // Setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [vru] c
     ○    [roy] b
     ├─╮
@@ -329,13 +325,11 @@ fn test_bug_2600_rootcommit_special_case() {
     ├─╯
     ○  [rlv] base
     ◆  [zzz]
-    "###);
+    ");
 
     // Now, the test
     let stderr = test_env.jj_cmd_failure(&repo_path, &["abandon", "base"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The Git backend does not support creating merge commits with the root commit as one of the parents.");
 }
 
 #[test]
@@ -348,10 +342,10 @@ fn test_double_abandon() {
     // Test the setup
     insta::assert_snapshot!(
     test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r", "a"])
-        , @r###"
+        , @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 2443ea76
     a
-    "###);
+    ");
 
     let commit_id = test_env.jj_cmd_success(
         &repo_path,
@@ -369,10 +363,10 @@ fn test_double_abandon() {
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", &commit_id]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit rlvkpnrz hidden 2443ea76 a
     Nothing changed.
-    "###);
+    ");
 }
 
 #[test]
@@ -391,14 +385,14 @@ fn test_abandon_restore_descendants() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["abandon", "-r@-", "--restore-descendants"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit rlvkpnrz 225adef1 (no description set)
     Rebased 1 descendant commits (while preserving their content) onto parents of abandoned commits
     Working copy now at: kkmpptxz a734deb0 (no description set)
     Parent commit      : qpvuntsm 485d52a9 (no description set)
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file b/file
     index 257cc5642c..76018072e0 100644
     --- a/file
@@ -406,7 +400,7 @@ fn test_abandon_restore_descendants() {
     @@ -1,1 +1,1 @@
     -foo
     +baz
-    "#);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -392,7 +392,7 @@ fn test_absorb_conflict() {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     std::fs::write(repo_path.join("file1"), "2a\n2b\n").unwrap();
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r@", "-ddescription(1)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: kkmpptxz 74405a07 (conflict) (no description set)
     Parent commit      : qpvuntsm 3619e4e5 1
@@ -406,7 +406,7 @@ fn test_absorb_conflict() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 
     let conflict_content =
         String::from_utf8(std::fs::read(repo_path.join("file1")).unwrap()).unwrap();

--- a/cli/tests/test_acls.rs
+++ b/cli/tests/test_acls.rs
@@ -41,7 +41,7 @@ fn test_diff() {
     SecretBackend::adopt_git_repo(&repo_path);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--color-words"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     Modified regular file a-first:
        1    1: foobar
     Access denied to added-secret: No access
@@ -50,27 +50,27 @@ fn test_diff() {
     Access denied to modified-secret: No access
     Modified regular file z-last:
        1    1: foobar
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--summary"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     M a-first
     C {a-first => added-secret}
     D deleted-secret
     M dir/secret
     M modified-secret
     M z-last
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--types"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     FF a-first
     FF {a-first => added-secret}
     F- deleted-secret
     FF dir/secret
     FF modified-secret
     FF z-last
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     a-first                   | 2 +-
     {a-first => added-secret} | 2 +-
     deleted-secret            | 1 -
@@ -78,12 +78,12 @@ fn test_diff() {
     modified-secret           | 0
     z-last                    | 2 +-
     6 files changed, 3 insertions(+), 4 deletions(-)
-    "###);
+    ");
     let assert = test_env
         .jj_cmd(&repo_path, &["diff", "--git"])
         .assert()
         .failure();
-    insta::assert_snapshot!(get_stdout_string(&assert).replace('\\', "/"), @r###"
+    insta::assert_snapshot!(get_stdout_string(&assert).replace('\\', "/"), @r"
     diff --git a/a-first b/a-first
     index 257cc5642c..5716ca5987 100644
     --- a/a-first
@@ -91,11 +91,11 @@ fn test_diff() {
     @@ -1,1 +1,1 @@
     -foo
     +bar
-    "###);
-    insta::assert_snapshot!(get_stderr_string(&assert), @r#"
+    ");
+    insta::assert_snapshot!(get_stderr_string(&assert), @r"
     Error: Access denied to added-secret
     Caused by: No access
-    "#);
+    ");
 
     // TODO: Test external tool
 }
@@ -122,11 +122,9 @@ fn test_file_list_show() {
     insta::assert_snapshot!(stderr, @"");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "show", "."]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     foo
     baz
-    "###);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
-    Warning: Path 'secret' exists but access is denied: No access
-    "###);
+    ");
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @"Warning: Path 'secret' exists but access is denied: No access");
 }

--- a/cli/tests/test_advance_bookmarks.rs
+++ b/cli/tests/test_advance_bookmarks.rs
@@ -75,32 +75,32 @@ fn test_advance_bookmarks_enabled(make_commit: CommitFn) {
 
     // Check the initial state of the repo.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    ");
     }
 
     // Run jj commit, which will advance the bookmark pointing to @-.
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 
     // Now disable advance bookmarks and commit again. The bookmark shouldn't move.
     set_advance_bookmarks(&test_env, false);
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 }
 
@@ -117,19 +117,19 @@ fn test_advance_bookmarks_at_minus(make_commit: CommitFn) {
     test_env.jj_cmd_ok(&workspace_path, &["bookmark", "create", "test_bookmark"]);
 
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{test_bookmark} desc:
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 
     // Create a second bookmark pointing to @. On the next commit, only the first
@@ -137,12 +137,12 @@ fn test_advance_bookmarks_at_minus(make_commit: CommitFn) {
     test_env.jj_cmd_ok(&workspace_path, &["bookmark", "create", "test_bookmark2"]);
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark test_bookmark2} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 }
 
@@ -163,20 +163,20 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
 
     // Check the initial state of the repo.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    ");
     }
 
     // Commit will not advance the bookmark since advance-bookmarks is disabled.
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: first
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    ");
     }
 
     // Now enable advance bookmarks for "test_bookmark", move the bookmark, and
@@ -191,20 +191,20 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
         &["bookmark", "set", "test_bookmark", "-r", "@-"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 
     // Now disable advance bookmarks for "test_bookmark" and "second_bookmark",
@@ -217,13 +217,13 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
     );
     make_commit(&test_env, &workspace_path, "third");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 
     // If we create a new bookmark at @- and move test_bookmark there as well. When
@@ -238,24 +238,24 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
         &["bookmark", "set", "test_bookmark", "-r", "@-"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{second_bookmark test_bookmark} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
     make_commit(&test_env, &workspace_path, "fourth");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: fourth
     ○  bookmarks{second_bookmark test_bookmark} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 }
 
@@ -279,20 +279,20 @@ fn test_advance_bookmarks_multiple_bookmarks(make_commit: CommitFn) {
 
     insta::allow_duplicates! {
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{first_bookmark second_bookmark} desc:
-    "###);
+    ");
     }
 
     // Both bookmarks are eligible and both will advance.
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{first_bookmark second_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
     }
 }
 
@@ -307,10 +307,10 @@ fn test_new_advance_bookmarks_interior() {
     set_advance_bookmarks(&test_env, true);
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{} desc:
-    "###);
+    ");
 
     // Create a gap in the commits for us to insert our new commit with --before.
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "first"]);
@@ -320,23 +320,23 @@ fn test_new_advance_bookmarks_interior() {
         &workspace_path,
         &["bookmark", "create", "-r", "@---", "test_bookmark"],
     );
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["new", "-r", "@--"]);
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     │ ○  bookmarks{} desc: third
     ├─╯
     ○  bookmarks{test_bookmark} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
 }
 
 // If the `--before` flag is passed to `jj new`, bookmarks are not advanced.
@@ -349,10 +349,10 @@ fn test_new_advance_bookmarks_before() {
     set_advance_bookmarks(&test_env, true);
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{} desc:
-    "###);
+    ");
 
     // Create a gap in the commits for us to insert our new commit with --before.
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "first"]);
@@ -362,22 +362,22 @@ fn test_new_advance_bookmarks_before() {
         &workspace_path,
         &["bookmark", "create", "-r", "@---", "test_bookmark"],
     );
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["new", "--before", "@-"]);
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     ○  bookmarks{} desc: third
     @  bookmarks{} desc:
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    ");
 }
 
 // If the `--after` flag is passed to `jj new`, bookmarks are not advanced.
@@ -394,18 +394,18 @@ fn test_new_advance_bookmarks_after() {
     );
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m", "first"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "--after", "@"]);
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: first
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    ");
 }
 
 #[test]
@@ -430,20 +430,20 @@ fn test_new_advance_bookmarks_merge_children() {
     );
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc: 2
     │ ○  bookmarks{} desc: 1
     ├─╯
     ○  bookmarks{test_bookmark} desc: 0
     ◆  bookmarks{} desc:
-    "###);
+    ");
 
     // The bookmark won't advance because `jj  new` had multiple targets.
     test_env.jj_cmd_ok(
         &workspace_path,
         &["new", "description(1)", "description(2)"],
     );
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @    bookmarks{} desc:
     ├─╮
     │ ○  bookmarks{} desc: 2
@@ -451,5 +451,5 @@ fn test_new_advance_bookmarks_merge_children() {
     ├─╯
     ○  bookmarks{test_bookmark} desc: 0
     ◆  bookmarks{} desc:
-    "###);
+    ");
 }

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -27,11 +27,11 @@ fn test_alias_basic() {
     test_env.add_config(r#"aliases.bk = ["log", "-r", "@", "-T", "bookmarks"]"#);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["bk"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  my-bookmark
     │
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -41,13 +41,13 @@ fn test_alias_bad_name() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["foo."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: unrecognized subcommand 'foo.'
 
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -63,19 +63,15 @@ fn test_alias_calls_empty_command() {
     "#,
     );
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["empty"]);
-    insta::assert_snapshot!(stderr.lines().take(3).join("\n"), @r###"
+    insta::assert_snapshot!(stderr.lines().take(3).join("\n"), @r"
     Jujutsu (An experimental VCS)
 
     Usage: jj [OPTIONS] <COMMAND>
-    "###);
+    ");
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["empty", "--no-pager"]);
-    insta::assert_snapshot!(stderr.lines().next().unwrap_or_default(), @r###"
-    error: 'jj' requires a subcommand but one was not provided
-    "###);
+    insta::assert_snapshot!(stderr.lines().next().unwrap_or_default(), @"error: 'jj' requires a subcommand but one was not provided");
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["empty_command_with_opts"]);
-    insta::assert_snapshot!(stderr.lines().next().unwrap_or_default(), @r###"
-    error: 'jj' requires a subcommand but one was not provided
-    "###);
+    insta::assert_snapshot!(stderr.lines().next().unwrap_or_default(), @"error: 'jj' requires a subcommand but one was not provided");
 }
 
 #[test]
@@ -86,7 +82,7 @@ fn test_alias_calls_unknown_command() {
 
     test_env.add_config(r#"aliases.foo = ["nonexistent"]"#);
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: unrecognized subcommand 'nonexistent'
 
       tip: a similar subcommand exists: 'next'
@@ -94,7 +90,7 @@ fn test_alias_calls_unknown_command() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -105,7 +101,7 @@ fn test_alias_calls_command_with_invalid_option() {
 
     test_env.add_config(r#"aliases.foo = ["log", "--nonexistent"]"#);
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: unexpected argument '--nonexistent' found
 
       tip: to pass '--nonexistent' as a value, use '-- --nonexistent'
@@ -113,7 +109,7 @@ fn test_alias_calls_command_with_invalid_option() {
     Usage: jj log [OPTIONS] [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -123,13 +119,13 @@ fn test_alias_calls_help() {
     let repo_path = test_env.env_root().join("repo");
     test_env.add_config(r#"aliases.h = ["--help"]"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["h"]);
-    insta::assert_snapshot!(stdout.lines().take(5).join("\n"), @r###"
+    insta::assert_snapshot!(stdout.lines().take(5).join("\n"), @r"
     Jujutsu (An experimental VCS)
 
     To get started, see the tutorial at https://jj-vcs.github.io/jj/latest/tutorial/.
 
     Usage: jj [OPTIONS] <COMMAND>
-    "###);
+    ");
 }
 
 #[test]
@@ -141,10 +137,8 @@ fn test_alias_cannot_override_builtin() {
     test_env.add_config(r#"aliases.log = ["rebase"]"#);
     // Alias should give a warning
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "root()"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  zzzzzzzz root() 00000000
-    "###);
-    insta::assert_snapshot!(stderr, @"Warning: Cannot define an alias that overrides the built-in command 'log'\n");
+    insta::assert_snapshot!(stdout, @"◆  zzzzzzzz root() 00000000");
+    insta::assert_snapshot!(stderr, @"Warning: Cannot define an alias that overrides the built-in command 'log'");
 }
 
 #[test]
@@ -176,31 +170,25 @@ fn test_alias_global_args_before_and_after() {
     test_env.add_config(r#"aliases.l = ["log", "-T", "commit_id", "-r", "all()"]"#);
     // Test the setup
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Can pass global args before
     let stdout = test_env.jj_cmd_success(&repo_path, &["l", "--at-op", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  0000000000000000000000000000000000000000
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  0000000000000000000000000000000000000000");
     // Can pass global args after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "@-", "l"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  0000000000000000000000000000000000000000
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  0000000000000000000000000000000000000000");
     // Test passing global args both before and after
     let stdout = test_env.jj_cmd_success(&repo_path, &["--at-op", "abc123", "l", "--at-op", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  0000000000000000000000000000000000000000
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  0000000000000000000000000000000000000000");
     let stdout = test_env.jj_cmd_success(&repo_path, &["-R", "../nonexistent", "l", "-R", "."]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 }
 
 #[test]
@@ -214,9 +202,7 @@ fn test_alias_global_args_in_definition() {
 
     // The global argument in the alias is respected
     let stdout = test_env.jj_cmd_success(&repo_path, &["l"]);
-    insta::assert_snapshot!(stdout, @r###"
-    [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    insta::assert_snapshot!(stdout, @"[1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m");
 }
 
 #[test]
@@ -266,22 +252,16 @@ fn test_alias_in_repo_config() {
 
     // In repo1 sub directory, aliases can be loaded from the repo1 config.
     let stdout = test_env.jj_cmd_success(&repo1_path.join("sub"), &["l"]);
-    insta::assert_snapshot!(stdout, @r###"
-    repo1 alias
-    "###);
+    insta::assert_snapshot!(stdout, @"repo1 alias");
 
     // In repo2 directory, no repo-local aliases exist.
     let stdout = test_env.jj_cmd_success(&repo2_path, &["l"]);
-    insta::assert_snapshot!(stdout, @r###"
-    user alias
-    "###);
+    insta::assert_snapshot!(stdout, @"user alias");
 
     // Aliases can't be loaded from the -R path due to chicken and egg problem.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo2_path, &["l", "-R", repo1_path.to_str().unwrap()]);
-    insta::assert_snapshot!(stdout, @r###"
-    user alias
-    "###);
+    insta::assert_snapshot!(stdout, @"user alias");
     insta::assert_snapshot!(
         stderr,
         @"Warning: Command aliases cannot be loaded from -R/--repository path or --config/--config-file arguments.");
@@ -289,9 +269,7 @@ fn test_alias_in_repo_config() {
     // Aliases are loaded from the cwd-relative workspace even with -R.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo1_path, &["l", "-R", repo2_path.to_str().unwrap()]);
-    insta::assert_snapshot!(stdout, @r###"
-    repo1 alias
-    "###);
+    insta::assert_snapshot!(stdout, @"repo1 alias");
     insta::assert_snapshot!(
         stderr,
         @"Warning: Command aliases cannot be loaded from -R/--repository path or --config/--config-file arguments.");

--- a/cli/tests/test_backout_command.rs
+++ b/cli/tests/test_backout_command.rs
@@ -44,37 +44,33 @@ fn test_backout() {
 
     create_commit(&test_env, &repo_path, "a", &[], &[("a", "a\n")]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
-    A a
-    "###);
+    insta::assert_snapshot!(stdout, @"A a");
 
     // Backout the commit
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["backout", "-r", "@"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     ○  6d845ed9fb6a Back out "a"
     │
     │  This backs out commit 2443ea76b0b1c531326908326aab7020abab8e6c.
     @  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@+"]);
-    insta::assert_snapshot!(stdout, @r###"
-    D a
-    "###);
+    insta::assert_snapshot!(stdout, @"D a");
 
     // Backout the new backed-out commit
     test_env.jj_cmd_ok(&repo_path, &["edit", "@+"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["backout", "-r", "@"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     ○  79555ea9040b Back out "Back out "a""
     │
     │  This backs out commit 6d845ed9fb6a3d367e2d7068ef0256b1a10705a9.
@@ -83,11 +79,9 @@ fn test_backout() {
     │  This backs out commit 2443ea76b0b1c531326908326aab7020abab8e6c.
     ○  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@+"]);
-    insta::assert_snapshot!(stdout, @r###"
-    A a
-    "###);
+    insta::assert_snapshot!(stdout, @"A a");
 }
 
 #[test]
@@ -109,21 +103,21 @@ fn test_backout_multiple() {
     create_commit(&test_env, &repo_path, "e", &["d"], &[("a", "a\nb\nc\n")]);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  208f8612074a e
     ○  ceeec03be46b d
     ○  413337bbd11f c
     ○  46cc97af6802 b
     ○  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    ");
 
     // Backout multiple commits
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["backout", "-r", "b", "-r", "c", "-r", "e"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     ○  6504c4ded177 Back out "b"
     │
     │  This backs out commit 46cc97af6802301d8db381386e8485ff3ff24ae6.
@@ -139,7 +133,7 @@ fn test_backout_multiple() {
     ○  46cc97af6802 b
     ○  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    "#);
     // View the output of each backed out commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "@+"]);
     insta::assert_snapshot!(stdout, @r#"

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -24,62 +24,56 @@ fn test_bookmark_multiple_names() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo", "bar"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 2 bookmarks pointing to qpvuntsm 230dd059 bar foo | (empty) (no description set)
     Hint: Use -r to specify the target revision.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar foo 230dd059e1b0
     ◆   000000000000
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo", "bar"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 2 bookmarks to zsuskuln 8bb159bc bar foo | (empty) (no description set)
     Hint: Use -r to specify the target revision.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar foo 8bb159bc30a9
     ○   230dd059e1b0
     ◆   000000000000
-    "###);
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo", "bar", "foo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Deleted 2 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Deleted 2 bookmarks.");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   8bb159bc30a9
     ○   230dd059e1b0
     ◆   000000000000
-    "###);
+    ");
 
     // Hint should be omitted if -r is specified
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@-", "foo", "bar"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Created 2 bookmarks pointing to qpvuntsm 230dd059 bar foo | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Created 2 bookmarks pointing to qpvuntsm 230dd059 bar foo | (empty) (no description set)");
 
     // Create and move with explicit -r
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "-r@", "bar", "baz"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to zsuskuln 8bb159bc bar baz | (empty) (no description set)
     Moved 1 bookmarks to zsuskuln 8bb159bc bar baz | (empty) (no description set)
     Hint: Consider using `jj bookmark move` if your intention was to move existing bookmarks.
-    "###);
+    ");
 
     // Noop changes should not be included in the stats
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "-r@", "foo", "bar", "baz"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to zsuskuln 8bb159bc bar baz foo | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to zsuskuln 8bb159bc bar baz foo | (empty) (no description set)");
 }
 
 #[test]
@@ -91,16 +85,14 @@ fn test_bookmark_at_root() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "fred", "-r=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Created 1 bookmarks pointing to zzzzzzzz 00000000 fred | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Created 1 bookmarks pointing to zzzzzzzz 00000000 fred | (empty) (no description set)");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
     Warning: Failed to export some bookmarks:
       fred: Ref cannot point to the root commit in Git
-    "###);
+    ");
 }
 
 #[test]
@@ -110,18 +102,18 @@ fn test_bookmark_empty_name() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "create", ""]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '<NAMES>...' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "set", ""]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '<NAMES>...' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -139,98 +131,84 @@ fn test_bookmark_move() {
     );
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "move", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such bookmark: foo
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No such bookmark: foo");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to qpvuntsm 230dd059 foo | (empty) (no description set)
     Hint: Consider using `jj bookmark move` if your intention was to move existing bookmarks.
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "create", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Bookmark already exists: foo
     Hint: Use `jj bookmark set` to update it.
-    "###);
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to mzvwutvl 167f90e7 foo | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to mzvwutvl 167f90e7 foo | (empty) (no description set)");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "set", "-r@-", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: foo
     Hint: Use --allow-backwards to allow it.
-    "###);
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "set", "-r@-", "--allow-backwards", "foo"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to mzvwutvl 167f90e7 foo | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to mzvwutvl 167f90e7 foo | (empty) (no description set)");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "move", "--to=@-", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: foo
     Hint: Use --allow-backwards to allow it.
-    "###);
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "move", "--to=@-", "--allow-backwards", "foo"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)");
 
     // Delete bookmark locally, but is still tracking remote
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-mcommit"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new", "-r@-"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     foo (deleted)
       @origin: qpvuntsm 1eb845f3 (empty) commit
-    "###);
+    ");
 
     // Deleted tracking bookmark name should still be allocated
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "create", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Tracked remote bookmarks exist for deleted bookmark: foo
     Hint: Use `jj bookmark set` to recreate the local bookmark. Run `jj bookmark untrack 'glob:foo@*'` to disassociate them.
-    "###);
+    ");
 
     // Restoring local target shouldn't invalidate tracking state
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to mzvwutvl 66d48752 foo* | (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to mzvwutvl 66d48752 foo* | (empty) (no description set)");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     foo: mzvwutvl 66d48752 (empty) (no description set)
       @origin (behind by 1 commits): qpvuntsm 1eb845f3 (empty) commit
-    "###);
+    ");
 
     // Untracked remote bookmark shouldn't block creation of local bookmark
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "foo@origin"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo"]);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Created 1 bookmarks pointing to mzvwutvl 66d48752 foo | (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Created 1 bookmarks pointing to mzvwutvl 66d48752 foo | (empty) (no description set)");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     foo: mzvwutvl 66d48752 (empty) (no description set)
     foo@origin: qpvuntsm 1eb845f3 (empty) commit
-    "###);
+    ");
 }
 
 #[test]
@@ -246,7 +224,7 @@ fn test_bookmark_move_matching() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c1"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mhead2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   a2781dd9ee37
     ○  c1 f4f38657a3dd
     ○  b1 f652c32197cf
@@ -254,45 +232,39 @@ fn test_bookmark_move_matching() {
     │ ○  a1 a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    ");
 
     // The default could be considered "--from=all() glob:*", but is disabled
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "move"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <--from <REVSETS>|NAMES>
 
     Usage: jj bookmark move <--from <REVSETS>|NAMES>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // No bookmarks pointing to the source revisions
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "--from=none()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    No bookmarks to update.
-    "###);
+    insta::assert_snapshot!(stderr, @"No bookmarks to update.");
 
     // No matching bookmarks within the source revisions
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["bookmark", "move", "--from=::@", "glob:a?"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No matching bookmarks for patterns: a?
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No matching bookmarks for patterns: a?");
 
     // Noop move
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "--to=a1", "a2"]);
-    insta::assert_snapshot!(stderr, @r###"
-    No bookmarks to update.
-    "###);
+    insta::assert_snapshot!(stderr, @"No bookmarks to update.");
 
     // Move from multiple revisions
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "--from=::@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 2 bookmarks to vruxwmqv a2781dd9 b1 c1 | (empty) head2
     Hint: Specify bookmark by name to update just one of the bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b1 c1 a2781dd9ee37
     ○   f4f38657a3dd
     ○   f652c32197cf
@@ -300,16 +272,16 @@ fn test_bookmark_move_matching() {
     │ ○  a1 a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Try to move multiple bookmarks, but one of them isn't fast-forward
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "move", "glob:?1"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: a1
     Hint: Use --allow-backwards to allow it.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   a2781dd9ee37
     ○  c1 f4f38657a3dd
     ○  b1 f652c32197cf
@@ -317,17 +289,15 @@ fn test_bookmark_move_matching() {
     │ ○  a1 a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    ");
 
     // Select by revision and name
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "move", "--from=::a1+", "--to=a1+", "glob:?1"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to kkmpptxz 6b5e840e a1 | (empty) head1
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to kkmpptxz 6b5e840e a1 | (empty) head1");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   a2781dd9ee37
     ○  c1 f4f38657a3dd
     ○  b1 f652c32197cf
@@ -335,7 +305,7 @@ fn test_bookmark_move_matching() {
     │ ○  a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    ");
 }
 
 #[test]
@@ -369,7 +339,7 @@ fn test_bookmark_move_conflicting() {
             "foo",
         ],
     );
-    insta::assert_snapshot!(get_log(), @r###"
+    insta::assert_snapshot!(get_log(), @r"
     @  A1
     ○  A0 foo??
     │ ○  C0
@@ -377,24 +347,22 @@ fn test_bookmark_move_conflicting() {
     │ ○  B0 foo??
     ├─╯
     ◆
-    "###);
+    ");
 
     // Can't move the bookmark to C0 since it's sibling.
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["bookmark", "set", "-rdescription(C0)", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: foo
     Hint: Use --allow-backwards to allow it.
-    "###);
+    ");
 
     // Can move the bookmark to A1 since it's descendant of A0. It's not
     // descendant of B0, though.
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "-rdescription(A1)", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to mzvwutvl 9328d344 foo | (empty) A1
-    "###);
-    insta::assert_snapshot!(get_log(), @r###"
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to mzvwutvl 9328d344 foo | (empty) A1");
+    insta::assert_snapshot!(get_log(), @r"
     @  A1 foo
     ○  A0
     │ ○  C0
@@ -402,7 +370,7 @@ fn test_bookmark_move_conflicting() {
     │ ○  B0
     ├─╯
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -420,9 +388,7 @@ fn test_bookmark_rename() {
     );
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "rename", "bnoexist", "blocal"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such bookmark: bnoexist
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No such bookmark: bnoexist");
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-0"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "blocal"]);
@@ -434,9 +400,7 @@ fn test_bookmark_rename() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-1"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "bexist"]);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "rename", "blocal1", "bexist"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Bookmark already exists: bexist
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Bookmark already exists: bexist");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-2"]);
@@ -444,16 +408,16 @@ fn test_bookmark_rename() {
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new", "-b=bremote"]);
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "rename", "bremote", "bremote2"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Tracked remote bookmarks for bookmark bremote were not renamed.
     Hint: To rename the bookmark on the remote, you can `jj git push --bookmark bremote` first (to delete it on the remote), and then `jj git push --bookmark bremote2`. `jj git push --all` would also be sufficient.
-    "###);
+    ");
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "rename", "bremote2", "bremote"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Tracked remote bookmarks for bookmark bremote exist.
     Hint: Run `jj bookmark untrack 'glob:bremote@*'` to disassociate them.
-    "###);
+    ");
 }
 
 #[test]
@@ -482,27 +446,23 @@ fn test_bookmark_forget_glob() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo-3"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo-4"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1 foo-3 foo-4 230dd059e1b0
     ◆   000000000000
-    "###);
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Forgot 2 bookmarks.
-    "###);
+    insta::assert_snapshot!(stderr, @"Forgot 2 bookmarks.");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Forgot 2 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Forgot 2 bookmarks.");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-4 230dd059e1b0
     ◆   000000000000
-    "###);
+    ");
 
     // Forgetting a bookmark via both explicit name and glob pattern, or with
     // multiple glob patterns, shouldn't produce an error.
@@ -511,30 +471,26 @@ fn test_bookmark_forget_glob() {
         &["bookmark", "forget", "foo-4", "glob:foo-*", "glob:foo-*"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Forgot 1 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Forgot 1 bookmarks.");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 230dd059e1b0
     ◆   000000000000
-    "###);
+    ");
 
     // Malformed glob
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "forget", "glob:foo-[1-3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value 'glob:foo-[1-3' for '<NAMES>...': Pattern syntax error near position 4: invalid range pattern
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // We get an error if none of the globs match anything
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["bookmark", "forget", "glob:bar*", "glob:baz*", "glob:boom*"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No matching bookmarks for patterns: baz*, boom*
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No matching bookmarks for patterns: baz*, boom*");
 }
 
 #[test]
@@ -563,34 +519,28 @@ fn test_bookmark_delete_glob() {
     // Push to create remote-tracking bookmarks
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--all"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1 foo-3 foo-4 312a98d6f27b
     ◆   000000000000
-    "###);
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Deleted 2 bookmarks.
-    "###);
+    insta::assert_snapshot!(stderr, @"Deleted 2 bookmarks.");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Deleted 2 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Deleted 2 bookmarks.");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1@origin foo-3@origin foo-4 312a98d6f27b
     ◆   000000000000
-    "###);
+    ");
 
     // We get an error if none of the globs match live bookmarks. Unlike `jj
     // bookmark forget`, it's not allowed to delete already deleted bookmarks.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "delete", "glob:foo-[1-3]"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No matching bookmarks for patterns: foo-[1-3]
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No matching bookmarks for patterns: foo-[1-3]");
 
     // Deleting a bookmark via both explicit name and glob pattern, or with
     // multiple glob patterns, shouldn't produce an error.
@@ -599,16 +549,14 @@ fn test_bookmark_delete_glob() {
         &["bookmark", "delete", "foo-4", "glob:foo-*", "glob:foo-*"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Deleted 1 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Deleted 1 bookmarks.");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1@origin foo-3@origin foo-4@origin 312a98d6f27b
     ◆   000000000000
-    "###);
+    ");
 
     // The deleted bookmarks are still there
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     bar-2: qpvuntsm 312a98d6 (empty) commit
       @origin: qpvuntsm 312a98d6 (empty) commit
     foo-1 (deleted)
@@ -617,15 +565,15 @@ fn test_bookmark_delete_glob() {
       @origin: qpvuntsm 312a98d6 (empty) commit
     foo-4 (deleted)
       @origin: qpvuntsm 312a98d6 (empty) commit
-    "###);
+    ");
 
     // Malformed glob
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "delete", "glob:foo-[1-3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value 'glob:foo-[1-3' for '<NAMES>...': Pattern syntax error near position 4: invalid range pattern
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Unknown pattern kind
     let stderr =
@@ -650,17 +598,14 @@ fn test_bookmark_delete_export() {
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "--all-remotes"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     foo (deleted)
       @git: rlvkpnrz 65b6b74e (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be deleted from the underlying Git repo on the next `jj git export`.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be deleted from the underlying Git repo on the next `jj git export`.");
 
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
 }
 
 #[test]
@@ -671,9 +616,7 @@ fn test_bookmark_forget_export() {
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    foo: rlvkpnrz 65b6b74e (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"foo: rlvkpnrz 65b6b74e (empty) (no description set)");
 
     // Exporting the bookmark to git creates a local-git tracking bookmark
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
@@ -681,9 +624,7 @@ fn test_bookmark_forget_export() {
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "foo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Forgot 1 bookmarks.
-    "###);
+    insta::assert_snapshot!(stderr, @"Forgot 1 bookmarks.");
     // Forgetting a bookmark deletes local and remote-tracking bookmarks including
     // the corresponding git-tracking bookmark.
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
@@ -739,10 +680,10 @@ fn test_bookmark_forget_fetched_bookmark() {
 
     // Fetch normally
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
 
     // TEST 1: with export-import
     // Forget the bookmark
@@ -762,21 +703,17 @@ fn test_bookmark_forget_fetched_bookmark() {
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
 
     // We can fetch feature1 again.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: feature1@origin [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"bookmark: feature1@origin [new] tracked");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
 
     // TEST 2: No export/import (otherwise the same as test 1)
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "feature1"]);
@@ -784,13 +721,11 @@ fn test_bookmark_forget_fetched_bookmark() {
     // Fetch works even without the export-import
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: feature1@origin [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"bookmark: feature1@origin [new] tracked");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
 
     // TEST 3: fetch bookmark that was moved & forgotten
 
@@ -807,20 +742,16 @@ fn test_bookmark_forget_fetched_bookmark() {
         .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "feature1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Forgot 1 bookmarks.
-    "###);
+    insta::assert_snapshot!(stderr, @"Forgot 1 bookmarks.");
 
     // Fetching a moved bookmark does not create a conflict
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: feature1@origin [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"bookmark: feature1@origin [new] tracked");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: ooosovrs 38aefb17 (empty) another message
       @origin: ooosovrs 38aefb17 (empty) another message
-    "###);
+    ");
 }
 
 #[test]
@@ -864,10 +795,10 @@ fn test_bookmark_forget_deleted_or_nonexistent_bookmark() {
     // Fetch and then delete the bookmark
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "feature1"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1 (deleted)
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
 
     // ============ End of test setup ============
 
@@ -877,9 +808,7 @@ fn test_bookmark_forget_deleted_or_nonexistent_bookmark() {
 
     // Can't forget a non-existent bookmark
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "forget", "i_do_not_exist"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such bookmark: i_do_not_exist
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No such bookmark: i_do_not_exist");
 }
 
 #[test]
@@ -928,40 +857,40 @@ fn test_bookmark_track_untrack() {
     );
     test_env.add_config("git.auto-local-bookmark = false");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [new] untracked
     bookmark: feature2@origin [new] untracked
     bookmark: main@origin     [new] untracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1@origin: sptzoqmo 7b33f629 commit 1
     feature2@origin: sptzoqmo 7b33f629 commit 1
     main@origin: sptzoqmo 7b33f629 commit 1
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
     │ ◆  feature1@origin feature2@origin main@origin 7b33f6295eda
     ├─╯
     ◆   000000000000
-    "#);
+    ");
 
     // Track new bookmark. Local bookmark should be created.
     test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "track", "feature1@origin", "main@origin"],
     );
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: sptzoqmo 7b33f629 commit 1
       @origin: sptzoqmo 7b33f629 commit 1
     feature2@origin: sptzoqmo 7b33f629 commit 1
     main: sptzoqmo 7b33f629 commit 1
       @origin: sptzoqmo 7b33f629 commit 1
-    "###);
+    ");
 
     // Track existing bookmark. Local bookmark should result in conflict.
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "feature2"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "feature2@origin"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: sptzoqmo 7b33f629 commit 1
       @origin: sptzoqmo 7b33f629 commit 1
     feature2 (conflicted):
@@ -970,7 +899,7 @@ fn test_bookmark_track_untrack() {
       @origin (behind by 1 commits): sptzoqmo 7b33f629 commit 1
     main: sptzoqmo 7b33f629 commit 1
       @origin: sptzoqmo 7b33f629 commit 1
-    "###);
+    ");
 
     // Untrack existing and locally-deleted bookmarks. Bookmark targets should be
     // unchanged
@@ -979,19 +908,19 @@ fn test_bookmark_track_untrack() {
         &repo_path,
         &["bookmark", "untrack", "feature1@origin", "feature2@origin"],
     );
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: sptzoqmo 7b33f629 commit 1
     feature1@origin: sptzoqmo 7b33f629 commit 1
     feature2@origin: sptzoqmo 7b33f629 commit 1
     main: sptzoqmo 7b33f629 commit 1
       @origin: sptzoqmo 7b33f629 commit 1
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
     │ ◆  feature1 feature1@origin feature2@origin main 7b33f6295eda
     ├─╯
     ◆   000000000000
-    "#);
+    ");
 
     // Fetch new commit. Only tracking bookmark "main" should be merged.
     create_remote_commit(
@@ -1004,26 +933,26 @@ fn test_bookmark_track_untrack() {
         ],
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [updated] untracked
     bookmark: feature2@origin [updated] untracked
     bookmark: main@origin     [updated] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: sptzoqmo 7b33f629 commit 1
     feature1@origin: mmqqkyyt 40dabdaf commit 2
     feature2@origin: mmqqkyyt 40dabdaf commit 2
     main: mmqqkyyt 40dabdaf commit 2
       @origin: mmqqkyyt 40dabdaf commit 2
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
     │ ◆  feature1@origin feature2@origin main 40dabdaf4abe
     ├─╯
     │ ○  feature1 7b33f6295eda
     ├─╯
     ◆   000000000000
-    "#);
+    ");
 
     // Fetch new commit with auto tracking. Tracking bookmark "main" and new
     // bookmark "feature3" should be merged.
@@ -1039,14 +968,14 @@ fn test_bookmark_track_untrack() {
     );
     test_env.add_config("git.auto-local-bookmark = true");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [updated] untracked
     bookmark: feature2@origin [updated] untracked
     bookmark: feature3@origin [new] tracked
     bookmark: main@origin     [updated] tracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: sptzoqmo 7b33f629 commit 1
     feature1@origin: wwnpyzpo 3f0f86fa commit 3
     feature2@origin: wwnpyzpo 3f0f86fa commit 3
@@ -1054,15 +983,15 @@ fn test_bookmark_track_untrack() {
       @origin: wwnpyzpo 3f0f86fa commit 3
     main: wwnpyzpo 3f0f86fa commit 3
       @origin: wwnpyzpo 3f0f86fa commit 3
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
     │ ◆  feature1@origin feature2@origin feature3 main 3f0f86fa0e57
     ├─╯
     │ ○  feature1 7b33f6295eda
     ├─╯
     ◆   000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -1086,13 +1015,13 @@ fn test_bookmark_track_conflict() {
         &["describe", "-m", "b", "-r", "main", "--ignore-immutable"],
     );
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "main@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Started tracking 1 remote bookmarks.
     main (conflicted):
       + qpvuntsm e802c4f8 (empty) b
       + qpvuntsm hidden 427890ea (empty) a
       @origin (behind by 1 commits): qpvuntsm hidden 427890ea (empty) a
-    "###);
+    ");
 }
 
 #[test]
@@ -1130,96 +1059,86 @@ fn test_bookmark_track_untrack_patterns() {
     // Fetch new commit without auto tracking
     test_env.add_config("git.auto-local-bookmark = false");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [new] untracked
     bookmark: feature2@origin [new] untracked
-    "###);
+    ");
 
     // Track local bookmark
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
     insta::assert_snapshot!(
-        test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "track", "main"]), @r###"
+        test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "track", "main"]), @r"
     error: invalid value 'main' for '<BOOKMARK@REMOTE>...': remote bookmark must be specified in bookmark@remote form
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Track/untrack unknown bookmark
     insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "main@origin"]), @r###"
-    Error: No such remote bookmark: main@origin
-    "###);
+        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "main@origin"]), @"Error: No such remote bookmark: main@origin");
     insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["bookmark", "untrack", "main@origin"]), @r###"
-    Error: No such remote bookmark: main@origin
-    "###);
+        test_env.jj_cmd_failure(&repo_path, &["bookmark", "untrack", "main@origin"]), @"Error: No such remote bookmark: main@origin");
     insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "glob:maine@*"]), @r###"
-    Error: No matching remote bookmarks for patterns: maine@*
-    "###);
+        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "glob:maine@*"]), @"Error: No matching remote bookmarks for patterns: maine@*");
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(
             &repo_path,
             &["bookmark", "untrack", "main@origin", "glob:main@o*"],
-        ), @r###"
-    Error: No matching remote bookmarks for patterns: main@origin, main@o*
-    "###);
+        ), @"Error: No matching remote bookmarks for patterns: main@origin, main@o*");
 
     // Track already tracked bookmark
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "feature1@origin"]);
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "feature1@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Remote bookmark already tracked: feature1@origin
     Nothing changed.
-    "###);
+    ");
 
     // Untrack non-tracking bookmark
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "feature2@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Remote bookmark not tracked yet: feature2@origin
     Nothing changed.
-    "###);
+    ");
 
     // Untrack Git-tracking bookmark
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "main@git"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Git-tracking bookmark cannot be untracked: main@git
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: omvolwpu 1336caed commit
       @git: omvolwpu 1336caed commit
       @origin: omvolwpu 1336caed commit
     feature2@origin: omvolwpu 1336caed commit
     main: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
 
     // Untrack by pattern
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "glob:*@*"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Git-tracking bookmark cannot be untracked: feature1@git
     Warning: Remote bookmark not tracked yet: feature2@origin
     Warning: Git-tracking bookmark cannot be untracked: main@git
     Stopped tracking 1 remote bookmarks.
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: omvolwpu 1336caed commit
       @git: omvolwpu 1336caed commit
     feature1@origin: omvolwpu 1336caed commit
     feature2@origin: omvolwpu 1336caed commit
     main: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
 
     // Track by pattern
     let (_, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "glob:feature?@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Started tracking 2 remote bookmarks.
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Started tracking 2 remote bookmarks.");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: omvolwpu 1336caed commit
       @git: omvolwpu 1336caed commit
       @origin: omvolwpu 1336caed commit
@@ -1227,7 +1146,7 @@ fn test_bookmark_track_untrack_patterns() {
       @origin: omvolwpu 1336caed commit
     main: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -1276,20 +1195,18 @@ fn test_bookmark_list() {
     // Synchronized tracking remotes and non-tracking remotes aren't listed by
     // default
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: wqnwkozp 4e887f78 (empty) local-only
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
     remote-sync: zwtyzrop c761c7ea (empty) remote-sync
     remote-unsync: wqnwkozp 4e887f78 (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list", "--all-remotes"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: wqnwkozp 4e887f78 (empty) local-only
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
@@ -1298,10 +1215,8 @@ fn test_bookmark_list() {
     remote-unsync: wqnwkozp 4e887f78 (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
     remote-untrack@origin: vmortlor 71a16b05 (empty) remote-untrack
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     let template = r#"
     concat(
@@ -1321,7 +1236,7 @@ fn test_bookmark_list() {
         &local_path,
         &["bookmark", "list", "--all-remotes", "-T", template],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [local-only]
     present: true
     conflict: false
@@ -1402,10 +1317,8 @@ fn test_bookmark_list() {
     tracking_present: false
     tracking_ahead_count: <Error: Not a tracked remote ref>
     tracking_behind_count: <Error: Not a tracked remote ref>
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 }
 
 #[test]
@@ -1445,7 +1358,7 @@ fn test_bookmark_list_filtered() {
             &local_path,
             &["log", "-r::(bookmarks() | remote_bookmarks())", "-T", template],
         ),
-        @r#"
+        @r"
     @  c7b4c09cd77c local-keep
     │ ○  e31634b64294 remote-rewrite*
     ├─╯
@@ -1456,21 +1369,19 @@ fn test_bookmark_list_filtered() {
     │ ○  911e912015fb remote-keep
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     // All bookmarks are listed by default.
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     let query =
         |args: &[&str]| test_env.jj_cmd_ok(&local_path, &[&["bookmark", "list"], args].concat());
@@ -1481,81 +1392,79 @@ fn test_bookmark_list_filtered() {
     // "all()" doesn't include deleted bookmarks since they have no local targets.
     // So "all()" is identical to "bookmarks()".
     let (stdout, stderr) = query(&["-rall()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Exclude remote-only bookmarks. "remote-rewrite@origin" is included since
     // local "remote-rewrite" target matches.
     let (stdout, stderr) = query(&["-rbookmarks()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Select bookmarks by name.
     let (stdout, stderr) = query(&["remote-rewrite"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = query(&["-rbookmarks(remote-rewrite)"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Select bookmarks by name, combined with --all-remotes
     test_env.jj_cmd_ok(&local_path, &["git", "export"]);
     let (stdout, stderr) = query(&["--all-remotes", "remote-rewrite"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = query(&["--all-remotes", "-rbookmarks(remote-rewrite)"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Select bookmarks with --remote
     let (stdout, stderr) = query(&["--remote", "origin"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
       @origin: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "#);
-    insta::assert_snapshot!(stderr, @r#"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "#);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
     let (stdout, stderr) = query(&["--remote", "glob:gi?"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
       @git: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
       @git: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = query(&["--remote", "origin", "--remote", "git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
       @git: kpqxywon c7b4c09c (empty) local-keep
     remote-delete (deleted)
@@ -1566,23 +1475,18 @@ fn test_bookmark_list_filtered() {
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "#);
-    insta::assert_snapshot!(stderr, @r#"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "#);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     // Can select deleted bookmark by name pattern, but not by revset.
     let (stdout, stderr) = query(&["remote-delete"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
     let (stdout, stderr) = query(&["-rbookmarks(remote-delete)"]);
-    insta::assert_snapshot!(stdout, @r###"
-    "###);
+    insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(query_error(&["-rremote-delete"]), @r"
     Error: Revision `remote-delete` doesn't exist
     Hint: Did you mean `remote-delete@origin`, `remote-keep`, `remote-rewrite`, `remote-rewrite@origin`?
@@ -1591,30 +1495,26 @@ fn test_bookmark_list_filtered() {
 
     // Name patterns are OR-ed.
     let (stdout, stderr) = query(&["glob:*-keep", "remote-delete"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     // Unmatched name pattern shouldn't be an error. A warning can be added later.
     let (stdout, stderr) = query(&["local-keep", "glob:push-*"]);
-    insta::assert_snapshot!(stdout, @r###"
-    local-keep: kpqxywon c7b4c09c (empty) local-keep
-    "###);
+    insta::assert_snapshot!(stdout, @"local-keep: kpqxywon c7b4c09c (empty) local-keep");
     insta::assert_snapshot!(stderr, @"");
 
     // Name pattern and revset are OR-ed.
     let (stdout, stderr) = query(&["local-keep", "-rbookmarks(remote-rewrite)"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // … but still filtered by --remote
@@ -1624,12 +1524,12 @@ fn test_bookmark_list_filtered() {
         "--remote",
         "git",
     ]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
       @git: kpqxywon c7b4c09c (empty) local-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -1670,11 +1570,11 @@ fn test_bookmark_list_much_remote_divergence() {
     );
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: zkyosouw 4ab3f751 (empty) local-only
     remote-unsync: zkyosouw 4ab3f751 (empty) local-only
       @origin (ahead by at least 10 commits, behind by at least 10 commits): lxyktnks 19582022 (empty) remote-unsync
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -1768,7 +1668,7 @@ fn test_bookmark_list_tracked() {
     );
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list", "--all-remotes"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: nmzmmopx e1da745b (empty) local-only
       @git: nmzmmopx e1da745b (empty) local-only
     remote-delete (deleted)
@@ -1784,13 +1684,11 @@ fn test_bookmark_list_tracked() {
     upstream-sync: lolpmnqw 32fa6da0 (empty) upstream-sync
       @git: lolpmnqw 32fa6da0 (empty) upstream-sync
       @upstream: lolpmnqw 32fa6da0 (empty) upstream-sync
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list", "--tracked"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
     remote-sync: zwtyzrop c761c7ea (empty) remote-sync
@@ -1800,38 +1698,34 @@ fn test_bookmark_list_tracked() {
       @upstream (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
     upstream-sync: lolpmnqw 32fa6da0 (empty) upstream-sync
       @upstream: lolpmnqw 32fa6da0 (empty) upstream-sync
-    "###
+    "
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &local_path,
         &["bookmark", "list", "--tracked", "--remote", "origin"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
     remote-sync: zwtyzrop c761c7ea (empty) remote-sync
       @origin: zwtyzrop c761c7ea (empty) remote-sync
     remote-unsync: nmzmmopx e1da745b (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "#
+    "
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    insta::assert_snapshot!(stderr, @"Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &local_path,
         &["bookmark", "list", "--tracked", "remote-unsync"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-unsync: nmzmmopx e1da745b (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
       @upstream (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1850,10 +1744,10 @@ fn test_bookmark_list_tracked() {
         &local_path,
         &["bookmark", "list", "--tracked", "remote-unsync"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-unsync: nmzmmopx e1da745b (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -1883,17 +1777,17 @@ fn test_bookmark_list_conflicted() {
         ],
     );
     test_env.jj_cmd_ok(&repo_path, &["status"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     bar: kkmpptxz 06a973bc (empty) b
     foo (conflicted):
       + rlvkpnrz d8d5f980 (empty) a
       + kkmpptxz 06a973bc (empty) b
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["bookmark", "list", "--conflicted"]), @r###"
+    ");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["bookmark", "list", "--conflicted"]), @r"
     foo (conflicted):
       + rlvkpnrz d8d5f980 (empty) a
       + kkmpptxz 06a973bc (empty) b
-    "###);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -51,11 +51,11 @@ fn test_builtin_alias_trunk_matches_main() {
     let (test_env, workspace_root) = set_up("main");
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -63,11 +63,11 @@ fn test_builtin_alias_trunk_matches_master() {
     let (test_env, workspace_root) = set_up("master");
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 master d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -75,11 +75,11 @@ fn test_builtin_alias_trunk_matches_trunk() {
     let (test_env, workspace_root) = set_up("trunk");
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 trunk d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -90,11 +90,11 @@ fn test_builtin_alias_trunk_matches_exactly_one_commit() {
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "master"]);
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -106,11 +106,11 @@ fn test_builtin_alias_trunk_override_alias() {
     );
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 override-trunk d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -118,11 +118,8 @@ fn test_builtin_alias_trunk_no_match() {
     let (test_env, workspace_root) = set_up("no-match-trunk");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  zzzzzzzz root() 00000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  zzzzzzzz root() 00000000");
+    insta::assert_snapshot!(stderr, @"");
 }
 
 #[test]
@@ -130,11 +127,8 @@ fn test_builtin_alias_trunk_no_match_only_exact() {
     let (test_env, workspace_root) = set_up("maint");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  zzzzzzzz root() 00000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  zzzzzzzz root() 00000000");
+    insta::assert_snapshot!(stderr, @"");
 }
 
 #[test]
@@ -146,11 +140,11 @@ fn test_builtin_user_redefines_builtin_immutable_heads() {
     test_env.add_config(r#"revset-aliases.'immutable()' = '@'"#);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @r"
     Warning: Redefining `revset-aliases.builtin_immutable_heads()` is not recommended; redefine `immutable_heads()` instead
     Warning: Redefining `revset-aliases.mutable()` is not recommended; redefine `immutable_heads()` instead

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -25,11 +25,11 @@ fn test_commit_with_description_from_cli() {
 
     // Description applies to the current working-copy (not the new one)
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  e8ea92a8b6b3
     ○  fa15625b4a98 first
     ◆  000000000000
-    "###);
+    ");
 }
 
 #[test]
@@ -44,17 +44,17 @@ fn test_commit_with_editor() {
     let edit_script = test_env.set_up_fake_editor();
     std::fs::write(&edit_script, ["dump editor0", "write\nmodified"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  a57b2c95fb75
     ○  159271101e05 modified
     ◆  000000000000
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     initial
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Check that the editor content includes diff summary
     std::fs::write(workspace_path.join("file1"), "foo\n").unwrap();
@@ -63,7 +63,7 @@ fn test_commit_with_editor() {
     std::fs::write(&edit_script, "dump editor1").unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     add files
 
     JJ: This commit contains the following changes:
@@ -71,7 +71,7 @@ fn test_commit_with_editor() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]
@@ -112,23 +112,23 @@ fn test_commit_interactive() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-i"]);
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are splitting the working-copy commit: qpvuntsm 4219467e add files
 
     The diff initially shows all changes. Adjust the right side until it shows the
     contents you want for the first commit. The remainder will be included in the
     new working-copy commit.
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     add files
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Try again with --tool=<name>, which implies --interactive
     test_env.jj_cmd_ok(&workspace_path, &["undo"]);
@@ -142,14 +142,14 @@ fn test_commit_interactive() {
     );
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     add files
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["log", "--summary"]);
     insta::assert_snapshot!(stdout, @r"
@@ -235,13 +235,13 @@ fn test_commit_with_default_description() {
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  c65242099289
     ○  573b6df51aea TESTED=TODO
     ◆  000000000000
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     TESTED=TODO
 
     JJ: This commit contains the following changes:
@@ -249,7 +249,7 @@ fn test_commit_with_default_description() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]
@@ -288,7 +288,7 @@ fn test_commit_with_description_template() {
     // Only file1 should be included in the diff
     test_env.jj_cmd_ok(&workspace_path, &["commit", "file1"]);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Test User <test.user@example.com> (2001-02-03 08:05:08)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
 
@@ -296,7 +296,7 @@ fn test_commit_with_description_template() {
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Only file2 with modified author should be included in the diff
     test_env.jj_cmd_ok(
@@ -309,7 +309,7 @@ fn test_commit_with_description_template() {
         ],
     );
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Another User <another.user@example.com> (2001-02-03 08:05:08)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -317,12 +317,12 @@ fn test_commit_with_description_template() {
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Timestamp after the reset should be available to the template
     test_env.jj_cmd_ok(&workspace_path, &["commit", "--reset-author"]);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Test User <test.user@example.com> (2001-02-03 08:05:10)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:10)
 
@@ -330,7 +330,7 @@ fn test_commit_with_description_template() {
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]
@@ -341,9 +341,7 @@ fn test_commit_without_working_copy() {
 
     test_env.jj_cmd_ok(&workspace_path, &["workspace", "forget"]);
     let stderr = test_env.jj_cmd_failure(&workspace_path, &["commit", "-m=first"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: This command requires a working copy
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: This command requires a working copy");
 }
 
 #[test]
@@ -357,13 +355,13 @@ fn test_commit_paths() {
 
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first", "file1"]);
     let stdout = test_env.jj_cmd_success(&workspace_path, &["diff", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file1:
             1: foo
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file2:
             1: bar
     ");
@@ -379,20 +377,20 @@ fn test_commit_paths_warning() {
     std::fs::write(workspace_path.join("file2"), "bar\n").unwrap();
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first", "file3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: The given paths do not match any file: file3
     Working copy now at: rlvkpnrz d1872100 (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    ");
     insta::assert_snapshot!(stdout, @"");
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file1:
             1: foo
     Added regular file file2:
             1: bar
-    "###);
+    ");
 }
 
 #[test]
@@ -416,11 +414,11 @@ fn test_commit_reset_author() {
             ],
         )
     };
-    insta::assert_snapshot!(get_signatures(), @r###"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     ~
-    "###);
+    ");
 
     // Reset the author (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -433,11 +431,11 @@ fn test_commit_reset_author() {
             "-m1",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r###"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:09.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:09.000 +07:00
     ~
-    "###);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -30,7 +30,7 @@ fn test_log_parents() {
     let template =
         r#"commit_id ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|c| c.commit_id()) ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    c067170d4ca1bc6162b64f7550617ec809647f84
     ├─╮  P: 2 4db490c88528133d579540b6900b8098f0c17701 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ○ │  4db490c88528133d579540b6900b8098f0c17701
@@ -39,7 +39,7 @@ fn test_log_parents() {
     │  P: 1 0000000000000000000000000000000000000000
     ◆  0000000000000000000000000000000000000000
        P: 0
-    "###);
+    ");
 
     // List<Commit> can be filtered
     let template =
@@ -59,11 +59,11 @@ fn test_log_parents() {
         &repo_path,
         &["log", "-T", template, "-r@", "--color=always"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;4m4[0m[38;5;8mdb4[39m [1m[38;5;4m2[0m[38;5;8m30d[39m
     │
     ~
-    "###);
+    ");
 
     // Commit object isn't printable
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-T", "parents"]);
@@ -101,11 +101,11 @@ fn test_log_author_timestamp() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "second"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-03 04:05:09.000 +07:00
     ○  2001-02-03 04:05:08.000 +07:00
     ◆  1970-01-01 00:00:00.000 +00:00
-    "###);
+    ");
 }
 
 #[test]
@@ -133,10 +133,10 @@ fn test_log_author_timestamp_utc() {
     let repo_path = test_env.env_root().join("repo");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().utc()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-02 21:05:07.000 +00:00
     ◆  1970-01-01 00:00:00.000 +00:00
-    "###);
+    ");
 }
 
 #[cfg(unix)]
@@ -148,16 +148,16 @@ fn test_log_author_timestamp_local() {
 
     test_env.add_env_var("TZ", "UTC-05:30");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-03 08:05:07.000 +11:00
     ◆  1970-01-01 11:00:00.000 +11:00
-    "###);
+    ");
     test_env.add_env_var("TZ", "UTC+10:00");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-03 08:05:07.000 +11:00
     ◆  1970-01-01 11:00:00.000 +11:00
-    "###);
+    ");
 }
 
 #[test]
@@ -177,10 +177,10 @@ fn test_log_author_timestamp_after_before() {
       if(author.timestamp().before("now"), "(before now)", "(after now)")
     ) ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     2001-02-03 04:05:08.000 +07:00 : (after 1969) (after 1975) (before now)
     1970-01-01 00:00:00.000 +00:00 : (after 1969) (before 1975) (before now)
-    "#);
+    ");
 
     // Should display error with invalid date.
     let template = r#"author.timestamp().after("invalid date")"#;
@@ -220,11 +220,11 @@ fn test_mine_is_true_when_author_is_user() {
             r#"coalesce(if(mine, "mine"), author.email(), email_placeholder)"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  johndoe@example.com
     ○  mine
     ◆  (no email set)
-    "###);
+    ");
 }
 
 #[test]
@@ -240,33 +240,33 @@ fn test_log_default() {
 
     // Test default log output format
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-bookmark bac9ff9e
     │  (empty) description 1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aa2015d7
     │  add a file
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
     │  add a file
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    ");
 
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
     [1m[38;5;10m(empty)[39m description 1[0m
     [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
     add a file
     [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    ");
 }
 
 #[test]
@@ -277,9 +277,7 @@ fn test_log_default_without_working_copy() {
 
     test_env.jj_cmd_ok(&repo_path, &["workspace", "forget"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r#"
-    ◆  zzzzzzzz root() 00000000
-    "#);
+    insta::assert_snapshot!(stdout, @"◆  zzzzzzzz root() 00000000");
 }
 
 #[test]
@@ -298,23 +296,23 @@ fn test_log_builtin_templates() {
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
 
-    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
+    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r"
     rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark dc315397 (empty) (no description set)
     qpvuntsm test.user 2001-02-03 08:05:07 230dd059 (empty) (no description set)
     zzzzzzzz root() 00000000
     [EOF]
-    "###);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
+    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r"
     rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark dc315397
     (empty) (no description set)
     qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     (empty) (no description set)
     zzzzzzzz root() 00000000
     [EOF]
-    "###);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
+    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r"
     rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark dc315397
     (empty) (no description set)
 
@@ -324,9 +322,9 @@ fn test_log_builtin_templates() {
     zzzzzzzz root() 00000000
 
     [EOF]
-    "###);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r"
     Commit ID: dc31539712c7294d1d712cec63cef4504b94ca74
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Bookmarks: my-bookmark
@@ -350,7 +348,7 @@ fn test_log_builtin_templates() {
         (no description set)
 
     [EOF]
-    "#);
+    ");
 }
 
 #[test]
@@ -367,21 +365,21 @@ fn test_log_builtin_templates_colored() {
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
 
-    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     │
@@ -389,10 +387,9 @@ fn test_log_builtin_templates_colored() {
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     │
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    ");
 
-    "#);
-
-    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r"
     [1m[38;5;2m@[0m  Commit ID: [38;5;4mdc31539712c7294d1d712cec63cef4504b94ca74[39m
     │  Change ID: [38;5;5mrlvkpnrzqnoowoytxnquwvuryrwnrmlp[39m
     │  Bookmarks: [38;5;5mmy-bookmark[39m
@@ -414,7 +411,7 @@ fn test_log_builtin_templates_colored() {
        Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
 
        [38;5;2m    (no description set)[39m
-    "#);
+    ");
 }
 
 #[test]
@@ -431,21 +428,21 @@ fn test_log_builtin_templates_colored_debug() {
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "my-bookmark"]);
 
-    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy bookmarks name::my-bookmark>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
     <<node::○>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email local::test.user>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log:: >>[38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
     [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
-    "#);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy bookmarks name::my-bookmark>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
     │  [1m[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
     <<node::○>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email local::test.user>><<log author email::@>><<log author email domain::example.com>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log::>>
     │  [38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
     [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
-    "#);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy bookmarks name::my-bookmark>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
     │  [1m[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
     │  <<log::>>
@@ -454,9 +451,9 @@ fn test_log_builtin_templates_colored_debug() {
     │  <<log::>>
     [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
        <<log::>>
-    "#);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  <<log::Commit ID: >>[38;5;4m<<log commit_id::dc31539712c7294d1d712cec63cef4504b94ca74>>[39m<<log::>>
     │  <<log::Change ID: >>[38;5;5m<<log change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<log::>>
     │  <<log::Bookmarks: >>[38;5;5m<<log local_bookmarks name::my-bookmark>>[39m<<log::>>
@@ -479,7 +476,7 @@ fn test_log_builtin_templates_colored_debug() {
        <<log::>>
        [38;5;2m<<log empty description placeholder::    (no description set)>>[39m<<log::>>
        <<log::>>
-    "#);
+    ");
 }
 
 #[test]
@@ -492,11 +489,11 @@ fn test_log_evolog_divergence() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 1"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     // Create divergence
     test_env.jj_cmd_ok(
@@ -504,48 +501,46 @@ fn test_log_evolog_divergence() {
         &["describe", "-m", "description 2", "--at-operation", "@-"],
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
     │ ○  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 6ba70e00
     ├─╯  description 2
     ◆  zzzzzzzz root() 00000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Concurrent modification detected, resolving automatically.");
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     │  [1mdescription 1[0m
     │ ○  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m6[0m[38;5;8mba70e00[39m
     ├─╯  description 2
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    ");
 
     // Evolog and hidden divergent
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 485d52a9
     │  (no description set)
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
-    "###);
+    ");
 
     // Colored evolog
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     │  [1mdescription 1[0m
     ○  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m85d52a9[39m
     │  [38;5;3m(no description set)[39m
     ○  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    "###);
+    ");
 }
 
 #[test]
@@ -600,7 +595,7 @@ fn test_log_bookmarks() {
 
     let template = r#"commit_id.short() ++ " " ++ if(bookmarks, bookmarks, "(no bookmarks)")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     @  a5b4d15489cc bookmark2* new-bookmark
     ○  8476341eb395 bookmark2@origin unchanged
     │ ○  fed794e2ba44 bookmark3?? bookmark3@origin
@@ -610,11 +605,11 @@ fn test_log_bookmarks() {
     │ ○  4a7e4246fc4d bookmark1*
     ├─╯
     ◆  000000000000 (no bookmarks)
-    "#);
+    ");
 
     let template = r#"bookmarks.map(|b| separate("/", b.remote(), b.name())).join(", ")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     @  bookmark2, new-bookmark
     ○  origin/bookmark2, unchanged
     │ ○  bookmark3, origin/bookmark3
@@ -624,11 +619,11 @@ fn test_log_bookmarks() {
     │ ○  bookmark1
     ├─╯
     ◆
-    "#);
+    ");
 
     let template = r#"separate(" ", "L:", local_bookmarks, "R:", remote_bookmarks)"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     @  L: bookmark2* new-bookmark R:
     ○  L: unchanged R: bookmark2@origin unchanged@origin
     │ ○  L: bookmark3?? R: bookmark3@origin
@@ -638,7 +633,7 @@ fn test_log_bookmarks() {
     │ ○  L: bookmark1* R:
     ├─╯
     ◆  L: R:
-    "#);
+    ");
 
     let template = r#"
     remote_bookmarks.map(|ref| concat(
@@ -652,14 +647,14 @@ fn test_log_bookmarks() {
         &workspace_root,
         &["log", "-r::remote_bookmarks()", "-T", template],
     );
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ○  bookmark3@origin(+0/-1)
     │ ○  bookmark2@origin(+0/-1) unchanged@origin(+0/-0)
     ├─╯
     │ ○  bookmark1@origin(+1/-1)
     ├─╯
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -673,20 +668,20 @@ fn test_log_git_head() {
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "git_head"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  false
     ○  true
     ◆  false
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
     │  [1minitial[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [38;5;2mgit_head()[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    ");
 }
 
 #[test]
@@ -706,12 +701,12 @@ fn test_log_commit_id_normal_hex() {
             r#"commit_id ++ ": " ++ commit_id.normal_hex()"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  6572f22267c6f0f2bf7b8a37969ee5a7d54b8aae: 6572f22267c6f0f2bf7b8a37969ee5a7d54b8aae
     ○  222fa9f0b41347630a1371203b8aad3897d34e5f: 222fa9f0b41347630a1371203b8aad3897d34e5f
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22: 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000: 0000000000000000000000000000000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -731,12 +726,12 @@ fn test_log_change_id_normal_hex() {
             r#"change_id ++ ": " ++ change_id.normal_hex()"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  kkmpptxzrspxrzommnulwmwkkqwworpl: ffdaa62087a280bddc5e3d3ff933b8ae
     ○  rlvkpnrzqnoowoytxnquwvuryrwnrmlp: 8e4fac809cbb3b162c953458183c8dea
     ○  qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu: 9a45c67d3e96a7e5007c110ede34dec5
     ◆  zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz: 00000000000000000000000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -757,11 +752,11 @@ fn test_log_customize_short_id() {
             &format!(r#"{decl}='id.shortest(5).prefix().upper() ++ "_" ++ id.shortest(5).rest()'"#),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  Q_pvun test.user@example.com 2001-02-03 08:05:08 F_a156
     │  (empty) first
     ◆  Z_zzzz root() 0_0000
-    "###);
+    ");
 
     // Customize only the change id
     let stdout = test_env.jj_cmd_success(
@@ -771,11 +766,11 @@ fn test_log_customize_short_id() {
             "--config=template-aliases.'format_short_change_id(id)'='format_short_id(id).upper()'",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  QPVUNTSM test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
     ◆  ZZZZZZZZ root() 00000000
-    "###);
+    ");
 }
 
 #[test]
@@ -799,14 +794,14 @@ fn test_log_immutable() {
 
     test_env.add_config("revset-aliases.'immutable_heads()' = 'main'");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r::", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  D
     │ ○  C
     │ ◆  B main [immutable]
     │ ◆  A [immutable]
     ├─╯
     ◆  [immutable]
-    "###);
+    ");
 
     // Suppress error that could be detected earlier
     test_env.add_config("revsets.short-prefixes = ''");
@@ -871,14 +866,14 @@ fn test_log_contained_in() {
             &template_for_revset(r#"description(A)::"#),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  D
     │ ○  C [contained_in]
     │ ○  B main [contained_in]
     │ ○  A [contained_in]
     ├─╯
     ◆
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -889,14 +884,14 @@ fn test_log_contained_in() {
             &template_for_revset(r#"visible_heads()"#),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  D [contained_in]
     │ ○  C [contained_in]
     │ ○  B main
     │ ○  A
     ├─╯
     ◆
-    "###);
+    ");
 
     // Suppress error that could be detected earlier
     let stderr = test_env.jj_cmd_failure(
@@ -1000,13 +995,11 @@ fn test_short_prefix_in_transaction() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["new", parent_id, "--no-edit", "-m", "test"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Created new commit km[kuslswpqwq] 7[4ac55dd119b] test
-    "###);
+    insta::assert_snapshot!(stderr, @"Created new commit km[kuslswpqwq] 7[4ac55dd119b] test");
 
     // Should match log's short prefixes
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     km[kuslswpqwq] 7[4ac55dd119b] test
     y[qosqzytrlsw] 5[8731db5875e] commit4
     r[oyxmykxtrkr] 9[95cc897bca7] commit3
@@ -1015,12 +1008,12 @@ fn test_short_prefix_in_transaction() {
     kk[mpptxzrspx] 05[2755155952] commit0
     q[pvuntsmwlqt] e[0e22b9fae75] initial
     zz[zzzzzzzzzz] 00[0000000000]
-    "###);
+    ");
 
     test_env.add_config(r#"revsets.short-prefixes = """#);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     kmk[uslswpqwq] 74ac[55dd119b] test
     yq[osqzytrlsw] 587[31db5875e] commit4
     ro[yxmykxtrkr] 99[5cc897bca7] commit3
@@ -1029,7 +1022,7 @@ fn test_short_prefix_in_transaction() {
     kk[mpptxzrspx] 052[755155952] commit0
     qp[vuntsmwlqt] e0[e22b9fae75] initial
     zz[zzzzzzzzzz] 00[0000000000]
-    "###);
+    ");
 }
 
 #[test]
@@ -1068,7 +1061,7 @@ fn test_log_diff_predefined_formats() {
         &repo_path,
         &["log", "--no-graph", "--color=always", "-r@", "-T", template],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === color_words ===
     [38;5;3mModified regular file file1:[39m
     [38;5;1m   1[39m [38;5;2m   1[39m: a
@@ -1107,14 +1100,14 @@ fn test_log_diff_predefined_formats() {
     [38;5;6mM file1[39m
     [38;5;6mM file2[39m
     [38;5;6mR {rename-source => rename-target}[39m
-    "###);
+    ");
 
     // color labels
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "--no-graph", "--color=debug", "-r@", "-T", template],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<log::=== color_words ===>>
     [38;5;3m<<log diff color_words header::Modified regular file file1:>>[39m
     [38;5;1m<<log diff color_words removed line_number::   1>>[39m<<log diff color_words:: >>[38;5;2m<<log diff color_words added line_number::   1>>[39m<<log diff color_words::: a>>
@@ -1153,14 +1146,14 @@ fn test_log_diff_predefined_formats() {
     [38;5;6m<<log diff summary modified::M file1>>[39m
     [38;5;6m<<log diff summary modified::M file2>>[39m
     [38;5;6m<<log diff summary renamed::R {rename-source => rename-target}>>[39m
-    "###);
+    ");
 
     // cwd != workspace root
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["log", "-Rrepo", "--no-graph", "-r@", "-T", template],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     === color_words ===
     Modified regular file repo/file1:
        1    1: a
@@ -1199,7 +1192,7 @@ fn test_log_diff_predefined_formats() {
     M repo/file1
     M repo/file2
     R repo/{rename-source => rename-target}
-    "###);
+    ");
 
     // with non-default config
     std::fs::write(
@@ -1294,16 +1287,16 @@ fn test_log_diff_predefined_formats() {
     // color_words() with parameters
     let template = "self.diff('file1').color_words(0)";
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
         ...
             3: c
-    "###);
+    ");
 
     // git() with parameters
     let template = "self.diff('file1').git(1)";
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 422c2b7ab3..de980441c3 100644
     --- a/file1
@@ -1311,7 +1304,7 @@ fn test_log_diff_predefined_formats() {
     @@ -2,1 +2,2 @@
      b
     +c
-    "###);
+    ");
 
     // custom template with files()
     let template = indoc! {r#"
@@ -1472,13 +1465,13 @@ fn test_signature_templates() {
 
     // show that signatures can render
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  good test-display signature
     ○  no signature
     ◆  no signature
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"good test-display signature"#);
+    insta::assert_snapshot!(stdout, @"good test-display signature");
 
     // builtin templates
     test_env.add_config("ui.show-cryptographic-signatures = true");
@@ -1486,24 +1479,24 @@ fn test_signature_templates() {
     let args: &[_] = &["log", "-r", "..", "-T"];
 
     let stdout = test_env.jj_cmd_success(&repo_path, &[args, &["builtin_log_oneline"]].concat());
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user 2001-02-03 08:05:09 a0909ee9 [✓︎] (empty) signed
     ○  qpvuntsm test.user 2001-02-03 08:05:08 879d5d20 (empty) unsigned
     │
     ~
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &[args, &["builtin_log_compact"]].concat());
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a0909ee9 [✓︎]
     │  (empty) signed
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 879d5d20
     │  (empty) unsigned
     ~
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &[args, &["builtin_log_detailed"]].concat());
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  Commit ID: a0909ee96bb5c66311a0c579dc8ebed4456dfc1b
     │  Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     │  Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -1519,7 +1512,7 @@ fn test_signature_templates() {
        Signature: (no signature)
 
            unsigned
-    "#);
+    ");
 
     // customization point
     let config_val = r#"template-aliases."format_short_cryptographic_signature(signature)"="'status: ' ++ signature.status()""#;
@@ -1527,10 +1520,10 @@ fn test_signature_templates() {
         &repo_path,
         &[args, &["builtin_log_oneline", "--config", config_val]].concat(),
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user 2001-02-03 08:05:09 a0909ee9 status: good (empty) signed
     ○  qpvuntsm test.user 2001-02-03 08:05:08 879d5d20 status: <Error: No CryptographicSignature available> (empty) unsigned
     │
     ~
-    "#);
+    ");
 }

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -263,37 +263,37 @@ fn test_remote_names() {
         test_env.env_root(),
         &["--", "jj", "git", "remote", "remove", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @"origin");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "remote", "rename", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @"origin");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "remote", "set-url", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @"origin");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "push", "--remote", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @"origin");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "fetch", "--remote", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @"origin");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "bookmark", "list", "--remote", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @"origin");
 }
 
 #[test]
@@ -717,7 +717,7 @@ fn test_files() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "--summary"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     @  wqnwkozp test.user@example.com 2001-02-03 08:05:20 working_copy 45c3a621
     │  working_copy
     │  A f_added_2
@@ -753,7 +753,7 @@ fn test_files() {
     │    A f_interdiff_only_from
     │    A f_interdiff_same
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     let mut test_env = test_env;
     test_env.add_env_var("COMPLETE", "fish");
@@ -887,5 +887,5 @@ fn test_files() {
 
     let outside_repo = test_env.env_root();
     let stdout = test_env.jj_cmd_success(outside_repo, &["--", "jj", "log", "f_"]);
-    insta::assert_snapshot!(stdout, @r"");
+    insta::assert_snapshot!(stdout, @"");
 }

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -39,26 +39,24 @@ fn test_concurrent_operation_divergence() {
 
     // "op log --at-op" should work without merging the head operations
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--at-op=d74dff64472e"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  d74dff64472e test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'message 2' --at-op @-
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  message 1
     │ ○  message 2
     ├─╯
     ◆
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Concurrent modification detected, resolving automatically.");
 }
 
 #[test]
@@ -70,7 +68,7 @@ fn test_concurrent_operations_auto_rebase() {
     std::fs::write(repo_path.join("file"), "contents").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  c62ace5c0522 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
@@ -80,7 +78,7 @@ fn test_concurrent_operations_auto_rebase() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
     let op_id_hex = stdout[3..15].to_string();
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "rewritten"]);
@@ -91,15 +89,15 @@ fn test_concurrent_operations_auto_rebase() {
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  db141860e12c2d5591c56fde4fc99caf71cec418 new child
     @  07c3641e495cce57ea4ca789123b52f421c57aa2 rewritten
     ◆  0000000000000000000000000000000000000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    "###);
+    ");
 }
 
 #[test]
@@ -125,18 +123,16 @@ fn test_concurrent_operations_wc_modified() {
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  4eadcf3df11f46ef3d825c776496221cc8303053 new child1
     │ ○  68119f1643b7e3c301c5f7c2b6c9bf4ccba87379 new child2
     ├─╯
     ○  2ff7ae858a3a11837fdf9d1a76be295ef53f1bb3 initial
     ◆  0000000000000000000000000000000000000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Concurrent modification detected, resolving automatically.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file b/file
     index 12f00e90b6..2e0996000b 100644
     --- a/file
@@ -144,11 +140,11 @@ fn test_concurrent_operations_wc_modified() {
     @@ -1,1 +1,1 @@
     -contents
     +modified
-    "###);
+    ");
 
     // The working copy should be committed after merging the operations
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  snapshot working copy
     ○    reconcile divergent operations
     ├─╮
@@ -159,7 +155,7 @@ fn test_concurrent_operations_wc_modified() {
     ○  snapshot working copy
     ○  add workspace 'default'
     ○
-    "#);
+    ");
 }
 
 #[test]
@@ -182,7 +178,7 @@ fn test_concurrent_snapshot_wc_reloadable() {
 
     let template = r#"id ++ "\n" ++ description ++ "\n" ++ tags"#;
     let op_log_stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template]);
-    insta::assert_snapshot!(op_log_stdout, @r#"
+    insta::assert_snapshot!(op_log_stdout, @r"
     @  ec6bf266624bbaed55833a34ae62fa95c0e9efa651b94eb28846972da645845052dcdc8580332a5628849f23f48b9e99fc728dc3fb13106df8d0666d746f8b85
     │  commit 554d22b2c43c1c47e279430197363e8daabe2fd6
     │  args: jj commit -m 'new child1'
@@ -198,8 +194,7 @@ fn test_concurrent_snapshot_wc_reloadable() {
     ○  eac759b9ab75793fd3da96e60939fb48f2cd2b2a9c1f13ffe723cf620f3005b8d3e7e923634a07ea39513e4f2f360c87b9ad5d331cf90d7a844864b83b72eba1
     │  add workspace 'default'
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-
-    "#);
+    ");
     let op_log_lines = op_log_stdout.lines().collect_vec();
     let current_op_id = op_log_lines[0].split_once("  ").unwrap().1;
     let previous_op_id = op_log_lines[6].split_once("  ").unwrap().1;
@@ -214,16 +209,16 @@ fn test_concurrent_snapshot_wc_reloadable() {
     std::fs::write(repo_path.join("child2"), "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "new child2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 1795621b new child2
     Parent commit      : rlvkpnrz 86f54245 new child1
-    "###);
+    ");
 
     // Since the repo can be reloaded before snapshotting, "child2" should be
     // a child of "child1", not of "initial".
     let template = r#"commit_id ++ " " ++ description"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template, "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  1795621b54f4ebb435978b65d66bc0f90d8f20b6 new child2
     │  A child2
     ○  86f54245e13f850f8275b5541e56da996b6a47b7 new child1
@@ -231,7 +226,7 @@ fn test_concurrent_snapshot_wc_reloadable() {
     ○  84f07f6bca2ffeddac84a8b09f60c6b81112375c initial
     │  A base
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 }
 
 fn get_log_output_with_stderr(test_env: &TestEnvironment, cwd: &Path) -> (String, String) {

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -36,17 +36,13 @@ fn test_config_list_single() {
         test_env.env_root(),
         &["config", "list", "test-table.somekey"],
     );
-    insta::assert_snapshot!(stdout, @r###"
-    test-table.somekey = "some value"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"test-table.somekey = "some value""#);
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["config", "list", r#"-Tname ++ "\n""#, "test-table.somekey"],
     );
-    insta::assert_snapshot!(stdout, @r###"
-    test-table.somekey
-    "###);
+    insta::assert_snapshot!(stdout, @"test-table.somekey");
 }
 
 #[test]
@@ -57,9 +53,7 @@ fn test_config_list_nonexistent() {
         &["config", "list", "nonexistent-test-key"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: No matching config key for nonexistent-test-key
-    "###);
+    insta::assert_snapshot!(stderr, @"Warning: No matching config key for nonexistent-test-key");
 }
 
 #[test]
@@ -77,12 +71,12 @@ fn test_config_list_table() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "test-table"]);
     insta::assert_snapshot!(
         stdout,
-        @r###"
+        @r#"
     test-table.x = true
     test-table.y.foo = "abc"
     test-table.y.bar = 123
     test-table.z."with space"."function()" = 5
-    "###);
+    "#);
 }
 
 #[test]
@@ -113,9 +107,7 @@ fn test_config_list_array() {
     "#,
     );
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "test-array"]);
-    insta::assert_snapshot!(stdout, @r###"
-    test-array = [1, "b", 3.4]
-    "###);
+    insta::assert_snapshot!(stdout, @r#"test-array = [1, "b", 3.4]"#);
 }
 
 #[test]
@@ -132,9 +124,7 @@ fn test_config_list_array_of_tables() {
     );
     // Array is a value, so is array of tables
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "test-table"]);
-    insta::assert_snapshot!(stdout, @r###"
-    test-table = [{ x = 1 }, { y = ["z"], z = { "key=with whitespace" = [] } }]
-    "###);
+    insta::assert_snapshot!(stdout, @r#"test-table = [{ x = 1 }, { y = ["z"], z = { "key=with whitespace" = [] } }]"#);
 }
 
 #[test]
@@ -153,12 +143,12 @@ fn test_config_list_all() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list"]);
     insta::assert_snapshot!(
         find_stdout_lines(r"(test-val|test-table\b[^=]*)", &stdout),
-        @r###"
+        @r#"
     test-val = [1, 2, 3]
     test-table.x = true
     test-table.y.foo = "abc"
     test-table.y.bar = 123
-    "###);
+    "#);
 }
 
 #[test]
@@ -227,10 +217,10 @@ fn test_config_list_layer() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", "--user"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     test-key = "test-val"
     test-layered-key = "test-original-val"
-    "###);
+    "#);
 
     // Repo
     test_env.jj_cmd_ok(
@@ -245,14 +235,10 @@ fn test_config_list_layer() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", "--user"]);
-    insta::assert_snapshot!(stdout, @r###"
-    test-key = "test-val"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"test-key = "test-val""#);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", "--repo"]);
-    insta::assert_snapshot!(stdout, @r###"
-    test-layered-key = "test-layered-val"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"test-layered-key = "test-layered-val""#);
 }
 
 #[test]
@@ -267,9 +253,7 @@ fn test_config_layer_override_default() {
         &repo_path,
         &["config", "list", config_key, "--include-defaults"],
     );
-    insta::assert_snapshot!(stdout, @r###"
-    merge-tools.vimdiff.program = "vim"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"merge-tools.vimdiff.program = "vim""#);
 
     // User
     test_env.add_config(format!(
@@ -277,9 +261,7 @@ fn test_config_layer_override_default() {
         value = to_toml_value("user")
     ));
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    merge-tools.vimdiff.program = "user"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"merge-tools.vimdiff.program = "user""#);
 
     // Repo
     std::fs::write(
@@ -288,9 +270,7 @@ fn test_config_layer_override_default() {
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    merge-tools.vimdiff.program = "repo"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"merge-tools.vimdiff.program = "repo""#);
 
     // Command argument
     let stdout = test_env.jj_cmd_success(
@@ -303,9 +283,7 @@ fn test_config_layer_override_default() {
             &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
-    merge-tools.vimdiff.program = "command-arg"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"merge-tools.vimdiff.program = "command-arg""#);
 
     // Allow printing overridden values
     let stdout = test_env.jj_cmd_success(
@@ -319,11 +297,11 @@ fn test_config_layer_override_default() {
             &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r##"
     # merge-tools.vimdiff.program = "user"
     # merge-tools.vimdiff.program = "repo"
     merge-tools.vimdiff.program = "command-arg"
-    "###);
+    "##);
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -335,10 +313,10 @@ fn test_config_layer_override_default() {
             "--include-overridden",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     [38;5;8m# merge-tools.vimdiff.program = "user"[39m
     [38;5;2mmerge-tools.vimdiff.program[39m = [38;5;3m"repo"[39m
-    "###);
+    "#);
 }
 
 #[test]
@@ -351,9 +329,7 @@ fn test_config_layer_override_env() {
     // Environment base
     test_env.add_env_var("EDITOR", "env-base");
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    ui.editor = "env-base"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"ui.editor = "env-base""#);
 
     // User
     test_env.add_config(format!(
@@ -361,9 +337,7 @@ fn test_config_layer_override_env() {
         value = to_toml_value("user")
     ));
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    ui.editor = "user"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"ui.editor = "user""#);
 
     // Repo
     std::fs::write(
@@ -372,16 +346,12 @@ fn test_config_layer_override_env() {
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    ui.editor = "repo"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"ui.editor = "repo""#);
 
     // Environment override
     test_env.add_env_var("JJ_EDITOR", "env-override");
     let stdout = test_env.jj_cmd_success(&repo_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    ui.editor = "env-override"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"ui.editor = "env-override""#);
 
     // Command argument
     let stdout = test_env.jj_cmd_success(
@@ -394,9 +364,7 @@ fn test_config_layer_override_env() {
             &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
-    ui.editor = "command-arg"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"ui.editor = "command-arg""#);
 
     // Allow printing overridden values
     let stdout = test_env.jj_cmd_success(
@@ -410,13 +378,13 @@ fn test_config_layer_override_env() {
             &format!("{config_key}={value}", value = to_toml_value("command-arg")),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r##"
     # ui.editor = "env-base"
     # ui.editor = "user"
     # ui.editor = "repo"
     # ui.editor = "env-override"
     ui.editor = "command-arg"
-    "###);
+    "##);
 }
 
 #[test]
@@ -444,20 +412,16 @@ fn test_config_layer_workspace() {
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&main_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    ui.editor = "main-repo"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"ui.editor = "main-repo""#);
     let stdout = test_env.jj_cmd_success(&secondary_path, &["config", "list", config_key]);
-    insta::assert_snapshot!(stdout, @r###"
-    ui.editor = "main-repo"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"ui.editor = "main-repo""#);
 }
 
 #[test]
 fn test_config_set_bad_opts() {
     let test_env = TestEnvironment::default();
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["config", "set"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <--user|--repo>
       <NAME>
@@ -466,11 +430,11 @@ fn test_config_set_bad_opts() {
     Usage: jj config set <--user|--repo> <NAME> <VALUE>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     let stderr =
         test_env.jj_cmd_cli_error(test_env.env_root(), &["config", "set", "--user", "", "x"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value '' for '<NAME>': TOML parse error at line 1, column 1
       |
     1 | 
@@ -479,7 +443,7 @@ fn test_config_set_bad_opts() {
 
 
     For more information, try '--help'.
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(
         test_env.env_root(),
@@ -584,12 +548,12 @@ fn test_config_set_for_repo() {
                 expected_repo_config_path.display()
             )
         });
-    insta::assert_snapshot!(repo_config_toml, @r###"
+    insta::assert_snapshot!(repo_config_toml, @r#"
     test-key = "test-val"
 
     [test-table]
     foo = true
-    "###);
+    "#);
 }
 
 #[test]
@@ -610,7 +574,7 @@ fn test_config_set_toml_types() {
     set_value("test-table.boolean", "true");
     set_value("test-table.string", r#""foo""#);
     set_value("test-table.invalid", r"a + b");
-    insta::assert_snapshot!(std::fs::read_to_string(&user_config_path).unwrap(), @r###"
+    insta::assert_snapshot!(std::fs::read_to_string(&user_config_path).unwrap(), @r#"
     [test-table]
     integer = 42
     float = 3.14
@@ -618,7 +582,7 @@ fn test_config_set_toml_types() {
     boolean = true
     string = "foo"
     invalid = "a + b"
-    "###);
+    "#);
 }
 
 #[test]
@@ -774,9 +738,7 @@ fn test_config_unset_for_user() {
     test_env.jj_cmd_ok(&repo_path, &["config", "unset", "--user", "table.inline"]);
 
     let user_config_toml = std::fs::read_to_string(&user_config_path).unwrap();
-    insta::assert_snapshot!(user_config_toml, @r#"
-        [table]
-        "#);
+    insta::assert_snapshot!(user_config_toml, @"[table]");
 }
 
 #[test]
@@ -800,14 +762,14 @@ fn test_config_unset_for_repo() {
 fn test_config_edit_missing_opt() {
     let test_env = TestEnvironment::default();
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["config", "edit"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <--user|--repo>
 
     Usage: jj config edit <--user|--repo>
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -928,14 +890,10 @@ fn test_config_get() {
     ");
 
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "get", "table.string"]);
-    insta::assert_snapshot!(stdout, @r###"
-    some value 1
-    "###);
+    insta::assert_snapshot!(stdout, @"some value 1");
 
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "get", "table.int"]);
-    insta::assert_snapshot!(stdout, @r###"
-    123
-    "###);
+    insta::assert_snapshot!(stdout, @"123");
 
     let stdout = test_env.jj_cmd_failure(test_env.env_root(), &["config", "get", "table.list"]);
     insta::assert_snapshot!(stdout, @r"
@@ -973,34 +931,24 @@ fn test_config_path_syntax() {
     );
 
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "a.'b()'"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a.'b()' = 0
-    "###);
+    insta::assert_snapshot!(stdout, @"a.'b()' = 0");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "'b c'"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     'b c'.d = 1
     'b c'.e."f[]" = 2
-    "###);
+    "#);
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "'b c'.d"]);
-    insta::assert_snapshot!(stdout, @r###"
-    'b c'.d = 1
-    "###);
+    insta::assert_snapshot!(stdout, @"'b c'.d = 1");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "'b c'.e.'f[]'"]);
-    insta::assert_snapshot!(stdout, @r###"
-    'b c'.e.'f[]' = 2
-    "###);
+    insta::assert_snapshot!(stdout, @"'b c'.e.'f[]' = 2");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "get", "'b c'.e.'f[]'"]);
-    insta::assert_snapshot!(stdout, @r###"
-    2
-    "###);
+    insta::assert_snapshot!(stdout, @"2");
 
     // Not a table
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["config", "list", "a.'b()'.x"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: No matching config key for a.'b()'.x
-    "###);
+    insta::assert_snapshot!(stderr, @"Warning: No matching config key for a.'b()'.x");
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["config", "get", "a.'b()'.x"]);
     insta::assert_snapshot!(stderr, @r"
     Config error: Value not found for a.'b()'.x
@@ -1009,25 +957,17 @@ fn test_config_path_syntax() {
 
     // "-" and "_" are valid TOML keys
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "-"]);
-    insta::assert_snapshot!(stdout, @r###"
-    - = 3
-    "###);
+    insta::assert_snapshot!(stdout, @"- = 3");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "_"]);
-    insta::assert_snapshot!(stdout, @r###"
-    _ = 4
-    "###);
+    insta::assert_snapshot!(stdout, @"_ = 4");
 
     // "." requires quoting
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "'.'"]);
-    insta::assert_snapshot!(stdout, @r###"
-    '.' = 5
-    "###);
+    insta::assert_snapshot!(stdout, @"'.' = 5");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "get", "'.'"]);
-    insta::assert_snapshot!(stdout, @r###"
-    5
-    "###);
+    insta::assert_snapshot!(stdout, @"5");
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["config", "get", "."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value '.' for '<NAME>': TOML parse error at line 1, column 1
       |
     1 | .
@@ -1036,11 +976,11 @@ fn test_config_path_syntax() {
 
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Invalid TOML keys
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["config", "list", "b c"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value 'b c' for '[NAME]': TOML parse error at line 1, column 3
       |
     1 | b c
@@ -1049,9 +989,9 @@ fn test_config_path_syntax() {
 
 
     For more information, try '--help'.
-    "###);
+    ");
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["config", "list", ""]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value '' for '[NAME]': TOML parse error at line 1, column 1
       |
     1 | 
@@ -1060,7 +1000,7 @@ fn test_config_path_syntax() {
 
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -1113,31 +1053,31 @@ fn test_config_conditional() {
     let stdout = test_env.jj_cmd_success(&repo1_path, &["config", "get", "qux"]);
     insta::assert_snapshot!(stdout, @"get");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list", "--user"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     foo = 'global'
     baz = 'config'
     qux = 'list'
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo1_path, &["config", "list", "--user"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     foo = 'repo1'
     baz = 'config'
     qux = 'list'
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo2_path, &["config", "list", "--user"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     foo = 'repo2'
     baz = 'config'
     qux = 'list'
-    "#);
+    ");
 
     // relative workspace path
     let stdout = test_env.jj_cmd_success(&repo2_path, &["config", "list", "--user", "-R../repo1"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     foo = 'repo1'
     baz = 'config'
     qux = 'list'
-    "#);
+    ");
 
     // set and unset should refer to the source config
     // (there's no option to update scoped table right now.)
@@ -1256,11 +1196,11 @@ fn test_config_author_change_warning() {
         &["config", "set", "--repo", "user.email", "'Foo'"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Warning: This setting will only impact future commits.
     The author of the working copy will stay "Test User <test.user@example.com>".
     To change the working copy author, use "jj describe --reset-author --no-edit"
-    "###);
+    "#);
 
     // test_env.jj_cmd resets state for every invocation
     // for this test, the state (user.email) is needed

--- a/cli/tests/test_copy_detection.rs
+++ b/cli/tests/test_copy_detection.rs
@@ -28,7 +28,5 @@ fn test_simple_rename() {
     std::fs::write(repo_path.join("modified"), "original").unwrap();
     std::fs::write(repo_path.join("something"), "changed").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["debug", "copy-detection"]).replace('\\', "/"),
-    @r###"
-    original -> modified
-    "###);
+    @"original -> modified");
 }

--- a/cli/tests/test_debug_command.rs
+++ b/cli/tests/test_debug_command.rs
@@ -24,16 +24,16 @@ fn test_debug_fileset() {
     let workspace_path = test_env.env_root().join("repo");
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "fileset", "all()"]);
-    assert_snapshot!(stdout, @r###"
+    assert_snapshot!(stdout, @r"
     -- Parsed:
     All
 
     -- Matcher:
     EverythingMatcher
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&workspace_path, &["debug", "fileset", "cwd:.."]);
-    assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -44,7 +44,7 @@ fn test_debug_fileset() {
       = Invalid file pattern
     2: Path ".." is not in the repo "."
     3: Invalid component ".." in repo-relative path "../"
-    "###);
+    "#);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_debug_index() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let workspace_path = test_env.env_root().join("repo");
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "index"]);
-    assert_snapshot!(filter_index_stats(&stdout), @r###"
+    assert_snapshot!(filter_index_stats(&stdout), @r"
     Number of commits: 2
     Number of merges: 0
     Max generation number: 1
@@ -99,7 +99,7 @@ fn test_debug_index() {
       Level 0:
         Number of commits: 2
         Name: [hash]
-    "###
+    "
     );
 }
 
@@ -111,7 +111,7 @@ fn test_debug_reindex() {
     test_env.jj_cmd_ok(&workspace_path, &["new"]);
     test_env.jj_cmd_ok(&workspace_path, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "index"]);
-    assert_snapshot!(filter_index_stats(&stdout), @r###"
+    assert_snapshot!(filter_index_stats(&stdout), @r"
     Number of commits: 4
     Number of merges: 0
     Max generation number: 3
@@ -124,15 +124,13 @@ fn test_debug_reindex() {
       Level 1:
         Number of commits: 1
         Name: [hash]
-    "###
+    "
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["debug", "reindex"]);
     assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Finished indexing 4 commits.
-    "###);
+    insta::assert_snapshot!(stderr, @"Finished indexing 4 commits.");
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "index"]);
-    assert_snapshot!(filter_index_stats(&stdout), @r###"
+    assert_snapshot!(filter_index_stats(&stdout), @r"
     Number of commits: 4
     Number of merges: 0
     Max generation number: 3
@@ -142,7 +140,7 @@ fn test_debug_reindex() {
       Level 0:
         Number of commits: 4
         Name: [hash]
-    "###
+    "
     );
 }
 
@@ -159,24 +157,20 @@ fn test_debug_tree() {
 
     // Defaults to showing the tree at the current commit
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "tree"]);
-    assert_snapshot!(stdout.replace('\\',"/"), @r###"
+    assert_snapshot!(stdout.replace('\\',"/"), @r#"
     dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    "#
     );
 
     // Can show the tree at another commit
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "tree", "-r@-"]);
-    assert_snapshot!(stdout.replace('\\',"/"), @r###"
-    dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
-    "###
+    assert_snapshot!(stdout.replace('\\',"/"), @r#"dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))"#
     );
 
     // Can filter by paths
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "tree", "dir/subdir/file2"]);
-    assert_snapshot!(stdout.replace('\\',"/"), @r###"
-    dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    assert_snapshot!(stdout.replace('\\',"/"), @r#"dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))"#
     );
 
     // Can a show the root tree by id
@@ -188,10 +182,10 @@ fn test_debug_tree() {
             "--id=0958358e3f80e794f032b25ed2be96cf5825da6c",
         ],
     );
-    assert_snapshot!(stdout.replace('\\',"/"), @r###"
+    assert_snapshot!(stdout.replace('\\',"/"), @r#"
     dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    "#
     );
 
     // Can a show non-root tree by id
@@ -204,10 +198,10 @@ fn test_debug_tree() {
             "--id=6ac232efa713535ae518a1a898b77e76c0478184",
         ],
     );
-    assert_snapshot!(stdout.replace('\\',"/"), @r###"
+    assert_snapshot!(stdout.replace('\\',"/"), @r#"
     dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    "#
     );
 
     // Can filter by paths when showing non-root tree (matcher applies from root)
@@ -221,9 +215,7 @@ fn test_debug_tree() {
             "dir/subdir/file2",
         ],
     );
-    assert_snapshot!(stdout.replace('\\',"/"), @r###"
-    dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    assert_snapshot!(stdout.replace('\\',"/"), @r#"dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))"#
     );
 }
 
@@ -234,9 +226,7 @@ fn test_debug_operation_id() {
     let workspace_path = test_env.env_root().join("repo");
     let stdout =
         test_env.jj_cmd_success(&workspace_path, &["debug", "operation", "--display", "id"]);
-    assert_snapshot!(filter_index_stats(&stdout), @r#"
-    eac759b9ab75793fd3da96e60939fb48f2cd2b2a9c1f13ffe723cf620f3005b8d3e7e923634a07ea39513e4f2f360c87b9ad5d331cf90d7a844864b83b72eba1
-    "#
+    assert_snapshot!(filter_index_stats(&stdout), @"eac759b9ab75793fd3da96e60939fb48f2cd2b2a9c1f13ffe723cf620f3005b8d3e7e923634a07ea39513e4f2f360c87b9ad5d331cf90d7a844864b83b72eba1"
     );
 }
 

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -32,42 +32,38 @@ fn test_describe() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description from CLI"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 95979928 (empty) description from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     // Set the same description using `-m` flag, but with explicit newline
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description from CLI\n"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 
     // Check that the text file gets initialized with the current description and
     // make no changes
     std::fs::write(&edit_script, "dump editor0").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     description from CLI
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Set a description in editor
     std::fs::write(&edit_script, "write\ndescription from editor").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 94fcb906 (empty) description from editor
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     // Lines in editor starting with "JJ: " are ignored
     std::fs::write(
@@ -77,64 +73,60 @@ fn test_describe() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 7a348923 (empty) description among comment
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     // Multi-line description
     std::fs::write(&edit_script, "write\nline1\nline2\n\nline4\n\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 749361b5 (empty) line1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     line1
     line2
 
     line4
-    "###);
+    ");
 
     // Multi-line description again with CRLF, which should make no changes
     std::fs::write(&edit_script, "write\nline1\r\nline2\r\n\r\nline4\r\n\r\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 
     // Multi-line description starting with newlines
     std::fs::write(&edit_script, "write\n\n\nline1\nline2").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm dc44dbee (empty) line1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     line1
     line2
-    "#);
+    ");
 
     // Clear description
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-m", ""]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 6296963b (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
     std::fs::write(&edit_script, "write\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 
     // Fails if the editor fails
     std::fs::write(&edit_script, "fail").unwrap();
@@ -170,17 +162,17 @@ fn test_describe() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 10fa2dc7 (empty) description from editor
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "#);
+    ");
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     description from editor
 
     content of message from editor
-    "#);
+    ");
 }
 
 #[test]
@@ -235,12 +227,12 @@ fn test_describe_multiple_commits() {
     // Initial setup
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c6349e79bbfd
     ○  65b6b74e0897
     ○  230dd059e1b0
     ◆  000000000000
-    "###);
+    ");
 
     // Set the description of multiple commits using `-m` flag
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -248,18 +240,18 @@ fn test_describe_multiple_commits() {
         &["describe", "-r@", "-r@--", "-m", "description from CLI"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Updated 2 commits
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 41659b84 (empty) description from CLI
     Parent commit      : rlvkpnrz 8d650510 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  41659b846096 description from CLI
     ○  8d650510daad
     ○  a42f5755e688 description from CLI
     ◆  000000000000
-    "###);
+    ");
 
     // Check that the text file gets initialized with the current description of
     // each commit and doesn't update commits if no changes are made.
@@ -267,11 +259,9 @@ fn test_describe_multiple_commits() {
     std::fs::write(&edit_script, "dump editor0").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-r@", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
     JJ: Warning:
     JJ: - The text you enter will be lost on a syntax error.
@@ -283,7 +273,7 @@ fn test_describe_multiple_commits() {
     description from CLI
 
     JJ: Lines starting with "JJ: " (like this one) will be removed.
-    "###);
+    "#);
 
     // Set the description of multiple commits in the editor
     std::fs::write(
@@ -310,12 +300,12 @@ fn test_describe_multiple_commits() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "@", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Updated 2 commits
     Working copy now at: kkmpptxz f203494a (empty) description from editor of @
     Parent commit      : rlvkpnrz 0d76a92c (empty) description from editor of @-
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f203494a4507 description from editor of @
     │
     │  further commit message of @
@@ -324,7 +314,7 @@ fn test_describe_multiple_commits() {
     │  further commit message of @-
     ○  a42f5755e688 description from CLI
     ◆  000000000000
-    "###);
+    ");
 
     // Fails if the edited message has a commit with multiple descriptions
     std::fs::write(
@@ -351,9 +341,7 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The following commits were found in the edited message multiple times: 0d76a92ca7cc
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The following commits were found in the edited message multiple times: 0d76a92ca7cc");
 
     // Fails if the edited message has unexpected commit IDs
     std::fs::write(
@@ -378,9 +366,7 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The following commits were not being edited, but were found in the edited message: 000000000000
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The following commits were not being edited, but were found in the edited message: 000000000000");
 
     // Fails if the edited message has missing commit messages
     std::fs::write(
@@ -397,9 +383,7 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The description for the following commits were not found in the edited message: 0d76a92ca7cc
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The description for the following commits were not found in the edited message: 0d76a92ca7cc");
 
     // Fails if the edited message has a line which does not have any preceding
     // `JJ: describe` headers
@@ -417,9 +401,7 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Found the following line without a commit header: "description from editor of @-"
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: Found the following line without a commit header: "description from editor of @-""#);
 
     // Fails if the editor fails
     std::fs::write(&edit_script, "fail").unwrap();
@@ -459,20 +441,20 @@ fn test_describe_multiple_commits() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "@--"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Updated 2 commits
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 1d7701ee (empty) description from editor of @
     Parent commit      : rlvkpnrz 5389926e (empty) description from editor for @-
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  1d7701eec9bc description from editor of @
     │
     │  further commit message of @
     ○  5389926ebed6 description from editor for @-
     ○  eaa8547ae37a description from editor for @--
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -493,18 +475,18 @@ fn test_multiple_message_args() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 99a36a50 (empty) First Paragraph from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     First Paragraph from CLI
 
     Second Paragraph from CLI
-    "###);
+    ");
 
     // Set the same description, with existing newlines
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -518,9 +500,7 @@ fn test_multiple_message_args() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 
     // Use an empty -m flag between paragraphs to insert an extra blank line
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -536,19 +516,19 @@ fn test_multiple_message_args() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 01ac40b3 (empty) First Paragraph from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     First Paragraph from CLI
 
 
     Second Paragraph from CLI
-    "###);
+    ");
 }
 
 #[test]
@@ -564,12 +544,12 @@ fn test_describe_default_description() {
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 573b6df5 TESTED=TODO
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     TESTED=TODO
 
     JJ: This commit contains the following changes:
@@ -577,7 +557,7 @@ fn test_describe_default_description() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]
@@ -626,7 +606,7 @@ fn test_describe_author() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    insta::assert_snapshot!(get_signatures(), @r###"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Test User test.user@example.com 2001-02-03 04:05:10.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:10.000 +07:00
     ○  Test User test.user@example.com 2001-02-03 04:05:09.000 +07:00
@@ -636,7 +616,7 @@ fn test_describe_author() {
     ○  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     ~
-    "###);
+    ");
 
     // Change the author for the latest commit (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -647,7 +627,7 @@ fn test_describe_author() {
             "Super Seeder <super.seeder@example.com>",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Super Seeder super.seeder@example.com 2001-02-03 04:05:12.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:12.000 +07:00
     ○  Test User test.user@example.com 2001-02-03 04:05:09.000 +07:00
@@ -657,16 +637,16 @@ fn test_describe_author() {
     ○  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     ~
-    "#);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Super Seeder <super.seeder@example.com> (2001-02-03 08:05:12)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:12)
 
     JJ: 0 files changed, 0 insertions(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Change the author for multiple commits (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -680,7 +660,7 @@ fn test_describe_author() {
             "Super Seeder <super.seeder@example.com>",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Super Seeder super.seeder@example.com 2001-02-03 04:05:12.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:14.000 +07:00
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
@@ -690,7 +670,7 @@ fn test_describe_author() {
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:14.000 +07:00
     ~
-    "#);
+    ");
 
     // Reset the author for the latest commit (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -703,7 +683,7 @@ fn test_describe_author() {
             "--reset-author",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:16.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:16.000 +07:00
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
@@ -713,7 +693,7 @@ fn test_describe_author() {
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:14.000 +07:00
     ~
-    "#);
+    ");
 
     // Reset the author for multiple commits (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -727,7 +707,7 @@ fn test_describe_author() {
             "--reset-author",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     ○  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
@@ -737,7 +717,7 @@ fn test_describe_author() {
     ○  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     ~
-    "#);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter or edit commit descriptions after the `JJ: describe` lines.

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -35,7 +35,7 @@ fn test_diff_basic() {
     std::fs::write(repo_path.join("file4"), "1\n2\n3\n4\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: 1
        2    2: 25
@@ -43,10 +43,10 @@ fn test_diff_basic() {
        4     : 4
     Modified regular file file3 (file1 => file3):
     Modified regular file file4 (file2 => file4):
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=0"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: 1
        2    2: 25
@@ -54,10 +54,10 @@ fn test_diff_basic() {
        4     : 4
     Modified regular file file3 (file1 => file3):
     Modified regular file file4 (file2 => file4):
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3m<<diff header::Modified regular file file2:>>[39m
     [38;5;1m<<diff removed line_number::   1>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: 1>>
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;1m<<diff removed token::2>>[38;5;2m<<diff added token::5>>[24m[39m<<diff::>>
@@ -65,27 +65,27 @@ fn test_diff_basic() {
     [38;5;1m<<diff removed line_number::   4>>[39m<<diff::     : >>[4m[38;5;1m<<diff removed token::4>>[24m[39m
     [38;5;3m<<diff header::Modified regular file file3 (file1 => file3):>>[39m
     [38;5;3m<<diff header::Modified regular file file4 (file2 => file4):>>[39m
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
     R {file1 => file3}
     C {file2 => file4}
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--types"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     FF file2
     FF {file1 => file3}
     FF {file2 => file4}
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--types", "glob:file[12]"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     F- file1
     FF file2
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "file1"]);
     insta::assert_snapshot!(stdout, @r"
@@ -99,7 +99,7 @@ fn test_diff_basic() {
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file2 b/file2
     index 94ebaf9001..1ffc51b472 100644
     --- a/file2
@@ -116,7 +116,7 @@ fn test_diff_basic() {
     diff --git a/file2 b/file4
     copy from file2
     copy to file4
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=0"]);
     insta::assert_snapshot!(stdout, @r"
@@ -138,7 +138,7 @@ fn test_diff_basic() {
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m<<diff file_header::diff --git a/file2 b/file2>>[0m
     [1m<<diff file_header::index 94ebaf9001..1ffc51b472 100644>>[0m
     [1m<<diff file_header::--- a/file2>>[0m
@@ -155,10 +155,10 @@ fn test_diff_basic() {
     [1m<<diff file_header::diff --git a/file2 b/file4>>[0m
     [1m<<diff file_header::copy from file2>>[0m
     [1m<<diff file_header::copy to file4>>[0m
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
     R {file1 => file3}
     C {file2 => file4}
@@ -178,22 +178,22 @@ fn test_diff_basic() {
     diff --git a/file2 b/file4
     copy from file2
     copy to file4
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2            | 3 +--
     {file1 => file3} | 0
     {file2 => file4} | 0
     3 files changed, 1 insertion(+), 2 deletions(-)
-    "###);
+    ");
 
     // Filter by glob pattern
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "glob:file[12]"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
 
     // Unmatched paths should generate warnings
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -208,14 +208,12 @@ fn test_diff_basic() {
             "repo/y/z",
         ],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     M repo/file2
     R repo/{file1 => file3}
     C repo/{file2 => file4}
-    "###);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
-    Warning: No matching entries for paths: repo/x, repo/y/z
-    "###);
+    ");
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @"Warning: No matching entries for paths: repo/x, repo/y/z");
 
     // Unmodified paths shouldn't generate warnings
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diff", "-s", "--from=@", "file2"]);
@@ -231,24 +229,24 @@ fn test_diff_empty() {
 
     std::fs::write(repo_path.join("file1"), "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file1:
         (empty)
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::remove_file(repo_path.join("file1")).unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Removed regular file file1:
         (empty)
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 0
     1 file changed, 0 insertions(+), 0 deletions(-)
-    "###);
+    ");
 }
 
 #[test]
@@ -282,7 +280,7 @@ fn test_diff_file_mode() {
     std::fs::remove_file(repo_path.join("file4")).unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@--"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added executable file file1:
         (empty)
     Added executable file file2:
@@ -291,18 +289,18 @@ fn test_diff_file_mode() {
             1: 1
     Added regular file file4:
         (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Executable file became non-executable at file1:
             1: 2
     Executable file became non-executable at file2:
     Non-executable file became executable at file3:
        1    1: 12
     Non-executable file became executable at file4:
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Removed regular file file1:
        1     : 2
     Removed regular file file2:
@@ -311,7 +309,7 @@ fn test_diff_file_mode() {
        1     : 2
     Removed executable file file4:
         (empty)
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@--", "--git"]);
     insta::assert_snapshot!(stdout, @r"
@@ -439,24 +437,14 @@ fn test_diff_types() {
             ],
         )
     };
-    insta::assert_snapshot!(diff("missing", "file"), @r###"
-    -F foo
-    "###);
-    insta::assert_snapshot!(diff("file", "conflict"), @r###"
-    FC foo
-    "###);
-    insta::assert_snapshot!(diff("conflict", "missing"), @r###"
-    C- foo
-    "###);
+    insta::assert_snapshot!(diff("missing", "file"), @"-F foo");
+    insta::assert_snapshot!(diff("file", "conflict"), @"FC foo");
+    insta::assert_snapshot!(diff("conflict", "missing"), @"C- foo");
 
     #[cfg(unix)]
     {
-        insta::assert_snapshot!(diff("symlink", "file"), @r###"
-        LF foo
-        "###);
-        insta::assert_snapshot!(diff("missing", "executable"), @r###"
-        -F foo
-        "###);
+        insta::assert_snapshot!(diff("symlink", "file"), @"LF foo");
+        insta::assert_snapshot!(diff("missing", "executable"), @"-F foo");
     }
 }
 
@@ -469,10 +457,10 @@ fn test_diff_name_only() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("deleted"), "d").unwrap();
     std::fs::write(repo_path.join("modified"), "m").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]), @r"
     deleted
     modified
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["commit", "-mfirst"]);
     std::fs::remove_file(repo_path.join("deleted")).unwrap();
     std::fs::write(repo_path.join("modified"), "mod").unwrap();
@@ -480,12 +468,12 @@ fn test_diff_name_only() {
     std::fs::create_dir(repo_path.join("sub")).unwrap();
     std::fs::write(repo_path.join("sub/added"), "sub/add").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]).replace('\\', "/"),
-    @r###"
+    @r"
     added
     deleted
     modified
     sub/added
-    "###);
+    ");
 }
 
 #[test]
@@ -495,22 +483,22 @@ fn test_diff_bad_args() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["diff", "-s", "--types"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--summary' cannot be used with '--types'
 
     Usage: jj diff --summary [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["diff", "--color-words", "--git"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--color-words' cannot be used with '--git'
 
     Usage: jj diff --color-words [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -541,7 +529,7 @@ fn test_diff_relative_paths() {
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: foo2bar2
     Modified regular file subdir1/file3:
@@ -550,7 +538,7 @@ fn test_diff_relative_paths() {
        1    1: foo4bar4
     Modified regular file ../file1:
        1    1: foo1bar1
-    "###);
+    ");
     #[cfg(windows)]
     insta::assert_snapshot!(stdout, @r###"
     Modified regular file file2:
@@ -565,12 +553,12 @@ fn test_diff_relative_paths() {
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "-s"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
     M subdir1/file3
     M ../dir2/file4
     M ../file1
-    "###);
+    ");
     #[cfg(windows)]
     insta::assert_snapshot!(stdout, @r###"
     M file2
@@ -581,12 +569,12 @@ fn test_diff_relative_paths() {
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "--types"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     FF file2
     FF subdir1/file3
     FF ../dir2/file4
     FF ../file1
-    "###);
+    ");
     #[cfg(windows)]
     insta::assert_snapshot!(stdout, @r###"
     FF file2
@@ -596,7 +584,7 @@ fn test_diff_relative_paths() {
     "###);
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/dir1/file2 b/dir1/file2
     index 54b060eee9..1fe912cdd8 100644
     --- a/dir1/file2
@@ -625,17 +613,17 @@ fn test_diff_relative_paths() {
     @@ -1,1 +1,1 @@
     -foo1
     +bar1
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "--stat"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2         | 2 +-
     subdir1/file3 | 2 +-
     ../dir2/file4 | 2 +-
     ../file1      | 2 +-
     4 files changed, 4 insertions(+), 4 deletions(-)
-    "###);
+    ");
     #[cfg(windows)]
     insta::assert_snapshot!(stdout, @r###"
     file2         | 2 +-
@@ -663,7 +651,7 @@ fn test_diff_hunks() {
     std::fs::write(repo_path.join("file3"), "foo\nbar\nbaz quux blah blah\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
             1: foo
     Modified regular file file2:
@@ -672,10 +660,10 @@ fn test_diff_hunks() {
        1    1: foo
             2: bar
        2    3: baz quxquux blah blah
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3m<<diff header::Modified regular file file1:>>[39m
     <<diff::     >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::foo>>[24m[39m
     [38;5;3m<<diff header::Modified regular file file2:>>[39m
@@ -684,7 +672,7 @@ fn test_diff_hunks() {
     [38;5;1m<<diff removed line_number::   1>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: foo>>
     <<diff::     >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::bar>>[24m[39m
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   3>>[39m<<diff::: baz >>[4m[38;5;1m<<diff removed token::qux>>[38;5;2m<<diff added token::quux>>[24m[39m<<diff:: blah blah>>
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
     insta::assert_snapshot!(stdout, @r"
@@ -853,7 +841,7 @@ fn test_diff_color_words_inlining_threshold() {
 
     // default
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -896,10 +884,10 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    ");
 
     // -1: inline all
-    insta::assert_snapshot!(render_diff(-1, &[]), @r###"
+    insta::assert_snapshot!(render_diff(-1, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -938,10 +926,10 @@ fn test_diff_color_words_inlining_threshold() {
       13   13: X a Y b
       14   13: c d
       14   14: Z e f g
-    "###);
+    ");
 
     // 0: no inlining
-    insta::assert_snapshot!(render_diff(0, &[]), @r###"
+    insta::assert_snapshot!(render_diff(0, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2     : a b c
@@ -995,10 +983,10 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    ");
 
     // 1: inline adds-only or removes-only lines
-    insta::assert_snapshot!(render_diff(1, &[]), @r###"
+    insta::assert_snapshot!(render_diff(1, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1048,10 +1036,10 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    ");
 
     // 2: inline up to adds + removes lines
-    insta::assert_snapshot!(render_diff(2, &[]), @r###"
+    insta::assert_snapshot!(render_diff(2, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1096,10 +1084,10 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    ");
 
     // 3: inline up to adds + removes + adds lines
-    insta::assert_snapshot!(render_diff(3, &[]), @r###"
+    insta::assert_snapshot!(render_diff(3, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1142,10 +1130,10 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    ");
 
     // 4: inline up to adds + removes + adds + removes lines
-    insta::assert_snapshot!(render_diff(4, &[]), @r###"
+    insta::assert_snapshot!(render_diff(4, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1184,10 +1172,10 @@ fn test_diff_color_words_inlining_threshold() {
       13   13: X a Y b
       14   13: c d
       14   14: Z e f g
-    "###);
+    ");
 
     // context words in added/removed lines should be labeled as such
-    insta::assert_snapshot!(render_diff(2, &["--color=always"]), @r###"
+    insta::assert_snapshot!(render_diff(2, &["--color=always"]), @r"
     [38;5;3mModified regular file file1-single-line:[39m
     [38;5;1m   1[39m [38;5;2m   1[39m: == adds ==
     [38;5;1m   2[39m [38;5;2m   2[39m: a [4m[38;5;2mX [24m[39mb [4m[38;5;2mY Z [24m[39mc
@@ -1232,8 +1220,8 @@ fn test_diff_color_words_inlining_threshold() {
     [38;5;1m  14[39m     : [4m[38;5;1mc[24m d e[4m f g[24m[39m
          [38;5;2m  13[39m: [4m[38;5;2mX [24ma [4mY [24mb d[4m[24m[39m
          [38;5;2m  14[39m: [4m[38;5;2mZ[24m e[39m
-    "###);
-    insta::assert_snapshot!(render_diff(2, &["--color=debug"]), @r###"
+    ");
+    insta::assert_snapshot!(render_diff(2, &["--color=debug"]), @r"
     [38;5;3m<<diff header::Modified regular file file1-single-line:>>[39m
     [38;5;1m<<diff removed line_number::   1>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: == adds ==>>
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: a >>[4m[38;5;2m<<diff added token::X >>[24m[39m<<diff::b >>[4m[38;5;2m<<diff added token::Y Z >>[24m[39m<<diff::c>>
@@ -1278,7 +1266,7 @@ fn test_diff_color_words_inlining_threshold() {
     [38;5;1m<<diff removed line_number::  14>>[39m<<diff::     : >>[4m[38;5;1m<<diff removed token::c>>[24m<<diff removed:: d e>>[4m<<diff removed token:: f g>>[24m<<diff removed::>>[39m
     <<diff::     >>[38;5;2m<<diff added line_number::  13>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::X >>[24m<<diff added::a >>[4m<<diff added token::Y >>[24m<<diff added::b d>>[4m<<diff added token::>>[24m[39m
     <<diff::     >>[38;5;2m<<diff added line_number::  14>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::Z>>[24m<<diff added:: e>>[39m
-    "###);
+    ");
 }
 
 #[test]
@@ -1294,17 +1282,17 @@ fn test_diff_missing_newline() {
     std::fs::write(repo_path.join("file2"), "foo").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: foo
             2: bar
     Modified regular file file2:
        1    1: foo
        2     : bar
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1910281566..a907ec3f43 100644
     --- a/file1
@@ -1325,14 +1313,14 @@ fn test_diff_missing_newline() {
     \ No newline at end of file
     +foo
     \ No newline at end of file
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 3 ++-
     file2 | 3 +--
     2 files changed, 3 insertions(+), 3 deletions(-)
-    "###);
+    ");
 }
 
 #[test]
@@ -1368,7 +1356,7 @@ fn test_color_words_diff_missing_newline() {
             "--reversed",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Empty
     Added regular file file1:
         (empty)
@@ -1433,7 +1421,7 @@ fn test_color_words_diff_missing_newline() {
        7     : g
        8     : h
        9     : I
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -1446,7 +1434,7 @@ fn test_color_words_diff_missing_newline() {
             "--reversed",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Empty
     Added regular file file1:
         (empty)
@@ -1516,7 +1504,7 @@ fn test_color_words_diff_missing_newline() {
        7     : g
        8     : h
        9     : I
-    "###);
+    ");
 }
 
 #[test]
@@ -1552,7 +1540,7 @@ fn test_diff_ignore_whitespace() {
 
     // Git diff as reference output
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--ignore-all-space"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index f532aa68ad..033c4a6168 100644
     --- a/file1
@@ -1564,9 +1552,9 @@ fn test_diff_ignore_whitespace() {
          }
     +}
      baz {  }
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--ignore-space-change"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index f532aa68ad..033c4a6168 100644
     --- a/file1
@@ -1580,26 +1568,26 @@ fn test_diff_ignore_whitespace() {
      }
     -baz {}
     +baz {  }
-    "#);
+    ");
 
     // Diff-stat should respects the whitespace options
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat", "--ignore-all-space"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 2 ++
     1 file changed, 2 insertions(+), 0 deletions(-)
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat", "--ignore-space-change"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 6 ++++--
     1 file changed, 4 insertions(+), 2 deletions(-)
-    "#);
+    ");
 
     // Word-level changes are still highlighted
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["diff", "--color=always", "--ignore-all-space"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3mModified regular file file1:[39m
          [38;5;2m   1[39m: [4m[38;5;2m{[24m[39m
     [38;5;1m   1[39m [38;5;2m   2[39m: [4m[38;5;2m    [24m[39mfoo {
@@ -1607,12 +1595,12 @@ fn test_diff_ignore_whitespace() {
     [38;5;1m   3[39m [38;5;2m   4[39m: [4m[38;5;2m    [24m[39m}
          [38;5;2m   5[39m: [4m[38;5;2m}[24m[39m
     [38;5;1m   4[39m [38;5;2m   6[39m: baz {[4m[38;5;2m  [24m[39m}
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["diff", "--color=always", "--ignore-space-change"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3mModified regular file file1:[39m
          [38;5;2m   1[39m: [4m[38;5;2m{[24m[39m
     [38;5;1m   1[39m [38;5;2m   2[39m: [4m[38;5;2m    [24m[39mfoo {
@@ -1620,7 +1608,7 @@ fn test_diff_ignore_whitespace() {
          [38;5;2m   4[39m: [4m[38;5;2m    }[24m[39m
     [38;5;1m   3[39m [38;5;2m   5[39m: }
     [38;5;1m   4[39m [38;5;2m   6[39m: baz {[4m[38;5;2m  [24m[39m}
-    "#);
+    ");
 }
 
 #[test]
@@ -1649,7 +1637,7 @@ fn test_diff_skipped_context() {
         &repo_path,
         &["log", "-Tdescription", "-p", "--no-graph", "--reversed"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Left side of diffs
     Added regular file file1:
             1: a
@@ -1731,7 +1719,7 @@ fn test_diff_skipped_context() {
        8    8: h
        9    9: i
       10   10: j
-    "###);
+    ");
 }
 
 #[test]
@@ -1757,7 +1745,7 @@ context = 0
         &repo_path,
         &["log", "-Tdescription", "-p", "--no-graph", "--reversed"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     === First commit
     Added regular file file1:
             1: a
@@ -1770,7 +1758,7 @@ context = 0
         ...
        3    3: cC
         ...
-    "#);
+    ");
 }
 
 #[test]
@@ -1859,7 +1847,7 @@ fn test_diff_skipped_context_nondefault() {
             "--context=0",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Left side of diffs
     Added regular file file1:
             1: a
@@ -1893,7 +1881,7 @@ fn test_diff_skipped_context_nondefault() {
         ...
        3    3: cC
        4    4: d
-    "###);
+    ");
 }
 
 #[test]
@@ -1917,7 +1905,7 @@ fn test_diff_leading_trailing_context() {
 
     // N=5 <= num_context_lines + 1: No room to skip.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=4"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: 1
        2    2: 2
@@ -1932,12 +1920,12 @@ fn test_diff_leading_trailing_context() {
       10   10: 9
       11   11: 10
       12   12: 11
-    "###);
+    ");
 
     // N=5 <= 2 * num_context_lines + 1: The last hunk wouldn't be split if
     // trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
         ...
        3    3: 3
@@ -1950,12 +1938,12 @@ fn test_diff_leading_trailing_context() {
        9    9: 8
       10   10: 9
         ...
-    "###);
+    ");
 
     // N=5 > 2 * num_context_lines + 1: The last hunk should be split no matter
     // if trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
         ...
        5    5: 5
@@ -1964,11 +1952,11 @@ fn test_diff_leading_trailing_context() {
             7: R
        8    8: 7
         ...
-    "###);
+    ");
 
     // N=5 <= num_context_lines: No room to skip.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=5"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1bf57dee4a..69b3e1865c 100644
     --- a/file1
@@ -1987,12 +1975,12 @@ fn test_diff_leading_trailing_context() {
      9
      10
      11
-    "###);
+    ");
 
     // N=5 <= 2 * num_context_lines: The last hunk wouldn't be split if
     // trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1bf57dee4a..69b3e1865c 100644
     --- a/file1
@@ -2007,12 +1995,12 @@ fn test_diff_leading_trailing_context() {
      7
      8
      9
-    "###);
+    ");
 
     // N=5 > 2 * num_context_lines: The last hunk should be split no matter
     // if trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1bf57dee4a..69b3e1865c 100644
     --- a/file1
@@ -2025,7 +2013,7 @@ fn test_diff_leading_trailing_context() {
     +R
      7
      8
-    "###);
+    ");
 }
 
 #[test]
@@ -2052,10 +2040,8 @@ fn test_diff_external_tool() {
     let mut insta_settings = insta::Settings::clone_current();
     insta_settings.add_filter("exit (status|code)", "<exit status>");
     insta_settings.bind(|| {
-        insta::assert_snapshot!(stdout, @r"");
-        insta::assert_snapshot!(stderr, @r#"
-        Warning: Tool exited with <exit status>: 1 (run with --debug to see the exact invocation)
-        "#);
+        insta::assert_snapshot!(stdout, @"");
+        insta::assert_snapshot!(stderr, @"Warning: Tool exited with <exit status>: 1 (run with --debug to see the exact invocation)");
     });
 
     // nonzero exit codes should not print a warning if it's an expected exit code
@@ -2069,8 +2055,8 @@ fn test_diff_external_tool() {
             "--config=merge-tools.fake-diff-editor.diff-expected-exit-codes=[1]",
         ],
     );
-    insta::assert_snapshot!(stdout, @r"");
-    insta::assert_snapshot!(stderr, @r"");
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @"");
 
     std::fs::write(
         &edit_script,
@@ -2080,23 +2066,23 @@ fn test_diff_external_tool() {
 
     // diff without file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r"
     file1
     file2
     --
     file2
     file3
-    "###);
+    ");
 
     // diff with file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor", "file1"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor", "file1"]), @r"
     file1
     --
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["log", "-p", "--tool=fake-diff-editor"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["log", "-p", "--tool=fake-diff-editor"]), @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 39d9055d
     │  (no description set)
     │  file1
@@ -2111,10 +2097,10 @@ fn test_diff_external_tool() {
     │  file2
     ◆  zzzzzzzz root() 00000000
        --
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["show", "--tool=fake-diff-editor"]), @r#"
+        test_env.jj_cmd_success(&repo_path, &["show", "--tool=fake-diff-editor"]), @r"
     Commit ID: 39d9055d70873099fd924b9af218289d5663eac8
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -2127,41 +2113,39 @@ fn test_diff_external_tool() {
     --
     file2
     file3
-    "#);
+    ");
 
     // Enabled by default, looks up the merge-tools table
     let config = "--config=ui.diff.tool=fake-diff-editor";
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", config]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", config]), @r"
     file1
     file2
     --
     file2
     file3
-    "###);
+    ");
 
     // Inlined command arguments
     let command_toml = to_toml_value(fake_diff_editor_path());
     let config = format!("--config=ui.diff.tool=[{command_toml}, '$right', '$left']");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", &config]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", &config]), @r"
     file2
     file3
     --
     file1
     file2
-    "###);
+    ");
 
     // Output of external diff tool shouldn't be escaped
     std::fs::write(&edit_script, "print \x1b[1;31mred").unwrap();
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["diff", "--color=always", "--tool=fake-diff-editor"]),
-        @r###"
-    [1;31mred
-    "###);
+        @"[1;31mred");
 
     // Non-zero exit code isn't an error
     std::fs::write(&edit_script, "print diff\0fail").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["show", "--tool=fake-diff-editor"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: 39d9055d70873099fd924b9af218289d5663eac8
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -2170,18 +2154,16 @@ fn test_diff_external_tool() {
         (no description set)
 
     diff
-    "#);
-    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
-    Warning: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "###);
+    ");
+    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @"Warning: Tool exited with exit status: 1 (run with --debug to see the exact invocation)");
 
     // --tool=:builtin shouldn't be ignored
     let stderr = test_env.jj_cmd_failure(&repo_path, &["diff", "--tool=:builtin"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r###"
+    insta::assert_snapshot!(strip_last_line(&stderr), @r"
     Error: Failed to generate diff
     Caused by:
     1: Error executing ':builtin' (run with --debug to see the exact invocation)
-    "###);
+    ");
 }
 
 #[test]
@@ -2213,7 +2195,7 @@ fn test_diff_external_file_by_file_tool() {
 
     // diff without file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["diff"], configs].concat()), @r###"
+        test_env.jj_cmd_success(&repo_path, &[&["diff"], configs].concat()), @r"
     ==
     file2
     --
@@ -2226,19 +2208,19 @@ fn test_diff_external_file_by_file_tool() {
     file1
     --
     file4
-    "###);
+    ");
 
     // diff with file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["diff", "file1"], configs].concat()), @r###"
+        test_env.jj_cmd_success(&repo_path, &[&["diff", "file1"], configs].concat()), @r"
     ==
     file1
     --
     file1
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["log", "-p"], configs].concat()), @r###"
+        test_env.jj_cmd_success(&repo_path, &[&["log", "-p"], configs].concat()), @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 7b01704a
     │  (no description set)
     │  ==
@@ -2264,10 +2246,10 @@ fn test_diff_external_file_by_file_tool() {
     │  --
     │  file2
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["show"], configs].concat()), @r#"
+        test_env.jj_cmd_success(&repo_path, &[&["show"], configs].concat()), @r"
     Commit ID: 7b01704a670bc77d11ed117d362855cff1d4513b
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -2287,7 +2269,7 @@ fn test_diff_external_file_by_file_tool() {
     file1
     --
     file4
-    "#);
+    ");
 }
 
 #[cfg(unix)]
@@ -2318,13 +2300,13 @@ fn test_diff_external_tool_symlink() {
 
     // Shouldn't try to change permission of symlinks
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r"
     dead
     file
     --
     dead
     file
-    "###);
+    ");
 
     // External file should be intact
     assert_eq!(
@@ -2421,7 +2403,7 @@ fn test_diff_external_tool_conflict_marker_style() {
     insta::assert_snapshot!(stderr, @"");
     // Conflicts should render using "snapshot" format
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("file")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("file")).unwrap(), @r"
     line 1
     line 2.1
     line 2.2
@@ -2437,7 +2419,7 @@ fn test_diff_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##);
+    ");
 }
 
 #[test]
@@ -2448,10 +2430,10 @@ fn test_diff_stat() {
     std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 1 +
     1 file changed, 1 insertion(+), 0 deletions(-)
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
@@ -2463,10 +2445,10 @@ fn test_diff_stat() {
     std::fs::write(repo_path.join("file1"), "bar\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 1 -
     1 file changed, 0 insertions(+), 1 deletion(-)
-    "###);
+    ");
 }
 
 #[test]
@@ -2490,97 +2472,97 @@ fn test_diff_stat_long_name_or_stat() {
         test_env.jj_cmd_success(&repo_path, &["diff", "--stat"])
     };
 
-    insta::assert_snapshot!(get_stat(&test_env, 1, 1), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 1, 1), @r"
     1   | 1 +
     一  | 1 +
     2 files changed, 2 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r"
     1   | 10 ++++++++++
     一  | 10 ++++++++++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 1, 100), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 1, 100), @r"
     1   | 100 +++++++++++++++++
     一  | 100 +++++++++++++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 10, 1), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 10, 1), @r"
     1234567890      | 1 +
     ...五六七八九十 | 1 +
     2 files changed, 2 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r"
     1234567890     | 10 +++++++
     ...六七八九十  | 10 +++++++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 10, 100), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 10, 100), @r"
     1234567890     | 100 ++++++
     ...六七八九十  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 50, 1), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 50, 1), @r"
     ...901234567890 | 1 +
     ...五六七八九十 | 1 +
     2 files changed, 2 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 50, 10), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 50, 10), @r"
     ...01234567890 | 10 +++++++
     ...六七八九十  | 10 +++++++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 50, 100), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 50, 100), @r"
     ...01234567890 | 100 ++++++
     ...六七八九十  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
+    ");
 
     // Lengths around where we introduce the ellipsis
-    insta::assert_snapshot!(get_stat(&test_env, 13, 100), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 13, 100), @r"
     1234567890123  | 100 ++++++
     ...九十一二三  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 14, 100), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 14, 100), @r"
     12345678901234 | 100 ++++++
     ...十一二三四  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 15, 100), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 15, 100), @r"
     ...56789012345 | 100 ++++++
     ...一二三四五  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 16, 100), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 16, 100), @r"
     ...67890123456 | 100 ++++++
     ...二三四五六  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
+    ");
 
     // Very narrow terminal (doesn't have to fit, just don't crash)
     test_env.add_env_var("COLUMNS", "10");
-    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r"
     ... | 10 ++
     ... | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
+    ");
     test_env.add_env_var("COLUMNS", "3");
-    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r"
     ... | 10 ++
     ... | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 3, 10), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 3, 10), @r"
     123 | 10 ++
     ... | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r###"
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r"
     1   | 10 ++
     一  | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
+    ");
 }
 
 #[test]
@@ -2599,7 +2581,7 @@ fn test_diff_binary() {
     std::fs::write(repo_path.join("file4.png"), b"\0\0\0").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Removed regular file file1.png:
         (binary)
     Modified regular file file2.png:
@@ -2608,10 +2590,10 @@ fn test_diff_binary() {
         (binary)
     Added regular file file4.png:
         (binary)
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1.png b/file1.png
     deleted file mode 100644
     index 2b65b23c22..0000000000
@@ -2627,14 +2609,14 @@ fn test_diff_binary() {
     new file mode 100644
     index 0000000000..4227ca4e87
     Binary files /dev/null and b/file4.png differ
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1.png | 3 ---
     file2.png | 5 ++---
     file3.png | 3 +++
     file4.png | 1 +
     4 files changed, 6 insertions(+), 6 deletions(-)
-    "###);
+    ");
 }

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -45,23 +45,21 @@ fn test_diffedit() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are editing changes in: kkmpptxz 3d4cce89 (no description set)
 
     The diff initially shows the commit's changes.
 
     Adjust the right side until it shows the contents you want. If you
     don't make any changes, then the operation will be aborted.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
 
     // Try again with ui.diff-instructions=false
     std::fs::write(&edit_script, "files-before file1 file2\0files-after file2").unwrap();
@@ -70,14 +68,12 @@ fn test_diffedit() {
         &["diffedit", "--config=ui.diff-instructions=false"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
 
     // Try again with --tool=<name>
     std::fs::write(
@@ -94,59 +90,53 @@ fn test_diffedit() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
 
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
     let stderr = &test_env.jj_cmd_failure(&repo_path, &["diffedit"]);
-    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
+    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r"
     Error: Failed to edit diff
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
 
     // Can edit changes to individual files
     std::fs::write(&edit_script, "reset file2").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz cbc7a725 (no description set)
     Working copy now at: kkmpptxz cbc7a725 (no description set)
     Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
-    D file1
-    "###);
+    insta::assert_snapshot!(stdout, @"D file1");
 
     // Changes to a commit are propagated to descendants
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&edit_script, "write file3\nmodified\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz d4eef3fc (no description set)
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 59ef1b95 (no description set)
     Parent commit      : rlvkpnrz d4eef3fc (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     let contents = String::from_utf8(std::fs::read(repo_path.join("file3")).unwrap()).unwrap();
-    insta::assert_snapshot!(contents, @r###"
-    modified
-    "###);
+    insta::assert_snapshot!(contents, @"modified");
 
     // Test diffedit --from @--
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -157,17 +147,17 @@ fn test_diffedit() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 5b585bd1 (no description set)
     Working copy now at: kkmpptxz 5b585bd1 (no description set)
     Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     D file2
-    "###);
+    ");
 }
 
 #[test]
@@ -191,30 +181,28 @@ fn test_diffedit_new_file() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     A file2
-    "###);
+    ");
 
     // Creating `file1` on the right side is noticed by `jj diffedit`
     std::fs::write(&edit_script, "write file1\nmodified\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz b0376e2b (no description set)
     Working copy now at: rlvkpnrz b0376e2b (no description set)
     Parent commit      : qpvuntsm b739eb46 (no description set)
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file1
     A file2
-    "###);
+    ");
 
     // Creating a file that wasn't on either side is ignored by diffedit.
     // TODO(ilyagr) We should decide whether we like this behavior.
@@ -226,14 +214,12 @@ fn test_diffedit_new_file() {
     std::fs::write(&edit_script, "write new_file\nnew file\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     A file2
-    "###);
+    ");
 }
 
 #[test]
@@ -329,7 +315,7 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created mzvwutvl fb39e804 (conflict) (empty) (no description set)
     Working copy now at: mzvwutvl fb39e804 (conflict) (empty) (no description set)
     Parent commit      : rlvkpnrz 3765cc27 side-a
@@ -339,10 +325,10 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     file    2-sided conflict
     Existing conflicts were resolved or abandoned from these commits:
       mzvwutvl hidden a813239f (conflict) (no description set)
-    "###);
+    ");
     // Conflicts should render using "snapshot" format in diff editor
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("before-file")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("before-file")).unwrap(), @r"
     line 1
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
@@ -364,9 +350,9 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("after-file")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("after-file")).unwrap(), @r"
     line 1
     line 2.1
     line 2.2
@@ -382,10 +368,10 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##);
+    ");
     // Conflicts should be materialized using "diff" format in working copy
     insta::assert_snapshot!(
-        std::fs::read_to_string(&file_path).unwrap(), @r##"
+        std::fs::read_to_string(&file_path).unwrap(), @r"
     line 1
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
@@ -405,18 +391,18 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
+    ");
 
     // File should be conflicted with no changes
     let stdout = test_env.jj_cmd_success(&repo_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     There are unresolved conflicts at these paths:
     file    2-sided conflict
     Working copy : mzvwutvl fb39e804 (conflict) (empty) (no description set)
     Parent commit: rlvkpnrz 3765cc27 side-a
     Parent commit: zsuskuln 8b3de837 side-b
-    "###);
+    ");
 }
 
 #[test]
@@ -453,28 +439,24 @@ fn test_diffedit_3pane() {
         &["diffedit", "--config", config_with_output_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
     // Nothing happens if we make no changes, `config_with_right_as_after` version
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["diffedit", "--config", config_with_right_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
 
     // Can edit changes to individual files
     std::fs::write(&edit_script, "reset file2").unwrap();
@@ -483,16 +465,14 @@ fn test_diffedit_3pane() {
         &["diffedit", "--config", config_with_output_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz ed8aada3 (no description set)
     Working copy now at: kkmpptxz ed8aada3 (no description set)
     Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
-    D file1
-    "###);
+    insta::assert_snapshot!(stdout, @"D file1");
 
     // Can write something new to `file1`
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -502,17 +482,17 @@ fn test_diffedit_3pane() {
         &["diffedit", "--config", config_with_output_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 7c19e689 (no description set)
     Working copy now at: kkmpptxz 7c19e689 (no description set)
     Parent commit      : rlvkpnrz a72506cd (no description set)
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file1
     M file2
-    "###);
+    ");
 
     // But nothing happens if we modify the right side
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -522,14 +502,12 @@ fn test_diffedit_3pane() {
         &["diffedit", "--config", config_with_right_as_after],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    ");
 
     // TODO: test with edit_script of "reset file2". This fails on right side
     // since the file is readonly.
@@ -558,10 +536,10 @@ fn test_diffedit_merge() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     // Test the setup
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r", "@-", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file1
     A file3
-    "###);
+    ");
 
     let edit_script = test_env.set_up_fake_diff_editor();
 
@@ -573,7 +551,7 @@ fn test_diffedit_merge() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "-r", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created royxmykx 0105de4a (conflict) merge
     Rebased 1 descendant commits
     Working copy now at: yqosqzyt abbb78c1 (conflict) (empty) (no description set)
@@ -581,15 +559,15 @@ fn test_diffedit_merge() {
     Added 0 files, modified 0 files, removed 1 files
     There are unresolved conflicts at these paths:
     file2    2-sided conflict
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     A file3
-    "###);
+    ");
     assert!(!repo_path.join("file1").exists());
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -a
@@ -597,7 +575,7 @@ fn test_diffedit_merge() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 }
 
 #[test]
@@ -618,56 +596,52 @@ fn test_diffedit_old_restore_interactive_tests() {
     // Nothing happens if we make no changes
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
     C {file2 => file3}
-    "###);
+    ");
 
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit", "--from", "@-"]);
-    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
+    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r"
     Error: Failed to edit diff
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
     C {file2 => file3}
-    "###);
+    ");
 
     // Can restore changes to individual files
     std::fs::write(&edit_script, "reset file2\0reset file3").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz 69811eda (no description set)
     Working copy now at: rlvkpnrz 69811eda (no description set)
     Parent commit      : qpvuntsm fc687cb8 (no description set)
     Added 0 files, modified 1 files, removed 1 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
-    D file1
-    "###);
+    insta::assert_snapshot!(stdout, @"D file1");
 
     // Can make unrelated edits
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&edit_script, "write file3\nunrelated\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diffedit", "--from", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz 2b76a42e (no description set)
     Working copy now at: rlvkpnrz 2b76a42e (no description set)
     Parent commit      : qpvuntsm fc687cb8 (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
     insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
@@ -715,12 +689,12 @@ fn test_diffedit_restore_descendants() {
         &["diffedit", "-r", "@-", "--restore-descendants"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz 62b8c2ce (no description set)
     Rebased 1 descendant commits (while preserving their content)
     Working copy now at: kkmpptxz 321d1cd1 (no description set)
     Parent commit      : rlvkpnrz 62b8c2ce (no description set)
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
     insta::assert_snapshot!(stdout, @r#"
     diff --git a/file b/file

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -38,31 +38,25 @@ fn test_duplicate() {
     create_commit(&test_env, &repo_path, "b", &[]);
     create_commit(&test_env, &repo_path, "c", &["a", "b"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    17a00fc21654   c
     ├─╮
     │ ○  d370aee184ba   b
     ○ │  2443ea76b0b1   a
     ├─╯
     ◆  000000000000
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "all()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Cannot duplicate the root commit
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Cannot duplicate the root commit");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "none()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    No revisions to duplicate.
-    "###);
+    insta::assert_snapshot!(stderr, @"No revisions to duplicate.");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Duplicated 2443ea76b0b1 as kpqxywon f5b1e687 a
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(stderr, @"Duplicated 2443ea76b0b1 as kpqxywon f5b1e687 a");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    17a00fc21654   c
     ├─╮
     │ ○  d370aee184ba   b
@@ -71,19 +65,15 @@ fn test_duplicate() {
     │ ○  f5b1e68729d6   a
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
-    Undid operation: b5bdbb51ab28 (2001-02-03 08:05:17) duplicate 1 commit(s)
-    "#);
+    insta::assert_snapshot!(stderr, @"Undid operation: b5bdbb51ab28 (2001-02-03 08:05:17) duplicate 1 commit(s)");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Duplicated 17a00fc21654 as lylxulpl ef3b0f3d c
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(stderr, @"Duplicated 17a00fc21654 as lylxulpl ef3b0f3d c");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    17a00fc21654   c
     ├─╮
     │ │ ○  ef3b0f3d1046   c
@@ -92,7 +82,7 @@ fn test_duplicate() {
     ○ │  2443ea76b0b1   a
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -107,7 +97,7 @@ fn test_duplicate_many() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["b", "d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -116,15 +106,15 @@ fn test_duplicate_many() {
     ├─╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b::"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 1394f625cbbd as wqnwkozp 3b74d969 b
     Duplicated 921dde6e55c0 as mouksmqu 8348ddce e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     ○ │  1394f625cbbd   b
@@ -137,16 +127,14 @@ fn test_duplicate_many() {
     ├───╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "#);
+    ");
 
     // Try specifying the same commit twice directly
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Duplicated 1394f625cbbd as nkmrtpmo 0276d3d7 b
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(stderr, @"Duplicated 1394f625cbbd as nkmrtpmo 0276d3d7 b");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -157,18 +145,18 @@ fn test_duplicate_many() {
     ├─╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "#);
+    ");
 
     // Try specifying the same commit twice indirectly
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b::", "d::"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 1394f625cbbd as xtnwkqum fa167d18 b
     Duplicated ebd06dba20ec as pqrnrkux 2181781b d
     Duplicated 921dde6e55c0 as ztxkyksq 0f7430f2 e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -183,11 +171,11 @@ fn test_duplicate_many() {
     ├───╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // Reminder of the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -196,15 +184,15 @@ fn test_duplicate_many() {
     ├─╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "d::", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 2443ea76b0b1 as nlrtlrxv c6f7f8c4 a
     Duplicated ebd06dba20ec as plymsszl d94e4c55 d
     Duplicated 921dde6e55c0 as urrlptpw 9bd4389f e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -219,20 +207,20 @@ fn test_duplicate_many() {
     │ ○  c6f7f8c4512e   a
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     // Check for BUG -- makes too many 'a'-s, etc.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a::"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 2443ea76b0b1 as uuuvxpvw 0fe67a05 a
     Duplicated 1394f625cbbd as nmpuuozl e13ac0ad b
     Duplicated c0cb3a0b73e7 as kzpokyyw df53fa58 c
     Duplicated ebd06dba20ec as yxrlprzz 2f2442db d
     Duplicated 921dde6e55c0 as mvkzkxrl ee8fe64e e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -249,7 +237,7 @@ fn test_duplicate_many() {
     │ ○  0fe67a05989e   a
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -267,7 +255,7 @@ fn test_duplicate_destination() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7550bb42c6f   d
     │ ○  b75b7aa4b90e   c
     ├─╯
@@ -278,7 +266,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     // Duplicate a single commit onto a single destination.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "-d", "c"]);
@@ -466,7 +454,7 @@ fn test_duplicate_insert_after() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
     │ ○  09560d60cac4   c2
@@ -481,7 +469,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     // Duplicate a single commit after a single commit with no direct relationship.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "--after", "b1"]);
@@ -902,13 +890,13 @@ fn test_duplicate_insert_after() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["duplicate", "a2", "a3", "--after", "a1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Warning: Duplicating commit 47df67757a64 as an ancestor of itself
     Duplicated 47df67757a64 as sukptuzs 4324d289 a2
     Duplicated 17072aa2b823 as rxnrppxl 47586b09 a3
     Rebased 3 commits onto duplicated commits
-    "#);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -1068,9 +1056,7 @@ fn test_duplicate_insert_after() {
         &repo_path,
         &["duplicate", "a1", "--after", "b1", "--after", "b2"],
     );
-    insta::assert_snapshot!(stderr, @r#"
-    Error: Refusing to create a loop: commit 7b44470918f4 would be both an ancestor and a descendant of the duplicated commits
-    "#);
+    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit 7b44470918f4 would be both an ancestor and a descendant of the duplicated commits");
 }
 
 #[test]
@@ -1092,7 +1078,7 @@ fn test_duplicate_insert_before() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
     │ ○  09560d60cac4   c2
@@ -1107,7 +1093,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     // Duplicate a single commit before a single commit with no direct relationship.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "--before", "b2"]);
@@ -1290,11 +1276,11 @@ fn test_duplicate_insert_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "b1", "--before", "c1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as sryyqqkq fa625d74 a1
     Duplicated dcc98bc8bbea as pxnqtknr 2233b9a8 b1
     Rebased 2 commits onto duplicated commits
-    "#);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -1390,15 +1376,15 @@ fn test_duplicate_insert_before() {
         &["duplicate", "a1", "b1", "--before", "c1", "--before", "d1"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as knltnxnu 056a0cb3 a1
     Duplicated dcc98bc8bbea as krtqozmx fb68a539 b1
     Rebased 4 commits onto duplicated commits
     Working copy now at: nmzmmopx 89f9b379 d2 | d2
     Parent commit      : xznxytkn 771d0e16 d1 | d1
     Added 2 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  89f9b37923a9   d2
     ○    771d0e16b40c   d1
     ├─╮
@@ -1417,7 +1403,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Duplicate multiple commits without a direct ancestry relationship before
@@ -1700,9 +1686,7 @@ fn test_duplicate_insert_before() {
         &repo_path,
         &["duplicate", "a1", "--before", "b1", "--before", "b2"],
     );
-    insta::assert_snapshot!(stderr, @r#"
-    Error: Refusing to create a loop: commit dcc98bc8bbea would be both an ancestor and a descendant of the duplicated commits
-    "#);
+    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit dcc98bc8bbea would be both an ancestor and a descendant of the duplicated commits");
 }
 
 #[test]
@@ -1724,7 +1708,7 @@ fn test_duplicate_insert_after_before() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
     │ ○  09560d60cac4   c2
@@ -1739,7 +1723,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     // Duplicate a single commit in between commits with no direct relationship.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1903,10 +1887,10 @@ fn test_duplicate_insert_after_before() {
         &["duplicate", "a2", "--after", "a1", "--before", "a4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 47df67757a64 as xpnwykqz 54cc0161 a2
     Rebased 1 commits onto duplicated commits
-    "#);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -2127,11 +2111,11 @@ fn test_duplicate_insert_after_before() {
         &["duplicate", "a3", "a4", "--after", "a2", "--before", "c2"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 17072aa2b823 as quyylypw d4d3c907 a3
     Duplicated 196bc1f0efc1 as prukwozq 96798f1b a4
     Rebased 1 commits onto duplicated commits
-    "#);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -2263,11 +2247,11 @@ fn test_duplicate_insert_after_before() {
         &["duplicate", "a2", "a3", "--after", "a1", "--before", "a4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 47df67757a64 as nwmqwkzz 8517eaa7 a2
     Duplicated 17072aa2b823 as uwrrnrtx 3ce18231 a3
     Rebased 1 commits onto duplicated commits
-    "#);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -2295,9 +2279,7 @@ fn test_duplicate_insert_after_before() {
         &repo_path,
         &["duplicate", "a1", "--after", "b2", "--before", "b1"],
     );
-    insta::assert_snapshot!(stderr, @r#"
-    Error: Refusing to create a loop: commit 7b44470918f4 would be both an ancestor and a descendant of the duplicated commits
-    "#);
+    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit 7b44470918f4 would be both an ancestor and a descendant of the duplicated commits");
 }
 
 // https://github.com/jj-vcs/jj/issues/1050
@@ -2308,32 +2290,28 @@ fn test_undo_after_duplicate() {
     let repo_path = test_env.env_root().join("repo");
 
     create_commit(&test_env, &repo_path, "a", &[]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Duplicated 2443ea76b0b1 as mzvwutvl f5cefcbb a
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(stderr, @"Duplicated 2443ea76b0b1 as mzvwutvl f5cefcbb a");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1   a
     │ ○  f5cefcbb65a4   a
     ├─╯
     ◆  000000000000
-    "#);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
-    Undid operation: e3dbefa46ed5 (2001-02-03 08:05:11) duplicate 1 commit(s)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Undid operation: e3dbefa46ed5 (2001-02-03 08:05:11) duplicate 1 commit(s)");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    ");
 }
 
 // https://github.com/jj-vcs/jj/issues/694
@@ -2347,24 +2325,20 @@ fn test_rebase_duplicates() {
     create_commit(&test_env, &repo_path, "b", &["a"]);
     create_commit(&test_env, &repo_path, "c", &["b"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r"
     @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
     ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
     ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Duplicated 7e4fbf4f2759 as yostqsxw 0ac2063b c
-    "###);
+    insta::assert_snapshot!(stderr, @"Duplicated 7e4fbf4f2759 as yostqsxw 0ac2063b c");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Duplicated 7e4fbf4f2759 as znkkpsqq ce5f4eeb c
-    "###);
-    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(stderr, @"Duplicated 7e4fbf4f2759 as znkkpsqq ce5f4eeb c");
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r"
     @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
     │ ○  ce5f4eeb69d1   c @ 2001-02-03 04:05:16.000 +07:00
     ├─╯
@@ -2373,19 +2347,19 @@ fn test_rebase_duplicates() {
     ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
     ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
-    "#);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Working copy now at: royxmykx ed671a3c c | c
     Parent commit      : zsuskuln 4c6f1569 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "#);
+    ");
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.
-    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r"
     @  ed671a3cbf35   c @ 2001-02-03 04:05:18.000 +07:00
     │ ○  b86e9f27d085   c @ 2001-02-03 04:05:16.000 +07:00
     ├─╯
@@ -2395,7 +2369,7 @@ fn test_rebase_duplicates() {
     │ ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ├─╯
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
-    "#);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -28,43 +28,41 @@ fn test_edit() {
 
     // Errors out without argument
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["edit"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <REVSET>
 
     Usage: jj edit <REVSET>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Makes the specified commit the working-copy commit
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 73383c0b first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  2c910ae2d628 second
     @  73383c0b6439 first
     ◆  000000000000
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(read_file(&repo_path.join("file1")), @"0");
 
     // Changes in the working copy are amended into the commit
     std::fs::write(repo_path.join("file2"), "0").unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  b384b2cc1883 second
     @  ff3f7b0dc386 first
     ◆  000000000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Rebased 1 descendant commits onto updated working copy
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Rebased 1 descendant commits onto updated working copy");
 }
 
 #[test]
@@ -101,13 +99,13 @@ fn test_edit_current_wc_commit_missing() {
         .jj_cmd(&repo_path, &["edit", "--ignore-working-copy", &wc_child_id])
         .assert()
         .code(255);
-    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    insta::assert_snapshot!(get_stderr_string(&assert), @r"
     Internal error: Failed to edit a commit
     Caused by:
     1: Current working-copy commit not found
     2: Object fa15625b4a986997697639dfc2844138900c79f2 of type commit not found
     3: An object with id fa15625b4a986997697639dfc2844138900c79f2 could not be found
-    "###);
+    ");
 }
 
 fn read_file(path: &Path) -> String {

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -29,7 +29,7 @@ fn test_evolog_with_or_without_diff() {
     std::fs::write(repo_path.join("file1"), "resolved\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
@@ -38,11 +38,11 @@ fn test_evolog_with_or_without_diff() {
     │  my description
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
-    "###);
+    ");
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "evolog"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
     │  [1mmy description[0m
     [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m07[0m[38;5;8mb18245[39m [38;5;1mconflict[39m
@@ -51,12 +51,12 @@ fn test_evolog_with_or_without_diff() {
     │  my description
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m2b[0m[38;5;8m023b5f[39m
        [38;5;2m(empty)[39m my description
-    "###);
+    ");
 
     // There should be no diff caused by the rebase because it was a pure rebase
     // (even even though it resulted in a conflict).
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "-p"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     │  Resolved conflict in file1:
@@ -78,20 +78,20 @@ fn test_evolog_with_or_without_diff() {
     │          1: foo
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
-    "###);
+    ");
 
     // Test `--limit`
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--limit=2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
     │  my description
-    "###);
+    ");
 
     // Test `--no-graph`
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     my description
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
@@ -100,11 +100,11 @@ fn test_evolog_with_or_without_diff() {
     my description
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
     (empty) my description
-    "###);
+    ");
 
     // Test `--git` format, and that it implies `-p`
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--no-graph", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     my description
     diff --git a/file1 b/file1
@@ -140,7 +140,7 @@ fn test_evolog_with_or_without_diff() {
     +foo
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
     (empty) my description
-    "###);
+    ");
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn test_evolog_with_custom_symbols() {
     let config = "templates.log_node='if(current_working_copy, \"$\", \"┝\")'";
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--config", config]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
@@ -168,7 +168,7 @@ fn test_evolog_with_custom_symbols() {
     │  my description
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
-    "###);
+    ");
 }
 
 #[test]
@@ -193,34 +193,34 @@ fn test_evolog_word_wrap() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "first"]);
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
-    insta::assert_snapshot!(render(&["evolog"], 40, false), @r###"
+    insta::assert_snapshot!(render(&["evolog"], 40, false), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(render(&["evolog"], 40, true), @r###"
+    ");
+    insta::assert_snapshot!(render(&["evolog"], 40, true), @r"
     @  qpvuntsm test.user@example.com
     │  2001-02-03 08:05:08 fa15625b
     │  (empty) first
     ○  qpvuntsm hidden test.user@example.com
        2001-02-03 08:05:07 230dd059
        (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, false), @r###"
+    ");
+    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, false), @r"
     qpvuntsm test.user@example.com 2001-02-03 08:05:08 fa15625b
     (empty) first
     qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
     (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, true), @r###"
+    ");
+    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, true), @r"
     qpvuntsm test.user@example.com
     2001-02-03 08:05:08 fa15625b
     (empty) first
     qpvuntsm hidden test.user@example.com
     2001-02-03 08:05:07 230dd059
     (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -264,7 +264,7 @@ fn test_evolog_squash() {
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["evolog", "-p", "-r", "description('squash')"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:15 d49749bf
     ├─┬─╮  squashed 3
     │ │ ○  vruxwmqv hidden test.user@example.com 2001-02-03 08:05:15 8f2ae2b5
@@ -316,7 +316,7 @@ fn test_evolog_squash() {
     │  (empty) first
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -54,7 +54,7 @@ fn test_chmod_regular_conflict() {
     create_commit(&test_env, &repo_path, "conflict", &["x", "n"], &[]);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  n
@@ -62,15 +62,13 @@ fn test_chmod_regular_conflict() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
-    file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))
-    "###);
+    @r#"file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -78,18 +76,16 @@ fn test_chmod_regular_conflict() {
     +++++++ Contents of side #2
     n
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Test chmodding a conflict
     test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "x", "file"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
-    file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: true })]))
-    "###);
+    @r#"file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: true })]))"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -97,16 +93,14 @@ fn test_chmod_regular_conflict() {
     +++++++ Contents of side #2
     n
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "n", "file"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
-    file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))
-    "###);
+    @r#"file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -114,12 +108,12 @@ fn test_chmod_regular_conflict() {
     +++++++ Contents of side #2
     n
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Unmatched paths should generate warnings
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "x", "nonexistent", "file"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No matching entries for paths: nonexistent
     Working copy now at: yostqsxw 2b11d002 conflict | (conflict) conflict
     Parent commit      : royxmykx 427fbd2f x | x
@@ -127,7 +121,7 @@ fn test_chmod_regular_conflict() {
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict including an executable
-    "###);
+    ");
 }
 
 // TODO: Test demonstrating that conflicts whose *base* is not a file are
@@ -160,7 +154,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
         &["file", "deletion"],
         &[],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    file_deletion
     ├─╮
     │ ○  deletion
@@ -172,50 +166,44 @@ fn test_chmod_file_dir_deletion_conflicts() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
 
     // The file-dir conflict cannot be chmod-ed
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_dir"]);
     insta::assert_snapshot!(stdout,
-    @r###"
-    file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(Tree(TreeId("133bb38fc4e4bf6b551f1f04db7e48f04cac2877")))]))
-    "###);
+    @r#"file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(Tree(TreeId("133bb38fc4e4bf6b551f1f04db7e48f04cac2877")))]))"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_dir", "file"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r"
     Conflict:
       Removing file with id df967b96a579e45a18b8251732d16804b2e56a55
       Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877
-    "###);
+    ");
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["file", "chmod", "x", "file", "-r=file_dir"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Some of the sides of the conflict are not files at 'file'.
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Some of the sides of the conflict are not files at 'file'.");
 
     // The file_deletion conflict can be chmod-ed
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout,
-    @r###"
-    file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), None]))
-    "###);
+    @r#"file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), None]))"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     a
     %%%%%%% Changes from base to side #2
     -base
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["file", "chmod", "x", "file", "-r=file_deletion"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kmkuslsw 139dee15 file_deletion | (conflict) file_deletion
     Parent commit      : zsuskuln c51c9c55 file | file
     Parent commit      : royxmykx 6b18b3c1 deletion | deletion
@@ -229,20 +217,18 @@ fn test_chmod_file_dir_deletion_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout,
-    @r###"
-    file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), None]))
-    "###);
+    @r#"file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), None]))"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     a
     %%%%%%% Changes from base to side #2
     -base
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 }

--- a/cli/tests/test_file_show_command.rs
+++ b/cli/tests/test_file_show_command.rs
@@ -28,15 +28,11 @@ fn test_show() {
 
     // Can print the contents of a file in a commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
 
     // Defaults to printing the working-copy version
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
 
     // Can print a file in a subdirectory
     let subdir_file = if cfg!(unix) {
@@ -45,45 +41,35 @@ fn test_show() {
         "dir\\file2"
     };
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", subdir_file]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 
     // Error if the path doesn't exist
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "nonexistent"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such path: nonexistent
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No such path: nonexistent");
 
     // Can print files under the specified directory
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 
     // Can print multiple files
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "."]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
     b
-    "###);
+    ");
 
     // Unmatched paths should generate warnings
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["file", "show", "file1", "non-existent"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: No matching entries for paths: non-existent
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
+    insta::assert_snapshot!(stderr, @"Warning: No matching entries for paths: non-existent");
 
     // Can print a conflict
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "@", "-d", "@--"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -b
@@ -91,7 +77,7 @@ fn test_show() {
     +++++++ Contents of side #2
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 }
 
 #[cfg(unix)]
@@ -108,11 +94,9 @@ fn test_show_symlink() {
 
     // Can print multiple files
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "show", "."]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
     a
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: Path 'symlink1' exists but is not a file
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Warning: Path 'symlink1' exists but is not a file");
 }

--- a/cli/tests/test_file_track_untrack_commands.rs
+++ b/cli/tests/test_file_track_untrack_commands.rs
@@ -40,27 +40,27 @@ fn test_track_untrack() {
     // Errors out when not run at the head operation
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["file", "untrack", "file1", "--at-op", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: This command must be able to update the working copy.
     Hint: Don't use --at-op.
-    "###);
+    ");
     // Errors out when no path is specified
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["file", "untrack"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <FILESETS>...
 
     Usage: jj file untrack <FILESETS>...
 
     For more information, try '--help'.
-    "###);
+    ");
     // Errors out when a specified file is not ignored
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "untrack", "file1", "file1.bak"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: 'file1' is not ignored.
     Hint: Files that are not ignored will be added back by the next command.
     Make sure they're ignored, then try again.
-    "###);
+    ");
     let files_after = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
     // There should be no changes to the state when there was an error
     assert_eq!(files_after, files_before);
@@ -69,10 +69,10 @@ fn test_track_untrack() {
     assert!(files_before.contains("file1.bak\n"));
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["untrack", "file1.bak"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj untrack` is deprecated; use `jj file untrack` instead, which is equivalent
     Warning: `jj untrack` will be removed in a future version, and this will be a hard error
-    "###);
+    ");
     let files_after = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
     // The file is no longer tracked
     assert!(!files_after.contains("file1.bak"));
@@ -116,27 +116,23 @@ fn test_track_untrack_sparse() {
     // doesn't need to be ignored (because it won't be automatically added
     // back).
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1
     file2
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["sparse", "set", "--clear", "--add", "file1"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "untrack", "file2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(stdout, @"file1");
     // Trying to manually track a file that's not included in the sparse working has
     // no effect. TODO: At least a warning would be useful
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "track", "file2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(stdout, @"file1");
 }
 
 #[test]
@@ -152,44 +148,38 @@ fn test_auto_track() {
 
     // Only configured paths get auto-tracked
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1.rs
-    "###);
+    insta::assert_snapshot!(stdout, @"file1.rs");
 
     // Can manually track paths
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "track", "file3.md"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1.rs
     file3.md
-    "###);
+    ");
 
     // Can manually untrack paths
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "untrack", "file3.md"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1.rs
-    "###);
+    insta::assert_snapshot!(stdout, @"file1.rs");
 
     // CWD-relative paths in `snapshot.auto-track` are evaluated from the repo root
     let subdir = repo_path.join("sub");
     std::fs::create_dir(&subdir).unwrap();
     std::fs::write(subdir.join("file1.rs"), "initial").unwrap();
     let stdout = test_env.jj_cmd_success(&subdir, &["file", "list"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
-    ../file1.rs
-    "###);
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @"../file1.rs");
 
     // But `jj file track` wants CWD-relative paths
     let stdout = test_env.jj_cmd_success(&subdir, &["file", "track", "file1.rs"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&subdir, &["file", "list"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     ../file1.rs
     file1.rs
-    "###);
+    ");
 }
 
 #[test]
@@ -207,16 +197,12 @@ fn test_track_ignored() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "track", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(stdout, @"file1");
     // Track an ignored path
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "track", "file1.bak"]);
     insta::assert_snapshot!(stdout, @"");
     // TODO: We should teach `jj file track` to track ignored paths (possibly
     // requiring a flag)
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(stdout, @"file1");
 }

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -60,7 +60,7 @@ fn test_config_no_tools() {
     ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content\n");
+    insta::assert_snapshot!(content, @"content");
 }
 
 #[test]
@@ -90,11 +90,11 @@ fn test_config_multiple_tools() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @"FOO");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @"bar\n");
+    insta::assert_snapshot!(content, @"bar");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "baz", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Baz\n");
+    insta::assert_snapshot!(content, @"Baz");
 }
 
 #[test]
@@ -139,9 +139,9 @@ fn test_config_multiple_tools_with_same_name() {
 
     test_env.set_config_path("/dev/null");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Foo\n");
+    insta::assert_snapshot!(content, @"Foo");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Bar\n");
+    insta::assert_snapshot!(content, @"Bar");
 }
 
 #[test]
@@ -178,11 +178,11 @@ fn test_config_disabled_tools() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @"FOO");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @"bar\n");
+    insta::assert_snapshot!(content, @"bar");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "baz", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Baz\n");
+    insta::assert_snapshot!(content, @"Baz");
 }
 
 #[test]
@@ -205,10 +205,10 @@ fn test_config_disabled_tools_warning_when_all_tools_are_disabled() {
     std::fs::write(repo_path.join("bar"), "Bar\n").unwrap();
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["fix"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Config error: At least one entry of `fix.tools` must be enabled.
     For help, see https://jj-vcs.github.io/jj/latest/config/.
-    "###);
+    ");
 }
 
 #[test]
@@ -239,21 +239,21 @@ fn test_config_tables_overlapping_patterns() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     foo
     tool-1
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     bar
     tool-1
     tool-2
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "baz", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     baz
     tool-2
-    "###);
+    ");
 }
 
 #[test]
@@ -283,7 +283,7 @@ fn test_config_tables_all_commands_missing() {
     ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"foo\n");
+    insta::assert_snapshot!(content, @"foo");
 }
 
 #[test]
@@ -317,7 +317,7 @@ fn test_config_tables_some_commands_missing() {
     ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"foo\n");
+    insta::assert_snapshot!(content, @"foo");
 }
 
 #[test]
@@ -340,13 +340,13 @@ fn test_config_tables_empty_patterns_list() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-      Fixed 0 commits of 1 checked.
-      Nothing changed.
-      "###);
+    insta::assert_snapshot!(stderr, @r"
+    Fixed 0 commits of 1 checked.
+    Nothing changed.
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"foo\n");
+    insta::assert_snapshot!(content, @"foo");
 }
 
 #[test]
@@ -380,11 +380,11 @@ fn test_config_filesets() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"A1\n");
+    insta::assert_snapshot!(content, @"A1");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"1b\n");
+    insta::assert_snapshot!(content, @"1b");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"2b\n");
+    insta::assert_snapshot!(content, @"2b");
 }
 
 #[test]
@@ -413,30 +413,30 @@ fn test_relative_paths() {
     // filesets.
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path.join("dir"), &["fix", "foo3"]);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @"unfixed");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @"unfixed");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir/foo3", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @"unfixed");
 
     // Positional arguments can specify a subset of the configured fileset.
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path.join("dir"), &["fix", "../foo1"]);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Fixed!\n");
+    insta::assert_snapshot!(content, @"Fixed!");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @"unfixed");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir/foo3", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @"unfixed");
 
     // The current directory does not change the interpretation of the config, so
     // foo2 is fixed but not dir/foo3.
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path.join("dir"), &["fix"]);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Fixed!\n");
+    insta::assert_snapshot!(content, @"Fixed!");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Fixed!\n");
+    insta::assert_snapshot!(content, @"Fixed!");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir/foo3", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @"unfixed");
 }
 
 #[test]
@@ -647,9 +647,7 @@ fn test_fix_some_paths() {
     Added 0 files, modified 1 files, removed 0 files
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(content, @r###"
-    FOO
-    "###);
+    insta::assert_snapshot!(content, @"FOO");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
     insta::assert_snapshot!(content, @"bar");
 }
@@ -668,7 +666,7 @@ fn test_fix_cyclic() {
     Added 0 files, modified 1 files, removed 0 files
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"tnetnoc\n");
+    insta::assert_snapshot!(content, @"tnetnoc");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
     insta::assert_snapshot!(stdout, @"");
@@ -679,7 +677,7 @@ fn test_fix_cyclic() {
     Added 0 files, modified 1 files, removed 0 files
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content\n");
+    insta::assert_snapshot!(content, @"content");
 }
 
 #[test]
@@ -712,18 +710,21 @@ fn test_deduplication() {
     Added 0 files, modified 1 files, removed 0 files
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "a"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @"FOO");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "b"]);
-    insta::assert_snapshot!(content, @"BAR\n");
+    insta::assert_snapshot!(content, @"BAR");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "c"]);
-    insta::assert_snapshot!(content, @"BAR\n");
+    insta::assert_snapshot!(content, @"BAR");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "d"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @"FOO");
 
     // Each new content string only appears once in the log, because all the other
     // inputs (like file name) were identical, and so the results were reused. We
     // sort the log because the order of execution inside `jj fix` is undefined.
-    insta::assert_snapshot!(sorted_lines(repo_path.join("file-fixlog")), @"BAR\nFOO\n");
+    insta::assert_snapshot!(sorted_lines(repo_path.join("file-fixlog")), @r"
+    BAR
+    FOO
+    ");
 }
 
 fn sorted_lines(path: PathBuf) -> String {
@@ -750,9 +751,9 @@ fn test_executed_but_nothing_changed() {
     Nothing changed.
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content\n");
+    insta::assert_snapshot!(content, @"content");
     let copy_content = std::fs::read_to_string(repo_path.join("file-copy").as_os_str()).unwrap();
-    insta::assert_snapshot!(copy_content, @"content\n");
+    insta::assert_snapshot!(copy_content, @"content");
 }
 
 #[test]
@@ -959,22 +960,18 @@ fn test_fix_both_sides_of_conflict() {
     file    2-sided conflict
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "a"]);
-    insta::assert_snapshot!(content, @r###"
-    CONTENT A
-    "###);
+    insta::assert_snapshot!(content, @"CONTENT A");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "b"]);
-    insta::assert_snapshot!(content, @r###"
-    CONTENT B
-    "###);
+    insta::assert_snapshot!(content, @"CONTENT B");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     +CONTENT A
     +++++++ Contents of side #2
     CONTENT B
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 }
 
 #[test]
@@ -1001,9 +998,7 @@ fn test_fix_resolve_conflict() {
     Added 0 files, modified 1 files, removed 0 files
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
-    CONTENT
-    "###);
+    insta::assert_snapshot!(content, @"CONTENT");
 }
 
 #[test]
@@ -1058,96 +1053,76 @@ fn test_all_files() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Fixed 2 commits of 2 checked.
     Working copy now at: rlvkpnrz c098d165 child
     Parent commit      : qpvuntsm 0bb31627 parent
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
-    parent aaa
-    "###);
+    insta::assert_snapshot!(content, @"parent aaa");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
     fixed
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
-    parent ccc
-    "###);
+    insta::assert_snapshot!(content, @"parent ccc");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
-    parent ddd
-    "###);
+    insta::assert_snapshot!(content, @"parent ddd");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
-    child aaa
-    "###);
+    insta::assert_snapshot!(content, @"child aaa");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
     fixed
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
-    parent ccc
-    "###);
+    insta::assert_snapshot!(content, @"parent ccc");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
-    child ddd
-    "###);
+    insta::assert_snapshot!(content, @"child ddd");
 
     // Not specifying files means all files will be fixed in each revision.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix", "--include-unchanged-files"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Fixed 2 commits of 2 checked.
     Working copy now at: rlvkpnrz c5d0aa1d child
     Parent commit      : qpvuntsm b4d02ca9 parent
     Added 0 files, modified 2 files, removed 0 files
-    "###);
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent aaa
     fixed
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
     fixed
     fixed
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
-    parent ccc
-    "###);
+    insta::assert_snapshot!(content, @"parent ccc");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
-    parent ddd
-    "###);
+    insta::assert_snapshot!(content, @"parent ddd");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     child aaa
     fixed
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
     fixed
     fixed
-    "###);
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
-    parent ccc
-    "###);
+    insta::assert_snapshot!(content, @"parent ccc");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
-    child ddd
-    "###);
+    insta::assert_snapshot!(content, @"child ddd");
 }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -68,10 +68,10 @@ fn test_git_clone(subprocess: bool) {
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "empty"]);
     insta::allow_duplicates! { insta::assert_snapshot!(stdout, @""); }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/empty"
     Nothing changed.
-    "###);
+    "#);
     }
 
     set_up_non_empty_git_repo(&git_repo);
@@ -101,9 +101,7 @@ fn test_git_clone(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
 
     // Failed clone should clean up the destination directory
@@ -160,36 +158,28 @@ fn test_git_clone(subprocess: bool) {
     // Failed clone (if attempted) shouldn't remove the existing workspace
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "bad", "clone"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
     assert!(test_env.env_root().join("clone").join(".jj").exists());
 
     // Try cloning into an existing workspace
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "clone"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
 
     // Try cloning into an existing file
     std::fs::write(test_env.env_root().join("file"), "contents").unwrap();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "file"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
 
     // Try cloning into non-empty, non-workspace directory
     std::fs::remove_dir_all(test_env.env_root().join("clone").join(".jj")).unwrap();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "clone"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
 
     // Clone into a nested path
@@ -258,10 +248,10 @@ fn test_git_clone_colocate(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/empty"
     Nothing changed.
-    "###);
+    "#);
     }
 
     // git_target path should be relative to the store
@@ -324,21 +314,21 @@ fn test_git_clone_colocate(subprocess: bool) {
         .map(|entry| format!("{:?} {}\n", entry.status(), entry.path().unwrap()))
         .collect();
     insta::allow_duplicates! {
-    insta::assert_snapshot!(git_statuses, @r###"
+    insta::assert_snapshot!(git_statuses, @r"
     Status(IGNORED) .jj/.gitignore
     Status(IGNORED) .jj/repo/
     Status(IGNORED) .jj/working_copy/
-    "###);
+    ");
     }
 
     // The old default bookmark "master" shouldn't exist.
     insta::allow_duplicates! {
     insta::assert_snapshot!(
-        get_bookmark_output(&test_env, &test_env.env_root().join("clone")), @r###"
+        get_bookmark_output(&test_env, &test_env.env_root().join("clone")), @r"
     main: mzyxwzks 9f01a0e0 message
       @git: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
     }
 
     // Subsequent fetch should just work even if the source path was relative
@@ -348,9 +338,7 @@ fn test_git_clone_colocate(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
 
     // Failed clone should clean up the destination directory
@@ -417,9 +405,7 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "--colocate", "bad", "clone"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
     assert!(test_env.env_root().join("clone").join(".git").exists());
     assert!(test_env.env_root().join("clone").join(".jj").exists());
@@ -430,9 +416,7 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "source", "clone", "--colocate"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
 
     // Try cloning into an existing file
@@ -442,9 +426,7 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "source", "file", "--colocate"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
 
     // Try cloning into non-empty, non-workspace directory
@@ -454,9 +436,7 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "source", "clone", "--colocate"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Destination path exists and is not an empty directory
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Destination path exists and is not an empty directory");
     }
 
     // Clone into a nested path
@@ -522,12 +502,12 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(
-        get_bookmark_output(&test_env, &test_env.env_root().join("clone1")), @r###"
+        get_bookmark_output(&test_env, &test_env.env_root().join("clone1")), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
     main: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
     }
 
     // "trunk()" alias should be set to default bookmark "main"
@@ -536,9 +516,7 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
         &["config", "list", "--repo", "revset-aliases.'trunk()'"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
-    revset-aliases.'trunk()' = "main@origin"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"revset-aliases.'trunk()' = "main@origin""#);
     }
 
     // Only the default bookmark will be imported if auto-local-bookmark is off
@@ -558,11 +536,11 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(
-        get_bookmark_output(&test_env, &test_env.env_root().join("clone2")), @r###"
+        get_bookmark_output(&test_env, &test_env.env_root().join("clone2")), @r"
     feature1@origin: mzyxwzks 9f01a0e0 message
     main: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
     }
 
     // Change the default bookmark in remote
@@ -595,9 +573,7 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
         &["config", "list", "--repo", "revset-aliases.'trunk()'"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
-    revset-aliases.'trunk()' = "feature1@origin"
-    "###);
+    insta::assert_snapshot!(stdout, @r#"revset-aliases.'trunk()' = "feature1@origin""#);
     }
 }
 
@@ -671,11 +647,11 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["status", "--ignore-working-copy"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     Working copy : sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit: mzyxwzks 9f01a0e0 main | message
-    "###);
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @"");
@@ -684,11 +660,11 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
     // TODO: Correct, but might be better to check out the root commit?
     let stderr = test_env.jj_cmd_failure(&clone_path, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation eac759b9ab75).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    ");
     }
 }
 
@@ -708,9 +684,7 @@ fn test_git_clone_at_operation(subprocess: bool) {
         &["git", "clone", "--at-op=@-", "source", "clone"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --at-op is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --at-op is not respected");
     }
 }
 
@@ -807,13 +781,13 @@ fn test_git_clone_trunk_deleted(subprocess: bool) {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["log"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 cad212e1
     │  (empty) (no description set)
     ○  mzyxwzks some.one@example.com 1970-01-01 11:00:00 9f01a0e0
     │  message
     ◆  zzzzzzzz root() 00000000
-    "#);
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r"
@@ -1023,21 +997,21 @@ fn test_git_clone_malformed(subprocess: bool) {
     // The cloned workspace isn't usable.
     let stderr = test_env.jj_cmd_failure(&clone_path, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation 4a8ddda0ff63).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    ");
     }
 
     // The error can be somehow recovered.
     // TODO: add an update-stale flag to reset the working-copy?
     let stderr = test_env.jj_cmd_internal_error(&clone_path, &["workspace", "update-stale"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Internal error: Failed to check out commit 039a1eae03465fd3be0fbad87c9ca97303742677
     Caused by: Reserved path component .jj in $TEST_ENV/clone/.jj
-    "#);
+    ");
     }
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&clone_path, &["new", "root()", "--ignore-working-copy"]);
@@ -1046,11 +1020,11 @@ fn test_git_clone_malformed(subprocess: bool) {
     }
     let stdout = test_env.jj_cmd_success(&clone_path, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     Working copy : zsuskuln f652c321 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "#);
+    ");
     }
 }
 

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -57,11 +57,11 @@ fn test_git_colocated() {
 
     // Import the repo
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  3e9369cd54227eb88455e1834dbc08aad6a16ac4
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"e61b6729ff4292870702f2f72b2a60165679ef37"
@@ -70,11 +70,11 @@ fn test_git_colocated() {
     // Modify the working copy. The working-copy commit should changed, but the Git
     // HEAD commit should not
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  4f546c80f30abc0803fb83e5032a4d49fede4d68
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"e61b6729ff4292870702f2f72b2a60165679ef37"
@@ -82,12 +82,12 @@ fn test_git_colocated() {
 
     // Create a new change from jj and check that it's reflected in Git
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  0e2301a42b288b9568344e32cfdd8c76d1e56a83
     ○  4f546c80f30abc0803fb83e5032a4d49fede4d68 git_head()
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"4f546c80f30abc0803fb83e5032a4d49fede4d68"
@@ -119,67 +119,67 @@ fn test_git_colocated_unborn_bookmark() {
         git_repo.find_reference("HEAD").unwrap().symbolic_target(),
         Some("refs/heads/master")
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Stage some change, and check out root. This shouldn't clobber the HEAD.
     add_file_to_index("file0", "");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz fcdbbd73 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    ");
     assert!(git_repo.head().is_err());
     assert_eq!(
         git_repo.find_reference("HEAD").unwrap().symbolic_target(),
         Some("refs/heads/master")
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  fcdbbd731496cae17161cd6be9b6cf1f759655a8
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
     // Staged change shouldn't persist.
     checkout_index();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r"
     The working copy is clean
     Working copy : kkmpptxz fcdbbd73 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     // Stage some change, and create new HEAD. This shouldn't move the default
     // bookmark.
     add_file_to_index("file1", "");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: royxmykx 0e146103 (empty) (no description set)
     Parent commit      : kkmpptxz e3e01407 (no description set)
-    "###);
+    ");
     assert!(git_repo.head().unwrap().symbolic_target().is_none());
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"e3e01407bd3539722ae4ffff077700d97c60cb11"
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  0e14610343ef50775f5c44db5aeef19aee45d9ad
     ○  e3e01407bd3539722ae4ffff077700d97c60cb11 git_head()
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
     // Staged change shouldn't persist.
     checkout_index();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r"
     The working copy is clean
     Working copy : royxmykx 0e146103 (empty) (no description set)
     Parent commit: kkmpptxz e3e01407 (no description set)
-    "###);
+    ");
 
     // Assign the default bookmark. The bookmark is no longer "unborn".
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@-", "master"]);
@@ -189,13 +189,13 @@ fn test_git_colocated_unborn_bookmark() {
     add_file_to_index("file2", "");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: znkkpsqq 10dd328b (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 2 files
-    "###);
+    ");
     assert!(git_repo.head().is_err());
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  10dd328bb906e15890e55047740eab2812a3b2f7
     │ ○  ef75c0b0dcc9b080e00226908c21316acaa84dc6
     │ ○  e3e01407bd3539722ae4ffff077700d97c60cb11 master
@@ -203,24 +203,24 @@ fn test_git_colocated_unborn_bookmark() {
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
     // Staged change shouldn't persist.
     checkout_index();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r"
     The working copy is clean
     Working copy : znkkpsqq 10dd328b (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     // New snapshot and commit can be created after the HEAD got unset.
     std::fs::write(workspace_root.join("file3"), "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: wqnwkozp 101e2723 (empty) (no description set)
     Parent commit      : znkkpsqq fc8af934 (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  101e272377a9daff75358f10dbd078df922fe68c
     ○  fc8af9345b0830dcb14716e04cd2af26e2d19f63 git_head()
     │ ○  ef75c0b0dcc9b080e00226908c21316acaa84dc6
@@ -229,7 +229,7 @@ fn test_git_colocated_unborn_bookmark() {
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -245,18 +245,18 @@ fn test_git_colocated_export_bookmarks_on_snapshot() {
     // Create bookmark pointing to the initial commit
     std::fs::write(workspace_root.join("file"), "initial").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "foo"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7 foo
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // The bookmark gets updated when we modify the working copy, and it should get
     // exported to Git without requiring any other changes
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf foo
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
     insta::assert_snapshot!(git_repo
         .find_reference("refs/heads/foo")
         .unwrap()
@@ -294,19 +294,19 @@ fn test_git_colocated_rebase_on_import() {
     let commit1 = commit2.parents().next().unwrap();
     git_repo.branch("master", &commit1, true).unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  15b1d70c5e33b5d2b18383292b85324d5153ffed
     ○  47fe984daf66f7bf3ebf31b9cb3513c995afb857 master git_head() add a file
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Abandoned 1 commits that are no longer reachable.
     Rebased 1 descendant commits off of commits rewritten from git
     Working copy now at: zsuskuln 15b1d70c (empty) (no description set)
     Parent commit      : qpvuntsm 47fe984d master | add a file
     Added 0 files, modified 1 files, removed 0 files
     Done importing changes from the underlying Git repo.
-    "###);
+    ");
 }
 
 #[test]
@@ -317,13 +317,13 @@ fn test_git_colocated_bookmarks() {
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m", "foo"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "@-", "-m", "bar"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  3560559274ab431feea00b7b7e0b9250ecce951f bar
     │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda foo
     ├─╯
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Create a bookmark in jj. It should be exported to Git even though it points
     // to the working- copy commit.
@@ -351,19 +351,19 @@ fn test_git_colocated_bookmarks() {
         )
         .unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
     │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
     ├─╯
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Abandoned 1 commits that are no longer reachable.
     Working copy now at: yqosqzyt 096dc80d (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     Done importing changes from the underlying Git repo.
-    "###);
+    ");
 }
 
 #[test]
@@ -374,21 +374,19 @@ fn test_git_colocated_bookmark_forget() {
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "foo"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  65b6b74e08973b88d38404430f119c8c79465250 foo
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
       @git: rlvkpnrz 65b6b74e (empty) (no description set)
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["bookmark", "forget", "foo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Forgot 1 bookmarks.
-    "###);
+    insta::assert_snapshot!(stderr, @"Forgot 1 bookmarks.");
     // A forgotten bookmark is deleted in the git repo. For a detailed demo
     // explaining this, see `test_bookmark_forget_export` in
     // `test_bookmark_command.rs`.
@@ -403,16 +401,14 @@ fn test_git_colocated_bookmark_at_root() {
 
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo", "-r=root()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to zzzzzzzz 00000000 foo | (empty) (no description set)
     Warning: Failed to export some bookmarks:
       foo: Ref cannot point to the root commit in Git
-    "###);
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -424,11 +420,11 @@ fn test_git_colocated_bookmark_at_root() {
             "--to=root()",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to zzzzzzzz 00000000 foo* | (empty) (no description set)
     Warning: Failed to export some bookmarks:
       foo: Ref cannot point to the root commit in Git
-    "###);
+    ");
 }
 
 #[test]
@@ -441,14 +437,14 @@ fn test_git_colocated_conflicting_git_refs() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "main/sub"]);
     insta::assert_snapshot!(stdout, @"");
     insta::with_settings!({filters => vec![("Failed to set: .*", "Failed to set: ...")]}, {
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r#"
         Created 1 bookmarks pointing to qpvuntsm 230dd059 main main/sub | (empty) (no description set)
         Warning: Failed to export some bookmarks:
           main/sub: Failed to set: ...
         Hint: Git doesn't allow a branch name that looks like a parent directory of
         another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
         export or their "parent" bookmarks.
-        "###);
+        "#);
     });
 }
 
@@ -495,23 +491,23 @@ fn test_git_colocated_checkout_non_empty_working_copy() {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "two"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "@-"]);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "new"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 149cc31c (empty) new
     Parent commit      : lnksqltp e61b6729 master | initial
-    "###);
+    ");
 
     let git_head = git_repo.find_reference("HEAD").unwrap();
     let git_head_target = git_head.symbolic_target().unwrap();
 
     assert_eq!(git_head_target, "refs/heads/master");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  149cc31cb08a1589e6c5ee2cb2061559dc758ecb new
     │ ○  4ec6f6506bd1903410f15b80058a7f0d8f62deea two
     ├─╯
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -532,7 +528,7 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
     git2::Repository::clone(origin_path.to_str().unwrap(), &clone_path).unwrap();
     test_env.jj_cmd_ok(&clone_path, &["git", "init", "--git-repo=."]);
     test_env.jj_cmd_ok(&clone_path, &["new", "A"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r"
     @  9c2de797c3c299a40173c5af724329012b77cbdd
     │ ○  4a191a9013d3f3398ccf5e172792a61439dbcf3a C_to_move original C
     ├─╯
@@ -540,27 +536,27 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
     ├─╯
     ◆  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A git_head() A
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "delete", "B_to_delete"]);
     // Move bookmark C sideways
     test_env.jj_cmd_ok(&origin_path, &["describe", "C_to_move", "-m", "moved C"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["git", "fetch"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: B_to_delete@origin [deleted] untracked
     bookmark: C_to_move@origin   [updated] tracked
     Abandoned 2 commits that are no longer reachable.
-    "###);
+    ");
     // "original C" and "B_to_delete" are abandoned, as the corresponding bookmarks
     // were deleted or moved on the remote (#864)
-    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r"
     @  9c2de797c3c299a40173c5af724329012b77cbdd
     │ ○  4f3d13296f978cbc351c46a43b4619c91b888475 C_to_move moved C
     ├─╯
     ◆  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A git_head() A
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -586,7 +582,7 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     // Because the working copy is dirty, the new working-copy commit will be
     // diverged. Therefore, the feature bookmark has change-delete conflict.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : rlvkpnrz 6bad94b1 feature?? | (no description set)
@@ -594,17 +590,17 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     These bookmarks have conflicts:
       feature
       Use `jj bookmark list` to see details. Use `jj bookmark set <name> -r <rev>` to resolve.
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Warning: Failed to export some bookmarks:
       feature: Modified ref had been deleted in Git
     Done importing changes from the underlying Git repo.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6bad94b10401f5fafc8a91064661224650d10d1b feature??
     ○  3230d52258f6de7e9afbd10da8d64503cc7cdca5 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // The working-copy content shouldn't be lost.
     insta::assert_snapshot!(
@@ -629,13 +625,13 @@ fn test_git_colocated_external_checkout() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
     // Checked out anonymous bookmark
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f8a23336e41840ed1757ef323402a770427dc89a
     ○  eccedddfa5152d99fc8ddd1081b375387a8a382a git_head() B
     │ ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Check out another bookmark by external command
     git_check_out_ref("refs/heads/master");
@@ -643,35 +639,33 @@ fn test_git_colocated_external_checkout() {
     // The old working-copy commit gets abandoned, but the whole bookmark should not
     // be abandoned. (#1042)
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  8bb9e8d42a37c2a4e8dcfad97fce0b8f49bc7afa
     ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master git_head() A
     │ ○  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
-    Reset the working copy parent to the new Git HEAD.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Reset the working copy parent to the new Git HEAD.");
 
     // Edit non-head commit
     test_env.jj_cmd_ok(&repo_path, &["new", "description(B)"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=C", "--no-edit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
     @  81e086b7f9b1dd7fde252e28bdcf4ba4abd86ce5
     ○  eccedddfa5152d99fc8ddd1081b375387a8a382a git_head() B
     │ ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Check out another bookmark by external command
     git_check_out_ref("refs/heads/master");
 
     // The old working-copy commit shouldn't be abandoned. (#3747)
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  ca2a4e32f08688c6fb795c4c034a0a7e09c0d804
     ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master git_head() A
     │ ○  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
@@ -679,10 +673,8 @@ fn test_git_colocated_external_checkout() {
     │ ○  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
-    Reset the working copy parent to the new Git HEAD.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Reset the working copy parent to the new Git HEAD.");
 }
 
 #[test]
@@ -693,26 +685,26 @@ fn test_git_colocated_squash_undo() {
     test_env.jj_cmd_ok(&repo_path, &["git", "init", "--git-repo=."]);
     test_env.jj_cmd_ok(&repo_path, &["ci", "-m=A"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r"
     @  rlvkpnrzqnoo 9670380ac379
     ○  qpvuntsmwlqt a7e4cec4256b A git_head()
     ◆  zzzzzzzzzzzz 000000000000
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r"
     @  zsuskulnrvyr 6ee662324e5a
     ○  qpvuntsmwlqt 13ab6b96d82e A git_head()
     ◆  zzzzzzzzzzzz 000000000000
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
-    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r"
     @  rlvkpnrzqnoo 9670380ac379
     ○  qpvuntsmwlqt a7e4cec4256b A git_head()
     ◆  zzzzzzzzzzzz 000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -727,29 +719,29 @@ fn test_git_colocated_undo_head_move() {
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  65b6b74e08973b88d38404430f119c8c79465250
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // HEAD should be unset
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     assert!(git_repo.head().is_err());
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Create commit on non-root commit
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  69b19f73cf584f162f078fb0d91c55ca39d10bc7
     ○  eb08b363bb5ef8ee549314260488980d7bbe8f63 git_head()
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"eb08b363bb5ef8ee549314260488980d7bbe8f63");
@@ -757,19 +749,19 @@ fn test_git_colocated_undo_head_move() {
     // HEAD should be moved back
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Undid operation: b50ec983d1c1 (2001-02-03 08:05:13) new empty commit
     Working copy now at: royxmykx eb08b363 (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
-    "#);
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  eb08b363bb5ef8ee549314260488980d7bbe8f63
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -792,64 +784,64 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "commit2"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  051508d190ffd04fe2d79367ad8e9c3713ac2375
     ○  563dbc583c0d82eb10c40d3f3276183ea28a0fa7 commit2 git_head()
     ○  3c270b473dd871b20d196316eb038f078f80c219 commit1
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=0:0 mtime=0:0 size=0 file1.txt
     Unconflicted Mode(FILE) 2e0996000b7e ctime=0:0 mtime=0:0 size=0 file2.txt
     Unconflicted Mode(FILE) d5f7fc3f74f7 ctime=0:0 mtime=0:0 size=0 file4.txt
-    "#);
+    ");
 
     // Update index with stats for all files. We may want to do this automatically
     // in the future after we update the index in `git::reset_head` (#3786), but for
     // now, we at least want to preserve existing stat information when possible.
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=[nonzero] mtime=[nonzero] size=18 file1.txt
     Unconflicted Mode(FILE) 2e0996000b7e ctime=[nonzero] mtime=[nonzero] size=9 file2.txt
     Unconflicted Mode(FILE) d5f7fc3f74f7 ctime=[nonzero] mtime=[nonzero] size=6 file4.txt
-    "#);
+    ");
 
     // Edit parent commit, causing the changes to be removed from the index without
     // touching the working copy
     test_env.jj_cmd_ok(&repo_path, &["edit", "commit2"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  563dbc583c0d82eb10c40d3f3276183ea28a0fa7 commit2
     ○  3c270b473dd871b20d196316eb038f078f80c219 commit1 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Index should contain stat for unchanged file still.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=[nonzero] mtime=[nonzero] size=18 file1.txt
     Unconflicted Mode(FILE) 28d2718c947b ctime=0:0 mtime=0:0 size=0 file2.txt
     Unconflicted Mode(FILE) 528557ab3a42 ctime=0:0 mtime=0:0 size=0 file3.txt
-    "#);
+    ");
 
     // Create sibling commit, causing working copy to match index
     test_env.jj_cmd_ok(&repo_path, &["new", "commit1"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  ccb1b1807383dba5ff4d335fd9fb92aa540f4632
     │ ○  563dbc583c0d82eb10c40d3f3276183ea28a0fa7 commit2
     ├─╯
     ○  3c270b473dd871b20d196316eb038f078f80c219 commit1 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Index should contain stat for unchanged file still.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=[nonzero] mtime=[nonzero] size=18 file1.txt
     Unconflicted Mode(FILE) 28d2718c947b ctime=0:0 mtime=0:0 size=0 file2.txt
     Unconflicted Mode(FILE) 528557ab3a42 ctime=0:0 mtime=0:0 size=0 file3.txt
-    "#);
+    ");
 }
 
 #[test]
@@ -873,23 +865,23 @@ fn test_git_colocated_update_index_merge_conflict() {
     std::fs::write(repo_path.join("right.txt"), "right\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "right"]);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Update index with stat for base.txt
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Create merge conflict
     test_env.jj_cmd_ok(&repo_path, &["new", "left", "right"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    aea7acd77752c3f74914de1fe327075a579bf7c6
     ├─╮
     │ ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right
@@ -897,22 +889,22 @@ fn test_git_colocated_update_index_merge_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Conflict should be added in index with correct blob IDs. The stat for
     // base.txt should not change.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Ours         Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
     Theirs       Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  cae33b49a8a514996983caaf171c5edbf0d70e78
     ×    aea7acd77752c3f74914de1fe327075a579bf7c6 git_head()
     ├─╮
@@ -921,17 +913,17 @@ fn test_git_colocated_update_index_merge_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Index should be the same after `jj new`.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Ours         Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
     Theirs       Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 }
 
 #[test]
@@ -957,65 +949,65 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     test_env.jj_cmd_ok(&repo_path, &["edit", "left"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  68cc2177623364e4f0719d6ec8da1d6ea8d6087e left
     │ ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Update index with stat for base.txt
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Create rebase conflict
     test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "left", "-d", "right"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  233cb41e128e74aa2fcbf01c85d69b33a118faa8 left
     ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right git_head()
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Index should contain files from parent commit, so there should be no conflict
     // in conflict.txt yet. The stat for base.txt should not change.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6d84b9021f9e07b69770687071c4e8e71113e688
     ×  233cb41e128e74aa2fcbf01c85d69b33a118faa8 left git_head()
     ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Now the working copy commit's parent is conflicted, so the index should have
     // a conflict with correct blob IDs.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Ours         Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Theirs       Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 }
 
 #[test]
@@ -1044,23 +1036,23 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     std::fs::write(repo_path.join("side-3.txt"), "side-3\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "side-3"]);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Update index with stat for base.txt
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Create 3-sided merge conflict
     test_env.jj_cmd_ok(&repo_path, &["new", "side-1", "side-2", "side-3"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @      faee07ad76218d193f2784f4988daa2ac46db30c
     ├─┬─╮
     │ │ ○  86e722ea6a9da2551f1e05bc9aa914acd1cb2304 side-3
@@ -1070,22 +1062,22 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // We can't add conflicts with more than 2 sides to the index, so we add a dummy
     // conflict instead. The stat for base.txt should not change.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Ours         Mode(FILE) eb8299123d2a ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
     Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
     Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b0e5644063c2a12fb265e5f65cd88c6a2e1cf865
     ×      faee07ad76218d193f2784f4988daa2ac46db30c git_head()
     ├─┬─╮
@@ -1096,30 +1088,30 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
 
     // Index should be the same after `jj new`.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Ours         Mode(FILE) eb8299123d2a ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
     Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
     Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
-    "#);
+    ");
 
     // If we add a file named ".jj-do-not-resolve-this-conflict", it should take
     // precedence over the dummy conflict.
     std::fs::write(repo_path.join(".jj-do-not-resolve-this-conflict"), "file\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) f73f3093ff86 ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
     Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
     Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
-    "#);
+    ");
 }
 
 fn get_log_output_divergence(test_env: &TestEnvironment, repo_path: &Path) -> String {
@@ -1257,11 +1249,11 @@ fn test_git_colocated_unreachable_commits() {
 
     // Import the repo while there is no path to the second commit
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  66ae47cee4f8c28ee8d7e4f5d9401b03c07e22f2
     ○  2ee37513d2b5e549f7478c671a780053614bff19 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"2ee37513d2b5e549f7478c671a780053614bff19"

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -127,9 +127,7 @@ fn test_git_fetch_with_default_config(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    origin@origin: oputwtnw ffecd2d6 message
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"origin@origin: oputwtnw ffecd2d6 message");
     }
 }
 
@@ -147,10 +145,10 @@ fn test_git_fetch_default_remote(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 }
 
@@ -168,16 +166,16 @@ fn test_git_fetch_single_remote(subprocess: bool) {
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Hint: Fetching from the only existing remote: rem1
     bookmark: rem1@rem1 [new] tracked
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    ");
     }
 }
 
@@ -198,10 +196,10 @@ fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
         .assert()
         .success();
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    ");
     }
 }
 
@@ -219,10 +217,10 @@ fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote", "rem1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    ");
     }
 }
 
@@ -241,10 +239,10 @@ fn test_git_fetch_single_remote_from_config(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    ");
     }
 }
 
@@ -266,12 +264,12 @@ fn test_git_fetch_multiple_remotes(subprocess: bool) {
         &["git", "fetch", "--remote", "rem1", "--remote", "rem2"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    ");
     }
 }
 
@@ -294,12 +292,12 @@ fn test_git_fetch_all_remotes(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--all-remotes"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    ");
     }
 }
 
@@ -319,12 +317,12 @@ fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    ");
     }
 }
 
@@ -394,11 +392,11 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     // Try fetching from the remote named 'git'.
     let stderr = &test_env.jj_cmd_failure(&repo_path, &["git", "fetch", "--remote=git"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to import refs from underlying Git repo
     Caused by: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give different name.
-    "###);
+    ");
     }
 
     // Implicit import shouldn't fail because of the remote ref.
@@ -422,16 +420,14 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "git", "bar"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "--all-remotes"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     git: mrylzrtu 76fc7466 message
       @bar: mrylzrtu 76fc7466 message
       @git: mrylzrtu 76fc7466 message
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Done importing changes from the underlying Git repo.
-    "###);
+    insta::assert_snapshot!(stderr, @"Done importing changes from the underlying Git repo.");
     }
 }
 
@@ -448,10 +444,10 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     let git_repo = add_git_remote(&test_env, &repo_path, "origin");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 
     // Remove origin bookmark in git repo and create origin/subname
@@ -463,10 +459,10 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin/subname: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 }
 
@@ -486,9 +482,7 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "rem1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    rem1: kkmpptxz fcdbbd73 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"rem1: kkmpptxz fcdbbd73 (empty) (no description set)");
     }
 
     test_env.jj_cmd_ok(
@@ -497,12 +491,12 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     );
     // This should result in a CONFLICTED bookmark
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1 (conflicted):
       + kkmpptxz fcdbbd73 (empty) (no description set)
       + qxosxrvv 6a211027 message
       @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
-    "###);
+    ");
     }
 }
 
@@ -527,10 +521,10 @@ fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "rem1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: zsuskuln f652c321 (empty) (no description set)
       @git: zsuskuln f652c321 (empty) (no description set)
-    "###);
+    ");
     }
 
     test_env.jj_cmd_ok(
@@ -540,13 +534,13 @@ fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     // This should result in a CONFLICTED bookmark
     // See https://github.com/jj-vcs/jj/pull/1146#discussion_r1112372340 for the bug this tests for.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1 (conflicted):
       + zsuskuln f652c321 (empty) (no description set)
       + qxosxrvv 6a211027 message
       @git (behind by 1 commits): zsuskuln f652c321 (empty) (no description set)
       @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
-    "###);
+    ");
     }
 }
 
@@ -598,17 +592,17 @@ fn test_git_fetch_all(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -617,15 +611,15 @@ fn test_git_fetch_all(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
 
     // Nothing in our repo before the fetch
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @"");
@@ -635,15 +629,15 @@ fn test_git_fetch_all(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
         }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
-    "###);
+    ");
         }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: nknoxmzm 359a9a02 descr_for_a1
       @origin: nknoxmzm 359a9a02 descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
@@ -652,10 +646,10 @@ fn test_git_fetch_all(subprocess: bool) {
       @origin: vpupmnsl c7d4bdcb descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
       @origin: zowqyktl ff36dc55 descr_for_trunk1
-    "###);
+    ");
         }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -665,14 +659,14 @@ fn test_git_fetch_all(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     ○  babc49226c14 descr_for_b b
     │ ○  91e46b4b2653 descr_for_a2 a2
@@ -682,7 +676,7 @@ fn test_git_fetch_all(subprocess: bool) {
     @  8f1f14fbbf42 descr_for_trunk2 trunk2
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -692,7 +686,7 @@ fn test_git_fetch_all(subprocess: bool) {
 
     // Our repo before and after fetch
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  061eddbb43ab new_descr_for_b_to_create_conflict b*
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -702,10 +696,10 @@ fn test_git_fetch_all(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: nknoxmzm 359a9a02 descr_for_a1
       @origin: nknoxmzm 359a9a02 descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
@@ -714,23 +708,23 @@ fn test_git_fetch_all(subprocess: bool) {
       @origin (ahead by 1 commits, behind by 1 commits): vpupmnsl hidden c7d4bdcb descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
       @origin: zowqyktl ff36dc55 descr_for_trunk1
-    "###);
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [updated] tracked
     bookmark: a2@origin     [updated] tracked
     bookmark: b@origin      [updated] tracked
     bookmark: trunk2@origin [new] tracked
     Abandoned 2 commits that are no longer reachable.
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: quxllqov 0424f6df descr_for_a1
       @origin: quxllqov 0424f6df descr_for_a1
     a2: osusxwst 91e46b4b descr_for_a2
@@ -744,10 +738,10 @@ fn test_git_fetch_all(subprocess: bool) {
       @origin: zowqyktl ff36dc55 descr_for_trunk1
     trunk2: umznmzko 8f1f14fb descr_for_trunk2
       @origin: umznmzko 8f1f14fb descr_for_trunk2
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  babc49226c14 descr_for_b b?? b@origin
     │ │ ○  91e46b4b2653 descr_for_a2 a2
@@ -760,7 +754,7 @@ fn test_git_fetch_all(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
 }
 
@@ -783,17 +777,17 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -802,7 +796,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
 
     // Test an error message
@@ -823,10 +817,10 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
 
     // Nothing in our repo before the fetch
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    ");
     }
     // Fetch one bookmark...
     let (stdout, stderr) =
@@ -835,25 +829,23 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: b@origin [new] tracked
-    "###);
+    insta::assert_snapshot!(stderr, @"bookmark: b@origin [new] tracked");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
     // ...check what the intermediate state looks like...
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     b: vpupmnsl c7d4bdcb descr_for_b
       @origin: vpupmnsl c7d4bdcb descr_for_b
-    "###);
+    ");
     }
     // ...then fetch two others with a glob.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -864,13 +856,13 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin [new] tracked
     bookmark: a2@origin [new] tracked
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  decaa3966c83 descr_for_a2 a2
     │ │ ○  359a9a02457d descr_for_a1 a1
@@ -880,7 +872,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
     // Fetching the same bookmark again
     let (stdout, stderr) =
@@ -909,7 +901,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     ○  01d115196c39 descr_for_b b
     │ ○  31c7d94b1f29 descr_for_a2 a2
@@ -919,7 +911,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     @  2bb3ebd2bba3 descr_for_trunk2 trunk2
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -929,7 +921,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
 
     // Our repo before and after fetch of two bookmarks
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b*
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -939,7 +931,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
@@ -949,14 +941,14 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  01d115196c39 descr_for_b b?? b@origin
     │ │ ○  6df2d34cf0da descr_for_a1 a1
@@ -969,12 +961,12 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
 
     // We left a2 where it was before, let's see how `jj bookmark list` sees this.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: ypowunwp 6df2d34c descr_for_a1
       @origin: ypowunwp 6df2d34c descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
@@ -984,7 +976,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
       + vpupmnsl 6ebd41dc new_descr_for_b_to_create_conflict
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
-    "###);
+    ");
     }
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
     // anything.
@@ -996,13 +988,13 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a2@origin [updated] tracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  31c7d94b1f29 descr_for_a2 a2
     │ │ ○  01d115196c39 descr_for_b b?? b@origin
@@ -1015,10 +1007,10 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: ypowunwp 6df2d34c descr_for_a1
       @origin: ypowunwp 6df2d34c descr_for_a1
     a2: qrmzolkr 31c7d94b descr_for_a2
@@ -1028,7 +1020,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
       + vpupmnsl 6ebd41dc new_descr_for_b_to_create_conflict
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
-    "###);
+    ");
     }
 }
 
@@ -1051,10 +1043,10 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--branch", "noexist"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `noexist` found on any specified/configured remote
     Nothing changed.
-    "###);
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
@@ -1068,11 +1060,11 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
         ],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `noexist1` found on any specified/configured remote
     Warning: No branch matching `noexist2` found on any specified/configured remote
     Nothing changed.
-    "###);
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
@@ -1081,15 +1073,13 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     // single existing bookmark, implicit remotes (@origin)
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--branch", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: origin@origin [new] tracked
-    "###);
+    insta::assert_snapshot!(stderr, @"bookmark: origin@origin [new] tracked");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 
     // multiple existing bookmark, explicit remotes, each bookmark is only in one
@@ -1110,15 +1100,15 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     }
     insta::allow_duplicates! {
      insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
-    origin: oputwtnw ffecd2d6 message
-      @origin: oputwtnw ffecd2d6 message
-    rem1: qxosxrvv 6a211027 message
-      @rem1: qxosxrvv 6a211027 message
-    rem2: yszkquru 2497a8a0 message
-      @rem2: yszkquru 2497a8a0 message
-    rem3: lvsrtwwm 4ffdff2b message
-      @rem3: lvsrtwwm 4ffdff2b message
-    ");
+     origin: oputwtnw ffecd2d6 message
+       @origin: oputwtnw ffecd2d6 message
+     rem1: qxosxrvv 6a211027 message
+       @rem1: qxosxrvv 6a211027 message
+     rem2: yszkquru 2497a8a0 message
+       @rem2: yszkquru 2497a8a0 message
+     rem3: lvsrtwwm 4ffdff2b message
+       @rem3: lvsrtwwm 4ffdff2b message
+     ");
     }
 
     // multiple bookmarks, one exists, one doesn't
@@ -1129,10 +1119,10 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
         ],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `notexist` found on any specified/configured remote
     Nothing changed.
-    "###);
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
@@ -1196,17 +1186,17 @@ fn test_git_fetch_undo(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1215,7 +1205,7 @@ fn test_git_fetch_undo(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
 
     // Fetch 2 bookmarks
@@ -1295,17 +1285,17 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    "#);
     }
     let repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1314,7 +1304,7 @@ fn test_fetch_undo_what(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
 
     // Initial state we will try to return to after `op restore`. There are no
@@ -1330,24 +1320,22 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: b@origin [new] tracked
-    "###);
+    insta::assert_snapshot!(stderr, @"bookmark: b@origin [new] tracked");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     b: vpupmnsl c7d4bdcb descr_for_b
       @origin: vpupmnsl c7d4bdcb descr_for_b
-    "###);
+    ");
     }
 
     // We can undo the change in the repo without moving the remote-tracking
@@ -1360,26 +1348,24 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
-    Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
-    "#);
+    insta::assert_snapshot!(stderr, @"Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     b (deleted)
       @origin: vpupmnsl hidden c7d4bdcb descr_for_b
-    "###);
+    ");
     }
 
     // Now, let's demo restoring just the remote-tracking bookmark. First, let's
     // change our local repo state...
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "newbookmark"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     b (deleted)
       @origin: vpupmnsl hidden c7d4bdcb descr_for_b
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
     }
     // Restoring just the remote-tracking state will not affect `newbookmark`, but
     // will eliminate `b@origin`.
@@ -1397,14 +1383,10 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
-    Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
-    "#);
+    insta::assert_snapshot!(stderr, @"Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    newbookmark: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"newbookmark: qpvuntsm 230dd059 (empty) (no description set)");
     }
 }
 
@@ -1422,28 +1404,26 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    origin: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"origin: qpvuntsm 230dd059 (empty) (no description set)");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "remove", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "add", "origin", "../origin"]);
@@ -1454,17 +1434,15 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: origin@origin [new] tracked
-    "###);
+    insta::assert_snapshot!(stderr, @"bookmark: origin@origin [new] tracked");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 }
 
@@ -1482,19 +1460,17 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    origin: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"origin: qpvuntsm 230dd059 (empty) (no description set)");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 
     test_env.jj_cmd_ok(
@@ -1502,12 +1478,12 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
         &["git", "remote", "rename", "origin", "upstream"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @upstream (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    ");
     }
 
     // Check that jj indicates that nothing has changed
@@ -1517,9 +1493,7 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
 }
 
@@ -1541,17 +1515,17 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1560,7 +1534,7 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
 
     // Fetch all bookmarks
@@ -1569,15 +1543,15 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1587,7 +1561,7 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
 
     // Remove a2 bookmark in origin
@@ -1600,12 +1574,10 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1615,7 +1587,7 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
 
     // Fetch bookmarks a2 from origin, and check that it has been removed locally
@@ -1659,17 +1631,17 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1678,7 +1650,7 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    ");
     }
 
     // Fetch all bookmarks
@@ -1687,15 +1659,15 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1705,7 +1677,7 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
 
     // Remove all bookmarks in origin.
@@ -1724,15 +1696,15 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [deleted] untracked
     bookmark: trunk1@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
     Warning: No branch matching `master` found on any specified/configured remote
-    "###);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1740,7 +1712,7 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
 }
 
@@ -1785,10 +1757,10 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
     }
 
     git_repo
@@ -1806,19 +1778,19 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     test_env.add_config("git.auto-local-bookmark = false");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  230dd059e1b0
     │ ◆  9f01a0e04879 message feature1 feature2@origin
     ├─╯
     ◆  000000000000
-    "#);
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
     feature2@origin: mzyxwzks 9f01a0e0 message
-    "###);
+    ");
     }
 }
 

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -32,10 +32,10 @@ fn test_resolution_of_git_tracking_bookmarks() {
     insta::assert_snapshot!(stderr, @"");
     // Move the local bookmark somewhere else
     test_env.jj_cmd_ok(&repo_path, &["describe", "-r", "main", "-m", "new_message"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm b61d21b6 (empty) new_message
       @git (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 03757d22 (empty) old_message
-    "###);
+    ");
 
     // Test that we can address both revisions
     let query = |expr| {
@@ -45,12 +45,8 @@ fn test_resolution_of_git_tracking_bookmarks() {
             &["log", "-r", expr, "-T", template, "--no-graph"],
         )
     };
-    insta::assert_snapshot!(query("main"), @r###"
-    b61d21b660c17a7191f3f73873bfe7d3f7938628 new_message
-    "###);
-    insta::assert_snapshot!(query("main@git"), @r###"
-    03757d2212d89990ec158e97795b612a38446652 old_message
-    "###);
+    insta::assert_snapshot!(query("main"), @"b61d21b660c17a7191f3f73873bfe7d3f7938628 new_message");
+    insta::assert_snapshot!(query("main@git"), @"03757d2212d89990ec158e97795b612a38446652 old_message");
     // Can't be selected by remote_bookmarks()
     insta::assert_snapshot!(query(r#"remote_bookmarks(exact:"main", exact:"git")"#), @"");
 }
@@ -66,13 +62,13 @@ fn test_git_export_conflicting_git_refs() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::with_settings!({filters => vec![("Failed to set: .*", "Failed to set: ...")]}, {
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r#"
         Warning: Failed to export some bookmarks:
           main/sub: Failed to set: ...
         Hint: Git doesn't allow a branch name that looks like a parent directory of
         another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
         export or their "parent" bookmarks.
-        "###);
+        "#);
     });
 }
 
@@ -84,26 +80,22 @@ fn test_git_export_undo() {
     let git_repo = git2::Repository::open(repo_path.join(".jj/repo/store/git")).unwrap();
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "a"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    a: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"a: qpvuntsm 230dd059 (empty) (no description set)");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 a 230dd059
     │  (empty) (no description set)
     ~
-    "###);
+    ");
 
     // Exported refs won't be removed by undoing the export, but the git-tracking
     // bookmark is. This is the same as remote-tracking bookmarks.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
-    Undid operation: b27a68390bea (2001-02-03 08:05:10) export git refs
-    "#);
-    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
+    insta::assert_snapshot!(stderr, @"Undid operation: b27a68390bea (2001-02-03 08:05:10) export git refs");
+    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
     [
         (
             "refs/heads/a",
@@ -112,7 +104,7 @@ fn test_git_export_undo() {
             ),
         ),
     ]
-    "###);
+    "#);
     insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["log", "-ra@git"]), @r"
     Error: Revision `a@git` doesn't exist
     Hint: Did you mean `a`?
@@ -122,11 +114,11 @@ fn test_git_export_undo() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 a 230dd059
     │  (empty) (no description set)
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -150,31 +142,25 @@ fn test_git_import_undo() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"bookmark: a [new] tracked");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
 
     // "git import" can be undone by default.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
-    Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
-    "#);
+    insta::assert_snapshot!(stderr, @"Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
     // Try "git import" again, which should re-import the bookmark "a".
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"bookmark: a [new] tracked");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -199,41 +185,39 @@ fn test_git_import_move_export_with_default_undo() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"bookmark: a [new] tracked");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
 
     // Move bookmark "a" and export to git repo
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "a"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: yqosqzyt 096dc80d (empty) (no description set)
       @git (behind by 1 commits): qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: yqosqzyt 096dc80d (empty) (no description set)
       @git: yqosqzyt 096dc80d (empty) (no description set)
-    "###);
+    ");
 
     // "git import" can be undone with the default `restore` behavior, as shown in
     // the previous test. However, "git export" can't: the bookmarks in the git
     // repo stay where they were.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     Working copy now at: qpvuntsm 230dd059 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "#);
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
-    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
+    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
     [
         (
             "refs/heads/a",
@@ -242,19 +226,17 @@ fn test_git_import_move_export_with_default_undo() {
             ),
         ),
     ]
-    "###);
+    "#);
 
     // The last bookmark "a" state is imported from git. No idea what's the most
     // intuitive result here.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"bookmark: a [new] tracked");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: yqosqzyt 096dc80d (empty) (no description set)
       @git: yqosqzyt 096dc80d (empty) (no description set)
-    "###);
+    ");
 }
 
 fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -89,9 +89,7 @@ fn test_git_init_internal() {
     let test_env = TestEnvironment::default();
     let (stdout, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Initialized repo in "repo"
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Initialized repo in "repo""#);
 
     let workspace_root = test_env.env_root().join("repo");
     let jj_path = workspace_root.join(".jj");
@@ -115,9 +113,7 @@ fn test_git_init_internal_ignore_working_copy() {
 
     let stderr =
         test_env.jj_cmd_cli_error(&workspace_root, &["git", "init", "--ignore-working-copy"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --ignore-working-copy is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --ignore-working-copy is not respected");
 }
 
 #[test]
@@ -127,9 +123,7 @@ fn test_git_init_internal_at_operation() {
     std::fs::create_dir(&workspace_root).unwrap();
 
     let stderr = test_env.jj_cmd_cli_error(&workspace_root, &["git", "init", "--at-op=@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --at-op is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --at-op is not respected");
 }
 
 #[test_case(false; "full")]
@@ -178,11 +172,11 @@ fn test_git_init_external(bare: bool) {
 
     // Check that the Git repo's HEAD got checked out
     insta::allow_duplicates! {
-        insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+        insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
         @  f6950fc115ae
         ○  8d698d4a8ee1 my-bookmark git_head() My commit message
         ◆  000000000000
-        "#);
+        ");
     }
 }
 
@@ -241,9 +235,7 @@ fn test_git_init_external_import_trunk(bare: bool) {
         &["config", "list", "--repo", "revset-aliases.\"trunk()\""],
     );
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
-        revset-aliases."trunk()" = "trunk@origin"
-        "###);
+        insta::assert_snapshot!(stdout, @r#"revset-aliases."trunk()" = "trunk@origin""#);
     }
 }
 
@@ -267,9 +259,7 @@ fn test_git_init_external_ignore_working_copy() {
             git_repo_path.to_str().unwrap(),
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --ignore-working-copy is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --ignore-working-copy is not respected");
 }
 
 #[test]
@@ -290,9 +280,7 @@ fn test_git_init_external_at_operation() {
             git_repo_path.to_str().unwrap(),
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --at-op is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --at-op is not respected");
 }
 
 #[test]
@@ -302,11 +290,11 @@ fn test_git_init_external_non_existent_directory() {
         test_env.env_root(),
         &["git", "init", "repo", "--git-repo", "non-existent"],
     );
-    insta::assert_snapshot!(strip_last_line(&stderr), @r###"
+    insta::assert_snapshot!(strip_last_line(&stderr), @r"
     Error: Failed to access the repository
     Caused by:
     1: Cannot access $TEST_ENV/non-existent
-    "###);
+    ");
 }
 
 #[test]
@@ -318,13 +306,13 @@ fn test_git_init_external_non_existent_git_directory() {
         &["git", "init", "repo", "--git-repo", "repo"],
     );
 
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r#"
     Error: Failed to access the repository
     Caused by:
     1: Failed to open git repository
     2: "$TEST_ENV/repo" does not appear to be a git repository
     3: Missing HEAD at '.git/HEAD'
-    "###);
+    "#);
     let jj_path = workspace_root.join(".jj");
     assert!(!jj_path.exists());
 }
@@ -336,10 +324,10 @@ fn test_git_init_colocated_via_git_repo_path() {
     init_git_repo(&workspace_root, false);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    "#);
 
     let jj_path = workspace_root.join(".jj");
     let repo_path = jj_path.join("repo");
@@ -354,20 +342,20 @@ fn test_git_init_colocated_via_git_repo_path() {
         .ends_with("../../../.git"));
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f61b77cd4bb5
     ○  8d698d4a8ee1 my-bookmark git_head() My commit message
     ◆  000000000000
-    "#);
+    ");
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f1c7aa7c62d8
     ○  f61b77cd4bb5 git_head()
     ○  8d698d4a8ee1 my-bookmark My commit message
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -383,27 +371,27 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     assert!(workspace_root.join(".git").is_file());
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f61b77cd4bb5
     ○  8d698d4a8ee1 my-bookmark git_head() My commit message
     ◆  000000000000
-    "#);
+    ");
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f1c7aa7c62d8
     ○  f61b77cd4bb5 git_head()
     ○  8d698d4a8ee1 my-bookmark My commit message
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[cfg(unix)]
@@ -418,27 +406,27 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     std::os::unix::fs::symlink(git_repo_path.join(".git"), workspace_root.join(".git")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f61b77cd4bb5
     ○  8d698d4a8ee1 my-bookmark git_head() My commit message
     ◆  000000000000
-    "#);
+    ");
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f1c7aa7c62d8
     ○  f61b77cd4bb5 git_head()
     ○  8d698d4a8ee1 my-bookmark My commit message
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[cfg(unix)]
@@ -456,27 +444,27 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     std::os::unix::fs::symlink(&git_repo_path, workspace_root.join(".git")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f61b77cd4bb5
     ○  8d698d4a8ee1 my-bookmark git_head() My commit message
     ◆  000000000000
-    "#);
+    ");
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f1c7aa7c62d8
     ○  f61b77cd4bb5 git_head()
     ○  8d698d4a8ee1 my-bookmark My commit message
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[cfg(unix)]
@@ -496,27 +484,27 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     std::os::unix::fs::symlink(git_workdir_path.join(".git"), workspace_root.join(".git")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f61b77cd4bb5
     ○  8d698d4a8ee1 my-bookmark git_head() My commit message
     ◆  000000000000
-    "#);
+    ");
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f1c7aa7c62d8
     ○  f61b77cd4bb5 git_head()
     ○  8d698d4a8ee1 my-bookmark My commit message
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -555,37 +543,37 @@ fn test_git_init_colocated_via_git_repo_path_imported_refs() {
     let local_path = test_env.env_root().join("local1");
     set_up_local_repo(&local_path);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["git", "init", "--git-repo=."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r###"
+    "#);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r"
     local-remote: vvkvtnvv 230dd059 (empty) (no description set)
       @git: vvkvtnvv 230dd059 (empty) (no description set)
       @origin: vvkvtnvv 230dd059 (empty) (no description set)
     remote-only: vvkvtnvv 230dd059 (empty) (no description set)
       @git: vvkvtnvv 230dd059 (empty) (no description set)
       @origin: vvkvtnvv 230dd059 (empty) (no description set)
-    "###);
+    ");
 
     // With git.auto-local-bookmark = false
     test_env.add_config("git.auto-local-bookmark = false");
     let local_path = test_env.env_root().join("local2");
     set_up_local_repo(&local_path);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["git", "init", "--git-repo=."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Hint: The following remote bookmarks aren't associated with the existing local bookmarks:
       local-remote@origin
     Hint: Run `jj bookmark track local-remote@origin` to keep local bookmarks updated on future pulls.
     Initialized repo in "."
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r###"
+    "#);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r"
     local-remote: vvkvtnvv 230dd059 (empty) (no description set)
       @git: vvkvtnvv 230dd059 (empty) (no description set)
     local-remote@origin: vvkvtnvv 230dd059 (empty) (no description set)
     remote-only@origin: vvkvtnvv 230dd059 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -611,22 +599,22 @@ fn test_git_init_colocated_dirty_working_copy() {
     add_file_to_index("some-file", "new content");
     add_file_to_index("new-staged-file", "new content");
     std::fs::write(workspace_root.join("unstaged-file"), "new content").unwrap();
-    insta::assert_snapshot!(get_git_statuses(), @r###"
+    insta::assert_snapshot!(get_git_statuses(), @r"
     Status(INDEX_NEW) new-staged-file
     Status(INDEX_MODIFIED) some-file
     Status(WT_NEW) unstaged-file
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    "#);
 
     // Working-copy changes should have been snapshotted.
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-s", "--ignore-working-copy"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 cd1e144d
     │  (no description set)
     │  C {some-file => new-staged-file}
@@ -636,20 +624,20 @@ fn test_git_init_colocated_dirty_working_copy() {
     │  My commit message
     │  A some-file
     ◆  zzzzzzzz root() 00000000
-    "#);
+    ");
 
     // Git index should be consistent with the working copy parent. With the
     // current implementation, the index is unchanged. Since jj created new
     // working copy commit, it's also okay to update the index reflecting the
     // working copy commit or the working copy parent.
-    insta::assert_snapshot!(get_git_statuses(), @r###"
+    insta::assert_snapshot!(get_git_statuses(), @r"
     Status(IGNORED) .jj/.gitignore
     Status(IGNORED) .jj/repo/
     Status(IGNORED) .jj/working_copy/
     Status(INDEX_NEW) new-staged-file
     Status(INDEX_MODIFIED) some-file
     Status(WT_NEW) unstaged-file
-    "###);
+    ");
 }
 
 #[test]
@@ -663,9 +651,7 @@ fn test_git_init_colocated_ignore_working_copy() {
         &workspace_root,
         &["git", "init", "--ignore-working-copy", "--colocate"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --ignore-working-copy is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --ignore-working-copy is not respected");
 }
 
 #[test]
@@ -678,9 +664,7 @@ fn test_git_init_colocated_at_operation() {
         &workspace_root,
         &["git", "init", "--at-op=@-", "--colocate"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --at-op is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --at-op is not respected");
 }
 
 #[test]
@@ -695,23 +679,21 @@ fn test_git_init_external_but_git_dir_exists() {
         &["git", "init", "--git-repo", git_repo_path.to_str().unwrap()],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Initialized repo in "."
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Initialized repo in ".""#);
 
     // The local ".git" repository is unrelated, so no commits should be imported
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    ");
 
     // Check that Git HEAD is not set because this isn't a colocated repo
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  4db490c88528
     ○  230dd059e1b0
     ◆  000000000000
-    "###);
+    ");
 }
 
 #[test]
@@ -723,26 +705,26 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "--colocate", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "repo"
-    "###);
+    "#);
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f61b77cd4bb5
     ○  8d698d4a8ee1 my-bookmark git_head() My commit message
     ◆  000000000000
-    "#);
+    ");
 
     // Check that the Git repo's HEAD moves
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  f1c7aa7c62d8
     ○  f61b77cd4bb5 git_head()
     ○  8d698d4a8ee1 my-bookmark My commit message
     ◆  000000000000
-    "#);
+    ");
 }
 
 #[test]
@@ -752,24 +734,22 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "--colocate", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Initialized repo in "repo"
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Initialized repo in "repo""#);
     // No HEAD ref is available yet
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    ");
 
     // Create the default bookmark (create both in case we change the default)
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "main", "master"]);
 
     // If .git/HEAD pointed to the default bookmark, new working-copy commit would
     // be created on top.
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b0 main master
     ◆  000000000000
-    "###);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -97,13 +97,13 @@ fn test_git_private_commits_block_pushing() {
     // May push when the commit is removed from git.private-commits
     test_env.add_config(r#"git.private-commits = "none()""#);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to aa3058ff8663
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: znkkpsqq 2e1adf47 (empty) (no description set)
     Parent commit      : yqosqzyt aa3058ff main | (empty) private 1
-    "#);
+    ");
 }
 
 #[test]
@@ -127,13 +127,13 @@ fn test_git_private_commits_can_be_overridden() {
         &workspace_root,
         &["git", "push", "--all", "--allow-private"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to aa3058ff8663
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: znkkpsqq 2e1adf47 (empty) (no description set)
     Parent commit      : yqosqzyt aa3058ff main | (empty) private 1
-    "#);
+    ");
 }
 
 #[test]
@@ -146,13 +146,13 @@ fn test_git_private_commits_are_not_checked_if_immutable() {
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "all()""#);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to aa3058ff8663
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: yostqsxw dce4a15c (empty) (no description set)
     Parent commit      : yqosqzyt aa3058ff main | (empty) private 1
-    "#);
+    ");
 }
 
 #[test]
@@ -187,10 +187,10 @@ fn test_git_private_commits_descending_from_commits_pushed_do_not_block_pushing(
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-b=main"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to 05ef53bc99ec
-    "#);
+    ");
 }
 
 #[test]
@@ -212,14 +212,14 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &workspace_root,
         &["git", "push", "--allow-new", "-b=main", "-b=bookmark1"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to fbb352762352
       Add bookmark bookmark1 to 7eb97bf230ad
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: kpqxywon a7b08364 (empty) (no description set)
     Parent commit      : yostqsxw fbb35276 main | (empty) public 3
-    "#);
+    ");
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
 
@@ -229,10 +229,10 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &["bookmark", "set", "bookmark1", "-r=main"],
     );
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark1 from 7eb97bf230ad to fbb352762352
-    "#);
+    ");
 
     // Ensure that the already-pushed commit doesn't block a new bookmark from
     // being pushed
@@ -245,10 +245,10 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &workspace_root,
         &["git", "push", "--allow-new", "-b=bookmark2"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark2 to ee5b808b0b95
-    "#);
+    ");
 }
 
 #[test]
@@ -263,10 +263,10 @@ fn test_git_private_commits_are_evaluated_separately_for_each_remote() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m=public 3"]);
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main"]);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-b=main"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to d8632ce893ab
-    "#);
+    ");
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -58,12 +58,12 @@ fn test_git_push_nothing(subprocess: bool) {
     }
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: xtvrqkyv d13ecdbd (empty) description 1
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    ");
     }
     // No bookmarks to push yet
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
@@ -71,9 +71,7 @@ fn test_git_push_nothing(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
 }
 
@@ -97,13 +95,13 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: xtvrqkyv 0f8dc656 (empty) modified bookmark1 commit
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
     bookmark2: yostqsxw bc7610b6 (empty) foo
       @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
     my-bookmark: yostqsxw bc7610b6 (empty) foo
-    "###);
+    ");
     }
     // First dry-run. `bookmark1` should not get pushed.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -114,12 +112,12 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to bc7610b65a91
       Add bookmark my-bookmark to bc7610b65a91
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
@@ -159,10 +157,10 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    ");
     }
     // We can move a bookmark backwards
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-bbookmark2"]);
@@ -170,10 +168,10 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move backward bookmark bookmark2 from bc7610b65a91 to 8476341eb395
-    "#);
+    ");
     }
 }
 
@@ -197,10 +195,10 @@ fn test_git_push_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to e612d524a5c6
-    "#);
+    ");
     }
 }
 
@@ -217,10 +215,10 @@ fn test_git_push_no_matching_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    ");
     }
 }
 
@@ -237,10 +235,10 @@ fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    ");
     }
 }
 
@@ -281,10 +279,10 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to a657f1b61b94
-    "#);
+    ");
     }
     // Since it's already pushed to origin, nothing will happen if push again
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -292,10 +290,10 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    ");
     }
     // The bookmark was moved on the "other" remote as well (since it's actually the
     // same remote), but `jj` is not aware of that since it thinks this is a
@@ -313,10 +311,10 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to other:
       Add bookmark bookmark1 to a657f1b61b94
-    "#);
+    ");
     }
 }
 
@@ -343,12 +341,12 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     // Pushing should fail
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    ");
     }
 }
 
@@ -366,12 +364,12 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     std::fs::write(origin_path.join("remote"), "remote").unwrap();
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "set", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r"
     bookmark1: vruxwmqv 80284bec remote
       @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
     bookmark2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
-    "###);
+    ");
     }
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
@@ -383,22 +381,22 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
         &["bookmark", "set", "bookmark1", "--allow-backwards"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: kmkuslsw 0f8bf988 local
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    ");
     }
 
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    ");
     }
 }
 
@@ -418,35 +416,35 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     std::fs::write(origin_path.join("remote"), "remote").unwrap();
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "set", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r"
     bookmark1: vruxwmqv 80284bec remote
       @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
     bookmark2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
-    "###);
+    ");
     }
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
     // Delete bookmark1 locally
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    ");
     }
 
     let stderr =
         test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--bookmark", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    ");
     }
 }
 
@@ -462,12 +460,12 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     let origin_path = test_env.env_root().join("origin");
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "delete", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r"
     bookmark1 (deleted)
       @git: qpvuntsm d13ecdbd (empty) description 1
     bookmark2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
-    "###);
+    ");
     }
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
@@ -479,33 +477,33 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
         &["bookmark", "set", "bookmark1", "--allow-backwards"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: kpqxywon 1ebe27ba local
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    ");
     }
 
     // Pushing a moved bookmark fails if deleted on remote
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    ");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    ");
     }
 
     if subprocess {
@@ -523,10 +521,10 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
         // bookmark1@origin to exist and point somewhere.
         let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-bbookmark1"]);
         insta::assert_snapshot!(stdout, @"");
-        insta::assert_snapshot!(stderr, @r#"
+        insta::assert_snapshot!(stderr, @r"
         Changes to push to origin:
           Delete bookmark bookmark1 from d13ecdbda2a2
-        "#);
+        ");
     }
 }
 
@@ -546,21 +544,21 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     std::fs::write(workspace_root.join("local"), "local").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: yostqsxw cb17dcdc new bookmark1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    ");
     }
 
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark1 to cb17dcdc74d5
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    ");
     }
 }
 
@@ -602,10 +600,10 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
         &["git", "push", "--config=git.push-new-bookmarks=true"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my to fcc999921ce9
-    "#);
+    ");
     }
 
     // Rewrite it and push again, which would fail if the pushed bookmark weren't
@@ -646,13 +644,13 @@ fn test_git_push_multiple(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: yqosqzyt c4a3c310 (empty) foo
       @origin (ahead by 1 commits, behind by 1 commits): rlzusymt 8476341e (empty) description 2
     my-bookmark: yqosqzyt c4a3c310 (empty) foo
-    "###);
+    ");
     }
     // First dry-run
     let (stdout, stderr) =
@@ -661,13 +659,13 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Move sideways bookmark bookmark2 from 8476341eb395 to c4a3c3105d92
       Add bookmark my-bookmark to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
     // Dry run requesting two specific bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -685,12 +683,12 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Add bookmark my-bookmark to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
     // Dry run requesting two specific bookmarks twice
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -710,12 +708,12 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Add bookmark my-bookmark to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
     // Dry run with glob pattern
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -726,29 +724,25 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Move sideways bookmark bookmark2 from 8476341eb395 to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
 
     // Unmatched bookmark name is error
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "-b=foo"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such bookmark: foo
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No such bookmark: foo");
     }
     let stderr = test_env.jj_cmd_failure(
         &workspace_root,
         &["git", "push", "-b=foo", "-b=glob:?bookmark"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No matching bookmarks for patterns: foo, ?bookmark
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No matching bookmarks for patterns: foo, ?bookmark");
     }
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
@@ -771,7 +765,7 @@ fn test_git_push_multiple(subprocess: bool) {
     }
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 bookmark2 my-bookmark c4a3c310
     │  (empty) foo
     │ ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
@@ -779,7 +773,7 @@ fn test_git_push_multiple(subprocess: bool) {
     │ ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
     }
 }
 
@@ -800,11 +794,11 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark push-yostqsxwqrlt for revision yostqsxwqrlt
     Changes to push to origin:
       Add bookmark push-yostqsxwqrlt to cf1a53a8800a
-    "#);
+    ");
     }
     // test pushing two changes at once
     std::fs::write(workspace_root.join("file"), "modified2").unwrap();
@@ -824,12 +818,12 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from cf1a53a8800a to 16c169664e9f
       Add bookmark push-yqosqzytrlsw to a050abf4ff07
-    "#);
+    ");
     }
     // specifying the same change twice doesn't break things
     std::fs::write(workspace_root.join("file"), "modified3").unwrap();
@@ -838,10 +832,10 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from 16c169664e9f to ef6313d50ac1
-    "#);
+    ");
     }
 
     // specifying the same bookmark with --change/--bookmark doesn't break things
@@ -854,10 +848,10 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from ef6313d50ac1 to c1e65d3a64ce
-    "#);
+    ");
     }
 
     // try again with --change that moves the bookmark forward
@@ -874,12 +868,12 @@ fn test_git_push_changes(subprocess: bool) {
     );
     let stdout = test_env.jj_cmd_success(&workspace_root, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : yostqsxw 38cb417c bar
     Parent commit: yqosqzyt a050abf4 push-yostqsxwqrlt* push-yqosqzytrlsw | foo
-    "###);
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_root,
@@ -889,19 +883,19 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from c1e65d3a64ce to 38cb417ce3a6
-    "#);
+    ");
     }
     let stdout = test_env.jj_cmd_success(&workspace_root, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : yostqsxw 38cb417c push-yostqsxwqrlt | bar
     Parent commit: yqosqzyt a050abf4 push-yqosqzytrlsw | foo
-    "###);
+    ");
     }
 
     // Test changing `git.push-bookmark-prefix`. It causes us to push again.
@@ -918,11 +912,11 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark test-yostqsxwqrlt for revision yostqsxwqrlt
     Changes to push to origin:
       Add bookmark test-yostqsxwqrlt to 38cb417ce3a6
-    "#);
+    ");
     }
 
     // Test deprecation warning for `git.push-branch-prefix`
@@ -971,10 +965,10 @@ fn test_git_push_revisions(subprocess: bool) {
         &["git", "push", "--allow-new", "-r=none()"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks point to the specified revisions: none()
     Nothing changed.
-    "###);
+    ");
     }
     // Push a revision with no bookmarks
     let (stdout, stderr) =
@@ -983,10 +977,10 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks point to the specified revisions: @--
     Nothing changed.
-    "###);
+    ");
     }
     // Push a revision with a single bookmark
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -997,11 +991,11 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark-1 to 5f432a855e59
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
     // Push multiple revisions of which some have bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1012,12 +1006,12 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks point to the specified revisions: @--
     Changes to push to origin:
       Add bookmark bookmark-1 to 5f432a855e59
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
     // Push a revision with a multiple bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1028,12 +1022,12 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark-2a to 84f499037f5c
       Add bookmark bookmark-2b to 84f499037f5c
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
     // Repeating a commit doesn't result in repeated messages about the bookmark
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1044,11 +1038,11 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark-1 to 5f432a855e59
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
 }
 
@@ -1103,14 +1097,14 @@ fn test_git_push_mixed(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
     Changes to push to origin:
       Add bookmark push-yqosqzytrlsw to a050abf4ff07
       Add bookmark bookmark-1 to 5f432a855e59
       Add bookmark bookmark-2a to 84f499037f5c
       Add bookmark bookmark-2b to 84f499037f5c
-    "#);
+    ");
     }
 }
 
@@ -1137,10 +1131,10 @@ fn test_git_push_existing_long_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark push-19b790168e73f7a73a98deae21e807c0 to a050abf4ff07
-    "#);
+    ");
     }
 }
 
@@ -1175,10 +1169,10 @@ fn test_git_push_conflict(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "third"]);
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--all"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit e2221a796300 since it has conflicts
     Hint: Rejected commit: yostqsxw e2221a79 my-bookmark | (conflict) third
-    "###);
+    ");
     }
 }
 
@@ -1259,11 +1253,11 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my-bookmark to ea7373507ad9
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
 }
 
@@ -1360,11 +1354,11 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my-bookmark to 68fdae89de4f
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
 }
 
@@ -1477,11 +1471,11 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my-bookmark to c79f85e90b4a
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
 }
 
@@ -1499,14 +1493,14 @@ fn test_git_push_deleted(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
-    "#);
+    ");
     }
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 5b36783c
     │  (empty) (no description set)
     │ ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 bookmark2 8476341e
@@ -1514,16 +1508,14 @@ fn test_git_push_deleted(subprocess: bool) {
     │ ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
     ◆  zzzzzzzz root() 00000000
-    "#);
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--deleted"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
 }
 
@@ -1552,14 +1544,14 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "bookmark2"]);
     test_env.jj_cmd_ok(&workspace_root, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: xtvrqkyv d13ecdbd (empty) description 1
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2 (conflicted):
       + yostqsxw 8e670e2d (empty) description 3
       + rlzusymt 8476341e (empty) description 2
       @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
-    "###);
+    ");
     }
 
     let bump_bookmark1 = || {
@@ -1573,11 +1565,11 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Nothing changed.
-    "###);
+    ");
     }
 
     // --bookmark should be blocked by conflicting bookmark
@@ -1586,10 +1578,10 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
         &["git", "push", "--allow-new", "--bookmark", "bookmark2"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
-    "###);
+    ");
     }
 
     // --all shouldn't be blocked by conflicting bookmark
@@ -1599,12 +1591,12 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Changes to push to origin:
       Move forward bookmark bookmark1 from d13ecdbda2a2 to 8df52121b022
-    "#);
+    ");
     }
 
     // --revisions shouldn't be blocked by conflicting bookmark
@@ -1615,12 +1607,12 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Changes to push to origin:
       Move forward bookmark bookmark1 from 8df52121b022 to 345e1f64a64d
-    "#);
+    ");
     }
 }
 
@@ -1641,15 +1633,11 @@ fn test_git_push_deleted_untracked(subprocess: bool) {
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--deleted"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--bookmark=bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No such bookmark: bookmark1
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No such bookmark: bookmark1");
     }
 }
 
@@ -1670,13 +1658,13 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     );
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "bookmark3"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: vruxwmqv db059e3f (empty) moved bookmark1
     bookmark1@origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2 (deleted)
       @origin: rlzusymt 8476341e (empty) description 2
     bookmark3: znkkpsqq 1aa4f1f2 (empty) moved bookmark2
-    "###);
+    ");
     }
 
     // At this point, only bookmark2 is still tracked. `jj git push --tracked` would
@@ -1684,11 +1672,11 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--tracked", "--dry-run"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark2 from 8476341eb395
     Dry-run requested, not pushing.
-    "#);
+    ");
     }
 
     // Untrack the last remaining tracked bookmark.
@@ -1697,20 +1685,18 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
         &["bookmark", "untrack", "bookmark2@origin"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: vruxwmqv db059e3f (empty) moved bookmark1
     bookmark1@origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2@origin: rlzusymt 8476341e (empty) description 2
     bookmark3: znkkpsqq 1aa4f1f2 (empty) moved bookmark2
-    "###);
+    ");
     }
 
     // Now, no bookmarks are tracked. --tracked does not push anything
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--tracked"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
     }
 
     // All bookmarks are still untracked.
@@ -1731,12 +1717,12 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     //   bookmark2@origin` instead of showing an error here.
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Non-tracking remote bookmark bookmark1@origin exists
     Hint: Run `jj bookmark track bookmark1@origin` to import the remote bookmark.
     Changes to push to origin:
       Add bookmark bookmark3 to 1aa4f1f2ef7f
-    "#);
+    ");
     }
 }
 
@@ -1756,11 +1742,11 @@ fn test_git_push_moved_forward_untracked(subprocess: bool) {
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Non-tracking remote bookmark bookmark1@origin exists
     Hint: Run `jj bookmark track bookmark1@origin` to import the remote bookmark.
     Nothing changed.
-    "###);
+    ");
     }
 }
 
@@ -1783,11 +1769,11 @@ fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Non-tracking remote bookmark bookmark1@origin exists
     Hint: Run `jj bookmark track bookmark1@origin` to import the remote bookmark.
     Nothing changed.
-    "###);
+    ");
     }
 }
 
@@ -1808,12 +1794,12 @@ fn test_git_push_to_remote_named_git(subprocess: bool) {
     let stderr =
         test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--all", "--remote=git"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to git:
       Add bookmark bookmark1 to d13ecdbda2a2
       Add bookmark bookmark2 to 8476341eb395
     Error: Git remote named 'git' is reserved for local Git repository
-    "#);
+    ");
     }
 }
 
@@ -1848,7 +1834,7 @@ fn test_git_push_sign_on_push() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template]);
     // There should be no signed commits initially
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ○  commit which should not be signed 1
     ○  commit to be signed 2
@@ -1857,7 +1843,7 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @"");
     test_env.add_config(
         r#"
@@ -1868,14 +1854,14 @@ fn test_git_push_sign_on_push() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--dry-run"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to 8710e91a14a1
     Dry-run requested, not pushing.
-    "#);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template]);
     // There should be no signed commits after performing a dry run
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ○  commit which should not be signed 1
     ○  commit to be signed 2
@@ -1884,21 +1870,21 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Updated signatures of 2 commits
     Rebased 2 descendant commits
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to a6259c482040
     Working copy now at: kmkuslsw b5f47345 (empty) commit which should not be signed 2
     Parent commit      : kpqxywon 90df08d3 (empty) commit which should not be signed 1
-    "#);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template]);
     // Only commits which are being pushed should be signed
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ○  commit which should not be signed 1
     ○  commit to be signed 2
@@ -1909,7 +1895,7 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Immutable commits should not be signed
@@ -1934,15 +1920,15 @@ fn test_git_push_sign_on_push() {
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmark3""#);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Refusing to create new remote bookmark bookmark3@origin
     Hint: Use --allow-new to push new bookmark. Use --remote to specify the remote to push to.
     Changes to push to origin:
       Move forward bookmark bookmark2 from a6259c482040 to 90df08d3d612
-    "#);
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template, "-r", "::"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ◆  commit which should not be signed 1
     ◆  commit to be signed 2
@@ -1953,7 +1939,7 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -39,20 +39,17 @@ fn test_git_remotes() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar http://example.com/repo/bar
     foo http://example.com/repo/foo
-    "###);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "remote", "remove", "foo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @"bar http://example.com/repo/bar
-");
+    insta::assert_snapshot!(stdout, @"bar http://example.com/repo/bar");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "remove", "nonexistent"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No git remote named 'nonexistent'
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No git remote named 'nonexistent'");
 }
 
 #[test]
@@ -75,20 +72,14 @@ fn test_git_remote_add() {
             "http://example.com/repo/foo2",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Git remote named 'foo' already exists
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Git remote named 'foo' already exists");
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["git", "remote", "add", "git", "http://example.com/repo/git"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Git remote named 'git' is reserved for local Git repository");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    foo http://example.com/repo/foo
-    "###);
+    insta::assert_snapshot!(stdout, @"foo http://example.com/repo/foo");
 }
 
 #[test]
@@ -111,9 +102,7 @@ fn test_git_remote_set_url() {
             "http://example.com/repo/bar",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No git remote named 'bar'
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No git remote named 'bar'");
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &[
@@ -124,9 +113,7 @@ fn test_git_remote_set_url() {
             "http://example.com/repo/git",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Git remote named 'git' is reserved for local Git repository");
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &[
@@ -140,9 +127,7 @@ fn test_git_remote_set_url() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    foo http://example.com/repo/bar
-    "###);
+    insta::assert_snapshot!(stdout, @"foo http://example.com/repo/bar");
 }
 
 #[test]
@@ -184,26 +169,20 @@ fn test_git_remote_rename() {
         &["git", "remote", "add", "baz", "http://example.com/repo/baz"],
     );
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "bar", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: No git remote named 'bar'
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: No git remote named 'bar'");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "foo", "baz"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Git remote named 'baz' already exists
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Git remote named 'baz' already exists");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "foo", "git"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Git remote named 'git' is reserved for local Git repository");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "foo", "bar"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar http://example.com/repo/foo
     baz http://example.com/repo/baz
-    "###);
+    ");
 }
 
 #[test]
@@ -225,22 +204,18 @@ fn test_git_remote_named_git() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    bar http://example.com/repo/repo
-    "###);
+    insta::assert_snapshot!(stdout, @"bar http://example.com/repo/repo");
     // @git bookmark shouldn't be renamed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rmain@git", "-Tbookmarks"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  main
     │
     ~
-    "###);
+    ");
 
     // The remote cannot be renamed back by jj.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "bar", "git"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Git remote named 'git' is reserved for local Git repository");
 
     // Reinitialize the repo with remote named 'git'.
     fs::remove_dir_all(repo_path.join(".jj")).unwrap();
@@ -252,13 +227,12 @@ fn test_git_remote_named_git() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    "###);
+    insta::assert_snapshot!(stdout, @"");
     // @git bookmark shouldn't be removed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rmain@git", "-Tbookmarks"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  main
     │
     ~
-    "###);
+    ");
 }

--- a/cli/tests/test_git_submodule.rs
+++ b/cli/tests/test_git_submodule.rs
@@ -47,19 +47,17 @@ fn test_gitsubmodule_print_gitmodules() {
         &workspace_root,
         &["git", "submodule", "print-gitmodules", "-r", "@-"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     name:old
     url:https://github.com/old/old.git
     path:old
-
-
-    "###);
+    ");
 
     let stdout =
         test_env.jj_cmd_success(&workspace_root, &["git", "submodule", "print-gitmodules"]);
-    insta::assert_snapshot!(stdout, @r###"
-	name:new
-	url:https://github.com/new/new.git
-	path:new
-    "###);
+    insta::assert_snapshot!(stdout, @r"
+    name:new
+    url:https://github.com/new/new.git
+    path:new
+    ");
 }

--- a/cli/tests/test_gitignores.rs
+++ b/cli/tests/test_gitignores.rs
@@ -57,11 +57,11 @@ fn test_gitignores() {
     std::fs::write(workspace_root.join("file3"), "contents").unwrap();
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     A .gitignore
     A file0
     A file3
-    "###);
+    ");
 }
 
 #[test]
@@ -86,13 +86,9 @@ fn test_gitignores_relative_excludes_file_path() {
     // to the cwd.
     std::fs::create_dir(workspace_root.join("sub")).unwrap();
     let stdout = test_env.jj_cmd_success(&workspace_root.join("sub"), &["diff", "-s"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
-    A ../not-ignored
-    "###);
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @"A ../not-ignored");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["-Rrepo", "diff", "-s"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
-    A repo/not-ignored
-    "###);
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @"A repo/not-ignored");
 }
 
 #[test]
@@ -118,19 +114,19 @@ fn test_gitignores_ignored_file_in_target_commit() {
     // Update to the commit with the "ignored" file
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["edit", "with-file"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 5ada929e with-file | (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 1 files, modified 0 files, removed 0 files
     Warning: 1 of those updates were skipped because there were conflicting changes in the working copy.
     Hint: Inspect the changes compared to the intended target with `jj diff --from 5ada929e5d2e`.
     Discard the conflicting changes with `jj restore --from 5ada929e5d2e`.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(
         &workspace_root,
         &["diff", "--git", "--from", &target_commit_id],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/ignored b/ignored
     index 8a69467466..4d9be5127b 100644
     --- a/ignored
@@ -138,5 +134,5 @@ fn test_gitignores_ignored_file_in_target_commit() {
     @@ -1,1 +1,1 @@
     -committed contents
     +contents in working copy
-    "###);
+    ");
 }

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -43,9 +43,7 @@ fn test_non_utf8_arg() {
         .assert()
         .code(2);
     let stderr = get_stderr_string(&assert);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Non-utf8 argument
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Non-utf8 argument");
 }
 
 #[test]
@@ -72,17 +70,15 @@ fn test_no_subcommand() {
 
     // Outside of a repo.
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &[]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Hint: Use `jj -h` for a list of available commands.
     Run `jj config set --user ui.default-command log` to disable this message.
     Error: There is no jj repo in "."
-    "###);
+    "#);
 
     test_env.add_config(r#"ui.default-command="log""#);
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &[]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: There is no jj repo in "."
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in ".""#);
 
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["--help"]);
     insta::assert_snapshot!(stdout.lines().next().unwrap(), @"Jujutsu (An experimental VCS)");
@@ -99,16 +95,16 @@ fn test_no_subcommand() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "log"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "show"]);
     // TODO: test_env.jj_cmd_ok(&repo_path, &["-r", "help"])
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "log"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "log"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 help log show 230dd059
     │  (empty) (no description set)
     ~
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "show"]), @r###"
+    ");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "show"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 help log show 230dd059
     │  (empty) (no description set)
     ~
-    "###);
+    ");
 
     // Multiple default command strings work.
     test_env.add_config(r#"ui.default-command=["commit", "-m", "foo"]"#);
@@ -116,10 +112,10 @@ fn test_no_subcommand() {
     std::fs::write(repo_path.join("file.txt"), "file").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &[]);
     assert_eq!(stdout, "");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kxryzmor 89c70edf (empty) (no description set)
     Parent commit      : lylxulpl 51bd3589 foo
-    "###);
+    ");
 }
 
 #[test]
@@ -131,10 +127,10 @@ fn test_ignore_working_copy() {
 
     std::fs::write(repo_path.join("file"), "initial").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Modify the file. With --ignore-working-copy, we still get the same commit
     // ID.
@@ -147,28 +143,24 @@ fn test_ignore_working_copy() {
 
     // But without --ignore-working-copy, we get a new commit ID.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 }
 
 #[test]
 fn test_repo_arg_with_init() {
     let test_env = TestEnvironment::default();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["init", "-R=.", "repo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: There is no jj repo in "."
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in ".""#);
 }
 
 #[test]
 fn test_repo_arg_with_git_clone() {
     let test_env = TestEnvironment::default();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "-R=.", "remote"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: There is no jj repo in "."
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in ".""#);
 }
 
 #[test]
@@ -181,31 +173,27 @@ fn test_resolve_workspace_directory() {
 
     // Ancestor of cwd
     let stdout = test_env.jj_cmd_success(&subdir, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     Working copy : qpvuntsm 230dd059 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     // Explicit subdirectory path
     let stderr = test_env.jj_cmd_failure(&subdir, &["status", "-R", "."]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: There is no jj repo in "."
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in ".""#);
 
     // Valid explicit path
     let stdout = test_env.jj_cmd_success(&subdir, &["status", "-R", "../.."]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     Working copy : qpvuntsm 230dd059 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     // "../../..".ancestors() contains "../..", but it should never be looked up.
     let stderr = test_env.jj_cmd_failure(&subdir, &["status", "-R", "../../.."]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: There is no jj repo in "../../.."
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in "../../..""#);
 }
 
 #[test]
@@ -215,22 +203,18 @@ fn test_no_workspace_directory() {
     std::fs::create_dir(&repo_path).unwrap();
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["status"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: There is no jj repo in "."
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in ".""#);
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["status", "-R", "repo"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: There is no jj repo in "repo"
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in "repo""#);
 
     std::fs::create_dir(repo_path.join(".git")).unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["status"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
     Hint: It looks like this is a git repo. You can create a jj repo backed by it by running this:
     jj git init --colocate
-    "###);
+    "#);
 }
 
 #[test]
@@ -243,7 +227,7 @@ fn test_bad_path() {
 
     // cwd == workspace_root
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "../out"]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -254,11 +238,11 @@ fn test_bad_path() {
       = Invalid file pattern
     2: Path "../out" is not in the repo "."
     3: Invalid component ".." in repo-relative path "../out"
-    "###);
+    "#);
 
     // cwd != workspace_root, can't be parsed as repo-relative path
     let stderr = test_env.jj_cmd_failure(&subdir, &["file", "show", "../.."]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -269,11 +253,11 @@ fn test_bad_path() {
       = Invalid file pattern
     2: Path "../.." is not in the repo "../"
     3: Invalid component ".." in repo-relative path "../"
-    "###);
+    "#);
 
     // cwd != workspace_root, can be parsed as repo-relative path
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["file", "show", "-Rrepo", "out"]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -285,7 +269,7 @@ fn test_bad_path() {
     2: Path "out" is not in the repo "repo"
     3: Invalid component ".." in repo-relative path "../out"
     Hint: Consider using root:"out" to specify repo-relative path
-    "###);
+    "#);
 }
 
 #[test]
@@ -295,7 +279,7 @@ fn test_invalid_filesets_looking_like_filepaths() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "abc~"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse fileset: Syntax error
     Caused by:  --> 1:5
       |
@@ -304,7 +288,7 @@ fn test_invalid_filesets_looking_like_filepaths() {
       |
       = expected `~` or <primary>
     Hint: See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
-    "#);
+    ");
 }
 
 #[test]
@@ -318,43 +302,43 @@ fn test_broken_repo_structure() {
     // Test the error message when the git repository can't be located.
     std::fs::remove_file(store_path.join("git_target")).unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r###"
+    insta::assert_snapshot!(strip_last_line(&stderr), @r"
     Internal error: The repository appears broken or inaccessible
     Caused by:
     1: Cannot access $TEST_ENV/repo/.jj/repo/store/git_target
-    "###);
+    ");
 
     // Test the error message when the commit backend is of unknown type.
     std::fs::write(&store_type_path, "unknown").unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Internal error: This version of the jj binary doesn't support this type of repo
     Caused by: Unsupported commit backend type 'unknown'
-    "###);
+    ");
 
     // Test the error message when the file indicating the commit backend type
     // cannot be read.
     std::fs::remove_file(&store_type_path).unwrap();
     std::fs::create_dir(&store_type_path).unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r###"
+    insta::assert_snapshot!(strip_last_line(&stderr), @r"
     Internal error: The repository appears broken or inaccessible
     Caused by:
     1: Failed to read commit backend type
     2: Cannot access $TEST_ENV/repo/.jj/repo/store/type
-    "###);
+    ");
 
     // Test when the .jj directory is empty. The error message is identical to
     // the previous one, but writing the default type file would also fail.
     std::fs::remove_dir_all(repo_path.join(".jj")).unwrap();
     std::fs::create_dir(repo_path.join(".jj")).unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r###"
+    insta::assert_snapshot!(strip_last_line(&stderr), @r"
     Internal error: The repository appears broken or inaccessible
     Caused by:
     1: Failed to read commit backend type
     2: Cannot access $TEST_ENV/repo/.jj/repo/store/type
-    "###);
+    ");
 }
 
 #[test]
@@ -366,42 +350,42 @@ fn test_color_config() {
 
     // Test that --color=always is respected.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    ");
 
     // Test that color is used if it's requested in the config file
     test_env.add_config(r#"ui.color="always""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    ");
 
     // Test that --color=never overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=never", "log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Test that --color=auto overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=auto", "log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Test that --config 'ui.color=never' overrides the config.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["--config=ui.color=never", "log", "-T", "commit_id"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // --color overrides --config 'ui.color=...'.
     let stdout = test_env.jj_cmd_success(
@@ -415,18 +399,18 @@ fn test_color_config() {
             "commit_id",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Test that NO_COLOR does NOT override the request for color in the config file
     test_env.add_env_var("NO_COLOR", "1");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    ");
 
     // Test that per-repo config overrides the user config.
     std::fs::write(
@@ -435,10 +419,10 @@ fn test_color_config() {
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Invalid --color
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["log", "--color=foo"]);
@@ -467,15 +451,15 @@ fn test_color_ui_messages() {
 
     // hint and error
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["-R."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     [1m[38;5;6mHint: [0m[39mUse `jj -h` for a list of available commands.[39m
     [39mRun `jj config set --user ui.default-command log` to disable this message.[39m
     [1m[38;5;1mError: [39mThere is no jj repo in "."[0m
-    "###);
+    "#);
 
     // error source
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", ".."]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     [1m[38;5;1mError: [39mFailed to parse fileset: Invalid file pattern[0m
     [1m[39mCaused by:[0m
     [1m[39m1: [0m[39m --> 1:1[39m
@@ -486,13 +470,11 @@ fn test_color_ui_messages() {
     [39m  = Invalid file pattern[39m
     [1m[39m2: [0m[39mPath ".." is not in the repo "."[39m
     [1m[39m3: [0m[39mInvalid component ".." in repo-relative path "../"[39m
-    "###);
+    "#);
 
     // warning
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "@"]);
-    insta::assert_snapshot!(stderr, @r###"
-    [1m[38;5;3mWarning: [39mThe argument "@" is being interpreted as a fileset expression. To specify a revset, pass -r "@" instead.[0m
-    "###);
+    insta::assert_snapshot!(stderr, @r#"[1m[38;5;3mWarning: [39mThe argument "@" is being interpreted as a fileset expression. To specify a revset, pass -r "@" instead.[0m"#);
 
     // error inlined in template output
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -505,11 +487,11 @@ fn test_color_ui_messages() {
             "-Tdescription",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;4m167f90e7600a50f85c4f909b53eaf546faa82879[39m
     [1m[39m<[38;5;1mError: [39mNo Commit available>[0m  [38;5;8m(elided revisions)[39m
     [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    ");
 
     // formatted hint
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", ".."]);
@@ -523,11 +505,11 @@ fn test_color_ui_messages() {
 
     // debugging colors
     let (stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["st", "--color", "debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     Working copy : [1m[38;5;13m<<working_copy change_id shortest prefix::m>>[38;5;8m<<working_copy change_id shortest rest::zvwutvl>>[39m<<working_copy:: >>[38;5;12m<<working_copy commit_id shortest prefix::1>>[38;5;8m<<working_copy commit_id shortest rest::67f90e7>>[39m<<working_copy:: >>[38;5;10m<<working_copy empty::(empty)>>[39m<<working_copy:: >>[38;5;10m<<working_copy empty description placeholder::(no description set)>>[0m
     Parent commit: [1m[38;5;5m<<change_id shortest prefix::q>>[0m[38;5;8m<<change_id shortest rest::pvuntsm>>[39m [1m[38;5;4m<<commit_id shortest prefix::2>>[0m[38;5;8m<<commit_id shortest rest::30dd059>>[39m [38;5;2m<<empty::(empty)>>[39m [38;5;2m<<empty description placeholder::(no description set)>>[39m
-    "###);
+    ");
 }
 
 #[test]
@@ -883,36 +865,36 @@ fn test_no_user_configured() {
         .env_remove("JJ_USER")
         .assert()
         .success();
-    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    insta::assert_snapshot!(get_stderr_string(&assert), @r#"
     Working copy now at: qpvuntsm 7a7d6016 (empty) without name
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Warning: Name not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
       jj config set --user user.name "Some One"
-    "###);
+    "#);
     let assert = test_env
         .jj_cmd(&repo_path, &["describe", "-m", "without email"])
         .env_remove("JJ_EMAIL")
         .assert()
         .success();
-    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    insta::assert_snapshot!(get_stderr_string(&assert), @r#"
     Working copy now at: qpvuntsm 906f8b89 (empty) without email
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Warning: Email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
       jj config set --user user.email "someone@example.com"
-    "###);
+    "#);
     let assert = test_env
         .jj_cmd(&repo_path, &["describe", "-m", "without name and email"])
         .env_remove("JJ_USER")
         .env_remove("JJ_EMAIL")
         .assert()
         .success();
-    insta::assert_snapshot!(get_stderr_string(&assert), @r###"
+    insta::assert_snapshot!(get_stderr_string(&assert), @r#"
     Working copy now at: qpvuntsm 57d3a489 (empty) without name and email
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Warning: Name and email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
       jj config set --user user.name "Some One"
       jj config set --user user.email "someone@example.com"
-    "###);
+    "#);
 }
 
 #[test]

--- a/cli/tests/test_help_command.rs
+++ b/cli/tests/test_help_command.rs
@@ -37,23 +37,19 @@ fn test_help() {
 
     // Help command should not work recursively
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["workspace", "help", "root"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: unrecognized subcommand 'help'
 
     Usage: jj workspace [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "#);
+    ");
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["workspace", "add", "help"]);
-    insta::assert_snapshot!(stderr, @r#"
-    Error: There is no jj repo in "."
-    "#);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in ".""#);
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["new", "help", "main"]);
-    insta::assert_snapshot!(stderr, @r#"
-    Error: There is no jj repo in "."
-    "#);
+    insta::assert_snapshot!(stderr, @r#"Error: There is no jj repo in ".""#);
 
     // Help command should output the same as --help for nonexistent commands
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "nonexistent"]);
@@ -67,7 +63,7 @@ fn test_help() {
     assert_eq!(help_cmd_stdout, help_flag_stdout);
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "unknown"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: unrecognized subcommand 'unknown'
 
       tip: a similar subcommand exists: 'undo'
@@ -75,14 +71,14 @@ fn test_help() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "#);
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "log", "--", "-r"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--revisions <REVSETS>' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -102,38 +98,38 @@ fn test_help_keyword() {
 
     // It should give hints if a similar keyword is present
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "-k", "rev"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r###"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: invalid value 'rev' for '--keyword <KEYWORD>'
       [possible values: bookmarks, config, filesets, glossary, revsets, templates, tutorial]
 
       tip: a similar value exists: 'revsets'
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // It should give error with a hint if no similar keyword is found
     let help_cmd_stderr =
         test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "-k", "<no-similar-keyword>"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r###"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: invalid value '<no-similar-keyword>' for '--keyword <KEYWORD>'
       [possible values: bookmarks, config, filesets, glossary, revsets, templates, tutorial]
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // The keyword flag with no argument should error with a hint
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "-k"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r###"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: a value is required for '--keyword <KEYWORD>' but none was supplied
       [possible values: bookmarks, config, filesets, glossary, revsets, templates, tutorial]
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // It shouldn't show help for a certain keyword if the `--keyword` is not
     // present
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "revsets"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r#"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: unrecognized subcommand 'revsets'
 
       tip: some similar subcommands exist: 'resolve', 'prev', 'restore', 'rebase', 'revert'
@@ -141,5 +137,5 @@ fn test_help_keyword() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "#);
+    ");
 }

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -27,7 +27,7 @@ fn test_rewrite_immutable_generic() {
     test_env.jj_cmd_ok(&repo_path, &["new", "main-", "-m=c"]);
     std::fs::write(repo_path.join("file"), "c").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:12 7adb43e8
     │  c
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 main 72e1b68c
@@ -35,29 +35,27 @@ fn test_rewrite_immutable_generic() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 b84b821b
     │  a
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     // Cannot rewrite a commit in the configured set
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "main"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit 72e1b68cbcf2 is immutable
     Hint: Could not modify commit: kkmpptxz 72e1b68c main | b
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "#);
+    ");
     // Cannot rewrite an ancestor of the configured set
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "main-"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit b84b821b8a2b is immutable
     Hint: Could not modify commit: qpvuntsm b84b821b a
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "#);
+    ");
     // Cannot rewrite the root commit even with an empty set of immutable commits
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 
     // Error mutating the repo if immutable_heads() uses a ref that can't be
     // resolved
@@ -74,37 +72,31 @@ fn test_rewrite_immutable_generic() {
     // Can use --ignore-immutable to override
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["--ignore-immutable", "edit", "main"]);
-    insta::assert_snapshot!(stdout, @r###"
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 72e1b68c main | b
     Parent commit      : qpvuntsm b84b821b a
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     // ... but not the root commit
     let stderr = test_env.jj_cmd_failure(&repo_path, &["--ignore-immutable", "edit", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 
     // Mutating the repo works if ref is wrapped in present()
     test_env.add_config(
         r#"revset-aliases."immutable_heads()" = "present(bookmark_that_does_not_exist)""#,
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "main"]);
-    insta::assert_snapshot!(stdout, @r###"
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: wqnwkozp fc921593 (empty) (no description set)
     Parent commit      : kkmpptxz 72e1b68c main | b
-    "###);
+    ");
 
     // immutable_heads() of different arity doesn't shadow the 0-ary one
     test_env.add_config(r#"revset-aliases."immutable_heads(foo)" = "none()""#);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 }
 
 #[test]
@@ -115,12 +107,12 @@ fn test_new_wc_commit_when_wc_immutable() {
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     test_env.jj_cmd_ok(test_env.env_root(), &["new", "-m=a"]);
     let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "set", "main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to kkmpptxz a164195b main | (empty) a
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: zsuskuln ef5fa85b (empty) (no description set)
     Parent commit      : kkmpptxz a164195b main | (empty) a
-    "###);
+    ");
 }
 
 #[test]
@@ -130,11 +122,11 @@ fn test_immutable_heads_set_to_working_copy() {
     test_env.jj_cmd_ok(test_env.env_root(), &["bookmark", "create", "main"]);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "@""#);
     let (_, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["new", "-m=a"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: pmmvwywv 7278b2d8 (empty) (no description set)
     Parent commit      : kkmpptxz a713ef56 (empty) a
-    "###);
+    ");
 }
 
 #[test]
@@ -149,16 +141,16 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     let workspace1_envroot = test_env.env_root().join("workspace1");
     test_env.jj_cmd_ok(&workspace1_envroot, &["edit", "default@"]);
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to kkmpptxz 7796c4df main | (empty) a
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
     Working copy now at: royxmykx 896465c4 (empty) (no description set)
     Parent commit      : kkmpptxz 7796c4df main | (empty) a
-    "###);
+    ");
     test_env.jj_cmd_ok(&workspace1_envroot, &["workspace", "update-stale"]);
     let (stdout, _) = test_env.jj_cmd_ok(&workspace1_envroot, &["log", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     nppvrztz test.user@example.com 2001-02-03 08:05:11 workspace1@ ee0671fd
     (empty) (no description set)
     royxmykx test.user@example.com 2001-02-03 08:05:12 default@ 896465c4
@@ -166,7 +158,7 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     kkmpptxz test.user@example.com 2001-02-03 08:05:09 main 7796c4df
     (empty) a
     zzzzzzzz root() 00000000
-    "###);
+    ");
 }
 
 #[test]
@@ -192,7 +184,7 @@ fn test_rewrite_immutable_commands() {
 
     // Log shows mutable commits, their parents, and trunk() by default
     let (stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:14 55641cc5
     │  (no description set)
     │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main bcab555f conflict
@@ -203,15 +195,15 @@ fn test_rewrite_immutable_commands() {
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:10 72e1b68c
     │  b
     ~
-    "###);
+    ");
 
     // abandon
     let stderr = test_env.jj_cmd_failure(&repo_path, &["abandon", "main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // absorb
     let stderr = test_env.jj_cmd_failure(&repo_path, &["absorb", "--into=::@-"]);
     insta::assert_snapshot!(stderr, @r"
@@ -221,130 +213,130 @@ fn test_rewrite_immutable_commands() {
     ");
     // chmod
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "chmod", "-r=main", "x", "file"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // describe
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // diffedit
     let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit", "-r=main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // edit
     let stderr = test_env.jj_cmd_failure(&repo_path, &["edit", "main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // new --insert-before
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "--insert-before", "main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // new --insert-after parent_of_main
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "--insert-after", "description(b)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // parallelize
     let stderr = test_env.jj_cmd_failure(&repo_path, &["parallelize", "description(b)", "main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // rebase -s
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s=main", "-d=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // rebase -b
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-b=main", "-d=@"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit 77cee210cbf5 is immutable
     Hint: Could not modify commit: zsuskuln 77cee210 c
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "#);
+    ");
     // rebase -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r=main", "-d=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // resolve
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve", "-r=description(merge)", "file"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // restore -c
     let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "-c=main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // restore --into
     let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "--into=main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // split
     let stderr = test_env.jj_cmd_failure(&repo_path, &["split", "-r=main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // squash -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "-r=description(b)"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit 72e1b68cbcf2 is immutable
     Hint: Could not modify commit: kkmpptxz 72e1b68c b
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "#);
+    ");
     // squash --from
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "--from=main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // squash --into
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "--into=main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
     // unsquash
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash", "-r=main"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
-    "###);
+    ");
 }

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -18,11 +18,11 @@ use crate::common::TestEnvironment;
 fn test_init_local_disallowed() {
     let test_env = TestEnvironment::default();
     let stdout = test_env.jj_cmd_failure(test_env.env_root(), &["init", "repo"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Error: The native backend is disallowed by default.
     Hint: Did you mean to call `jj git init`?
     Set `ui.allow-init-native` to allow initializing a repo with the native backend.
-    "###);
+    ");
 }
 
 #[test]
@@ -31,9 +31,7 @@ fn test_init_local() {
     test_env.add_config(r#"ui.allow-init-native = true"#);
     let (stdout, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Initialized repo in "repo"
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Initialized repo in "repo""#);
 
     let workspace_root = test_env.env_root().join("repo");
     let jj_path = workspace_root.join(".jj");
@@ -54,12 +52,8 @@ fn test_init_local() {
         test_env.env_root(),
         &["init", "--ignore-working-copy", "repo2"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --ignore-working-copy is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --ignore-working-copy is not respected");
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["init", "--at-op=@-", "repo3"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --at-op is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --at-op is not respected");
 }

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -33,11 +33,11 @@ fn test_interdiff_basic() {
 
     // implicit --to
     let stdout = test_env.jj_cmd_success(&repo_path, &["interdiff", "--from", "left"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: foo
             2: bar
-    "###);
+    ");
 
     // explicit --to
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
@@ -45,11 +45,11 @@ fn test_interdiff_basic() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: foo
             2: bar
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // formats specifiers
@@ -57,15 +57,13 @@ fn test_interdiff_basic() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "-s"],
     );
-    insta::assert_snapshot!(stdout, @r###"
-    M file2
-    "###);
+    insta::assert_snapshot!(stdout, @"M file2");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file2 b/file2
     index 257cc5642c..3bd1f0e297 100644
     --- a/file2
@@ -73,7 +71,7 @@ fn test_interdiff_basic() {
     @@ -1,1 +1,2 @@
      foo
     +bar
-    "###);
+    ");
 }
 
 #[test]
@@ -101,10 +99,10 @@ fn test_interdiff_paths() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "file1"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: barbaz
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -118,12 +116,12 @@ fn test_interdiff_paths() {
             "file2",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: barbaz
     Modified regular file file2:
        1    1: barbaz
-    "###);
+    ");
 }
 
 #[test]
@@ -147,7 +145,7 @@ fn test_interdiff_conflicting() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file b/file
     index 0000000000..24c5735c3e 100644
     --- a/file
@@ -161,5 +159,5 @@ fn test_interdiff_conflicting() {
     -bar
     ->>>>>>> Conflict 1 of 1 ends
     +def
-    "###);
+    ");
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -22,11 +22,11 @@ fn test_log_with_empty_revision() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["log", "-r="]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--revisions <REVSETS>' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -72,14 +72,14 @@ fn test_log_with_or_without_diff() {
     std::fs::write(repo_path.join("file1"), "foo\nbar\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     ○  add a file
     ◆
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  Modified regular file file1:
     │     1    1: foo
@@ -88,17 +88,17 @@ fn test_log_with_or_without_diff() {
     │  Added regular file file1:
     │          1: foo
     ◆
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     add a file
-    "###);
+    ");
 
     // `-p` for default diff output, `-s` for summary
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  M file1
     │  Modified regular file file1:
@@ -109,7 +109,7 @@ fn test_log_with_or_without_diff() {
     │  Added regular file file1:
     │          1: foo
     ◆
-    "###);
+    ");
 
     // `-s` for summary, `--git` for git diff (which implies `-p`)
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-s", "--git"]);
@@ -147,20 +147,20 @@ fn test_log_with_or_without_diff() {
             "--config=ui.diff.format=summary",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  M file1
     ○  add a file
     │  A file1
     ◆
-    "###);
+    ");
 
     // `-p` enables default "color-words" diff output, so `--color-words` is noop
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-p", "--color-words"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  Modified regular file file1:
     │     1    1: foo
@@ -169,7 +169,7 @@ fn test_log_with_or_without_diff() {
     │  Added regular file file1:
     │          1: foo
     ◆
-    "###);
+    ");
 
     // `--git` enables git diff, so `-p` is noop
     let stdout = test_env.jj_cmd_success(
@@ -208,40 +208,40 @@ fn test_log_with_or_without_diff() {
             "--color-words",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--git' cannot be used with '--color-words'
 
     Usage: jj log --template <TEMPLATE> --no-graph --patch --git [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // `-s` with or without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  M file1
     ○  add a file
     │  A file1
     ◆
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "--no-graph", "-s"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     M file1
     add a file
     A file1
-    "###);
+    ");
 
     // `--git` implies `-p`, with or without graph
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-r", "@", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  diff --git a/file1 b/file1
     ~  index 257cc5642c..3bd1f0e297 100644
@@ -250,12 +250,12 @@ fn test_log_with_or_without_diff() {
        @@ -1,1 +1,2 @@
         foo
        +bar
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-r", "@", "--no-graph", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     diff --git a/file1 b/file1
     index 257cc5642c..3bd1f0e297 100644
@@ -264,19 +264,19 @@ fn test_log_with_or_without_diff() {
     @@ -1,1 +1,2 @@
      foo
     +bar
-    "###);
+    ");
 
     // `--color-words` implies `-p`, with or without graph
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-r", "@", "--color-words"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  Modified regular file file1:
     ~     1    1: foo
                2: bar
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -289,12 +289,12 @@ fn test_log_with_or_without_diff() {
             "--color-words",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     Modified regular file file1:
        1    1: foo
             2: bar
-    "###);
+    ");
 }
 
 #[test]
@@ -329,7 +329,7 @@ fn test_log_null_terminate_multiline_descriptions() {
     );
     insta::assert_debug_snapshot!(
         stdout,
-        @r###""commit 3 line 1\n\ncommit 3 line 2\n\0commit 2 line 1\n\ncommit 2 line 2\n\0commit 1 line 1\n\ncommit 1 line 2\n\0""###
+        @r#""commit 3 line 1\n\ncommit 3 line 2\n\0commit 2 line 1\n\ncommit 2 line 2\n\0commit 1 line 1\n\ncommit 1 line 2\n\0""#
     );
 }
 
@@ -374,7 +374,7 @@ fn test_log_shortest_accessors() {
 
     insta::assert_snapshot!(
         render("::@", r#"change_id.shortest() ++ " " ++ commit_id.shortest() ++ "\n""#),
-        @r###"
+        @r"
     wq ed
     km ef3
     kp af
@@ -386,11 +386,11 @@ fn test_log_shortest_accessors() {
     mz 1b
     qpv e0
     zzz 00
-    "###);
+    ");
 
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
-        @r###"
+        @r"
     wq[nwkozpkust] ed[e204633421]
     km[kuslswpqwq] ef3[d013266cd]
     kp[qxywonksrl] af[95b841712d]
@@ -402,13 +402,13 @@ fn test_log_shortest_accessors() {
     mz[vwutvlkqwt] 1b[7b715afc3f]
     qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
-    "###);
+    ");
 
     // Can get shorter prefixes in configured revset
     test_env.add_config(r#"revsets.short-prefixes = "(@----)::""#);
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
-        @r###"
+        @r"
     w[qnwkozpkust] ed[e204633421]
     km[kuslswpqwq] ef[3d013266cd]
     kp[qxywonksrl] a[f95b841712d]
@@ -420,13 +420,13 @@ fn test_log_shortest_accessors() {
     mz[vwutvlkqwt] 1b[7b715afc3f]
     qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
-    "###);
+    ");
 
     // Can disable short prefixes by setting to empty string
     test_env.add_config(r#"revsets.short-prefixes = """#);
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
-        @r###"
+        @r"
     wq[nwkozpkust] ed[e204633421]
     km[kuslswpqwq] ef3[d013266cd]
     kp[qxywonksrl] af[95b841712d]
@@ -438,7 +438,7 @@ fn test_log_shortest_accessors() {
     mz[vwutvlkqwt] 1b[7b715afc3f]
     qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
-    "###);
+    ");
 }
 
 #[test]
@@ -468,10 +468,10 @@ fn test_log_bad_short_prefixes() {
     // Warn on resolution of short prefixes
     test_env.add_config("revsets.short-prefixes = 'missing'");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-Tcommit_id.shortest()"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  2
     ◆  0
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @r"
     Warning: In template expression
      --> 1:11
@@ -519,11 +519,11 @@ fn test_log_prefix_highlight_styled() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "original"]);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
-        @r###"
+        @r"
     @  Change qpvuntsmwlqt initial e0e22b9fae75 original
     │
     ~
-    "###
+    "
     );
 
     // Create a chain of 10 commits
@@ -538,11 +538,11 @@ fn test_log_prefix_highlight_styled() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
-        @r###"
+        @r"
     ○  Change qpvuntsmwlqt initial e0e22b9fae75 original
     │
     ~
-    "###
+    "
     );
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -556,7 +556,7 @@ fn test_log_prefix_highlight_styled() {
         ],
     );
     insta::assert_snapshot!(stdout,
-        @r###"
+        @r"
     [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4med[0m[38;5;8me204633421[39m
     ○  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mef3[0m[38;5;8md013266cd[39m
     ○  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4maf[0m[38;5;8m95b841712d[39m
@@ -568,7 +568,7 @@ fn test_log_prefix_highlight_styled() {
     ○  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7b715afc3f[39m
     ○  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4me0[0m[38;5;8me22b9fae75[39m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
-    "###
+    "
     );
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -582,7 +582,7 @@ fn test_log_prefix_highlight_styled() {
         ],
     );
     insta::assert_snapshot!(stdout,
-        @r###"
+        @r"
     [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4med[0m[38;5;8me[39m
     ○  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mef3[0m
     ○  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4maf[0m[38;5;8m9[39m
@@ -594,7 +594,7 @@ fn test_log_prefix_highlight_styled() {
     ○  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7[39m
     ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m[38;5;8me[39m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
-    "###
+    "
     );
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -608,7 +608,7 @@ fn test_log_prefix_highlight_styled() {
         ],
     );
     insta::assert_snapshot!(stdout,
-        @r###"
+        @r"
     [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4med[0m
     ○  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mef3[0m
     ○  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4maf[0m
@@ -620,7 +620,7 @@ fn test_log_prefix_highlight_styled() {
     ○  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m1b[0m
     ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
-    "###
+    "
     );
 }
 
@@ -653,10 +653,10 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "original"]);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
-        @r###"
+        @r"
     @  Change q[pvuntsmwlqt] initial e0[e22b9fae75] original
     ◆  Change z[zzzzzzzzzzz] 0[00000000000]
-    "###
+    "
     );
 
     // Create 2^7 hidden commits
@@ -669,12 +669,12 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     // The unique prefixes became longer.
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", prefix_format]),
-        @r###"
+        @r"
     @  Change wq[nwkozpkust] 44[4c3c5066d3]
     │ ○  Change qpv[untsmwlqt] initial e0e[22b9fae75] original
     ├─╯
     ◆  Change zzz[zzzzzzzzz] 00[0000000000]
-    "###
+    "
     );
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(&repo_path, &["log", "-r", "4", "-T", prefix_format]),
@@ -682,11 +682,11 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     );
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "44", "-T", prefix_format]),
-        @r###"
+        @r"
     @  Change wq[nwkozpkust] 44[4c3c5066d3]
     │
     ~
-    "###
+    "
     );
 }
 
@@ -698,25 +698,25 @@ fn test_log_short_shortest_length_parameter() {
     let render = |template| test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
 
     insta::assert_snapshot!(
-        render(r#"commit_id.short(0) ++ "|" ++ commit_id.shortest(0)"#), @r###"
+        render(r#"commit_id.short(0) ++ "|" ++ commit_id.shortest(0)"#), @r"
     @  |2
     ◆  |0
-    "###);
+    ");
     insta::assert_snapshot!(
-        render(r#"commit_id.short(-0) ++ "|" ++ commit_id.shortest(-0)"#), @r###"
+        render(r#"commit_id.short(-0) ++ "|" ++ commit_id.shortest(-0)"#), @r"
     @  |2
     ◆  |0
-    "###);
+    ");
     insta::assert_snapshot!(
-        render(r#"commit_id.short(-100) ++ "|" ++ commit_id.shortest(-100)"#), @r###"
+        render(r#"commit_id.short(-100) ++ "|" ++ commit_id.shortest(-100)"#), @r"
     @  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
     ◆  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
-    "###);
+    ");
     insta::assert_snapshot!(
-        render(r#"commit_id.short(100) ++ "|" ++ commit_id.shortest(100)"#), @r###"
+        render(r#"commit_id.short(100) ++ "|" ++ commit_id.shortest(100)"#), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22|230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000|0000000000000000000000000000000000000000
-    "###);
+    ");
 }
 
 #[test]
@@ -727,11 +727,11 @@ fn test_log_author_format() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "--revisions=@"]),
-        @r###"
+        @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
-    "###
+    "
     );
 
     let decl = "template-aliases.'format_short_signature(signature)'";
@@ -745,11 +745,11 @@ fn test_log_author_format() {
                 "--revisions=@",
             ],
         ),
-        @r###"
+        @r"
     @  qpvuntsm test.user 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
-    "###
+    "
     );
 }
 
@@ -764,10 +764,10 @@ fn test_log_divergence() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 1"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     // No divergence
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  description 1
     ◆
-    "###);
+    ");
 
     // Create divergence
     test_env.jj_cmd_ok(
@@ -775,15 +775,13 @@ fn test_log_divergence() {
         &["describe", "-m", "description 2", "--at-operation", "@-"],
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  description 1 !divergence!
     │ ○  description 2 !divergence!
     ├─╯
     ◆
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Concurrent modification detected, resolving automatically.");
 }
 
 #[test]
@@ -796,20 +794,20 @@ fn test_log_reversed() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "second"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--reversed"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆
     ○  first
     @  second
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "--reversed", "--no-graph"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     first
     second
-    "###);
+    ");
 }
 
 #[test]
@@ -825,48 +823,48 @@ fn test_log_filtered_by_path() {
     std::fs::write(repo_path.join("file2"), "baz\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     ○  first
     │
     ~
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     │
     ~
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-s", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     │  M file1
     ○  first
     │  A file1
     ~
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-s", "file2", "--no-graph"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     second
     A file2
-    "###);
+    ");
 
     // empty revisions are filtered out by "all()" fileset.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-Tdescription", "-s", "all()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     │  M file1
     │  A file2
     ○  first
     │  A file1
     ~
-    "###);
+    ");
 
     // "root:<path>" is resolved relative to the workspace root.
     let stdout = test_env.jj_cmd_success(
@@ -880,13 +878,13 @@ fn test_log_filtered_by_path() {
             "root:file1",
         ],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     @  second
     │  M repo/file1
     ○  first
     │  A repo/file1
     ~
-    "###);
+    ");
 
     // files() revset doesn't filter the diff.
     let stdout = test_env.jj_cmd_success(
@@ -900,11 +898,11 @@ fn test_log_filtered_by_path() {
             "--no-graph",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     second
     M file1
     A file2
-    "###);
+    ");
 }
 
 #[test]
@@ -925,30 +923,30 @@ fn test_log_limit() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--limit=3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    d
     ├─╮
     │ ○  b
     ○ │  c
     ├─╯
-    "###);
+    ");
 
     // Applied on sorted DAG
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--limit=2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    d
     ├─╮
     │ ○  b
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "--limit=2", "--no-graph"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     d
     c
-    "###);
+    ");
 
     // Applied on reversed DAG: Because the node "a" is omitted, "b" and "c" are
     // rendered as roots.
@@ -984,11 +982,11 @@ fn test_log_limit() {
         &repo_path,
         &["log", "-T", "description", "--limit=1", "b", "c"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  c
     │
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -1001,20 +999,20 @@ fn test_log_warn_path_might_be_revset() {
 
     // Don't warn if the file actually exists.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "file1", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @
     │
     ~
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Warn for `jj log .` specifically, for former Mercurial users.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", ".", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @
     │
     ~
-    "###);
+    ");
     insta::assert_snapshot!(stderr, @r#"Warning: The argument "." is being interpreted as a fileset expression, but this is often not useful because all non-empty commits touch '.'. If you meant to show the working copy commit, pass -r '@' instead."#);
 
     // ...but checking `jj log .` makes sense in a subdirectory.
@@ -1038,8 +1036,7 @@ fn test_log_warn_path_might_be_revset() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["log", "@", "-r", "@", "-T", "description"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    "###);
+    insta::assert_snapshot!(stderr, @"");
 }
 
 #[test]
@@ -1067,11 +1064,11 @@ fn test_default_revset() {
     // The default revset is not used if a path is specified
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "file1", "-T", "description"]),
-        @r###"
+        @r"
     @  add a file
     │
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -1116,27 +1113,27 @@ fn test_multiple_revsets() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "bookmarks", "-rfoo"]),
-        @r###"
+        @r"
     ○  foo
     │
     ~
-    "###);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "bookmarks", "-rfoo", "-rbar", "-rbaz"]),
-        @r###"
+        @r"
     @  baz
     ○  bar
     ○  foo
     │
     ~
-    "###);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "bookmarks", "-rfoo", "-rfoo"]),
-        @r###"
+        @r"
     ○  foo
     │
     ~
-    "###);
+    ");
 }
 
 #[test]
@@ -1162,29 +1159,29 @@ fn test_graph_template_color() {
     // First test without color for comparison
     let template = r#"label(if(current_working_copy, "working_copy"), description)"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  single line
     ○  first line
     │  second line
     │  third line
     ◆
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;2msingle line[0m
     ○  [38;5;1mfirst line[39m
     │  [38;5;1msecond line[39m
     │  [38;5;1mthird line[39m
     [1m[38;5;14m◆[0m
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=debug", "log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;2m<<log working_copy description::single line>>[0m
     <<node::○>>  [38;5;1m<<log description::first line>>[39m
     │  [38;5;1m<<log description::second line>>[39m
     │  [38;5;1m<<log description::third line>>[39m
     [1m[38;5;14m<<node immutable::◆>>[0m
-    "###);
+    ");
 }
 
 #[test]
@@ -1214,7 +1211,7 @@ fn test_graph_styles() {
 
     // Default (curved) style
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     ├─╮
     │ ○  side bookmark
@@ -1226,12 +1223,12 @@ fn test_graph_styles() {
     ○  main bookmark 1
     ○  initial
     ◆
-    "###);
+    ");
 
     // ASCII style
     test_env.add_config(r#"ui.graph.style = "ascii""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     |\
     | o  side bookmark
@@ -1243,12 +1240,12 @@ fn test_graph_styles() {
     o  main bookmark 1
     o  initial
     +
-    "###);
+    ");
 
     // Large ASCII style
     test_env.add_config(r#"ui.graph.style = "ascii-large""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @     merge
     |\
     | \
@@ -1262,12 +1259,12 @@ fn test_graph_styles() {
     o  main bookmark 1
     o  initial
     +
-    "###);
+    ");
 
     // Curved style
     test_env.add_config(r#"ui.graph.style = "curved""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     ├─╮
     │ ○  side bookmark
@@ -1279,12 +1276,12 @@ fn test_graph_styles() {
     ○  main bookmark 1
     ○  initial
     ◆
-    "###);
+    ");
 
     // Square style
     test_env.add_config(r#"ui.graph.style = "square""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     ├─┐
     │ ○  side bookmark
@@ -1296,7 +1293,7 @@ fn test_graph_styles() {
     ○  main bookmark 1
     ○  initial
     ◆
-    "###);
+    ");
 
     // Invalid style name
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "--config=ui.graph.style=unknown"]);
@@ -1333,36 +1330,36 @@ fn test_log_word_wrap() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "merge", "@--", "@"]);
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
-    insta::assert_snapshot!(render(&["log", "-r@"], 40, false), @r###"
+    insta::assert_snapshot!(render(&["log", "-r@"], 40, false), @r"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 f3efbd00
     │  (empty) merge
     ~
-    "###);
-    insta::assert_snapshot!(render(&["log", "-r@"], 40, true), @r###"
+    ");
+    insta::assert_snapshot!(render(&["log", "-r@"], 40, true), @r"
     @  mzvwutvl test.user@example.com
     │  2001-02-03 08:05:11 f3efbd00
     ~  (empty) merge
-    "###);
-    insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, false), @r###"
+    ");
+    insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, false), @r"
     mzvwutvl test.user@example.com 2001-02-03 08:05:11 f3efbd00
     (empty) merge
-    "###);
-    insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, true), @r###"
+    ");
+    insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, true), @r"
     mzvwutvl test.user@example.com
     2001-02-03 08:05:11 f3efbd00
     (empty) merge
-    "###);
+    ");
 
     // Color labels should be preserved
-    insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @r###"
+    insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
     │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12mf[38;5;8m3efbd00[39m[0m
     ~  [1m[38;5;10m(empty)[39m merge[0m
-    "###);
+    ");
 
     // Graph width should be subtracted from the term width
     let template = r#""0 1 2 3 4 5 6 7 8 9""#;
-    insta::assert_snapshot!(render(&["log", "-T", template], 10, true), @r###"
+    insta::assert_snapshot!(render(&["log", "-T", template], 10, true), @r"
     @    0 1 2
     ├─╮  3 4 5
     │ │  6 7 8
@@ -1381,10 +1378,10 @@ fn test_log_word_wrap() {
     ◆  0 1 2 3
        4 5 6 7
        8 9
-    "###);
+    ");
 
     // Shouldn't panic with $COLUMNS < graph_width
-    insta::assert_snapshot!(render(&["log", "-r@"], 0, true), @r###"
+    insta::assert_snapshot!(render(&["log", "-r@"], 0, true), @r"
     @  mzvwutvl
     │  test.user@example.com
     ~  2001-02-03
@@ -1392,8 +1389,8 @@ fn test_log_word_wrap() {
        f3efbd00
        (empty)
        merge
-    "###);
-    insta::assert_snapshot!(render(&["log", "-r@"], 1, true), @r###"
+    ");
+    insta::assert_snapshot!(render(&["log", "-r@"], 1, true), @r"
     @  mzvwutvl
     │  test.user@example.com
     ~  2001-02-03
@@ -1401,7 +1398,7 @@ fn test_log_word_wrap() {
        f3efbd00
        (empty)
        merge
-    "###);
+    ");
 }
 
 #[test]
@@ -1423,7 +1420,7 @@ fn test_log_diff_stat_width() {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     std::fs::write(repo_path.join("file2"), "foo\n".repeat(100)).unwrap();
 
-    insta::assert_snapshot!(render(&["log", "--stat", "--no-graph"], 30), @r###"
+    insta::assert_snapshot!(render(&["log", "--stat", "--no-graph"], 30), @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:09 287520bf
     (no description set)
     file2 | 100 +++++++++++++++
@@ -1434,10 +1431,10 @@ fn test_log_diff_stat_width() {
     1 file changed, 100 insertions(+), 0 deletions(-)
     zzzzzzzz root() 00000000
     0 files changed, 0 insertions(+), 0 deletions(-)
-    "###);
+    ");
 
     // Graph width should be subtracted
-    insta::assert_snapshot!(render(&["log", "--stat"], 30), @r###"
+    insta::assert_snapshot!(render(&["log", "--stat"], 30), @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 287520bf
     │  (no description set)
     │  file2 | 100 ++++++++++++
@@ -1448,7 +1445,7 @@ fn test_log_diff_stat_width() {
     │    1 file changed, 100 insertions(+), 0 deletions(-)
     ◆  zzzzzzzz root() 00000000
        0 files changed, 0 insertions(+), 0 deletions(-)
-    "###);
+    ");
 }
 
 #[test]
@@ -1482,7 +1479,7 @@ fn test_elided() {
     };
 
     // Test the setup
-    insta::assert_snapshot!(get_log("::"), @r###"
+    insta::assert_snapshot!(get_log("::"), @r"
     @    merge
     ├─╮
     │ ○  side bookmark 2
@@ -1496,12 +1493,12 @@ fn test_elided() {
     ○  initial
     │
     ◆
-    "###);
+    ");
 
     // Elide some commits from each side of the merge. It's unclear that a revision
     // was skipped on the left side.
     test_env.add_config("ui.log-synthetic-elided-nodes = false");
-    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r"
     @    merge
     ├─╮
     │ ○  side bookmark 2
@@ -1511,23 +1508,23 @@ fn test_elided() {
     ○  initial
     │
     ~
-    "###);
+    ");
 
     // Elide shared commits. It's unclear that a revision was skipped on the right
     // side (#1252).
-    insta::assert_snapshot!(get_log("@-- | root()"), @r###"
+    insta::assert_snapshot!(get_log("@-- | root()"), @r"
     ○  side bookmark 1
     ╷
     ╷ ○  main bookmark 1
     ╭─╯
     ◆
-    "###);
+    ");
 
     // Now test the same thing with synthetic nodes for elided commits
 
     // Elide some commits from each side of the merge
     test_env.add_config("ui.log-synthetic-elided-nodes = true");
-    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r"
     @    merge
     ├─╮
     │ ○  side bookmark 2
@@ -1540,11 +1537,11 @@ fn test_elided() {
     ○  initial
     │
     ~
-    "###);
+    ");
 
     // Elide shared commits. To keep the implementation simple, it still gets
     // rendered as two synthetic nodes.
-    insta::assert_snapshot!(get_log("@-- | root()"), @r###"
+    insta::assert_snapshot!(get_log("@-- | root()"), @r"
     ○  side bookmark 1
     │
     ~  (elided revisions)
@@ -1553,7 +1550,7 @@ fn test_elided() {
     │ ~  (elided revisions)
     ├─╯
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -1593,7 +1590,7 @@ fn test_log_with_custom_symbols() {
         templates.log_node = 'if(self, if(current_working_copy, "$", if(root, "┴", "┝")), "🮀")'
         "###,
     );
-    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r"
     $    merge
     ├─╮
     │ ┝  side bookmark 2
@@ -1606,7 +1603,7 @@ fn test_log_with_custom_symbols() {
     ┝  initial
     │
     ┴
-    "###);
+    ");
 
     // Simple test with showing default and elided nodes, ascii style.
     test_env.add_config(
@@ -1616,7 +1613,7 @@ fn test_log_with_custom_symbols() {
         templates.log_node = 'if(self, if(current_working_copy, "$", if(root, "^", "*")), ":")'
         "###,
     );
-    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r"
     $    merge
     |\
     | *  side bookmark 2
@@ -1629,7 +1626,7 @@ fn test_log_with_custom_symbols() {
     *  initial
     |
     ^
-    "###);
+    ");
 }
 
 #[test]
@@ -1651,12 +1648,12 @@ fn test_log_full_description_template() {
         &repo_path,
         &["log", "-T", "builtin_log_compact_full_description"],
     );
-    insta::assert_snapshot!(log, @r#"
+    insta::assert_snapshot!(log, @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 1c504ec6
     │  (empty) this is commit with a multiline description
     │
     │  <full description>
     │
     ◆  zzzzzzzz root() 00000000
-    "#);
+    ");
 }

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -25,42 +25,42 @@ fn test_new() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "add a file"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "a new commit"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
     ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Start a new change off of a specific commit (the root commit in this case).
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "off of root", "root()"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  026537ddb96b801b9cb909985d5443aab44616c1 off of root
     │ ○  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
     │ ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // --edit is a no-op
     test_env.jj_cmd_ok(&repo_path, &["new", "--edit", "-m", "yet another commit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  101cbec5cae8049cb9850a906ef3675631ed48fa yet another commit
     ○  026537ddb96b801b9cb909985d5443aab44616c1 off of root
     │ ○  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
     │ ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // --edit cannot be used with --no-edit
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["new", "--edit", "B", "--no-edit", "D"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--edit' cannot be used with '--no-edit'
 
     Usage: jj new <REVSETS>...
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -77,14 +77,14 @@ fn test_new_merge() {
 
     // Create a merge commit
     test_env.jj_cmd_ok(&repo_path, &["new", "main", "@"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    2f9a61ea1fef257eca52fcee2feec1cbd2e41660
     ├─╮
     │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
     ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
     insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
@@ -94,29 +94,27 @@ fn test_new_merge() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "main", "@", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Created new commit znkkpsqq 496490a6 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Created new commit znkkpsqq 496490a6 (empty) (no description set)");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    496490a66cebb31730c4103b7b22a1098d49af91
     ├─╮
     │ @  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
     ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // Same test with `jj new`
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "main", "@"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    114023233c454e2eca22b8b209f9e42f755eb28c
     ├─╮
     │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
     ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
 
     // merge with non-unique revisions
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "@", "3a44e"]);
@@ -124,16 +122,14 @@ fn test_new_merge() {
     // if prefixed with all:, duplicates are allowed
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "@", "all:visible_heads()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: nkmrtpmo ed2dc1d9 (empty) (no description set)
     Parent commit      : wqnwkozp 11402323 (empty) (no description set)
-    "#);
+    ");
 
     // merge with root
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "@", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The Git backend does not support creating merge commits with the root commit as one of the parents.");
 }
 
 #[test]
@@ -142,7 +138,7 @@ fn test_new_insert_after() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -153,7 +149,7 @@ fn test_new_insert_after() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     // --insert-after can be repeated; --after is an alias
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -161,13 +157,13 @@ fn test_new_insert_after() {
         &["new", "-m", "G", "--insert-after", "B", "--after", "D"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kxryzmor 1fc93fd1 (empty) G
     Parent commit      : kkmpptxz bfd4157e B | (empty) B
     Parent commit      : vruxwmqv c9257eff D | (empty) D
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○  C
     │ ○  F
     ╭─┤
@@ -180,17 +176,17 @@ fn test_new_insert_after() {
     │ ○  E
     ├─╯
     ◆  root
-    "###);
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["new", "-m", "H", "--insert-after", "D"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 descendant commits
     Working copy now at: uyznsvlq fcf8281b (empty) H
     Parent commit      : vruxwmqv c9257eff D | (empty) D
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○  C
     │ ○  F
     ╭─┤
@@ -204,17 +200,17 @@ fn test_new_insert_after() {
     │ ○  E
     ├─╯
     ◆  root
-    "###);
+    ");
 
     // --after cannot be used with revisions
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["new", "--after", "B", "D"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--insert-after <REVSETS>' cannot be used with '[REVSETS]...'
 
     Usage: jj new --insert-after <REVSETS> [REVSETS]...
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -223,7 +219,7 @@ fn test_new_insert_after_children() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -234,7 +230,7 @@ fn test_new_insert_after_children() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     // Check that inserting G after A and C doesn't try to rebase B (which is
     // initially a child of A) onto G as that would create a cycle since B is
@@ -252,12 +248,12 @@ fn test_new_insert_after_children() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kxryzmor 6d63e17b (empty) G
     Parent commit      : qpvuntsm 5ef24e4b A | (empty) A
     Parent commit      : mzvwutvl 83376b27 C | (empty) C
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    G
     ├─╮
     │ ○  C
@@ -271,7 +267,7 @@ fn test_new_insert_after_children() {
     │ ○  D
     ├─╯
     ◆  root
-    "###);
+    ");
 }
 
 #[test]
@@ -280,7 +276,7 @@ fn test_new_insert_before() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -291,7 +287,7 @@ fn test_new_insert_before() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -306,14 +302,14 @@ fn test_new_insert_before() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kxryzmor 7ed2d6ff (empty) G
     Parent commit      : kkmpptxz bfd4157e B | (empty) B
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     Parent commit      : znkkpsqq 41a89ffc E | (empty) E
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○  F
     │ ○  C
     ├─╯
@@ -326,17 +322,17 @@ fn test_new_insert_before() {
     ○ │  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     // --before cannot be used with revisions
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["new", "--before", "B", "D"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--insert-before <REVSETS>' cannot be used with '[REVSETS]...'
 
     Usage: jj new --insert-before <REVSETS> [REVSETS]...
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 #[test]
@@ -345,7 +341,7 @@ fn test_new_insert_before_root_successors() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -356,7 +352,7 @@ fn test_new_insert_before_root_successors() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -371,12 +367,12 @@ fn test_new_insert_before_root_successors() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 5 descendant commits
     Working copy now at: kxryzmor 36541977 (empty) G
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○    F
     ├─╮
     │ ○  E
@@ -388,7 +384,7 @@ fn test_new_insert_before_root_successors() {
     @ │  G
     ├─╯
     ◆  root
-    "###);
+    ");
 }
 
 #[test]
@@ -399,7 +395,7 @@ fn test_new_insert_before_no_loop() {
     setup_before_insertion(&test_env, &repo_path);
     let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    7705d353bf5d F
     ├─╮
     │ ○  41a89ffcbba2 E
@@ -410,7 +406,7 @@ fn test_new_insert_before_no_loop() {
     │ ○  5ef24e4bf2be A
     ├─╯
     ◆  000000000000 root
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
@@ -424,9 +420,7 @@ fn test_new_insert_before_no_loop() {
             "C",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Refusing to create a loop: commit bfd4157e6ea4 would be both an ancestor and a descendant of the new commit
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit bfd4157e6ea4 would be both an ancestor and a descendant of the new commit");
 }
 
 #[test]
@@ -435,7 +429,7 @@ fn test_new_insert_before_no_root_merge() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -446,7 +440,7 @@ fn test_new_insert_before_no_root_merge() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
@@ -460,9 +454,7 @@ fn test_new_insert_before_no_root_merge() {
             "D",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The Git backend does not support creating merge commits with the root commit as one of the parents.");
 }
 
 #[test]
@@ -471,7 +463,7 @@ fn test_new_insert_before_root() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -482,13 +474,11 @@ fn test_new_insert_before_root() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["new", "-m", "G", "--insert-before", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 }
 
 #[test]
@@ -497,7 +487,7 @@ fn test_new_insert_after_before() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -508,19 +498,19 @@ fn test_new_insert_after_before() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["new", "-m", "G", "--after", "C", "--before", "F"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: kxryzmor 78a97058 (empty) G
     Parent commit      : mzvwutvl 83376b27 C | (empty) C
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○      F
     ├─┬─╮
     │ │ @  G
@@ -532,19 +522,19 @@ fn test_new_insert_after_before() {
     ○ │  D
     ├─╯
     ◆  root
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["new", "-m", "H", "--after", "D", "--before", "B"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 descendant commits
     Working copy now at: uyznsvlq fcf8281b (empty) H
     Parent commit      : vruxwmqv c9257eff D | (empty) D
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○      F
     ├─┬─╮
     │ │ ○  G
@@ -559,7 +549,7 @@ fn test_new_insert_after_before() {
     │ ○  E
     ├─╯
     ◆  root
-    "###);
+    ");
 }
 
 #[test]
@@ -570,7 +560,7 @@ fn test_new_insert_after_before_no_loop() {
     setup_before_insertion(&test_env, &repo_path);
     let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    7705d353bf5d F
     ├─╮
     │ ○  41a89ffcbba2 E
@@ -581,7 +571,7 @@ fn test_new_insert_after_before_no_loop() {
     │ ○  5ef24e4bf2be A
     ├─╯
     ◆  000000000000 root
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
@@ -595,9 +585,7 @@ fn test_new_insert_after_before_no_loop() {
             "C",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Refusing to create a loop: commit 83376b270925 would be both an ancestor and a descendant of the new commit
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit 83376b270925 would be both an ancestor and a descendant of the new commit");
 }
 
 #[test]

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -35,40 +35,40 @@ fn test_next_simple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     // Move to `first`
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 0c7d7732 (empty) (no description set)
     Parent commit      : kkmpptxz 30056b0c (empty) third
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn test_next_multiple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@---"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  zsuskulnrvyr fourth
     │ ○  kkmpptxzrspx third
@@ -91,24 +91,24 @@ fn test_next_multiple() {
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "2"]);
     // We should now be the child of the fourth commit.
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 41cc776d (empty) (no description set)
     Parent commit      : zsuskuln 9d7e5e99 (empty) fourth
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -120,29 +120,29 @@ fn test_prev_simple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: royxmykx 6db74f64 (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -155,23 +155,23 @@ fn test_prev_multiple_without_root() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: yqosqzyt 794ffd20 (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yqosqzytrlsw
     │ ○  zsuskulnrvyr fourth
     │ ○  kkmpptxzrspx third
@@ -179,7 +179,7 @@ fn test_prev_multiple_without_root() {
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -193,19 +193,19 @@ fn test_next_exceeding_history() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "-r", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "3"]);
     // `jj next` beyond existing history fails.
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No other descendant found 3 commit(s) forward from the working copy parent(s)
     Hint: Working copy parent: qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 }
 
 // The working copy commit is a child of a "fork" with two children on each
@@ -221,29 +221,29 @@ fn test_next_parent_has_multiple_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()", "-m", "3"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  mzvwutvlkqwt 4
     @  zsuskulnrvyr 3
     │ ○  kkmpptxzrspx 2
     │ ○  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
-    insta::assert_snapshot!(stdout,@r###""###);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stdout,@"");
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: mzvwutvl 1b8531ce (empty) 4
     Parent commit      : zsuskuln b1394455 (empty) 3
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt 4
     ○  zsuskulnrvyr 3
     │ ○  kkmpptxzrspx 2
     │ ○  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -260,7 +260,7 @@ fn test_next_with_merge_commit_parent() {
     );
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["prev", "0"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  mzvwutvlkqwt 4
     ├─╯
@@ -270,15 +270,15 @@ fn test_next_with_merge_commit_parent() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
-    insta::assert_snapshot!(stdout,@r###""###);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stdout,@"");
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: vruxwmqv e2cefcb7 (empty) (no description set)
     Parent commit      : mzvwutvl b54bbdea (empty) 4
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     ○  mzvwutvlkqwt 4
     ○    zsuskulnrvyr 3
@@ -287,7 +287,7 @@ fn test_next_with_merge_commit_parent() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -304,7 +304,7 @@ fn test_next_on_merge_commit() {
     );
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  mzvwutvlkqwt 4
     @    zsuskulnrvyr 3
     ├─╮
@@ -312,15 +312,15 @@ fn test_next_on_merge_commit() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
-    insta::assert_snapshot!(stdout,@r###""###);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stdout,@"");
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: mzvwutvl b54bbdea (empty) 4
     Parent commit      : zsuskuln 5542f0b4 (empty) 3
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt 4
     ○    zsuskulnrvyr 3
     ├─╮
@@ -328,7 +328,7 @@ fn test_next_on_merge_commit() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -342,7 +342,7 @@ fn test_next_fails_on_bookmarking_children_no_stdin() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  zsuskulnrvyr third
     ├─╯
@@ -350,14 +350,12 @@ fn test_next_fails_on_bookmarking_children_no_stdin() {
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     // Try to advance the working copy commit.
     let assert = test_env.jj_cmd(&repo_path, &["next"]).assert().code(1);
     let stderr = test_env.normalize_output(&get_stderr_string(&assert));
-    insta::assert_snapshot!(stderr,@r###"
-    Error: Cannot prompt for input since the output is not connected to a terminal
-    "###);
+    insta::assert_snapshot!(stderr,@"Error: Cannot prompt for input since the output is not connected to a terminal");
 }
 
 #[test]
@@ -371,7 +369,7 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  zsuskulnrvyr third
     ├─╯
@@ -379,7 +377,7 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     // Try to advance the working copy commit.
     let assert = test_env
@@ -388,15 +386,13 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
         .code(1);
     let stdout = test_env.normalize_output(&get_stdout_string(&assert));
     let stderr = test_env.normalize_output(&get_stderr_string(&assert));
-    insta::assert_snapshot!(stdout,@r###"
+    insta::assert_snapshot!(stdout,@r"
     ambiguous next commit, choose one to target:
     1: zsuskuln 5f24490d (empty) third
     2: rlvkpnrz 9ed53a4a (empty) second
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
-    enter the index of the commit you want to target: Error: ambiguous target commit
-    "###);
+    ");
+    insta::assert_snapshot!(stderr,@"enter the index of the commit you want to target: Error: ambiguous target commit");
 }
 
 #[test]
@@ -413,17 +409,17 @@ fn test_next_choose_bookmarking_child() {
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
     // Advance the working copy commit.
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["next"], "2\n");
-    insta::assert_snapshot!(stdout,@r###"
+    insta::assert_snapshot!(stdout,@r"
     ambiguous next commit, choose one to target:
     1: royxmykx d00fe885 (empty) fourth
     2: zsuskuln 5f24490d (empty) third
     3: rlvkpnrz 9ed53a4a (empty) second
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: yostqsxw 5c8fa96d (empty) (no description set)
     Parent commit      : zsuskuln 5f24490d (empty) third
-    "###);
+    ");
 }
 
 #[test]
@@ -438,34 +434,34 @@ fn test_prev_on_merge_commit() {
     test_env.jj_cmd_ok(&repo_path, &["new", "left", "right"]);
 
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    royxmykxtrkr
     ├─╮
     │ ○  zsuskulnrvyr right second
     ○ │  qpvuntsmwlqt left first
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: vruxwmqv 41658cf4 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev", "--edit"], "2\n");
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ambiguous prev commit, choose one to target:
     1: zsuskuln b0d21db3 right | (empty) second
     2: qpvuntsm fa15625b left | (empty) first
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: qpvuntsm fa15625b left | (empty) first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -486,7 +482,7 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     );
 
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    royxmykxtrkr M
     ├─╮
     │ ○  mzvwutvlkqwt 1
@@ -497,34 +493,34 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     ○ │  qpvuntsmwlqt x
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev"], "2\n");
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ambiguous prev commit, choose one to target:
     1: kkmpptxz 146d5c67 (empty) y
     2: qpvuntsm 6799aaa2 (empty) x
     3: zzzzzzzz 00000000 (empty) (no description set)
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: vruxwmqv e5a6794c (empty) (no description set)
     Parent commit      : qpvuntsm 6799aaa2 (empty) x
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev", "--edit"], "2\n");
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ambiguous prev commit, choose one to target:
     1: mzvwutvl 89b8a355 (empty) 1
     2: zsuskuln a83fc061 (empty) z
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: zsuskuln a83fc061 (empty) z
     Parent commit      : qpvuntsm 6799aaa2 (empty) x
     Parent commit      : kkmpptxz 146d5c67 (empty) y
-    "###);
+    ");
 }
 
 #[test]
@@ -543,7 +539,7 @@ fn test_prev_prompts_on_multiple_parents() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "merge+1"]);
 
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yostqsxwqrlt
     ○  vruxwmqvtpmx merge+1
     ○      yqosqzytrlsw merge
@@ -554,23 +550,23 @@ fn test_prev_prompts_on_multiple_parents() {
     ○ │  mzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     // Move @ backwards.
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev", "2"], "3\n");
-    insta::assert_snapshot!(stdout,@r###"
+    insta::assert_snapshot!(stdout,@r"
     ambiguous prev commit, choose one to target:
     1: mzvwutvl bc4f4fe3 (empty) third
     2: kkmpptxz b0d21db3 (empty) second
     3: qpvuntsm fa15625b (empty) first
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: kpqxywon ddac00b0 (empty) (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kpqxywonksrl
     │ ○  vruxwmqvtpmx merge+1
     │ ○    yqosqzytrlsw merge
@@ -581,12 +577,12 @@ fn test_prev_prompts_on_multiple_parents() {
     │ ○  mzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["next"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  vruxwmqvtpmx merge+1
     @      yqosqzytrlsw merge
     ├─┬─╮
@@ -596,15 +592,15 @@ fn test_prev_prompts_on_multiple_parents() {
     ○ │  mzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "--no-edit"]);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Error: No other descendant found 1 commit(s) forward from the working copy parent(s)
     Hint: Working copy parent: mzvwutvl bc4f4fe3 (empty) third
     Hint: Working copy parent: kkmpptxz b0d21db3 (empty) second
     Hint: Working copy parent: qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 }
 
 #[test]
@@ -616,20 +612,20 @@ fn test_prev_beyond_root_fails() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
     // @- is at "fourth", and there is no parent 5 commits behind it.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "5"]);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Error: No ancestor found 5 commit(s) back from the working copy parents(s)
     Hint: Working copy parent: zsuskuln 9d7e5e99 (empty) fourth
-    "###);
+    ");
 }
 
 #[test]
@@ -645,28 +641,28 @@ fn test_prev_editing() {
     // Edit the "fourth" commit, which becomes the leaf.
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--edit"]);
-    insta::assert_snapshot!(stdout, @r"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr fourth
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -681,28 +677,28 @@ fn test_next_editing() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "@---"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr fourth
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -723,16 +719,16 @@ fn test_prev_conflict() {
     test_env.jj_cmd_ok(&repo_path, &["new", "description(third)"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yqosqzytrlsw conflict
     ×  royxmykxtrkr conflict fourth
     ×  kkmpptxzrspx conflict third
     ×  rlvkpnrzqnoo conflict second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["prev", "--conflict"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yostqsxwqrlt conflict
     │ ×  royxmykxtrkr conflict fourth
     ├─╯
@@ -740,7 +736,7 @@ fn test_prev_conflict() {
     ×  rlvkpnrzqnoo conflict second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -759,21 +755,21 @@ fn test_prev_conflict_editing() {
     std::fs::write(&file_path, "first text").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "description(third)"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr conflict
     ×  kkmpptxzrspx conflict third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["prev", "--conflict", "--edit"]);
     // We now should be editing the third commit.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx conflict third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -794,22 +790,22 @@ fn test_next_conflict() {
     std::fs::write(&file_path, "first v2").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["squash", "--into", "description(third)"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ×  kkmpptxzrspx conflict third
     │ ○  rlvkpnrzqnoo second
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["next", "--conflict"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx conflict
     ×  kkmpptxzrspx conflict third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -829,19 +825,19 @@ fn test_next_conflict_editing() {
     std::fs::write(&file_path, "modified second").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ×  kkmpptxzrspx conflict
     ○  rlvkpnrzqnoo second
     @  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["next", "--conflict", "--edit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx conflict
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -856,22 +852,22 @@ fn test_next_conflict_head() {
     std::fs::write(&file_path, "second").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["abandon", "@-"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  rlvkpnrzqnoo conflict
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "--conflict"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy parent(s) have no other descendants with conflicts
     Hint: Working copy parent: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "--conflict", "--edit"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy has no descendants with conflicts
     Hint: Working copy: rlvkpnrz 0273eeab (conflict) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -885,121 +881,119 @@ fn test_movement_edit_mode_true() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["prev"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 9ed53a4a (empty) second
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm fa15625b (empty) first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     @  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 9ed53a4a (empty) second
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: uyznsvlq 7ad57fb8 (empty) (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  uyznsvlquzzm
     │ ○  kkmpptxzrspx third
     │ ○  rlvkpnrzqnoo second
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: xtnwkqum 7ac7a1c4 (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  xtnwkqumpolk
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No descendant found 1 commit(s) forward from the working copy
     Hint: Working copy: xtnwkqum 7ac7a1c4 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -1013,97 +1007,97 @@ fn test_movement_edit_mode_false() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["prev"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 087a65b1 (empty) (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     │ ○  kkmpptxzrspx third
     │ ○  rlvkpnrzqnoo second
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No ancestor found 3 commit(s) back from the working copy parents(s)
     Hint: Working copy parent: qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kpqxywon d06750fb (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kpqxywonksrl
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: wqnwkozp 10fa181f (empty) (no description set)
     Parent commit      : kkmpptxz 30056b0c (empty) third
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--edit", "2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 9ed53a4a (empty) second
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 #[test]
@@ -1125,7 +1119,7 @@ fn test_next_offset_when_wc_has_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "left-2"]);
 
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(right-wc)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr right-2
     ○  kkmpptxzrspx right-1
     @  rlvkpnrzqnoo right-wc
@@ -1135,10 +1129,10 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["next", "2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kmkuslswpqwq
     │ ○  vruxwmqvtpmx left-2
     ├─╯
@@ -1150,10 +1144,10 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(left-wc)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  vruxwmqvtpmx left-2
     ○  yqosqzytrlsw left-1
     @  royxmykxtrkr left-wc
@@ -1163,10 +1157,10 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["next"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  nkmrtpmomlro
     │ ○  zsuskulnrvyr right-2
     │ ○  kkmpptxzrspx right-1
@@ -1178,7 +1172,7 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "###);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -29,44 +29,40 @@ fn test_op_log() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     @  d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
     let op_log_lines = stdout.lines().collect_vec();
     let add_workspace_id = op_log_lines[3].split(' ').nth(2).unwrap();
 
     // Can load the repo at a specific operation ID
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path, add_workspace_id), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path, add_workspace_id), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
     // "@" resolves to the head operation
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@"), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@"), @r"
     @  19611c995a342c01f525583e5fcafdd211f6d009
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
     // "@-" resolves to the parent of the head operation
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path, "@-"), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    ");
     insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["log", "--at-op", "@---"]), @r###"
-    Error: The "@---" expression resolved to no operations
-    "###);
+        test_env.jj_cmd_failure(&repo_path, &["log", "--at-op", "@---"]), @r#"Error: The "@---" expression resolved to no operations"#);
 
     // We get a reasonable message if an invalid operation ID is specified
-    insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["log", "--at-op", "foo"]), @r###"
-    Error: Operation ID "foo" is not a valid hexadecimal prefix
-    "###);
+    insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["log", "--at-op", "foo"]), @r#"Error: Operation ID "foo" is not a valid hexadecimal prefix"#);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--op-diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     @  d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
@@ -80,7 +76,7 @@ fn test_op_log() {
     │  Changed commits:
     │  ○  + qpvuntsm 230dd059 (empty) (no description set)
     ○  000000000000 root()
-    "#);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 1"]);
     test_env.jj_cmd_ok(
@@ -114,14 +110,14 @@ fn test_op_log_with_custom_symbols() {
             "--config=templates.op_log_node='if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
         ],
     );
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     $  d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'description 0'
     ┝  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ┴  000000000000 root()
-    "#);
+    ");
 }
 
 #[test]
@@ -162,9 +158,7 @@ fn test_op_log_limit() {
     let repo_path = test_env.env_root().join("repo");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-Tdescription", "--limit=1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    @  add workspace 'default'
-    "###);
+    insta::assert_snapshot!(stdout, @"@  add workspace 'default'");
 }
 
 #[test]
@@ -175,21 +169,21 @@ fn test_op_log_no_graph() {
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["op", "log", "--no-graph", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;12meac759b9ab75[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
     [1madd workspace 'default'[0m
     [38;5;4m000000000000[39m [38;5;2mroot()[39m
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--op-diff", "--no-graph"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     Changed commits:
     + qpvuntsm 230dd059 (empty) (no description set)
     000000000000 root()
-    "#);
+    ");
 }
 
 #[test]
@@ -200,14 +194,14 @@ fn test_op_log_reversed() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--reversed"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     ○  000000000000 root()
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     @  d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
        describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
        args: jj describe -m 'description 0'
-    "#);
+    ");
 
     test_env.jj_cmd_ok(
         &repo_path,
@@ -217,7 +211,7 @@ fn test_op_log_reversed() {
     // Should be able to display log with fork and branch points
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "log", "--reversed"]);
     insta::assert_snapshot!(&stderr, @"Concurrent modification detected, resolving automatically.");
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     ○  000000000000 root()
     ○    eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     ├─╮  add workspace 'default'
@@ -230,11 +224,11 @@ fn test_op_log_reversed() {
     @  e4538ffdc13d test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
-    "#);
+    ");
 
     // Should work correctly with `--no-graph`
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--reversed", "--no-graph"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     000000000000 root()
     eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
@@ -247,7 +241,7 @@ fn test_op_log_reversed() {
     e4538ffdc13d test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
-    "#);
+    ");
 
     // Should work correctly with `--limit`
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--reversed", "--limit=3"]);
@@ -306,22 +300,22 @@ fn test_op_log_template() {
     let repo_path = test_env.env_root().join("repo");
     let render = |template| test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template]);
 
-    insta::assert_snapshot!(render(r#"id ++ "\n""#), @r#"
+    insta::assert_snapshot!(render(r#"id ++ "\n""#), @r"
     @  eac759b9ab75793fd3da96e60939fb48f2cd2b2a9c1f13ffe723cf620f3005b8d3e7e923634a07ea39513e4f2f360c87b9ad5d331cf90d7a844864b83b72eba1
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-    "#);
+    ");
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
-                                time.start(), time.end(), time.duration()) ++ "\n""#), @r#"
+                                time.start(), time.end(), time.duration()) ++ "\n""#), @r"
     @  eac75 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     ○  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
-    "#);
+    ");
 
     // Negative length shouldn't cause panic.
-    insta::assert_snapshot!(render(r#"id.short(-1) ++ "|""#), @r#"
+    insta::assert_snapshot!(render(r#"id.short(-1) ++ "|""#), @r"
     @  <Error: out of range integral type conversion attempted>|
     ○  <Error: out of range integral type conversion attempted>|
-    "#);
+    ");
 
     // Test the default template, i.e. with relative start time and duration. We
     // don't generally use that template because it depends on the current time,
@@ -334,11 +328,11 @@ fn test_op_log_template() {
     );
     let regex = Regex::new(r"\d\d years").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(regex.replace_all(&stdout, "NN years"), @r#"
+    insta::assert_snapshot!(regex.replace_all(&stdout, "NN years"), @r"
     @  eac759b9ab75 test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
 }
 
 #[test]
@@ -353,7 +347,7 @@ fn test_op_log_builtin_templates() {
     };
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 0"]);
 
-    insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r"
     d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     args: jj describe -m 'description 0'
@@ -361,9 +355,9 @@ fn test_op_log_builtin_templates() {
     add workspace 'default'
     000000000000 root()
     [EOF]
-    "#);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r"
     d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     args: jj describe -m 'description 0'
@@ -374,7 +368,7 @@ fn test_op_log_builtin_templates() {
     000000000000 root()
 
     [EOF]
-    "#);
+    ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @r"
     d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22 args: jj describe -m 'description 0'
@@ -407,15 +401,15 @@ fn test_op_log_word_wrap() {
     };
 
     // ui.log-word-wrap option works
-    insta::assert_snapshot!(render(&["op", "log"], 40, false), @r#"
+    insta::assert_snapshot!(render(&["op", "log"], 40, false), @r"
     @  b7cd3d0069f6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
-    insta::assert_snapshot!(render(&["op", "log"], 40, true), @r#"
+    ");
+    insta::assert_snapshot!(render(&["op", "log"], 40, true), @r"
     @  b7cd3d0069f6
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
@@ -428,10 +422,10 @@ fn test_op_log_word_wrap() {
     │  2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
 
     // Nested graph should be wrapped
-    insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @r#"
+    insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @r"
     @  b7cd3d0069f6
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
@@ -454,10 +448,10 @@ fn test_op_log_word_wrap() {
     │  ○  + qpvuntsm 230dd059 (empty) (no
     │     description set)
     ○  000000000000 root()
-    "#);
+    ");
 
     // Nested diff stat shouldn't exceed the terminal width
-    insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @r#"
+    insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @r"
     @  b7cd3d0069f6
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
@@ -472,8 +466,8 @@ fn test_op_log_word_wrap() {
     │     (no description set)
     │     file1 | 100 +++++++++++++++++++
     │     1 file changed, 100 insertions(+), 0 deletions(-)
-    "#);
-    insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @r#"
+    ");
+    insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @r"
     b7cd3d0069f6
     test-username@host.example.com
     2001-02-03 04:05:08.000 +07:00 -
@@ -487,12 +481,12 @@ fn test_op_log_word_wrap() {
     description set)
     file1 | 100 +++++++++++++++++++++++++
     1 file changed, 100 insertions(+), 0 deletions(-)
-    "#);
+    ");
 
     // Nested graph widths should be subtracted from the term width
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
-        render(&["op", "log", "-T''", "--op-diff", "-n1", "--config", config], 15, true), @r#"
+        render(&["op", "log", "-T''", "--op-diff", "-n1", "--config", config], 15, true), @r"
     @
     │
     │  Changed
@@ -503,7 +497,7 @@ fn test_op_log_word_wrap() {
     │     - 0 1 2 3
     │     4 5 6 7 8
     │     9
-    "#);
+    ");
 }
 
 #[test]
@@ -534,7 +528,7 @@ fn test_op_abandon_ancestors() {
 
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "commit 1"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "commit 2"]);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r"
     @  116edde65ded test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
@@ -544,34 +538,30 @@ fn test_op_abandon_ancestors() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
 
     // Abandon old operations. The working-copy operation id should be updated.
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "abandon", "..@-"]);
-    insta::assert_snapshot!(stderr, @r#"
-    Abandoned 2 operations and reparented 1 descendant operations.
-    "#);
+    insta::assert_snapshot!(stderr, @"Abandoned 2 operations and reparented 1 descendant operations.");
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
     Current operation: OperationId("8545e013752445fd845c84eb961dbfbce47e1deb628e4ef20df10f6dc9aae2ef9e47200b0fcc70ca51f050aede05d0fa6dd1db40e20ae740876775738a07d02e")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r###"
+    "#);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r"
     @  8545e0137524 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
-    "###);
+    ");
 
     // Abandon operation range.
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "commit 3"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "commit 4"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "commit 5"]);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "abandon", "@---..@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Abandoned 2 operations and reparented 1 descendant operations.
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r###"
+    insta::assert_snapshot!(stderr, @"Abandoned 2 operations and reparented 1 descendant operations.");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r"
     @  d92d0753399f test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit c5f7dd51add0046405055336ef443f882a0a8968
     │  args: jj commit -m 'commit 5'
@@ -579,33 +569,29 @@ fn test_op_abandon_ancestors() {
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
-    "###);
+    ");
 
     // Can't abandon the current operation.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["op", "abandon", "..@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Cannot abandon the current operation d92d0753399f
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
-    "###);
+    ");
 
     // Can't create concurrent abandoned operations explicitly.
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["op", "abandon", "--at-op=@-", "@"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --at-op is not respected
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --at-op is not respected");
 
     // Abandon the current operation by undoing it first.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "abandon", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Abandoned 1 operations and reparented 1 descendant operations.
-    "###);
+    insta::assert_snapshot!(stderr, @"Abandoned 1 operations and reparented 1 descendant operations.");
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
     Current operation: OperationId("0699d720d0cecd80fb7d765c45955708c61b12feb1d7ed9ff2777ae719471f04ffed3c1dc24efdbf94bdb74426065d6fa9a4f0862a89db2c8c8e359eefc45462")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r###"
+    "#);
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log"]), @r"
     @  0699d720d0ce test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     │  undo operation d92d0753399f732e438bdd88fa7e5214cba2a310d120ec1714028a514c7116bcf04b4a0b26c04dbecf0a917f1d4c8eb05571b8816dd98b0502aaf321e92500b3
     │  args: jj undo
@@ -613,18 +599,16 @@ fn test_op_abandon_ancestors() {
     │  commit 81a4ef3dd421f3184289df1c58bd3a16ea1e3d8e
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
-    "###);
+    ");
 
     // Abandon empty range.
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "abandon", "@-..@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1"]), @r###"
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1"]), @r"
     @  0699d720d0ce test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     │  undo operation d92d0753399f732e438bdd88fa7e5214cba2a310d120ec1714028a514c7116bcf04b4a0b26c04dbecf0a917f1d4c8eb05571b8816dd98b0502aaf321e92500b3
     │  args: jj undo
-    "###);
+    ");
 }
 
 #[test]
@@ -642,40 +626,38 @@ fn test_op_abandon_without_updating_working_copy() {
         &repo_path,
         &["op", "abandon", "@-", "--ignore-working-copy"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Abandoned 1 operations and reparented 1 descendant operations.
-    "###);
+    insta::assert_snapshot!(stderr, @"Abandoned 1 operations and reparented 1 descendant operations.");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
     Current operation: OperationId("b0711a8ac91f5ac088cff9b57c9daf29dc61b1b4fedcbb9a07fe4c7f7da1e60e333c787eacf73d1e0544db048a4fe9c6c089991b4a67e25365c4f411fa8b489f")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     "#);
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1", "--ignore-working-copy"]), @r#"
+        test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1", "--ignore-working-copy"]), @r"
     @  0508a30825ed test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 220cb0b1b5d1c03cc0d351139d824598bb3c1967
     │  args: jj commit -m 'commit 3'
-    "#);
+    ");
 
     // The working-copy operation id isn't updated if it differs from the repo.
     // It could be updated if the tree matches, but there's no extra logic for
     // that.
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "abandon", "@-"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned 1 operations and reparented 1 descendant operations.
     Warning: The working copy operation b0711a8ac91f is not updated because it differs from the repo 0508a30825ed.
-    "#);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
     Current operation: OperationId("b0711a8ac91f5ac088cff9b57c9daf29dc61b1b4fedcbb9a07fe4c7f7da1e60e333c787eacf73d1e0544db048a4fe9c6c089991b4a67e25365c4f411fa8b489f")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     "#);
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1", "--ignore-working-copy"]), @r#"
+        test_env.jj_cmd_success(&repo_path, &["op", "log", "-n1", "--ignore-working-copy"]), @r"
     @  2631d5576876 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 220cb0b1b5d1c03cc0d351139d824598bb3c1967
     │  args: jj commit -m 'commit 3'
-    "#);
+    ");
 }
 
 #[test]
@@ -711,26 +693,20 @@ fn test_op_abandon_multiple_heads() {
 
     // Can't abandon one of the head operations.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["op", "abandon", head_op_id]);
-    insta::assert_snapshot!(stderr, @r#"
-    Error: Cannot abandon the current operation b0711a8ac91f
-    "#);
+    insta::assert_snapshot!(stderr, @"Error: Cannot abandon the current operation b0711a8ac91f");
 
     // Can't abandon the other head operation.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["op", "abandon", other_head_op_id]);
-    insta::assert_snapshot!(stderr, @r#"
-    Error: Cannot abandon the current operation 617923db9f7a
-    "#);
+    insta::assert_snapshot!(stderr, @"Error: Cannot abandon the current operation 617923db9f7a");
 
     // Can abandon the operation which is not an ancestor of the other head.
     // This would crash if we attempted to remap the unchanged op in the op
     // heads store.
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "abandon", prev_op_id]);
-    insta::assert_snapshot!(stderr, @r###"
-    Abandoned 1 operations and reparented 2 descendant operations.
-    "###);
+    insta::assert_snapshot!(stderr, @"Abandoned 1 operations and reparented 2 descendant operations.");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @    7e65e7e27e34 test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
@@ -746,10 +722,8 @@ fn test_op_abandon_multiple_heads() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Concurrent modification detected, resolving automatically.");
 }
 
 #[test]
@@ -799,18 +773,18 @@ fn test_op_recover_from_bad_gc() {
 
     let stderr =
         test_env.jj_cmd_internal_error(&repo_path, &["--at-op", head_op_id, "debug", "reindex"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r#"
+    insta::assert_snapshot!(strip_last_line(&stderr), @r"
     Internal error: Failed to index commits at operation e7377e6a642bae88039615ee159117d49688719e9d5ece9de8b0b42d7be7076904d2fa8381391f8289a0c3527405de81e8dd6504655311c69175c3681786dd3c
     Caused by:
     1: Object ddf84fc5e0dd314092b3dfb13e09e37fa7d04ef9 of type commit not found
-    "#);
+    ");
 
     // "op log" should still be usable.
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["op", "log", "--ignore-working-copy", "--at-op", head_op_id],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  f999e12a5d8b test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  describe commit 37bb762e5dc08073ec4323bdffc023a0f0cc901e
     │  args: jj describe -m4
@@ -829,19 +803,17 @@ fn test_op_recover_from_bad_gc() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // "op abandon" should work.
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["op", "abandon", &format!("..{bad_op_id}")]);
-    insta::assert_snapshot!(stderr, @r#"
-    Abandoned 3 operations and reparented 4 descendant operations.
-    "#);
+    insta::assert_snapshot!(stderr, @"Abandoned 3 operations and reparented 4 descendant operations.");
 
     // The repo should no longer be corrupt.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  mzvwutvl?? test.user@example.com 2001-02-03 08:05:12 6d868f04
     │  (empty) 4
     │ ○  mzvwutvl?? test.user@example.com 2001-02-03 08:05:15 dc2c6d52
@@ -849,10 +821,8 @@ fn test_op_recover_from_bad_gc() {
     ○  zsuskuln test.user@example.com 2001-02-03 08:05:10 git_head() f652c321
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Concurrent modification detected, resolving automatically.");
 }
 
 #[test]
@@ -865,9 +835,7 @@ fn test_op_summary_diff_template() {
     test_env.jj_cmd_ok(&repo_path, &["new", "--no-edit", "-m=scratch"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=always"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r#"
-    Undid operation: [38;5;4mac20a4ff4791[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
-    "#);
+    insta::assert_snapshot!(&stderr, @"Undid operation: [38;5;4mac20a4ff4791[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -892,9 +860,7 @@ fn test_op_summary_diff_template() {
     test_env.jj_cmd_ok(&repo_path, &["new", "--no-edit", "-m=scratch"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo", "--color=debug"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r#"
-    Undid operation: [38;5;4m<<operation id short::2301f6e6ec31>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
-    "#);
+    insta::assert_snapshot!(&stderr, @"Undid operation: [38;5;4m<<operation id short::2301f6e6ec31>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -926,7 +892,7 @@ fn test_op_diff() {
 
     // Overview of op log.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     @  4d05b146ac44 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  check out git remote's default branch
     │  args: jj git clone git-repo repo
@@ -936,28 +902,28 @@ fn test_op_diff() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
 
     // Diff between the same operation should be empty.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["op", "diff", "--from", "0000000", "--to", "0000000"],
     );
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 000000000000 root()
       To operation: 000000000000 root()
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--from", "@", "--to", "@"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
       To operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
-    "#);
+    ");
 
     // Diff from parent operation to latest operation.
     // `jj op diff --op @` should behave identically to `jj op diff --from
     // @- --to @` (if `@` is not a merge commit).
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--from", "@-", "--to", "@"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 85a54acdbc88 (2001-02-03 08:05:07) fetch from git remote into empty repo
       To operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
 
@@ -974,13 +940,13 @@ fn test_op_diff() {
     bookmark-1@origin:
     + tracked ulyvmwyz 1d843d1f bookmark-1 | Commit 1
     - untracked ulyvmwyz 1d843d1f bookmark-1 | Commit 1
-    "#);
+    ");
     let stdout_without_from_to = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
     assert_eq!(stdout, stdout_without_from_to);
 
     // Diff from root operation to latest operation
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--from", "0000000"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 000000000000 root()
       To operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
 
@@ -1005,11 +971,11 @@ fn test_op_diff() {
     bookmark-3@origin:
     + untracked tqyxmszt 3e785984 bookmark-3@origin | Commit 3
     - untracked (absent)
-    "#);
+    ");
 
     // Diff from latest operation to root operation
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--to", "0000000"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
       To operation: 000000000000 root()
 
@@ -1034,7 +1000,7 @@ fn test_op_diff() {
     bookmark-3@origin:
     + untracked (absent)
     - untracked tqyxmszt hidden 3e785984 Commit 3
-    "#);
+    ");
 
     // Create a conflicted bookmark using a concurrent operation.
     test_env.jj_cmd_ok(
@@ -1050,11 +1016,9 @@ fn test_op_diff() {
         ],
     );
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
-    insta::assert_snapshot!(&stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    insta::assert_snapshot!(&stderr, @"Concurrent modification detected, resolving automatically.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     @    cd3fc3ddbdd9 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
@@ -1070,7 +1034,7 @@ fn test_op_diff() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
     let op_log_lines = stdout.lines().collect_vec();
     let op_id = op_log_lines[0].split(' ').nth(4).unwrap();
     let first_parent_id = op_log_lines[3].split(' ').nth(3).unwrap();
@@ -1081,7 +1045,7 @@ fn test_op_diff() {
         &repo_path,
         &["op", "diff", "--from", first_parent_id, "--to", op_id],
     );
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 4d05b146ac44 (2001-02-03 08:05:07) check out git remote's default branch
       To operation: cd3fc3ddbdd9 (2001-02-03 08:05:16) reconcile divergent operations
 
@@ -1090,7 +1054,7 @@ fn test_op_diff() {
     + (added) ulyvmwyz 1d843d1f bookmark-1?? bookmark-1@origin | Commit 1
     + (added) yuvsmzqk 3d9189bc bookmark-1?? bookmark-2@origin | Commit 2
     - ulyvmwyz 1d843d1f bookmark-1?? bookmark-1@origin | Commit 1
-    "#);
+    ");
 
     // Diff between the second parent of the merge operation and the merge
     // operation.
@@ -1098,7 +1062,7 @@ fn test_op_diff() {
         &repo_path,
         &["op", "diff", "--from", second_parent_id, "--to", op_id],
     );
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 484785c371e5 (2001-02-03 08:05:15) point bookmark bookmark-1 to commit 3d9189bc56a1972729350456eb95ec5bf90be2a8
       To operation: cd3fc3ddbdd9 (2001-02-03 08:05:16) reconcile divergent operations
 
@@ -1116,21 +1080,20 @@ fn test_op_diff() {
     bookmark-1@origin:
     + tracked ulyvmwyz 1d843d1f bookmark-1?? bookmark-1@origin | Commit 1
     - untracked ulyvmwyz 1d843d1f bookmark-1?? bookmark-1@origin | Commit 1
-    "#);
+    ");
 
     // Test fetching from git remote.
     modify_git_repo(git_repo);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     bookmark: bookmark-1@origin [updated] tracked
     bookmark: bookmark-2@origin [updated] untracked
     bookmark: bookmark-3@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: cd3fc3ddbdd9 (2001-02-03 08:05:16) reconcile divergent operations
       To operation: 894f1f54aabe (2001-02-03 08:05:20) fetch from git remote(s) origin
 
@@ -1156,7 +1119,7 @@ fn test_op_diff() {
     bookmark-3@origin:
     + untracked (absent)
     - untracked tqyxmszt hidden 3e785984 Commit 3
-    "#);
+    ");
 
     // Test creation of bookmark.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1169,13 +1132,10 @@ fn test_op_diff() {
             "bookmark-2@origin",
         ],
     );
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Created 1 bookmarks pointing to qzxslznx d487febd bookmark-2 bookmark-2@origin | Commit 5
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Created 1 bookmarks pointing to qzxslznx d487febd bookmark-2 bookmark-2@origin | Commit 5");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 894f1f54aabe (2001-02-03 08:05:20) fetch from git remote(s) origin
       To operation: ed134e3dc5c6 (2001-02-03 08:05:22) create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
 
@@ -1183,18 +1143,15 @@ fn test_op_diff() {
     bookmark-2:
     + qzxslznx d487febd bookmark-2 bookmark-2@origin | Commit 5
     - (absent)
-    "#);
+    ");
 
     // Test tracking of bookmark.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "bookmark-2@origin"]);
-    insta::assert_snapshot!(&stdout, @r###"
-     "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Started tracking 1 remote bookmarks.
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Started tracking 1 remote bookmarks.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: ed134e3dc5c6 (2001-02-03 08:05:22) create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
       To operation: 871bda1a359f (2001-02-03 08:05:24) track remote bookmark bookmark-2@origin
 
@@ -1202,20 +1159,19 @@ fn test_op_diff() {
     bookmark-2@origin:
     + tracked qzxslznx d487febd bookmark-2 | Commit 5
     - untracked qzxslznx d487febd bookmark-2 | Commit 5
-    "#);
+    ");
 
     // Test creation of new commit.
     // Test tracking of bookmark.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "bookmark-2@origin"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     Warning: Remote bookmark already tracked: bookmark-2@origin
     Nothing changed.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: ed134e3dc5c6 (2001-02-03 08:05:22) create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
       To operation: 871bda1a359f (2001-02-03 08:05:24) track remote bookmark bookmark-2@origin
 
@@ -1223,40 +1179,36 @@ fn test_op_diff() {
     bookmark-2@origin:
     + tracked qzxslznx d487febd bookmark-2 | Commit 5
     - untracked qzxslznx d487febd bookmark-2 | Commit 5
-    "#);
+    ");
 
     // Test creation of new commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["new", "bookmark-1@origin", "-m", "new commit"],
     );
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     Working copy now at: wvuyspvk 358b82d6 (empty) new commit
     Parent commit      : slvtnnzx 4f856199 bookmark-1?? bookmark-1@origin | Commit 4
     Added 1 files, modified 0 files, removed 1 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 871bda1a359f (2001-02-03 08:05:24) track remote bookmark bookmark-2@origin
       To operation: 2604b8b3b9e5 (2001-02-03 08:05:28) new empty commit
 
     Changed commits:
     ○  + wvuyspvk 358b82d6 (empty) new commit
     ○  - sqpuoqvx hidden 9708515f (empty) (no description set)
-    "#);
+    ");
 
     // Test updating of local bookmark.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "bookmark-1", "-r", "@"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Moved 1 bookmarks to wvuyspvk 358b82d6 bookmark-1* | (empty) new commit
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Moved 1 bookmarks to wvuyspvk 358b82d6 bookmark-1* | (empty) new commit");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 2604b8b3b9e5 (2001-02-03 08:05:28) new empty commit
       To operation: e64617a51cdb (2001-02-03 08:05:30) point bookmark bookmark-1 to commit 358b82d6be53fa9b062325abb8bc820a8b34c68d
 
@@ -1265,17 +1217,14 @@ fn test_op_diff() {
     + wvuyspvk 358b82d6 bookmark-1* | (empty) new commit
     - (added) slvtnnzx 4f856199 bookmark-1@origin | Commit 4
     - (added) yuvsmzqk 3d9189bc Commit 2
-    "#);
+    ");
 
     // Test deletion of local bookmark.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "bookmark-2"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Deleted 1 bookmarks.
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Deleted 1 bookmarks.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: e64617a51cdb (2001-02-03 08:05:30) point bookmark bookmark-1 to commit 358b82d6be53fa9b062325abb8bc820a8b34c68d
       To operation: e07e94fbdd09 (2001-02-03 08:05:32) delete bookmark bookmark-2
 
@@ -1283,22 +1232,21 @@ fn test_op_diff() {
     bookmark-2:
     + (absent)
     - qzxslznx d487febd bookmark-2@origin | Commit 5
-    "#);
+    ");
 
     // Test pushing to Git remote.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "push", "--tracked"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r#"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark-1 from 4f856199edbf to 358b82d6be53
       Delete bookmark bookmark-2 from d487febd08e6
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: oupztwtk 2f0718a0 (empty) (no description set)
     Parent commit      : wvuyspvk 358b82d6 bookmark-1 | (empty) new commit
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: e07e94fbdd09 (2001-02-03 08:05:32) delete bookmark bookmark-2
       To operation: 203fe2a7ed9e (2001-02-03 08:05:34) push all tracked bookmarks to git remote origin
 
@@ -1312,7 +1260,7 @@ fn test_op_diff() {
     bookmark-2@origin:
     + untracked (absent)
     - tracked qzxslznx d487febd Commit 5
-    "#);
+    ");
 }
 
 #[test]
@@ -1325,10 +1273,10 @@ fn test_op_diff_patch() {
     std::fs::write(repo_path.join("file"), "a\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r"
     Working copy now at: rlvkpnrz 56950632 (empty) (no description set)
     Parent commit      : qpvuntsm 6b1027d2 (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--op", "@-", "-p", "--git"]);
     insta::assert_snapshot!(&stdout, @r"
     From operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
@@ -1346,24 +1294,24 @@ fn test_op_diff_patch() {
        +a
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "--op", "@", "-p", "--git"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 187a5a9d8a22 (2001-02-03 08:05:08) snapshot working copy
       To operation: a7e535e73c4b (2001-02-03 08:05:08) new empty commit
 
     Changed commits:
     ○  + rlvkpnrz 56950632 (empty) (no description set)
-    "#);
+    ");
 
     // Squash the working copy commit.
     std::fs::write(repo_path.join("file"), "b\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r"
     Working copy now at: mzvwutvl 9f4fb57f (empty) (no description set)
     Parent commit      : qpvuntsm 2ac85fd1 (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "-p", "--git"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 15c3c5d0baf0 (2001-02-03 08:05:11) snapshot working copy
       To operation: 894c12d90345 (2001-02-03 08:05:11) squash commits into 6b1027d2770cd0a39c468e525e52bf8c47e1464a
 
@@ -1386,25 +1334,25 @@ fn test_op_diff_patch() {
        @@ -1,1 +1,1 @@
        -a
        +b
-    "#);
+    ");
 
     // Abandon the working copy commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r"
     Abandoned commit mzvwutvl 9f4fb57f (empty) (no description set)
     Working copy now at: yqosqzyt 33f321c4 (empty) (no description set)
     Parent commit      : qpvuntsm 2ac85fd1 (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "diff", "-p", "--git"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 894c12d90345 (2001-02-03 08:05:11) squash commits into 6b1027d2770cd0a39c468e525e52bf8c47e1464a
       To operation: e5505aa79d31 (2001-02-03 08:05:13) abandon commit 9f4fb57fba25a7b47ce5980a5d9a4766778331e8
 
     Changed commits:
     ○  + yqosqzyt 33f321c4 (empty) (no description set)
     ○  - mzvwutvl hidden 9f4fb57f (empty) (no description set)
-    "#);
+    ");
 }
 
 #[test]
@@ -1432,7 +1380,7 @@ fn test_op_diff_sibling() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "--at-op", base_op_id, "-mB"]);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     @    779ecb7ea7f0 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
@@ -1457,10 +1405,8 @@ fn test_op_diff_sibling() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
-    insta::assert_snapshot!(&stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(&stderr, @"Concurrent modification detected, resolving automatically.");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#],
@@ -1486,7 +1432,7 @@ fn test_op_diff_sibling() {
             "--summary",
         ],
     );
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: d700dc16fded (2001-02-03 08:05:11) new empty commit
       To operation: 13b143e1f4f9 (2001-02-03 08:05:12) describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
 
@@ -1498,7 +1444,7 @@ fn test_op_diff_sibling() {
     │    A file1
     ○  - zsuskuln hidden 8afecaef A.2
        A file2
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -1513,7 +1459,7 @@ fn test_op_diff_sibling() {
             "--summary",
         ],
     );
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     From operation: 13b143e1f4f9 (2001-02-03 08:05:12) describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
       To operation: d700dc16fded (2001-02-03 08:05:11) new empty commit
 
@@ -1525,7 +1471,7 @@ fn test_op_diff_sibling() {
     ○  + zsuskuln 8afecaef A.2
        A file2
     ○  - qpvuntsm hidden 02ef2bc4 (empty) B
-    "#);
+    ");
 }
 
 #[test]
@@ -1554,7 +1500,7 @@ fn test_op_diff_word_wrap() {
     test_env.jj_cmd_ok(&repo_path, &["debug", "snapshot"]);
 
     // ui.log-word-wrap option works, and diff stat respects content width
-    insta::assert_snapshot!(render(&["op", "diff", "--from=@---", "--stat"], 40, true), @r#"
+    insta::assert_snapshot!(render(&["op", "diff", "--from=@---", "--stat"], 40, true), @r"
     From operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
       To operation: f3052392e08c (2001-02-03 08:05:08) snapshot working copy
 
@@ -1598,12 +1544,12 @@ fn test_op_diff_word_wrap() {
     + untracked tqyxmszt 3e785984
     bookmark-3@origin | Commit 3
     - untracked (absent)
-    "#);
+    ");
 
     // Graph width should be subtracted from the term width
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
-        render(&["op", "diff", "--from=@---", "--config", config], 10, true), @r#"
+        render(&["op", "diff", "--from=@---", "--config", config], 10, true), @r"
     From operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
       To operation: f3052392e08c (2001-02-03 08:05:08) snapshot working copy
 
@@ -1660,7 +1606,7 @@ fn test_op_diff_word_wrap() {
     -
     untracked
     (absent)
-    "#);
+    ");
 }
 
 #[test]
@@ -1673,7 +1619,7 @@ fn test_op_show() {
 
     // Overview of op log.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     @  4d05b146ac44 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  check out git remote's default branch
     │  args: jj git clone git-repo repo
@@ -1683,17 +1629,15 @@ fn test_op_show() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
 
     // The root operation is empty.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show", "0000000"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    000000000000 root()
-    "###);
+    insta::assert_snapshot!(&stdout, @"000000000000 root()");
 
     // Showing the latest operation.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show", "@"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     4d05b146ac44 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     check out git remote's default branch
     args: jj git clone git-repo repo
@@ -1711,14 +1655,14 @@ fn test_op_show() {
     bookmark-1@origin:
     + tracked ulyvmwyz 1d843d1f bookmark-1 | Commit 1
     - untracked ulyvmwyz 1d843d1f bookmark-1 | Commit 1
-    "#);
+    ");
     // `jj op show @` should behave identically to `jj op show`.
     let stdout_without_op_id = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
     assert_eq!(stdout, stdout_without_op_id);
 
     // Showing a given operation.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show", "@-"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     85a54acdbc88 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     fetch from git remote into empty repo
     args: jj git clone git-repo repo
@@ -1738,7 +1682,7 @@ fn test_op_show() {
     bookmark-3@origin:
     + untracked tqyxmszt 3e785984 bookmark-3@origin | Commit 3
     - untracked (absent)
-    "#);
+    ");
 
     // Create a conflicted bookmark using a concurrent operation.
     test_env.jj_cmd_ok(
@@ -1754,30 +1698,27 @@ fn test_op_show() {
         ],
     );
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
-    insta::assert_snapshot!(&stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    insta::assert_snapshot!(&stderr, @"Concurrent modification detected, resolving automatically.");
     // Showing a merge operation is empty.
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     140254f5a707 test-username@host.example.com 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
     reconcile divergent operations
     args: jj log
-    "#);
+    ");
 
     // Test fetching from git remote.
     modify_git_repo(git_repo);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     bookmark: bookmark-1@origin [updated] tracked
     bookmark: bookmark-2@origin [updated] untracked
     bookmark: bookmark-3@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     4d5647c16e09 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
@@ -1804,7 +1745,7 @@ fn test_op_show() {
     bookmark-3@origin:
     + untracked (absent)
     - untracked tqyxmszt hidden 3e785984 Commit 3
-    "#);
+    ");
 
     // Test creation of bookmark.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1817,13 +1758,10 @@ fn test_op_show() {
             "bookmark-2@origin",
         ],
     );
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Created 1 bookmarks pointing to qzxslznx d487febd bookmark-2 bookmark-2@origin | Commit 5
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Created 1 bookmarks pointing to qzxslznx d487febd bookmark-2 bookmark-2@origin | Commit 5");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     c23f32312992 test-username@host.example.com 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
     create bookmark bookmark-2 pointing to commit d487febd08e690ee775a4e0387e30d544307e409
     args: jj bookmark create bookmark-2 -r bookmark-2@origin
@@ -1832,18 +1770,15 @@ fn test_op_show() {
     bookmark-2:
     + qzxslznx d487febd bookmark-2 bookmark-2@origin | Commit 5
     - (absent)
-    "#);
+    ");
 
     // Test tracking of a bookmark.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "bookmark-2@origin"]);
-    insta::assert_snapshot!(&stdout, @r###"
-     "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Started tracking 1 remote bookmarks.
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Started tracking 1 remote bookmarks.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     eb6a6c523f67 test-username@host.example.com 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2@origin
@@ -1852,19 +1787,18 @@ fn test_op_show() {
     bookmark-2@origin:
     + tracked qzxslznx d487febd bookmark-2 | Commit 5
     - untracked qzxslznx d487febd bookmark-2 | Commit 5
-    "#);
+    ");
 
     // Test creation of new commit.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "bookmark-2@origin"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     Warning: Remote bookmark already tracked: bookmark-2@origin
     Nothing changed.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     eb6a6c523f67 test-username@host.example.com 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2@origin
@@ -1873,22 +1807,21 @@ fn test_op_show() {
     bookmark-2@origin:
     + tracked qzxslznx d487febd bookmark-2 | Commit 5
     - untracked qzxslznx d487febd bookmark-2 | Commit 5
-    "#);
+    ");
 
     // Test creation of new commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["new", "bookmark-1@origin", "-m", "new commit"],
     );
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     Working copy now at: xznxytkn eb6c2b21 (empty) new commit
     Parent commit      : slvtnnzx 4f856199 bookmark-1?? bookmark-1@origin | Commit 4
     Added 1 files, modified 0 files, removed 1 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     0228d6c4044a test-username@host.example.com 2001-02-03 04:05:24.000 +07:00 - 2001-02-03 04:05:24.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
@@ -1896,18 +1829,15 @@ fn test_op_show() {
     Changed commits:
     ○  + xznxytkn eb6c2b21 (empty) new commit
     ○  - sqpuoqvx hidden 9708515f (empty) (no description set)
-    "#);
+    ");
 
     // Test updating of local bookmark.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "bookmark-1", "-r", "@"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Moved 1 bookmarks to xznxytkn eb6c2b21 bookmark-1* | (empty) new commit
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Moved 1 bookmarks to xznxytkn eb6c2b21 bookmark-1* | (empty) new commit");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     f37c3d23beab test-username@host.example.com 2001-02-03 04:05:26.000 +07:00 - 2001-02-03 04:05:26.000 +07:00
     point bookmark bookmark-1 to commit eb6c2b21ec20a33ab6a1c44bc86c59d84ffd93ac
     args: jj bookmark set bookmark-1 -r @
@@ -1917,17 +1847,14 @@ fn test_op_show() {
     + xznxytkn eb6c2b21 bookmark-1* | (empty) new commit
     - (added) slvtnnzx 4f856199 bookmark-1@origin | Commit 4
     - (added) yuvsmzqk 3d9189bc Commit 2
-    "#);
+    ");
 
     // Test deletion of local bookmark.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "bookmark-2"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r###"
-    Deleted 1 bookmarks.
-    "###);
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @"Deleted 1 bookmarks.");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     ee9e64b76138 test-username@host.example.com 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
     delete bookmark bookmark-2
     args: jj bookmark delete bookmark-2
@@ -1936,22 +1863,21 @@ fn test_op_show() {
     bookmark-2:
     + (absent)
     - qzxslznx d487febd bookmark-2@origin | Commit 5
-    "#);
+    ");
 
     // Test pushing to Git remote.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "push", "--tracked"]);
-    insta::assert_snapshot!(&stdout, @r###"
-    "###);
-    insta::assert_snapshot!(&stderr, @r#"
+    insta::assert_snapshot!(&stdout, @"");
+    insta::assert_snapshot!(&stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark-1 from 4f856199edbf to eb6c2b21ec20
       Delete bookmark bookmark-2 from d487febd08e6
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: pzsxstzt 7ab2d837 (empty) (no description set)
     Parent commit      : xznxytkn eb6c2b21 bookmark-1 | (empty) new commit
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     cd1704964f59 test-username@host.example.com 2001-02-03 04:05:30.000 +07:00 - 2001-02-03 04:05:30.000 +07:00
     push all tracked bookmarks to git remote origin
     args: jj git push --tracked
@@ -1966,7 +1892,7 @@ fn test_op_show() {
     bookmark-2@origin:
     + untracked (absent)
     - tracked qzxslznx d487febd Commit 5
-    "#);
+    ");
 }
 
 #[test]
@@ -1979,10 +1905,10 @@ fn test_op_show_patch() {
     std::fs::write(repo_path.join("file"), "a\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r"
     Working copy now at: rlvkpnrz 56950632 (empty) (no description set)
     Parent commit      : qpvuntsm 6b1027d2 (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show", "@-", "-p", "--git"]);
     insta::assert_snapshot!(&stdout, @r"
     187a5a9d8a22 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
@@ -2001,25 +1927,25 @@ fn test_op_show_patch() {
        +a
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show", "@", "-p", "--git"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     a7e535e73c4b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     new empty commit
     args: jj new
 
     Changed commits:
     ○  + rlvkpnrz 56950632 (empty) (no description set)
-    "#);
+    ");
 
     // Squash the working copy commit.
     std::fs::write(repo_path.join("file"), "b\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r"
     Working copy now at: mzvwutvl 9f4fb57f (empty) (no description set)
     Parent commit      : qpvuntsm 2ac85fd1 (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show", "-p", "--git"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     894c12d90345 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     squash commits into 6b1027d2770cd0a39c468e525e52bf8c47e1464a
     args: jj squash
@@ -2043,18 +1969,18 @@ fn test_op_show_patch() {
        @@ -1,1 +1,1 @@
        -a
        +b
-    "#);
+    ");
 
     // Abandon the working copy commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon"]);
     insta::assert_snapshot!(&stdout, @"");
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r"
     Abandoned commit mzvwutvl 9f4fb57f (empty) (no description set)
     Working copy now at: yqosqzyt 33f321c4 (empty) (no description set)
     Parent commit      : qpvuntsm 2ac85fd1 (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "show", "-p", "--git"]);
-    insta::assert_snapshot!(&stdout, @r#"
+    insta::assert_snapshot!(&stdout, @r"
     e5505aa79d31 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     abandon commit 9f4fb57fba25a7b47ce5980a5d9a4766778331e8
     args: jj abandon
@@ -2062,7 +1988,7 @@ fn test_op_show_patch() {
     Changed commits:
     ○  + yqosqzyt 33f321c4 (empty) (no description set)
     ○  - mzvwutvl hidden 9f4fb57f (empty) (no description set)
-    "#);
+    ");
 
     // Try again with "op log".
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--git"]);

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -26,7 +26,7 @@ fn test_parallelize_no_descendants() {
         test_env.jj_cmd_ok(&workspace_path, &["commit", &format!("-m{n}")]);
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  02b7709cc4e9 6 parents: 5
     ○  1b2f08d76b66 5 parents: 4
     ○  e5c4cf44e237 4 parents: 3
@@ -34,10 +34,10 @@ fn test_parallelize_no_descendants() {
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4850b4629edb 6 parents:
     │ ○  87627fbb7d29 5 parents:
     ├─╯
@@ -50,7 +50,7 @@ fn test_parallelize_no_descendants() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 // Only the head commit has descendants.
@@ -64,7 +64,7 @@ fn test_parallelize_with_descendants_simple() {
         test_env.jj_cmd_ok(&workspace_path, &["commit", &format!("-m{n}")]);
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  02b7709cc4e9 6 parents: 5
     ○  1b2f08d76b66 5 parents: 4
     ○  e5c4cf44e237 4 parents: 3
@@ -72,13 +72,13 @@ fn test_parallelize_with_descendants_simple() {
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(4)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  9bc057f8b6e3 6 parents: 5
     ○        9e36a8afe793 5 parents: 1 2 3 4
     ├─┬─┬─╮
@@ -90,7 +90,7 @@ fn test_parallelize_with_descendants_simple() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 // One of the commits being parallelized has a child that isn't being
@@ -107,7 +107,7 @@ fn test_parallelize_where_interior_has_non_target_children() {
     }
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(2)", "-m=2c"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(5)", "-m=6"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  2508ea92308a 6 parents: 5
     ○  1b2f08d76b66 5 parents: 4
     ○  e5c4cf44e237 4 parents: 3
@@ -117,13 +117,13 @@ fn test_parallelize_where_interior_has_non_target_children() {
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(4)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  c9525dff9d03 6 parents: 5
     ○        b3ad09518546 5 parents: 1 2 3 4
     ├─┬─┬─╮
@@ -137,7 +137,7 @@ fn test_parallelize_where_interior_has_non_target_children() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn test_parallelize_where_root_has_non_target_children() {
     }
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(1)", "-m=1c"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m=4"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  9132691e6256 4 parents: 3
     ○  4cd999dfaac0 3 parents: 2
     ○  d3902619fade 2 parents: 1
@@ -159,12 +159,12 @@ fn test_parallelize_where_root_has_non_target_children() {
     ├─╯
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(3)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @      3397916989e7 4 parents: 1 2 3
     ├─┬─╮
     │ │ ○  1f768c1bc591 3 parents:
@@ -175,7 +175,7 @@ fn test_parallelize_where_root_has_non_target_children() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 // One of the commits being parallelized has a child that is a merge commit.
@@ -195,7 +195,7 @@ fn test_parallelize_with_merge_commit_child() {
         &["new", "description(2)", "description(a)", "-m", "2a-c"],
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m", "4"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  99ffaf5b3984 4 parents: 3
     ○  4cd999dfaac0 3 parents: 2
     │ ○  4313cc3b476f 2a-c parents: 2 a
@@ -205,14 +205,14 @@ fn test_parallelize_with_merge_commit_child() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 
     // After this finishes, child-2a will have three parents: "1", "2", and "a".
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(3)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @      3ee9279847a6 4 parents: 1 2 3
     ├─┬─╮
     │ │ ○  bb1bb465ccc2 3 parents:
@@ -225,7 +225,7 @@ fn test_parallelize_with_merge_commit_child() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -238,27 +238,25 @@ fn test_parallelize_disconnected_target_commits() {
         test_env.jj_cmd_ok(&workspace_path, &["commit", &format!("-m{n}")]);
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4cd999dfaac0 3 parents: 2
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)", "description(3)"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4cd999dfaac0 3 parents: 2
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -276,7 +274,7 @@ fn test_parallelize_head_is_a_merge() {
         &workspace_path,
         &["new", "description(2)", "description(b)", "-m=merged-head"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    1fb53c45237e merged-head parents: 2 b
     ├─╮
     │ ○  a7bf5001cfd8 b parents: a
@@ -286,10 +284,10 @@ fn test_parallelize_head_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    82131a679769 merged-head parents: 0 b
     ├─╮
     │ ○  a7bf5001cfd8 b parents: a
@@ -301,7 +299,7 @@ fn test_parallelize_head_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -317,7 +315,7 @@ fn test_parallelize_interior_target_is_a_merge() {
         &["new", "description(1)", "description(a)", "-m=2"],
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  9b77792c77ac 3 parents: 2
     ○    1e29145c95fd 2 parents: 1 a
     ├─╮
@@ -326,10 +324,10 @@ fn test_parallelize_interior_target_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    042fc3f4315c 3 parents: 0 a
     ├─╮
     │ │ ○  80603361bb48 2 parents: 0 a
@@ -340,7 +338,7 @@ fn test_parallelize_interior_target_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -356,7 +354,7 @@ fn test_parallelize_root_is_a_merge() {
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=2"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  cc239b744d01 3 parents: 2
     ○  2bf00c2ad44c 2 parents: 1
     ○    1c6853121f3c 1 parents: y x
@@ -365,13 +363,13 @@ fn test_parallelize_root_is_a_merge() {
     ○ │  ca57511e158f y parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(2)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    2c7fdfa00b38 3 parents: 1 2
     ├─╮
     │ ○    3acbd32944d6 2 parents: y x
@@ -382,7 +380,7 @@ fn test_parallelize_root_is_a_merge() {
       ○ │  ca57511e158f y parents:
       ├─╯
       ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -393,23 +391,23 @@ fn test_parallelize_multiple_heads() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=0"]);
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=1"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  97d7522f40e8 2 parents: 0
     │ ○  0c058af014a6 1 parents: 0
     ├─╯
     ○  745bea8029c1 0 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(0)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  e84481c26195 2 parents:
     │ ○  6270540ee067 1 parents:
     ├─╯
     │ ○  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 // All heads must have the same children as the other heads, but only if they
@@ -423,25 +421,25 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=0"]);
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=1"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  97d7522f40e8 2 parents: 0
     │ ○  0c058af014a6 1 parents: 0
     ├─╯
     ○  745bea8029c1 0 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(0)", "description(1)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  97d7522f40e8 2 parents: 0
     ○  745bea8029c1 0 parents:
     │ ○  6270540ee067 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "#);
+    ");
 }
 
 #[test]
@@ -456,7 +454,7 @@ fn test_parallelize_multiple_roots() {
         &["new", "description(1)", "description(a)", "-m=2"],
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  34da938ad94a 3 parents: 2
     ○    85d5043b881d 2 parents: 1 a
     ├─╮
@@ -464,11 +462,11 @@ fn test_parallelize_multiple_roots() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 
     // Succeeds because the roots have the same parents.
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "root().."]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  3c90598481cd 3 parents:
     │ ○  b96aa55582e5 2 parents:
     ├─╯
@@ -477,7 +475,7 @@ fn test_parallelize_multiple_roots() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -492,7 +490,7 @@ fn test_parallelize_multiple_heads_with_different_children() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=a"]);
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=b"]);
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=c"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4bc4dace0e65 parents: c
     ○  63b0da9212c0 c parents: b
     ○  a7bf5001cfd8 b parents: a
@@ -502,7 +500,7 @@ fn test_parallelize_multiple_heads_with_different_children() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
@@ -512,7 +510,7 @@ fn test_parallelize_multiple_heads_with_different_children() {
             "description(a)::description(b)",
         ],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  f6c9d9ee3db8 parents: c
     ○    62661d5f0c77 c parents: a b
     ├─╮
@@ -526,7 +524,7 @@ fn test_parallelize_multiple_heads_with_different_children() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -543,7 +541,7 @@ fn test_parallelize_multiple_roots_with_different_parents() {
         &workspace_path,
         &["new", "description(2)", "description(b)", "-m=merged-head"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    ba4297d53c1a merged-head parents: 2 b
     ├─╮
     │ ○  6577defaca2d b parents: a
@@ -552,13 +550,13 @@ fn test_parallelize_multiple_roots_with_different_parents() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(2)::", "description(b)::"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    0943ed52b3ed merged-head parents: 1 a
     ├─╮
     │ │ ○  6577defaca2d b parents: a
@@ -569,7 +567,7 @@ fn test_parallelize_multiple_roots_with_different_parents() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 #[test]
@@ -585,7 +583,7 @@ fn test_parallelize_complex_nonlinear_target() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=1c", "description(1)"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=2c", "description(2)"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3c", "description(3)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  b043eb81416c 3c parents: 3
     │ ○    48277ee9afe0 4 parents: 3 2 1
     ╭─┼─╮
@@ -600,18 +598,18 @@ fn test_parallelize_complex_nonlinear_target() {
     ├─╯
     ○  745bea8029c1 0 parents:
     ◆  000000000000 parents:
-    "###);
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(0)::description(4)"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: yostqsxw 59a216e5 (empty) 3c
     Parent commit      : rlvkpnrz 745bea80 (empty) 0
     Parent commit      : mzvwutvl cb944786 (empty) 3
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    59a216e537c4 3c parents: 0 3
     ├─╮
     │ ○  cb9447869bf0 3 parents:
@@ -628,7 +626,7 @@ fn test_parallelize_complex_nonlinear_target() {
     │ ○  14ca4df576b3 4 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -39,80 +39,74 @@ fn test_rebase_invalid() {
 
     // Missing destination
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["rebase"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     Usage: jj rebase <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Both -r and -s
     let stderr =
         test_env.jj_cmd_cli_error(&repo_path, &["rebase", "-r", "a", "-s", "a", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--revisions <REVSETS>' cannot be used with '--source <REVSETS>'
 
     Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Both -b and -s
     let stderr =
         test_env.jj_cmd_cli_error(&repo_path, &["rebase", "-b", "a", "-s", "a", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--branch <REVSETS>' cannot be used with '--source <REVSETS>'
 
     Usage: jj rebase --branch <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Both -d and --after
     let stderr = test_env.jj_cmd_cli_error(
         &repo_path,
         &["rebase", "-r", "a", "-d", "b", "--after", "b"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--destination <REVSETS>' cannot be used with '--insert-after <REVSETS>'
 
     Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Both -d and --before
     let stderr = test_env.jj_cmd_cli_error(
         &repo_path,
         &["rebase", "-r", "a", "-d", "b", "--before", "b"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--destination <REVSETS>' cannot be used with '--insert-before <REVSETS>'
 
     Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    ");
 
     // Rebase onto self with -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "a"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Cannot rebase 2443ea76b0b1 onto itself
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Cannot rebase 2443ea76b0b1 onto itself");
 
     // Rebase root with -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "root()", "-d", "a"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 
     // Rebase onto descendant with -s
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s", "a", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Cannot rebase 2443ea76b0b1 onto descendant 1394f625cbbd
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Cannot rebase 2443ea76b0b1 onto descendant 1394f625cbbd");
 }
 
 #[test]
@@ -150,7 +144,7 @@ fn test_rebase_bookmark() {
     create_commit(&test_env, &repo_path, "d", &["b"]);
     create_commit(&test_env, &repo_path, "e", &["a"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: a
     │ ○  d: b
     │ │ ○  c: b
@@ -159,12 +153,12 @@ fn test_rebase_bookmark() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "e"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"Rebased 3 commits onto destination");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  d: b
     │ ○  c: b
     ├─╯
@@ -172,20 +166,20 @@ fn test_rebase_bookmark() {
     @  e: a
     ○  a
     ◆
-    "###);
+    ");
 
     // Test rebasing multiple bookmarks at once
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b=e", "-b=d", "-d=b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 1 commits onto destination
     Working copy now at: znkkpsqq 9ca2a154 e | e
     Parent commit      : zsuskuln 1394f625 b | b
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: b
     │ ○  d: b
     ├─╯
@@ -194,7 +188,7 @@ fn test_rebase_bookmark() {
     ○  b: a
     ○  a
     ◆
-    "###);
+    ");
 
     // Same test but with more than one revision per argument
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -208,14 +202,14 @@ fn test_rebase_bookmark() {
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b=all:e|d", "-d=b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 1 commits onto destination
     Working copy now at: znkkpsqq 817e3fb0 e | e
     Parent commit      : zsuskuln 1394f625 b | b
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: b
     │ ○  d: b
     ├─╯
@@ -224,7 +218,7 @@ fn test_rebase_bookmark() {
     ○  b: a
     ○  a
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -239,7 +233,7 @@ fn test_rebase_bookmark_with_merge() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["a", "d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: a d
     ├─╮
     │ ○  d: c
@@ -249,18 +243,18 @@ fn test_rebase_bookmark_with_merge() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: znkkpsqq 5f8a3db2 e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : vruxwmqv 1677f795 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: a d
     ├─╮
     │ ○  d: c
@@ -269,19 +263,19 @@ fn test_rebase_bookmark_with_merge() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: znkkpsqq a331ac11 e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : vruxwmqv 3d0f3644 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: a d
     ├─╮
     │ ○  d: c
@@ -290,7 +284,7 @@ fn test_rebase_bookmark_with_merge() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -305,7 +299,7 @@ fn test_rebase_single_revision() {
     create_commit(&test_env, &repo_path, "d", &["b", "c"]);
     create_commit(&test_env, &repo_path, "e", &["d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: d
     ○    d: b c
     ├─╮
@@ -314,20 +308,20 @@ fn test_rebase_single_revision() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     // Descendants of the rebased commit "c" should be rebased onto parents. First
     // we test with a non-merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: znkkpsqq 2668ffbe e | e
     Parent commit      : vruxwmqv 7b370c85 d | d
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: d
     ○    d: b a
     ├─╮
@@ -337,22 +331,22 @@ fn test_rebase_single_revision() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Now, let's try moving the merge commit. After, both parents of "d" ("b" and
     // "c") should become parents of "e".
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: znkkpsqq ed210c15 e | e
     Parent commit      : zsuskuln 1394f625 b | b
     Parent commit      : royxmykx c0cb3a0b c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: b c
     ├─╮
     │ ○  c: a
@@ -362,7 +356,7 @@ fn test_rebase_single_revision() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -376,7 +370,7 @@ fn test_rebase_single_revision_merge_parent() {
     create_commit(&test_env, &repo_path, "c", &["b"]);
     create_commit(&test_env, &repo_path, "d", &["a", "c"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    d: a c
     ├─╮
     │ ○  c: b
@@ -384,21 +378,21 @@ fn test_rebase_single_revision_merge_parent() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    ");
 
     // Descendants of the rebased commit should be rebased onto parents, and if
     // the descendant is a merge commit, it shouldn't forget its other parents.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: vruxwmqv a37531e8 d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : zsuskuln d370aee1 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    d: a b
     ├─╮
     │ ○  b
@@ -407,7 +401,7 @@ fn test_rebase_single_revision_merge_parent() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -426,7 +420,7 @@ fn test_rebase_multiple_revisions() {
     create_commit(&test_env, &repo_path, "h", &["g"]);
     create_commit(&test_env, &repo_path, "i", &["f"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  i: f
     │ ○  h: g
     │ ○  g: f
@@ -440,20 +434,20 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     // Test with two non-related non-merge commits.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-r", "e", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 016685dc i | i
     Parent commit      : kmkuslsw e04d3932 f | f
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  i: f
     │ ○  h: g
     │ ○  g: f
@@ -469,7 +463,7 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test with two related non-merge commits. Since "b" is a parent of "c", when
@@ -478,14 +472,14 @@ fn test_rebase_multiple_revisions() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b", "-r", "c", "-d", "e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 94538385 i | i
     Parent commit      : kmkuslsw dae8d293 f | f
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  i: f
     │ ○  h: g
     │ ○  g: f
@@ -500,7 +494,7 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test with a subgraph containing a merge commit. Since the merge commit "f"
@@ -510,15 +504,15 @@ fn test_rebase_multiple_revisions() {
     // a descendant of any new children.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e::g", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 1868ded4 i | i
     Parent commit      : royxmykx 7e4fbf4f c | c
     Parent commit      : vruxwmqv 4cc44fbf d | d
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    i: c d
     ├─╮
     │ │ ○  h: c d
@@ -534,7 +528,7 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test with commits in a disconnected subgraph. The subgraph has the
@@ -547,15 +541,15 @@ fn test_rebase_multiple_revisions() {
         &["rebase", "-r", "d", "-r", "f", "-r", "h", "-d", "b"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn 9cfd1635 i | i
     Parent commit      : royxmykx 7e4fbf4f c | c
     Parent commit      : znkkpsqq ecf9a1d5 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    i: c e
     ├─╮
     │ │ ○  g: c e
@@ -571,20 +565,20 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test rebasing a subgraph onto its descendants.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d::e", "-d", "i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 5d911e5c i | i
     Parent commit      : kmkuslsw d1bfda8c f | f
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: d
     ○  d: i
     @  i: f
@@ -598,7 +592,7 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
 }
 
 #[test]
@@ -612,7 +606,7 @@ fn test_rebase_revision_onto_descendant() {
     create_commit(&test_env, &repo_path, "b", &["base"]);
     create_commit(&test_env, &repo_path, "merge", &["b", "a"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    merge: b a
     ├─╮
     │ ○  a: base
@@ -620,21 +614,21 @@ fn test_rebase_revision_onto_descendant() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Simpler example
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: vruxwmqv bff4a4eb merge | merge
     Parent commit      : royxmykx c84e900d b | b
     Parent commit      : zsuskuln d57db87b a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    merge: b a
     ├─╮
     ○ │  b
@@ -643,29 +637,29 @@ fn test_rebase_revision_onto_descendant() {
     │ ○  a
     ├─╯
     ◆
-    "###);
+    ");
 
     // Now, let's rebase onto the descendant merge
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Restored to operation: cc1a7e3419ad (2001-02-03 08:05:15) create bookmark merge pointing to commit b05964d109522cd06e48f1a2661e1a0f58be0984
     Working copy now at: vruxwmqv b05964d1 merge | merge
     Parent commit      : royxmykx cea87a87 b | b
     Parent commit      : zsuskuln 2c5b7858 a | a
     Added 1 files, modified 0 files, removed 0 files
-    "#);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "merge"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: vruxwmqv 986b7a49 merge | merge
     Parent commit      : royxmykx c07c677c b | b
     Parent commit      : zsuskuln abc90087 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  base: merge
     @    merge: b a
     ├─╮
@@ -673,7 +667,7 @@ fn test_rebase_revision_onto_descendant() {
     ○ │  b
     ├─╯
     ◆
-    "###);
+    ");
 
     // TODO(ilyagr): These will be good tests for `jj rebase --insert-after` and
     // `--insert-before`, once those are implemented.
@@ -689,29 +683,27 @@ fn test_rebase_multiple_destinations() {
     create_commit(&test_env, &repo_path, "b", &[]);
     create_commit(&test_env, &repo_path, "c", &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c
     │ ○  b
     ├─╯
     │ ○  a
     ├─╯
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Rebased 1 commits onto destination
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Rebased 1 commits onto destination");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    a: b c
     ├─╮
     │ @  c
     ○ │  b
     ├─╯
     ◆
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b|c"]);
     insta::assert_snapshot!(stderr, @r"
@@ -725,17 +717,15 @@ fn test_rebase_multiple_destinations() {
     // try with 'all:' and succeed
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "all:b|c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Rebased 1 commits onto destination
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Rebased 1 commits onto destination");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    a: c b
     ├─╮
     │ ○  b
     @ │  c
     ├─╯
     ◆
-    "###);
+    ");
 
     // undo and do it again, but with 'ui.always-allow-large-revsets'
     let (_, _) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -748,36 +738,30 @@ fn test_rebase_multiple_destinations() {
             "-d=b|c",
         ],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    a: c b
     ├─╮
     │ ○  b
     @ │  c
     ├─╯
     ◆
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: More than one revset resolved to revision d370aee184ba
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: More than one revset resolved to revision d370aee184ba");
 
     // Same error with 'all:' if there is overlap.
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["rebase", "-r", "a", "-d", "all:b|c", "-d", "b"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: More than one revset resolved to revision d370aee184ba
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: More than one revset resolved to revision d370aee184ba");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["rebase", "-r", "a", "-d", "b", "-d", "root()"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The Git backend does not support creating merge commits with the root commit as one of the parents.");
 }
 
 #[test]
@@ -791,7 +775,7 @@ fn test_rebase_with_descendants() {
     create_commit(&test_env, &repo_path, "c", &["a", "b"]);
     create_commit(&test_env, &repo_path, "d", &["c"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: c
     ○    c: a b
     ├─╮
@@ -799,16 +783,16 @@ fn test_rebase_with_descendants() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: vruxwmqv 705832bd d | d
     Parent commit      : royxmykx 57c7246a c | c
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: c
     ○    c: a b
     ├─╮
@@ -816,19 +800,19 @@ fn test_rebase_with_descendants() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     // Rebase several subtrees at once.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=c", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Working copy now at: vruxwmqv 92c2bc9a d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: a
     │ ○  c: a
     ├─╯
@@ -836,11 +820,11 @@ fn test_rebase_with_descendants() {
     │ ○  b
     ├─╯
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // Reminder of the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: c
     ○    c: a b
     ├─╮
@@ -848,19 +832,19 @@ fn test_rebase_with_descendants() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    ");
 
     // `d` was a descendant of `b`, and both are moved to be direct descendants of
     // `a`. `c` remains a descendant of `b`.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=b", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: vruxwmqv f1e71cb7 d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: a
     │ ○  c: a b
     ╭─┤
@@ -868,7 +852,7 @@ fn test_rebase_with_descendants() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
 
     // Same test as above, but with multiple commits per argument
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -882,13 +866,13 @@ fn test_rebase_with_descendants() {
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=all:b|d", "-d=a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: vruxwmqv d17539f7 d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: a
     │ ○  c: a b
     ╭─┤
@@ -896,7 +880,7 @@ fn test_rebase_with_descendants() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
 }
 
 #[test]
@@ -931,7 +915,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -940,18 +924,18 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     // ===================== rebase -s tests =================
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "base", "-d", "notroot"]);
     insta::assert_snapshot!(stdout, @"");
     // This should be a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -960,17 +944,17 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "a", "-d", "base"]);
     insta::assert_snapshot!(stdout, @"");
     // This should be a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 3 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -979,19 +963,19 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "a", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: znkkpsqq cf8ecff5 c | c
     Parent commit      : vruxwmqv 24e1a270 b | b
-    "#);
+    ");
     // Commit "a" should be rebased onto the root commit. Commit "b" should have
     // "base" and "a" as parents as before.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1000,12 +984,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○ │  notroot
     ├─╯
     ◆
-    "###);
+    ");
 
     // ===================== rebase -b tests =================
     // ====== Reminder of the setup =========
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1014,17 +998,17 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "base"]);
     insta::assert_snapshot!(stdout, @"");
     // The commits in roots(base..c), i.e. commit "a" should be rebased onto "base",
     // which is a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 3 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1033,36 +1017,36 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Working copy now at: znkkpsqq 76914dcc c | c
     Parent commit      : vruxwmqv f73f03c7 b | b
-    "#);
+    ");
     // The commits in roots(a..c), i.e. commit "b" should be rebased onto "a",
     // which means "b" loses its "base" parent
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○  b: a
     ○  a: base
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "a", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
     // This should be a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 5 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1071,12 +1055,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     // ===================== rebase -r tests =================
     // ====== Reminder of the setup =========
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1085,20 +1069,20 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq 45371aaf c | c
     Parent commit      : vruxwmqv c0a76bf4 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    ");
     // The user would expect unsimplified ancestry here.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: notroot a
     ├─╮
@@ -1108,21 +1092,21 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     │ ○  base
     ├─╯
     ◆
-    "###);
+    ");
 
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq e28fa972 c | c
     Parent commit      : vruxwmqv 8d0eeb6a b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     │ ○  base: b
     ├─╯
@@ -1132,21 +1116,21 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ├─╯
     ○  notroot
     ◆
-    "###);
+    ");
 
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq a9da974c c | c
     Parent commit      : vruxwmqv 0072139c b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: notroot a
     ├─╮
@@ -1156,11 +1140,11 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ├─╯
     ○  notroot
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ====== Reminder of the setup =========
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1169,20 +1153,20 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: znkkpsqq 7210b05e c | c
     Parent commit      : vruxwmqv da3f7511 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    ");
     // In this case, it is unclear whether the user would always prefer unsimplified
     // ancestry (whether `b` should also be a direct child of the root commit).
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○  b: base
     ○  base: notroot
@@ -1190,21 +1174,21 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     │ ○  a
     ├─╯
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: znkkpsqq f280545e c | c
     Parent commit      : zsuskuln 0a7fb8f6 base | base
     Parent commit      : royxmykx 86a06598 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    ");
     // The user would expect unsimplified ancestry here.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    c: base a
     ├─╮
     │ ○  a: base
@@ -1214,22 +1198,22 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     │ ○  b
     ├─╯
     ◆
-    "###);
+    ");
 
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: znkkpsqq c0a7cd80 c | c
     Parent commit      : zsuskuln 0a7fb8f6 base | base
     Parent commit      : royxmykx 86a06598 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  b: c
     @    c: base a
     ├─╮
@@ -1238,20 +1222,20 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 
     // In this test, the commit with weird ancestry is not rebased (neither directly
     // nor indirectly).
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: znkkpsqq 7a3bc050 c | c
     Parent commit      : royxmykx 86a06598 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: a
     │ ○  b: base a
     ╭─┤
@@ -1260,7 +1244,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -1279,7 +1263,7 @@ fn test_rebase_after() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1293,7 +1277,7 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Rebasing a commit after its parents should be a no-op.
@@ -1302,11 +1286,11 @@ fn test_rebase_after() {
         &["rebase", "-r", "c", "--after", "b2", "--after", "b4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1320,16 +1304,16 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     // Rebasing a commit after itself should be a no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1343,19 +1327,19 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     // Rebase a commit after another commit. "c" has parents "b2" and "b4", so its
     // children "d" and "e" should be rebased onto "b2" and "b4" respectively.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--after", "e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn e0e873c8 f | f
     Parent commit      : kmkuslsw 754793f3 c | c
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     ○  c: e
     ○    e: b2 b4
@@ -1369,20 +1353,20 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after a leaf commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e", "--after", "f"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: xznxytkn 9804b742 f | f
     Parent commit      : kmkuslsw cd86b3e4 c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: f
     @  f: c
     │ ○  d: c
@@ -1396,20 +1380,20 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after a commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--after", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 80c27408 f | f
     Parent commit      : zsuskuln 072d5ae1 b1 | b1
     Added 0 files, modified 0 files, removed 5 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1423,20 +1407,20 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after the last commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--after", "b2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn ebbc24b1 f | f
     Parent commit      : royxmykx 2b8e1148 b2 | b2
     Added 0 files, modified 0 files, removed 4 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1450,7 +1434,7 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after a commit with multiple children.
@@ -1458,14 +1442,14 @@ fn test_rebase_after() {
     // two children.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 8f8c91d3 f | f
     Parent commit      : kmkuslsw cd86b3e4 c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: f
     │ ○  d: f
     ├─╯
@@ -1479,7 +1463,7 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after multiple commits.
@@ -1488,14 +1472,14 @@ fn test_rebase_after() {
         &["rebase", "-r", "f", "--after", "e", "--after", "d"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: xznxytkn 7784e5a0 f | f
     Parent commit      : nkmrtpmo 858693f7 e | e
     Parent commit      : lylxulpl 7d0512e5 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    f: e d
     ├─╮
     │ ○  d: c
@@ -1510,7 +1494,7 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase two unrelated commits.
@@ -1519,14 +1503,14 @@ fn test_rebase_after() {
         &["rebase", "-r", "d", "-r", "e", "--after", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn 0b53613e f | f
     Parent commit      : kmkuslsw 193687bb c | c
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     ○    c: b2 b4
     ├─╮
@@ -1541,7 +1525,7 @@ fn test_rebase_after() {
       ├─╯
       ○  a
       ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with merge commit and two parents, which should preserve
@@ -1551,14 +1535,14 @@ fn test_rebase_after() {
         &["rebase", "-r", "b2", "-r", "b4", "-r", "c", "--after", "f"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn eaf1d6b8 f | f
     Parent commit      : nkmrtpmo 0d7e4ce9 e | e
     Added 0 files, modified 0 files, removed 3 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    c: b2 b4
     ├─╮
     │ ○  b4: f
@@ -1574,21 +1558,21 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with four commits after one of the commits itself.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b1::d", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 9bc7e54c f | f
     Parent commit      : nkmrtpmo 0f80251b e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: d
     ○  d: c
@@ -1602,7 +1586,7 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph before the parents of one of the commits in the subgraph.
@@ -1611,14 +1595,14 @@ fn test_rebase_after() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b2::d", "--after", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn 0875aabc f | f
     Parent commit      : nkmrtpmo d429661b e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b1 b4
     ├─╮
@@ -1631,7 +1615,7 @@ fn test_rebase_after() {
     ○  c: b2
     ○  b2
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with disconnected commits. Since "b2" is an ancestor of
@@ -1641,14 +1625,14 @@ fn test_rebase_after() {
         &["rebase", "-r", "e", "-r", "b2", "--after", "d"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn 3238a418 f | f
     Parent commit      : kmkuslsw 6a51bd41 c | c
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     │ ○  e: b2
     │ ○  b2: d
@@ -1662,17 +1646,17 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of commit "c" and its descendants after itself should be a no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "c", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1686,7 +1670,7 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of a commit and its descendants after multiple commits.
@@ -1695,14 +1679,14 @@ fn test_rebase_after() {
         &["rebase", "-s", "c", "--after", "b1", "--after", "b3"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn a4ace41c f | f
     Parent commit      : nkmrtpmo c7744d08 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    b4: d f
     ├─╮
     │ │ ○  b2: d f
@@ -1718,7 +1702,7 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -b` of commit "b3" after "b1" moves its descendants which are not
@@ -1726,14 +1710,14 @@ fn test_rebase_after() {
     // child "b2".
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "b3", "--after", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 6 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: xznxytkn b4078b57 f | f
     Parent commit      : nkmrtpmo 1b95558f e | e
     Added 0 files, modified 0 files, removed 1 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    b2: d f
     ├─╮
     │ @  f: e
@@ -1746,7 +1730,7 @@ fn test_rebase_after() {
     ○  b1: a
     ○  a
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Should error if a loop will be created.
@@ -1754,9 +1738,7 @@ fn test_rebase_after() {
         &repo_path,
         &["rebase", "-r", "e", "--after", "a", "--after", "b2"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Refusing to create a loop: commit 2b8e1148290f would be both an ancestor and a descendant of the rebased commits
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit 2b8e1148290f would be both an ancestor and a descendant of the rebased commits");
 }
 
 #[test]
@@ -1775,7 +1757,7 @@ fn test_rebase_before() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1789,7 +1771,7 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Rebasing a commit before its children should be a no-op.
@@ -1798,11 +1780,11 @@ fn test_rebase_before() {
         &["rebase", "-r", "c", "--before", "d", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1816,16 +1798,16 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     // Rebasing a commit before itself should be a no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--before", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1839,25 +1821,23 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     // Rebasing a commit before the root commit should error.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "c", "--before", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 
     // Rebase a commit before another commit. "c" has parents "b2" and "b4", so its
     // children "d" and "e" should be rebased onto "b2" and "b4" respectively.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--before", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 8 descendant commits
     Working copy now at: xznxytkn 24335685 f | f
     Parent commit      : nkmrtpmo e9a28d4b e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b2 b4
     ├─╮
@@ -1871,20 +1851,20 @@ fn test_rebase_before() {
     ○  a: c
     ○  c
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before its parent.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: xznxytkn 8e3b728a f | f
     Parent commit      : kmkuslsw cd86b3e4 c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: f
     @  f: c
     │ ○  d: c
@@ -1898,20 +1878,20 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before a commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "b2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 2b4f48f8 f | f
     Parent commit      : zsuskuln 072d5ae1 b1 | b1
     Added 0 files, modified 0 files, removed 5 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1925,20 +1905,20 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before the first commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 5 descendant commits
     Working copy now at: xznxytkn 488ebb95 f | f
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 6 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1952,7 +1932,7 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before a merge commit. "c" has two parents "b2" and "b4", so
@@ -1960,15 +1940,15 @@ fn test_rebase_before() {
     // parents.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn aae1bc10 f | f
     Parent commit      : royxmykx 2b8e1148 b2 | b2
     Parent commit      : znkkpsqq a52a83a4 b4 | b4
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1982,7 +1962,7 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before multiple commits.
@@ -1991,13 +1971,13 @@ fn test_rebase_before() {
         &["rebase", "-r", "b1", "--before", "d", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 5 descendant commits
     Working copy now at: xznxytkn 8268ec4d f | f
     Parent commit      : nkmrtpmo fd26fbd4 e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: b1
     │ ○  d: b1
@@ -2011,7 +1991,7 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before two commits in separate bookmarks to create a merge
@@ -2021,15 +2001,15 @@ fn test_rebase_before() {
         &["rebase", "-r", "f", "--before", "b2", "--before", "b4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 5 descendant commits
     Working copy now at: xznxytkn 7ba8014f f | f
     Parent commit      : zsuskuln 072d5ae1 b1 | b1
     Parent commit      : vruxwmqv 523e6a8b b3 | b3
     Added 0 files, modified 0 files, removed 4 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -2045,7 +2025,7 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase two unrelated commits "b2" and "b4" before a single commit "a". This
@@ -2055,13 +2035,13 @@ fn test_rebase_before() {
         &["rebase", "-r", "b2", "-r", "b4", "--before", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 7 descendant commits
     Working copy now at: xznxytkn fabd8dd7 f | f
     Parent commit      : nkmrtpmo b5933877 e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2077,7 +2057,7 @@ fn test_rebase_before() {
     ○ │  b2
     ├─╯
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with a merge commit and two parents.
@@ -2086,13 +2066,13 @@ fn test_rebase_before() {
         &["rebase", "-r", "b2", "-r", "b4", "-r", "c", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn cbe2be58 f | f
     Parent commit      : nkmrtpmo e31053d1 e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     ○    c: b2 b4
@@ -2108,7 +2088,7 @@ fn test_rebase_before() {
       ├─╯
       ○  a
       ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with disconnected commits. Since "b1" is an ancestor of
@@ -2118,13 +2098,13 @@ fn test_rebase_before() {
         &["rebase", "-r", "b1", "-r", "e", "--before", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 7 descendant commits
     Working copy now at: xznxytkn 1c48b514 f | f
     Parent commit      : kmkuslsw c0fd979a c | c
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     │ ○  d: c
     ├─╯
@@ -2138,7 +2118,7 @@ fn test_rebase_before() {
     ○  e: b1
     ○  b1
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph before the parents of one of the commits in the subgraph.
@@ -2147,14 +2127,14 @@ fn test_rebase_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b2::d", "--before", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn f5991dc7 f | f
     Parent commit      : nkmrtpmo 37894e3c e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b1 b4
     ├─╮
@@ -2167,7 +2147,7 @@ fn test_rebase_before() {
     ○  c: b2
     ○  b2
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph before the parents of one of the commits in the subgraph.
@@ -2176,14 +2156,14 @@ fn test_rebase_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b2::d", "--before", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn 308a31e9 f | f
     Parent commit      : nkmrtpmo 538444a5 e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b1 b4
     ├─╮
@@ -2196,18 +2176,18 @@ fn test_rebase_before() {
     ○  c: b2
     ○  b2
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of commit "c" and its descendants before itself should be a
     // no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "c", "--before", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2221,7 +2201,7 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of a commit and its descendants before multiple commits.
@@ -2230,14 +2210,14 @@ fn test_rebase_before() {
         &["rebase", "-s", "c", "--before", "b2", "--before", "b4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 84704387 f | f
     Parent commit      : nkmrtpmo cff61821 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    b4: d f
     ├─╮
     │ │ ○  b2: d f
@@ -2253,7 +2233,7 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -b` of commit "b3" before "b2" moves its descendants which are not
@@ -2262,15 +2242,15 @@ fn test_rebase_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "b3", "--before", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 2 commits that were already in place
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 16422f85 f | f
     Parent commit      : nkmrtpmo ef9dea83 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  b2: b1
     ○    b1: d f
     ├─╮
@@ -2283,7 +2263,7 @@ fn test_rebase_before() {
     ○  b3: a
     ○  a
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Should error if a loop will be created.
@@ -2291,9 +2271,7 @@ fn test_rebase_before() {
         &repo_path,
         &["rebase", "-r", "e", "--before", "b2", "--before", "c"],
     );
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Refusing to create a loop: commit 2b8e1148290f would be both an ancestor and a descendant of the rebased commits
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit 2b8e1148290f would be both an ancestor and a descendant of the rebased commits");
 }
 
 #[test]
@@ -2313,7 +2291,7 @@ fn test_rebase_after_before() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2329,7 +2307,7 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Rebase a commit after another commit and before that commit's child to
@@ -2339,14 +2317,14 @@ fn test_rebase_after_before() {
         &["rebase", "-r", "d", "--after", "e", "--before", "f"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx 56c81c6d f | f
     Parent commit      : nkmrtpmo ff196f69 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: d
     ○  d: e
     ○  e: c
@@ -2361,7 +2339,7 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after another commit and before that commit's descendant to
@@ -2371,15 +2349,15 @@ fn test_rebase_after_before() {
         &["rebase", "-r", "d", "--after", "a", "--before", "f"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx 398173ed f | f
     Parent commit      : xznxytkn b3e6aadf e | e
     Parent commit      : nkmrtpmo db529447 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    f: e d
     ├─╮
     │ ○  d: a
@@ -2396,7 +2374,7 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // "c" has parents "b1" and "b2", so when it is rebased, its children "d" and
@@ -2408,14 +2386,14 @@ fn test_rebase_after_before() {
         &["rebase", "-r", "c", "--after", "d", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: nmzmmopx 2be98daf f | f
     Parent commit      : xznxytkn 911fc846 e | e
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○      e: b1 b2 c
     ├─┬─╮
@@ -2431,7 +2409,7 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase multiple commits and preserve their ancestry. Apart from the heads of
@@ -2445,7 +2423,7 @@ fn test_rebase_after_before() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx bee09b10 f | f
@@ -2454,8 +2432,8 @@ fn test_rebase_after_before() {
     Parent commit      : nkmrtpmo 4a8ca156 d | d
     Parent commit      : xznxytkn 0cc1825e e | e
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @        f: b1 b2 d e
     ├─┬─┬─╮
     │ │ │ ○  e: c
@@ -2472,7 +2450,7 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of a commit and its descendants.
@@ -2481,14 +2459,14 @@ fn test_rebase_after_before() {
         &["rebase", "-s", "c", "--before", "b1", "--after", "b2"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx 951204cf f | f
     Parent commit      : xznxytkn fe8ec4e2 e | e
     Added 0 files, modified 0 files, removed 1 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○      b1: a d f
     ├─┬─╮
     │ │ @  f: e
@@ -2504,7 +2482,7 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -b` of a commit "y" to a destination after "a" will rebase all
@@ -2515,14 +2493,14 @@ fn test_rebase_after_before() {
         &["rebase", "-b", "y", "--after", "a", "--before", "c"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: nmzmmopx 4496f88e f | f
     Parent commit      : xznxytkn a85404a6 e | e
     Added 3 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2538,7 +2516,7 @@ fn test_rebase_after_before() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Should error if a loop will be created.
@@ -2564,7 +2542,7 @@ fn test_rebase_skip_emptied() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  will become empty
@@ -2572,30 +2550,30 @@ fn test_rebase_skip_emptied() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=b", "--skip-emptied"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Abandoned 1 newly emptied commits
     Working copy now at: yostqsxw bc4222f2 (empty) also already empty
     Parent commit      : vruxwmqv 6b41ecb2 (empty) already empty
-    "#);
+    ");
 
     // The parent commit became empty and was dropped, but the already empty commits
     // were kept
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  b
     ○  a
     ◆
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // Test the setup
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  will become empty
@@ -2603,7 +2581,7 @@ fn test_rebase_skip_emptied() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -2615,24 +2593,24 @@ fn test_rebase_skip_emptied() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Abandoned 1 newly emptied commits
     Working copy now at: yostqsxw 74149b9b (empty) also already empty
     Parent commit      : vruxwmqv 3bdb2801 (empty) already empty
     Added 0 files, modified 0 files, removed 1 files
-    "#);
+    ");
 
     // Rebasing a single commit which becomes empty abandons that commit, whilst its
     // already empty descendants were kept
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     │ ○  b
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
 }
 
 #[test]
@@ -2650,7 +2628,7 @@ fn test_rebase_skip_emptied_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "also already empty"]);
 
     // Test the setup
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  c (will become empty)
@@ -2658,30 +2636,30 @@ fn test_rebase_skip_emptied_descendants() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["rebase", "-r", "b", "--before", "c", "--skip-emptied"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq 353bac5c (empty) also already empty
     Parent commit      : yostqsxw 0a3f76fd (empty) already empty
-    "#);
+    ");
 
     // Commits not in the rebase target set should not be abandoned even if they
     // were emptied.
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  c (will become empty)
     ○  b
     ○  a
     ◆
-    "#);
+    ");
 }
 
 #[test]
@@ -2698,7 +2676,7 @@ fn test_rebase_skip_if_on_destination() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2710,16 +2688,16 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase with -b
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 6 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2731,17 +2709,17 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "c", "-d", "b1", "-d", "b2"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase with -s
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2753,16 +2731,16 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase with -r since commit has no children
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2774,19 +2752,19 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase of commit, but rebases children onto destination with -r
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 1 descendant commits
     Working copy now at: lylxulpl 77cb229f f | f
     Parent commit      : vruxwmqv c41e416e c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  77cb229f:  c
     │ ○  e  kmkuslsw  48dd9e3f:  c
     ├─╯
@@ -2799,7 +2777,7 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -30,7 +30,7 @@ fn test_report_conflicts() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln f8a2c4e0 (conflict) (empty) (no description set)
     Parent commit      : kkmpptxz 2271a49e (conflict) C
@@ -45,11 +45,11 @@ fn test_report_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln d70c003d (empty) (no description set)
     Parent commit      : kkmpptxz 43e94449 C
@@ -57,13 +57,13 @@ fn test_report_conflicts() {
     Existing conflicts were resolved or abandoned from these commits:
       kkmpptxz hidden 2271a49e (conflict) C
       rlvkpnrz hidden b7d83633 (conflict) B
-    "###);
+    ");
 
     // Can get hint about multiple root commits
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: zsuskuln 588bd15c (conflict) (empty) (no description set)
@@ -80,27 +80,27 @@ fn test_report_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 
     // Resolve one of the conflicts by (mostly) following the instructions
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "rlvkpnrzqnoo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 0485e30f (conflict) (empty) (no description set)
     Parent commit      : rlvkpnrz b42f84eb (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
-    "###);
+    ");
     std::fs::write(repo_path.join("file"), "resolved\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: yostqsxw f5a0cf8c (empty) (no description set)
     Parent commit      : rlvkpnrz 87370844 B
     Existing conflicts were resolved or abandoned from these commits:
       rlvkpnrz hidden b42f84eb (conflict) B
-    "###);
+    ");
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn test_report_conflicts_with_divergent_commits() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln?? 4ca807ad (conflict) C2
@@ -138,11 +138,11 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln?? f2d7a228 C2
     Parent commit      : kkmpptxz db069a22 B
@@ -151,13 +151,13 @@ fn test_report_conflicts_with_divergent_commits() {
       zsuskuln hidden 1db43f23 (conflict) C3
       zsuskuln hidden 4ca807ad (conflict) C2
       kkmpptxz hidden b42f84eb (conflict) B
-    "###);
+    ");
 
     // Same thing when rebasing the divergent commits one at a time
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(C2)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: zsuskuln?? 3c36afc9 (conflict) C2
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
@@ -171,12 +171,12 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(C3)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     New conflicts appeared in these commits:
       zsuskuln?? e3ff827e (conflict) C3
@@ -185,30 +185,30 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["rebase", "-s=description(C2)", "-d=description(B)"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: zsuskuln?? 1f9680bd C2
     Parent commit      : kkmpptxz db069a22 B
     Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from these commits:
       zsuskuln hidden 3c36afc9 (conflict) C2
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["rebase", "-s=description(C3)", "-d=description(B)"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Existing conflicts were resolved or abandoned from these commits:
       zsuskuln hidden e3ff827e (conflict) C3
-    "###);
+    ");
 }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -53,7 +53,7 @@ fn test_resolution() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -61,14 +61,12 @@ fn test_resolution() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict
-    "###);
+    @"file    2-sided conflict");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -76,7 +74,7 @@ fn test_resolution() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     let editor_script = test_env.set_up_fake_editor();
     // Check that output file starts out empty and resolve the conflict
@@ -87,18 +85,17 @@ fn test_resolution() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv e069f073 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
-    "###);
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
     --- a/file
@@ -112,11 +109,9 @@ fn test_resolution() {
     -b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    Error: No conflicts found at this revision
-    "###);
+    @"Error: No conflicts found at this revision");
 
     // Try again with --tool=<name>
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -130,15 +125,15 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 1a70c7c6 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]),
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
     --- a/file
@@ -152,11 +147,9 @@ fn test_resolution() {
     -b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]),
-    @r###"
-    Error: No conflicts found at this revision
-    "###);
+    @"Error: No conflicts found at this revision");
 
     // Check that the output file starts with conflict markers if
     // `merge-tool-edits-conflict-markers=true`
@@ -176,7 +169,7 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -184,9 +177,9 @@ fn test_resolution() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
     --- a/file
@@ -200,7 +193,7 @@ fn test_resolution() {
     -b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
-    "###);
+    ");
 
     // Check that if merge tool leaves conflict markers in output file and
     // `merge-tool-edits-conflict-markers=true`, these markers are properly parsed.
@@ -233,7 +226,7 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 608a2310 conflict | (conflict) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -248,9 +241,9 @@ fn test_resolution() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -258,10 +251,10 @@ fn test_resolution() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     // Note the "Modified" below
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -276,11 +269,9 @@ fn test_resolution() {
     -b
     +conflict
      >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict
-    "###);
+    @"file    2-sided conflict");
 
     // Check that if merge tool leaves conflict markers in output file but
     // `merge-tool-edits-conflict-markers=false` or is not specified,
@@ -308,19 +299,18 @@ fn test_resolution() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 3166dfd2 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor3")).unwrap(), @r###"
-    "###);
+        std::fs::read_to_string(test_env.env_root().join("editor3")).unwrap(), @"");
     // Note the "Resolved" below
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..0610716cc1 100644
     --- a/file
@@ -340,11 +330,9 @@ fn test_resolution() {
     ++++++++
     +conflict
     +>>>>>>>
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    Error: No conflicts found at this revision
-    "###);
+    @"Error: No conflicts found at this revision");
 
     // Check that merge tool can override conflict marker style setting, and that
     // the merge tool can output Git-style conflict markers
@@ -378,7 +366,7 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 8e03fefa conflict | (conflict) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -393,9 +381,9 @@ fn test_resolution() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor4")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("editor4")).unwrap(), @r"
     <<<<<<< Side #1 (Conflict 1 of 1)
     a
     ||||||| Base
@@ -403,9 +391,9 @@ fn test_resolution() {
     =======
     b
     >>>>>>> Side #2 (Conflict 1 of 1 ends)
-    "##);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -420,11 +408,9 @@ fn test_resolution() {
     -b
     +conflict
      >>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict
-    "###);
+    @"file    2-sided conflict");
 
     // Check that merge tool can leave conflict markers by returning exit code 1
     // when using `merge-conflict-exit-codes = [1]`. The Git "diff3" conflict
@@ -459,7 +445,7 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv a786ac2f conflict | (conflict) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -474,11 +460,11 @@ fn test_resolution() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor5")).unwrap(), @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -493,11 +479,9 @@ fn test_resolution() {
     -b
     +conflict
      >>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict
-    "###);
+    @"file    2-sided conflict");
 
     // Check that an error is reported if a merge tool indicated it would leave
     // conflict markers, but the output file didn't contain valid conflict markers.
@@ -528,11 +512,11 @@ fn test_resolution() {
         ],
     );
     // On Windows, the ExitStatus struct prints "exit code" instead of "exit status"
-    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r#"
+    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r"
     Resolving conflicts in: file
     Error: Failed to resolve conflicts
     Caused by: Tool exited with exit status: 1, but did not produce valid conflict markers (run with --debug to see the exact invocation)
-    "#);
+    ");
 
     // TODO: Check that running `jj new` and then `jj resolve -r conflict` works
     // correctly.
@@ -578,7 +562,7 @@ fn test_normal_conflict_input_files() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -586,14 +570,12 @@ fn test_normal_conflict_input_files() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict
-    "###);
+    @"file    2-sided conflict");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -601,7 +583,7 @@ fn test_normal_conflict_input_files() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "base", "base\n");
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "left", "a\n");
@@ -619,7 +601,7 @@ fn test_baseless_conflict_input_files() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -627,21 +609,19 @@ fn test_baseless_conflict_input_files() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict
-    "###);
+    @"file    2-sided conflict");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     +a
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "base", "");
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "left", "a\n");
@@ -660,21 +640,17 @@ fn test_too_many_parents() {
     create_commit(&test_env, &repo_path, "c", &["base"], &[("file", "c\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b", "c"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    3-sided conflict
-    "###);
+    @"file    3-sided conflict");
     // Test warning color
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
-    @r###"
-    file    [38;5;1m3-sided[38;5;3m conflict[39m
-    "###);
+    @"file    [38;5;1m3-sided[38;5;3m conflict[39m");
 
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(error, @r###"
+    insta::assert_snapshot!(error, @r#"
     Hint: Using default editor ':builtin'; run `jj config set --user ui.merge-editor :builtin` to disable this message.
     Error: Failed to resolve conflicts
     Caused by: The conflict at "file" has 3 sides. At most 2 sides are supported.
-    "###);
+    "#);
 }
 
 #[test]
@@ -710,17 +686,17 @@ fn test_simplify_conflict_sides() {
     // Even though the tree-level conflict is a 4-sided conflict, each file is
     // materialized as a 2-sided conflict.
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["debug", "tree"]),
-    @r###"
+    @r#"
     fileA: Ok(Conflicted([Some(File { id: FileId("d00491fd7e5bb6fa28c517a0bb32b8b506539d4d"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("0cfbf08886fca9a91cb753ec8734c84fcbe52c9f"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false })]))
     fileB: Ok(Conflicted([Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("d00491fd7e5bb6fa28c517a0bb32b8b506539d4d"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("0cfbf08886fca9a91cb753ec8734c84fcbe52c9f"), executable: false })]))
-    "###);
+    "#);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-    @r###"
+    @r"
     fileA    2-sided conflict
     fileB    2-sided conflict
-    "###);
+    ");
     insta::assert_snapshot!(
-    std::fs::read_to_string(repo_path.join("fileA")).unwrap(), @r###"
+    std::fs::read_to_string(repo_path.join("fileA")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -728,9 +704,9 @@ fn test_simplify_conflict_sides() {
     +++++++ Contents of side #2
     2
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(
-    std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r###"
+    std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -738,7 +714,7 @@ fn test_simplify_conflict_sides() {
     +++++++ Contents of side #2
     2
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Conflict should be simplified before being handled by external merge tool.
     check_resolve_produces_input_file(&mut test_env, &repo_path, "fileA", "base", "base\n");
@@ -774,7 +750,7 @@ fn test_simplify_conflict_sides() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: fileB
     Working copy now at: nkmrtpmo 69cc0c2d conflict | (conflict) conflict
     Parent commit      : kmkuslsw 4601566f conflictA | (conflict) (empty) conflictA
@@ -790,8 +766,8 @@ fn test_simplify_conflict_sides() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
-    insta::assert_snapshot!(std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r###"
+    ");
+    insta::assert_snapshot!(std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base_edited
@@ -799,12 +775,12 @@ fn test_simplify_conflict_sides() {
     +++++++ Contents of side #2
     2_edited
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-    @r###"
+    @r"
     fileA    2-sided conflict
     fileB    2-sided conflict
-    "###);
+    ");
 }
 
 #[test]
@@ -819,7 +795,7 @@ fn test_edit_delete_conflict_input_files() {
     std::fs::remove_file(repo_path.join("file")).unwrap();
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -827,21 +803,19 @@ fn test_edit_delete_conflict_input_files() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict including 1 deletion
-    "###);
+    @"file    2-sided conflict including 1 deletion");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     a
     %%%%%%% Changes from base to side #2
     -base
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "base", "base\n");
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "left", "a\n");
@@ -862,7 +836,7 @@ fn test_file_vs_dir() {
     // Without a placeholder file, `jj` ignores an empty directory
     std::fs::write(repo_path.join("file").join("placeholder"), "").unwrap();
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -870,14 +844,12 @@ fn test_file_vs_dir() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    2-sided conflict including a directory
-    "###);
+    @"file    2-sided conflict including a directory");
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(error, @r###"
+    insta::assert_snapshot!(error, @r#"
     Hint: Using default editor ':builtin'; run `jj config set --user ui.merge-editor :builtin` to disable this message.
     Error: Failed to resolve conflicts
     Caused by: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
@@ -885,8 +857,7 @@ fn test_file_vs_dir() {
       Removing file with id df967b96a579e45a18b8251732d16804b2e56a55
       Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877
-
-    "###);
+    "#);
 }
 
 #[test]
@@ -911,7 +882,7 @@ fn test_description_with_dir_and_deletion() {
         &["edit", "dir", "del"],
         &[],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @      conflict
     ├─┬─╮
     │ │ ○  del
@@ -921,19 +892,15 @@ fn test_description_with_dir_and_deletion() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    file    3-sided conflict including 1 deletion and a directory
-    "###);
+    @"file    3-sided conflict including 1 deletion and a directory");
     // Test warning color. The deletion is fine, so it's not highlighted
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
-    @r###"
-    file    [38;5;1m3-sided[38;5;3m conflict including 1 deletion and [38;5;1ma directory[39m
-    "###);
+    @"file    [38;5;1m3-sided[38;5;3m conflict including 1 deletion and [38;5;1ma directory[39m");
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(error, @r###"
+    insta::assert_snapshot!(error, @r#"
     Hint: Using default editor ':builtin'; run `jj config set --user ui.merge-editor :builtin` to disable this message.
     Error: Failed to resolve conflicts
     Caused by: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
@@ -942,8 +909,7 @@ fn test_description_with_dir_and_deletion() {
       Removing file with id df967b96a579e45a18b8251732d16804b2e56a55
       Adding file with id 61780798228d17af2d34fce4cfbdf35556832472
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877
-
-    "###);
+    "#);
 }
 
 #[test]
@@ -979,13 +945,13 @@ fn test_resolve_conflicts_with_executable() {
     test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "x", "file2"]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r#"
+    @r"
     file1    2-sided conflict including an executable
     file2    2-sided conflict including an executable
-    "#);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file1")).unwrap(),
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base1
@@ -993,11 +959,11 @@ fn test_resolve_conflicts_with_executable() {
     +++++++ Contents of side #2
     b1
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file2")).unwrap(),
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base2
@@ -1005,15 +971,15 @@ fn test_resolve_conflicts_with_executable() {
     +++++++ Contents of side #2
     b2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     let editor_script = test_env.set_up_fake_editor();
 
     // Test resolving the conflict in "file1", which should produce an executable
     std::fs::write(&editor_script, b"write\nresolution1\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "file1"]);
-    insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file1
     Working copy now at: znkkpsqq eb159d56 conflict | (conflict) conflict
     Parent commit      : mzvwutvl 08932848 a | a
@@ -1028,9 +994,9 @@ fn test_resolve_conflicts_with_executable() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100755
     --- a/file1
@@ -1044,7 +1010,7 @@ fn test_resolve_conflicts_with_executable() {
     -b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
-    "##);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
         @"file2    2-sided conflict including an executable"
@@ -1054,8 +1020,8 @@ fn test_resolve_conflicts_with_executable() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&editor_script, b"write\nresolution2\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "file2"]);
-    insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file2
     Working copy now at: znkkpsqq 4dccbb3c conflict | (conflict) conflict
     Parent commit      : mzvwutvl 08932848 a | a
@@ -1070,9 +1036,9 @@ fn test_resolve_conflicts_with_executable() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file2 b/file2
     index 0000000000..775f078581 100755
     --- a/file2
@@ -1086,7 +1052,7 @@ fn test_resolve_conflicts_with_executable() {
     -b2
     ->>>>>>> Conflict 1 of 1 ends
     +resolution2
-    "##);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
         @"file1    2-sided conflict including an executable"
@@ -1129,7 +1095,7 @@ fn test_resolve_long_conflict_markers() {
     @"file    2-sided conflict");
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file")).unwrap(),
-        @r##"
+        @r"
     <<<<<<<<<<< Conflict 1 of 1
     +++++++++++ Contents of side #1
     <<<<<<< a
@@ -1138,7 +1104,7 @@ fn test_resolve_long_conflict_markers() {
     +++++++++++ Contents of side #2
     >>>>>>> b
     >>>>>>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     let editor_script = test_env.set_up_fake_editor();
     // Allow signaling that conflict markers were produced even if not editing
@@ -1163,8 +1129,8 @@ fn test_resolve_long_conflict_markers() {
     )
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 2b985546 conflict | (conflict) conflict
     Parent commit      : zsuskuln 64177fd4 a | a
@@ -1179,9 +1145,9 @@ fn test_resolve_long_conflict_markers() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -1202,7 +1168,7 @@ fn test_resolve_long_conflict_markers() {
     ++++++++ Contents of side #2
     +B
     +>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
         @"file    2-sided conflict"
@@ -1234,8 +1200,8 @@ fn test_resolve_long_conflict_markers() {
             "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
         ],
     );
-    insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv fac9406d conflict | (conflict) conflict
     Parent commit      : zsuskuln 64177fd4 a | a
@@ -1250,9 +1216,9 @@ fn test_resolve_long_conflict_markers() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r"
     <<<<<<<<<<< Conflict 1 of 1
     +++++++++++ Contents of side #1
     <<<<<<< a
@@ -1261,9 +1227,9 @@ fn test_resolve_long_conflict_markers() {
     +++++++++++ Contents of side #2
     >>>>>>> b
     >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -1279,7 +1245,7 @@ fn test_resolve_long_conflict_markers() {
     ->>>>>>> b
     +>>>>>>> B
      >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
         @"file    2-sided conflict"
@@ -1311,8 +1277,8 @@ fn test_resolve_long_conflict_markers() {
             r#"--config=merge-tools.fake-editor.merge-args=["$output", "$marker_length"]"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stdout, @"");
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 1b29631a conflict | (conflict) conflict
     Parent commit      : zsuskuln 64177fd4 a | a
@@ -1327,9 +1293,9 @@ fn test_resolve_long_conflict_markers() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -1345,7 +1311,7 @@ fn test_resolve_long_conflict_markers() {
     ->>>>>>> b
     +>>>>>>> B
      >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
         @"file    2-sided conflict"
@@ -1399,7 +1365,7 @@ fn test_multiple_conflicts() {
     );
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -1407,10 +1373,10 @@ fn test_multiple_conflicts() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("this_file_has_a_very_long_name_to_test_padding")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -first base
@@ -1418,10 +1384,10 @@ fn test_multiple_conflicts() {
     +++++++ Contents of side #2
     first b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("another_file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -second base
@@ -1429,18 +1395,18 @@ fn test_multiple_conflicts() {
     +++++++ Contents of side #2
     second b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     another_file                        2-sided conflict
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
-    "###);
+    ");
     // Test colors
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
-    @r###"
+    @r"
     another_file                        [38;5;3m2-sided conflict[39m
     this_file_has_a_very_long_name_to_test_padding [38;5;3m2-sided conflict[39m
-    "###);
+    ");
 
     let editor_script = test_env.set_up_fake_editor();
 
@@ -1448,7 +1414,7 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "another_file"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: another_file
     Working copy now at: vruxwmqv 309e981c conflict | (conflict) conflict
     Parent commit      : zsuskuln de7553ef a | a
@@ -1463,9 +1429,9 @@ fn test_multiple_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/another_file b/another_file
     index 0000000000..a9fcc7d486 100644
     --- a/another_file
@@ -1479,11 +1445,9 @@ fn test_multiple_conflicts() {
     -second b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution another_file
-    "###);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    this_file_has_a_very_long_name_to_test_padding 2-sided conflict
-    "###);
+    @"this_file_has_a_very_long_name_to_test_padding 2-sided conflict");
 
     // Repeat the above with the `--quiet` option.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -1510,7 +1474,7 @@ fn test_multiple_conflicts() {
     .unwrap();
     test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/another_file b/another_file
     index 0000000000..7903e1c1c7 100644
     --- a/another_file
@@ -1537,16 +1501,12 @@ fn test_multiple_conflicts() {
     -first b
     ->>>>>>> Conflict 1 of 1 ends
     +second resolution for auto-chosen file
-    "###);
+    ");
 
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
-    @r###"
-    Error: No conflicts found at this revision
-    "###);
+    @"Error: No conflicts found at this revision");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve"]), 
-    @r###"
-    Error: No conflicts found at this revision
-    "###);
+    @"Error: No conflicts found at this revision");
 }
 
 #[test]
@@ -1583,13 +1543,13 @@ fn test_multiple_conflicts_with_error() {
     );
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r#"
+    @r"
     file1    2-sided conflict
     file2    2-sided conflict
-    "#);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file1")).unwrap(),
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base1
@@ -1597,11 +1557,11 @@ fn test_multiple_conflicts_with_error() {
     +++++++ Contents of side #2
     b1
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file2")).unwrap(),
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base2
@@ -1609,7 +1569,7 @@ fn test_multiple_conflicts_with_error() {
     +++++++ Contents of side #2
     b2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     let editor_script = test_env.set_up_fake_editor();
 
@@ -1620,7 +1580,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r#"
+    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r"
     Resolving conflicts in: file1
     Resolving conflicts in: file2
     Working copy now at: vruxwmqv d2f3f858 conflict | (conflict) conflict
@@ -1638,9 +1598,9 @@ fn test_multiple_conflicts_with_error() {
     Then run `jj squash` to move the resolution into the conflicted commit.
     Error: Stopped due to error after resolving 1 conflicts
     Caused by: The output file is either unchanged or empty after the editor quit (run with --debug to see the exact invocation).
-    "#);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644
     --- a/file1
@@ -1654,7 +1614,7 @@ fn test_multiple_conflicts_with_error() {
     -b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
-    "##);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
         @"file2    2-sided conflict"
@@ -1668,7 +1628,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r#"
+    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r"
     Resolving conflicts in: file1
     Resolving conflicts in: file2
     Working copy now at: vruxwmqv 0a54e8ed conflict | (conflict) conflict
@@ -1686,9 +1646,9 @@ fn test_multiple_conflicts_with_error() {
     Then run `jj squash` to move the resolution into the conflicted commit.
     Error: Stopped due to error after resolving 1 conflicts
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "#);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644
     --- a/file1
@@ -1702,7 +1662,7 @@ fn test_multiple_conflicts_with_error() {
     -b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
-    "##);
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
         @"file2    2-sided conflict"
@@ -1712,17 +1672,17 @@ fn test_multiple_conflicts_with_error() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&editor_script, "fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r#"
+    insta::assert_snapshot!(stderr.replace("exit code", "exit status"), @r"
     Resolving conflicts in: file1
     Error: Failed to resolve conflicts
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "#);
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @"");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @r#"
+        @r"
     file1    2-sided conflict
     file2    2-sided conflict
-    "#
+    "
     );
 }

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -32,33 +32,31 @@ fn test_restore() {
 
     // There is no `-r` argument
     let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "-r=@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: `jj restore` does not have a `--revision`/`-r` option. If you'd like to modify
     the *current* revision, use `--from`. If you'd like to modify a *different* revision,
     use `--into` or `--changes-in`.
-    "###);
+    ");
 
     // Restores from parent by default
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 370d81ea (empty) (no description set)
     Working copy now at: kkmpptxz 370d81ea (empty) (no description set)
     Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 1 files, modified 1 files, removed 1 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
 
     // Can restore another revision from its parents
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
-    insta::assert_snapshot!(stdout, @r###"
-    A file2
-    "###);
+    insta::assert_snapshot!(stdout, @"A file2");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "-c=@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz b9b6011e (empty) (no description set)
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 5b361547 (conflict) (no description set)
@@ -73,7 +71,7 @@ fn test_restore() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
     insta::assert_snapshot!(stdout, @"");
 
@@ -81,70 +79,66 @@ fn test_restore() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 1154634b (no description set)
     Working copy now at: kkmpptxz 1154634b (no description set)
     Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 1 files, modified 0 files, removed 2 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
-    D file2
-    "###);
+    insta::assert_snapshot!(stdout, @"D file2");
 
     // Can restore into other revision
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "--into", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz ad805965 (no description set)
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 3fcdcbf2 (empty) (no description set)
     Parent commit      : rlvkpnrz ad805965 (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     A file2
     A file3
-    "###);
+    ");
 
     // Can combine `--from` and `--into`
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["restore", "--from", "@", "--into", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz f256040a (no description set)
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 9c6f2083 (empty) (no description set)
     Parent commit      : rlvkpnrz f256040a (no description set)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     A file2
     A file3
-    "###);
+    ");
 
     // Can restore only specified paths
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 4ad35a2f (no description set)
     Working copy now at: kkmpptxz 4ad35a2f (no description set)
     Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 0 files, modified 1 files, removed 1 files
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
-    D file1
-    "###);
+    insta::assert_snapshot!(stdout, @"D file1");
 }
 
 // Much of this test is copied from test_resolve_command
@@ -159,7 +153,7 @@ fn test_restore_conflicted_merge() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -167,10 +161,10 @@ fn test_restore_conflicted_merge() {
     ├─╯
     ○  base
     ◆
-    "###);
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -178,12 +172,12 @@ fn test_restore_conflicted_merge() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Overwrite the file...
     std::fs::write(repo_path.join("file"), "resolution").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
-    @r###"
+    @r"
     Resolved conflict in file:
        1     : <<<<<<< Conflict 1 of 1
        2     : %%%%%%% Changes from base to side #1
@@ -193,12 +187,12 @@ fn test_restore_conflicted_merge() {
        6     : b
        7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
-    "###);
+    ");
 
     // ...and restore it back again.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "file"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created vruxwmqv 25a37060 conflict | (conflict) (empty) conflict
     Working copy now at: vruxwmqv 25a37060 conflict | (conflict) (empty) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -206,10 +200,10 @@ fn test_restore_conflicted_merge() {
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict
-    "###);
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -217,14 +211,14 @@ fn test_restore_conflicted_merge() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
     insta::assert_snapshot!(stdout, @"");
 
     // The same, but without the `file` argument. Overwrite the file...
     std::fs::write(repo_path.join("file"), "resolution").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
-    @r###"
+    @r"
     Resolved conflict in file:
        1     : <<<<<<< Conflict 1 of 1
        2     : %%%%%%% Changes from base to side #1
@@ -234,12 +228,12 @@ fn test_restore_conflicted_merge() {
        6     : b
        7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
-    "###);
+    ");
 
     // ... and restore it back again.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created vruxwmqv f2c82b9c conflict | (conflict) (empty) conflict
     Working copy now at: vruxwmqv f2c82b9c conflict | (conflict) (empty) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -247,10 +241,10 @@ fn test_restore_conflicted_merge() {
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict
-    "###);
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -258,7 +252,7 @@ fn test_restore_conflicted_merge() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 }
 
 #[test]
@@ -284,7 +278,7 @@ fn test_restore_restore_descendants() {
         &[("file", "ab\n")],
     );
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    ab
     ├─╮
     │ ○  b
@@ -292,11 +286,9 @@ fn test_restore_restore_descendants() {
     ├─╯
     ○  base
     ◆
-    "#);
+    ");
     insta::assert_snapshot!(
-    std::fs::read_to_string(repo_path.join("file")).unwrap(), @r#"
-    ab
-    "#);
+    std::fs::read_to_string(repo_path.join("file")).unwrap(), @"ab");
 
     // Commit "b" was not supposed to modify "file", restore it from its parent
     // while preserving its child commit content.
@@ -305,13 +297,13 @@ fn test_restore_restore_descendants() {
         &["restore", "-c", "b", "file", "--restore-descendants"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Created royxmykx 3fd5aa05 b | b
     Rebased 1 descendant commits (while preserving their content)
     Working copy now at: vruxwmqv bf5491a0 ab | ab
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx 3fd5aa05 b | b
-    "#);
+    ");
 
     // Check that "a", "b", and "ab" have their expected content by diffing them.
     // "ab" must have kept its content.
@@ -331,7 +323,7 @@ fn test_restore_restore_descendants() {
     @@ -0,0 +1,1 @@
     +b
     ");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--from=b", "--to=ab", "--git"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--from=b", "--to=ab", "--git"]), @r"
     diff --git a/file b/file
     index df967b96a5..81bf396956 100644
     --- a/file
@@ -339,7 +331,7 @@ fn test_restore_restore_descendants() {
     @@ -1,1 +1,1 @@
     -base
     +ab
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -33,7 +33,7 @@ fn test_syntax_error() {
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "x &"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Syntax error
     Caused by:  --> 1:4
       |
@@ -41,7 +41,7 @@ fn test_syntax_error() {
       |    ^---
       |
       = expected `::`, `..`, `~`, or <primary>
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "x - y"]);
     insta::assert_snapshot!(stderr, @r"
@@ -119,7 +119,7 @@ fn test_bad_function_call() {
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "latest(a, not_an_integer)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Expected expression of type integer
     Caused by:  --> 1:11
       |
@@ -127,7 +127,7 @@ fn test_bad_function_call() {
       |           ^------------^
       |
       = Expected expression of type integer
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "files()"]);
     insta::assert_snapshot!(stderr, @r"
@@ -141,7 +141,7 @@ fn test_bad_function_call() {
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "files(not::a-fileset)"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: In fileset expression
     Caused by:
     1:  --> 1:7
@@ -157,7 +157,7 @@ fn test_bad_function_call() {
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
     Hint: See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
-    "#);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", r#"files(foo:"bar")"#]);
     insta::assert_snapshot!(stderr, @r#"
@@ -179,7 +179,7 @@ fn test_bad_function_call() {
     "#);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", r#"files(a, "../out")"#]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Error: Failed to parse revset: In fileset expression
     Caused by:
     1:  --> 1:10
@@ -196,7 +196,7 @@ fn test_bad_function_call() {
       = Invalid file pattern
     3: Path "../out" is not in the repo "."
     4: Invalid component ".." in repo-relative path "../out"
-    "###);
+    "#);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "bookmarks(bad:pattern)"]);
     insta::assert_snapshot!(stderr, @r"
@@ -213,7 +213,7 @@ fn test_bad_function_call() {
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "bookmarks(regex:'(')"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Invalid string pattern
     Caused by:
     1:  --> 1:11
@@ -226,7 +226,7 @@ fn test_bad_function_call() {
         (
         ^
     error: unclosed group
-    "###);
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root()::whatever()"]);
     insta::assert_snapshot!(stderr, @r"
@@ -277,7 +277,7 @@ fn test_bad_function_call() {
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_bookmarks(remote=)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Syntax error
     Caused by:  --> 1:25
       |
@@ -285,7 +285,7 @@ fn test_bad_function_call() {
       |                         ^---
       |
       = expected <expression>
-    "###);
+    ");
 }
 
 #[test]
@@ -304,7 +304,7 @@ fn test_parse_warning() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: In revset expression
      --> 1:1
       |
@@ -333,11 +333,11 @@ fn test_parse_warning() {
       |                                                              ^-----------------------^
       |
       = untracked_remote_branches() is deprecated; use untracked_remote_bookmarks() instead
-    "#);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "files(foo, bar)"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: In revset expression
      --> 1:7
       |
@@ -345,7 +345,7 @@ fn test_parse_warning() {
       |       ^------^
       |
       = Multi-argument patterns syntax is deprecated; separate them with |
-    "###);
+    ");
 }
 
 #[test]
@@ -429,14 +429,10 @@ fn test_alias() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  zzzzzzzz root() 00000000
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  zzzzzzzz root() 00000000");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  zzzzzzzz root() 00000000
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  zzzzzzzz root() 00000000");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root() & syntax-error"]);
     insta::assert_snapshot!(stderr, @r"
@@ -596,9 +592,7 @@ fn test_bad_alias_decl() {
 
     // Invalid declaration should be warned and ignored.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "my-root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    ◆  zzzzzzzz root() 00000000
-    "###);
+    insta::assert_snapshot!(stdout, @"◆  zzzzzzzz root() 00000000");
     insta::assert_snapshot!(stderr, @r#"
     Warning: Failed to load `revset-aliases."bad"`:  --> 1:1
       |
@@ -631,23 +625,19 @@ fn test_all_modifier() {
     Hint: Prefix the expression with `all:` to allow any number of revisions (i.e. `all:all()`).
     ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "all:all()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The Git backend does not support creating merge commits with the root commit as one of the parents.");
 
     // Command that accepts multiple revisions by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rall:all()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     // Command that accepts only single revision
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-rall:@", "x"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Created 1 bookmarks pointing to qpvuntsm 230dd059 x | (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stderr, @"Created 1 bookmarks pointing to qpvuntsm 230dd059 x | (empty) (no description set)");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "set", "-rall:all()", "x"]);
     insta::assert_snapshot!(stderr, @r"
     Error: Revset `all:all()` resolved to more than one revision
@@ -658,10 +648,10 @@ fn test_all_modifier() {
 
     // Template expression that accepts multiple revisions by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-Tself.contained_in('all:all()')"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  true
     ◆  true
-    "###);
+    ");
 
     // Typo
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "ale:x"]);
@@ -798,43 +788,37 @@ fn test_revset_committer_date_with_time_zone() {
 
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-25 12:00", "2023-02-01T00:00:00-05:00", NEW_YORK);
-    insta::assert_snapshot!(before_log, @r###"
-    first 2023-01-25 11:30:00.000 -05:00
-    "###);
-    insta::assert_snapshot!(after_log, @r###"
+    insta::assert_snapshot!(before_log, @"first 2023-01-25 11:30:00.000 -05:00");
+    insta::assert_snapshot!(after_log, @r"
     third 2023-01-25 13:30:00.000 -05:00
     second 2023-01-25 12:30:00.000 -05:00
-    "###);
+    ");
 
     // Switch to DST and ensure we get the same results, because it should
     // evaluate 12:00 on commit date, not the current date
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-25 12:00", "2023-06-01T00:00:00-04:00", NEW_YORK);
-    insta::assert_snapshot!(before_log, @r###"
-    first 2023-01-25 11:30:00.000 -05:00
-    "###);
-    insta::assert_snapshot!(after_log, @r###"
+    insta::assert_snapshot!(before_log, @"first 2023-01-25 11:30:00.000 -05:00");
+    insta::assert_snapshot!(after_log, @r"
     third 2023-01-25 13:30:00.000 -05:00
     second 2023-01-25 12:30:00.000 -05:00
-    "###);
+    ");
 
     // Change the local time zone and ensure the result changes
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-25 12:00", "2023-06-01T00:00:00-06:00", CHICAGO);
-    insta::assert_snapshot!(before_log, @r###"
+    insta::assert_snapshot!(before_log, @r"
     second 2023-01-25 12:30:00.000 -05:00
     first 2023-01-25 11:30:00.000 -05:00
-    "###);
+    ");
     insta::assert_snapshot!(after_log, @"third 2023-01-25 13:30:00.000 -05:00");
 
     // Time zone far outside USA with no DST
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-26 03:00", "2023-06-01T00:00:00+10:00", AUSTRALIA);
-    insta::assert_snapshot!(before_log, @r###"
-    first 2023-01-25 11:30:00.000 -05:00
-    "###);
-    insta::assert_snapshot!(after_log, @r###"
+    insta::assert_snapshot!(before_log, @"first 2023-01-25 11:30:00.000 -05:00");
+    insta::assert_snapshot!(after_log, @r"
     third 2023-01-25 13:30:00.000 -05:00
     second 2023-01-25 12:30:00.000 -05:00
-    "###);
+    ");
 }

--- a/cli/tests/test_root.rs
+++ b/cli/tests/test_root.rs
@@ -36,7 +36,5 @@ fn test_root(backend: TestRepoBackend) {
 fn test_root_outside_a_repo() {
     let test_env = TestEnvironment::default();
     let stdout = test_env.jj_cmd_failure(Path::new("/"), &["root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    Error: There is no jj repo in "."
-    "###);
+    insta::assert_snapshot!(stdout, @r#"Error: There is no jj repo in ".""#);
 }

--- a/cli/tests/test_shell_completion.rs
+++ b/cli/tests/test_shell_completion.rs
@@ -23,10 +23,10 @@ fn test_deprecated_flags() {
         test_env.jj_cmd_ok(test_env.env_root(), &["util", "completion", "--bash"]);
     assert_snapshot!(
         stderr,
-        @r###"
+        @r"
     Warning: `jj util completion --bash` will be removed in a future version, and this will be a hard error
     Hint: Use `jj util completion bash` instead
-    "###
+    "
     );
     assert!(stdout.contains("COMPREPLY"));
 }

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -26,12 +26,12 @@ fn test_show() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["show"]);
     let stdout = stdout.lines().skip(2).join("\n");
 
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:07)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:07)
 
         (no description set)
-    "#);
+    ");
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_show_basic() {
     std::fs::write(repo_path.join("file3"), "foo\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -61,10 +61,10 @@ fn test_show_basic() {
             2: bar
        2    3: baz quxquux
     Modified regular file file3 (file1 => file3):
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--context=0"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -77,10 +77,10 @@ fn test_show_basic() {
             2: bar
        2    3: baz quxquux
     Modified regular file file3 (file1 => file3):
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: [38;5;4m<<commit_id::e34f04317a81edc6ba41fef239c0d0180f10656f>>[39m
     Change ID: [38;5;5m<<change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m
     Author   : [38;5;3m<<author name::Test User>>[39m <[38;5;3m<<author email local::test.user>><<author email::@>><<author email domain::example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
@@ -93,10 +93,10 @@ fn test_show_basic() {
     <<diff::     >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::bar>>[24m[39m
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   3>>[39m<<diff::: baz >>[4m[38;5;1m<<diff removed token::qux>>[38;5;2m<<diff added token::quux>>[24m[39m<<diff::>>
     [38;5;3m<<diff header::Modified regular file file3 (file1 => file3):>>[39m
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-s"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -106,10 +106,10 @@ fn test_show_basic() {
 
     M file2
     R {file1 => file3}
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--types"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -119,10 +119,10 @@ fn test_show_basic() {
 
     FF file2
     FF {file1 => file3}
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -142,10 +142,10 @@ fn test_show_basic() {
     diff --git a/file1 b/file3
     rename from file1
     rename to file3
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--git", "--context=0"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -164,10 +164,10 @@ fn test_show_basic() {
     diff --git a/file1 b/file3
     rename from file1
     rename to file3
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--git", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: [38;5;4m<<commit_id::e34f04317a81edc6ba41fef239c0d0180f10656f>>[39m
     Change ID: [38;5;5m<<change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m
     Author   : [38;5;3m<<author name::Test User>>[39m <[38;5;3m<<author email local::test.user>><<author email::@>><<author email domain::example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
@@ -187,10 +187,10 @@ fn test_show_basic() {
     [1m<<diff file_header::diff --git a/file1 b/file3>>[0m
     [1m<<diff file_header::rename from file1>>[0m
     [1m<<diff file_header::rename to file3>>[0m
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-s", "--git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -212,10 +212,10 @@ fn test_show_basic() {
     diff --git a/file1 b/file3
     rename from file1
     rename to file3
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--stat"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -226,7 +226,7 @@ fn test_show_basic() {
     file2            | 3 ++-
     {file1 => file3} | 0
     2 files changed, 2 insertions(+), 1 deletion(-)
-    "#);
+    ");
 }
 
 #[test]
@@ -238,9 +238,7 @@ fn test_show_with_template() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-T", "description"]);
 
-    insta::assert_snapshot!(stdout, @r###"
-    a new commit
-    "###);
+    insta::assert_snapshot!(stdout, @"a new commit");
 }
 
 #[test]
@@ -295,10 +293,10 @@ fn test_show_relative_timestamps() {
         .map(|x| timestamp_re.replace_all(x, "(...timestamp...)"))
         .join("\n");
 
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Author   : Test User <test.user@example.com> (...timestamp...)
     Committer: Test User <test.user@example.com> (...timestamp...)
 
         (no description set)
-    "#);
+    ");
 }

--- a/cli/tests/test_simplify_parents_command.rs
+++ b/cli/tests/test_simplify_parents_command.rs
@@ -43,9 +43,7 @@ fn test_simplify_parents_no_commits() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["simplify-parents", "-r", "root() ~ root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 }
 
 #[test]
@@ -53,9 +51,7 @@ fn test_simplify_parents_immutable() {
     let (test_env, repo_path) = create_repo();
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["simplify-parents", "-r", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The root commit 000000000000 is immutable
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The root commit 000000000000 is immutable");
 }
 
 #[test]
@@ -65,24 +61,22 @@ fn test_simplify_parents_no_change() {
     create_commit(&test_env, &repo_path, "a", &["root()"]);
     create_commit(&test_env, &repo_path, "b", &["a"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  b
     ○  a
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["simplify-parents", "-s", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  b
     ○  a
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -94,7 +88,7 @@ fn test_simplify_parents_no_change_diamond() {
     create_commit(&test_env, &repo_path, "c", &["a"]);
     create_commit(&test_env, &repo_path, "d", &["b", "c"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    d
     ├─╮
     │ ○  c
@@ -102,17 +96,15 @@ fn test_simplify_parents_no_change_diamond() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["simplify-parents", "-r", "all() ~ root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    d
     ├─╮
     │ ○  c
@@ -120,7 +112,7 @@ fn test_simplify_parents_no_change_diamond() {
     ├─╯
     ○  a
     ◆
-    "###);
+    ");
 }
 
 #[test_case(&["simplify-parents", "-r", "@", "-r", "@-"] ; "revisions")]
@@ -133,35 +125,35 @@ fn test_simplify_parents_redundant_parent(args: &[&str]) {
     create_commit(&test_env, &repo_path, "c", &["a", "b"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         @    c
         ├─╮
         │ ○  b
         ├─╯
         ○  a
         ◆
-        "###);
+        ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, args);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r"
         Removed 1 edges from 1 out of 3 commits.
         Working copy now at: royxmykx 0ac2063b c | c
         Parent commit      : zsuskuln 1394f625 b | b
-        "###);
+        ");
     }
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         @  c
         ○  b
         ○  a
         ◆
-        "###);
+        ");
     }
 }
 
@@ -176,7 +168,7 @@ fn test_simplify_parents_multiple_redundant_parents() {
     create_commit(&test_env, &repo_path, "e", &["d"]);
     create_commit(&test_env, &repo_path, "f", &["d", "e"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @    f
     ├─╮
     │ ○  e
@@ -188,22 +180,22 @@ fn test_simplify_parents_multiple_redundant_parents() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test with `-r`.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["simplify-parents", "-r", "c", "-r", "f"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Removed 2 edges from 2 out of 2 commits.
     Rebased 2 descendant commits
     Working copy now at: kmkuslsw 8cc01e1b f | f
     Parent commit      : znkkpsqq 040ae3a6 e | e
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  f
     ○  e
     ○  d
@@ -211,21 +203,21 @@ fn test_simplify_parents_multiple_redundant_parents() {
     ○  b
     ○  a
     ◆
-    "#);
+    ");
 
     // Test with `-s`.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["simplify-parents", "-s", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Removed 2 edges from 2 out of 4 commits.
     Rebased 2 descendant commits
     Working copy now at: kmkuslsw 70a39dff f | f
     Parent commit      : znkkpsqq a021fee9 e | e
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  f
     ○  e
     ○  d
@@ -233,7 +225,7 @@ fn test_simplify_parents_multiple_redundant_parents() {
     ○  b
     ○  a
     ◆
-    "#);
+    ");
 }
 
 #[test]
@@ -247,7 +239,7 @@ fn test_simplify_parents_no_args() {
     create_commit(&test_env, &repo_path, "e", &["d"]);
     create_commit(&test_env, &repo_path, "f", &["d", "e"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @    f
     ├─╮
     │ ○  e
@@ -259,20 +251,20 @@ fn test_simplify_parents_no_args() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["simplify-parents"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Removed 2 edges from 2 out of 6 commits.
     Rebased 2 descendant commits
     Working copy now at: kmkuslsw 8cc01e1b f | f
     Parent commit      : znkkpsqq 040ae3a6 e | e
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  f
     ○  e
     ○  d
@@ -280,21 +272,21 @@ fn test_simplify_parents_no_args() {
     ○  b
     ○  a
     ◆
-    "#);
+    ");
 
     // Test with custom `revsets.simplify-parents`.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     test_env.add_config(r#"revsets.simplify-parents = "d::""#);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["simplify-parents"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Removed 1 edges from 1 out of 3 commits.
     Working copy now at: kmkuslsw 0c6b4c43 f | f
     Parent commit      : znkkpsqq 6a679611 e | e
-    "#);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  f
     ○  e
     ○  d
@@ -304,5 +296,5 @@ fn test_simplify_parents_no_args() {
     ├─╯
     ○  a
     ◆
-    "#);
+    ");
 }

--- a/cli/tests/test_sparse_command.rs
+++ b/cli/tests/test_sparse_command.rs
@@ -31,16 +31,12 @@ fn test_sparse_manage_patterns() {
 
     // By default, all files are tracked
     let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    .
-    "###);
+    insta::assert_snapshot!(stdout, @".");
 
     // Can stop tracking all files
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["sparse", "set", "--remove", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Added 0 files, modified 0 files, removed 3 files
-    "###);
+    insta::assert_snapshot!(stderr, @"Added 0 files, modified 0 files, removed 3 files");
     // The list is now empty
     let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @"");
@@ -50,11 +46,11 @@ fn test_sparse_manage_patterns() {
     assert!(!repo_path.join("file3").exists());
     // But they're still in the commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1
     file2
     file3
-    "###);
+    ");
 
     // Run commands in sub directory to ensure that patterns are parsed as
     // workspace-relative paths, not cwd-relative ones.
@@ -63,11 +59,11 @@ fn test_sparse_manage_patterns() {
 
     // Not a workspace-relative path
     let stderr = test_env.jj_cmd_cli_error(&sub_dir, &["sparse", "set", "--add=../file2"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     error: invalid value '../file2' for '--add <ADD>': Invalid component ".." in repo-relative path "../file2"
 
     For more information, try '--help'.
-    "###);
+    "#);
 
     // Can `--add` a few files
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -75,14 +71,12 @@ fn test_sparse_manage_patterns() {
         &["sparse", "set", "--add", "file2", "--add", "file3"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Added 2 files, modified 0 files, removed 0 files
-    "###);
+    insta::assert_snapshot!(stderr, @"Added 2 files, modified 0 files, removed 0 files");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2
     file3
-    "###);
+    ");
     assert!(!repo_path.join("file1").exists());
     assert!(repo_path.join("file2").exists());
     assert!(repo_path.join("file3").exists());
@@ -95,13 +89,9 @@ fn test_sparse_manage_patterns() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Added 1 files, modified 0 files, removed 2 files
-    "###);
+    insta::assert_snapshot!(stderr, @"Added 1 files, modified 0 files, removed 2 files");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(stdout, @"file1");
     assert!(repo_path.join("file1").exists());
     assert!(!repo_path.join("file2").exists());
     assert!(!repo_path.join("file3").exists());
@@ -110,13 +100,9 @@ fn test_sparse_manage_patterns() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&sub_dir, &["sparse", "set", "--clear", "--add", "file2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Added 1 files, modified 0 files, removed 1 files
-    "###);
+    insta::assert_snapshot!(stderr, @"Added 1 files, modified 0 files, removed 1 files");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file2
-    "###);
+    insta::assert_snapshot!(stdout, @"file2");
     assert!(!repo_path.join("file1").exists());
     assert!(repo_path.join("file2").exists());
     assert!(!repo_path.join("file3").exists());
@@ -124,13 +110,9 @@ fn test_sparse_manage_patterns() {
     // Can reset back to all files
     let (stdout, stderr) = test_env.jj_cmd_ok(&sub_dir, &["sparse", "reset"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Added 2 files, modified 0 files, removed 0 files
-    "###);
+    insta::assert_snapshot!(stderr, @"Added 2 files, modified 0 files, removed 0 files");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    .
-    "###);
+    insta::assert_snapshot!(stdout, @".");
     assert!(repo_path.join("file1").exists());
     assert!(repo_path.join("file2").exists());
     assert!(repo_path.join("file3").exists());
@@ -149,30 +131,22 @@ fn test_sparse_manage_patterns() {
     edit_patterns(&["file1"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&sub_dir, &["sparse", "edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Added 0 files, modified 0 files, removed 2 files
-    "###);
+    insta::assert_snapshot!(stderr, @"Added 0 files, modified 0 files, removed 2 files");
     insta::assert_snapshot!(read_patterns(), @".");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(stdout, @"file1");
 
     // Can edit with multiple files
     edit_patterns(&["file3", "file2", "file3"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&sub_dir, &["sparse", "edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Added 2 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(read_patterns(), @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(stderr, @"Added 2 files, modified 0 files, removed 1 files");
+    insta::assert_snapshot!(read_patterns(), @"file1");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2
     file3
-    "###);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -37,14 +37,14 @@ fn test_split_by_paths() {
     std::fs::write(repo_path.join("file2"), "foo").unwrap();
     std::fs::write(repo_path.join("file3"), "foo").unwrap();
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  qpvuntsmwlqt false
     ◆  zzzzzzzzzzzz true
-    "###);
-    insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r###"
+    ");
+    insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r"
     Author date:  2001-02-03 04:05:08.000 +07:00
     Committer date: 2001-02-03 04:05:08.000 +07:00
-    "###);
+    ");
 
     let edit_script = test_env.set_up_fake_editor();
     std::fs::write(
@@ -54,74 +54,70 @@ fn test_split_by_paths() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "file2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     First part: qpvuntsm 65569ca7 (no description set)
     Second part: zsuskuln 709756f0 (no description set)
     Working copy now at: zsuskuln 709756f0 (no description set)
     Parent commit      : qpvuntsm 65569ca7 (no description set)
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
     JJ: This commit contains the following changes:
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     assert!(!test_env.env_root().join("editor1").exists());
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr false
     ○  qpvuntsmwlqt false
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     // The author dates of the new commits should be inherited from the commit being
     // split. The committer dates should be newer.
-    insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r###"
+    insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@"), @r"
     Author date:  2001-02-03 04:05:08.000 +07:00
     Committer date: 2001-02-03 04:05:10.000 +07:00
-    "###);
-    insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@-"), @r###"
+    ");
+    insta::assert_snapshot!(get_recorded_dates(&test_env, &repo_path,"@-"), @r"
     Author date:  2001-02-03 04:05:08.000 +07:00
     Committer date: 2001-02-03 04:05:10.000 +07:00
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
-    A file2
-    "###);
+    insta::assert_snapshot!(stdout, @"A file2");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     A file1
     A file3
-    "###);
+    ");
 
     // Insert an empty commit after @- with "split ."
     test_env.set_up_fake_editor();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: All changes have been selected, so the second commit will be empty
     Rebased 1 descendant commits
     First part: qpvuntsm 9da0eea0 (no description set)
     Second part: znkkpsqq 5b5714a3 (empty) (no description set)
     Working copy now at: zsuskuln 0c798ee7 (no description set)
     Parent commit      : znkkpsqq 5b5714a3 (empty) (no description set)
-    "#);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr false
     ○  znkkpsqqskkl true
     ○  qpvuntsmwlqt false
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@--"]);
-    insta::assert_snapshot!(stdout, @r###"
-    A file2
-    "###);
+    insta::assert_snapshot!(stdout, @"A file2");
 
     // Remove newly created empty commit
     test_env.jj_cmd_ok(&repo_path, &["abandon", "@-"]);
@@ -130,26 +126,24 @@ fn test_split_by_paths() {
     test_env.set_up_fake_editor();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No changes have been selected, so the first commit will be empty
     Rebased 1 descendant commits
     First part: qpvuntsm bd42f95a (empty) (no description set)
     Second part: lylxulpl ed55c86b (no description set)
     Working copy now at: zsuskuln 1e1ed741 (no description set)
     Parent commit      : lylxulpl ed55c86b (no description set)
-    "#);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr false
     ○  lylxulplsnyw false
     ○  qpvuntsmwlqt true
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
-    A file2
-    "###);
+    insta::assert_snapshot!(stdout, @"A file2");
 }
 
 #[test]
@@ -177,15 +171,15 @@ fn test_split_with_non_empty_description() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     First part: qpvuntsm 231a3c00 part 1
     Second part: kkmpptxz e96291aa part 2
     Working copy now at: kkmpptxz e96291aa part 2
     Parent commit      : qpvuntsm 231a3c00 part 1
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
     test
 
@@ -193,9 +187,9 @@ fn test_split_with_non_empty_description() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r#"
     JJ: Enter a description for the second commit.
     test
 
@@ -203,12 +197,12 @@ fn test_split_with_non_empty_description() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    "#);
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  kkmpptxzrspx false part 2
     ○  qpvuntsmwlqt false part 1
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 }
 
 #[test]
@@ -233,19 +227,19 @@ fn test_split_with_default_description() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     First part: qpvuntsm 48018df6 TESTED=TODO
     Second part: kkmpptxz 350b4c13 test_bookmark | (no description set)
     Working copy now at: kkmpptxz 350b4c13 test_bookmark | (no description set)
     Parent commit      : qpvuntsm 48018df6 TESTED=TODO
-    "###);
+    ");
 
     // Since the commit being split has no description, the user will only be
     // prompted to add a description to the first commit, which will use the
     // default value we set. The second commit will inherit the empty
     // description from the commit being split.
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
 
@@ -255,13 +249,13 @@ fn test_split_with_default_description() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     assert!(!test_env.env_root().join("editor2").exists());
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  kkmpptxzrspx false test_bookmark
     ○  qpvuntsmwlqt false TESTED=TODO
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 }
 
 // This test makes sure that the children of the commit being split retain any
@@ -279,14 +273,14 @@ fn test_split_with_merge_child() {
         &workspace_path,
         &["new", "description(1)", "description(a)", "-m=2"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    zsuskulnrvyr true 2
     ├─╮
     │ ○  kkmpptxzrspx false a
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     // Set up the editor and do the split.
     let edit_script = test_env.set_up_fake_editor();
@@ -298,15 +292,15 @@ fn test_split_with_merge_child() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&workspace_path, &["split", "-r", "description(a)", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
     Second part: royxmykx 5e1b793d Add file2
     Working copy now at: zsuskuln 696935af (empty) 2
     Parent commit      : qpvuntsm 8b64ddff (empty) 1
     Parent commit      : royxmykx 5e1b793d Add file2
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    zsuskulnrvyr true 2
     ├─╮
     │ ○  royxmykxtrkr false Add file2
@@ -314,7 +308,7 @@ fn test_split_with_merge_child() {
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 }
 
 #[test]
@@ -332,10 +326,10 @@ fn test_split_siblings_no_descendants() {
     // Create a bookmark pointing to the commit. It will be moved to the second
     // commit after the split.
     test_env.jj_cmd_ok(&workspace_path, &["bookmark", "create", "test_bookmark"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  qpvuntsmwlqt false test_bookmark
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     let edit_script = test_env.set_up_fake_editor();
     std::fs::write(
@@ -345,26 +339,26 @@ fn test_split_siblings_no_descendants() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--parallel", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     First part: qpvuntsm 0dced07a TESTED=TODO
     Second part: zsuskuln 0473f014 test_bookmark | (no description set)
     Working copy now at: zsuskuln 0473f014 test_bookmark | (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  zsuskulnrvyr false test_bookmark
     │ ○  qpvuntsmwlqt false TESTED=TODO
     ├─╯
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     // Since the commit being split has no description, the user will only be
     // prompted to add a description to the first commit, which will use the
     // default value we set. The second commit will inherit the empty
     // description from the commit being split.
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
 
@@ -374,7 +368,7 @@ fn test_split_siblings_no_descendants() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     assert!(!test_env.env_root().join("editor2").exists());
 }
 
@@ -400,12 +394,12 @@ fn test_split_siblings_with_descendants() {
     // to the split command.
     test_env.jj_cmd_ok(&workspace_path, &["prev", "--edit"]);
     test_env.jj_cmd_ok(&workspace_path, &["prev", "--edit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     ○  kkmpptxzrspx false Add file4
     ○  rlvkpnrzqnoo false Add file3
     @  qpvuntsmwlqt false Add file1 & file2
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     // Set up the editor and do the split.
     let edit_script = test_env.set_up_fake_editor();
@@ -423,15 +417,15 @@ fn test_split_siblings_with_descendants() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--parallel", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     First part: qpvuntsm 84df941d Add file1
     Second part: vruxwmqv 94753be3 Add file2
     Working copy now at: vruxwmqv 94753be3 Add file2
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     ○  kkmpptxzrspx false Add file4
     ○    rlvkpnrzqnoo false Add file3
     ├─╮
@@ -439,12 +433,12 @@ fn test_split_siblings_with_descendants() {
     ○ │  qpvuntsmwlqt false Add file1
     ├─╯
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     // The commit we're splitting has a description, so the user will be
     // prompted to enter a description for each of the sibling commits.
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
     Add file1 & file2
 
@@ -452,9 +446,9 @@ fn test_split_siblings_with_descendants() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r#"
     JJ: Enter a description for the second commit.
     Add file1 & file2
 
@@ -462,7 +456,7 @@ fn test_split_siblings_with_descendants() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 // This test makes sure that the children of the commit being split retain any
@@ -480,14 +474,14 @@ fn test_split_siblings_with_merge_child() {
         &workspace_path,
         &["new", "description(1)", "description(a)", "-m=2"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    zsuskulnrvyr true 2
     ├─╮
     │ ○  kkmpptxzrspx false a
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 
     // Set up the editor and do the split.
     let edit_script = test_env.set_up_fake_editor();
@@ -501,7 +495,7 @@ fn test_split_siblings_with_merge_child() {
         &["split", "-r", "description(a)", "--parallel", "file1"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
     Second part: royxmykx 2cc60f3d Add file2
@@ -509,8 +503,8 @@ fn test_split_siblings_with_merge_child() {
     Parent commit      : qpvuntsm 8b64ddff (empty) 1
     Parent commit      : kkmpptxz e8006b47 Add file1
     Parent commit      : royxmykx 2cc60f3d Add file2
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @      zsuskulnrvyr true 2
     ├─┬─╮
     │ │ ○  royxmykxtrkr false Add file2
@@ -519,7 +513,7 @@ fn test_split_siblings_with_merge_child() {
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
-    "###);
+    ");
 }
 
 // Make sure `jj split` would refuse to split an empty commit.
@@ -531,10 +525,10 @@ fn test_split_empty() {
     test_env.jj_cmd_ok(&workspace_path, &["describe", "--message", "abc"]);
 
     let stderr = test_env.jj_cmd_failure(&workspace_path, &["split"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to split empty commit 2ab033062e9fdf7fad2ded8e89c1f145e3698190.
     Hint: Use `jj new` if you want to create another empty commit.
-    "###);
+    ");
 }
 
 #[test]
@@ -577,32 +571,32 @@ fn test_split_interactive() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split"]);
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r#"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are splitting a commit into two: qpvuntsm 44af2155 (no description set)
 
     The diff initially shows the changes in the commit you're splitting.
 
     Adjust the right side until it shows the contents you want for the first commit.
     The remainder will be in the second commit.
-    "#);
+    ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     First part: qpvuntsm 0e15949e (no description set)
     Second part: rlvkpnrz 9ed12e4c (no description set)
     Working copy now at: rlvkpnrz 9ed12e4c (no description set)
     Parent commit      : qpvuntsm 0e15949e (no description set)
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["log", "--summary"]);
     insta::assert_snapshot!(stdout, @r"
@@ -650,14 +644,14 @@ fn test_split_interactive_with_paths() {
     ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["log", "--summary"]);
     insta::assert_snapshot!(stdout, @r"

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -32,53 +32,47 @@ fn test_squash() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  382c9bad7d42 c
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     // Squashes the working copy into the parent by default
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv f7bb78d8 (empty) (no description set)
     Parent commit      : kkmpptxz 59f44460 b c | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7bb78d8da62 (empty)
     ○  59f4446070a0 b c
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 
     // Can squash a given commit into its parent
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl 1d70f50a c | (no description set)
     Parent commit      : qpvuntsm 9146bcc8 a b | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  1d70f50afa6d c
     ○  9146bcc8d996 a b
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 
     // Cannot squash a merge commit (because it's unclear which parent it should go
     // into)
@@ -89,7 +83,7 @@ fn test_squash() {
     std::fs::write(repo_path.join("file2"), "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "c", "d"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "e"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    41219719ab5f e (empty)
     ├─╮
     │ ○  f86e2b3af3e3 d
@@ -98,23 +92,23 @@ fn test_squash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Cannot squash merge commits without a specified destination
     Hint: Use `--into` to specify which parent to squash into
-    "#);
+    ");
 
     // Can squash into a merge commit
     test_env.jj_cmd_ok(&repo_path, &["new", "e"]);
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: xlzxqlsl b50b843d (empty) (no description set)
     Parent commit      : nmzmmopx 338cbc05 e | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b50b843d8555 (empty)
     ○    338cbc05e4e6 e
     ├─╮
@@ -124,11 +118,9 @@ fn test_squash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "e"]);
-    insta::assert_snapshot!(stdout, @r###"
-    e
-    "###);
+    insta::assert_snapshot!(stdout, @"e");
 }
 
 #[test]
@@ -149,12 +141,12 @@ fn test_squash_partial() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a0b1a272ebc4 c
     ○  d117da276a0f b
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     // If we don't make any changes in the diff-editor, the whole change is moved
     // into the parent
@@ -162,14 +154,14 @@ fn test_squash_partial() {
     std::fs::write(&edit_script, "dump JJ-INSTRUCTIONS instrs").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl 3c633226 c | (no description set)
     Parent commit      : qpvuntsm 38ffd8b9 a b | (no description set)
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are moving changes from: kkmpptxz d117da27 b | (no description set)
     into commit: qpvuntsm 54d3c1c0 a | (no description set)
 
@@ -180,50 +172,40 @@ fn test_squash_partial() {
     Adjust the right side until the diff shows the changes you want to move
     to the destination. If you don't make any changes, then all the changes
     from the source will be moved into the destination.
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  3c6332267ea8 c
     ○  38ffd8b98578 a b
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
 
     // Can squash only some changes in interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&edit_script, "reset file1").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: mzvwutvl 57c3cf20 c | (no description set)
     Parent commit      : kkmpptxz c4925e01 b | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  57c3cf20d0b1 c
     ○  c4925e01d298 b
     ○  1fc159063ed3 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
 
     // Can squash only some changes in non-interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -231,41 +213,31 @@ fn test_squash_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "file2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: mzvwutvl 64d7ad7c c | (no description set)
     Parent commit      : kkmpptxz 60a26452 b | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  64d7ad7c43c1 c
     ○  60a264527aee b
     ○  7314692d32e3 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
 
     // If we specify only a non-existent file, then nothing changes.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 
     // We get a warning if we pass a positional argument that looks like a revset
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -293,31 +265,29 @@ fn test_squash_keep_emptied() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  382c9bad7d42 c
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "--keep-emptied"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: mzvwutvl 7ee7f18a c | (no description set)
     Parent commit      : kkmpptxz 9490bd7f b | (empty) (no description set)
-    "###);
+    ");
     // With --keep-emptied, b remains even though it is now empty.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  7ee7f18a5223 c
     ○  9490bd7f1e6a b (empty)
     ○  53bf93080518 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
 }
 
 #[test]
@@ -358,7 +328,7 @@ fn test_squash_from_to() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "f"]);
     std::fs::write(repo_path.join("file2"), "f\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a847ab4967fe f
     ○  c2f9de87325d e
     ○  e0dac715116f d
@@ -367,23 +337,21 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     // Errors out if source and destination are the same
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "--into", "@"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Source and destination cannot be the same
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Source and destination cannot be the same");
 
     // Can squash from sibling, which results in the source being abandoned
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kmkuslsw b902d1dd f | (no description set)
     Parent commit      : znkkpsqq c2f9de87 e | (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b902d1dd59d9 f
     ○  c2f9de87325d e
     ○  e0dac715116f d
@@ -391,29 +359,25 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     // File `file2`, which was not changed in source, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
-    f
-    "###);
+    insta::assert_snapshot!(stdout, @"f");
 
     // Can squash from ancestor
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kmkuslsw cfc5eb87 f | (no description set)
     Parent commit      : znkkpsqq 4dc7c279 e | (no description set)
-    "###);
+    ");
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  cfc5eb876eb1 f
     ○  4dc7c27994bd e
     │ ○  59597b34a0d8 c
@@ -421,27 +385,25 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a d
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
-    f
-    "###);
+    insta::assert_snapshot!(stdout, @"f");
 
     // Can squash from descendant
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "e", "--into", "d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: kmkuslsw 6de62c22 f | (no description set)
     Parent commit      : vruxwmqv 32196a11 d e | (no description set)
-    "###);
+    ");
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6de62c22fa07 f
     ○  32196a117ee3 d e
     │ ○  59597b34a0d8 c
@@ -449,12 +411,10 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "d"]);
-    insta::assert_snapshot!(stdout, @r###"
-    e
-    "###);
+    insta::assert_snapshot!(stdout, @"e");
 }
 
 #[test]
@@ -485,80 +445,68 @@ fn test_squash_from_to_partial() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "d"]);
     std::fs::write(repo_path.join("file3"), "d\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e0dac715116f d
     │ ○  087591be5a01 c
     │ ○  12d6103dc0c8 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     let edit_script = test_env.set_up_fake_diff_editor();
 
     // If we don't make any changes in the diff-editor, the whole change is moved
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 987bcfb2 d | (no description set)
     Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 2 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  987bcfb2eb62 d
     │ ○  12d6103dc0c8 b c
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The changes from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     // File `file3`, which was not changed in source, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
-    insta::assert_snapshot!(stdout, @r###"
-    d
-    "###);
+    insta::assert_snapshot!(stdout, @"d");
 
     // Can squash only part of the change in interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&edit_script, "reset file2").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 576244e8 d | (no description set)
     Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  576244e87883 d
     │ ○  6f486f2f4539 c
     │ ○  12d6103dc0c8 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     // The unselected change from the source has not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     // File `file3`, which was changed in source's parent, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
-    insta::assert_snapshot!(stdout, @r###"
-    d
-    "###);
+    insta::assert_snapshot!(stdout, @"d");
 
     // Can squash only part of the change from a sibling in non-interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -566,34 +514,28 @@ fn test_squash_from_to_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 5b407c24 d | (no description set)
     Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  5b407c249fa7 d
     │ ○  724d64da1487 c
     │ ○  12d6103dc0c8 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     // The unselected change from the source has not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     // File `file3`, which was changed in source's parent, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
-    insta::assert_snapshot!(stdout, @r###"
-    d
-    "###);
+    insta::assert_snapshot!(stdout, @"d");
 
     // Can squash only part of the change from a descendant in non-interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -604,36 +546,28 @@ fn test_squash_from_to_partial() {
         &["squash", "--from", "c", "--into", "b", "file1"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Rebased 1 descendant commits
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(stderr, @"Rebased 1 descendant commits");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e0dac715116f d
     │ ○  d2a587ae205d c
     │ ○  a53394306362 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "#);
+    ");
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     // The unselected change from the source has not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
 
     // If we specify only a non-existent file, then nothing changes.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 }
 
 #[test]
@@ -669,7 +603,7 @@ fn test_squash_from_multiple() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "f"]);
     std::fs::write(&file, "f\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  94e57ecb8d4f f
     ○      78ed28eb87b8 e
     ├─┬─╮
@@ -680,13 +614,13 @@ fn test_squash_from_multiple() {
     ├─╯
     ○  3b1673b6370c a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     // Squash a few commits sideways
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b", "--from=c", "--into=d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kpqxywon 7ea39167 f | (no description set)
     Parent commit      : yostqsxw acfbf2a0 e | (no description set)
@@ -697,8 +631,8 @@ fn test_squash_from_multiple() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  7ea391676d52 f
     ○    acfbf2a0600d e
     ├─╮
@@ -706,10 +640,10 @@ fn test_squash_from_multiple() {
     ├─╯
     ○  3b1673b6370c a b c
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The changes from the sources have been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
     -a
@@ -720,18 +654,18 @@ fn test_squash_from_multiple() {
     +++++++ Contents of side #3
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Squash a few commits up an down
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b|c|f", "--into=e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: xznxytkn 6a670d1a (empty) (no description set)
     Parent commit      : yostqsxw c1293ff7 e f | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6a670d1ac76e (empty)
     ○    c1293ff7be51 e f
     ├─╮
@@ -739,19 +673,15 @@ fn test_squash_from_multiple() {
     ├─╯
     ○  3b1673b6370c a b c
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The changes from the sources have been applied to the destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=e", "file"]);
-    insta::assert_snapshot!(stdout, @r###"
-    f
-    "###);
+    insta::assert_snapshot!(stdout, @"f");
 
     // Empty squash shouldn't crash
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from=none()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 }
 
 #[test]
@@ -794,7 +724,7 @@ fn test_squash_from_multiple_partial() {
     std::fs::write(&file1, "f\n").unwrap();
     std::fs::write(&file2, "f\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  30980b9045f7 f
     ○      5326a04aac1f e
     ├─┬─╮
@@ -805,13 +735,13 @@ fn test_squash_from_multiple_partial() {
     ├─╯
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     // Partially squash a few commits sideways
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b|c", "--into=d", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kpqxywon a8530305 f | (no description set)
     Parent commit      : yostqsxw 0a3637fc e | (no description set)
@@ -822,8 +752,8 @@ fn test_squash_from_multiple_partial() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a8530305127c f
     ○      0a3637fca632 e
     ├─┬─╮
@@ -834,19 +764,15 @@ fn test_squash_from_multiple_partial() {
     ├─╯
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=c", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     // The selected changes from the sources have been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
     -a
@@ -857,25 +783,23 @@ fn test_squash_from_multiple_partial() {
     +++++++ Contents of side #3
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     // The unselected change from the sources have not been applied to the
     // destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
-    d
-    "###);
+    insta::assert_snapshot!(stdout, @"d");
 
     // Partially squash a few commits up an down
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b|c|f", "--into=e", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: kpqxywon 3b7559b8 f | (no description set)
     Parent commit      : yostqsxw a3b1714c e | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  3b7559b89a57 f
     ○      a3b1714cdfb2 e
     ├─┬─╮
@@ -886,30 +810,20 @@ fn test_squash_from_multiple_partial() {
     ├─╯
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    ");
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=c", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=f", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    f
-    "###);
+    insta::assert_snapshot!(stdout, @"f");
     // The selected changes from the sources have been applied to the destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=e", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    f
-    "###);
+    insta::assert_snapshot!(stdout, @"f");
     // The unselected changes from the sources have not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
-    d
-    "###);
+    insta::assert_snapshot!(stdout, @"d");
 }
 
 #[test]
@@ -935,7 +849,7 @@ fn test_squash_from_multiple_partial_no_op() {
     test_env.jj_cmd_ok(&repo_path, &["new", "@-", "-m=d"]);
     std::fs::write(file_d, "d\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b37ca1ee3306 d
     │ ○  f40b442af3e8 c
     ├─╯
@@ -943,7 +857,7 @@ fn test_squash_from_multiple_partial_no_op() {
     ├─╯
     ○  2443ea76b0b1 a
     ◆  000000000000 (empty)
-    "###);
+    ");
 
     // Source commits that didn't match the paths are not rewritten
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -951,18 +865,18 @@ fn test_squash_from_multiple_partial_no_op() {
         &["squash", "--from=@-+ ~ @", "--into=@", "-m=d", "b"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: mzvwutvl e178068a d
     Parent commit      : qpvuntsm 2443ea76 a
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e178068add8c d
     │ ○  f40b442af3e8 c
     ├─╯
     ○  2443ea76b0b1 a
     ◆  000000000000 (empty)
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -971,14 +885,14 @@ fn test_squash_from_multiple_partial_no_op() {
             r#"separate(" ", commit_id.short(), description)"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    e178068add8c d
     ├─╮
     │ ○  b73077b08c59 b
     │ ○  a786561e909f b
     ○  b37ca1ee3306 d
     ○  1d9eb34614c9 d
-    "###);
+    ");
 
     // If no source commits match the paths, then the whole operation is a no-op
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -987,10 +901,8 @@ fn test_squash_from_multiple_partial_no_op() {
         &["squash", "--from=@-+ ~ @", "--into=@", "-m=d", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b37ca1ee3306 d
     │ ○  f40b442af3e8 c
     ├─╯
@@ -998,7 +910,7 @@ fn test_squash_from_multiple_partial_no_op() {
     ├─╯
     ○  2443ea76b0b1 a
     ◆  000000000000 (empty)
-    "###);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
@@ -1035,36 +947,30 @@ fn test_squash_description() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "source"]);
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
-    source
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @"source");
 
     // If the destination description is non-empty and the source's description is
     // empty, the resulting description is from the destination
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", "@--"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "destination"]);
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
-    destination
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @"destination");
 
     // An explicit description on the command-line overrides this
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["squash", "-m", "custom"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
-    custom
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @"custom");
 
     // If both descriptions were non-empty, we get asked for a combined description
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "source"]);
     std::fs::write(&edit_script, "dump editor0").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     destination
 
     source
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the combined commit.
@@ -1085,20 +991,14 @@ fn test_squash_description() {
     // editor
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["squash", "-m", "custom"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
-    custom
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @"custom");
 
     // If the source's *content* doesn't become empty, then the source remains and
     // both descriptions are unchanged
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["squash", "file1"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
-    destination
-    "###);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
-    source
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @"destination");
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @"source");
 }
 
 #[test]
@@ -1137,22 +1037,20 @@ fn test_squash_empty() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz adece6e8 (empty) (no description set)
     Parent commit      : qpvuntsm 5076fc41 (empty) parent
-    "###);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
-    parent
-    "###);
+    ");
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @"parent");
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "child"]);
     test_env.set_up_fake_editor();
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     parent
 
     child
-    "###);
+    ");
 }
 
 #[test]
@@ -1165,21 +1063,21 @@ fn test_squash_use_destination_message() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m=b"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=c"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r"
     @  8aac283daeac c
     ○  017c7f689ed7 b
     ○  d8d5f980a897 a
     ◆  000000000000
-    "###);
+    ");
 
     // Squash the current revision using the short name for the option.
     test_env.jj_cmd_ok(&repo_path, &["squash", "-u"]);
-    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r"
     @  fd33e4bc332b
     ○  3a17aa5dcce9 b
     ○  d8d5f980a897 a
     ◆  000000000000
-    "###);
+    ");
 
     // Undo and squash again, but this time squash both "b" and "c" into "a".
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -1194,11 +1092,11 @@ fn test_squash_use_destination_message() {
             "description(a)",
         ],
     );
-    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r"
     @  7c832accbf60
     ○  688660377651 a
     ◆  000000000000
-    "###);
+    ");
 }
 
 // The --use-destination-message and --message options are incompatible.
@@ -1216,13 +1114,13 @@ fn test_squash_use_destination_message_and_message_mutual_exclusion() {
             "--message=123",
             "--use-destination-message",
         ],
-    ), @r###"
+    ), @r"
     error: the argument '--message <MESSAGE>' cannot be used with '--use-destination-message'
 
     Usage: jj squash --message <MESSAGE> [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    ");
 }
 
 fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> String {

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -59,14 +59,14 @@ fn test_status_copies() {
     std::fs::write(repo_path.join("rename-target"), "rename").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M copy-source
     C {copy-source => copy-target}
     R {rename-source => rename-target}
     Working copy : rlvkpnrz a96c3086 (no description set)
     Parent commit: qpvuntsm e3e2c703 (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -85,12 +85,12 @@ fn test_status_merge() {
     // The output should mention each parent, and the diff should be empty (compared
     // to the auto-merged parents)
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     Working copy : mzvwutvl a538c72d (empty) (no description set)
     Parent commit: rlvkpnrz d3dd19f1 left | (empty) left
     Parent commit: zsuskuln 705a356d right
-    "###);
+    ");
 }
 
 // See https://github.com/jj-vcs/jj/issues/2051.
@@ -110,12 +110,12 @@ fn test_status_ignored_gitignore() {
     std::fs::write(repo_path.join(".gitignore"), "untracked/\n!dummy\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A .gitignore
     Working copy : qpvuntsm 3cef2183 (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -129,12 +129,12 @@ fn test_status_filtered() {
 
     // The output filtered to file_1 should not list the addition of file_2.
     let stdout = test_env.jj_cmd_success(&repo_path, &["status", "file_1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A file_1
     Working copy : qpvuntsm c8fb8395 (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 }
 
 // See <https://github.com/jj-vcs/jj/issues/3108>
@@ -179,7 +179,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 dcb25635 conflict
     │  (empty) boom-cont-2
     ×  royxmykx test.user@example.com 2001-02-03 08:05:12 664a4c6c conflict
@@ -193,11 +193,11 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     There are unresolved conflicts at these paths:
     conflicted.txt    2-sided conflict
@@ -208,7 +208,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 
     // Resolve conflict
     test_env.jj_cmd_ok(&repo_path, &["new", "--message", "fixed 1"]);
@@ -221,7 +221,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     // wc is now conflict free, parent is also conflict free
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  kpqxywon test.user@example.com 2001-02-03 08:05:18 d313f2e1
     │  fixed 2
     ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 23e58975
@@ -239,23 +239,23 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M conflicted.txt
     Working copy : kpqxywon d313f2e1 fixed 2
     Parent commit: znkkpsqq 23e58975 fixed 1
-    "###);
+    ");
 
     // Step back one.
     // wc is still conflict free, parent has a conflict.
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  kpqxywon test.user@example.com 2001-02-03 08:05:18 d313f2e1
     │  fixed 2
     @  znkkpsqq test.user@example.com 2001-02-03 08:05:17 23e58975
@@ -273,17 +273,17 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M conflicted.txt
     Working copy : znkkpsqq 23e58975 fixed 1
     Parent commit: yqosqzyt dcb25635 (conflict) (empty) boom-cont-2
     Conflict in parent commit has been resolved in working copy
-    "###);
+    ");
 
     // Step back to all the way to `root()+` so that wc has no conflict, even though
     // there is a conflict later in the tree. So that we can confirm
@@ -291,7 +291,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     test_env.jj_cmd_ok(&repo_path, &["edit", "root()+"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  kpqxywon test.user@example.com 2001-02-03 08:05:18 d313f2e1
     │  fixed 2
     ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 23e58975
@@ -309,16 +309,16 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A conflicted.txt
     Working copy : qpvuntsm aade7195 Initial contents
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -352,7 +352,7 @@ fn test_status_simplify_conflict_sides() {
     );
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]),
-    @r###"
+    @r"
     The working copy is clean
     There are unresolved conflicts at these paths:
     fileA    2-sided conflict
@@ -366,7 +366,7 @@ fn test_status_simplify_conflict_sides() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -51,38 +51,34 @@ fn test_tag_list() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list"]),
-        @r###"
+        @r"
     conflicted_tag (conflicted):
       - rlvkpnrz caf975d0 (empty) commit1
       + zsuskuln 3db783e0 (empty) commit2
       + royxmykx 68d950ce (empty) commit3
     test_tag: rlvkpnrz caf975d0 (empty) commit1
     test_tag2: zsuskuln 3db783e0 (empty) commit2
-    "###);
+    ");
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "--color=always"]),
-        @r###"
+        @r"
     [38;5;5mconflicted_tag[39m [38;5;1m(conflicted)[39m:
       - [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4mc[0m[38;5;8maf975d0[39m [38;5;2m(empty)[39m commit1
       + [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m3[0m[38;5;8mdb783e0[39m [38;5;2m(empty)[39m commit2
       + [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m6[0m[38;5;8m8d950ce[39m [38;5;2m(empty)[39m commit3
     [38;5;5mtest_tag[39m: [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4mc[0m[38;5;8maf975d0[39m [38;5;2m(empty)[39m commit1
     [38;5;5mtest_tag2[39m: [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m3[0m[38;5;8mdb783e0[39m [38;5;2m(empty)[39m commit2
-    "###);
+    ");
 
     // Test pattern matching.
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "test_tag2"]),
-        @r###"
-    test_tag2: zsuskuln 3db783e0 (empty) commit2
-    "###);
+        @"test_tag2: zsuskuln 3db783e0 (empty) commit2");
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "glob:test_tag?"]),
-        @r###"
-    test_tag2: zsuskuln 3db783e0 (empty) commit2
-    "###);
+        @"test_tag2: zsuskuln 3db783e0 (empty) commit2");
 
     let template = r#"
     concat(
@@ -96,7 +92,7 @@ fn test_tag_list() {
     "#;
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "-T", template]),
-        @r###"
+        @r"
     [conflicted_tag]
     present: true
     conflict: true
@@ -115,5 +111,5 @@ fn test_tag_list() {
     normal_target: commit2
     removed_targets:
     added_targets: commit2
-    "###);
+    ");
 }

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -25,7 +25,7 @@ fn test_templater_parse_error() {
     let repo_path = test_env.env_root().join("repo");
     let render_err = |template| test_env.jj_cmd_failure(&repo_path, &["log", "-T", template]);
 
-    insta::assert_snapshot!(render_err(r#"description ()"#), @r#"
+    insta::assert_snapshot!(render_err(r#"description ()"#), @r"
     Error: Failed to parse template: Syntax error
     Caused by:  --> 1:13
       |
@@ -33,7 +33,7 @@ fn test_templater_parse_error() {
       |             ^---
       |
       = expected <EOI>, `++`, `||`, `&&`, `==`, `!=`, `>=`, `>`, `<=`, or `<`
-    "#);
+    ");
 
     // Typo
     test_env.add_config(
@@ -133,12 +133,12 @@ fn test_template_parse_warning() {
         )
     "#};
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r@", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  false test.user
     │
     ~
-    "#);
-    insta::assert_snapshot!(stderr, @r#"
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Warning: In template expression
      --> 2:3
       |
@@ -180,7 +180,7 @@ fn test_template_parse_warning() {
       |          ^------^
       |
       = username() is deprecated; use email().local() instead
-    "#);
+    ");
 }
 
 #[test]
@@ -383,11 +383,11 @@ fn test_templater_alias() {
     ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r@", "-Tdeprecated()"]);
-    insta::assert_snapshot!(stdout, @r##"
+    insta::assert_snapshot!(stdout, @r"
     #  false
     │
     ~
-    "##);
+    ");
     insta::assert_snapshot!(stderr, @r#"
     Warning: In template expression
      --> 1:1

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -29,21 +29,21 @@ fn test_undo_rewrite_with_child() {
     let op_id_hex = stdout[3..15].to_string();
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "child"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  child
     ○  modified
     ◆
-    "###);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo", &op_id_hex]);
 
     // Since we undid the description-change, the child commit should now be on top
     // of the initial commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  child
     ○  initial
     ◆
-    "###);
+    ");
 }
 
 #[test]
@@ -68,10 +68,10 @@ fn test_git_push_undo() {
     //   ------------------------------------------
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
@@ -80,10 +80,10 @@ fn test_git_push_undo() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    ");
 
     // Undo the push
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &pre_push_opid]);
@@ -93,10 +93,10 @@ fn test_git_push_undo() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
@@ -108,13 +108,13 @@ fn test_git_push_undo() {
     // One option to solve this would be to have undo not restore remote-tracking
     // bookmarks, but that also has undersired consequences: the second fetch in
     // `jj git fetch && jj undo && jj git fetch` would become a no-op.
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main (conflicted):
       - qpvuntsm hidden 2080bdb8 (empty) AA
       + qpvuntsm?? 20b2cc4b (empty) CC
       + qpvuntsm?? 75e78001 (empty) BB
       @origin (behind by 1 commits): qpvuntsm?? 75e78001 (empty) BB
-    "###);
+    ");
 }
 
 /// This test is identical to the previous one, except for one additional
@@ -141,10 +141,10 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
@@ -153,10 +153,10 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    ");
 
     // Undo the push
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &pre_push_opid]);
@@ -166,10 +166,10 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    ");
 
     // PROBLEM: inserting this import changes the outcome compared to previous test
     // TODO: decide if this is the better behavior, and whether import of
@@ -181,19 +181,19 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     // There is not a conflict. This seems like a good outcome; undoing `git push`
     // was essentially a no-op.
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 20b2cc4b (empty) CC
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 75e78001 (empty) BB
-    "###);
+    ");
 }
 
 // This test is currently *identical* to `test_git_push_undo` except the repo
@@ -221,11 +221,11 @@ fn test_git_push_undo_colocated() {
     //   ------------------------------------------
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @git: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
@@ -234,11 +234,11 @@ fn test_git_push_undo_colocated() {
     //   ------------------------------------------
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @git: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    ");
 
     // Undo the push
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &pre_push_opid]);
@@ -256,24 +256,24 @@ fn test_git_push_undo_colocated() {
     //   ------------------------------------------
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @git: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     // We have the same conflict as `test_git_push_undo`. TODO: why did we get the
     // same result in a seemingly different way?
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main (conflicted):
       - qpvuntsm hidden 2080bdb8 (empty) AA
       + qpvuntsm?? 20b2cc4b (empty) CC
       + qpvuntsm?? 75e78001 (empty) BB
       @git (behind by 1 commits): qpvuntsm?? 20b2cc4b (empty) CC
       @origin (behind by 1 commits): qpvuntsm?? 75e78001 (empty) BB
-    "###);
+    ");
 }
 
 // This test is currently *identical* to `test_git_push_undo` except
@@ -292,16 +292,16 @@ fn test_git_push_undo_repo_only() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 2080bdb8 (empty) AA
       @origin: qpvuntsm 2080bdb8 (empty) AA
-    "###);
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
 
@@ -310,18 +310,18 @@ fn test_git_push_undo_repo_only() {
         &repo_path,
         &["op", "restore", "--what=repo", &pre_push_opid],
     );
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     // This currently gives an identical result to `test_git_push_undo_import`.
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 20b2cc4b (empty) CC
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 75e78001 (empty) BB
-    "###);
+    ");
 }
 
 #[test]
@@ -337,52 +337,52 @@ fn test_bookmark_track_untrack_undo() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "feature1", "feature2"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "feature2"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
       @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2 (deleted)
       @origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    ");
 
     // Track/untrack can be undone so long as states can be trivially merged.
     test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "untrack", "feature1@origin", "feature2@origin"],
     );
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
     feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
       @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2 (deleted)
       @origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
     feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "feature1@origin"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
       @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
     feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -32,56 +32,50 @@ fn test_unsquash() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  382c9bad7d42 c
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000
-    "###);
+    ");
 
     // Unsquashes into the working copy from its parent by default
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: mzvwutvl 9177132c c | (no description set)
     Parent commit      : qpvuntsm 184ddbcc a b | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  9177132cfbb9 c
     ○  184ddbcce5a9 a b
     ◆  000000000000
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 
     // Can unsquash into a given commit from its parent
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl b353b29c c | (no description set)
     Parent commit      : kkmpptxz 27772b15 b | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b353b29c423d c
     ○  27772b156771 b
     ◆  000000000000 a
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 
     // Cannot unsquash into a merge commit (because it's unclear which parent it
     // should come from)
@@ -92,7 +86,7 @@ fn test_unsquash() {
     std::fs::write(repo_path.join("file2"), "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "merge", "c", "d"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "e"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    b780e7469252 e
     ├─╮
     │ ○  f86e2b3af3e3 d
@@ -101,27 +95,27 @@ fn test_unsquash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000
-    "###);
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Error: Cannot unsquash merge commits
-    "#);
+    ");
 
     // Can unsquash from a merge commit
     test_env.jj_cmd_ok(&repo_path, &["new", "e"]);
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: pzsxstzt bd05eb69 merge
     Parent commit      : mzvwutvl 382c9bad c e?? | (no description set)
     Parent commit      : xznxytkn f86e2b3a d e?? | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    bd05eb698d1e
     ├─╮
     │ ○  f86e2b3af3e3 d e??
@@ -130,11 +124,9 @@ fn test_unsquash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
-    e
-    "###);
+    insta::assert_snapshot!(stdout, @"e");
 }
 
 #[test]
@@ -155,12 +147,12 @@ fn test_unsquash_partial() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a0b1a272ebc4 c
     ○  d117da276a0f b
     ○  54d3c1c0e9fd a
     ◆  000000000000
-    "###);
+    ");
 
     // If we don't make any changes in the diff-editor, the whole change is moved
     // from the parent
@@ -168,16 +160,16 @@ fn test_unsquash_partial() {
     std::fs::write(&edit_script, "dump JJ-INSTRUCTIONS instrs").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl 8802263d c | (no description set)
     Parent commit      : kkmpptxz 5bd83140 b | (no description set)
-    "#);
+    ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are moving changes from: qpvuntsm 54d3c1c0 a | (no description set)
     into its child: kkmpptxz d117da27 b | (no description set)
 
@@ -187,52 +179,42 @@ fn test_unsquash_partial() {
     the parent commit. The changes you edited out will be moved into the
     child commit. If you don't make any changes, then the operation will be
     aborted.
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  8802263dbd92 c
     ○  5bd83140fd47 b
     ○  c93de9257191 a
     ◆  000000000000
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
 
     // Can unsquash only some changes in interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(edit_script, "reset file1").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: mzvwutvl a896ffde c | (no description set)
     Parent commit      : kkmpptxz 904111b4 b | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a896ffdebb85 c
     ○  904111b4d3c4 b
     ○  54d3c1c0e9fd a
     ◆  000000000000
-    "###);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 
     // Try again with --tool=<name>, which implies --interactive
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -245,28 +227,20 @@ fn test_unsquash_partial() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: mzvwutvl aaca9268 c | (no description set)
     Parent commit      : kkmpptxz fe8eb117 b | (no description set)
-    "#);
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    a
-    "###);
+    insta::assert_snapshot!(stdout, @"a");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
-    b
-    "###);
+    insta::assert_snapshot!(stdout, @"b");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
-    c
-    "###);
+    insta::assert_snapshot!(stdout, @"c");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
@@ -297,31 +271,27 @@ fn test_unsquash_description() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "source"]);
     test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
-    source
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @"source");
 
     // If the destination description is non-empty and the source's description is
     // empty, the resulting description is from the destination
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", "@--"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "destination"]);
     test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
-    destination
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @"destination");
 
     // If both descriptions were non-empty, we get asked for a combined description
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "source"]);
     std::fs::write(&edit_script, "dump editor0").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r"
     destination
 
     source
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the combined commit.
     JJ: Description from the destination commit:
     destination
@@ -330,17 +300,13 @@ fn test_unsquash_description() {
     source
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // If the source's *content* doesn't become empty, then the source remains and
     // both descriptions are unchanged
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
-    source
-    "###);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
-    destination
-    "###);
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @"source");
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @"destination");
 }
 
 #[test]

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -23,7 +23,7 @@ fn test_util_config_schema() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["util", "config-schema"]);
     // Validate partial snapshot, redacting any lines nested 2+ indent levels.
     insta::with_settings!({filters => vec![(r"(?m)(^        .*$\r?\n)+", "        [...]\n")]}, {
-        assert_snapshot!(stdout, @r###"
+        assert_snapshot!(stdout, @r#"
         {
             "$schema": "http://json-schema.org/draft-07/schema",
             "title": "Jujutsu config",
@@ -35,7 +35,7 @@ fn test_util_config_schema() {
                 [...]
             }
         }
-        "###);
+        "#);
     });
 }
 
@@ -53,14 +53,10 @@ fn test_gc_args() {
     insta::assert_snapshot!(stderr, @"");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["util", "gc", "--at-op=@-"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Cannot garbage collect from a non-head operation
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Cannot garbage collect from a non-head operation");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["util", "gc", "--expire=foobar"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: --expire only accepts 'now'
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: --expire only accepts 'now'");
 }
 
 #[test]
@@ -91,9 +87,7 @@ fn test_gc_operation_log() {
 
     // Now this doesn't work.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["debug", "operation", &op_to_remove]);
-    insta::assert_snapshot!(stderr, @r#"
-    Error: No operation ID matching "8382f401329617b0c91a63354b86ca48fc28dee8d7a916fdad5310030f9a1260e969c43ed2b13d1d48eaf38f6f45541ecf593bcb6105495d514d21b3b6a98846"
-    "#);
+    insta::assert_snapshot!(stderr, @r#"Error: No operation ID matching "8382f401329617b0c91a63354b86ca48fc28dee8d7a916fdad5310030f9a1260e969c43ed2b13d1d48eaf38f6f45541ecf593bcb6105495d514d21b3b6a98846""#);
 }
 
 #[test]

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -185,7 +185,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
     );
 
     // File should have Git-style conflict markers
-    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r##"
+    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r"
     line 1
     <<<<<<< Side #1 (Conflict 1 of 1)
     line 2 - a
@@ -197,7 +197,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
     line 2 - b
     line 3 - b
     >>>>>>> Side #2 (Conflict 1 of 1 ends)
-    "##);
+    ");
 
     // Configure to use JJ-style "snapshot" conflict markers
     test_env.add_config(r#"ui.conflict-marker-style = "snapshot""#);
@@ -222,7 +222,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
     .unwrap();
 
     // Git-style markers should be parsed, then rendered with new config
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r##"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -235,7 +235,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
      ------- Contents of base
      line 2
      line 3
-    "##);
+    ");
 }
 
 #[test]
@@ -247,21 +247,21 @@ fn test_snapshot_invalid_ignore_pattern() {
 
     // Test invalid pattern in .gitignore
     std::fs::write(&gitignore_path, " []\n").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r"
     Internal error: Failed to snapshot the working copy
     Caused by:
     1: Failed to parse ignore patterns from file $TEST_ENV/repo/.gitignore
     2: error parsing glob ' []': unclosed character class; missing ']'
-    "#);
+    ");
 
     // Test invalid UTF-8 in .gitignore
     std::fs::write(&gitignore_path, b"\xff\n").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r##"
+    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r"
     Internal error: Failed to snapshot the working copy
     Caused by:
     1: Invalid UTF-8 for ignore pattern in $TEST_ENV/repo/.gitignore on line #1: �
     2: invalid utf-8 sequence of 1 bytes from index 0
-    "##);
+    ");
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     );
 
     // File should be materialized with long conflict markers
-    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r##"
+    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r"
     line 1
     <<<<<<<<<<< Conflict 1 of 1
     %%%%%%%%%%% Changes from base to side #1
@@ -324,7 +324,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     ======= fake marker
     line 3
     >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
 
     // The timestamps in the `jj debug local-working-copy` output change, so we want
     // to remove them before asserting the snapshot
@@ -373,7 +373,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
 
     // The file should still be conflicted, and the new content should be saved
     let stdout = test_env.jj_cmd_success(&repo_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     There are unresolved conflicts at these paths:
@@ -381,8 +381,8 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     Working copy : mzvwutvl 3a981880 (conflict) (no description set)
     Parent commit: rlvkpnrz ce613b49 side-a
     Parent commit: zsuskuln 7b2b03ab side-b
-    "#);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r##"
+    ");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -398,7 +398,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
      line 3
     +>>>>>>> fake marker
      >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
 
     // Working copy should still contain conflict marker length
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy"]);
@@ -425,13 +425,13 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     .unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : mzvwutvl 1aefd866 (no description set)
     Parent commit: rlvkpnrz ce613b49 side-a
     Parent commit: zsuskuln 7b2b03ab side-b
-    "#);
+    ");
 
     // When the file is resolved, the conflict marker length is removed from the
     // working copy

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -30,21 +30,19 @@ fn test_workspaces_add_second_workspace() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "initial"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz 8183d0fc (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stdout, @"default: rlvkpnrz 8183d0fc (empty) (no description set)");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &main_path,
         &["workspace", "add", "--name", "second", "../secondary"],
     );
     insta::assert_snapshot!(stdout.replace('\\', "/"), @"");
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "../secondary"
     Working copy now at: rzvqmyuk 5ed2222c (empty) (no description set)
     Parent commit      : qpvuntsm 751b12b7 initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    "#);
 
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
@@ -55,20 +53,20 @@ fn test_workspaces_add_second_workspace() {
     ○  751b12b7b981
     ◆  000000000000
     ");
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  5ed2222c28e2 second@
     │ ○  8183d0fcaa4c default@
     ├─╯
     ○  751b12b7b981
     ◆  000000000000
-    "###);
+    ");
 
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 8183d0fc (empty) (no description set)
     second: rzvqmyuk 5ed2222c (empty) (no description set)
-    "###);
+    ");
 }
 
 /// Test how sparse patterns are inherited
@@ -86,34 +84,30 @@ fn test_workspaces_sparse_patterns() {
     test_env.jj_cmd_ok(&ws1_path, &["sparse", "set", "--clear", "--add=foo"]);
     test_env.jj_cmd_ok(&ws1_path, &["workspace", "add", "../ws2"]);
     let stdout = test_env.jj_cmd_success(&ws2_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    foo
-    "###);
+    insta::assert_snapshot!(stdout, @"foo");
     test_env.jj_cmd_ok(&ws2_path, &["sparse", "set", "--add=bar"]);
     test_env.jj_cmd_ok(&ws2_path, &["workspace", "add", "../ws3"]);
     let stdout = test_env.jj_cmd_success(&ws3_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar
     foo
-    "###);
+    ");
     // --sparse-patterns behavior
     test_env.jj_cmd_ok(
         &ws3_path,
         &["workspace", "add", "--sparse-patterns=copy", "../ws4"],
     );
     let stdout = test_env.jj_cmd_success(&ws4_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar
     foo
-    "###);
+    ");
     test_env.jj_cmd_ok(
         &ws3_path,
         &["workspace", "add", "--sparse-patterns=full", "../ws5"],
     );
     let stdout = test_env.jj_cmd_success(&ws5_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    .
-    "###);
+    insta::assert_snapshot!(stdout, @".");
     test_env.jj_cmd_ok(
         &ws3_path,
         &["workspace", "add", "--sparse-patterns=empty", "../ws6"],
@@ -135,9 +129,7 @@ fn test_workspaces_add_second_workspace_on_merge() {
     test_env.jj_cmd_ok(&main_path, &["new", "all:@-+", "-m=merge"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    default: zsuskuln 35e47bff (empty) merge
-    "###);
+    insta::assert_snapshot!(stdout, @"default: zsuskuln 35e47bff (empty) merge");
 
     test_env.jj_cmd_ok(
         &main_path,
@@ -169,11 +161,11 @@ fn test_workspaces_add_ignore_working_copy() {
         &main_path,
         &["workspace", "add", "--ignore-working-copy", "../secondary"],
     );
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "../secondary"
     Error: This command must be able to update the working copy.
     Hint: Don't use --ignore-working-copy.
-    "###);
+    "#);
 }
 
 /// Test that --at-op is respected
@@ -185,17 +177,17 @@ fn test_workspaces_add_at_operation() {
 
     std::fs::write(main_path.join("file1"), "").unwrap();
     let (_stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["commit", "-m1"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 18d8b994 (empty) (no description set)
     Parent commit      : qpvuntsm 3364a7ed 1
-    "###);
+    ");
 
     std::fs::write(main_path.join("file2"), "").unwrap();
     let (_stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["commit", "-m2"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 2e7dc5ab (empty) (no description set)
     Parent commit      : rlvkpnrz 0dbaa19a 2
-    "###);
+    ");
 
     // --at-op should disable snapshot in the main workspace, but the newly
     // created workspace should still be writable.
@@ -204,29 +196,27 @@ fn test_workspaces_add_at_operation() {
         &main_path,
         &["workspace", "add", "--at-op=@-", "../secondary"],
     );
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "../secondary"
     Working copy now at: rzvqmyuk a4d1cbc9 (empty) (no description set)
     Parent commit      : qpvuntsm 3364a7ed 1
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    "#);
     let secondary_path = test_env.env_root().join("secondary");
 
     // New snapshot can be taken in the secondary workspace.
     std::fs::write(secondary_path.join("file4"), "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A file4
     Working copy : rzvqmyuk 2ba74f85 (no description set)
     Parent commit: qpvuntsm 3364a7ed 1
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Concurrent modification detected, resolving automatically.
-    "###);
+    ");
+    insta::assert_snapshot!(stderr, @"Concurrent modification detected, resolving automatically.");
 
     let stdout = test_env.jj_cmd_success(&secondary_path, &["op", "log", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  snapshot working copy
     ○    reconcile divergent operations
     ├─╮
@@ -239,7 +229,7 @@ fn test_workspaces_add_at_operation() {
     ○  snapshot working copy
     ○  add workspace 'default'
     ○
-    "#);
+    ");
 }
 
 /// Test adding a workspace, but at a specific revision using '-r'
@@ -257,9 +247,7 @@ fn test_workspaces_add_workspace_at_revision() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "second"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    default: kkmpptxz dadeedb4 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stdout, @"default: kkmpptxz dadeedb4 (empty) (no description set)");
 
     let (_, stderr) = test_env.jj_cmd_ok(
         &main_path,
@@ -273,12 +261,12 @@ fn test_workspaces_add_workspace_at_revision() {
             "@--",
         ],
     );
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "../secondary"
     Working copy now at: zxsnswpr e374e74a (empty) (no description set)
     Parent commit      : qpvuntsm f6097c2f first
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    "#);
 
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
@@ -290,14 +278,14 @@ fn test_workspaces_add_workspace_at_revision() {
     ○  f6097c2f7cac
     ◆  000000000000
     ");
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  e374e74aa0c8 second@
     │ ○  dadeedb493e8 default@
     │ ○  c420244c6398
     ├─╯
     ○  f6097c2f7cac
     ◆  000000000000
-    "###);
+    ");
 }
 
 /// Test multiple `-r` flags to `workspace add` to create a workspace
@@ -320,7 +308,7 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&main_path, &["new", "-r", "root()"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  5b36783cd11c
     │ ○  6c843d62ca29
     ├─╯
@@ -329,7 +317,7 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     │ ○  f6097c2f7cac
     ├─╯
     ◆  000000000000
-    "###);
+    ");
 
     let (_, stderr) = test_env.jj_cmd_ok(
         &main_path,
@@ -343,14 +331,14 @@ fn test_workspaces_add_workspace_multiple_revisions() {
             "-r=description(first)",
         ],
     );
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "../merged"
     Working copy now at: wmwvqwsz f4fa64f4 (empty) (no description set)
     Parent commit      : mzvwutvl 6c843d62 third
     Parent commit      : kkmpptxz 544cd61f second
     Parent commit      : qpvuntsm f6097c2f first
     Added 3 files, modified 0 files, removed 0 files
-    "###);
+    "#);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  5b36783cd11c default@
@@ -379,27 +367,25 @@ fn test_workspaces_add_workspace_from_subdir() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "initial"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz e1038e77 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stdout, @"default: rlvkpnrz e1038e77 (empty) (no description set)");
 
     // Create workspace while in sub-directory of current workspace
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&subdir_path, &["workspace", "add", "../../secondary"]);
     insta::assert_snapshot!(stdout.replace('\\', "/"), @"");
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "../../secondary"
     Working copy now at: rzvqmyuk 7ad84461 (empty) (no description set)
     Parent commit      : qpvuntsm a3a43d9e initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    "#);
 
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz e1038e77 (empty) (no description set)
     secondary: rzvqmyuk 7ad84461 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -414,47 +400,47 @@ fn test_workspaces_add_workspace_in_current_workspace() {
     // Try to create workspace using name instead of path
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "add", "secondary"]);
     insta::assert_snapshot!(stdout.replace('\\', "/"), @"");
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "secondary"
     Warning: Workspace created inside current directory. If this was unintentional, delete the "secondary" directory and run `jj workspace forget secondary` to remove it.
     Working copy now at: pmmvwywv 0a77a39d (empty) (no description set)
     Parent commit      : qpvuntsm 751b12b7 initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    "#);
 
     // Workspace created despite warning
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 46d9ba8b (no description set)
     secondary: pmmvwywv 0a77a39d (empty) (no description set)
-    "###);
+    ");
 
     // Use explicit path instead (no warning)
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "add", "./third"]);
     insta::assert_snapshot!(stdout.replace('\\', "/"), @"");
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.replace('\\', "/"), @r#"
     Created workspace in "third"
     Working copy now at: zxsnswpr 64746d4b (empty) (no description set)
     Parent commit      : qpvuntsm 751b12b7 initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    "#);
 
     // Both workspaces created
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 477c647f (no description set)
     secondary: pmmvwywv 0a77a39d (empty) (no description set)
     third: zxsnswpr 64746d4b (empty) (no description set)
-    "###);
+    ");
 
     // Can see files from the other workspaces in main workspace, since they are
     // child directories and will therefore be snapshotted
     let stdout = test_env.jj_cmd_success(&main_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     file
     secondary/file
     third/file
-    "###);
+    ");
 }
 
 /// Test making changes to the working copy in a workspace as it gets rewritten
@@ -486,47 +472,47 @@ fn test_workspaces_conflicting_edits() {
     // running any command in the secondary workspace
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
     Parent commit      : qpvuntsm d4124476 (no description set)
-    "###);
+    ");
 
     // The secondary workspace's working-copy commit was updated
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  a58c9a9b19ce default@
     │ ○  e82cd4ee8faa secondary@
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    ");
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation c81af45155a2).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    ");
     // Same error on second run, and from another command
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["log"]);
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation c81af45155a2).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     // It was detected that the working copy is now stale.
     // Since there was an uncommitted change in the working copy, it should
     // have been committed first (causing divergence)
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
     Working copy now at: pmmvwywv?? e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit e82cd4ee8faa
-    "###);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
-    @r###"
+    @r"
     @  e82cd4ee8faa secondary@ (divergent)
     │ ×  30816012e0da (divergent)
     ├─╯
@@ -534,11 +520,11 @@ fn test_workspaces_conflicting_edits() {
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    ");
     // The stale working copy should have been resolved by the previous command
     let stdout = get_log_output(&test_env, &secondary_path);
     assert!(!stdout.starts_with("The working copy is stale"));
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  e82cd4ee8faa secondary@ (divergent)
     │ ×  30816012e0da (divergent)
     ├─╯
@@ -546,7 +532,7 @@ fn test_workspaces_conflicting_edits() {
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    ");
 }
 
 /// Test a clean working copy that gets rewritten from another workspace
@@ -574,35 +560,35 @@ fn test_workspaces_updated_by_other() {
     std::fs::write(main_path.join("file"), "changed in main\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
     Parent commit      : qpvuntsm d4124476 (no description set)
-    "###);
+    ");
 
     // The secondary workspace's working-copy commit was updated.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  a58c9a9b19ce default@
     │ ○  e82cd4ee8faa secondary@
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    ");
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation c81af45155a2).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     // It was detected that the working copy is now stale, but clean. So no
     // divergent commit should be created.
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: pmmvwywv e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit e82cd4ee8faa
-    "###);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r"
     @  e82cd4ee8faa secondary@
@@ -640,33 +626,33 @@ fn test_workspaces_updated_by_other_automatic() {
     std::fs::write(main_path.join("file"), "changed in main\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
     Parent commit      : qpvuntsm d4124476 (no description set)
-    "###);
+    ");
 
     // The secondary workspace's working-copy commit was updated.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  a58c9a9b19ce default@
     │ ○  e82cd4ee8faa secondary@
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    ");
 
     // The first working copy gets automatically updated.
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy is clean
     Working copy : pmmvwywv e82cd4ee (empty) (no description set)
     Parent commit: qpvuntsm d4124476 (no description set)
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: pmmvwywv e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit e82cd4ee8faa
-    "###);
+    ");
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r"
@@ -732,7 +718,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ],
     );
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r#"
+        insta::assert_snapshot!(stdout, @r"
         @  757bc1140b abandon commit 20dd439c4bd12c6ad56c187ac490bd0141804618f638dc5c4dc92ff9aecba20f152b23160db9dcf61beb31a5cb14091d9def5a36d11c9599cc4d2e5689236af1
         ○  8d4abed655 create initial working-copy commit in workspace secondary
         ○  3de27432e5 add workspace 'secondary'
@@ -742,7 +728,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ○  829c93f6a3 snapshot working copy
         ○  2557266dd2 add workspace 'default'
         ○  0000000000
-        "#);
+        ");
     }
 
     // Abandon ops, including the one the secondary workspace is currently on.
@@ -764,31 +750,31 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         test_env.jj_cmd_success(&secondary_path, &["help"]);
 
         let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["st"]);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Working copy changes:
         A added
         D deleted
         M modified
         Working copy : kmkuslsw 15df8cb5 RECOVERY COMMIT FROM `jj workspace update-stale`
         Parent commit: rzvqmyuk 96b31daf (empty) (no description set)
-        "###);
-        insta::assert_snapshot!(stderr, @r###"
+        ");
+        insta::assert_snapshot!(stderr, @r"
         Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 8d4abed655badb70b1bab62aa87136619dbc3c8015a8ce8dfb7abfeca4e2f36c713d8f84e070a0613907a6cee7e1cc05323fe1205a319b93fe978f11a060c33c of type operation not found
         Created and checked out recovery commit 76d0126b3e5c
-        "###);
+        ");
     } else {
         let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r"
         Error: Could not read working copy's operation.
         Hint: Run `jj workspace update-stale` to recover.
         See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-        "###);
+        ");
 
         let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r"
         Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 8d4abed655badb70b1bab62aa87136619dbc3c8015a8ce8dfb7abfeca4e2f36c713d8f84e070a0613907a6cee7e1cc05323fe1205a319b93fe978f11a060c33c of type operation not found
         Created and checked out recovery commit 76d0126b3e5c
-        "###);
+        ");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -806,32 +792,30 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
     // The sparse patterns should remain
     let stdout = test_env.jj_cmd_success(&secondary_path, &["sparse", "list"]);
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         added
         deleted
         modified
-        "###);
+        ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["st"]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stderr, @"");
     }
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Working copy changes:
         A added
         D deleted
         M modified
         Working copy : kmkuslsw 15df8cb5 RECOVERY COMMIT FROM `jj workspace update-stale`
         Parent commit: rzvqmyuk 96b31daf (empty) (no description set)
-        "###);
+        ");
     }
     insta::allow_duplicates! {
         // The modified file should have the same contents it had before (not reset to
         // the base contents)
-        insta::assert_snapshot!(std::fs::read_to_string(secondary_path.join("modified")).unwrap(), @r###"
-        secondary
-        "###);
+        insta::assert_snapshot!(std::fs::read_to_string(secondary_path.join("modified")).unwrap(), @"secondary");
     }
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["evolog"]);
@@ -839,12 +823,12 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         insta::assert_snapshot!(stderr, @"");
     }
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 15df8cb5
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
         ○  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 76d0126b
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-        "###);
+        ");
     }
 }
 
@@ -862,16 +846,16 @@ fn test_workspaces_update_stale_noop() {
         &main_path,
         &["workspace", "update-stale", "--ignore-working-copy"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: This command must be able to update the working copy.
     Hint: Don't use --ignore-working-copy.
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  add workspace 'default'
     ○
-    "#);
+    ");
 }
 
 /// Test "update-stale" in a dirty, but not stale working copy.
@@ -894,19 +878,19 @@ fn test_workspaces_update_stale_snapshot() {
     std::fs::write(secondary_path.join("file"), "changed in second\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Attempted recovery, but the working copy is not stale
-    "###);
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  e672fd8fefac secondary@
     │ ○  ea37b073f5ab default@
     │ ○  b13c81dedc64
     ├─╯
     ○  e6e9989f1179
     ◆  000000000000
-    "###);
+    ");
 }
 
 /// Test forgetting workspaces
@@ -926,26 +910,22 @@ fn test_workspaces_forget() {
 
     // When listing workspaces, only the secondary workspace shows up
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    secondary: pmmvwywv 18463f43 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stdout, @"secondary: pmmvwywv 18463f43 (empty) (no description set)");
 
     // `jj status` tells us that there's no working copy here
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r###"
-    No working copy
-    "###);
+    insta::assert_snapshot!(stdout, @"No working copy");
     insta::assert_snapshot!(stderr, @"");
 
     // The old working copy doesn't get an "@" in the log output
     // TODO: It seems useful to still have the "secondary@" marker here even though
     // there's only one workspace. We should show it when the command is not run
     // from that workspace.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  18463f438cc9
     ○  4e8f9d2be039
     ◆  000000000000
-    "###);
+    ");
 
     // Revision "@" cannot be used
     let stderr = test_env.jj_cmd_failure(&main_path, &["log", "-r", "@"]);
@@ -954,9 +934,7 @@ fn test_workspaces_forget() {
     // Try to add back the workspace
     // TODO: We should make this just add it back instead of failing
     let stderr = test_env.jj_cmd_failure(&main_path, &["workspace", "add", "."]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: Workspace already exists
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: Workspace already exists");
 
     // Add a third workspace...
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../third"]);
@@ -984,37 +962,35 @@ fn test_workspaces_forget_multi_transaction() {
 
     // there should be three workspaces
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 909d51b1 (empty) (no description set)
     second: pmmvwywv 18463f43 (empty) (no description set)
     third: rzvqmyuk cc383fa2 (empty) (no description set)
-    "###);
+    ");
 
     // delete two at once, in a single tx
     test_env.jj_cmd_ok(&main_path, &["workspace", "forget", "second", "third"]);
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
-    default: rlvkpnrz 909d51b1 (empty) (no description set)
-    "###);
+    insta::assert_snapshot!(stdout, @"default: rlvkpnrz 909d51b1 (empty) (no description set)");
 
     // the op log should have multiple workspaces forgotten in a single tx
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "--limit", "1"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  60b2b5a71a84 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third
-    "#);
+    ");
 
     // now, undo, and that should restore both workspaces
     test_env.jj_cmd_ok(&main_path, &["op", "undo"]);
 
     // finally, there should be three workspaces at the end
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 909d51b1 (empty) (no description set)
     second: pmmvwywv 18463f43 (empty) (no description set)
     third: rzvqmyuk cc383fa2 (empty) (no description set)
-    "###);
+    ");
 }
 
 #[test]
@@ -1035,12 +1011,12 @@ fn test_workspaces_forget_abandon_commits() {
 
     // there should be four workspaces, three of which are at the same empty commit
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: qpvuntsm 4e8f9d2b (no description set)
     fourth: uuqppmxq 57d63245 (empty) (no description set)
     second: uuqppmxq 57d63245 (empty) (no description set)
     third: uuqppmxq 57d63245 (empty) (no description set)
-    "###);
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  4e8f9d2be039 default@
     │ ○  57d63245a308 fourth@ second@ third@
@@ -1050,30 +1026,30 @@ fn test_workspaces_forget_abandon_commits() {
 
     // delete the default workspace (should not abandon commit since not empty)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "default"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  57d63245a308 fourth@ second@ third@
     │ ○  4e8f9d2be039
     ├─╯
     ◆  000000000000
-    "###);
+    ");
 
     // delete the second workspace (should not abandon commit since other workspaces
     // still have commit checked out)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "second"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  57d63245a308 fourth@ third@
     │ ○  4e8f9d2be039
     ├─╯
     ◆  000000000000
-    "###);
+    ");
 
     // delete the last 2 workspaces (commit should be abandoned now even though
     // forgotten in same tx)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "third", "fourth"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  4e8f9d2be039
     ◆  000000000000
-    "###);
+    ");
 }
 
 /// Test context of commit summary template
@@ -1099,16 +1075,16 @@ fn test_list_workspaces_template() {
 
     // "current_working_copy" should point to the workspace we operate on
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: 8183d0fcaa4c  (current)
-    second: 0a77a39d7d6f 
-    "###);
+    second: 0a77a39d7d6f
+    ");
 
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: 8183d0fcaa4c 
     second: 0a77a39d7d6f  (current)
-    "###);
+    ");
 }
 
 /// Test getting the workspace root from primary and secondary workspaces
@@ -1120,30 +1096,22 @@ fn test_workspaces_root() {
     let secondary_path = test_env.env_root().join("secondary");
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    $TEST_ENV/main
-    "###);
+    insta::assert_snapshot!(stdout, @"$TEST_ENV/main");
     let main_subdir_path = main_path.join("subdir");
     std::fs::create_dir(&main_subdir_path).unwrap();
     let stdout = test_env.jj_cmd_success(&main_subdir_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    $TEST_ENV/main
-    "###);
+    insta::assert_snapshot!(stdout, @"$TEST_ENV/main");
 
     test_env.jj_cmd_ok(
         &main_path,
         &["workspace", "add", "--name", "secondary", "../secondary"],
     );
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    $TEST_ENV/secondary
-    "###);
+    insta::assert_snapshot!(stdout, @"$TEST_ENV/secondary");
     let secondary_subdir_path = secondary_path.join("subdir");
     std::fs::create_dir(&secondary_subdir_path).unwrap();
     let stdout = test_env.jj_cmd_success(&secondary_subdir_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
-    $TEST_ENV/secondary
-    "###);
+    insta::assert_snapshot!(stdout, @"$TEST_ENV/secondary");
 }
 
 #[test]
@@ -1155,17 +1123,17 @@ fn test_debug_snapshot() {
     std::fs::write(repo_path.join("file"), "contents").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["debug", "snapshot"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  c55ebc67e3db test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  c9a40b951848 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
@@ -1175,7 +1143,7 @@ fn test_debug_snapshot() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    ");
 }
 
 #[test]
@@ -1185,9 +1153,7 @@ fn test_workspaces_rename_nothing_changed() {
     let main_path = test_env.env_root().join("main");
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "rename", "default"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Nothing changed.
-    "###);
+    insta::assert_snapshot!(stderr, @"Nothing changed.");
 }
 
 #[test]
@@ -1200,10 +1166,10 @@ fn test_workspaces_rename_new_workspace_name_already_used() {
         &["workspace", "add", "--name", "second", "../secondary"],
     );
     let stderr = test_env.jj_cmd_failure(&main_path, &["workspace", "rename", "second"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to rename a workspace
     Caused by: Workspace second already exists
-    "###);
+    ");
 }
 
 #[test]
@@ -1218,9 +1184,7 @@ fn test_workspaces_rename_forgotten_workspace() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "forget", "second"]);
     let secondary_path = test_env.env_root().join("secondary");
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["workspace", "rename", "third"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Error: The current workspace 'second' is not tracked in the repo.
-    "###);
+    insta::assert_snapshot!(stderr, @"Error: The current workspace 'second' is not tracked in the repo.");
 }
 
 #[test]
@@ -1236,19 +1200,19 @@ fn test_workspaces_rename_workspace() {
 
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: qpvuntsm 230dd059 (empty) (no description set)
     second: uuqppmxq 57d63245 (empty) (no description set)
-    "###);
+    ");
 
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "rename", "third"]);
     insta::assert_snapshot!(stdout, @"");
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: qpvuntsm 230dd059 (empty) (no description set)
     third: uuqppmxq 57d63245 (empty) (no description set)
-    "###);
+    ");
 
     // Can see the working-copy commit in each workspace in the log output.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
@@ -1257,12 +1221,12 @@ fn test_workspaces_rename_workspace() {
     ├─╯
     ◆  000000000000
     ");
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  57d63245a308 third@
     │ ○  230dd059e1b0 default@
     ├─╯
     ◆  000000000000
-    "###);
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {

--- a/lib/src/config_resolver.rs
+++ b/lib/src/config_resolver.rs
@@ -663,7 +663,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         let context = ConfigResolutionContext {
             home_dir: None,
@@ -672,9 +672,9 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 3);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.1 foo'");
-        insta::assert_snapshot!(resolved_config.layers()[2].data, @r"a = 'a #0.2 foo|bar'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.1 foo'");
+        insta::assert_snapshot!(resolved_config.layers()[2].data, @"a = 'a #0.2 foo|bar'");
 
         let context = ConfigResolutionContext {
             home_dir: None,
@@ -683,8 +683,8 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 2);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.2 foo|bar'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.2 foo|bar'");
 
         let context = ConfigResolutionContext {
             home_dir: None,
@@ -693,10 +693,10 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 4);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.1 foo'");
-        insta::assert_snapshot!(resolved_config.layers()[2].data, @r"a = 'a #0.2 foo|bar'");
-        insta::assert_snapshot!(resolved_config.layers()[3].data, @r"a = 'a #0.3 foo baz'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.1 foo'");
+        insta::assert_snapshot!(resolved_config.layers()[2].data, @"a = 'a #0.2 foo|bar'");
+        insta::assert_snapshot!(resolved_config.layers()[3].data, @"a = 'a #0.3 foo baz'");
 
         // "fooqux" shares "foo" prefix, but should *not* match
         let context = ConfigResolutionContext {
@@ -706,7 +706,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
     }
 
     #[test]
@@ -727,7 +727,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         // only repo matches
         let context = ConfigResolutionContext {
@@ -737,7 +737,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         // only command matches
         let context = ConfigResolutionContext {
@@ -747,7 +747,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         // both match
         let context = ConfigResolutionContext {
@@ -757,8 +757,8 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 2);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.1'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.1'");
     }
 
     #[test]

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -751,20 +751,20 @@ mod tests {
 
         insta::assert_debug_snapshot!(parse("all()").unwrap(), @"All");
         insta::assert_debug_snapshot!(parse("none()").unwrap(), @"None");
-        insta::assert_debug_snapshot!(parse("all(x)").unwrap_err().kind(), @r###"
+        insta::assert_debug_snapshot!(parse("all(x)").unwrap_err().kind(), @r#"
         InvalidArguments {
             name: "all",
             message: "Expected 0 arguments",
         }
-        "###);
-        insta::assert_debug_snapshot!(parse("ale()").unwrap_err().kind(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("ale()").unwrap_err().kind(), @r#"
         NoSuchFunction {
             name: "ale",
             candidates: [
                 "all",
             ],
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -777,13 +777,13 @@ mod tests {
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
-        insta::assert_debug_snapshot!(parse("~x").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("~x").unwrap(), @r#"
         Difference(
             All,
             Pattern(PrefixPath("cur/x")),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("x|y|root:z").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("x|y|root:z").unwrap(), @r#"
         UnionAll(
             [
                 Pattern(PrefixPath("cur/x")),
@@ -791,8 +791,8 @@ mod tests {
                 Pattern(PrefixPath("z")),
             ],
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("x|y&z").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("x|y&z").unwrap(), @r#"
         UnionAll(
             [
                 Pattern(PrefixPath("cur/x")),
@@ -802,7 +802,7 @@ mod tests {
                 ),
             ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -847,22 +847,22 @@ mod tests {
         insta::assert_debug_snapshot!(FilesetExpression::all().to_matcher(), @"EverythingMatcher");
         insta::assert_debug_snapshot!(
             FilesetExpression::file_path(repo_path_buf("foo")).to_matcher(),
-            @r###"
+            @r#"
         FilesMatcher {
             tree: Dir {
                 "foo": File {},
             },
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             FilesetExpression::prefix_path(repo_path_buf("foo")).to_matcher(),
-            @r###"
+            @r#"
         PrefixMatcher {
             tree: Dir {
                 "foo": Prefix {},
             },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -922,7 +922,7 @@ mod tests {
             FilesetExpression::file_path(repo_path_buf("foo")),
             FilesetExpression::file_path(repo_path_buf("foo/bar")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         FilesMatcher {
             tree: Dir {
                 "foo": File {
@@ -930,13 +930,13 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
 
         let expr = FilesetExpression::union_all(vec![
             FilesetExpression::prefix_path(repo_path_buf("bar")),
             FilesetExpression::prefix_path(repo_path_buf("bar/baz")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         PrefixMatcher {
             tree: Dir {
                 "bar": Prefix {
@@ -944,7 +944,7 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -956,7 +956,7 @@ mod tests {
             FilesetExpression::file_path(repo_path_buf("foo")),
             FilesetExpression::prefix_path(repo_path_buf("bar")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         UnionMatcher {
             input1: FilesMatcher {
                 tree: Dir {
@@ -969,7 +969,7 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -982,12 +982,12 @@ mod tests {
 
         let expr =
             FilesetExpression::UnionAll(vec![FilesetExpression::None, FilesetExpression::All]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r"
         UnionMatcher {
             input1: NothingMatcher,
             input2: EverythingMatcher,
         }
-        "###);
+        ");
     }
 
     #[test]
@@ -1001,7 +1001,7 @@ mod tests {
             FilesetExpression::file_path(repo_path_buf("foo")),
             FilesetExpression::prefix_path(repo_path_buf("bar")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         UnionMatcher {
             input1: UnionMatcher {
                 input1: IntersectionMatcher {
@@ -1026,6 +1026,6 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
     }
 }

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -725,13 +725,13 @@ mod tests {
 
     #[test]
     fn test_parse_error() {
-        insta::assert_snapshot!(parse_program("foo|").unwrap_err().to_string(), @r###"
+        insta::assert_snapshot!(parse_program("foo|").unwrap_err().to_string(), @r"
          --> 1:5
           |
         1 | foo|
           |     ^---
           |
           = expected `~` or <primary>
-        "###);
+        ");
     }
 }

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -2168,7 +2168,7 @@ mod tests {
         let obj = git_repo
             .find_object(gix::ObjectId::try_from(id.as_bytes()).unwrap())
             .unwrap();
-        insta::assert_snapshot!(std::str::from_utf8(&obj.data).unwrap(), @r###"
+        insta::assert_snapshot!(std::str::from_utf8(&obj.data).unwrap(), @r"
         tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
         author Someone <someone@example.com> 0 +0000
         committer Someone <someone@example.com> 0 +0000
@@ -2178,7 +2178,7 @@ mod tests {
          hash=9ad9526c3b2103c41a229f2f3c82d107a0ecd902f476a855f0e1dd5f7bef1430663de12749b73e293a877113895a8a2a0f29da4bbc5a5f9a19c3523fb0e53518
 
         initial
-        "###);
+        ");
 
         let returned_sig = commit.secure_sig.expect("failed to return the signature");
 
@@ -2187,19 +2187,19 @@ mod tests {
         let sig = commit.secure_sig.expect("failed to read the signature");
         assert_eq!(&sig, &returned_sig);
 
-        insta::assert_snapshot!(std::str::from_utf8(&sig.sig).unwrap(), @r###"
+        insta::assert_snapshot!(std::str::from_utf8(&sig.sig).unwrap(), @r"
         test sig
 
 
         hash=9ad9526c3b2103c41a229f2f3c82d107a0ecd902f476a855f0e1dd5f7bef1430663de12749b73e293a877113895a8a2a0f29da4bbc5a5f9a19c3523fb0e53518
-        "###);
-        insta::assert_snapshot!(std::str::from_utf8(&sig.data).unwrap(), @r###"
+        ");
+        insta::assert_snapshot!(std::str::from_utf8(&sig.data).unwrap(), @r"
         tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
         author Someone <someone@example.com> 0 +0000
         committer Someone <someone@example.com> 0 +0000
 
         initial
-        "###);
+        ");
     }
 
     fn git_id(commit_id: &CommitId) -> Oid {

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -402,7 +402,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph), @r###"
+        insta::assert_snapshot!(format_graph(graph), @r"
         D    direct(C), indirect(B)
         ├─╮
         C ╷  direct(A)
@@ -412,8 +412,7 @@ mod tests {
         │ ~
         │
         A
-
-        "###);
+        ");
     }
 
     fn topo_grouped<I, E>(graph_iter: I) -> TopoGroupedGraphIterator<char, I::IntoIter>
@@ -431,7 +430,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         C  missing(Y)
         │
         ~
@@ -441,8 +440,8 @@ mod tests {
         ~
 
         A
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         C  missing(Y)
         │
         ~
@@ -452,7 +451,7 @@ mod tests {
         ~
 
         A
-        "###);
+        ");
 
         // All nodes can be lazily emitted.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -472,7 +471,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         E  direct(B)
         │
         │ D  direct(A)
@@ -482,11 +481,10 @@ mod tests {
         B │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
         // D-A is found earlier than B-A, but B is emitted first because it belongs to
         // the emitting branch.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         E  direct(B)
         │
         │ C  direct(B)
@@ -496,8 +494,7 @@ mod tests {
         │ D  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // E can be lazy, then D and C will be queued.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -520,7 +517,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         F  direct(D)
         │
         │ E  direct(C)
@@ -532,9 +529,8 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         F  direct(D)
         │
         D  direct(B)
@@ -546,8 +542,7 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
 
         // F can be lazy, then E will be queued, then C.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -573,7 +568,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         I  direct(E)
         │
         │ H  direct(C)
@@ -591,9 +586,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         I  direct(E)
         │
         │ F  direct(E)
@@ -611,8 +605,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // I can be lazy, then H, G, and F will be queued.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -640,7 +633,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         I  direct(A)
         │
         │ H  direct(C)
@@ -662,9 +655,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         I  direct(A)
         │
         │ B  direct(A)
@@ -686,7 +678,7 @@ mod tests {
         E  missing(Y)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -713,7 +705,7 @@ mod tests {
         )
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         G  direct(A)
         │
         │ F  direct(C)
@@ -727,10 +719,9 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
         // A::F is picked at A, and A will be unblocked. Then, C::D at C, ...
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         G  direct(A)
         │
         │ F  direct(C)
@@ -744,8 +735,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // Two nested fork sub graphs from A
         let graph = itertools::chain!(
@@ -756,7 +746,7 @@ mod tests {
         )
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         L  direct(A)
         │
         │ K  direct(H)
@@ -780,10 +770,9 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
         // A::K is picked at A, and A will be unblocked. Then, H::I at H, ...
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         L  direct(A)
         │
         │ K  direct(H)
@@ -807,8 +796,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // Two nested fork sub graphs from A, interleaved
         let graph = itertools::chain!(
@@ -820,7 +808,7 @@ mod tests {
         .sorted_by(|(id1, _), (id2, _)| id2.cmp(id1))
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         L  direct(A)
         │
         │ K  direct(E)
@@ -844,10 +832,9 @@ mod tests {
         │   B  direct(A)
         ├───╯
         A
-
-        "###);
+        ");
         // A::K is picked at A, and A will be unblocked. Then, E::G at E, ...
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         L  direct(A)
         │
         │ K  direct(E)
@@ -871,8 +858,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // Merged fork sub graphs at K
         let graph = itertools::chain!(
@@ -882,7 +868,7 @@ mod tests {
         )
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         K    direct(E), direct(J)
         ├─╮
         │ J  direct(G)
@@ -908,10 +894,10 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
         // K-E,J is resolved without queuing new heads. Then, G::H, F::I, B::C, and
         // A::D.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         K    direct(E), direct(J)
         ├─╮
         │ J  direct(G)
@@ -937,7 +923,7 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
 
         // Merged fork sub graphs at K, interleaved
         let graph = itertools::chain!(
@@ -948,7 +934,7 @@ mod tests {
         .sorted_by(|(id1, _), (id2, _)| id2.cmp(id1))
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         K    direct(I), direct(J)
         ├─╮
         │ J  direct(D)
@@ -974,10 +960,10 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
         // K-I,J is resolved without queuing new heads. Then, D::F, B::H, C::E, and
         // A::G.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         K    direct(I), direct(J)
         ├─╮
         │ J  direct(D)
@@ -1003,7 +989,7 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -1017,7 +1003,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         F  direct(E)
         │
         E    direct(C), direct(D)
@@ -1029,9 +1015,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         F  direct(E)
         │
         E    direct(C), direct(D)
@@ -1043,8 +1028,7 @@ mod tests {
         C │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // F, E, and D can be lazy, then C will be queued, then B.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -1068,7 +1052,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         E  direct(D)
         │
         D    missing(Y), direct(C)
@@ -1084,9 +1068,8 @@ mod tests {
           B  direct(A)
           │
           A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         E  direct(D)
         │
         D    missing(Y), direct(C)
@@ -1102,8 +1085,7 @@ mod tests {
           B  direct(A)
           │
           A
-
-        "###);
+        ");
 
         // All nodes can be lazily emitted.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -1129,7 +1111,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         G  direct(E)
         │
         │ F  direct(D)
@@ -1143,9 +1125,8 @@ mod tests {
         B   │  direct(A)
         ├───╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         G  direct(E)
         │
         E    direct(B), direct(C)
@@ -1159,8 +1140,7 @@ mod tests {
         B │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1176,7 +1156,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         H  direct(F)
         │
         │ G  direct(E)
@@ -1192,9 +1172,8 @@ mod tests {
         B │  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         H  direct(F)
         │
         F  direct(D)
@@ -1210,8 +1189,7 @@ mod tests {
         C │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1223,7 +1201,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         D  direct(C)
         │
         C    direct(B), direct(A)
@@ -1233,10 +1211,9 @@ mod tests {
         ~ │
           │
           A
-
-        "###);
+        ");
         // A is emitted first because it's the second parent.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         D  direct(C)
         │
         C    direct(B), direct(A)
@@ -1246,7 +1223,7 @@ mod tests {
         B  missing(X)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -1267,7 +1244,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         J    direct(I), direct(G)
         ├─╮
         I │    direct(H), direct(E)
@@ -1287,10 +1264,9 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
         // Second branches are visited first.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         J    direct(I), direct(G)
         ├─╮
         │ G  direct(D)
@@ -1310,8 +1286,7 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1329,7 +1304,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         J  direct(F)
         │
         │ I  direct(E)
@@ -1349,9 +1324,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         J  direct(F)
         │
         F  direct(C)
@@ -1371,8 +1345,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1390,7 +1363,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         J  direct(F)
         │
         │ I  direct(G)
@@ -1412,9 +1385,8 @@ mod tests {
         │ ~
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         J  direct(F)
         │
         F  direct(D)
@@ -1436,8 +1408,7 @@ mod tests {
         │ C  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1450,7 +1421,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         E  direct(C)
         │
         │ D  direct(B)
@@ -1462,9 +1433,8 @@ mod tests {
         │ ~
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         E  direct(C)
         │
         C  direct(A)
@@ -1476,7 +1446,7 @@ mod tests {
         B  missing(X)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -1493,7 +1463,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         I    direct(H), direct(G)
         ├─╮
         H │  direct(D)
@@ -1511,11 +1481,10 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
         // Topological order must be preserved. Depending on the implementation,
         // E might be requested more than once by paths D->E and B->D->E.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         I    direct(H), direct(G)
         ├─╮
         │ G  direct(B)
@@ -1533,8 +1502,7 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1835,22 +1803,20 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         C    direct(A), direct(B)
         ├─╮
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         C    direct(A), direct(B)
         ├─╮
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // A is queued once by C-A because B isn't populated at this point. Since
         // B is the second parent, B-A is processed next and A is queued again. So
@@ -1870,18 +1836,16 @@ mod tests {
         // The graph shouldn't have duplicated parent->child edges, but topo-grouped
         // iterator can handle it anyway.
         let graph = [('B', vec![direct('A'), direct('A')]), ('A', vec![])].map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         B  direct(A), direct(A)
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         B  direct(A), direct(A)
         │
         A
-
-        "###);
+        ");
 
         let mut iter = topo_grouped(graph.iter().cloned());
         assert_eq!(iter.next().unwrap().unwrap().0, 'B');

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2829,94 +2829,94 @@ mod tests {
 
         insta::assert_debug_snapshot!(
             current_wc,
-            @r###"CommitRef(WorkingCopy(WorkspaceId("default")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("default")))"#);
         insta::assert_debug_snapshot!(
             current_wc.heads(),
-            @r###"Heads(CommitRef(WorkingCopy(WorkspaceId("default"))))"###);
+            @r#"Heads(CommitRef(WorkingCopy(WorkspaceId("default"))))"#);
         insta::assert_debug_snapshot!(
             current_wc.roots(),
-            @r###"Roots(CommitRef(WorkingCopy(WorkspaceId("default"))))"###);
+            @r#"Roots(CommitRef(WorkingCopy(WorkspaceId("default"))))"#);
         insta::assert_debug_snapshot!(
-            current_wc.parents(), @r###"
+            current_wc.parents(), @r#"
         Ancestors {
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            current_wc.ancestors(), @r###"
+            current_wc.ancestors(), @r#"
         Ancestors {
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.children(), @r###"
+            foo_symbol.children(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.descendants(), @r###"
+            foo_symbol.descendants(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.dag_range_to(&current_wc), @r###"
+            foo_symbol.dag_range_to(&current_wc), @r#"
         DagRange {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.connected(), @r###"
+            foo_symbol.connected(), @r#"
         DagRange {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("foo")),
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.range(&current_wc), @r###"
+            foo_symbol.range(&current_wc), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             foo_symbol.negated(),
-            @r###"NotIn(CommitRef(Symbol("foo")))"###);
+            @r#"NotIn(CommitRef(Symbol("foo")))"#);
         insta::assert_debug_snapshot!(
-            foo_symbol.union(&current_wc), @r###"
+            foo_symbol.union(&current_wc), @r#"
         Union(
             CommitRef(Symbol("foo")),
             CommitRef(WorkingCopy(WorkspaceId("default"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             UserRevsetExpression::union_all(&[]),
             @"None");
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[current_wc.clone()]),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("default")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("default")))"#);
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[current_wc.clone(), foo_symbol.clone()]),
-            @r###"
+            @r#"
         Union(
             CommitRef(WorkingCopy(WorkspaceId("default"))),
             CommitRef(Symbol("foo")),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[
                 current_wc.clone(),
                 foo_symbol.clone(),
                 bar_symbol.clone(),
             ]),
-            @r###"
+            @r#"
         Union(
             CommitRef(WorkingCopy(WorkspaceId("default"))),
             Union(
@@ -2924,7 +2924,7 @@ mod tests {
                 CommitRef(Symbol("bar")),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[
                 current_wc.clone(),
@@ -2932,7 +2932,7 @@ mod tests {
                 bar_symbol.clone(),
                 baz_symbol.clone(),
             ]),
-            @r###"
+            @r#"
         Union(
             Union(
                 CommitRef(WorkingCopy(WorkspaceId("default"))),
@@ -2943,27 +2943,27 @@ mod tests {
                 CommitRef(Symbol("baz")),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.intersection(&current_wc), @r###"
+            foo_symbol.intersection(&current_wc), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(WorkingCopy(WorkspaceId("default"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.minus(&current_wc), @r###"
+            foo_symbol.minus(&current_wc), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(WorkingCopy(WorkspaceId("default"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             UserRevsetExpression::coalesce(&[]),
             @"None");
         insta::assert_debug_snapshot!(
             RevsetExpression::coalesce(&[current_wc.clone()]),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("default")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("default")))"#);
         insta::assert_debug_snapshot!(
             RevsetExpression::coalesce(&[current_wc.clone(), foo_symbol.clone()]),
             @r#"
@@ -3002,33 +3002,33 @@ mod tests {
             @"WorkingCopyWithoutWorkspace");
         insta::assert_debug_snapshot!(
             parse("main@").unwrap(),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("main")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("main")))"#);
         insta::assert_debug_snapshot!(
             parse_with_workspace("@", &main_workspace_id).unwrap(),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("main")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("main")))"#);
         insta::assert_debug_snapshot!(
             parse_with_workspace("main@", &other_workspace_id).unwrap(),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("main")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("main")))"#);
         // "@" in function argument must be quoted
         insta::assert_debug_snapshot!(
             parse("author_name(foo@)").unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"author_name("foo@")"#).unwrap(),
             @r#"Filter(AuthorName(Substring("foo@")))"#);
         // Parse a single symbol
         insta::assert_debug_snapshot!(
             parse("foo").unwrap(),
-            @r###"CommitRef(Symbol("foo"))"###);
+            @r#"CommitRef(Symbol("foo"))"#);
         // Default arguments for *bookmarks() are all ""
         insta::assert_debug_snapshot!(
             parse("bookmarks()").unwrap(),
-            @r###"CommitRef(Bookmarks(Substring("")))"###);
+            @r#"CommitRef(Bookmarks(Substring("")))"#);
         // Default argument for tags() is ""
         insta::assert_debug_snapshot!(
             parse("tags()").unwrap(),
-            @r###"CommitRef(Tags(Substring("")))"###);
-        insta::assert_debug_snapshot!(parse("remote_bookmarks()").unwrap(), @r###"
+            @r#"CommitRef(Tags(Substring("")))"#);
+        insta::assert_debug_snapshot!(parse("remote_bookmarks()").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3036,8 +3036,8 @@ mod tests {
                 remote_ref_state: None,
             },
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("tracked_remote_bookmarks()").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("tracked_remote_bookmarks()").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3045,8 +3045,8 @@ mod tests {
                 remote_ref_state: Some(Tracking),
             },
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("untracked_remote_bookmarks()").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("untracked_remote_bookmarks()").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3054,46 +3054,46 @@ mod tests {
                 remote_ref_state: Some(New),
             },
         )
-        "###);
+        "#);
         // Parse a quoted symbol
         insta::assert_debug_snapshot!(
             parse("'foo'").unwrap(),
-            @r###"CommitRef(Symbol("foo"))"###);
+            @r#"CommitRef(Symbol("foo"))"#);
         // Parse the "parents" operator
-        insta::assert_debug_snapshot!(parse("foo-").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo-").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         // Parse the "children" operator
-        insta::assert_debug_snapshot!(parse("foo+").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo+").unwrap(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         // Parse the "ancestors" operator
-        insta::assert_debug_snapshot!(parse("::foo").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("::foo").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         // Parse the "descendants" operator
-        insta::assert_debug_snapshot!(parse("foo::").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo::").unwrap(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         // Parse the "dag range" operator
-        insta::assert_debug_snapshot!(parse("foo::bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo::bar").unwrap(), @r#"
         DagRange {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
         }
-        "###);
+        "#);
         // Parse the nullary "dag range" operator
         insta::assert_debug_snapshot!(parse("::").unwrap(), @"All");
         // Parse the "range" prefix operator
@@ -3111,13 +3111,13 @@ mod tests {
             generation: 0..18446744073709551615,
         }
         "#);
-        insta::assert_debug_snapshot!(parse("foo..bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo..bar").unwrap(), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         // Parse the nullary "range" operator
         insta::assert_debug_snapshot!(parse("..").unwrap(), @r"
         Range {
@@ -3129,28 +3129,28 @@ mod tests {
         // Parse the "negate" operator
         insta::assert_debug_snapshot!(
             parse("~ foo").unwrap(),
-            @r###"NotIn(CommitRef(Symbol("foo")))"###);
+            @r#"NotIn(CommitRef(Symbol("foo")))"#);
         // Parse the "intersection" operator
-        insta::assert_debug_snapshot!(parse("foo & bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo & bar").unwrap(), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
         // Parse the "union" operator
-        insta::assert_debug_snapshot!(parse("foo | bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo | bar").unwrap(), @r#"
         Union(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
         // Parse the "difference" operator
-        insta::assert_debug_snapshot!(parse("foo ~ bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo ~ bar").unwrap(), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3159,17 +3159,17 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse_with_modifier("all:foo").unwrap(), @r###"
+            parse_with_modifier("all:foo").unwrap(), @r#"
         (
             CommitRef(Symbol("foo")),
             Some(All),
         )
-        "###);
+        "#);
 
         // Top-level string pattern can't be parsed, which is an error anyway
         insta::assert_debug_snapshot!(
             parse_with_modifier(r#"exact:"foo""#).unwrap_err().kind(),
-            @r###"NoSuchModifier("exact")"###);
+            @r#"NoSuchModifier("exact")"#);
     }
 
     #[test]
@@ -3179,41 +3179,41 @@ mod tests {
 
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks("foo")"#).unwrap(),
-            @r###"CommitRef(Bookmarks(Substring("foo")))"###);
+            @r#"CommitRef(Bookmarks(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(exact:"foo")"#).unwrap(),
-            @r###"CommitRef(Bookmarks(Exact("foo")))"###);
+            @r#"CommitRef(Bookmarks(Exact("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(substring:"foo")"#).unwrap(),
-            @r###"CommitRef(Bookmarks(Substring("foo")))"###);
+            @r#"CommitRef(Bookmarks(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(bad:"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Invalid string pattern")"###);
+            @r#"Expression("Invalid string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(exact::"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(exact:"foo"+)"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
 
         insta::assert_debug_snapshot!(
             parse(r#"tags("foo")"#).unwrap(),
-            @r###"CommitRef(Tags(Substring("foo")))"###);
+            @r#"CommitRef(Tags(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(exact:"foo")"#).unwrap(),
-            @r###"CommitRef(Tags(Exact("foo")))"###);
+            @r#"CommitRef(Tags(Exact("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(substring:"foo")"#).unwrap(),
-            @r###"CommitRef(Tags(Substring("foo")))"###);
+            @r#"CommitRef(Tags(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(bad:"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Invalid string pattern")"###);
+            @r#"Expression("Invalid string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(exact::"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(exact:"foo"+)"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
 
         // String pattern isn't allowed at top level.
         assert_matches!(
@@ -3228,21 +3228,21 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse("parents(foo)").unwrap(), @r###"
+            parse("parents(foo)").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("parents(\"foo\")").unwrap(), @r###"
+            parse("parents(\"foo\")").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("ancestors(parents(foo))").unwrap(), @r###"
+            parse("ancestors(parents(foo))").unwrap(), @r#"
         Ancestors {
             heads: Ancestors {
                 heads: CommitRef(Symbol("foo")),
@@ -3250,30 +3250,30 @@ mod tests {
             },
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("parents(foo,foo)").unwrap_err().kind(), @r###"
+            parse("parents(foo,foo)").unwrap_err().kind(), @r#"
         InvalidFunctionArguments {
             name: "parents",
             message: "Expected 1 arguments",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse("root()").unwrap(),
             @"Root");
         assert!(parse("root(a)").is_err());
         insta::assert_debug_snapshot!(
             parse(r#"description("")"#).unwrap(),
-            @r###"Filter(Description(Substring("")))"###);
+            @r#"Filter(Description(Substring("")))"#);
         insta::assert_debug_snapshot!(
             parse("description(foo)").unwrap(),
-            @r###"Filter(Description(Substring("foo")))"###);
+            @r#"Filter(Description(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse("description(visible_heads())").unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse("description(\"(foo)\")").unwrap(),
-            @r###"Filter(Description(Substring("(foo)")))"###);
+            @r#"Filter(Description(Substring("(foo)")))"#);
         assert!(parse("mine(foo)").is_err());
         insta::assert_debug_snapshot!(
             parse_with_workspace("empty()", &WorkspaceId::default()).unwrap(),
@@ -3282,15 +3282,15 @@ mod tests {
         assert!(parse_with_workspace("file()", &WorkspaceId::default()).is_err());
         insta::assert_debug_snapshot!(
             parse_with_workspace("file(foo)", &WorkspaceId::default()).unwrap(),
-            @r###"Filter(File(Pattern(PrefixPath("foo"))))"###);
+            @r#"Filter(File(Pattern(PrefixPath("foo"))))"#);
         insta::assert_debug_snapshot!(
             parse_with_workspace("file(all())", &WorkspaceId::default()).unwrap(),
             @"Filter(File(All))");
         insta::assert_debug_snapshot!(
             parse_with_workspace(r#"file(file:"foo")"#, &WorkspaceId::default()).unwrap(),
-            @r###"Filter(File(Pattern(FilePath("foo"))))"###);
+            @r#"Filter(File(Pattern(FilePath("foo"))))"#);
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(foo|bar&baz)", &WorkspaceId::default()).unwrap(), @r###"
+            parse_with_workspace("file(foo|bar&baz)", &WorkspaceId::default()).unwrap(), @r#"
         Filter(
             File(
                 UnionAll(
@@ -3304,9 +3304,9 @@ mod tests {
                 ),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(foo, bar, baz)", &WorkspaceId::default()).unwrap(), @r###"
+            parse_with_workspace("file(foo, bar, baz)", &WorkspaceId::default()).unwrap(), @r#"
         Filter(
             File(
                 UnionAll(
@@ -3318,7 +3318,7 @@ mod tests {
                 ),
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3365,7 +3365,7 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse("remote_bookmarks(remote=foo)").unwrap(), @r###"
+            parse("remote_bookmarks(remote=foo)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3373,9 +3373,9 @@ mod tests {
                 remote_ref_state: None,
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("remote_bookmarks(foo, remote=bar)").unwrap(), @r###"
+            parse("remote_bookmarks(foo, remote=bar)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring("foo"),
@@ -3383,9 +3383,9 @@ mod tests {
                 remote_ref_state: None,
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("tracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r###"
+            parse("tracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring("foo"),
@@ -3393,9 +3393,9 @@ mod tests {
                 remote_ref_state: Some(Tracking),
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("untracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r###"
+            parse("untracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring("foo"),
@@ -3403,39 +3403,39 @@ mod tests {
                 remote_ref_state: Some(New),
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks(remote=foo, bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Positional argument follows keyword argument",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks("", foo, remote=bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Got multiple values for keyword \"remote\"",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks(remote=bar, remote=bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Got multiple values for keyword \"remote\"",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks(unknown=bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Unexpected keyword argument \"unknown\"",
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -3444,7 +3444,7 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse_with_aliases("AB|c", [("AB", "a|b")]).unwrap(), @r###"
+            parse_with_aliases("AB|c", [("AB", "a|b")]).unwrap(), @r#"
         Union(
             Union(
                 CommitRef(Symbol("a")),
@@ -3452,13 +3452,13 @@ mod tests {
             ),
             CommitRef(Symbol("c")),
         )
-        "###);
+        "#);
 
         // Alias can be substituted to string literal.
         insta::assert_debug_snapshot!(
             parse_with_aliases_and_workspace("file(A)", [("A", "a")], &WorkspaceId::default())
                 .unwrap(),
-            @r###"Filter(File(Pattern(PrefixPath("a"))))"###);
+            @r#"Filter(File(Pattern(PrefixPath("a"))))"#);
 
         // Alias can be substituted to string pattern.
         insta::assert_debug_snapshot!(
@@ -3501,77 +3501,77 @@ mod tests {
         // (e.g. Range -> DagRange) nor reorders arguments unintentionally.
 
         insta::assert_debug_snapshot!(
-            optimize(parse("parents(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("parents(bookmarks() & all())").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Bookmarks(Substring(""))),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("children(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("children(bookmarks() & all())").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Bookmarks(Substring(""))),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("ancestors(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("ancestors(bookmarks() & all())").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Bookmarks(Substring(""))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("descendants(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("descendants(bookmarks() & all())").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Bookmarks(Substring(""))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all())..(all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all())..(all() & tags())").unwrap()), @r#"
         Range {
             roots: CommitRef(Bookmarks(Substring(""))),
             heads: CommitRef(Tags(Substring(""))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all())::(all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all())::(all() & tags())").unwrap()), @r#"
         DagRange {
             roots: CommitRef(Bookmarks(Substring(""))),
             heads: CommitRef(Tags(Substring(""))),
         }
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
             optimize(parse("heads(bookmarks() & all())").unwrap()),
-            @r###"Heads(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"Heads(CommitRef(Bookmarks(Substring(""))))"#);
         insta::assert_debug_snapshot!(
             optimize(parse("roots(bookmarks() & all())").unwrap()),
-            @r###"Roots(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"Roots(CommitRef(Bookmarks(Substring(""))))"#);
 
         insta::assert_debug_snapshot!(
-            optimize(parse("latest(bookmarks() & all(), 2)").unwrap()), @r###"
+            optimize(parse("latest(bookmarks() & all(), 2)").unwrap()), @r#"
         Latest {
             candidates: CommitRef(Bookmarks(Substring(""))),
             count: 2,
         }
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
-            optimize(parse("present(foo ~ bar)").unwrap()), @r###"
+            optimize(parse("present(foo ~ bar)").unwrap()), @r#"
         Present(
             Difference(
                 CommitRef(Symbol("foo")),
                 CommitRef(Symbol("bar")),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             optimize(parse("present(bookmarks() & all())").unwrap()),
-            @r###"Present(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"Present(CommitRef(Bookmarks(Substring(""))))"#);
 
         insta::assert_debug_snapshot!(
             optimize(parse("at_operation(@-, bookmarks() & all())").unwrap()), @r#"
@@ -3595,28 +3595,28 @@ mod tests {
 
         insta::assert_debug_snapshot!(
             optimize(parse("~bookmarks() & all()").unwrap()),
-            @r###"NotIn(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"NotIn(CommitRef(Bookmarks(Substring(""))))"#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all()) | (all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all()) | (all() & tags())").unwrap()), @r#"
         Union(
             CommitRef(Bookmarks(Substring(""))),
             CommitRef(Tags(Substring(""))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all()) & (all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all()) & (all() & tags())").unwrap()), @r#"
         Intersection(
             CommitRef(Bookmarks(Substring(""))),
             CommitRef(Tags(Substring(""))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all()) ~ (all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all()) ~ (all() & tags())").unwrap()), @r#"
         Difference(
             CommitRef(Bookmarks(Substring(""))),
             CommitRef(Tags(Substring(""))),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3673,19 +3673,19 @@ mod tests {
         let settings = insta_settings();
         let _guard = settings.bind_to_scope();
 
-        insta::assert_debug_snapshot!(optimize(parse("foo & ~bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~foo & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~foo & bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("bar")),
             CommitRef(Symbol("foo")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~foo & bar & ~baz").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~foo & bar & ~baz").unwrap()), @r#"
         Difference(
             Difference(
                 CommitRef(Symbol("bar")),
@@ -3693,46 +3693,46 @@ mod tests {
             ),
             CommitRef(Symbol("baz")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(all() & ~foo) & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(all() & ~foo) & bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("bar")),
             CommitRef(Symbol("foo")),
         )
-        "###);
+        "#);
 
         // Binary difference operation should go through the same optimization passes.
         insta::assert_debug_snapshot!(
             optimize(parse("all() ~ foo").unwrap()),
-            @r###"NotIn(CommitRef(Symbol("foo")))"###);
-        insta::assert_debug_snapshot!(optimize(parse("foo ~ bar").unwrap()), @r###"
+            @r#"NotIn(CommitRef(Symbol("foo")))"#);
+        insta::assert_debug_snapshot!(optimize(parse("foo ~ bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(all() ~ foo) & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(all() ~ foo) & bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("bar")),
             CommitRef(Symbol("foo")),
         )
-        "###);
+        "#);
 
         // Range expression.
-        insta::assert_debug_snapshot!(optimize(parse("::foo & ~::bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("::foo & ~::bar").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("bar")),
             heads: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~::foo & ::bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~::foo & ::bar").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(optimize(parse("foo..").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
@@ -3740,41 +3740,41 @@ mod tests {
             generation: 0..18446744073709551615,
         }
         "#);
-        insta::assert_debug_snapshot!(optimize(parse("foo..bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo..bar").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
 
         // Double/triple negates.
-        insta::assert_debug_snapshot!(optimize(parse("foo & ~~bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~~bar").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("foo & ~~~bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~~~bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~(all() & ~foo) & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~(all() & ~foo) & bar").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
 
         // Should be better than '(all() & ~foo) & (all() & ~bar)'.
-        insta::assert_debug_snapshot!(optimize(parse("~foo & ~bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("~foo & ~bar").unwrap()), @r#"
         Difference(
             NotIn(CommitRef(Symbol("foo"))),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3814,22 +3814,22 @@ mod tests {
         "#);
 
         // Bounded ancestors shouldn't be substituted.
-        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo, 1)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo, 1)").unwrap()), @r#"
         NotIn(
             Ancestors {
                 heads: CommitRef(Symbol("foo")),
                 generation: 0..1,
             },
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo-, 1)").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo-, 1)").unwrap()), @r#"
         NotIn(
             Ancestors {
                 heads: CommitRef(Symbol("foo")),
                 generation: 1..2,
             },
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3892,12 +3892,12 @@ mod tests {
             optimize(parse("author_name(foo)").unwrap()),
             @r#"Filter(AuthorName(Substring("foo")))"#);
 
-        insta::assert_debug_snapshot!(optimize(parse("foo & description(bar)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo & description(bar)").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             Filter(Description(Substring("bar"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(optimize(parse("author_name(foo) & bar").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("bar")),
@@ -3958,7 +3958,7 @@ mod tests {
             Filter(AuthorName(Substring("baz"))),
         )
         "#);
-        insta::assert_debug_snapshot!(optimize(parse_with_workspace("foo & file(bar) & baz", &WorkspaceId::default()).unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse_with_workspace("foo & file(bar) & baz", &WorkspaceId::default()).unwrap()), @r#"
         Intersection(
             Intersection(
                 CommitRef(Symbol("foo")),
@@ -3966,7 +3966,7 @@ mod tests {
             ),
             Filter(File(Pattern(PrefixPath("bar")))),
         )
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
             optimize(parse("foo & description(bar) & author_name(baz) & qux").unwrap()), @r#"
@@ -4194,27 +4194,27 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         // Typical scenario: fold nested parents()
-        insta::assert_debug_snapshot!(optimize(parse("foo--").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo--").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 2..3,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("::(foo---)").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("::(foo---)").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(::foo)---").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(::foo)---").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
+        "#);
 
         // 'foo-+' is not 'foo'.
-        insta::assert_debug_snapshot!(optimize(parse("foo---+").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo---+").unwrap()), @r#"
         Descendants {
             roots: Ancestors {
                 heads: CommitRef(Symbol("foo")),
@@ -4222,18 +4222,18 @@ mod tests {
             },
             generation: 1..2,
         }
-        "###);
+        "#);
 
         // For 'roots..heads', heads can be folded.
-        insta::assert_debug_snapshot!(optimize(parse("foo..(bar--)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo..(bar--)").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 2..18446744073709551615,
         }
-        "###);
+        "#);
         // roots can also be folded, and the range expression is reconstructed.
-        insta::assert_debug_snapshot!(optimize(parse("(foo--)..(bar---)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("(foo--)..(bar---)").unwrap()), @r#"
         Range {
             roots: Ancestors {
                 heads: CommitRef(Symbol("foo")),
@@ -4242,10 +4242,10 @@ mod tests {
             heads: CommitRef(Symbol("bar")),
             generation: 3..18446744073709551615,
         }
-        "###);
+        "#);
         // Bounded ancestors shouldn't be substituted to range.
         insta::assert_debug_snapshot!(
-            optimize(parse("~ancestors(foo, 2) & ::bar").unwrap()), @r###"
+            optimize(parse("~ancestors(foo, 2) & ::bar").unwrap()), @r#"
         Difference(
             Ancestors {
                 heads: CommitRef(Symbol("bar")),
@@ -4256,11 +4256,11 @@ mod tests {
                 generation: 0..2,
             },
         )
-        "###);
+        "#);
 
         // If inner range is bounded by roots, it cannot be merged.
         // e.g. '..(foo..foo)' is equivalent to '..none()', not to '..foo'
-        insta::assert_debug_snapshot!(optimize(parse("(foo..bar)--").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("(foo..bar)--").unwrap()), @r#"
         Ancestors {
             heads: Range {
                 roots: CommitRef(Symbol("foo")),
@@ -4269,8 +4269,8 @@ mod tests {
             },
             generation: 2..3,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("foo..(bar..baz)").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("foo..(bar..baz)").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: Range {
@@ -4280,24 +4280,24 @@ mod tests {
             },
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
 
         // Ancestors of empty generation range should be empty.
         insta::assert_debug_snapshot!(
-            optimize(parse("ancestors(ancestors(foo), 0)").unwrap()), @r###"
+            optimize(parse("ancestors(ancestors(foo), 0)").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 0..0,
         }
-        "###
+        "#
         );
         insta::assert_debug_snapshot!(
-            optimize(parse("ancestors(ancestors(foo, 0))").unwrap()), @r###"
+            optimize(parse("ancestors(ancestors(foo, 0))").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 0..0,
         }
-        "###
+        "#
         );
     }
 
@@ -4307,27 +4307,27 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         // Typical scenario: fold nested children()
-        insta::assert_debug_snapshot!(optimize(parse("foo++").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo++").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 2..3,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(foo+++)::").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(foo+++)::").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(foo::)+++").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(foo::)+++").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
+        "#);
 
         // 'foo+-' is not 'foo'.
-        insta::assert_debug_snapshot!(optimize(parse("foo+++-").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo+++-").unwrap()), @r#"
         Ancestors {
             heads: Descendants {
                 roots: CommitRef(Symbol("foo")),
@@ -4335,12 +4335,12 @@ mod tests {
             },
             generation: 1..2,
         }
-        "###);
+        "#);
 
         // TODO: Inner Descendants can be folded into DagRange. Perhaps, we can rewrite
         // 'x::y' to 'x:: & ::y' first, so the common substitution rule can handle both
         // 'x+::y' and 'x+ & ::y'.
-        insta::assert_debug_snapshot!(optimize(parse("(foo++)::bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("(foo++)::bar").unwrap()), @r#"
         DagRange {
             roots: Descendants {
                 roots: CommitRef(Symbol("foo")),
@@ -4348,7 +4348,7 @@ mod tests {
             },
             heads: CommitRef(Symbol("bar")),
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/lib/tests/test_annotate.rs
+++ b/lib/tests/test_annotate.rs
@@ -124,18 +124,18 @@ fn test_annotate_linear() {
     drop(create_commit);
 
     insta::assert_snapshot!(annotate(tx.repo(), &commit1, file_path), @"");
-    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path), @r"
     commit2: 2a
     commit2: 2b
-    "#);
-    insta::assert_snapshot!(annotate(tx.repo(), &commit3, file_path), @r#"
+    ");
+    insta::assert_snapshot!(annotate(tx.repo(), &commit3, file_path), @r"
     commit2: 2b
     commit3: 3
-    "#);
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    ");
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2b
     commit3: 3
-    "#);
+    ");
 }
 
 #[test]
@@ -169,11 +169,11 @@ fn test_annotate_merge_simple() {
     let commit4 = create_commit("commit4", &[commit2.id(), commit3.id()], tree4.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2
     commit1: 1
     commit3: 3
-    "#);
+    ");
 
     // Exclude the fork commit and its ancestors.
     let domain = RevsetExpression::commit(commit1.id().clone())
@@ -243,13 +243,13 @@ fn test_annotate_merge_split() {
     let commit4 = create_commit("commit4", &[commit2.id(), commit3.id()], tree4.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2
     commit1: 1a
     commit1: 1b
     commit3: 3
     commit4: 4
-    "#);
+    ");
 }
 
 #[test]
@@ -293,7 +293,7 @@ fn test_annotate_merge_split_interleaved() {
     let commit6 = create_commit("commit6", &[commit4.id(), commit5.id()], tree6.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit6, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit6, file_path), @r"
     commit1: 1a
     commit4: 4
     commit1: 1b
@@ -301,7 +301,7 @@ fn test_annotate_merge_split_interleaved() {
     commit2: 2a
     commit5: 5
     commit2: 2b
-    "#);
+    ");
 }
 
 #[test]
@@ -338,13 +338,13 @@ fn test_annotate_merge_dup() {
     // Both "1"s can be propagated to commit1 through commit2 and commit3.
     // Alternatively, it's also good to interpret that one of the "1"s was
     // produced at commit2, commit3, or commit4.
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2
     commit1: 1
     commit1: 1
     commit3: 3
     commit4: 4
-    "#);
+    ");
 
     // For example, the parent tree of commit4 doesn't contain multiple "1"s.
     // If annotation were computed compared to the parent tree, not trees of the
@@ -373,7 +373,5 @@ fn test_annotate_file_directory_transition() {
     let commit2 = create_commit("commit2", &[commit1.id()], tree2.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path2), @r#"
-    commit2: 2
-    "#);
+    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path2), @"commit2: 2");
 }

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -79,7 +79,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -93,7 +93,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
     // Swap the positive terms in the conflict. The diff should still use the right
     // side, but now the right side should come first.
@@ -103,7 +103,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -117,7 +117,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
     // Test materializing "snapshot" conflict markers
     let conflict = Merge::from_removes_adds(
@@ -126,7 +126,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot),
-        @r##"
+        @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -141,7 +141,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "##
+    "
     );
     // Test materializing "git" conflict markers
     let conflict = Merge::from_removes_adds(
@@ -150,7 +150,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Git),
-        @r##"
+        @r"
     line 1
     line 2
     <<<<<<< Side #1 (Conflict 1 of 1)
@@ -164,7 +164,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Side #2 (Conflict 1 of 1 ends)
     line 4
     line 5
-    "##
+    "
     );
 }
 
@@ -234,7 +234,7 @@ fn test_materialize_conflict_three_sides() {
     // Test materializing "diff" conflict markers
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -252,12 +252,12 @@ fn test_materialize_conflict_three_sides() {
     +line 3 c.2
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##
+    "
     );
     // Test materializing "snapshot" conflict markers
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot),
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
@@ -279,13 +279,13 @@ fn test_materialize_conflict_three_sides() {
     line 3 c.2
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##
+    "
     );
     // Test materializing "git" conflict markers (falls back to "snapshot" since
     // "git" conflict markers don't support more than 2 sides)
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Git),
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
@@ -307,7 +307,7 @@ fn test_materialize_conflict_three_sides() {
     line 3 c.2
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##
+    "
     );
 }
 
@@ -366,7 +366,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
@@ -382,7 +382,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     +line 2 c.1
     >>>>>>> Conflict 1 of 1 ends
     line 3
-    "###
+    "
     );
     let conflict = Merge::from_removes_adds(
         vec![Some(base_id.clone()), Some(base_id.clone())],
@@ -390,7 +390,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -406,7 +406,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     line 2 a.3
     >>>>>>> Conflict 1 of 1 ends
     line 3
-    "###
+    "
     );
     let conflict = Merge::from_removes_adds(
         vec![Some(base_id.clone()), Some(base_id.clone())],
@@ -414,7 +414,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -430,7 +430,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     +line 2 b.2
     >>>>>>> Conflict 1 of 1 ends
     line 3
-    "###
+    "
     );
 }
 
@@ -483,7 +483,7 @@ fn test_materialize_parse_roundtrip() {
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(
         materialized,
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
     line 1 left
@@ -503,13 +503,13 @@ fn test_materialize_parse_roundtrip() {
     line 4 right
     line 5 right
     >>>>>>> Conflict 2 of 2 ends
-    "###
+    "
     );
 
     // The first add should always be from the left side
     insta::assert_debug_snapshot!(
         parse_conflict(materialized.as_bytes(), conflict.num_sides(), MIN_CONFLICT_MARKER_LEN),
-        @r###"
+        @r#"
     Some(
         [
             Conflicted(
@@ -531,7 +531,7 @@ fn test_materialize_parse_roundtrip() {
             ),
         ],
     )
-    "###);
+    "#);
 }
 
 #[test]
@@ -627,14 +627,14 @@ fn test_materialize_conflict_no_newlines_at_eof() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1 (adds terminating newline)
     -base
     +++++++ Contents of side #2 (no terminating newline)
     right
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     // The conflict markers are parsed with the trailing newline, but it is removed
     // by `update_from_content`
@@ -703,7 +703,7 @@ fn test_materialize_conflict_modify_delete() {
         vec![Some(base_id.clone())],
         vec![Some(modified_id.clone()), Some(deleted_id.clone())],
     );
-    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r###"
+    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -714,7 +714,7 @@ fn test_materialize_conflict_modify_delete() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
 
     // right modifies a line, left deletes the same line.
@@ -722,7 +722,7 @@ fn test_materialize_conflict_modify_delete() {
         vec![Some(base_id.clone())],
         vec![Some(deleted_id.clone()), Some(modified_id.clone())],
     );
-    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r###"
+    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -733,7 +733,7 @@ fn test_materialize_conflict_modify_delete() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
 
     // modify/delete conflict at the file level
@@ -741,7 +741,7 @@ fn test_materialize_conflict_modify_delete() {
         vec![Some(base_id.clone())],
         vec![Some(modified_id.clone()), None],
     );
-    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r###"
+    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
      line 1
@@ -752,7 +752,7 @@ fn test_materialize_conflict_modify_delete() {
      line 5
     +++++++ Contents of side #2
     >>>>>>> Conflict 1 of 1 ends
-    "###
+    "
     );
 }
 
@@ -794,7 +794,7 @@ fn test_materialize_conflict_two_forward_diffs() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     A
@@ -807,7 +807,7 @@ fn test_materialize_conflict_two_forward_diffs() {
     ------- Contents of base #3
     E
     >>>>>>> Conflict 1 of 1 ends
-    "###
+    "
     );
 }
 
@@ -848,7 +848,7 @@ fn test_parse_conflict_simple() {
             2,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -866,7 +866,7 @@ fn test_parse_conflict_simple() {
             ),
         ],
     )
-    "###
+    "#
     );
     insta::assert_debug_snapshot!(
         parse_conflict(indoc! {b"
@@ -885,7 +885,7 @@ fn test_parse_conflict_simple() {
             2,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -903,7 +903,7 @@ fn test_parse_conflict_simple() {
             ),
         ],
     )
-    "###
+    "#
     );
     // Test "snapshot" style
     insta::assert_debug_snapshot!(
@@ -1127,7 +1127,7 @@ fn test_parse_conflict_multi_way() {
             3,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -1147,7 +1147,7 @@ fn test_parse_conflict_multi_way() {
             ),
         ],
     )
-    "###
+    "#
     );
     insta::assert_debug_snapshot!(
         parse_conflict(indoc! {b"
@@ -1171,7 +1171,7 @@ fn test_parse_conflict_multi_way() {
             3,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -1191,7 +1191,7 @@ fn test_parse_conflict_multi_way() {
             ),
         ],
     )
-    "###
+    "#
     );
     // Test "snapshot" style
     insta::assert_debug_snapshot!(
@@ -1784,7 +1784,7 @@ fn test_update_conflict_from_content_simplified_conflict() {
     };
     insta::assert_snapshot!(
         materialized,
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 2
     %%%%%%% Changes from base to side #1
     -line 1
@@ -1800,7 +1800,7 @@ fn test_update_conflict_from_content_simplified_conflict() {
     +++++++ Contents of side #2
     right 3
     >>>>>>> Conflict 2 of 2 ends
-    "###
+    "
     );
     assert_eq!(parse(materialized.as_bytes()), conflict);
 
@@ -1892,7 +1892,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     assert!(materialized_marker_len > MIN_CONFLICT_MARKER_LEN);
     let materialized =
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot);
-    insta::assert_snapshot!(materialized, @r##"
+    insta::assert_snapshot!(materialized, @r"
     <<<<<<<<<<<<<<<< Conflict 1 of 2
     ++++++++++++++++ Contents of side #1
     <<<< left 1
@@ -1910,7 +1910,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     ++++++++++++++++ Contents of side #2
     >>>>>>>>>>>> right 3
     >>>>>>>>>>>>>>>> Conflict 2 of 2 ends
-    "##
+    "
     );
 
     // Parse the conflict markers using a different conflict marker style. This is
@@ -1977,21 +1977,21 @@ fn test_update_conflict_from_content_with_long_markers() {
     let [new_left_side, new_base, new_right_side] = new_conflict_terms.as_slice() else {
         unreachable!()
     };
-    insta::assert_snapshot!(new_left_side, @r#"
+    insta::assert_snapshot!(new_left_side, @r"
     <<<< left 1
     line 2
     line 3
-    "#);
-    insta::assert_snapshot!(new_base, @r#"
+    ");
+    insta::assert_snapshot!(new_base, @r"
     line 1
     line 2
     line 3
-    "#);
-    insta::assert_snapshot!(new_right_side, @r#"
+    ");
+    insta::assert_snapshot!(new_right_side, @r"
     >>>>>>> right 1
     line 2
     line 3
-    "#);
+    ");
 
     // The conflict markers should still parse in future snapshots even though
     // they're now longer than necessary
@@ -2009,7 +2009,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     // conflict markers now
     insta::assert_snapshot!(
         materialize_conflict_string(store, path, &new_conflict, ConflictMarkerStyle::Snapshot),
-        @r##"
+        @r"
     <<<<<<<<<<< Conflict 1 of 1
     +++++++++++ Contents of side #1
     <<<< left 1
@@ -2020,7 +2020,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     >>>>>>>>>>> Conflict 1 of 1 ends
     line 2
     line 3
-    "##
+    "
     );
 }
 
@@ -2043,7 +2043,7 @@ fn test_update_conflict_from_content_no_eol() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 2
     %%%%%%% Changes from base to side #1
@@ -2061,7 +2061,7 @@ fn test_update_conflict_from_content_no_eol() {
     -base
     +right
     >>>>>>> Conflict 2 of 2 ends
-    "##
+    "
     );
     // Parse with "snapshot" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2081,7 +2081,7 @@ fn test_update_conflict_from_content_no_eol() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
@@ -2101,7 +2101,7 @@ fn test_update_conflict_from_content_no_eol() {
     +++++++ Contents of side #2 (no terminating newline)
     right
     >>>>>>> Conflict 2 of 2 ends
-    "##
+    "
     );
     // Parse with "diff" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2121,7 +2121,7 @@ fn test_update_conflict_from_content_no_eol() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Git);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Side #1 (Conflict 1 of 2)
     line 2 left
@@ -2139,7 +2139,7 @@ fn test_update_conflict_from_content_no_eol() {
     =======
     right
     >>>>>>> Side #2 (Conflict 2 of 2 ends)
-    "##
+    "
     );
     // Parse with "diff" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2193,7 +2193,7 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     side
@@ -2214,7 +2214,7 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
     -line 1
     +line 2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     // Parse with "snapshot" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2250,7 +2250,7 @@ fn test_update_conflict_from_content_only_no_eol_change() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1 (removes terminating newline)
@@ -2258,7 +2258,7 @@ fn test_update_conflict_from_content_only_no_eol_change() {
     +++++++ Contents of side #2
     line 2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     // Parse with "snapshot" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2330,7 +2330,7 @@ fn test_update_from_content_malformed_conflict() {
 
     let materialized =
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
-    insta::assert_snapshot!(materialized, @r##"
+    insta::assert_snapshot!(materialized, @r"
     line 1
     <<<<<<< Conflict 1 of 2
     %%%%%%% Changes from base to side #1
@@ -2348,7 +2348,7 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##
+    "
     );
 
     let parse = |conflict, content| {
@@ -2400,7 +2400,7 @@ fn test_update_from_content_malformed_conflict() {
     let [new_left_side, new_base, new_right_side] = new_conflict_terms.as_slice() else {
         unreachable!()
     };
-    insta::assert_snapshot!(new_left_side, @r##"
+    insta::assert_snapshot!(new_left_side, @r"
     line 1
     line 2 left
     line 3
@@ -2411,8 +2411,8 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
-    insta::assert_snapshot!(new_base, @r##"
+    ");
+    insta::assert_snapshot!(new_base, @r"
     line 1
     line 2
     line 3
@@ -2423,8 +2423,8 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
-    insta::assert_snapshot!(new_right_side, @r##"
+    ");
+    insta::assert_snapshot!(new_right_side, @r"
     line 1
     line 2 right
     line 3
@@ -2435,7 +2435,7 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
+    ");
 
     // Even though the file now contains markers of length 7, the materialized
     // markers of length 7 are still parsed

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2325,12 +2325,12 @@ fn test_reset_head_with_index_no_conflict() {
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
-    insta::assert_snapshot!(get_index_state(&workspace_root), @r#"
+    insta::assert_snapshot!(get_index_state(&workspace_root), @r"
     Unconflicted some/dir/commit Mode(DIR | SYMLINK)
     Unconflicted some/dir/executable-file Mode(FILE | FILE_EXECUTABLE)
     Unconflicted some/dir/normal-file Mode(FILE)
     Unconflicted some/dir/symlink Mode(SYMLINK)
-    "#);
+    ");
 }
 
 #[test]
@@ -2455,7 +2455,7 @@ fn test_reset_head_with_index_merge_conflict() {
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
-    insta::assert_snapshot!(get_index_state(&workspace_root), @r#"
+    insta::assert_snapshot!(get_index_state(&workspace_root), @r"
     Base some/dir/commit Mode(DIR | SYMLINK)
     Ours some/dir/commit Mode(DIR | SYMLINK)
     Theirs some/dir/commit Mode(DIR | SYMLINK)
@@ -2468,7 +2468,7 @@ fn test_reset_head_with_index_merge_conflict() {
     Base some/dir/symlink Mode(SYMLINK)
     Ours some/dir/symlink Mode(SYMLINK)
     Theirs some/dir/symlink Mode(SYMLINK)
-    "#);
+    ");
 }
 
 #[test]

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -134,7 +134,7 @@ fn gpg_signing_roundtrip_explicit_key() {
     let data = b"hello world";
     let signature = backend.sign(data, Some("Someone Else")).unwrap();
 
-    assert_debug_snapshot!(backend.verify(data, &signature).unwrap(), @r###"
+    assert_debug_snapshot!(backend.verify(data, &signature).unwrap(), @r#"
     Verification {
         status: Good,
         key: Some(
@@ -144,8 +144,8 @@ fn gpg_signing_roundtrip_explicit_key() {
             "Someone Else (jj test signing key) <someone-else@example.com>",
         ),
     }
-    "###);
-    assert_debug_snapshot!(backend.verify(b"so so bad", &signature).unwrap(), @r###"
+    "#);
+    assert_debug_snapshot!(backend.verify(b"so so bad", &signature).unwrap(), @r#"
     Verification {
         status: Bad,
         key: Some(
@@ -155,7 +155,7 @@ fn gpg_signing_roundtrip_explicit_key() {
             "Someone Else (jj test signing key) <someone-else@example.com>",
         ),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -172,7 +172,7 @@ fn unknown_key() {
     e+U6bvqw3pOBoI53Th35drQ0qPI+jAE=
     =kwsk
     -----END PGP SIGNATURE-----";
-    assert_debug_snapshot!(backend.verify(b"hello world", signature).unwrap(), @r###"
+    assert_debug_snapshot!(backend.verify(b"hello world", signature).unwrap(), @r#"
     Verification {
         status: Unknown,
         key: Some(
@@ -180,8 +180,8 @@ fn unknown_key() {
         ),
         display: None,
     }
-    "###);
-    assert_debug_snapshot!(backend.verify(b"so bad", signature).unwrap(), @r###"
+    "#);
+    assert_debug_snapshot!(backend.verify(b"so bad", signature).unwrap(), @r#"
     Verification {
         status: Unknown,
         key: Some(
@@ -189,7 +189,7 @@ fn unknown_key() {
         ),
         display: None,
     }
-    "###);
+    "#);
 }
 
 #[test]

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -66,7 +66,7 @@ fn test_id_prefix() {
         .map(|(i, commit)| format!("{} {}", &commit.id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(commit_prefixes, @r###"
+    insta::assert_snapshot!(commit_prefixes, @r"
     11a 5
     214 24
     2a6 2
@@ -93,14 +93,14 @@ fn test_id_prefix() {
     eec 15
     efe 7
     fa3 11
-    "###);
+    ");
     let change_prefixes = commits
         .iter()
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.change_id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(change_prefixes, @r###"
+    insta::assert_snapshot!(change_prefixes, @r"
     026 9
     030 13
     1b5 6
@@ -127,7 +127,7 @@ fn test_id_prefix() {
     c24 15
     d64 12
     fee 25
-    "###);
+    ");
 
     let prefix = |x| HexPrefix::new(x).unwrap();
 
@@ -300,21 +300,21 @@ fn test_id_prefix_divergent() {
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.change_id().hex()[..4], i))
         .join("\n");
-    insta::assert_snapshot!(change_prefixes, @r###"
+    insta::assert_snapshot!(change_prefixes, @r"
     a533 0
     a500 1
     a500 2
-    "###);
+    ");
     let commit_prefixes = commits
         .iter()
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.id().hex()[..4], i))
         .join("\n");
-    insta::assert_snapshot!(commit_prefixes, @r###"
+    insta::assert_snapshot!(commit_prefixes, @r"
     eafa 0
     d48d 1
     2fbb 2
-    "###);
+    ");
 
     let prefix = |x| HexPrefix::new(x).unwrap();
 
@@ -423,7 +423,7 @@ fn test_id_prefix_hidden() {
         .map(|(i, commit)| format!("{} {}", &commit.id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(commit_prefixes, @r#"
+    insta::assert_snapshot!(commit_prefixes, @r"
     15e 9
     397 6
     53c 7
@@ -434,14 +434,14 @@ fn test_id_prefix_hidden() {
     c0a 5
     ce9 0
     f10 1
-    "#);
+    ");
     let change_prefixes = commits
         .iter()
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.change_id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(change_prefixes, @r#"
+    insta::assert_snapshot!(change_prefixes, @r"
     026 9
     1b5 6
     26b 3
@@ -452,7 +452,7 @@ fn test_id_prefix_hidden() {
     896 5
     a2c 1
     b93 4
-    "#);
+    ");
 
     let hidden_commit = &commits[8];
     tx.repo_mut().record_abandoned_commit(hidden_commit);

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -842,7 +842,7 @@ fn test_materialize_snapshot_conflicted_files() {
     assert_eq!(file2_value.num_sides(), 3);
     insta::assert_snapshot!(
         std::fs::read_to_string(file1_path.to_fs_path_unchecked(&workspace_root)).ok().unwrap(),
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -b
@@ -850,10 +850,10 @@ fn test_materialize_snapshot_conflicted_files() {
     +++++++ Contents of side #2
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(file2_path.to_fs_path_unchecked(&workspace_root)).ok().unwrap(),
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -2
@@ -861,7 +861,7 @@ fn test_materialize_snapshot_conflicted_files() {
     +++++++ Contents of side #2
     4
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Editing a conflicted file should correctly propagate updates to each of
     // the conflicting trees.
@@ -2057,10 +2057,10 @@ fn test_fsmonitor() {
     {
         let mut locked_ws = ws.start_working_copy_mutation().unwrap();
         let tree_id = snapshot(&mut locked_ws, &[foo_path]);
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree d5e38c0a1b0ee5de47c5
           file "foo" (e99c2057c15160add351): "foo\n"
-        "###);
+        "#);
     }
 
     {
@@ -2069,12 +2069,12 @@ fn test_fsmonitor() {
             &mut locked_ws,
             &[foo_path, bar_path, nested_path, ignored_path],
         );
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree f408c8d080414f8e90e1
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "foo" (e99c2057c15160add351): "foo\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
-        "###);
+        "#);
         locked_ws.finish(repo.op_id().clone()).unwrap();
     }
 
@@ -2083,23 +2083,23 @@ fn test_fsmonitor() {
         testutils::write_working_copy_file(&workspace_root, bar_path, "updated bar\n");
         let mut locked_ws = ws.start_working_copy_mutation().unwrap();
         let tree_id = snapshot(&mut locked_ws, &[foo_path]);
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree e994a93c46f41dc91704
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "foo" (e0fbd106147cc04ccd05): "updated foo\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
-        "###);
+        "#);
     }
 
     {
         std::fs::remove_file(foo_path.to_fs_path_unchecked(&workspace_root)).unwrap();
         let mut locked_ws = ws.start_working_copy_mutation().unwrap();
         let tree_id = snapshot(&mut locked_ws, &[foo_path]);
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree 1df764981d4d74a4ecfa
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
-        "###);
+        "#);
         locked_ws.finish(repo.op_id().clone()).unwrap();
     }
 }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -610,7 +610,7 @@ fn test_resolve_symbol_bookmarks() {
 
     // Remote only (or locally deleted)
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "remote").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "remote").unwrap_err(), @r#"
     NoSuchRevision {
         name: "remote",
         candidates: [
@@ -618,7 +618,7 @@ fn test_resolve_symbol_bookmarks() {
             "remote@origin",
         ],
     }
-    "###);
+    "#);
     assert_eq!(
         resolve_symbol(mut_repo, "remote@origin").unwrap(),
         vec![commit2.id().clone()],
@@ -712,7 +712,7 @@ fn test_resolve_symbol_bookmarks() {
     // "local-remote@mirror" shouldn't be omitted just because it points to the same
     // target as "local-remote".
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "remote@mirror").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "remote@mirror").unwrap_err(), @r#"
     NoSuchRevision {
         name: "remote@mirror",
         candidates: [
@@ -720,11 +720,11 @@ fn test_resolve_symbol_bookmarks() {
             "remote@origin",
         ],
     }
-    "###);
+    "#);
 
     // Typo of remote-only bookmark name
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "emote").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "emote").unwrap_err(), @r#"
     NoSuchRevision {
         name: "emote",
         candidates: [
@@ -732,7 +732,7 @@ fn test_resolve_symbol_bookmarks() {
             "remote@origin",
         ],
     }
-    "###);
+    "#);
     insta::assert_debug_snapshot!(
         resolve_symbol(mut_repo, "emote@origin").unwrap_err(), @r#"
     NoSuchRevision {
@@ -868,12 +868,12 @@ fn test_resolve_symbol_git_refs() {
     );
     // bookmark alone is not recognized
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "bookmark").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "bookmark").unwrap_err(), @r#"
     NoSuchRevision {
         name: "bookmark",
         candidates: [],
     }
-    "###);
+    "#);
     // heads/bookmark does get resolved to the git ref refs/heads/bookmark
     assert_eq!(
         resolve_symbol(mut_repo, "heads/bookmark").unwrap(),


### PR DESCRIPTION
Run `cargo insta test --test-runner nextest --force-update-snapshots`.

There are a few additional changes that insta makes that break the tests, but only inside `allow_duplicates`, so that's related to https://github.com/mitsuhiko/insta/issues/712

```diff
Commit ID: 489c76379e4da3ed28bf69a4a0bdcebe7d99f2f5
Change ID: lmqxpvzykynsnmxwtkpuxvotrrsptomp
Author   : Jakob Hellermann <jakob.hellermann@protonmail.com> (26m ago)
Committer: Jakob Hellermann <jakob.hellermann@protonmail.com> (49s ago)

    insta failure: allow_multiple

diff --git a/cli/tests/test_git_fetch.rs b/cli/tests/test_git_fetch.rs
index 6951ada78d..5dbe606a5c 100644
--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -406,15 +406,11 @@
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @"");
 
     // Explicit import is an error.
     // (This could be warning if we add mechanism to report ignored refs.)
-    insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["git", "import"]), @r###"
-    Error: Failed to import refs from underlying Git repo
-    Caused by: Git remote named 'git' is reserved for local Git repository
-    Hint: Run `jj git remote rename` to give different name.
-    "###);
+    insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["git", "import"]), @"");
     }
 
     // The remote can be renamed, and the ref can be imported.
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "git", "bar"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "--all-remotes"]);
diff --git a/cli/tests/test_git_init.rs b/cli/tests/test_git_init.rs
index 501aefdd7c..8038d46821 100644
--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -143,17 +143,11 @@
             git_repo_path.to_str().unwrap(),
         ],
     );
     insta::allow_duplicates! {
         insta::assert_snapshot!(stdout, @"");
-        insta::assert_snapshot!(stderr, @r###"
-        Done importing changes from the underlying Git repo.
-        Working copy now at: sqpuoqvx f6950fc1 (empty) (no description set)
-        Parent commit      : mwrttmos 8d698d4a my-bookmark | My commit message
-        Added 1 files, modified 0 files, removed 0 files
-        Initialized repo in "repo"
-        "###);
+        insta::assert_snapshot!(stderr, @"");
     }
 
     let workspace_root = test_env.env_root().join("repo");
     let jj_path = workspace_root.join(".jj");
     let repo_path = jj_path.join("repo");
```

and
```diff
Commit ID: 9ea82f1e65794c0853cd13123aa44f17f63d33df
Change ID: nyrlvnsxwzrqurpyvqmzoxzxlmtxzskl
Author   : Jakob Hellermann <jakob.hellermann@protonmail.com> (27m ago)
Committer: Jakob Hellermann <jakob.hellermann@protonmail.com> (1m ago)

    insta failure: idk

diff --git a/cli/tests/test_git_fetch.rs b/cli/tests/test_git_fetch.rs
index 5dbe606a5c..ad4b28ed88 100644
--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -875,25 +875,15 @@
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     Nothing changed.
     "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
-    @  230dd059e1b0
-    │ ○  decaa3966c83 descr_for_a2 a2
-    │ │ ○  359a9a02457d descr_for_a1 a1
-    │ ├─╯
-    │ │ ○  c7d4bdcbc215 descr_for_b b
-    │ ├─╯
-    │ ○  ff36dc55760e descr_for_trunk1
-    ├─╯
-    ◆  000000000000
-    "#);
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @"Nothing changed.");
     }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r"
@@ -1184,55 +1174,41 @@
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a1@origin [new] tracked
     bookmark: b@origin  [new] tracked
     "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
-    @  230dd059e1b0
-    │ ○  c7d4bdcbc215 descr_for_b b
-    │ │ ○  359a9a02457d descr_for_a1 a1
-    │ ├─╯
-    │ ○  ff36dc55760e descr_for_trunk1
-    ├─╯
-    ◆  000000000000
-    "#);
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
+    bookmark: a1@origin [new] tracked
+    bookmark: b@origin  [new] tracked
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["undo"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r#"
     Undid operation: eb2029853b02 (2001-02-03 08:05:18) fetch from git remote(s) origin
     "#);
     // The undo works as expected
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
-    @  230dd059e1b0
-    ◆  000000000000
-    "###);
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @"Undid operation: eb2029853b02 (2001-02-03 08:05:18) fetch from git remote(s) origin");
     }
     // Now try to fetch just one bookmark
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch", "--branch", "b"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: b@origin [new] tracked
     "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
-    @  230dd059e1b0
-    │ ○  c7d4bdcbc215 descr_for_b b
-    │ ○  ff36dc55760e descr_for_trunk1
-    ├─╯
-    ◆  000000000000
-    "#);
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @"bookmark: b@origin [new] tracked");
     }
 }
 
 // Compare to `test_git_import_undo` in test_git_import_export
 // TODO: Explain why these behaviors are useful
 #[test_case(false; "use git2 for remote calls")]
 #[test_case(true; "spawn a git subprocess for remote calls")]
@@ -1564,23 +1540,18 @@
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r###"
     bookmark: a2@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
     "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
-    @  230dd059e1b0
-    │ ○  c7d4bdcbc215 descr_for_b b
-    │ │ ○  359a9a02457d descr_for_a1 a1
-    │ ├─╯
-    │ ○  ff36dc55760e descr_for_trunk1 trunk1
-    ├─╯
-    ◆  000000000000
-    "#);
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
+    bookmark: a2@origin [deleted] untracked
+    Abandoned 1 commits that are no longer reachable.
+    ");
     }
 }
 
 #[test_case(false; "use git2 for remote calls")]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
diff --git a/cli/tests/test_git_push.rs b/cli/tests/test_git_push.rs
index cd2b3b2f96..dbc72ed2b7 100644
--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -125,22 +125,19 @@
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r#"
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to bc7610b65a91
       Add bookmark my-bookmark to bc7610b65a91
     "#);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
-    bookmark1: xtvrqkyv 0f8dc656 (empty) modified bookmark1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
-    bookmark2: yostqsxw bc7610b6 (empty) foo
-      @origin: yostqsxw bc7610b6 (empty) foo
-    my-bookmark: yostqsxw bc7610b6 (empty) foo
-      @origin: yostqsxw bc7610b6 (empty) foo
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
+    Changes to push to origin:
+      Move forward bookmark bookmark2 from 8476341eb395 to bc7610b65a91
+      Add bookmark my-bookmark to bc7610b65a91
+    ");
     }
 
     // Try pushing backwards
     test_env.jj_cmd_ok(
         &workspace_root,
         &[
             "bookmark",
@@ -752,20 +749,20 @@
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r#"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Move sideways bookmark bookmark2 from 8476341eb395 to c4a3c3105d92
       Add bookmark my-bookmark to c4a3c3105d92
     "#);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
-    bookmark2: yqosqzyt c4a3c310 (empty) foo
-      @origin: yqosqzyt c4a3c310 (empty) foo
-    my-bookmark: yqosqzyt c4a3c310 (empty) foo
-      @origin: yqosqzyt c4a3c310 (empty) foo
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
+    Changes to push to origin:
+      Delete bookmark bookmark1 from d13ecdbda2a2
+      Move sideways bookmark bookmark2 from 8476341eb395 to c4a3c3105d92
+      Add bookmark my-bookmark to c4a3c3105d92
+    ");
     }
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 bookmark2 my-bookmark c4a3c310
     │  (empty) foo
     │ ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
```


If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
