### PR TITLE
docs: remove references to `jj amend`

### DIFF
--- a/docs/git-comparison.md
+++ b/docs/git-comparison.md
@@ -88,7 +88,7 @@ move a specific file.
 
 Note that all `jj` commands can be run on any commit (not just the working-copy
 commit), but that's left out of the table to keep it simple. For example,
-`jj squash/amend -r <revision>` will move the diff from that revision into its
+`jj squash -r <revision>` will move the diff from that revision into its
 parent.
 
 <table>
@@ -278,13 +278,13 @@ parent.
     </tr>
     <tr>
       <td>Move the diff in the current change into the parent change</td>
-      <td><code>jj squash/amend</code></td>
+      <td><code>jj squash</code></td>
       <td><code>git commit --amend -a</code></td>
     </tr>
     <tr>
       <td>Interactively move part of the diff in the current change into the
           parent change</td>
-      <td><code>jj squash/amend -i</code></td>
+      <td><code>jj squash -i</code></td>
       <td><code>git add -p; git commit --amend</code></td>
     </tr>
     <tr>
@@ -317,7 +317,7 @@ parent.
     </tr>
     <tr>
       <td>Resolve conflicts and continue interrupted operation</td>
-      <td><code>echo resolved > filename; jj squash/amend</code> (operations
+      <td><code>echo resolved > filename; jj squash</code> (operations
           don't get interrupted, so no need to continue)</td>
       <td><code>echo resolved > filename; git add filename; git
           rebase/merge/cherry-pick --continue</code></td>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -153,8 +153,7 @@ If we later realize that we want to make further changes, we can make them in
 the working copy and then run `jj squash`. That command squashes (moves) the
 changes from a given commit into its parent commit. Like most commands, it acts
 on the working-copy commit by default. When run on the working-copy commit, it
-behaves very similar to `git commit --amend`, and `jj amend` is in fact an alias
-for `jj squash`.
+behaves very similar to `git commit --amend`.
 
 Alternatively, we can use `jj edit <commit>` to resume editing a commit in the
 working copy. Any further changes in the working copy will then amend the


### PR DESCRIPTION
`jj amend` is discouraged and no longer a visible alias of `jj squash` since 6d78d92. This is the only remaining occurrence of it in the docs. We should recommend using `jj squash` directly instead.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
