### PR TITLE
docs: add language identifiers to code blocks to improve syntax highlighting

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -292,8 +292,8 @@ Parent commit      : yyyyyyyy b624cf12 Existing work
 To avoid pushing change _wwwwwwww_ by mistake, use the configuration
 [git.private-commits](config.md#set-of-private-commits):
 
-```
-$ jj config set --user git.private-commits 'description(glob:"private:*")'
+```shell
+jj config set --user git.private-commits 'description(glob:"private:*")'
 ```
 
 ### I accidentally changed files in the wrong commit, how do I move the recent changes into another commit?

--- a/docs/config.md
+++ b/docs/config.md
@@ -581,7 +581,7 @@ The special value `:builtin` enables usage of the [integrated pager called
 If you are using a standard Linux distro, your system likely already has
 `$PAGER` set and that will be preferred over the built-in. To use the built-in:
 
-```
+```shell
 jj config set --user ui.pager :builtin
 ```
 
@@ -802,7 +802,7 @@ one of them, or if you run multiple instances of `diffedit3` at the same time.
 
 Another way is to add a snippet to `~/.ssh/config`:
 
-```
+```ssh-config
 Host myhost
     User     myself
     Hostname myhost.example.com

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -65,7 +65,7 @@ a conflict).
 As an example, imagine that you have a file which contains the following text,
 all in lowercase:
 
-```
+```text
 apple
 grape
 orange
@@ -78,7 +78,7 @@ since Jujutsu can't figure out how to combine these changes. Therefore, Jujutsu
 will materialize the conflict in the working copy using conflict markers, which
 would look like this:
 
-```
+```diff
 <<<<<<< Conflict 1 of 1
 %%%%%%% Changes from base to side #1
  apple
@@ -99,7 +99,7 @@ Therefore, to resolve this conflict, you would apply the diff (changing "grape"
 to "grapefruit") to the snapshot (the side with every line in uppercase),
 editing the file to look like this:
 
-```
+```text
 APPLE
 GRAPEFRUIT
 ORANGE
@@ -123,7 +123,7 @@ If you prefer to just see the contents of each side of the conflict without the
 diff, Jujutsu also supports a "snapshot" style, which can be enabled by setting
 the `ui.conflict-marker-style` config option to "snapshot":
 
-```
+```diff
 <<<<<<< Conflict 1 of 1
 +++++++ Contents of side #1
 apple
@@ -145,7 +145,7 @@ Some tools expect Git-style conflict markers, so Jujutsu also supports [Git's
 conflict markers by setting the `ui.conflict-marker-style` config option to
 "git":
 
-```
+```diff
 <<<<<<< Side #1 (Conflict 1 of 1)
 apple
 grapefruit
@@ -173,7 +173,7 @@ conflict marker. To ensure that it's always unambiguous which lines are conflict
 markers and which are just part of the file contents, `jj` sometimes uses
 conflict markers which are longer than normal:
 
-```
+```diff
 <<<<<<<<<<<<<<< Conflict 1 of 1
 %%%%%%%%%%%%%%% Changes from base to side #1
 -Heading
@@ -203,7 +203,7 @@ character, and one person changed `grape` to `grapefruit`, while another person
 added the missing newline character to make `grape\n`, the resulting conflict
 would look like this:
 
-```
+```diff
 <<<<<<< Conflict 1 of 1
 +++++++ Contents of side #1 (no terminating newline)
 grapefruit

--- a/docs/filesets.md
+++ b/docs/filesets.md
@@ -65,18 +65,18 @@ You can also specify patterns by using functions.
 
 Show diff excluding `Cargo.lock`.
 
-```
+```shell
 jj diff '~Cargo.lock'
 ```
 
 List files in `src` excluding Rust sources.
 
-```
+```shell
 jj file list 'src ~ glob:"**/*.rs"'
 ```
 
 Split a revision in two, putting `foo` into the second commit.
 
-```
+```shell
 jj split '~foo'
 ```

--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -54,13 +54,13 @@ cargo install --locked --bin jj jj-cli
 #### Arch Linux
 You can install the `jujutsu` package from the [official extra repository](https://archlinux.org/packages/extra/x86_64/jujutsu/):
 
-```
+```shell
 pacman -S jujutsu
 ```
 
 Or install from the [AUR repository](https://aur.archlinux.org/packages/jujutsu-git) with an [AUR Helper](https://wiki.archlinux.org/title/AUR_helpers):
 
-```
+```shell
 yay -S jujutsu-git
 ```
 
@@ -100,8 +100,7 @@ Details on how to enable the GURU repository can be found [here](https://wiki.ge
 
 Once you have synced the GURU repository, you can install `dev-vcs/jj` via Portage:
 
-
-```
+```shell
 emerge -av dev-vcs/jj
 ```
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -539,37 +539,37 @@ xyz` will add `xyz` to the list of `w`'s parents.
 
 Show the parent(s) of the working-copy commit (like `git log -1 HEAD`):
 
-```
+```shell
 jj log -r @-
 ```
 
 Show all ancestors of the working copy (like plain `git log`)
 
-```
+```shell
 jj log -r ::@
 ```
 
 Show commits not on any remote bookmark:
 
-```
+```shell
 jj log -r 'remote_bookmarks()..'
 ```
 
 Show commits not on `origin` (if you have other remotes like `fork`):
 
-```
+```shell
 jj log -r 'remote_bookmarks(remote=origin)..'
 ```
 
 Show the initial commits in the repo (the ones Git calls "root commits"):
 
-```
+```shell
 jj log -r 'root()+'
 ```
 
 Show some important commits (like `git --simplify-by-decoration`):
 
-```
+```shell
 jj log -r 'tags() | bookmarks()'
 ```
 
@@ -577,13 +577,13 @@ Show local commits leading up to the working copy, as well as descendants of
 those commits:
 
 
-```
+```shell
 jj log -r '(remote_bookmarks()..@)::'
 ```
 
 Show commits authored by "martinvonz" and containing the word "reset" in the
 description:
 
-```
+```shell
 jj log -r 'author(martinvonz) & description(reset)'
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -70,7 +70,7 @@ change, resulting in a new commit hash, but the change ID will remain the same.
 
 You can see that our clone operation automatically created a new change:
 
-```
+```shell
 Working copy : kntqzsqt d7439b06 (empty) (no description set)
 ```
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
