### PR TITLE
squash: use draft description template to generate editor content

### DIFF
--- a/cli/src/commands/unsquash.rs
+++ b/cli/src/commands/unsquash.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::slice;
+
 use jj_lib::matchers::EverythingMatcher;
 use jj_lib::object_id::ObjectId;
 use tracing::instrument;
@@ -117,7 +119,7 @@ aborted.
     // case).
     if new_parent_tree_id == parent_base_tree.id() {
         tx.repo_mut().record_abandoned_commit(&parent);
-        let description = combine_messages(&text_editor, &[&parent], &commit)?;
+        let description = combine_messages(&text_editor, slice::from_ref(&parent), &commit)?;
         // Commit the new child on top of the parent's parents.
         tx.repo_mut()
             .rewrite_commit(&commit)

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -288,12 +288,12 @@ where
 /// user to edit the result in their editor.
 pub fn combine_messages(
     editor: &TextEditor,
-    sources: &[&Commit],
+    sources: &[Commit],
     destination: &Commit,
 ) -> Result<String, CommandError> {
     let non_empty = sources
         .iter()
-        .chain(std::iter::once(&destination))
+        .chain(std::iter::once(destination))
         .filter(|c| !c.description().is_empty())
         .take(2)
         .collect_vec();

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -286,7 +286,8 @@ where
 /// Combines the descriptions from the input commits. If only one is non-empty,
 /// then that one is used. Otherwise we concatenate the messages and ask the
 /// user to edit the result in their editor.
-pub fn combine_messages(
+// TODO: this can be removed with the deprecated "unsquash" command
+pub(crate) fn combine_messages(
     editor: &TextEditor,
     sources: &[Commit],
     destination: &Commit,

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -1066,7 +1066,7 @@ fn test_squash_description() {
     source
     "###);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the combined commit.
     JJ: Description from the destination commit:
     destination
@@ -1074,8 +1074,12 @@ fn test_squash_description() {
     JJ: Description from source commit:
     source
 
+    JJ: This commit contains the following changes:
+    JJ:     A file1
+    JJ:     A file2
+
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // An explicit description on the command-line overrides prevents launching an
     // editor


### PR DESCRIPTION
Closes #5559

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
