### PR TITLE
docs/windows: remove unused link

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -86,7 +86,6 @@ PS> jj workspace add --name wsl ~/my-repo
 
 Then only use the `~/my-repo` workspace from Linux.
 
-[issue-2040]: https://github.com/jj-vcs/jj/issues/2040
 [array-op]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-7.4#the-array-sub-expression-operator
 
 ## Symbolic link support


### PR DESCRIPTION
The only usage of this link was removed in 2d0b715.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
