### PR TITLE
docs/install-and-setup: replace `linuxbrew` with `Homebrew`

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -86,7 +86,7 @@ nix profile install 'github:jj-vcs/jj'
 
 #### Homebrew
 
-If you use linuxbrew, you can run:
+If you use Homebrew, you can run:
 
 ```shell
 # Installs the latest release


### PR DESCRIPTION
The name `Linuxbrew` is no longer used since Homebrew 2.0.0: https://brew.sh/2019/02/02/homebrew-2.0.0/

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
