### PR TITLE
Show a warning when undoing an undo operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj undo` now shows a hint when undoing an undo operation that the user may
+   be looking for `jj op restore` instead.
+
 * Template functions `truncate_start()` and `truncate_end()` gained an optional
   `ellipsis` parameter; passing this prepends or appends the ellipsis to the
   content if it is truncated to fit the maximum width.

--- a/cli/src/commands/operation/undo.rs
+++ b/cli/src/commands/operation/undo.rs
@@ -70,6 +70,7 @@ pub fn cmd_op_undo(
         &args.what,
     );
     tx.repo_mut().set_view(new_view);
+    let was_undo_op = *tx.repo().view() == parent_op.view()?;
     if let Some(mut formatter) = ui.status_formatter() {
         write!(formatter, "Undid operation: ")?;
         let template = tx.base_workspace_helper().operation_summary_template();
@@ -77,6 +78,19 @@ pub fn cmd_op_undo(
         writeln!(formatter)?;
     }
     tx.finish(ui, format!("undo operation {}", bad_op.id().hex()))?;
+
+    if args.operation == "@" && was_undo_op {
+        writeln!(
+            ui.hint_default(),
+            "This action reverted an 'undo' operation. The repository is now in the same state as \
+             it was before the original 'undo'."
+        )?;
+        writeln!(
+            ui.hint_default(),
+            "If your goal is to undo multiple operations, consider using `jj op log` to see past \
+             states, and `jj op restore` to restore one of these states."
+        )?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
One common issue that users run into with `jj undo` is that they expect it to behave like an "undo stack", in which every consecutive `jj undo` execution moves the current state further back in history. This is (currently) an incorrect intuition - running multiple `jj undo` commands back-to-back will only result in the previous non-undo change being reverted, then un-reverted, then reverted, and so on.

This change adds a hint when the user runs `jj undo` multiple times consecutively, suggesting that they may be looking for `jj restore`, which allows them to revert the whole state of the repository back to a previous snapshot.

See also #3700

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
