### PR TITLE
templater: add optional ellipsis arg to truncate template functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Template functions `truncate_start()` and `truncate_end()` gained an optional
+  `ellipsis` parameter; passing this prepends or appends the ellipsis to the
+  content if it is truncated to fit the maximum width.
+
 ### Fixed bugs
 
 * `jj status` now shows untracked files under untracked directories.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -59,10 +59,14 @@ The following functions are defined.
   content by adding both leading and trailing fill characters. If an odd number
   of fill characters are needed, the trailing fill will be one longer than the
   leading fill. The `content` shouldn't have newline characters.
-* `truncate_start(width: Integer, content: Template)`: Truncate `content` by
-  removing leading characters. The `content` shouldn't have newline character.
-* `truncate_end(width: Integer, content: Template)`: Truncate `content` by
-  removing trailing characters. The `content` shouldn't have newline character.
+* `truncate_start(width: Integer, content: Template[, ellipsis: Template])`:
+  Truncate `content` by removing leading characters. The `content` shouldn't
+  have newline character. If `ellipsis` is provided and `content` was truncated,
+  prepend the `ellipsis` to the result.
+* `truncate_end(width: Integer, content: Template[, ellipsis: Template])`:
+  Truncate `content` by removing trailing characters. The `content` shouldn't
+  have newline character. If `ellipsis` is provided and `content` was truncated,
+  append the `ellipsis` to the result.
 * `label(label: Template, content: Template) -> Template`: Apply label to
   the content. The `label` is evaluated as a space-separated string.
 * `raw_escape_sequence(content: Template) -> Template`: Preserves any escape


### PR DESCRIPTION
If an ellipsis arg is given to the truncate_* template functions, append (or prepend) the ellipsis when the template content is truncated to fit the maximum width.

Fixes #5085.

I went with "ellipsis" rather than "tail", because we already use "ellipsis" for the very similar `elide_*` functions in `text_util.rs`.

I did not use the `elide_*` functions directly, because they assume `&str` content, whereas IIUC, templates can be arbitrary bytes.

To determine whether or not the content should be truncated, I followed the example of the `write_padded_*` functions, which lossily convert the template args to strings to check their width; I assume that's OK, but would appreciate a confirmation.

As you can see in some of the tests, the prepended/appended ellipsis is not colored, even when the truncated output is. I *think* that's OK, but again would appreciate thoughts on the matter. When I tried to make the ellipsis share the coloring of the original content, I ended up duplicating the ellipsis when multiple labels were involved.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
