### PR TITLE
git: force git subprocess to not localize error messages

### DIFF
--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -88,6 +88,9 @@ impl<'a> GitSubprocessContext<'a> {
             .arg("--bare")
             .arg("--git-dir")
             .arg(&self.git_dir)
+            // Disable translation and other locale-dependent behavior so we can
+            // parse the output. LC_ALL precedes LC_* and LANG.
+            .env("LC_ALL", "C")
             .stdin(Stdio::null())
             .stderr(Stdio::piped());
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
