### PR TITLE
docs: use styled admonition blocks for warnings

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -910,9 +910,10 @@ obtained as follows:
   options](https://gist.github.com/ilyagr/1b40f6061d8ad320cee4c12843df1a23) but,
   as of this writing, this is by far the easiest.
 
-  *Warning:* Do *not* use the Homebrew `meld` package.
-  It does not work on ARM Macs and may have problems on recent versions of Mac
-  OS.
+  !!! warning
+
+      Do *not* use the Homebrew `meld` package.
+      It does not work on ARM Macs and may have problems on recent versions of macOS.
 
 `jj` has two diff editing configurations that use Meld: `meld` for a 2-pane view
 and `meld-3` for a [three-pane view](#experimental-3-pane-diff-editing).

--- a/docs/github.md
+++ b/docs/github.md
@@ -126,9 +126,10 @@ $ jj git push
 Notably, the above workflow creates a new commit for you. The same can be
 achieved without creating a new commit.
 
-> **Warning**
-> We strongly suggest to `jj new` after the example below, as all further edits
-> still get amended to the previous commit.
+!!! warning
+
+    We strongly suggest to `jj new` after the example below, as all further edits
+    still get amended to the previous commit.
 
 ```shell
 $ # Create a new commit on top of the `your-feature` bookmark from above.


### PR DESCRIPTION
This is consistent with the rest of the docs.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
