### PR TITLE
docs/install-and-setup: move 'prerelease version' sentence to after 'Cargo Binstall' section

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -8,9 +8,6 @@
 There are [pre-built binaries] of the last released version of `jj` for
 Windows, Mac, or Linux (the "musl" version should work on all distributions).
 
-If you'd like to install a prerelease version, you'll need to use one of the
-options below.
-
 #### Cargo Binstall
 
 If you use [`cargo-binstall`][cargo-binstall], you
@@ -24,6 +21,10 @@ cargo binstall --strategies crate-meta-data jj-cli
 Without the `--strategies` option, you may get equivalent binaries that should
 be compiled from the same source code.
 
+!!! note
+
+    If you'd like to install a prerelease version, you'll need to use one of the
+    options below.
 
 ### Linux
 


### PR DESCRIPTION
It seems that in 38daa9a the 'Cargo Binstall' section should have been inserted above the 'prelease version' sentence instead.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
