### PR TITLE
docs: Split out commit guidelines into their own section

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,12 +18,7 @@ You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
-### Code reviews
-
-All submissions, including submissions by project members, require review. We
-use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using pull requests.
+### Commit guidelines
 
 Unlike many GitHub projects (but like many VCS projects), we care more about the
 contents of commits than about the contents of PRs. We review each commit
@@ -50,6 +45,13 @@ it. [How to Write a Git Commit Message](https://cbea.ms/git-commit/) is a good
 guide if you're new to writing good commit messages. We are not particularly
 strict about the style, but please do explain the reason for the change unless
 it's obvious.
+
+### Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
 
 When you address comments on a PR, don't make the changes in a commit on top (as
 is typical on GitHub). Instead, please make the changes in the appropriate


### PR DESCRIPTION
Filing this as a suggestion but can close if it doesn't feel right.

The commit guidelines feel like they're relevant before documentation
about the code review process - they could conceivably apply while
developing a change.

These often seem to get missed and raised during reviews - giving them
their own section may increase visibility.

# Checklist

If applicable:
- [ ] ~I have updated `CHANGELOG.md`~
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] ~I have updated the config schema (cli/src/config-schema.json)~
- [ ] ~I have added tests to cover my changes~