### PR TITLE
cli: update "only_path" warnings to say fileset expression instead of path

### DIFF
--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -320,9 +320,9 @@ pub(crate) fn cmd_log(
             // For users of e.g. Mercurial, where `.` indicates the current commit.
             writeln!(
                 ui.warning_default(),
-                "The argument {only_path:?} is being interpreted as a path, but this is often not \
-                 useful because all non-empty commits touch '.'.  If you meant to show the \
-                 working copy commit, pass -r '@' instead."
+                "The argument {only_path:?} is being interpreted as a fileset expression, but \
+                 this is often not useful because all non-empty commits touch '.'. If you meant \
+                 to show the working copy commit, pass -r '@' instead."
             )?;
         } else if revset.is_empty()
             && workspace_command
@@ -331,8 +331,8 @@ pub(crate) fn cmd_log(
         {
             writeln!(
                 ui.warning_default(),
-                "The argument {only_path:?} is being interpreted as a path. To specify a revset, \
-                 pass -r {only_path:?} instead."
+                "The argument {only_path:?} is being interpreted as a fileset expression. To \
+                 specify a revset, pass -r {only_path:?} instead."
             )?;
         }
     }

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -210,8 +210,8 @@ pub(crate) fn cmd_squash(
             {
                 writeln!(
                     ui.warning_default(),
-                    "The argument {only_path:?} is being interpreted as a path. To specify a \
-                     revset, pass -r {only_path:?} instead."
+                    "The argument {only_path:?} is being interpreted as a fileset expression. To \
+                     specify a revset, pass -r {only_path:?} instead."
                 )?;
             }
         }

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -506,7 +506,7 @@ fn test_color_ui_messages() {
     // warning
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "@"]);
     insta::assert_snapshot!(stderr, @r###"
-    [1m[38;5;3mWarning: [39mThe argument "@" is being interpreted as a path. To specify a revset, pass -r "@" instead.[0m
+    [1m[38;5;3mWarning: [39mThe argument "@" is being interpreted as a fileset expression. To specify a revset, pass -r "@" instead.[0m
     "###);
 
     // error inlined in template output

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1031,9 +1031,7 @@ fn test_log_warn_path_might_be_revset() {
     │
     ~
     "###);
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: The argument "." is being interpreted as a path, but this is often not useful because all non-empty commits touch '.'.  If you meant to show the working copy commit, pass -r '@' instead.
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Warning: The argument "." is being interpreted as a fileset expression, but this is often not useful because all non-empty commits touch '.'. If you meant to show the working copy commit, pass -r '@' instead."#);
 
     // ...but checking `jj log .` makes sense in a subdirectory.
     let subdir = repo_path.join("dir");
@@ -1045,16 +1043,12 @@ fn test_log_warn_path_might_be_revset() {
     // Warn for `jj log @` instead of `jj log -r @`.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "@", "-T", "description"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: The argument "@" is being interpreted as a path. To specify a revset, pass -r "@" instead.
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Warning: The argument "@" is being interpreted as a fileset expression. To specify a revset, pass -r "@" instead."#);
 
     // Warn when there's no path with the provided name.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "file2", "-T", "description"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: The argument "file2" is being interpreted as a path. To specify a revset, pass -r "file2" instead.
-    "###);
+    insta::assert_snapshot!(stderr, @r#"Warning: The argument "file2" is being interpreted as a fileset expression. To specify a revset, pass -r "file2" instead."#);
 
     // If an explicit revision is provided, then suppress the warning.
     let (stdout, stderr) =

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -270,10 +270,10 @@ fn test_squash_partial() {
     // We get a warning if we pass a positional argument that looks like a revset
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
-    Warning: The argument "b" is being interpreted as a path. To specify a revset, pass -r "b" instead.
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: The argument "b" is being interpreted as a fileset expression. To specify a revset, pass -r "b" instead.
     Nothing changed.
-    "###);
+    "#);
     insta::assert_snapshot!(stdout, @"");
 }
 


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
