### PR TITLE
Fix backends.ssh.allowed-signers type in config-schema

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -639,9 +639,8 @@
                                     "default": "ssh-keygen"
                                 },
                                 "allowed-signers": {
-                                    "type": "boolean",
-                                    "description": "Path to an allowed signers file used for signature verification",
-                                    "default": true
+                                    "type": "string",
+                                    "description": "Path to an allowed signers file used for signature verification"
                                 }
                             }
                         }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

When adding a `"$schema"` to my config, it flagged `backends.ssh.allowed-signers` as boolean. This fixes the type to string and removes the default (as I don't think there is one?).

Let me know if I need to change things anywhere else.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
