### PR TITLE
local_working_copy: scan directory entries excluded by auto-track pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj status` now shows untracked files under untracked directories.
+  [#5389](https://github.com/jj-vcs/jj/issues/5389)
+
 ## [0.26.0] - 2025-02-05
 
 ### Release highlights

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -377,60 +377,89 @@ fn test_status_untracked_files() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    std::fs::write(repo_path.join("initially-untracked-file"), "...").unwrap();
     std::fs::write(repo_path.join("always-untracked-file"), "...").unwrap();
+    std::fs::write(repo_path.join("initially-untracked-file"), "...").unwrap();
+    std::fs::create_dir(repo_path.join("sub")).unwrap();
+    std::fs::write(repo_path.join("sub").join("always-untracked"), "...").unwrap();
+    std::fs::write(repo_path.join("sub").join("initially-untracked"), "...").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file
+    ? sub/always-untracked
+    ? sub/initially-untracked
     Working copy : qpvuntsm 230dd059 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     ");
 
-    test_env.jj_cmd_success(&repo_path, &["file", "track", "initially-untracked-file"]);
+    test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "file",
+            "track",
+            "initially-untracked-file",
+            "sub/initially-untracked",
+        ],
+    );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     Working copy changes:
     A initially-untracked-file
+    A sub/initially-untracked
     Untracked paths:
     ? always-untracked-file
-    Working copy : qpvuntsm 203bfea9 (no description set)
+    ? sub/always-untracked
+    Working copy : qpvuntsm 99798fcd (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     Untracked paths:
     ? always-untracked-file
-    Working copy : mzvwutvl 69b48d55 (empty) (no description set)
-    Parent commit: qpvuntsm 203bfea9 (no description set)
+    ? sub/always-untracked
+    Working copy : mzvwutvl 30e53c74 (empty) (no description set)
+    Parent commit: qpvuntsm 99798fcd (no description set)
     ");
 
-    test_env.jj_cmd_success(&repo_path, &["file", "untrack", "initially-untracked-file"]);
+    test_env.jj_cmd_success(
+        &repo_path,
+        &[
+            "file",
+            "untrack",
+            "initially-untracked-file",
+            "sub/initially-untracked",
+        ],
+    );
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     Working copy changes:
     D initially-untracked-file
+    D sub/initially-untracked
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file
-    Working copy : mzvwutvl 16169825 (no description set)
-    Parent commit: qpvuntsm 203bfea9 (no description set)
+    ? sub/always-untracked
+    ? sub/initially-untracked
+    Working copy : mzvwutvl bb362aaf (no description set)
+    Parent commit: qpvuntsm 99798fcd (no description set)
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r"
+    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file
-    Working copy : yostqsxw 9b87b665 (empty) (no description set)
-    Parent commit: mzvwutvl 16169825 (no description set)
+    ? sub/always-untracked
+    ? sub/initially-untracked
+    Working copy : yostqsxw 8e8c02fe (empty) (no description set)
+    Parent commit: mzvwutvl bb362aaf (no description set)
     ");
 }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1235,14 +1235,12 @@ impl FileSnapshotter<'_> {
 
         if file_type.is_dir() {
             let file_states = file_states.prefixed_at(dir, name);
-            if git_ignore.matches(&path.to_internal_dir_string())
-                || self.start_tracking_matcher.visit(&path).is_nothing()
-            {
-                // TODO: Report this directory to the caller if there are unignored paths we
-                // should not start tracking.
-
-                // If the whole directory is ignored, visit only paths we're already
-                // tracking.
+            if git_ignore.matches(&path.to_internal_dir_string()) {
+                // If the whole directory is ignored by .gitignore, visit only
+                // paths we're already tracking. This is because .gitignore in
+                // ignored directory must be ignored. It's also more efficient.
+                // start_tracking_matcher is NOT tested here because we need to
+                // scan directory entries to report untracked paths.
                 self.spawn_ok(scope, move |_| self.visit_tracked_files(file_states));
             } else if !self.matcher.visit(&path).is_nothing() {
                 let directory_to_visit = DirectoryToVisit {


### PR DESCRIPTION
Fixes #5389

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
