### PR TITLE
cli reference: fix `jj git push` link formatting

### DIFF
--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -73,6 +73,7 @@ use crate::ui::Ui;
 ///
 /// [safety checks]:
 ///     https://jj-vcs.github.io/jj/latest/bookmarks/#pushing-bookmarks-safety-checks
+///
 /// [bookmark conflicts]:
 ///     https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1200,7 +1200,9 @@ Unlike in Git, the remote to push to is not derived from the tracked remote book
 
 Before the command actually moves, creates, or deletes a remote bookmark, it makes several [safety checks]. If there is a problem, you may need to run `jj git fetch --remote <remote name>` and/or resolve some [bookmark conflicts].
 
-[safety checks]: https://jj-vcs.github.io/jj/latest/bookmarks/#pushing-bookmarks-safety-checks [bookmark conflicts]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
+[safety checks]: https://jj-vcs.github.io/jj/latest/bookmarks/#pushing-bookmarks-safety-checks
+
+[bookmark conflicts]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
 
 **Usage:** `jj git push [OPTIONS]`
 


### PR DESCRIPTION
Currently, the rendering in
https://jj-vcs.github.io/jj/prerelease/cli-reference/#jj-git-push is incorrect.

Fixup to 5b5a9e7
