### PR TITLE
docs: label prerelease docs with different title and header color, refactor mkdocs.yml

### DIFF
--- a/.github/scripts/docs-build-deploy
+++ b/.github/scripts/docs-build-deploy
@@ -2,13 +2,12 @@
 # Set up a virtual environment with the required tools, build, and deploy the docs.
 #
 # Run from the root directory of the project as
-# .github/scripts/docs-build-deploy 'https://jj-vcs.github.io' prerelease main
+# .github/scripts/docs-build-deploy prerelease main
 # All arguments after the first are passed to `mike deploy`, run
 # `uv run -- mike deploy --help` for options. Note that `mike deploy`
 # creates a commit directly on the `gh-pages` branch.
 set -ev
 
-export "SITE_URL_FOR_MKDOCS=$1"; shift
 # Affects the generation of `sitemap.xml.gz` by `mkdocs`. See
 # https://github.com/jimporter/mike/issues/103 and
 # https://reproducible-builds.org/docs/source-date-epoch/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           git config user.name 'jj-docs[bot]'
           git config user.email 'jj-docs[bot]@users.noreply.github.io'
+          export MKDOCS_SITE_NAME="Jujutsu docs (prerelease)"
+          export MKDOCS_PRIMARY_COLOR="blue grey"
           .github/scripts/docs-build-deploy prerelease --push
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,6 @@ jobs:
         run: |
           git config user.name 'jj-docs[bot]'
           git config user.email 'jj-docs[bot]@users.noreply.github.io'
-          .github/scripts/docs-build-deploy 'https://jj-vcs.github.io/jj' prerelease --push
+          .github/scripts/docs-build-deploy prerelease --push
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,6 @@ jobs:
           git config user.email 'jj-docs[bot]@users.noreply.github.io'
           # Using the 'latest' tag below makes the website default
           # to this version.
-          .github/scripts/docs-build-deploy 'https://jj-vcs.github.io/jj' "${{ github.event.release.tag_name }}" latest --update-aliases --push
+          .github/scripts/docs-build-deploy "${{ github.event.release.tag_name }}" latest --update-aliases --push
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -388,8 +388,7 @@ documentation](#previewing-the-html-documentation), and run the same `sh` script
 that is used in GitHub CI (details below):
 
     ```shell
-    .github/scripts/docs-build-deploy 'https://jjfan.github.io/jj/'\
-        prerelease main --push
+    .github/scripts/docs-build-deploy prerelease main --push
     ```
 
     This should build the version of the docs from the current commit,
@@ -406,8 +405,7 @@ back and forth, you can also rebuild the docs for the latest release as follows.
 
     ```shell
     jj new v1.33.1  # Let's say `jj 1.33.1` is the currently the latest release
-    .github/scripts/docs-build-deploy 'https://jjfan.github.io/jj/'\
-        v1.33.1 latest --push
+    .github/scripts/docs-build-deploy v1.33.1 latest --push
     ```
 
 7. (Optional) When you are done, you may want to reset the `gh-pages` bookmark to the
@@ -426,20 +424,22 @@ this can be done with:
 
 ### Explanation of the `docs-build-deploy` script
 
-The script sets up the `site_url` mkdocs config to
-`'https://jjfan.github.io/jj/'`. If this config does not match the URL
-where you loaded the website, some minor website features (like the
-version switching widget) will have reduced functionality.
-
-Then, the script passes the rest of its arguments to `uv run mike
-deploy`, which does the rest of the job. Run `uv run mike help deploy` to
-find out what the arguments do.
+The script sets up a few environment variables and invokes `uv run mike deploy`
+with some default arguments and whatever arguments were passed to
+`docs-build-deploy`. Run `uv run mike help deploy` to find out what the
+arguments do.
 
 If you need to do something more complicated, you can use `uv run mike
 ...` commands. You can also edit the `gh-pages` bookmark directly, but take care
 to avoid files that will be overwritten by future invocations of `mike`. Then,
 you can submit a PR based on the `gh-pages` bookmark of
-<https://martinvonz.github.com/jj> (instead of the usual `main` bookmark).
+<https://jj-vcs.github.com/jj> (instead of the usual `main` bookmark).
+
+Previously, the version switcher would not work unless the value of the
+`site_url` config in `mkdocs.yml` matched the actual URL the site is being
+served from. This bug should now be fixed, but if you are not serving the site
+from https://jj-vcs.github.com/jj and something does not work weirdly, you might
+want to adjust the `site_url` to something like `https://jjfan.github.io/jj`.
 
 
 ## Modifying protobuffers (this is not common)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Jujutsu docs
+site_name: !ENV [MKDOCS_SITE_NAME, 'Jujutsu docs']
 site_dir:  'rendered-docs'
 # Not having this (or viewing the site locally, or from any place other than the
 # site_url) leads to version switching failing to preserve the current path.
@@ -20,11 +20,13 @@ theme:
         name: Switch to system preference
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: !ENV [MKDOCS_PRIMARY_COLOR, 'indigo']
       toggle:
         icon: material/brightness-7
         name: Switch to light mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
+      primary: !ENV [MKDOCS_PRIMARY_COLOR, 'indigo']
       toggle:
         icon: material/brightness-4
         name: Switch to dark mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Jujutsu docs
 site_dir:  'rendered-docs'
 # Not having this (or viewing the site locally, or from any place other than the
 # site_url) leads to version switching failing to preserve the current path.
-site_url: !ENV [SITE_URL_FOR_MKDOCS, 'https://jj-vcs.github.io/jj/']
+site_url: 'https://jj-vcs.github.io/jj/'
 theme:
   name: 'material'
   language: 'en'


### PR DESCRIPTION
The main goal here is to make it easier to tell when you are viewing the prerelease docs vs other docs. This makes the prerelease docs have an adjusted header and a metallic grey header instead of the blue header all other docs have.

There is also a refactoring commit that also adjusts the contributing docs somewhat. This can be split into a separate PR, the main reason I put them together is because I wanted to change the convention for how environment variables inside `mkdocs.yml` are named.

Before:
<img width="524" alt="SCR-20250205-qtll" src="https://github.com/user-attachments/assets/2ecaa3fb-f3c9-419b-8944-1cc61de64749" />

After:

(The dropdown will not change, it's missing below because I used `mkdocs serve`)

<img width="529" alt="SCR-20250205-qtpz" src="https://github.com/user-attachments/assets/e6c8f092-69ee-4bee-8755-c55f8097deff" />

Light theme:

<img width="526" alt="SCR-20250205-qtcx" src="https://github.com/user-attachments/assets/5431d1b8-2396-4db4-a380-76b0c2d8b58e" />



See the commit descriptions for more details and thoughts.