### PR TITLE
cli split: Add a config option controlling how bookmarks move during splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a warning if the user does not specify target revision  explicitly. In the near
   future those commands will fail if target revision is not specified.
 
+* In the next release, `jj split` will no longer move bookmarks to the second
+  revision created by the split. Instead, local bookmarks associated with the
+  target revision will move to the first revision created by the split (which
+  inherits the target revision's change id). You can opt out of this change by
+  setting `split.legacy-bookmark-behavior = true`, but this will likely be
+  removed in a future release. You can also try the new behavior now by setting
+  `split.legacy-bookmark-behavior = false`.
+  [#3419](https://github.com/jj-vcs/jj/issues/3419)
+
+
 ### New features
 
 * `jj undo` now shows a hint when undoing an undo operation that the user may

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -684,6 +684,17 @@
                     "description": "Settings for tools run by jj fix"
                 }
             }
+        },
+        "split": {
+            "type": "object",
+            "description": "Settings for jj split",
+            "properties": {
+                "legacy-bookmark-behavior": {
+                    "type": "boolean",
+                    "description": "If true, bookmarks will move to the second commit instead of the first.",
+                    "default": false
+                }
+            }
         }
     }
 }

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -15,6 +15,8 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use test_case::test_case;
+
 use crate::common::TestEnvironment;
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
@@ -60,6 +62,9 @@ fn test_split_by_paths() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "file2"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 65569ca7 (no description set)
     Second part: zsuskuln 709756f0 (no description set)
     Working copy now at: zsuskuln 709756f0 (no description set)
@@ -107,14 +112,17 @@ fn test_split_by_paths() {
     test_env.set_up_fake_editor();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Warning: All changes have been selected, so the second commit will be empty
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: qpvuntsm 9da0eea0 (no description set)
     Second part: znkkpsqq 5b5714a3 (empty) (no description set)
     Working copy now at: zsuskuln 0c798ee7 (no description set)
     Parent commit      : znkkpsqq 5b5714a3 (empty) (no description set)
-    "#);
+    "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
@@ -135,14 +143,17 @@ fn test_split_by_paths() {
     test_env.set_up_fake_editor();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["split", "-r", "@-", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r###"
     Warning: No changes have been selected, so the first commit will be empty
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: qpvuntsm bd42f95a (empty) (no description set)
     Second part: lylxulpl ed55c86b (no description set)
     Working copy now at: zsuskuln 1e1ed741 (no description set)
     Parent commit      : lylxulpl ed55c86b (no description set)
-    "#);
+    "###);
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
     @  zsuskulnrvyr false
@@ -183,6 +194,9 @@ fn test_split_with_non_empty_description() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 231a3c00 part 1
     Second part: kkmpptxz e96291aa part 2
     Working copy now at: kkmpptxz e96291aa part 2
@@ -235,6 +249,9 @@ fn test_split_with_default_description() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 02ee5d60 TESTED=TODO
     Second part: rlvkpnrz 33cd046b (no description set)
     Working copy now at: rlvkpnrz 33cd046b (no description set)
@@ -300,6 +317,9 @@ fn test_split_with_merge_child() {
         test_env.jj_cmd_ok(&workspace_path, &["split", "-r", "description(a)", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
     Second part: royxmykx 5e1b793d Add file2
@@ -344,6 +364,9 @@ fn test_split_siblings_no_descendants() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--parallel", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 48018df6 TESTED=TODO
     Second part: kkmpptxz 7eddbf93 (no description set)
     Working copy now at: kkmpptxz 7eddbf93 (no description set)
@@ -422,6 +445,9 @@ fn test_split_siblings_with_descendants() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "--parallel", "file1"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 2 descendant commits
     First part: qpvuntsm 84df941d Add file1
     Second part: vruxwmqv 94753be3 Add file2
@@ -500,6 +526,9 @@ fn test_split_siblings_with_merge_child() {
     );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
     Second part: royxmykx 2cc60f3d Add file2
@@ -596,6 +625,9 @@ fn test_split_interactive() {
 
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 0e15949e (no description set)
     Second part: rlvkpnrz 9ed12e4c (no description set)
     Working copy now at: rlvkpnrz 9ed12e4c (no description set)
@@ -640,12 +672,15 @@ fn test_split_interactive_with_paths() {
 
     // Select file1 and file2 by args, then select file1 interactively
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "-i", "file1", "file2"]);
-    insta::assert_snapshot!(stderr, @r"
+    insta::assert_snapshot!(stderr, @r###"
+    Warning: `jj split` will leave bookmarks on the first commit in the next release.
+    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: rlvkpnrz e3d766b8 (no description set)
     Second part: kkmpptxz 4cf22d3b (no description set)
     Working copy now at: kkmpptxz 4cf22d3b (no description set)
     Parent commit      : rlvkpnrz e3d766b8 (no description set)
-    ");
+    "###);
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
@@ -797,21 +832,42 @@ fn test_split_with_multiple_workspaces_different_working_copy() {
     "###);
 }
 
-#[test]
-fn test_split_with_bookmarks() {
+enum BookmarkBehavior {
+    Default,
+    Legacy,
+    Modern,
+}
+
+// TODO: https://github.com/jj-vcs/jj/issues/3419 - Delete params when the config is removed.
+#[test_case(BookmarkBehavior::Default; "default_behavior")]
+#[test_case(BookmarkBehavior::Legacy; "legacy_behavior")]
+#[test_case(BookmarkBehavior::Modern; "modern_behavior")]
+fn test_split_with_bookmarks(bookmark_behavior: BookmarkBehavior) {
     let mut test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "main"]);
     let main_path = test_env.env_root().join("main");
+
+    match bookmark_behavior {
+        BookmarkBehavior::Modern => {
+            test_env.add_config("split.legacy-bookmark-behavior=false");
+        }
+        BookmarkBehavior::Legacy => {
+            test_env.add_config("split.legacy-bookmark-behavior=true");
+        }
+        BookmarkBehavior::Default => (),
+    }
 
     // Setup.
     test_env.jj_cmd_ok(&main_path, &["desc", "-m", "first-commit"]);
     std::fs::write(main_path.join("file1"), "foo").unwrap();
     std::fs::write(main_path.join("file2"), "foo").unwrap();
     test_env.jj_cmd_ok(&main_path, &["bookmark", "set", "*le-signet*", "-r", "@"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
     @  qpvuntsmwlqt false *le-signet* first-commit
     ◆  zzzzzzzzzzzz true
     "###);
+    }
 
     // Do the split.
     std::fs::write(
@@ -819,13 +875,46 @@ fn test_split_with_bookmarks() {
         ["", "next invocation\n", "write\nsecond-commit"].join("\0"),
     )
     .unwrap();
-    test_env.jj_cmd_ok(&main_path, &["split", "file2"]);
-    // The bookmark moves to the second commit.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    @  mzvwutvlkqwt false *le-signet* second-commit
-    ○  qpvuntsmwlqt false first-commit
-    ◆  zzzzzzzzzzzz true
-    "###);
+    let (_, stderr) = test_env.jj_cmd_ok(&main_path, &["split", "file2"]);
+    match bookmark_behavior {
+        BookmarkBehavior::Modern => {
+            insta::allow_duplicates! {
+            insta::assert_snapshot!(stderr, @r###"
+            First part: qpvuntsm 63d0c5ed *le-signet* | first-commit
+            Second part: mzvwutvl a9f5665f second-commit
+            Working copy now at: mzvwutvl a9f5665f second-commit
+            Parent commit      : qpvuntsm 63d0c5ed *le-signet* | first-commit
+            "###);
+            }
+            insta::allow_duplicates! {
+            insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+            @  mzvwutvlkqwt false second-commit
+            ○  qpvuntsmwlqt false *le-signet* first-commit
+            ◆  zzzzzzzzzzzz true
+            "###);
+            }
+        }
+        BookmarkBehavior::Default | BookmarkBehavior::Legacy => {
+            insta::allow_duplicates! {
+            insta::assert_snapshot!(stderr, @r###"
+            Warning: `jj split` will leave bookmarks on the first commit in the next release.
+            Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+            Warning: See https://github.com/jj-vcs/jj/issues/3419
+            First part: qpvuntsm 63d0c5ed first-commit
+            Second part: mzvwutvl a9f5665f *le-signet* | second-commit
+            Working copy now at: mzvwutvl a9f5665f *le-signet* | second-commit
+            Parent commit      : qpvuntsm 63d0c5ed first-commit
+            "###);
+            }
+            insta::allow_duplicates! {
+            insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+            @  mzvwutvlkqwt false *le-signet* second-commit
+            ○  qpvuntsmwlqt false first-commit
+            ◆  zzzzzzzzzzzz true
+            "###);
+            }
+        }
+    }
 
     // Test again with a --parallel split.
     test_env.jj_cmd_ok(&main_path, &["undo"]);
@@ -835,11 +924,26 @@ fn test_split_with_bookmarks() {
     )
     .unwrap();
     test_env.jj_cmd_ok(&main_path, &["split", "file2", "--parallel"]);
-    // The bookmark moves to the second commit.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-    @  vruxwmqvtpmx false *le-signet* second-commit
-    │ ○  qpvuntsmwlqt false first-commit
-    ├─╯
-    ◆  zzzzzzzzzzzz true
-    "###);
+    match bookmark_behavior {
+        BookmarkBehavior::Modern => {
+            insta::allow_duplicates! {
+            insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+            @  vruxwmqvtpmx false second-commit
+            │ ○  qpvuntsmwlqt false *le-signet* first-commit
+            ├─╯
+            ◆  zzzzzzzzzzzz true
+            "###);
+            }
+        }
+        BookmarkBehavior::Default | BookmarkBehavior::Legacy => {
+            insta::allow_duplicates! {
+            insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+            @  vruxwmqvtpmx false *le-signet* second-commit
+            │ ○  qpvuntsmwlqt false first-commit
+            ├─╯
+            ◆  zzzzzzzzzzzz true
+            "###);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Currently, `jj split` moves bookmarks from the target revision to the second
revision created by the split. Since the first revision inherits the change id
of the target revision, moving the bookmarks to the first revision is less
surprising (i.e. the bookmarks stay with the change id). This no-implicit-move
behavior also aligns with how `jj abandon` drops bookmarks instead of moving
them to the parent revision.

Two releases from now, `jj split` will no longer move bookmarks to the second
revision created by the split. Instead, local bookmarks associated with the
target revision will move to the first revision created by the split (which
inherits the target revision's change id). You can opt out of this change by
setting `split.legacy-bookmark-behavior = true`, but this will likely be
removed in a future release. You can also try the new behavior now by setting
`split.legacy-bookmark-behavior = false`.

Users who have not set the new config option will see a warning when they run
`jj split` informing them about the change.

The `jj split` tests for bookmarks are updated to run in all three configurations:

- Config setting enabled
- Config setting disabled
- Config setting unset

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
    - N/A: *I didn't see any docs describing the bookmark semantics.*
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
