### PR TITLE
cli: untrack remote bookmarks on `bookmark forget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `Commit`. All methods on `Commit` can be accessed with `commit.method()`, or
   `self.commit().method()`.
 
+* `jj bookmark forget` now untracks any corresponding remote bookmarks instead
+  of forgetting them, since forgetting a remote bookmark can be unintuitive.
+  The old behavior is still available with the new `--include-remotes` flag.
+
 ### Deprecations
 
 * This release takes the first steps to make target revision required in

--- a/cli/src/commands/bookmark/delete.rs
+++ b/cli/src/commands/bookmark/delete.rs
@@ -30,6 +30,9 @@ use crate::ui::Ui;
 /// revisions as well as bookmarks, use `jj abandon`. For example, `jj abandon
 /// main..<bookmark>` will abandon revisions belonging to the `<bookmark>`
 /// branch (relative to the `main` branch.)
+///
+/// If you don't want the deletion of the local bookmark to propagate to any
+/// tracked remote bookmarks, use `jj bookmark forget` instead.
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkDeleteArgs {
     /// The bookmarks to delete

--- a/cli/src/commands/bookmark/untrack.rs
+++ b/cli/src/commands/bookmark/untrack.rs
@@ -26,6 +26,9 @@ use crate::ui::Ui;
 ///
 /// A non-tracking remote bookmark is just a pointer to the last-fetched remote
 /// bookmark. It won't be imported as a local bookmark on future pulls.
+///
+/// If you want to forget a local bookmark while also untracking the
+/// corresponding remote bookmarks, use `jj bookmark forget` instead.
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkUntrackArgs {
     /// Remote bookmarks to untrack

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -290,7 +290,7 @@ See the [bookmark documentation] for more information.
 
 * `create` — Create a new bookmark
 * `delete` — Delete an existing bookmark and propagate the deletion to remotes on the next push
-* `forget` — Forget everything about a bookmark, including its local and remote targets
+* `forget` — Forget a bookmark without marking it as a deletion to be pushed
 * `list` — List bookmarks and their targets
 * `move` — Move existing bookmarks to target revision
 * `rename` — Rename `old` bookmark name to `new` bookmark name
@@ -322,6 +322,8 @@ Delete an existing bookmark and propagate the deletion to remotes on the next pu
 
 Revisions referred to by the deleted bookmarks are not abandoned. To delete revisions as well as bookmarks, use `jj abandon`. For example, `jj abandon main..<bookmark>` will abandon revisions belonging to the `<bookmark>` branch (relative to the `main` branch.)
 
+If you don't want the deletion of the local bookmark to propagate to any tracked remote bookmarks, use `jj bookmark forget` instead.
+
 **Usage:** `jj bookmark delete <NAMES>...`
 
 ###### **Arguments:**
@@ -336,11 +338,11 @@ Revisions referred to by the deleted bookmarks are not abandoned. To delete revi
 
 ## `jj bookmark forget`
 
-Forget everything about a bookmark, including its local and remote targets
+Forget a bookmark without marking it as a deletion to be pushed
 
-A forgotten bookmark will not impact remotes on future pushes. It will be recreated on future pulls if it still exists in the remote.
+If a local bookmark is forgotten, any corresponding remote bookmarks will become untracked to ensure that the forgotten bookmark will not impact remotes on future pushes.
 
-**Usage:** `jj bookmark forget <NAMES>...`
+**Usage:** `jj bookmark forget [OPTIONS] <NAMES>...`
 
 ###### **Arguments:**
 
@@ -349,6 +351,12 @@ A forgotten bookmark will not impact remotes on future pushes. It will be recrea
    By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
 
    [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+
+###### **Options:**
+
+* `--include-remotes` — When forgetting a local bookmark, also forget any corresponding remote bookmarks
+
+   A forgotten remote bookmark will not impact remotes on future pushes. It will be recreated on future fetches if it still exists on the remote. If there is a corresponding Git-tracking remote bookmark, it will also be forgotten.
 
 
 
@@ -484,6 +492,8 @@ A tracking remote bookmark will be imported as a local bookmark of the same name
 Stop tracking given remote bookmarks
 
 A non-tracking remote bookmark is just a pointer to the last-fetched remote bookmark. It won't be imported as a local bookmark on future pulls.
+
+If you want to forget a local bookmark while also untracking the corresponding remote bookmarks, use `jj bookmark forget` instead.
 
 **Usage:** `jj bookmark untrack <BOOKMARK@REMOTE>...`
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -793,16 +793,20 @@ fn test_git_clone_trunk_deleted(subprocess: bool) {
     "#);
     }
 
-    let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["bookmark", "forget", "main"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &clone_path,
+        &["bookmark", "forget", "--include-remotes", "main"],
+    );
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r"
-    Forgot 1 bookmarks.
+    insta::assert_snapshot!(stderr, @r#"
+    Forgot 1 local bookmarks.
+    Forgot 1 remote bookmarks.
     Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
-    ");
+    "#);
     }
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["log"]);

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -384,11 +384,15 @@ fn test_git_colocated_bookmark_forget() {
       @git: rlvkpnrz 65b6b74e (empty) (no description set)
     "###);
 
-    let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["bookmark", "forget", "foo"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &workspace_root,
+        &["bookmark", "forget", "--include-remotes", "foo"],
+    );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-    Forgot 1 bookmarks.
-    "###);
+    insta::assert_snapshot!(stderr, @r#"
+    Forgot 1 local bookmarks.
+    Forgot 1 remote bookmarks.
+    "#);
     // A forgotten bookmark is deleted in the git repo. For a detailed demo
     // explaining this, see `test_bookmark_forget_export` in
     // `test_bookmark_command.rs`.

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1590,7 +1590,10 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     }
 
     // Remove a2 bookmark in origin
-    test_env.jj_cmd_ok(&source_git_repo_path, &["bookmark", "forget", "a2"]);
+    test_env.jj_cmd_ok(
+        &source_git_repo_path,
+        &["bookmark", "forget", "--include-remotes", "a2"],
+    );
 
     // Fetch bookmark a1 from origin and check that a2 is still there
     let (stdout, stderr) =
@@ -1708,7 +1711,10 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     }
 
     // Remove all bookmarks in origin.
-    test_env.jj_cmd_ok(&source_git_repo_path, &["bookmark", "forget", "glob:*"]);
+    test_env.jj_cmd_ok(
+        &source_git_repo_path,
+        &["bookmark", "forget", "--include-remotes", "glob:*"],
+    );
 
     // Fetch bookmarks master, trunk1 and a1 from origin and check that only those
     // bookmarks have been removed and that others were not rebased because of

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -542,7 +542,10 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     }
 
     // Forget bookmark1 locally
-    test_env.jj_cmd_ok(&workspace_root, &["bookmark", "forget", "bookmark1"]);
+    test_env.jj_cmd_ok(
+        &workspace_root,
+        &["bookmark", "forget", "--include-remotes", "bookmark1"],
+    );
 
     // Create a new branh1
     test_env.jj_cmd_ok(&workspace_root, &["new", "root()", "-m=new bookmark1"]);


### PR DESCRIPTION
Fixes #5524. This solution was suggested by @yuja in #5546.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
