### PR TITLE
cli: remove `ui.allow-filesets` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* The `ui.allow-filesets` configuration option has been removed.
+  [The "fileset" language](docs/filesets.md) has been enabled by default since v0.20.
+
 ### Deprecations
 
 ### New features
@@ -834,7 +837,7 @@ Thanks to the people who made this release happen!
   `templates.op_log_node`.
 
 * [The "fileset" language](docs/filesets.md) is now enabled by default. It can
-  still be disable by setting `ui.allow-filesets=false`.
+  still be disabled by setting `ui.allow-filesets=false`.
 
 * On `jj git fetch`/`import`, commits referred to by `HEAD@git` are no longer
   preserved. If a checked-out named branch gets deleted locally or remotely, the

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1312,15 +1312,8 @@ to the current parents may contain changes from multiple commits.
         // empty arguments.
         if values.is_empty() {
             Ok(FilesetExpression::all())
-        } else if self.settings().get_bool("ui.allow-filesets")? {
-            self.parse_union_filesets(ui, values)
         } else {
-            let expressions = values
-                .iter()
-                .map(|v| self.parse_file_path(v))
-                .map_ok(FilesetExpression::prefix_path)
-                .try_collect()?;
-            Ok(FilesetExpression::union_all(expressions))
+            self.parse_union_filesets(ui, values)
         }
     }
 

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -572,7 +572,6 @@ fn all_files_from_rev(rev: String, current: &std::ffi::OsStr) -> Vec<CompletionC
             .arg("list")
             .arg("--revision")
             .arg(rev)
-            .arg("--config=ui.allow-filesets=true")
             .arg(current_prefix_to_fileset(current))
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
@@ -605,7 +604,6 @@ fn modified_files_from_rev_with_jj_cmd(
     };
     cmd.arg("diff")
         .arg("--summary")
-        .arg("--config=ui.allow-filesets=true")
         .arg(current_prefix_to_fileset(current));
     match rev {
         (rev, None) => cmd.arg("--revision").arg(rev),
@@ -657,7 +655,6 @@ fn conflicted_files_from_rev(rev: &str, current: &std::ffi::OsStr) -> Vec<Comple
             .arg("--list")
             .arg("--revision")
             .arg(rev)
-            .arg("--config=ui.allow-filesets=true")
             .arg(current_prefix_to_fileset(current))
             .output()
             .map_err(user_error)?;

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -53,11 +53,6 @@
                     "description": "Whether to allow initializing a repo with the native backend",
                     "default": false
                 },
-                "allow-filesets": {
-                    "type": "boolean",
-                    "description": "Whether to parse path arguments as fileset expressions",
-                    "default": true
-                },
                 "always-allow-large-revsets": {
                     "type": "boolean",
                     "description": "Whether to allow large revsets to be used in all commands without the `all:` modifier",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -20,8 +20,6 @@ push-new-bookmarks = false
 sign-on-push = false
 
 [ui]
-# TODO: delete ui.allow-filesets in jj 0.26+
-allow-filesets = true
 allow-init-native = false
 always-allow-large-revsets = false
 color = "auto"

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -636,10 +636,6 @@ fn test_files() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
 
-    // Completions for files use filesets internally.
-    // Ensure they still work if the user has them disabled.
-    test_env.add_config("ui.allow-filesets = false");
-
     create_commit(
         &test_env,
         &repo_path,

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -286,15 +286,6 @@ fn test_bad_path() {
     3: Invalid component ".." in repo-relative path "../out"
     Hint: Consider using root:"out" to specify repo-relative path
     "###);
-
-    test_env.add_config("ui.allow-filesets = false");
-
-    // If fileset/pattern syntax is disabled, no hint should be generated
-    let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["file", "show", "-Rrepo", "out"]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
-    Error: Path "out" is not in the repo "repo"
-    Caused by: Invalid component ".." in repo-relative path "../out"
-    "###);
 }
 
 #[test]
@@ -313,12 +304,6 @@ fn test_invalid_filesets_looking_like_filepaths() {
       |
       = expected `~` or <primary>
     Hint: See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
-    "#);
-
-    test_env.add_config(r#"ui.allow-filesets=false"#);
-    let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "abc~"]);
-    insta::assert_snapshot!(stderr, @r#"
-    Error: No such path: abc~
     "#);
 }
 

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -857,22 +857,6 @@ fn test_log_filtered_by_path() {
     A file2
     "###);
 
-    // Fileset/pattern syntax can be disabled.
-    let stderr = test_env.jj_cmd_failure(
-        test_env.env_root(),
-        &[
-            "log",
-            "--config=ui.allow-filesets=false",
-            "-R",
-            repo_path.to_str().unwrap(),
-            "all()",
-        ],
-    );
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
-    Error: Path "all()" is not in the repo "repo"
-    Caused by: Invalid component ".." in repo-relative path "../all()"
-    "###);
-
     // empty revisions are filtered out by "all()" fileset.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-Tdescription", "-s", "all()"]);
     insta::assert_snapshot!(stdout, @r###"


### PR DESCRIPTION
The "fileset" language has been enabled by default since v0.20.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [X] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
