### PR TITLE
repo: Change name for unused closure argument

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1386,7 +1386,7 @@ impl MutableRepo {
         self.maybe_abandon_wc_commit(&workspace_id)?;
         self.add_head(commit)?;
         self.set_wc_commit(workspace_id, commit.id().clone())
-            .map_err(|RewriteRootCommit| EditCommitError::RewriteRootCommit)
+            .map_err(|_: RewriteRootCommit| EditCommitError::RewriteRootCommit)
     }
 
     fn maybe_abandon_wc_commit(


### PR DESCRIPTION
The previous name violated the "snake case" convention for variable names. I suspect the intention was to use `RewriteRootCommit` as a type declaration, not the argument name. Since the argument isn't used, we can use an underscore as the name and leave the type declaration.

#cleanup
