### PR TITLE
sign: Support ~/ path expansion for allowed-signers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj status` now shows untracked files under untracked directories.
   [#5389](https://github.com/jj-vcs/jj/issues/5389)
 
+* The `signing.backends.ssh.allowed-signers` configuration option will now
+  expand `~/` to `$HOME/`.
+  [#5626](https://github.com/jj-vcs/jj/pull/5626)
+
 ## [0.26.0] - 2025-02-05
 
 ### Release highlights

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -123,7 +123,8 @@ impl SshBackend {
         let program = settings.get_string("signing.backends.ssh.program")?;
         let allowed_signers = settings
             .get_string("signing.backends.ssh.allowed-signers")
-            .optional()?;
+            .optional()?
+            .map(|v| crate::file_util::expand_home_path(v.as_str()));
         Ok(Self::new(program.into(), allowed_signers.map(|v| v.into())))
     }
 


### PR DESCRIPTION
I'm very new to rust so not sure this is the best approach - happy to hear any suggestions. I'll add tests and a changelog entry in a bit.

Fixes #5625

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] ~I have updated the documentation (README.md, docs/, demos/)~
- [ ] ~I have updated the config schema (cli/src/config-schema.json)~
- [ ] ~I have added tests to cover my changes~
