### PR TITLE
cli: add revsets.graph-prioritize setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   reversing colors rather than underlining, you can set
   `colors."diff token"={ underline = false, reverse = true }` in your config.
 
-### Fixed bugs
-
 * `jj log -p --stat` now shows diff stats as well as the default color-words/git
   diff output. [#5986](https://github.com/jj-vcs/jj/issues/5986)
 
@@ -103,6 +101,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj config set`/`--config` value parsing rule is relaxed in a way that
   unquoted apostrophes are allowed.
   [#5748](https://github.com/jj-vcs/jj/issues/5748)
+
+* Added `revsets.log-graph-prioritize`, which can be used to configure
+  which branch in the `jj log` graph is displayed on the left instead of `@`
+  (e.g. `coalesce(description("megamerge\n"), trunk())`)
 
 ## [0.27.0] - 2025-03-05
 

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -535,6 +535,11 @@
                     "type": "string",
                     "description": "Default set of revisions to sign when no explicit revset is given for jj sign",
                     "default": "reachable(@, mutable())"
+                },
+                "log-graph-prioritize": {
+                    "type": "string",
+                    "description": "Set of revisions to prioritize when rendering the graph for jj log",
+                    "default": "present(@)"
                 }
             },
             "additionalProperties": {

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -8,6 +8,9 @@ simplify-parents = "reachable(@, mutable())"
 # evaluate, lengthy warning messages would be printed. Use present(expr) to
 # suppress symbol resolution error.
 log = "present(@) | ancestors(immutable_heads().., 2) | present(trunk())"
+# Emit the working-copy branch first, which is usually most interesting.
+# This also helps stabilize output order.
+log-graph-prioritize = "present(@)"
 sign = "reachable(@, mutable())"
 
 [revset-aliases]


### PR DESCRIPTION
fixes #5506 

I've been using this for a while now, using
```toml
[revsets]
log-graph-prioritize = "coalesce(dev, present(main))"
```
where `dev` is my megamerge. I've found it to increase the readability of the graph by quite a lot.

**Before:**
![image](https://github.com/user-attachments/assets/3b5b6b65-ca96-4d7b-9c2b-a68324b82631)

**After:**
![image](https://github.com/user-attachments/assets/466e70c4-b169-43a8-ab0e-97cb45f990ea)


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] ~~I have updated the documentation (README.md, docs/, demos/)~~
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
