### PR TITLE
annotate: make AnnotationLine template type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `ui.allow-filesets` configuration option has been removed.
   [The "fileset" language](docs/filesets.md) has been enabled by default since v0.20.
 
+* `templates.annotate_commit_summary` is renamed to `templates.file_annotate`,
+  and now has an implicit `self` parameter of type `AnnotationLine`, instead of
+  `Commit`. All methods on `Commit` can be accessed with `commit.method()`, or
+  `self.commit().method()`.
+
 ### Deprecations
 
 * This release takes the first steps to make target revision required in
@@ -39,6 +44,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates now support additional string method `.escape_json(x)` which serializes
   the string in JSON format. It is useful for making machine-readable templates
   by escaping problematic characters like `\n`.
+
+* New `AnnotationLine` templater type. Used in `templates.file_annotate`.
+  Provides `self.commit()`, `self.line_number()`, and `self.first_line_in_hunk()`.
 
 ### Fixed bugs
 

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -323,6 +323,12 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                     function,
                 )
             }
+            CommitTemplatePropertyKind::AnnotationLine(property) => {
+                let type_name = "AnnotationLine";
+                let table = &self.build_fn_table.annotation_line_methods;
+                let build = template_parser::lookup_method(type_name, table, function)?;
+                build(self, diagnostics, build_ctx, property, function)
+            }
         }
     }
 }
@@ -441,6 +447,12 @@ impl<'repo> CommitTemplateLanguage<'repo> {
     ) -> CommitTemplatePropertyKind<'repo> {
         CommitTemplatePropertyKind::CryptographicSignatureOpt(Box::new(property))
     }
+
+    pub fn wrap_annotation_line(
+        property: impl TemplateProperty<Output = AnnotationLine> + 'repo,
+    ) -> CommitTemplatePropertyKind<'repo> {
+        CommitTemplatePropertyKind::AnnotationLine(Box::new(property))
+    }
 }
 
 pub enum CommitTemplatePropertyKind<'repo> {
@@ -463,6 +475,7 @@ pub enum CommitTemplatePropertyKind<'repo> {
     CryptographicSignatureOpt(
         Box<dyn TemplateProperty<Output = Option<CryptographicSignature>> + 'repo>,
     ),
+    AnnotationLine(Box<dyn TemplateProperty<Output = AnnotationLine> + 'repo>),
 }
 
 impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
@@ -487,6 +500,7 @@ impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
             CommitTemplatePropertyKind::CryptographicSignatureOpt(_) => {
                 "Option<CryptographicSignature>"
             }
+            CommitTemplatePropertyKind::AnnotationLine(_) => "AnnotationLine",
         }
     }
 
@@ -525,6 +539,7 @@ impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
             CommitTemplatePropertyKind::CryptographicSignatureOpt(property) => {
                 Some(Box::new(property.map(|sig| sig.is_some())))
             }
+            CommitTemplatePropertyKind::AnnotationLine(_) => None,
         }
     }
 
@@ -568,6 +583,7 @@ impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
             CommitTemplatePropertyKind::TreeEntry(_) => None,
             CommitTemplatePropertyKind::DiffStats(property) => Some(property.into_template()),
             CommitTemplatePropertyKind::CryptographicSignatureOpt(_) => None,
+            CommitTemplatePropertyKind::AnnotationLine(_) => None,
         }
     }
 
@@ -593,6 +609,7 @@ impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
             (CommitTemplatePropertyKind::TreeEntry(_), _) => None,
             (CommitTemplatePropertyKind::DiffStats(_), _) => None,
             (CommitTemplatePropertyKind::CryptographicSignatureOpt(_), _) => None,
+            (CommitTemplatePropertyKind::AnnotationLine(_), _) => None,
         }
     }
 
@@ -621,6 +638,7 @@ impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
             (CommitTemplatePropertyKind::TreeEntry(_), _) => None,
             (CommitTemplatePropertyKind::DiffStats(_), _) => None,
             (CommitTemplatePropertyKind::CryptographicSignatureOpt(_), _) => None,
+            (CommitTemplatePropertyKind::AnnotationLine(_), _) => None,
         }
     }
 }
@@ -643,6 +661,7 @@ pub struct CommitTemplateBuildFnTable<'repo> {
     pub diff_stats_methods: CommitTemplateBuildMethodFnMap<'repo, DiffStats>,
     pub cryptographic_signature_methods:
         CommitTemplateBuildMethodFnMap<'repo, CryptographicSignature>,
+    pub annotation_line_methods: CommitTemplateBuildMethodFnMap<'repo, AnnotationLine>,
 }
 
 impl<'repo> CommitTemplateBuildFnTable<'repo> {
@@ -660,6 +679,7 @@ impl<'repo> CommitTemplateBuildFnTable<'repo> {
             tree_entry_methods: builtin_tree_entry_methods(),
             diff_stats_methods: builtin_diff_stats_methods(),
             cryptographic_signature_methods: builtin_cryptographic_signature_methods(),
+            annotation_line_methods: builtin_annotation_line_methods(),
         }
     }
 
@@ -676,6 +696,7 @@ impl<'repo> CommitTemplateBuildFnTable<'repo> {
             tree_entry_methods: HashMap::new(),
             diff_stats_methods: HashMap::new(),
             cryptographic_signature_methods: HashMap::new(),
+            annotation_line_methods: HashMap::new(),
         }
     }
 
@@ -692,6 +713,7 @@ impl<'repo> CommitTemplateBuildFnTable<'repo> {
             tree_entry_methods,
             diff_stats_methods,
             cryptographic_signature_methods,
+            annotation_line_methods,
         } = extension;
 
         self.core.merge(core);
@@ -714,6 +736,7 @@ impl<'repo> CommitTemplateBuildFnTable<'repo> {
             &mut self.cryptographic_signature_methods,
             cryptographic_signature_methods,
         );
+        merge_fn_map(&mut self.annotation_line_methods, annotation_line_methods);
     }
 }
 
@@ -2193,6 +2216,45 @@ pub fn builtin_cryptographic_signature_methods<'repo>(
             function.expect_no_arguments()?;
             let out_property = self_property.and_then(|sig| Ok(sig.display()?));
             Ok(L::wrap_string(out_property))
+        },
+    );
+    map
+}
+
+// TODO: add `line: BString` field when available in template language
+#[derive(Debug, Clone)]
+pub struct AnnotationLine {
+    pub commit: Commit,
+    pub line_number: usize,
+    pub first_line_in_hunk: bool,
+}
+
+pub fn builtin_annotation_line_methods<'repo>(
+) -> CommitTemplateBuildMethodFnMap<'repo, AnnotationLine> {
+    type L<'repo> = CommitTemplateLanguage<'repo>;
+    let mut map = CommitTemplateBuildMethodFnMap::<AnnotationLine>::new();
+    map.insert(
+        "commit",
+        |_language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let out_property = self_property.and_then(|data| Ok(data.commit));
+            Ok(L::wrap_commit(out_property))
+        },
+    );
+    map.insert(
+        "line_number",
+        |_language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let out_property = self_property.and_then(|data| Ok(data.line_number.try_into()?));
+            Ok(L::wrap_integer(out_property))
+        },
+    );
+    map.insert(
+        "first_line_in_hunk",
+        |_language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let out_property = self_property.and_then(|data| Ok(data.first_line_in_hunk));
+            Ok(L::wrap_boolean(out_property))
         },
     );
     map

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -14,11 +14,12 @@ if(remote,
 
 commit_summary = 'format_commit_summary_with_refs(self, bookmarks)'
 
-annotate_commit_summary = '''
+file_annotate = '''
 separate(" ",
-  change_id.shortest(8),
-  pad_end(8, truncate_end(8, author.email().local())),
-  commit_timestamp(self).local().format('%Y-%m-%d %H:%M:%S'),
+  commit.change_id().shortest(8),
+  pad_end(8, truncate_end(8, commit.author().email().local())),
+  commit_timestamp(commit).local().format('%Y-%m-%d %H:%M:%S'),
+  pad_start(4, line_number) ++ ": ",
 )
 '''
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -885,7 +885,7 @@ File operations
 
 Show the source change for each line of the target file.
 
-Annotates a revision line by line. Each line includes the source change that introduced the associated line. A path to the desired file must be provided. The per-line prefix for each line can be customized via template with the `templates.annotate_commit_summary` config variable.
+Annotates a revision line by line. Each line includes the source change that introduced the associated line. A path to the desired file must be provided.
 
 **Usage:** `jj file annotate [OPTIONS] <PATH>`
 
@@ -896,6 +896,15 @@ Annotates a revision line by line. Each line includes the source change that int
 ###### **Options:**
 
 * `-r`, `--revision <REVSET>` — an optional revision to start at
+* `-T`, `--template <TEMPLATE>` — Render a prefix for each line using the given template
+
+   All 0-argument methods of the [`AnnotationLine` type] are available as keywords in the [template expression].
+
+   If not specified, this defaults to the `templates.file_annotate` setting.
+
+   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
+
+   [`AnnotationLine` type]: https://jj-vcs.github.io/jj/latest/templates/#annotationline-type
 
 
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -88,6 +88,15 @@ The following functions are defined.
 
 ## Types
 
+### AnnotationLine type
+
+The following methods are defined.
+
+* `.commit() -> Commit`: Commit responsible for changing the relevant line.
+* `.line_number() -> Integer`: 1-based line number.
+* `.first_line_in_hunk() -> Boolean`: False when the directly preceding line
+  references the same commit.
+
 ### Boolean type
 
 No methods are defined. Can be constructed with `false` or `true` literal.


### PR DESCRIPTION
Discord discussion: https://discord.com/channels/968932220549103686/1337969561793990757

Allows:
* self.commit()
* self.line_number()
* self.first_line_in_hunk()

Certain pagers (like `delta`), when used for `git blame`, only show the
commit information for the first line in a hunk. This would be a nice
addition to `jj file annotate`.

`jj file annotate` already uses a template to control the rendering of
commit information --- `templates.annotate_commit_summary`. Instead of
a custom CLI flag, the tools necessary to do this should be available in
the template language.

If `1 % 2` or `1.is_even()` was available in the template language, this
would also allow alternating colors (using `raw_escape_sequence`).

Example:

```toml
[templates]
# only show commit info for the first line of each hunk
annotate_commit_summary = '''
if(first_line_in_hunk,
  show_commit_info(commit),
  pad_end(20, " "),
)
'''
```


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
