### PR TITLE
cli: Fix single-character string constant used as pattern clippy warning

### DIFF
--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -435,7 +435,7 @@ fn parse_ref_pushes(stdout: &[u8]) -> Result<(Vec<String>, Vec<String>), GitSubp
             .map_err(GitSubprocessError::External)?;
 
         let reference = full_refspec
-            .split_once(":")
+            .split_once(':')
             .map(|(_refname, reference)| reference.to_string())
             .ok_or_else(|| {
                 GitSubprocessError::External(format!(


### PR DESCRIPTION
For further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

Apparently this got moved to "pedantic" in 1.80, but I ran clippy 1.79 and saw it. Seems harmless to fix though.
