### PR TITLE
Add a Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,21 @@
+[private]
+default:
+    @just --list
+  
+# Format all code
+format:
+    cargo +nightly fmt
+
+# Update generated CLI help (cli/tests/cli-reference@.md.snap)
+update-cli-reference:
+    cargo insta test --accept --workspace -- test_generate_md_cli_help
+
+# Preview documentation with live reloading
+[group('docs')]
+serve-docs:
+    uv run mkdocs serve
+
+# Build documentation into rendered-docs/ for offline use
+[group('docs')]
+build-docs:
+    uv run mkdocs build -f mkdocs-offline.yml


### PR DESCRIPTION
This lets us run common commands as `just <foo>` and reference them in the docs.

`just` is a popular alternative to managing project-specific commands in Makefiles. The nice parts are:

- Fewer syntax footguns
- Command descriptions and groups

Example:

```
❯ just
Available recipes:
    format               # Format all code
    update-cli-reference # Update generated CLI help (cli/tests/cli-reference@.md.snap)

    [docs]
    build-docs           # Build documentation into rendered-docs/ for offline use
    serve-docs           # Preview documentation with live reloading
```

If there is agreement, I will also update the docs to reference `just` for builds-docs, serve-docs, and update-cli-reference.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
