### PR TITLE
docs templates: add link to templates toml file

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -400,7 +400,10 @@ This type cannot be printed. The following methods are defined.
 
 The default templates and aliases() are defined in the `[templates]` and
 `[template-aliases]` sections of the config respectively. The exact definitions
-can be seen in the `cli/src/config/templates.toml` file in jj's source tree.
+can be seen in the [`cli/src/config/templates.toml`][1] file in jj's source
+tree.
+
+[1]: https://github.com/jj-vcs/jj/blob/main/cli/src/config/templates.toml
 
 <!--- TODO: Find a way to embed the default config files in the docs -->
 


### PR DESCRIPTION
I find myself going to this page and ending up wanting to see the list of templates in `templates.toml`.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [X] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
