### PR TITLE
git: enable subprocessing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Release highlights
 
+* `git.subprocess` is now enabled by default, improving compatibility with Git
+  fetches and pushes by spawning an external `git` process. Users can opt out
+  of this by setting `git.subprocess = false`, but this will likely be removed
+  in a future release. Please report any issues you run into.
+
 ### Breaking changes
 
 * The `ui.allow-filesets` configuration option has been removed.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -412,7 +412,7 @@
                 "subprocess": {
                     "type": "boolean",
                     "description": "Whether jj spawns a git subprocess for network operations (push/fetch/clone)",
-                    "default": false
+                    "default": true
                 },
                 "executable-path": {
                     "type": "string",

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -57,8 +57,8 @@ fn set_up_git_repo_with_file(git_repo: &git2::Repository, filename: &str) {
 fn test_git_clone(subprocess: bool) {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -216,8 +216,8 @@ fn test_git_clone(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_bad_source(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["git", "clone", "", "dest"]);
@@ -243,8 +243,8 @@ fn test_git_clone_bad_source(subprocess: bool) {
 fn test_git_clone_colocate(subprocess: bool) {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -489,8 +489,8 @@ fn test_git_clone_colocate(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -608,8 +608,8 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -648,8 +648,8 @@ fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_ignore_working_copy(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -696,8 +696,8 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_at_operation(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -719,8 +719,8 @@ fn test_git_clone_at_operation(subprocess: bool) {
 fn test_git_clone_with_remote_name(subprocess: bool) {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -750,8 +750,8 @@ fn test_git_clone_with_remote_name(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     git2::Repository::init(git_repo_path).unwrap();
@@ -769,8 +769,8 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_trunk_deleted(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -909,6 +909,7 @@ fn test_git_clone_conditional_config() {
 fn test_git_clone_with_depth_git2() {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
+    test_env.add_config("git.subprocess = false");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
     set_up_non_empty_git_repo(&git_repo);
@@ -931,7 +932,6 @@ fn test_git_clone_with_depth_git2() {
 fn test_git_clone_with_depth_subprocess() {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
-    test_env.add_config("git.subprocess = true");
     let clone_path = test_env.env_root().join("clone");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -968,8 +968,8 @@ fn test_git_clone_with_depth_subprocess() {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -997,8 +997,8 @@ fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_malformed(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1057,7 +1057,6 @@ fn test_git_clone_malformed(subprocess: bool) {
 #[test]
 fn test_git_clone_no_git_executable() {
     let test_env = TestEnvironment::default();
-    test_env.add_config("git.subprocess = true");
     test_env.add_config("git.executable-path = 'jj-test-missing-program'");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git2::Repository::init(git_repo_path).unwrap();
@@ -1074,7 +1073,6 @@ fn test_git_clone_no_git_executable() {
 fn test_git_clone_no_git_executable_with_path() {
     let test_env = TestEnvironment::default();
     let invalid_git_executable_path = test_env.env_root().join("invalid").join("path");
-    test_env.add_config("git.subprocess = true");
     test_env.add_config(format!(
         "git.executable-path = {}",
         to_toml_value(invalid_git_executable_path.to_str().unwrap())

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -118,8 +118,8 @@ fn clone_git_remote_into(
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_default_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -137,8 +137,8 @@ fn test_git_fetch_with_default_config(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_default_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -158,8 +158,8 @@ fn test_git_fetch_default_remote(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -185,8 +185,8 @@ fn test_git_fetch_single_remote(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -209,8 +209,8 @@ fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -230,8 +230,8 @@ fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -252,8 +252,8 @@ fn test_git_fetch_single_remote_from_config(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_multiple_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -279,8 +279,8 @@ fn test_git_fetch_multiple_remotes(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_all_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -307,8 +307,8 @@ fn test_git_fetch_all_remotes(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -332,8 +332,8 @@ fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -356,8 +356,8 @@ fn test_git_fetch_nonexistent_remote(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -378,8 +378,8 @@ fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let repo_path = test_env.env_root().join("repo");
@@ -439,8 +439,8 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -474,8 +474,8 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -510,8 +510,8 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let repo_path = test_env.env_root().join("repo");
@@ -583,8 +583,8 @@ fn create_trunk2_and_rebase_bookmarks(test_env: &TestEnvironment, repo_path: &Pa
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_all(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -768,8 +768,8 @@ fn test_git_fetch_all(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -1036,8 +1036,8 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -1151,7 +1151,6 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
 #[test]
 fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
     let test_env = TestEnvironment::default();
-    test_env.add_config("git.subprocess = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     add_git_remote(&test_env, &repo_path, "origin");
@@ -1182,8 +1181,8 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_undo(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1281,8 +1280,8 @@ fn test_git_fetch_undo(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_undo_what(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1412,8 +1411,8 @@ fn test_fetch_undo_what(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_remove_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -1472,8 +1471,8 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_rename_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
@@ -1527,8 +1526,8 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_removed_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1645,8 +1644,8 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let source_git_repo_path = test_env.env_root().join("source");
@@ -1748,8 +1747,8 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
@@ -1826,8 +1825,8 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     let test_env = TestEnvironment::default();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -53,8 +53,8 @@ fn set_up() -> (TestEnvironment, PathBuf) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_nothing(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
     insta::allow_duplicates! {
@@ -81,8 +81,8 @@ fn test_git_push_nothing(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_current_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     // Update some bookmarks. `bookmark1` is not a current bookmark, but
@@ -181,8 +181,8 @@ fn test_git_push_current_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_parent_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     test_env.jj_cmd_ok(&workspace_root, &["edit", "bookmark1"]);
@@ -208,8 +208,8 @@ fn test_git_push_parent_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_matching_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -228,8 +228,8 @@ fn test_git_push_no_matching_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["new", "bookmark1"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -251,8 +251,8 @@ fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     // Create another remote (but actually the same)
@@ -324,8 +324,8 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     // Move bookmark1 forward on the remote
@@ -356,8 +356,8 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     // Move bookmark1 forward on the remote
@@ -408,8 +408,8 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     // Move bookmark1 forward on the remote
@@ -454,8 +454,8 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     // Delete bookmark1 forward on the remote
@@ -534,8 +534,8 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     // Forget bookmark1 locally
@@ -568,8 +568,8 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     // Ensure that remote bookmarks aren't tracked automatically
     test_env.add_config("git.auto-local-bookmark = false");
@@ -634,8 +634,8 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_multiple(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
     test_env.jj_cmd_ok(
@@ -787,8 +787,8 @@ fn test_git_push_multiple(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_changes(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -952,8 +952,8 @@ fn test_git_push_changes(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_revisions(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1056,8 +1056,8 @@ fn test_git_push_revisions(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_mixed(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1118,8 +1118,8 @@ fn test_git_push_mixed(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_existing_long_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1148,8 +1148,8 @@ fn test_git_push_existing_long_bookmark(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_unsnapshotted_change(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     std::fs::write(workspace_root.join("file"), "contents").unwrap();
@@ -1162,8 +1162,8 @@ fn test_git_push_unsnapshotted_change(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_conflict(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     std::fs::write(workspace_root.join("file"), "first").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["commit", "-m", "first"]);
@@ -1186,8 +1186,8 @@ fn test_git_push_conflict(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_description(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "my-bookmark"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m="]);
@@ -1218,8 +1218,8 @@ fn test_git_push_no_description(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_description_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "imm"]);
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m="]);
@@ -1271,8 +1271,8 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_author(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1311,8 +1311,8 @@ fn test_git_push_missing_author(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1372,8 +1372,8 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_committer(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1427,8 +1427,8 @@ fn test_git_push_missing_committer(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let run_without_var = |var: &str, args: &[&str]| {
         test_env
@@ -1489,8 +1489,8 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deleted(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
@@ -1531,8 +1531,8 @@ fn test_git_push_deleted(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo = {
@@ -1628,8 +1628,8 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deleted_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     // Absent local bookmark shouldn't be considered "deleted" compared to
@@ -1657,8 +1657,8 @@ fn test_git_push_deleted_untracked(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_tracked_vs_all(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     test_env.jj_cmd_ok(&workspace_root, &["new", "bookmark1", "-mmoved bookmark1"]);
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "bookmark1"]);
@@ -1744,8 +1744,8 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_moved_forward_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "bookmark1", "-mmoved bookmark1"]);
@@ -1768,8 +1768,8 @@ fn test_git_push_moved_forward_untracked(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["new", "root()", "-mmoved bookmark1"]);
@@ -1795,8 +1795,8 @@ fn test_git_push_moved_sideways_untracked(subprocess: bool) {
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_to_remote_named_git(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
-    if subprocess {
-        test_env.add_config("git.subprocess = true");
+    if !subprocess {
+        test_env.add_config("git.subprocess = false");
     }
     let git_repo = {
         let mut git_repo_path = workspace_root.clone();

--- a/docs/config.md
+++ b/docs/config.md
@@ -1310,25 +1310,28 @@ would require pushing the private commit as well.
 
 ### Git subprocessing behaviour
 
-By default, Git remote interactions are handled by [`libgit2`](https://github.com/libgit2/libgit2).
-This sometimes causes [SSH problems](https://github.com/jj-vcs/jj/issues/4979) that
-cannot be solved by `jj` directly.
-
-To sidestep this, there is an option to spawn a `git` subprocess to handle those
-remote interactions:
-
-```toml
-[git]
-subprocess = true
-```
-
-Additionally, if `git` is not on your OS path, or you want to specify a
-particular binary, you can:
+By default, Git remote interactions are handled by spawning a `git` subprocess.
+If `git` is not on your OS path, or you want to specify a particular binary,
+you can:
 
 ```toml
 [git]
 executable-path = "/path/to/git"
 ```
+
+Previously, remote interactions were handled by
+[`libgit2`](https://github.com/libgit2/libgit2) by default, which sometimes
+caused [SSH problems](https://github.com/jj-vcs/jj/issues/4979) that could not
+be solved by `jj` directly. If you have any issues with the `git`
+subprocessing, you can switch back to `libgit2` with:
+
+```toml
+[git]
+subprocess = false
+```
+
+Note that `libgit2` support will likely be removed in the future, so you are
+encouraged to report any issues you experience with the default configuration.
 
 ## Filesystem monitor
 

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -12,7 +12,7 @@ register_snapshot_trigger = false
 [git]
 abandon-unreachable-commits = true
 auto-local-bookmark = false
-subprocess = false
+subprocess = true
 executable-path = "git"
 
 [operation]

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -79,7 +79,7 @@ impl Default for GitSettings {
         GitSettings {
             auto_local_bookmark: false,
             abandon_unreachable_commits: true,
-            subprocess: false,
+            subprocess: true,
             executable_path: PathBuf::from("git"),
         }
     }


### PR DESCRIPTION
Given the previously‐stated intention of making this default for the 0.27 release, prepare for that decision ahead of time by enabling subprocessing by default on trunk. This will help surface any regressions and workflow incompatibilities and therefore give us more information to decide whether to keep or revert this commit, without inconveniencing any users who haven’t already opted in to the bleeding edge.

Please feel free to revert without hesitation if any major issues arise; this is not intended as a strong commitment to enable this option for the next stable release if it turns out to not be ready. In that case, it’s better that we learn that early on in the cycle, rather than having to revert at the last minute or, worse, cutting a stable release that we later find contains a serious regression.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
