### PR TITLE
git: box `gix::Repository` large instances

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1646,7 +1646,7 @@ enum GitFetchImpl<'a> {
         git_repo: git2::Repository,
     },
     Subprocess {
-        git_repo: gix::Repository,
+        git_repo: Box<gix::Repository>,
         git_ctx: GitSubprocessContext<'a>,
     },
 }
@@ -1655,7 +1655,7 @@ impl<'a> GitFetchImpl<'a> {
     fn new(store: &Store, git_settings: &'a GitSettings) -> Result<Self, GitFetchPrepareError> {
         let git_backend = get_git_backend(store)?;
         if git_settings.subprocess {
-            let git_repo = git_backend.git_repo();
+            let git_repo = Box::new(git_backend.git_repo());
             let git_ctx =
                 GitSubprocessContext::from_git_backend(git_backend, &git_settings.executable_path);
             Ok(GitFetchImpl::Subprocess { git_repo, git_ctx })


### PR DESCRIPTION
`gix::Repository` instances are larger than 1KB on 64-bit machines. This makes Clippy warn about an unbalance between variants of `GitFetchImpl`: the `Git2` variant requires 8 bytes, while the `Subprocess` variant requires 1128 bytes.

Boxing the `gix::Repository` makes `GitFetchImpl` instances smaller, as well as the other structs embedding them such as `GitFetch`.
