### PR TITLE
docs: Change the docs color scheme to match the new logo better

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,13 +20,15 @@ theme:
         name: Switch to system preference
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: !ENV [MKDOCS_PRIMARY_COLOR, 'indigo']
+      primary: !ENV [MKDOCS_PRIMARY_COLOR, 'blue']
+      accent: 'blue'
       toggle:
         icon: material/brightness-7
         name: Switch to light mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: !ENV [MKDOCS_PRIMARY_COLOR, 'indigo']
+      primary: !ENV [MKDOCS_PRIMARY_COLOR, 'blue']
+      accent: 'blue'
       toggle:
         icon: material/brightness-4
         name: Switch to dark mode


### PR DESCRIPTION
This is totally unnecessary, but the current indigo color scheme doesn't really match the blue in the new blue jay logo.

Setting totally custom colors in mkdocs is a pain since you need to override lots of different css properties, but just using the built in 'blue' color works pretty well. The 'light blue' color actually matches the logo better, but I was a little concerned about readability for hyperlinks.

The accent color is overridden to 'blue' as well to match better. Note that even though the primary and accent have the same name, they are actually slightly different colors due to the way the material theme works.

Before:
<img width="1472" alt="Screenshot 2025-02-12 at 17 09 47" src="https://github.com/user-attachments/assets/d2a81c76-077f-4663-9916-4b14ae30091e" />

After:
<img width="1464" alt="Screenshot 2025-02-12 at 17 07 15" src="https://github.com/user-attachments/assets/331b2e0d-3e29-43b9-ac4c-068199ecc4d3" />
