### PR TITLE
json schema: Fix bad indentation for `jj fix` settings

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -617,7 +617,7 @@
                 }
             }
         },
-    "fix": {
+        "fix": {
             "type": "object",
             "description": "Settings for jj fix",
             "properties": {

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -23,7 +23,7 @@ fn test_util_config_schema() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["util", "config-schema"]);
     // Validate partial snapshot, redacting any lines nested 2+ indent levels.
     insta::with_settings!({filters => vec![(r"(?m)(^        .*$\r?\n)+", "        [...]\n")]}, {
-        assert_snapshot!(stdout, @r#"
+        assert_snapshot!(stdout, @r###"
         {
             "$schema": "http://json-schema.org/draft-04/schema",
             "$comment": "`taplo` and the corresponding VS Code plugins only support draft-04 verstion of JSON Schema, see <https://taplo.tamasfe.dev/configuration/developing-schemas.html>. draft-07 is mostly compatible with it, newer versions may not be.",
@@ -32,11 +32,9 @@ fn test_util_config_schema() {
             "description": "User configuration for Jujutsu VCS. See https://jj-vcs.github.io/jj/latest/config/ for details",
             "properties": {
                 [...]
-            "fix": {
-                [...]
             }
         }
-        "#);
+        "###);
     });
 }
 


### PR DESCRIPTION
The fix settings weren't indented consistent with the rest of the settings, causing them to appear in the redacted snapshot in the test_util_config_schema test.