### PR TITLE
Remove broken Sublime LSP TOML reference in config.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1453,9 +1453,6 @@ Here are some popular editors with TOML schema validation support:
 - JetBrains IDEs (IntelliJ, PyCharm, etc)
   - Install [TOML](https://plugins.jetbrains.com/plugin/8195-toml) plugin
 
-- Sublime Text
-  - Install [LSP](https://packagecontrol.io/packages/LSP) and [LSP-taplo](https://packagecontrol.io/packages/LSP-taplo)
-
 - Emacs
   - Install [lsp-mode](https://github.com/emacs-lsp/lsp-mode) and [toml-mode](https://github.com/dryman/toml-mode.el)
   - Configure [taplo](https://github.com/tamasfe/taplo) as the LSP server


### PR DESCRIPTION
Removes nonexistent Sublime TOML LSP server link in docs. I looked, but since I wasn't able to find an alternative, I removed the Sublime bit entirely.

Fixes #5664 

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
