### PR TITLE
tests: add [EOF] marker to command output when displaying

### DIFF
--- a/cli/src/commands/help.rs
+++ b/cli/src/commands/help.rs
@@ -58,7 +58,11 @@ pub(crate) fn cmd_help(
         return Ok(());
     }
 
-    let mut args_to_show_help = vec![command.app().get_name()];
+    let bin_name = command
+        .string_args()
+        .first()
+        .map_or(command.app().get_name(), |name| name.as_ref());
+    let mut args_to_show_help = vec![bin_name];
     args_to_show_help.extend(args.command.iter().map(|s| s.as_str()));
     args_to_show_help.push("--help");
 

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -14,6 +14,8 @@
 
 pub mod git;
 mod test_environment;
+
+pub use self::test_environment::CommandOutputString;
 pub use self::test_environment::TestEnvironment;
 
 #[track_caller]

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -394,7 +394,12 @@ impl CommandOutputString {
 
 impl Display for CommandOutputString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.normalized)
+        if self.is_empty() {
+            return Ok(());
+        }
+        // Append "[EOF]" marker to test line ending
+        // https://github.com/mitsuhiko/insta/issues/384
+        writeln!(f, "{}[EOF]", self.normalized)
     }
 }
 

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
@@ -353,10 +354,12 @@ fn test_double_abandon() {
     a
     "###);
 
-    let commit_id = test_env.jj_cmd_success(
-        &repo_path,
-        &["log", "--no-graph", "--color=never", "-T=commit_id", "-r=a"],
-    );
+    let commit_id = test_env
+        .jj_cmd_success(
+            &repo_path,
+            &["log", "--no-graph", "--color=never", "-T=commit_id", "-r=a"],
+        )
+        .into_raw();
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", &commit_id]);
     insta::assert_snapshot!(stdout, @"");
@@ -409,7 +412,7 @@ fn test_abandon_restore_descendants() {
     "#);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     test_env.jj_cmd_success(
         repo_path,
         &[

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -41,7 +41,7 @@ fn test_basics() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["a", "d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [znk] e
     ├─╮
     │ ○  [vru] d
@@ -51,19 +51,21 @@ fn test_basics() {
     ○ │  [rlv] a
     ├─╯
     ◆  [zzz]
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "--retain-bookmarks", "d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit vruxwmqv b7c62f28 d | d
     Rebased 1 descendant commits onto parents of abandoned commits
     Working copy now at: znkkpsqq 11a2e10e e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : royxmykx fe2e8e8b c d | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [znk] e
     ├─╮
     │ ○  [roy] c d
@@ -72,7 +74,8 @@ fn test_basics() {
     ○ │  [rlv] a
     ├─╯
     ◆  [zzz]
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -80,14 +83,15 @@ fn test_basics() {
         &["abandon", "--retain-bookmarks"], /* abandons `e` */
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit znkkpsqq 5557ece3 e | e
     Working copy now at: nkmrtpmo d4f8ea73 (empty) (no description set)
     Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Parent commit      : vruxwmqv b7c62f28 d e?? | d
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [nkm]
     ├─╮
     │ ○  [vru] d e??
@@ -97,7 +101,8 @@ fn test_basics() {
     ○ │  [rlv] a e??
     ├─╯
     ◆  [zzz]
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "descendants(d)"]);
@@ -111,6 +116,7 @@ fn test_basics() {
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : royxmykx fe2e8e8b c | c
     Added 0 files, modified 0 files, removed 2 files
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [xtn]
@@ -121,6 +127,7 @@ fn test_basics() {
     ○ │  [rlv] a
     ├─╯
     ◆  [zzz]
+    [EOF]
     ");
 
     // Test abandoning the same commit twice directly
@@ -130,6 +137,7 @@ fn test_basics() {
     insta::assert_snapshot!(stderr, @r"
     Abandoned commit zsuskuln 1394f625 b | b
     Deleted bookmarks: b
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [znk] e
@@ -139,6 +147,7 @@ fn test_basics() {
     ○ │  [rlv] a
     ├─╯
     ◆  [zzz]
+    [EOF]
     ");
 
     // Test abandoning the same commit twice indirectly
@@ -154,6 +163,7 @@ fn test_basics() {
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : royxmykx fe2e8e8b c | c
     Added 0 files, modified 0 files, removed 2 files
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    [xlz]
@@ -164,12 +174,14 @@ fn test_basics() {
     ○ │  [rlv] a
     ├─╯
     ◆  [zzz]
+    [EOF]
     ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", "none()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     No revisions to abandon.
-    "###);
+    [EOF]
+    ");
 }
 
 // This behavior illustrates https://github.com/jj-vcs/jj/issues/2600.
@@ -190,7 +202,7 @@ fn test_bug_2600() {
     create_commit(&test_env, &repo_path, "c", &["b"]);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [znk] c
     ○    [vru] b
     ├─╮
@@ -199,7 +211,8 @@ fn test_bug_2600() {
     ○  [zsu] base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
-    "###);
+    [EOF]
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -212,6 +225,7 @@ fn test_bug_2600() {
     Working copy now at: znkkpsqq 86e31bec c | c
     Parent commit      : vruxwmqv fd6eb121 b | b
     Added 0 files, modified 0 files, removed 1 files
+    [EOF]
     ");
     // Commits "a" and "b" should both have "nottherootcommit" as parent, and "b"
     // should keep "a" as second parent.
@@ -223,6 +237,7 @@ fn test_bug_2600() {
     ├─╯
     ○  [rlv] nottherootcommit
     ◆  [zzz]
+    [EOF]
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -235,6 +250,7 @@ fn test_bug_2600() {
     Working copy now at: znkkpsqq 683b9435 c | c
     Parent commit      : vruxwmqv c10cb7b4 b | b
     Added 0 files, modified 0 files, removed 1 files
+    [EOF]
     ");
     // Commit "b" should have "base" as parent. It should not have two parent
     // pointers to that commit even though it was a merge commit before we abandoned
@@ -245,6 +261,7 @@ fn test_bug_2600() {
     ○  [zsu] base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
+    [EOF]
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -258,6 +275,7 @@ fn test_bug_2600() {
     Parent commit      : zsuskuln 73c929fc base | base
     Parent commit      : royxmykx 98f3b9ba a | a
     Added 0 files, modified 0 files, removed 1 files
+    [EOF]
     ");
     // Commit "c" should inherit the parents from the abndoned commit "b".
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
@@ -268,11 +286,12 @@ fn test_bug_2600() {
     ○  [zsu] base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
+    [EOF]
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ========= Reminder of the setup ===========
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [znk] c
     ○    [vru] b
     ├─╮
@@ -281,11 +300,12 @@ fn test_bug_2600() {
     ○  [zsu] base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["abandon", "--retain-bookmarks", "a", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned the following commits:
       vruxwmqv 8c0dced0 b | b
       royxmykx 98f3b9ba a | a
@@ -293,19 +313,22 @@ fn test_bug_2600() {
     Working copy now at: znkkpsqq 84fac1f8 c | c
     Parent commit      : zsuskuln 73c929fc a b base | base
     Added 0 files, modified 0 files, removed 2 files
-    "###);
+    [EOF]
+    ");
     // Commit "c" should have "base" as parent. As when we abandoned "a", it should
     // not have two parent pointers to the same commit.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [znk] c
     ○  [zsu] a b base
     ○  [rlv] nottherootcommit
     ◆  [zzz]
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b: zsuskuln 73c929fc base
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -322,7 +345,7 @@ fn test_bug_2600_rootcommit_special_case() {
     create_commit(&test_env, &repo_path, "c", &["b"]);
 
     // Setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  [vru] c
     ○    [roy] b
     ├─╮
@@ -330,13 +353,15 @@ fn test_bug_2600_rootcommit_special_case() {
     ├─╯
     ○  [rlv] base
     ◆  [zzz]
-    "###);
+    [EOF]
+    ");
 
     // Now, the test
     let stderr = test_env.jj_cmd_failure(&repo_path, &["abandon", "base"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -348,11 +373,11 @@ fn test_double_abandon() {
     create_commit(&test_env, &repo_path, "a", &[]);
     // Test the setup
     insta::assert_snapshot!(
-    test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r", "a"])
-        , @r###"
+    test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r", "a"]), @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a 2443ea76
     a
-    "###);
+    [EOF]
+    ");
 
     let commit_id = test_env
         .jj_cmd_success(
@@ -369,13 +394,15 @@ fn test_double_abandon() {
     Working copy now at: royxmykx f37b4afd (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
+    [EOF]
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["abandon", &commit_id]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit rlvkpnrz hidden 2443ea76 a
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -394,14 +421,15 @@ fn test_abandon_restore_descendants() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["abandon", "-r@-", "--restore-descendants"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Abandoned commit rlvkpnrz 225adef1 (no description set)
     Rebased 1 descendant commits (while preserving their content) onto parents of abandoned commits
     Working copy now at: kkmpptxz a734deb0 (no description set)
     Parent commit      : qpvuntsm 485d52a9 (no description set)
-    "#);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file b/file
     index 257cc5642c..76018072e0 100644
     --- a/file
@@ -409,7 +437,8 @@ fn test_abandon_restore_descendants() {
     @@ -1,1 +1,1 @@
     -foo
     +baz
-    "#);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -729,12 +730,12 @@ fn test_absorb_immutable() {
     ");
 }
 
-fn get_diffs(test_env: &TestEnvironment, repo_path: &Path, revision: &str) -> String {
+fn get_diffs(test_env: &TestEnvironment, repo_path: &Path, revision: &str) -> CommandOutputString {
     let template = r#"format_commit_summary_with_refs(self, "") ++ "\n""#;
     test_env.jj_cmd_success(repo_path, &["log", "-r", revision, "-T", template, "--git"])
 }
 
-fn get_evolog(test_env: &TestEnvironment, repo_path: &Path, revision: &str) -> String {
+fn get_evolog(test_env: &TestEnvironment, repo_path: &Path, revision: &str) -> CommandOutputString {
     let template = r#"format_commit_summary_with_refs(self, "") ++ "\n""#;
     test_env.jj_cmd_success(repo_path, &["evolog", "-r", revision, "-T", template])
 }

--- a/cli/tests/test_acls.rs
+++ b/cli/tests/test_acls.rs
@@ -41,7 +41,7 @@ fn test_diff() {
     SecretBackend::adopt_git_repo(&repo_path);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--color-words"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     Modified regular file a-first:
        1    1: foobar
     Access denied to added-secret: No access
@@ -52,7 +52,7 @@ fn test_diff() {
        1    1: foobar
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--summary"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     M a-first
     C {a-first => added-secret}
     D deleted-secret
@@ -61,7 +61,7 @@ fn test_diff() {
     M z-last
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--types"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     FF a-first
     FF {a-first => added-secret}
     F- deleted-secret
@@ -70,7 +70,7 @@ fn test_diff() {
     FF z-last
     "###);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     a-first                   | 2 +-
     {a-first => added-secret} | 2 +-
     deleted-secret            | 1 -
@@ -122,11 +122,11 @@ fn test_file_list_show() {
     insta::assert_snapshot!(stderr, @"");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "show", "."]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     foo
     baz
     "###);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
     Warning: Path 'secret' exists but access is denied: No access
     "###);
 }

--- a/cli/tests/test_acls.rs
+++ b/cli/tests/test_acls.rs
@@ -41,7 +41,7 @@ fn test_diff() {
     SecretBackend::adopt_git_repo(&repo_path);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--color-words"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     Modified regular file a-first:
        1    1: foobar
     Access denied to added-secret: No access
@@ -50,27 +50,30 @@ fn test_diff() {
     Access denied to modified-secret: No access
     Modified regular file z-last:
        1    1: foobar
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--summary"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     M a-first
     C {a-first => added-secret}
     D deleted-secret
     M dir/secret
     M modified-secret
     M z-last
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--types"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     FF a-first
     FF {a-first => added-secret}
     F- deleted-secret
     FF dir/secret
     FF modified-secret
     FF z-last
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     a-first                   | 2 +-
     {a-first => added-secret} | 2 +-
     deleted-secret            | 1 -
@@ -78,7 +81,8 @@ fn test_diff() {
     modified-secret           | 0
     z-last                    | 2 +-
     6 files changed, 3 insertions(+), 4 deletions(-)
-    "###);
+    [EOF]
+    ");
     let assert = test_env
         .jj_cmd(&repo_path, &["diff", "--git"])
         .assert()
@@ -118,15 +122,18 @@ fn test_file_list_show() {
     a-first
     secret
     z-last
+    [EOF]
     ");
     insta::assert_snapshot!(stderr, @"");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "show", "."]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     foo
     baz
-    "###);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r"
     Warning: Path 'secret' exists but access is denied: No access
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_advance_bookmarks.rs
+++ b/cli/tests/test_advance_bookmarks.rs
@@ -76,32 +76,35 @@ fn test_advance_bookmarks_enabled(make_commit: CommitFn) {
 
     // Check the initial state of the repo.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // Run jj commit, which will advance the bookmark pointing to @-.
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // Now disable advance bookmarks and commit again. The bookmark shouldn't move.
     set_advance_bookmarks(&test_env, false);
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -121,19 +124,21 @@ fn test_advance_bookmarks_at_minus(make_commit: CommitFn) {
     );
 
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{test_bookmark} desc:
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // Create a second bookmark pointing to @. On the next commit, only the first
@@ -144,12 +149,13 @@ fn test_advance_bookmarks_at_minus(make_commit: CommitFn) {
     );
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark test_bookmark2} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -170,20 +176,22 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
 
     // Check the initial state of the repo.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // Commit will not advance the bookmark since advance-bookmarks is disabled.
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: first
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // Now enable advance bookmarks for "test_bookmark", move the bookmark, and
@@ -198,20 +206,22 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
         &["bookmark", "set", "test_bookmark", "-r", "@-"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
     make_commit(&test_env, &workspace_path, "second");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // Now disable advance bookmarks for "test_bookmark" and "second_bookmark",
@@ -224,13 +234,14 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
     );
     make_commit(&test_env, &workspace_path, "third");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // If we create a new bookmark at @- and move test_bookmark there as well. When
@@ -245,24 +256,26 @@ fn test_advance_bookmarks_overrides(make_commit: CommitFn) {
         &["bookmark", "set", "test_bookmark", "-r", "@-"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{second_bookmark test_bookmark} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
     make_commit(&test_env, &workspace_path, "fourth");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: fourth
     ○  bookmarks{second_bookmark test_bookmark} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -286,20 +299,22 @@ fn test_advance_bookmarks_multiple_bookmarks(make_commit: CommitFn) {
 
     insta::allow_duplicates! {
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{first_bookmark second_bookmark} desc:
-    "###);
+    [EOF]
+    ");
     }
 
     // Both bookmarks are eligible and both will advance.
     make_commit(&test_env, &workspace_path, "first");
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{first_bookmark second_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -314,10 +329,11 @@ fn test_new_advance_bookmarks_interior() {
     set_advance_bookmarks(&test_env, true);
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 
     // Create a gap in the commits for us to insert our new commit with --before.
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "first"]);
@@ -327,23 +343,25 @@ fn test_new_advance_bookmarks_interior() {
         &workspace_path,
         &["bookmark", "create", "-r", "@---", "test_bookmark"],
     );
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["new", "-r", "@--"]);
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     │ ○  bookmarks{} desc: third
     ├─╯
     ○  bookmarks{test_bookmark} desc: second
     ○  bookmarks{} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 }
 
 // If the `--before` flag is passed to `jj new`, bookmarks are not advanced.
@@ -356,10 +374,11 @@ fn test_new_advance_bookmarks_before() {
     set_advance_bookmarks(&test_env, true);
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 
     // Create a gap in the commits for us to insert our new commit with --before.
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m", "first"]);
@@ -369,22 +388,24 @@ fn test_new_advance_bookmarks_before() {
         &workspace_path,
         &["bookmark", "create", "-r", "@---", "test_bookmark"],
     );
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: third
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["new", "--before", "@-"]);
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     ○  bookmarks{} desc: third
     @  bookmarks{} desc:
     ○  bookmarks{} desc: second
     ○  bookmarks{test_bookmark} desc: first
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 }
 
 // If the `--after` flag is passed to `jj new`, bookmarks are not advanced.
@@ -401,18 +422,20 @@ fn test_new_advance_bookmarks_after() {
     );
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m", "first"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "--after", "@"]);
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc:
     ○  bookmarks{} desc: first
     ◆  bookmarks{test_bookmark} desc:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -437,20 +460,21 @@ fn test_new_advance_bookmarks_merge_children() {
     );
 
     // Check the initial state of the repo.
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @  bookmarks{} desc: 2
     │ ○  bookmarks{} desc: 1
     ├─╯
     ○  bookmarks{test_bookmark} desc: 0
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 
     // The bookmark won't advance because `jj  new` had multiple targets.
     test_env.jj_cmd_ok(
         &workspace_path,
         &["new", "description(1)", "description(2)"],
     );
-    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_bookmarks(&test_env, &workspace_path), @r"
     @    bookmarks{} desc:
     ├─╮
     │ ○  bookmarks{} desc: 2
@@ -458,5 +482,6 @@ fn test_new_advance_bookmarks_merge_children() {
     ├─╯
     ○  bookmarks{test_bookmark} desc: 0
     ◆  bookmarks{} desc:
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_advance_bookmarks.rs
+++ b/cli/tests/test_advance_bookmarks.rs
@@ -16,9 +16,10 @@ use std::path::Path;
 
 use test_case::test_case;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
-fn get_log_output_with_bookmarks(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_log_output_with_bookmarks(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     // Don't include commit IDs since they will be different depending on
     // whether the test runs with `jj commit` or `jj describe` + `jj new`.
     let template = r#""bookmarks{" ++ local_bookmarks ++ "} desc: " ++ description"#;

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -66,17 +66,17 @@ fn test_alias_calls_empty_command() {
     "#,
     );
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["empty"]);
-    insta::assert_snapshot!(stderr.lines().take(3).join("\n"), @r###"
+    insta::assert_snapshot!(stderr.normalized().lines().take(3).join("\n"), @r###"
     Jujutsu (An experimental VCS)
 
     Usage: jj [OPTIONS] <COMMAND>
     "###);
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["empty", "--no-pager"]);
-    insta::assert_snapshot!(stderr.lines().next().unwrap_or_default(), @r###"
+    insta::assert_snapshot!(stderr.normalized().lines().next().unwrap_or_default(), @r###"
     error: 'jj' requires a subcommand but one was not provided
     "###);
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["empty_command_with_opts"]);
-    insta::assert_snapshot!(stderr.lines().next().unwrap_or_default(), @r###"
+    insta::assert_snapshot!(stderr.normalized().lines().next().unwrap_or_default(), @r###"
     error: 'jj' requires a subcommand but one was not provided
     "###);
 }
@@ -126,7 +126,7 @@ fn test_alias_calls_help() {
     let repo_path = test_env.env_root().join("repo");
     test_env.add_config(r#"aliases.h = ["--help"]"#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["h"]);
-    insta::assert_snapshot!(stdout.lines().take(5).join("\n"), @r###"
+    insta::assert_snapshot!(stdout.normalized().lines().take(5).join("\n"), @r###"
     Jujutsu (An experimental VCS)
 
     To get started, see the tutorial at https://jj-vcs.github.io/jj/latest/tutorial/.
@@ -233,7 +233,7 @@ fn test_alias_invalid_definition() {
     "#,
     );
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["non-list"]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r"
     Config error: Invalid type or value for aliases.non-list
     Caused by: invalid type: integer `5`, expected a sequence
 

--- a/cli/tests/test_backout_command.rs
+++ b/cli/tests/test_backout_command.rs
@@ -45,37 +45,41 @@ fn test_backout() {
 
     create_commit(&test_env, &repo_path, "a", &[], &[("a", "a\n")]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     A a
-    "###);
+    [EOF]
+    ");
 
     // Backout the commit
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["backout", "-r", "@"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     ○  6d845ed9fb6a Back out "a"
     │
     │  This backs out commit 2443ea76b0b1c531326908326aab7020abab8e6c.
     @  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@+"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D a
-    "###);
+    [EOF]
+    ");
 
     // Backout the new backed-out commit
     test_env.jj_cmd_ok(&repo_path, &["edit", "@+"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["backout", "-r", "@"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     ○  79555ea9040b Back out "Back out "a""
     │
     │  This backs out commit 6d845ed9fb6a3d367e2d7068ef0256b1a10705a9.
@@ -84,11 +88,13 @@ fn test_backout() {
     │  This backs out commit 2443ea76b0b1c531326908326aab7020abab8e6c.
     ○  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@+"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     A a
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -110,21 +116,22 @@ fn test_backout_multiple() {
     create_commit(&test_env, &repo_path, "e", &["d"], &[("a", "a\nb\nc\n")]);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  208f8612074a e
     ○  ceeec03be46b d
     ○  413337bbd11f c
     ○  46cc97af6802 b
     ○  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Backout multiple commits
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["backout", "-r", "b", "-r", "c", "-r", "e"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
     ○  6504c4ded177 Back out "b"
     │
     │  This backs out commit 46cc97af6802301d8db381386e8485ff3ff24ae6.
@@ -140,7 +147,8 @@ fn test_backout_multiple() {
     ○  46cc97af6802 b
     ○  2443ea76b0b1 a
     ◆  000000000000
-    "###);
+    [EOF]
+    "#);
     // View the output of each backed out commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "@+"]);
     insta::assert_snapshot!(stdout, @r#"
@@ -157,6 +165,7 @@ fn test_backout_multiple() {
        1    1: a
        2    2: b
        3     : c
+    [EOF]
     "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "@++"]);
     insta::assert_snapshot!(stdout, @r#"
@@ -171,6 +180,7 @@ fn test_backout_multiple() {
 
     Removed regular file b:
        1     : b
+    [EOF]
     "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "@+++"]);
     insta::assert_snapshot!(stdout, @r#"
@@ -186,6 +196,7 @@ fn test_backout_multiple() {
     Modified regular file a:
        1    1: a
        2     : b
+    [EOF]
     "#);
 }
 
@@ -209,14 +220,16 @@ fn test_backout_description_template() {
     create_commit(&test_env, &repo_path, "a", &[], &[("a", "a\n")]);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1 a
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     A a
-    "###);
+    [EOF]
+    ");
 
     // Verify that message of backed out commit follows the template
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["backout", "-r", "a"]);
@@ -226,6 +239,7 @@ fn test_backout_description_template() {
     ○  1db880a5204e Revert commit 2443ea76b0b1 "a"
     @  2443ea76b0b1 a
     ◆  000000000000
+    [EOF]
     "#);
 }
 

--- a/cli/tests/test_backout_command.rs
+++ b/cli/tests/test_backout_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn create_commit(
@@ -228,7 +229,7 @@ fn test_backout_description_template() {
     "#);
 }
 
-fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     let template = r#"commit_id.short() ++ " " ++ description"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -50,41 +50,52 @@ fn test_bookmark_multiple_names() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo", "bar"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Created 2 bookmarks pointing to qpvuntsm 230dd059 bar foo | (empty) (no description set)");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @r"
+    Created 2 bookmarks pointing to qpvuntsm 230dd059 bar foo | (empty) (no description set)
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar foo 230dd059e1b0
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo", "bar", "--to=@"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Moved 2 bookmarks to zsuskuln 8bb159bc bar foo | (empty) (no description set)");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @r"
+    Moved 2 bookmarks to zsuskuln 8bb159bc bar foo | (empty) (no description set)
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar foo 8bb159bc30a9
     ○   230dd059e1b0
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo", "bar", "foo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Deleted 2 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   8bb159bc30a9
     ○   230dd059e1b0
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     // Hint should be omitted if -r is specified
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@-", "foo", "bar"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 2 bookmarks pointing to qpvuntsm 230dd059 bar foo | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Create and move with explicit -r
     let (_stdout, stderr) =
@@ -92,14 +103,16 @@ fn test_bookmark_multiple_names() {
     insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to zsuskuln 8bb159bc bar baz | (empty) (no description set)
     Moved 1 bookmarks to zsuskuln 8bb159bc bar baz | (empty) (no description set)
+    [EOF]
     ");
 
     // Noop changes should not be included in the stats
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "-r@", "foo", "bar", "baz"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to zsuskuln 8bb159bc bar baz foo | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -111,16 +124,18 @@ fn test_bookmark_at_root() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "fred", "-r=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to zzzzzzzz 00000000 fred | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
     Warning: Failed to export some bookmarks:
       fred: Ref cannot point to the root commit in Git
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -130,18 +145,20 @@ fn test_bookmark_empty_name() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "create", "-r@", ""]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '<NAMES>...' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "set", ""]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '<NAMES>...' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -159,98 +176,113 @@ fn test_bookmark_move() {
     );
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "move", "foo", "--to=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No such bookmark: foo
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo", "--to=@"]);
     insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to qpvuntsm 230dd059 foo | (empty) (no description set)
+    [EOF]
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "create", "-r@", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Bookmark already exists: foo
     Hint: Use `jj bookmark set` to update it.
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo", "--revision", "@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to mzvwutvl 167f90e7 foo | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "set", "-r@-", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: foo
     Hint: Use --allow-backwards to allow it.
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "set", "-r@-", "--allow-backwards", "foo"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "foo", "--to=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to mzvwutvl 167f90e7 foo | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "move", "--to=@-", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: foo
     Hint: Use --allow-backwards to allow it.
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "move", "--to=@-", "--allow-backwards", "foo"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Delete bookmark locally, but is still tracking remote
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-mcommit"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new", "-r@-"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     foo (deleted)
       @origin: qpvuntsm 1eb845f3 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     // Deleted tracking bookmark name should still be allocated
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "create", "-r@", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Tracked remote bookmarks exist for deleted bookmark: foo
     Hint: Use `jj bookmark set` to recreate the local bookmark. Run `jj bookmark untrack 'glob:foo@*'` to disassociate them.
-    "###);
+    [EOF]
+    ");
 
     // Restoring local target shouldn't invalidate tracking state
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "foo", "--to=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to mzvwutvl 66d48752 foo* | (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     foo: mzvwutvl 66d48752 (empty) (no description set)
       @origin (behind by 1 commits): qpvuntsm 1eb845f3 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     // Untracked remote bookmark shouldn't block creation of local bookmark
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "foo@origin"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo"]);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to mzvwutvl 66d48752 foo | (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     foo: mzvwutvl 66d48752 (empty) (no description set)
     foo@origin: qpvuntsm 1eb845f3 (empty) commit
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -266,7 +298,7 @@ fn test_bookmark_move_matching() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c1"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-mhead2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   a2781dd9ee37
     ○  c1 f4f38657a3dd
     ○  b1 f652c32197cf
@@ -274,7 +306,8 @@ fn test_bookmark_move_matching() {
     │ ○  a1 a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     // The default could be considered "--from=all() glob:*", but is disabled
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "move", "--to=@"]);
@@ -285,38 +318,43 @@ fn test_bookmark_move_matching() {
     Usage: jj bookmark move --to <REVSET> <--from <REVSETS>|NAMES>
 
     For more information, try '--help'.
+    [EOF]
     ");
 
     // No bookmarks pointing to the source revisions
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "--from=none()", "--to=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     No bookmarks to update.
-    "###);
+    [EOF]
+    ");
 
     // No matching bookmarks within the source revisions
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["bookmark", "move", "--from=::@", "glob:a?", "--to=@"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No matching bookmarks for patterns: a?
-    "###);
+    [EOF]
+    ");
 
     // Noop move
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "--to=a1", "a2"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     No bookmarks to update.
-    "###);
+    [EOF]
+    ");
 
     // Move from multiple revisions
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "--from=::@", "--to=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 2 bookmarks to vruxwmqv a2781dd9 b1 c1 | (empty) head2
     Hint: Specify bookmark by name to update just one of the bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b1 c1 a2781dd9ee37
     ○   f4f38657a3dd
     ○   f652c32197cf
@@ -324,16 +362,18 @@ fn test_bookmark_move_matching() {
     │ ○  a1 a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Try to move multiple bookmarks, but one of them isn't fast-forward
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "move", "glob:?1", "--to=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: a1
     Hint: Use --allow-backwards to allow it.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   a2781dd9ee37
     ○  c1 f4f38657a3dd
     ○  b1 f652c32197cf
@@ -341,17 +381,19 @@ fn test_bookmark_move_matching() {
     │ ○  a1 a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     // Select by revision and name
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "move", "--from=::a1+", "--to=a1+", "glob:?1"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to kkmpptxz 6b5e840e a1 | (empty) head1
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   a2781dd9ee37
     ○  c1 f4f38657a3dd
     ○  b1 f652c32197cf
@@ -359,7 +401,8 @@ fn test_bookmark_move_matching() {
     │ ○  a2 230dd059e1b0
     ├─╯
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -393,7 +436,7 @@ fn test_bookmark_move_conflicting() {
             "foo",
         ],
     );
-    insta::assert_snapshot!(get_log(), @r###"
+    insta::assert_snapshot!(get_log(), @r"
     @  A1
     ○  A0 foo??
     │ ○  C0
@@ -401,24 +444,27 @@ fn test_bookmark_move_conflicting() {
     │ ○  B0 foo??
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Can't move the bookmark to C0 since it's sibling.
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["bookmark", "set", "-rdescription(C0)", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to move bookmark backwards or sideways: foo
     Hint: Use --allow-backwards to allow it.
-    "###);
+    [EOF]
+    ");
 
     // Can move the bookmark to A1 since it's descendant of A0. It's not
     // descendant of B0, though.
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "-rdescription(A1)", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to mzvwutvl 9328d344 foo | (empty) A1
-    "###);
-    insta::assert_snapshot!(get_log(), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log(), @r"
     @  A1 foo
     ○  A0
     │ ○  C0
@@ -426,7 +472,8 @@ fn test_bookmark_move_conflicting() {
     │ ○  B0
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -444,9 +491,10 @@ fn test_bookmark_rename() {
     );
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "rename", "bnoexist", "blocal"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No such bookmark: bnoexist
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-0"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "blocal"]);
@@ -458,9 +506,10 @@ fn test_bookmark_rename() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-1"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "bexist"]);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "rename", "blocal1", "bexist"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Bookmark already exists: bexist
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=commit-2"]);
@@ -468,16 +517,18 @@ fn test_bookmark_rename() {
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new", "-b=bremote"]);
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "rename", "bremote", "bremote2"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Tracked remote bookmarks for bookmark bremote were not renamed.
     Hint: To rename the bookmark on the remote, you can `jj git push --bookmark bremote` first (to delete it on the remote), and then `jj git push --bookmark bremote2`. `jj git push --all` would also be sufficient.
-    "###);
+    [EOF]
+    ");
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "rename", "bremote2", "bremote"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Tracked remote bookmarks for bookmark bremote exist.
     Hint: Run `jj bookmark untrack 'glob:bremote@*'` to disassociate them.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -506,23 +557,31 @@ fn test_bookmark_forget_glob() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo-3"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo-4"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1 foo-3 foo-4 230dd059e1b0
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Forgot 2 local bookmarks.");
+    insta::assert_snapshot!(stderr, @r"
+    Forgot 2 local bookmarks.
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Forgot 2 local bookmarks.");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @r"
+    Forgot 2 local bookmarks.
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-4 230dd059e1b0
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     // Forgetting a bookmark via both explicit name and glob pattern, or with
     // multiple glob patterns, shouldn't produce an error.
@@ -531,28 +590,34 @@ fn test_bookmark_forget_glob() {
         &["bookmark", "forget", "foo-4", "glob:foo-*", "glob:foo-*"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Forgot 1 local bookmarks.");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @r"
+    Forgot 1 local bookmarks.
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 230dd059e1b0
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     // Malformed glob
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "forget", "glob:foo-[1-3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value 'glob:foo-[1-3' for '<NAMES>...': Pattern syntax error near position 4: invalid range pattern
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // We get an error if none of the globs match anything
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["bookmark", "forget", "glob:bar*", "glob:baz*", "glob:boom*"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No matching bookmarks for patterns: baz*, boom*
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -584,34 +649,39 @@ fn test_bookmark_delete_glob() {
     // Push to create remote-tracking bookmarks
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--all"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1 foo-3 foo-4 312a98d6f27b
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Deleted 2 bookmarks.
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "glob:foo-[1-3]"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Deleted 2 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1@origin foo-3@origin foo-4 312a98d6f27b
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     // We get an error if none of the globs match live bookmarks. Unlike `jj
     // bookmark forget`, it's not allowed to delete already deleted bookmarks.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "delete", "glob:foo-[1-3]"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No matching bookmarks for patterns: foo-[1-3]
-    "###);
+    [EOF]
+    ");
 
     // Deleting a bookmark via both explicit name and glob pattern, or with
     // multiple glob patterns, shouldn't produce an error.
@@ -620,16 +690,18 @@ fn test_bookmark_delete_glob() {
         &["bookmark", "delete", "foo-4", "glob:foo-*", "glob:foo-*"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Deleted 1 bookmarks.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  bar-2 foo-1@origin foo-3@origin foo-4@origin 312a98d6f27b
     ◆   000000000000
-    "###);
+    [EOF]
+    ");
 
     // The deleted bookmarks are still there
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     bar-2: qpvuntsm 312a98d6 (empty) commit
       @origin: qpvuntsm 312a98d6 (empty) commit
     foo-1 (deleted)
@@ -638,15 +710,17 @@ fn test_bookmark_delete_glob() {
       @origin: qpvuntsm 312a98d6 (empty) commit
     foo-4 (deleted)
       @origin: qpvuntsm 312a98d6 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     // Malformed glob
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "delete", "glob:foo-[1-3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: invalid value 'glob:foo-[1-3' for '<NAMES>...': Pattern syntax error near position 4: invalid range pattern
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Unknown pattern kind
     let stderr =
@@ -656,6 +730,7 @@ fn test_bookmark_delete_glob() {
 
     For more information, try '--help'.
     Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, or `substring:`
+    [EOF]
     ");
 }
 
@@ -671,13 +746,15 @@ fn test_bookmark_delete_export() {
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "foo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "--all-remotes"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     foo (deleted)
       @git: rlvkpnrz 65b6b74e (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be deleted from the underlying Git repo on the next `jj git export`.
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
@@ -692,9 +769,10 @@ fn test_bookmark_forget_export() {
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "foo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Exporting the bookmark to git creates a local-git tracking bookmark
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
@@ -705,15 +783,19 @@ fn test_bookmark_forget_export() {
         &["bookmark", "forget", "--include-remotes", "foo"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
-    "#);
+    [EOF]
+    ");
     // Forgetting a bookmark with --include-remotes deletes local and
     // remote-tracking bookmarks including the corresponding git-tracking bookmark.
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r=foo", "--no-graph"]);
-    insta::assert_snapshot!(stderr, @"Error: Revision `foo` doesn't exist");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revision `foo` doesn't exist
+    [EOF]
+    ");
 
     // `jj git export` will delete the bookmark from git. In a colocated repo,
     // this will happen automatically immediately after a `jj bookmark forget`.
@@ -759,6 +841,7 @@ fn test_bookmark_forget_fetched_bookmark() {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
+    [EOF]
     ");
 
     // TEST 1: with export-import
@@ -782,20 +865,23 @@ fn test_bookmark_forget_fetched_bookmark() {
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
 
     // We can fetch feature1 again.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
+    [EOF]
     ");
 
     // TEST 2: No export/import (otherwise the same as test 1)
@@ -807,12 +893,14 @@ fn test_bookmark_forget_fetched_bookmark() {
     // Fetch works even without the export-import
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
+    [EOF]
     ");
 
     // TEST 3: fetch bookmark that was moved & forgotten with --include-remotes
@@ -830,30 +918,42 @@ fn test_bookmark_forget_fetched_bookmark() {
         &["bookmark", "forget", "--include-remotes", "feature1"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
-    "#);
+    [EOF]
+    ");
 
     // Fetching a moved bookmark does not create a conflict
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: tyvxnvqr 9175cb32 (empty) another message
       @origin: tyvxnvqr 9175cb32 (empty) another message
+    [EOF]
     ");
 
     // TEST 4: If `--include-remotes` isn't used, remote bookmarks are untracked
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "forget", "feature1"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"feature1@origin: tyvxnvqr 9175cb32 (empty) another message");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
+    feature1@origin: tyvxnvqr 9175cb32 (empty) another message
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::assert_snapshot!(stdout, @"");
     // There should be no output here since the remote bookmark wasn't forgotten
-    insta::assert_snapshot!(stderr, @"Nothing changed.");
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"feature1@origin: tyvxnvqr 9175cb32 (empty) another message");
+    insta::assert_snapshot!(stderr, @r"
+    Nothing changed.
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
+    feature1@origin: tyvxnvqr 9175cb32 (empty) another message
+    [EOF]
+    ");
 }
 
 #[test]
@@ -889,6 +989,7 @@ fn test_bookmark_forget_deleted_or_nonexistent_bookmark() {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1 (deleted)
       @origin: qomsplrm ebeb70d8 message
+    [EOF]
     ");
 
     // ============ End of test setup ============
@@ -902,9 +1003,10 @@ fn test_bookmark_forget_deleted_or_nonexistent_bookmark() {
 
     // Can't forget a non-existent bookmark
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "forget", "i_do_not_exist"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No such bookmark: i_do_not_exist
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -935,21 +1037,24 @@ fn test_bookmark_track_untrack() {
     );
     test_env.add_config("git.auto-local-bookmark = false");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [new] untracked
     bookmark: feature2@origin [new] untracked
     bookmark: main@origin     [new] untracked
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1@origin: qxxqrkql bd843888 commit 1
     feature2@origin: qxxqrkql bd843888 commit 1
     main@origin: qxxqrkql bd843888 commit 1
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
     │ ◆  feature1@origin feature2@origin main@origin bd843888ee66
     ├─╯
     ◆   000000000000
+    [EOF]
     ");
 
     // Track new bookmark. Local bookmark should be created.
@@ -963,6 +1068,7 @@ fn test_bookmark_track_untrack() {
     feature2@origin: qxxqrkql bd843888 commit 1
     main: qxxqrkql bd843888 commit 1
       @origin: qxxqrkql bd843888 commit 1
+    [EOF]
     ");
 
     // Track existing bookmark. Local bookmark should result in conflict.
@@ -977,6 +1083,7 @@ fn test_bookmark_track_untrack() {
       @origin (behind by 1 commits): qxxqrkql bd843888 commit 1
     main: qxxqrkql bd843888 commit 1
       @origin: qxxqrkql bd843888 commit 1
+    [EOF]
     ");
 
     // Untrack existing and locally-deleted bookmarks. Bookmark targets should be
@@ -992,12 +1099,14 @@ fn test_bookmark_track_untrack() {
     feature2@origin: qxxqrkql bd843888 commit 1
     main: qxxqrkql bd843888 commit 1
       @origin: qxxqrkql bd843888 commit 1
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
     │ ◆  feature1 feature1@origin feature2@origin main bd843888ee66
     ├─╯
     ◆   000000000000
+    [EOF]
     ");
 
     // Fetch new commit. Only tracking bookmark "main" should be merged.
@@ -1012,17 +1121,19 @@ fn test_bookmark_track_untrack() {
         ],
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [updated] untracked
     bookmark: feature2@origin [updated] untracked
     bookmark: main@origin     [updated] tracked
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qxxqrkql bd843888 commit 1
     feature1@origin: psynomvr 48ec79a4 commit 2
     feature2@origin: psynomvr 48ec79a4 commit 2
     main: psynomvr 48ec79a4 commit 2
       @origin: psynomvr 48ec79a4 commit 2
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
@@ -1031,6 +1142,7 @@ fn test_bookmark_track_untrack() {
     │ ○  feature1 bd843888ee66
     ├─╯
     ◆   000000000000
+    [EOF]
     ");
 
     // Fetch new commit with auto tracking. Tracking bookmark "main" and new
@@ -1048,13 +1160,14 @@ fn test_bookmark_track_untrack() {
     );
     test_env.add_config("git.auto-local-bookmark = true");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [updated] untracked
     bookmark: feature2@origin [updated] untracked
     bookmark: feature3@origin [new] tracked
     bookmark: main@origin     [updated] tracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qxxqrkql bd843888 commit 1
     feature1@origin: yumopmsr d8cd3e02 commit 3
@@ -1063,6 +1176,7 @@ fn test_bookmark_track_untrack() {
       @origin: yumopmsr d8cd3e02 commit 3
     main: yumopmsr d8cd3e02 commit 3
       @origin: yumopmsr d8cd3e02 commit 3
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @   230dd059e1b0
@@ -1071,6 +1185,7 @@ fn test_bookmark_track_untrack() {
     │ ○  feature1 bd843888ee66
     ├─╯
     ◆   000000000000
+    [EOF]
     ");
 }
 
@@ -1095,13 +1210,14 @@ fn test_bookmark_track_conflict() {
         &["describe", "-m", "b", "-r", "main", "--ignore-immutable"],
     );
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "main@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Started tracking 1 remote bookmarks.
     main (conflicted):
       + qpvuntsm?? e802c4f8 (empty) b
       + qpvuntsm?? 427890ea (empty) a
       @origin (behind by 1 commits): qpvuntsm?? 427890ea (empty) a
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1129,63 +1245,72 @@ fn test_bookmark_track_untrack_patterns() {
     // Fetch new commit without auto tracking
     test_env.add_config("git.auto-local-bookmark = false");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: feature1@origin [new] untracked
     bookmark: feature2@origin [new] untracked
-    "###);
+    [EOF]
+    ");
 
     // Track local bookmark
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     insta::assert_snapshot!(
-        test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "track", "main"]), @r###"
+        test_env.jj_cmd_cli_error(&repo_path, &["bookmark", "track", "main"]), @r"
     error: invalid value 'main' for '<BOOKMARK@REMOTE>...': remote bookmark must be specified in bookmark@remote form
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Track/untrack unknown bookmark
     insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "main@origin"]), @r###"
+        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "main@origin"]), @r"
     Error: No such remote bookmark: main@origin
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["bookmark", "untrack", "main@origin"]), @r###"
+        test_env.jj_cmd_failure(&repo_path, &["bookmark", "untrack", "main@origin"]), @r"
     Error: No such remote bookmark: main@origin
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
-        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "glob:maine@*"]), @r###"
+        test_env.jj_cmd_failure(&repo_path, &["bookmark", "track", "glob:maine@*"]), @r"
     Error: No matching remote bookmarks for patterns: maine@*
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(
             &repo_path,
             &["bookmark", "untrack", "main@origin", "glob:main@o*"],
-        ), @r###"
+        ), @r"
     Error: No matching remote bookmarks for patterns: main@origin, main@o*
-    "###);
+    [EOF]
+    ");
 
     // Track already tracked bookmark
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "feature1@origin"]);
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "feature1@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Remote bookmark already tracked: feature1@origin
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 
     // Untrack non-tracking bookmark
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "feature2@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Remote bookmark not tracked yet: feature2@origin
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 
     // Untrack Git-tracking bookmark
     test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "main@git"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Git-tracking bookmark cannot be untracked: main@git
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: yrnqsqlx 41e7a49d commit
       @git: yrnqsqlx 41e7a49d commit
@@ -1193,16 +1318,18 @@ fn test_bookmark_track_untrack_patterns() {
     feature2@origin: yrnqsqlx 41e7a49d commit
     main: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
+    [EOF]
     ");
 
     // Untrack by pattern
     let (_, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "untrack", "glob:*@*"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Git-tracking bookmark cannot be untracked: feature1@git
     Warning: Remote bookmark not tracked yet: feature2@origin
     Warning: Git-tracking bookmark cannot be untracked: main@git
     Stopped tracking 1 remote bookmarks.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: yrnqsqlx 41e7a49d commit
       @git: yrnqsqlx 41e7a49d commit
@@ -1210,14 +1337,16 @@ fn test_bookmark_track_untrack_patterns() {
     feature2@origin: yrnqsqlx 41e7a49d commit
     main: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
+    [EOF]
     ");
 
     // Track by pattern
     let (_, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "glob:feature?@origin"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Started tracking 2 remote bookmarks.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: yrnqsqlx 41e7a49d commit
       @git: yrnqsqlx 41e7a49d commit
@@ -1226,6 +1355,7 @@ fn test_bookmark_track_untrack_patterns() {
       @origin: yrnqsqlx 41e7a49d commit
     main: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
+    [EOF]
     ");
 }
 
@@ -1281,20 +1411,22 @@ fn test_bookmark_list() {
     // Synchronized tracking remotes and non-tracking remotes aren't listed by
     // default
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: wqnwkozp 4e887f78 (empty) local-only
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
     remote-sync: zwtyzrop c761c7ea (empty) remote-sync
     remote-unsync: wqnwkozp 4e887f78 (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list", "--all-remotes"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: wqnwkozp 4e887f78 (empty) local-only
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
@@ -1303,10 +1435,12 @@ fn test_bookmark_list() {
     remote-unsync: wqnwkozp 4e887f78 (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
     remote-untrack@origin: vmortlor 71a16b05 (empty) remote-untrack
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 
     let template = r#"
     concat(
@@ -1326,7 +1460,7 @@ fn test_bookmark_list() {
         &local_path,
         &["bookmark", "list", "--all-remotes", "-T", template],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [local-only]
     present: true
     conflict: false
@@ -1407,10 +1541,12 @@ fn test_bookmark_list() {
     tracking_present: false
     tracking_ahead_count: <Error: Not a tracked remote ref>
     tracking_behind_count: <Error: Not a tracked remote ref>
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1450,7 +1586,7 @@ fn test_bookmark_list_filtered() {
             &local_path,
             &["log", "-r::(bookmarks() | remote_bookmarks())", "-T", template],
         ),
-        @r#"
+        @r"
     @  c7b4c09cd77c local-keep
     │ ○  e31634b64294 remote-rewrite*
     ├─╯
@@ -1461,21 +1597,24 @@ fn test_bookmark_list_filtered() {
     │ ○  911e912015fb remote-keep
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // All bookmarks are listed by default.
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 
     let query =
         |args: &[&str]| test_env.jj_cmd_ok(&local_path, &[&["bookmark", "list"], args].concat());
@@ -1486,81 +1625,90 @@ fn test_bookmark_list_filtered() {
     // "all()" doesn't include deleted bookmarks since they have no local targets.
     // So "all()" is identical to "bookmarks()".
     let (stdout, stderr) = query(&["-rall()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Exclude remote-only bookmarks. "remote-rewrite@origin" is included since
     // local "remote-rewrite" target matches.
     let (stdout, stderr) = query(&["-rbookmarks()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Select bookmarks by name.
     let (stdout, stderr) = query(&["remote-rewrite"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = query(&["-rbookmarks(remote-rewrite)"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Select bookmarks by name, combined with --all-remotes
     test_env.jj_cmd_ok(&local_path, &["git", "export"]);
     let (stdout, stderr) = query(&["--all-remotes", "remote-rewrite"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = query(&["--all-remotes", "-rbookmarks(remote-rewrite)"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Select bookmarks with --remote
     let (stdout, stderr) = query(&["--remote", "origin"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
       @origin: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "#);
-    insta::assert_snapshot!(stderr, @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "#);
+    [EOF]
+    ");
     let (stdout, stderr) = query(&["--remote", "glob:gi?"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
       @git: kpqxywon c7b4c09c (empty) local-keep
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
       @git: nlwprzpn 911e9120 (empty) remote-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = query(&["--remote", "origin", "--remote", "git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
       @git: kpqxywon c7b4c09c (empty) local-keep
     remote-delete (deleted)
@@ -1571,55 +1719,64 @@ fn test_bookmark_list_filtered() {
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "#);
-    insta::assert_snapshot!(stderr, @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "#);
+    [EOF]
+    ");
 
     // Can select deleted bookmark by name pattern, but not by revset.
     let (stdout, stderr) = query(&["remote-delete"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = query(&["-rbookmarks(remote-delete)"]);
     insta::assert_snapshot!(stdout, @r###"
     "###);
     insta::assert_snapshot!(query_error(&["-rremote-delete"]), @r"
     Error: Revision `remote-delete` doesn't exist
     Hint: Did you mean `remote-delete@origin`, `remote-keep`, `remote-rewrite`, `remote-rewrite@origin`?
+    [EOF]
     ");
     insta::assert_snapshot!(stderr, @"");
 
     // Name patterns are OR-ed.
     let (stdout, stderr) = query(&["glob:*-keep", "remote-delete"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-delete (deleted)
       @origin: yxusvupt dad5f298 (empty) remote-delete
     remote-keep: nlwprzpn 911e9120 (empty) remote-keep
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 
     // Unmatched name pattern shouldn't be an error. A warning can be added later.
     let (stdout, stderr) = query(&["local-keep", "glob:push-*"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Name pattern and revset are OR-ed.
     let (stdout, stderr) = query(&["local-keep", "-rbookmarks(remote-rewrite)"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @origin (ahead by 1 commits, behind by 1 commits): xyxluytn hidden 3e9a5af6 (empty) remote-rewrite
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // … but still filtered by --remote
@@ -1629,12 +1786,13 @@ fn test_bookmark_list_filtered() {
         "--remote",
         "git",
     ]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     local-keep: kpqxywon c7b4c09c (empty) local-keep
       @git: kpqxywon c7b4c09c (empty) local-keep
     remote-rewrite: xyxluytn e31634b6 (empty) rewritten
       @git: xyxluytn e31634b6 (empty) rewritten
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -1684,11 +1842,12 @@ fn test_bookmark_list_much_remote_divergence() {
     );
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: zkyosouw 4ab3f751 (empty) local-only
     remote-unsync: zkyosouw 4ab3f751 (empty) local-only
       @origin (ahead by at least 10 commits, behind by at least 10 commits): lxyktnks 19582022 (empty) remote-unsync
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -1791,7 +1950,7 @@ fn test_bookmark_list_tracked() {
     );
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list", "--all-remotes"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     local-only: nmzmmopx e1da745b (empty) local-only
       @git: nmzmmopx e1da745b (empty) local-only
     remote-delete (deleted)
@@ -1807,13 +1966,15 @@ fn test_bookmark_list_tracked() {
     upstream-sync: lolpmnqw 32fa6da0 (empty) upstream-sync
       @git: lolpmnqw 32fa6da0 (empty) upstream-sync
       @upstream: lolpmnqw 32fa6da0 (empty) upstream-sync
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["bookmark", "list", "--tracked"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
     remote-sync: zwtyzrop c761c7ea (empty) remote-sync
@@ -1823,38 +1984,43 @@ fn test_bookmark_list_tracked() {
       @upstream (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
     upstream-sync: lolpmnqw 32fa6da0 (empty) upstream-sync
       @upstream: lolpmnqw 32fa6da0 (empty) upstream-sync
-    "###
+    [EOF]
+    "
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &local_path,
         &["bookmark", "list", "--tracked", "--remote", "origin"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     remote-delete (deleted)
       @origin: mnmymoky 203e60eb (empty) remote-delete
     remote-sync: zwtyzrop c761c7ea (empty) remote-sync
       @origin: zwtyzrop c761c7ea (empty) remote-sync
     remote-unsync: nmzmmopx e1da745b (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "#
+    [EOF]
+    "
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Hint: Bookmarks marked as deleted will be *deleted permanently* on the remote on the next `jj git push`. Use `jj bookmark forget` to prevent this.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &local_path,
         &["bookmark", "list", "--tracked", "remote-unsync"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-unsync: nmzmmopx e1da745b (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
       @upstream (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1873,10 +2039,11 @@ fn test_bookmark_list_tracked() {
         &local_path,
         &["bookmark", "list", "--tracked", "remote-unsync"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     remote-unsync: nmzmmopx e1da745b (empty) local-only
       @origin (ahead by 1 commits, behind by 1 commits): qpsqxpyq 38ef8af7 (empty) remote-unsync
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -1906,17 +2073,19 @@ fn test_bookmark_list_conflicted() {
         ],
     );
     test_env.jj_cmd_ok(&repo_path, &["status"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     bar: kkmpptxz 06a973bc (empty) b
     foo (conflicted):
       + rlvkpnrz d8d5f980 (empty) a
       + kkmpptxz 06a973bc (empty) b
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["bookmark", "list", "--conflicted"]), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["bookmark", "list", "--conflicted"]), @r"
     foo (conflicted):
       + rlvkpnrz d8d5f980 (empty) a
       + kkmpptxz 06a973bc (empty) b
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1930,6 +2099,7 @@ fn test_bookmark_create_with_default_target_revision() {
     insta::assert_snapshot!(stderr, @r"
     Warning: Target revision was not specified, defaulting to the working copy (-r@). In the near future it will be required to explicitly specify target revision.
     Created 1 bookmarks pointing to qpvuntsm 230dd059 foo | (empty) (no description set)
+    [EOF]
     ");
 }
 
@@ -1944,6 +2114,7 @@ fn test_bookmark_set_with_default_target_revision() {
     insta::assert_snapshot!(stderr, @r"
     Warning: Target revision was not specified, defaulting to the working copy (--revision=@). In the near future it will be required to explicitly specify target revision.
     Created 1 bookmarks pointing to qpvuntsm 230dd059 foo | (empty) (no description set)
+    [EOF]
     ");
 }
 
@@ -1963,7 +2134,10 @@ fn test_bookmark_move_with_default_target_revision() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo", "-r@"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Created 1 bookmarks pointing to qpvuntsm 230dd059 foo | (empty) (no description set)");
+    insta::assert_snapshot!(stderr, @r"
+    Created 1 bookmarks pointing to qpvuntsm 230dd059 foo | (empty) (no description set)
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "foo"]);
@@ -1971,6 +2145,7 @@ fn test_bookmark_move_with_default_target_revision() {
     insta::assert_snapshot!(stderr, @r"
     Warning: Target revision was not specified, defaulting to the working copy (--to=@). In the near future it will be required to explicitly specify it.
     Moved 1 bookmarks to zsuskuln 8bb159bc foo | (empty) (no description set)
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 
 use crate::common::git;
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn create_commit_with_refs(
@@ -1973,12 +1974,12 @@ fn test_bookmark_move_with_default_target_revision() {
     ");
 }
 
-fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     let template = r#"bookmarks ++ " " ++ commit_id.short()"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }
 
-fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     // --quiet to suppress deleted bookmarks hint
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes", "--quiet"])
 }

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -54,11 +54,12 @@ fn test_builtin_alias_trunk_matches_main() {
     let (test_env, workspace_root) = set_up("main");
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -66,11 +67,12 @@ fn test_builtin_alias_trunk_matches_master() {
     let (test_env, workspace_root) = set_up("master");
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 master d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -78,11 +80,12 @@ fn test_builtin_alias_trunk_matches_trunk() {
     let (test_env, workspace_root) = set_up("trunk");
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 trunk d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -93,11 +96,12 @@ fn test_builtin_alias_trunk_matches_exactly_one_commit() {
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "create", "-r@", "master"]);
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -109,11 +113,12 @@ fn test_builtin_alias_trunk_override_alias() {
     );
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 override-trunk d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -121,9 +126,10 @@ fn test_builtin_alias_trunk_no_match() {
     let (test_env, workspace_root) = set_up("no-match-trunk");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @r###"
     "###);
 }
@@ -133,9 +139,10 @@ fn test_builtin_alias_trunk_no_match_only_exact() {
     let (test_env, workspace_root) = set_up("maint");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @r###"
     "###);
 }
@@ -149,14 +156,16 @@ fn test_builtin_user_redefines_builtin_immutable_heads() {
     test_env.add_config(r#"revset-aliases.'immutable()' = '@'"#);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 main d13ecdbd
     │  (empty) description 1
     ~
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @r"
     Warning: Redefining `revset-aliases.builtin_immutable_heads()` is not recommended; redefine `immutable_heads()` instead
     Warning: Redefining `revset-aliases.mutable()` is not recommended; redefine `immutable_heads()` instead
     Warning: Redefining `revset-aliases.immutable()` is not recommended; redefine `immutable_heads()` instead
+    [EOF]
     ");
 }

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -440,7 +441,7 @@ fn test_commit_reset_author() {
     "###);
 }
 
-fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     let template = r#"commit_id.short() ++ " " ++ description"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -26,11 +26,12 @@ fn test_commit_with_description_from_cli() {
 
     // Description applies to the current working-copy (not the new one)
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  e8ea92a8b6b3
     ○  fa15625b4a98 first
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -45,11 +46,12 @@ fn test_commit_with_editor() {
     let edit_script = test_env.set_up_fake_editor();
     std::fs::write(&edit_script, ["dump editor0", "write\nmodified"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  a57b2c95fb75
     ○  159271101e05 modified
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     initial
@@ -161,6 +163,7 @@ fn test_commit_interactive() {
     │  add files
     │  A file1
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 }
 
@@ -194,6 +197,7 @@ fn test_commit_interactive_with_paths() {
     insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz f3e6062e (no description set)
     Parent commit      : rlvkpnrz 9453cb28 edit
+    [EOF]
     ");
 
     insta::assert_snapshot!(
@@ -220,6 +224,7 @@ fn test_commit_interactive_with_paths() {
     │  A file2
     │  A file3
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 }
 
@@ -236,11 +241,12 @@ fn test_commit_with_default_description() {
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     test_env.jj_cmd_ok(&workspace_path, &["commit"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  c65242099289
     ○  573b6df51aea TESTED=TODO
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
     TESTED=TODO
@@ -342,9 +348,10 @@ fn test_commit_without_working_copy() {
 
     test_env.jj_cmd_ok(&workspace_path, &["workspace", "forget"]);
     let stderr = test_env.jj_cmd_failure(&workspace_path, &["commit", "-m=first"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: This command requires a working copy
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -358,15 +365,17 @@ fn test_commit_paths() {
 
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first", "file1"]);
     let stdout = test_env.jj_cmd_success(&workspace_path, &["diff", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file1:
             1: foo
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file2:
             1: bar
+    [EOF]
     ");
 }
 
@@ -380,20 +389,22 @@ fn test_commit_paths_warning() {
     std::fs::write(workspace_path.join("file2"), "bar\n").unwrap();
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=first", "file3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: The given paths do not match any file: file3
     Working copy now at: rlvkpnrz d1872100 (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stdout, @"");
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file1:
             1: foo
     Added regular file file2:
             1: bar
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -417,11 +428,12 @@ fn test_commit_reset_author() {
             ],
         )
     };
-    insta::assert_snapshot!(get_signatures(), @r###"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     ~
-    "###);
+    [EOF]
+    ");
 
     // Reset the author (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -434,11 +446,12 @@ fn test_commit_reset_author() {
             "-m1",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r###"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:09.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:09.000 +07:00
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -122,7 +122,7 @@ fn test_log_author_timestamp_ago() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T", template]);
     let line_re = Regex::new(r"[0-9]+ years ago").unwrap();
     assert!(
-        stdout.lines().all(|x| line_re.is_match(x)),
+        stdout.raw().lines().all(|x| line_re.is_match(x)),
         "expected every line to match regex"
     );
 }
@@ -290,7 +290,10 @@ fn test_log_builtin_templates() {
     let repo_path = test_env.env_root().join("repo");
     // Render without graph and append "[EOF]" marker to test line ending
     let render = |template| {
-        test_env.jj_cmd_success(&repo_path, &["log", "-T", template, "--no-graph"]) + "[EOF]\n"
+        test_env
+            .jj_cmd_success(&repo_path, &["log", "-T", template, "--no-graph"])
+            .to_string()
+            + "[EOF]\n"
     };
 
     test_env.jj_cmd_ok(
@@ -1164,7 +1167,7 @@ fn test_log_diff_predefined_formats() {
         test_env.env_root(),
         &["log", "-Rrepo", "--no-graph", "-r@", "-T", template],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     === color_words ===
     Modified regular file repo/file1:
        1    1: a
@@ -1443,14 +1446,14 @@ fn test_repo_path() {
         ) ++ "\n"
     "#};
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list", "-T", template]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     dir/file display=dir/file parent=dir parent^2=
     file display=file parent= parent^2=<none>
     ");
 
     let template = r#"separate(" ", path, "display=" ++ path.display()) ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir"), &["file", "list", "-T", template]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     dir/file display=file
     file display=../file
     ");

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -31,7 +31,7 @@ fn test_log_parents() {
     let template =
         r#"commit_id ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|c| c.commit_id()) ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    c067170d4ca1bc6162b64f7550617ec809647f84
     ├─╮  P: 2 4db490c88528133d579540b6900b8098f0c17701 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ○ │  4db490c88528133d579540b6900b8098f0c17701
@@ -40,7 +40,8 @@ fn test_log_parents() {
     │  P: 1 0000000000000000000000000000000000000000
     ◆  0000000000000000000000000000000000000000
        P: 0
-    "###);
+    [EOF]
+    ");
 
     // List<Commit> can be filtered
     let template =
@@ -53,6 +54,7 @@ fn test_log_parents() {
     ├─╯
     ○  P:
     ◆  P:
+    [EOF]
     ");
 
     let template = r#"parents.map(|c| c.commit_id().shortest(4))"#;
@@ -60,11 +62,12 @@ fn test_log_parents() {
         &repo_path,
         &["log", "-T", template, "-r@", "--color=always"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;4m4[0m[38;5;8mdb4[39m [1m[38;5;4m2[0m[38;5;8m30d[39m
     │
     ~
-    "###);
+    [EOF]
+    ");
 
     // Commit object isn't printable
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-T", "parents"]);
@@ -76,6 +79,7 @@ fn test_log_parents() {
       | ^-----^
       |
       = Expected expression of type `Template`, but actual type is `List<Commit>`
+    [EOF]
     ");
 
     // Redundant argument passed to keyword method
@@ -89,6 +93,7 @@ fn test_log_parents() {
       |                             ^^
       |
       = Function `commit_id`: Expected 0 arguments
+    [EOF]
     "#);
 }
 
@@ -102,11 +107,12 @@ fn test_log_author_timestamp() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "second"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-03 04:05:09.000 +07:00
     ○  2001-02-03 04:05:08.000 +07:00
     ◆  1970-01-01 00:00:00.000 +00:00
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -134,10 +140,11 @@ fn test_log_author_timestamp_utc() {
     let repo_path = test_env.env_root().join("repo");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().utc()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-02 21:05:07.000 +00:00
     ◆  1970-01-01 00:00:00.000 +00:00
-    "###);
+    [EOF]
+    ");
 }
 
 #[cfg(unix)]
@@ -149,16 +156,18 @@ fn test_log_author_timestamp_local() {
 
     test_env.add_env_var("TZ", "UTC-05:30");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-03 08:05:07.000 +11:00
     ◆  1970-01-01 11:00:00.000 +11:00
-    "###);
+    [EOF]
+    ");
     test_env.add_env_var("TZ", "UTC+10:00");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "author.timestamp().local()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  2001-02-03 08:05:07.000 +11:00
     ◆  1970-01-01 11:00:00.000 +11:00
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -178,10 +187,11 @@ fn test_log_author_timestamp_after_before() {
       if(author.timestamp().before("now"), "(before now)", "(after now)")
     ) ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     2001-02-03 04:05:08.000 +07:00 : (after 1969) (after 1975) (before now)
     1970-01-01 00:00:00.000 +00:00 : (after 1969) (before 1975) (before now)
-    "#);
+    [EOF]
+    ");
 
     // Should display error with invalid date.
     let template = r#"author.timestamp().after("invalid date")"#;
@@ -196,6 +206,7 @@ fn test_log_author_timestamp_after_before() {
       |
       = Invalid date pattern
     2: expected week day or month name
+    [EOF]
     "#);
 }
 
@@ -221,11 +232,12 @@ fn test_mine_is_true_when_author_is_user() {
             r#"coalesce(if(mine, "mine"), author.email(), email_placeholder)"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  johndoe@example.com
     ○  mine
     ◆  (no email set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -241,33 +253,36 @@ fn test_log_default() {
 
     // Test default log output format
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 my-bookmark bac9ff9e
     │  (empty) description 1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aa2015d7
     │  add a file
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
     │  add a file
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    [EOF]
+    ");
 
     // Color without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mb[38;5;8mac9ff9e[39m[0m
     [1m[38;5;10m(empty)[39m description 1[0m
     [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4ma[0m[38;5;8ma2015d7[39m
     add a file
     [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -278,9 +293,10 @@ fn test_log_default_without_working_copy() {
 
     test_env.jj_cmd_ok(&repo_path, &["workspace", "forget"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     ◆  zzzzzzzz root() 00000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -288,13 +304,9 @@ fn test_log_builtin_templates() {
     let test_env = TestEnvironment::default();
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
-    // Render without graph and append "[EOF]" marker to test line ending
-    let render = |template| {
-        test_env
-            .jj_cmd_success(&repo_path, &["log", "-T", template, "--no-graph"])
-            .to_string()
-            + "[EOF]\n"
-    };
+    // Render without graph to test line ending
+    let render =
+        |template| test_env.jj_cmd_success(&repo_path, &["log", "-T", template, "--no-graph"]);
 
     test_env.jj_cmd_ok(
         &repo_path,
@@ -371,21 +383,23 @@ fn test_log_builtin_templates_colored() {
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "my-bookmark"]);
 
-    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12md[38;5;8mc315397[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12md[38;5;8mc315397[39m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     │
@@ -394,9 +408,10 @@ fn test_log_builtin_templates_colored() {
     │
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
 
-    "#);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r"
     [1m[38;5;2m@[0m  Commit ID: [38;5;4mdc31539712c7294d1d712cec63cef4504b94ca74[39m
     │  Change ID: [38;5;5mrlvkpnrzqnoowoytxnquwvuryrwnrmlp[39m
     │  Bookmarks: [38;5;5mmy-bookmark[39m
@@ -418,7 +433,9 @@ fn test_log_builtin_templates_colored() {
        Committer: [38;5;1m(no name set)[39m <[38;5;1m(no email set)[39m> ([38;5;6m1970-01-01 11:00:00[39m)
 
        [38;5;2m    (no description set)[39m
-    "#);
+
+    [EOF]
+    ");
 }
 
 #[test]
@@ -435,21 +452,23 @@ fn test_log_builtin_templates_colored_debug() {
     );
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "my-bookmark"]);
 
-    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy bookmarks name::my-bookmark>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
     <<node::○>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email local::test.user>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log:: >>[38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
     [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
-    "#);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy bookmarks name::my-bookmark>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
     │  [1m[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
     <<node::○>>  [1m[38;5;5m<<log change_id shortest prefix::q>>[0m[38;5;8m<<log change_id shortest rest::pvuntsm>>[39m<<log:: >>[38;5;3m<<log author email local::test.user>><<log author email::@>><<log author email domain::example.com>>[39m<<log:: >>[38;5;6m<<log committer timestamp local format::2001-02-03 08:05:07>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::2>>[0m[38;5;8m<<log commit_id shortest rest::30dd059>>[39m<<log::>>
     │  [38;5;2m<<log empty::(empty)>>[39m<<log:: >>[38;5;2m<<log empty description placeholder::(no description set)>>[39m<<log::>>
     [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
-    "#);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;13m<<log working_copy change_id shortest prefix::r>>[38;5;8m<<log working_copy change_id shortest rest::lvkpnrz>>[39m<<log working_copy:: >>[38;5;9m<<log working_copy email placeholder::(no email set)>>[39m<<log working_copy:: >>[38;5;14m<<log working_copy committer timestamp local format::2001-02-03 08:05:08>>[39m<<log working_copy:: >>[38;5;13m<<log working_copy bookmarks name::my-bookmark>>[39m<<log working_copy:: >>[38;5;12m<<log working_copy commit_id shortest prefix::d>>[38;5;8m<<log working_copy commit_id shortest rest::c315397>>[39m<<log working_copy::>>[0m
     │  [1m[38;5;10m<<log working_copy empty::(empty)>>[39m<<log working_copy:: >>[38;5;10m<<log working_copy empty description placeholder::(no description set)>>[39m<<log working_copy::>>[0m
     │  <<log::>>
@@ -458,9 +477,10 @@ fn test_log_builtin_templates_colored_debug() {
     │  <<log::>>
     [1m[38;5;14m<<node immutable::◆>>[0m  [1m[38;5;5m<<log change_id shortest prefix::z>>[0m[38;5;8m<<log change_id shortest rest::zzzzzzz>>[39m<<log:: >>[38;5;2m<<log root::root()>>[39m<<log:: >>[1m[38;5;4m<<log commit_id shortest prefix::0>>[0m[38;5;8m<<log commit_id shortest rest::0000000>>[39m<<log::>>
        <<log::>>
-    "#);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  <<log::Commit ID: >>[38;5;4m<<log commit_id::dc31539712c7294d1d712cec63cef4504b94ca74>>[39m<<log::>>
     │  <<log::Change ID: >>[38;5;5m<<log change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m<<log::>>
     │  <<log::Bookmarks: >>[38;5;5m<<log local_bookmarks name::my-bookmark>>[39m<<log::>>
@@ -483,7 +503,8 @@ fn test_log_builtin_templates_colored_debug() {
        <<log::>>
        [38;5;2m<<log empty description placeholder::    (no description set)>>[39m<<log::>>
        <<log::>>
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -496,11 +517,12 @@ fn test_log_evolog_divergence() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 1"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log"]);
     // No divergence
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     // Create divergence
     test_env.jj_cmd_ok(
@@ -508,48 +530,53 @@ fn test_log_evolog_divergence() {
         &["describe", "-m", "description 2", "--at-operation", "@-"],
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
     │ ○  qpvuntsm?? test.user@example.com 2001-02-03 08:05:10 6ba70e00
     ├─╯  description 2
     ◆  zzzzzzzz root() 00000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
-    "###);
+    [EOF]
+    ");
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     │  [1mdescription 1[0m
     │ ○  [1m[4m[38;5;1mq[0m[38;5;1mpvuntsm??[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m6[0m[38;5;8mba70e00[39m
     ├─╯  description 2
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    [EOF]
+    ");
 
     // Evolog and hidden divergent
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm?? test.user@example.com 2001-02-03 08:05:08 ff309c29
     │  description 1
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 485d52a9
     │  (no description set)
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Colored evolog
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[4m[38;5;1mq[24mpvuntsm[38;5;9m??[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12mf[38;5;8mf309c29[39m[0m
     │  [1mdescription 1[0m
     ○  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m4[0m[38;5;8m85d52a9[39m
     │  [38;5;3m(no description set)[39m
     ○  [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -607,7 +634,7 @@ fn test_log_bookmarks() {
 
     let template = r#"commit_id.short() ++ " " ++ if(bookmarks, bookmarks, "(no bookmarks)")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     @  a5b4d15489cc bookmark2* new-bookmark
     ○  8476341eb395 bookmark2@origin unchanged
     │ ○  fed794e2ba44 bookmark3?? bookmark3@origin
@@ -617,11 +644,12 @@ fn test_log_bookmarks() {
     │ ○  4a7e4246fc4d bookmark1*
     ├─╯
     ◆  000000000000 (no bookmarks)
-    "#);
+    [EOF]
+    ");
 
     let template = r#"bookmarks.map(|b| separate("/", b.remote(), b.name())).join(", ")"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     @  bookmark2, new-bookmark
     ○  origin/bookmark2, unchanged
     │ ○  bookmark3, origin/bookmark3
@@ -631,11 +659,12 @@ fn test_log_bookmarks() {
     │ ○  bookmark1
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
 
     let template = r#"separate(" ", "L:", local_bookmarks, "R:", remote_bookmarks)"#;
     let output = test_env.jj_cmd_success(&workspace_root, &["log", "-T", template]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     @  L: bookmark2* new-bookmark R:
     ○  L: unchanged R: bookmark2@origin unchanged@origin
     │ ○  L: bookmark3?? R: bookmark3@origin
@@ -645,7 +674,8 @@ fn test_log_bookmarks() {
     │ ○  L: bookmark1* R:
     ├─╯
     ◆  L: R:
-    "#);
+    [EOF]
+    ");
 
     let template = r#"
     remote_bookmarks.map(|ref| concat(
@@ -659,14 +689,15 @@ fn test_log_bookmarks() {
         &workspace_root,
         &["log", "-r::remote_bookmarks()", "-T", template],
     );
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ○  bookmark3@origin(+0/-1)
     │ ○  bookmark2@origin(+0/-1) unchanged@origin(+0/-0)
     ├─╯
     │ ○  bookmark1@origin(+1/-1)
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -680,20 +711,22 @@ fn test_log_git_head() {
     std::fs::write(repo_path.join("file"), "foo\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "git_head"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  false
     ○  true
     ◆  false
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--color=always"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m5[38;5;8m0aaf475[39m[0m
     │  [1minitial[0m
     ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [38;5;2mgit_head()[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -713,12 +746,13 @@ fn test_log_commit_id_normal_hex() {
             r#"commit_id ++ ": " ++ commit_id.normal_hex()"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  6572f22267c6f0f2bf7b8a37969ee5a7d54b8aae: 6572f22267c6f0f2bf7b8a37969ee5a7d54b8aae
     ○  222fa9f0b41347630a1371203b8aad3897d34e5f: 222fa9f0b41347630a1371203b8aad3897d34e5f
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22: 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000: 0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -738,12 +772,13 @@ fn test_log_change_id_normal_hex() {
             r#"change_id ++ ": " ++ change_id.normal_hex()"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  kkmpptxzrspxrzommnulwmwkkqwworpl: ffdaa62087a280bddc5e3d3ff933b8ae
     ○  rlvkpnrzqnoowoytxnquwvuryrwnrmlp: 8e4fac809cbb3b162c953458183c8dea
     ○  qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu: 9a45c67d3e96a7e5007c110ede34dec5
     ◆  zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz: 00000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -764,11 +799,12 @@ fn test_log_customize_short_id() {
             &format!(r#"{decl}='id.shortest(5).prefix().upper() ++ "_" ++ id.shortest(5).rest()'"#),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  Q_pvun test.user@example.com 2001-02-03 08:05:08 F_a156
     │  (empty) first
     ◆  Z_zzzz root() 0_0000
-    "###);
+    [EOF]
+    ");
 
     // Customize only the change id
     let stdout = test_env.jj_cmd_success(
@@ -778,11 +814,12 @@ fn test_log_customize_short_id() {
             "--config=template-aliases.'format_short_change_id(id)'='format_short_id(id).upper()'",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  QPVUNTSM test.user@example.com 2001-02-03 08:05:08 fa15625b
     │  (empty) first
     ◆  ZZZZZZZZ root() 00000000
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -806,14 +843,15 @@ fn test_log_immutable() {
 
     test_env.add_config("revset-aliases.'immutable_heads()' = 'main'");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r::", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  D
     │ ○  C
     │ ◆  B main [immutable]
     │ ◆  A [immutable]
     ├─╯
     ◆  [immutable]
-    "###);
+    [EOF]
+    ");
 
     // Suppress error that could be detected earlier
     test_env.add_config("revsets.short-prefixes = ''");
@@ -829,6 +867,7 @@ fn test_log_immutable() {
       |
       = Function `unknown_fn` doesn't exist
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     test_env.add_config("revset-aliases.'immutable_heads()' = 'unknown_symbol'");
@@ -843,6 +882,7 @@ fn test_log_immutable() {
       |
       = Failed to evaluate revset
     2: Revision `unknown_symbol` doesn't exist
+    [EOF]
     "#);
 }
 
@@ -878,14 +918,15 @@ fn test_log_contained_in() {
             &template_for_revset(r#"description(A)::"#),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  D
     │ ○  C [contained_in]
     │ ○  B main [contained_in]
     │ ○  A [contained_in]
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -896,14 +937,15 @@ fn test_log_contained_in() {
             &template_for_revset(r#"visible_heads()"#),
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  D [contained_in]
     │ ○  C [contained_in]
     │ ○  B main
     │ ○  A
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Suppress error that could be detected earlier
     let stderr = test_env.jj_cmd_failure(
@@ -925,6 +967,7 @@ fn test_log_contained_in() {
       | ^--------^
       |
       = Function `unknown_fn` doesn't exist
+    [EOF]
     "#);
 
     let stderr = test_env.jj_cmd_failure(
@@ -948,6 +991,7 @@ fn test_log_contained_in() {
       = Invalid string pattern
     3: Invalid string pattern kind `x:`
     Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, or `substring:`
+    [EOF]
     "#);
 
     let stderr = test_env.jj_cmd_failure(
@@ -965,6 +1009,7 @@ fn test_log_contained_in() {
       = Failed to evaluate revset
     2: Revision `maine` doesn't exist
     Hint: Did you mean `main`?
+    [EOF]
     "#);
 }
 
@@ -1007,13 +1052,14 @@ fn test_short_prefix_in_transaction() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["new", parent_id, "--no-edit", "-m", "test"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created new commit km[kuslswpqwq] 7[4ac55dd119b] test
-    "###);
+    [EOF]
+    ");
 
     // Should match log's short prefixes
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     km[kuslswpqwq] 7[4ac55dd119b] test
     y[qosqzytrlsw] 5[8731db5875e] commit4
     r[oyxmykxtrkr] 9[95cc897bca7] commit3
@@ -1022,12 +1068,13 @@ fn test_short_prefix_in_transaction() {
     kk[mpptxzrspx] 05[2755155952] commit0
     q[pvuntsmwlqt] e[0e22b9fae75] initial
     zz[zzzzzzzzzz] 00[0000000000]
-    "###);
+    [EOF]
+    ");
 
     test_env.add_config(r#"revsets.short-prefixes = """#);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     kmk[uslswpqwq] 74ac[55dd119b] test
     yq[osqzytrlsw] 587[31db5875e] commit4
     ro[yxmykxtrkr] 99[5cc897bca7] commit3
@@ -1036,7 +1083,8 @@ fn test_short_prefix_in_transaction() {
     kk[mpptxzrspx] 052[755155952] commit0
     qp[vuntsmwlqt] e0[e22b9fae75] initial
     zz[zzzzzzzzzz] 00[0000000000]
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1075,7 +1123,7 @@ fn test_log_diff_predefined_formats() {
         &repo_path,
         &["log", "--no-graph", "--color=always", "-r@", "-T", template],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === color_words ===
     [38;5;3mModified regular file file1:[39m
     [38;5;1m   1[39m [38;5;2m   1[39m: a
@@ -1114,14 +1162,15 @@ fn test_log_diff_predefined_formats() {
     [38;5;6mM file1[39m
     [38;5;6mM file2[39m
     [38;5;6mR {rename-source => rename-target}[39m
-    "###);
+    [EOF]
+    ");
 
     // color labels
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "--no-graph", "--color=debug", "-r@", "-T", template],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<log::=== color_words ===>>
     [38;5;3m<<log diff color_words header::Modified regular file file1:>>[39m
     [38;5;1m<<log diff color_words removed line_number::   1>>[39m<<log diff color_words:: >>[38;5;2m<<log diff color_words added line_number::   1>>[39m<<log diff color_words::: a>>
@@ -1160,14 +1209,15 @@ fn test_log_diff_predefined_formats() {
     [38;5;6m<<log diff summary modified::M file1>>[39m
     [38;5;6m<<log diff summary modified::M file2>>[39m
     [38;5;6m<<log diff summary renamed::R {rename-source => rename-target}>>[39m
-    "###);
+    [EOF]
+    ");
 
     // cwd != workspace root
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["log", "-Rrepo", "--no-graph", "-r@", "-T", template],
     );
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     === color_words ===
     Modified regular file repo/file1:
        1    1: a
@@ -1206,7 +1256,8 @@ fn test_log_diff_predefined_formats() {
     M repo/file1
     M repo/file2
     R repo/{rename-source => rename-target}
-    "###);
+    [EOF]
+    ");
 
     // with non-default config
     std::fs::write(
@@ -1267,6 +1318,7 @@ fn test_log_diff_predefined_formats() {
     M file1
     M file2
     R {rename-source => rename-target}
+    [EOF]
     ");
 
     // bad config
@@ -1296,21 +1348,23 @@ fn test_log_diff_predefined_formats() {
     3: invalid type: string "not an integer", expected usize
 
     Hint: Check the config file: ../config-bad.toml
+    [EOF]
     "#);
 
     // color_words() with parameters
     let template = "self.diff('file1').color_words(0)";
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
         ...
             3: c
-    "###);
+    [EOF]
+    ");
 
     // git() with parameters
     let template = "self.diff('file1').git(1)";
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 422c2b7ab3..de980441c3 100644
     --- a/file1
@@ -1318,7 +1372,8 @@ fn test_log_diff_predefined_formats() {
     @@ -2,1 +2,2 @@
      b
     +c
-    "###);
+    [EOF]
+    ");
 
     // custom template with files()
     let template = indoc! {r#"
@@ -1350,6 +1405,7 @@ fn test_log_diff_predefined_formats() {
     * non-empty len=3
     === 000000000000 ===
     * empty len=0
+    [EOF]
     ");
 
     // custom diff stat template
@@ -1370,6 +1426,7 @@ fn test_log_diff_predefined_formats() {
     * total_added=4 total_removed=0
     === 000000000000 ===
     * total_added=0 total_removed=0
+    [EOF]
     ");
 }
 
@@ -1410,6 +1467,7 @@ fn test_file_list_entries() {
     conflict-file [conflict] conflict=true executable=false
     dir/file [file] conflict=false executable=false
     exec-file [file] conflict=false executable=true
+    [EOF]
     ");
 }
 
@@ -1424,7 +1482,10 @@ fn test_file_list_symlink() {
 
     let template = r#"separate(" ", path, "[" ++ file_type ++ "]") ++ "\n""#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list", "-T", template]);
-    insta::assert_snapshot!(stdout, @"symlink [symlink]");
+    insta::assert_snapshot!(stdout, @r"
+    symlink [symlink]
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1449,6 +1510,7 @@ fn test_repo_path() {
     insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     dir/file display=dir/file parent=dir parent^2=
     file display=file parent= parent^2=<none>
+    [EOF]
     ");
 
     let template = r#"separate(" ", path, "display=" ++ path.display()) ++ "\n""#;
@@ -1456,6 +1518,7 @@ fn test_repo_path() {
     insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     dir/file display=file
     file display=../file
+    [EOF]
     ");
 }
 
@@ -1479,13 +1542,14 @@ fn test_signature_templates() {
 
     // show that signatures can render
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  good test-display signature
     ○  no signature
     ◆  no signature
-    "#);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"good test-display signature"#);
+    insta::assert_snapshot!(stdout, @"good test-display signature[EOF]");
 
     // builtin templates
     test_env.add_config("ui.show-cryptographic-signatures = true");
@@ -1493,24 +1557,26 @@ fn test_signature_templates() {
     let args: &[_] = &["log", "-r", "..", "-T"];
 
     let stdout = test_env.jj_cmd_success(&repo_path, &[args, &["builtin_log_oneline"]].concat());
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user 2001-02-03 08:05:09 a0909ee9 [✓︎] (empty) signed
     ○  qpvuntsm test.user 2001-02-03 08:05:08 879d5d20 (empty) unsigned
     │
     ~
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &[args, &["builtin_log_compact"]].concat());
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 a0909ee9 [✓︎]
     │  (empty) signed
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 879d5d20
     │  (empty) unsigned
     ~
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &[args, &["builtin_log_detailed"]].concat());
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  Commit ID: a0909ee96bb5c66311a0c579dc8ebed4456dfc1b
     │  Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     │  Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -1526,7 +1592,9 @@ fn test_signature_templates() {
        Signature: (no signature)
 
            unsigned
-    "#);
+
+    [EOF]
+    ");
 
     // customization point
     let config_val = r#"template-aliases."format_short_cryptographic_signature(signature)"="'status: ' ++ signature.status()""#;
@@ -1534,10 +1602,11 @@ fn test_signature_templates() {
         &repo_path,
         &[args, &["builtin_log_oneline", "--config", config_val]].concat(),
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user 2001-02-03 08:05:09 a0909ee9 status: good (empty) signed
     ○  qpvuntsm test.user 2001-02-03 08:05:08 879d5d20 status: <Error: No CryptographicSignature available> (empty) unsigned
     │
     ~
-    "#);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -91,18 +91,21 @@ fn test_bookmark_names() {
     --config	Additional configuration options (can be repeated)
     --config-file	Additional configuration files (can be repeated)
     --help	Print help (see more with '--help')
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "bookmark", "rename", "a"]);
     insta::assert_snapshot!(stdout, @r"
     aaa-local	x
     aaa-tracked	x
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "bookmark", "delete", "a"]);
     insta::assert_snapshot!(stdout, @r"
     aaa-local	x
     aaa-tracked	x
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "bookmark", "forget", "a"]);
@@ -110,6 +113,7 @@ fn test_bookmark_names() {
     aaa-local	x
     aaa-tracked	x
     aaa-untracked
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(
@@ -120,30 +124,40 @@ fn test_bookmark_names() {
     aaa-local	x
     aaa-tracked	x
     aaa-untracked
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "bookmark", "move", "a"]);
     insta::assert_snapshot!(stdout, @r"
     aaa-local	x
     aaa-tracked	x
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "bookmark", "set", "a"]);
     insta::assert_snapshot!(stdout, @r"
     aaa-local	x
     aaa-tracked	x
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "bookmark", "track", "a"]);
-    insta::assert_snapshot!(stdout, @"aaa-untracked@origin	x");
+    insta::assert_snapshot!(stdout, @r"
+    aaa-untracked@origin	x
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "bookmark", "untrack", "a"]);
-    insta::assert_snapshot!(stdout, @"aaa-tracked@origin	x");
+    insta::assert_snapshot!(stdout, @r"
+    aaa-tracked@origin	x
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "git", "push", "-b", "a"]);
     insta::assert_snapshot!(stdout, @r"
     aaa-local	x
     aaa-tracked	x
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "git", "fetch", "-b", "a"]);
@@ -151,6 +165,7 @@ fn test_bookmark_names() {
     aaa-local	x
     aaa-tracked	x
     aaa-untracked
+    [EOF]
     ");
 }
 
@@ -178,7 +193,10 @@ fn test_global_arg_repository_is_respected() {
             "a",
         ],
     );
-    insta::assert_snapshot!(stdout, @"aaa	(no description set)");
+    insta::assert_snapshot!(stdout, @r"
+    aaa	(no description set)
+    [EOF]
+    ");
 }
 
 #[test]
@@ -202,10 +220,16 @@ fn test_aliases_are_resolved() {
     let test_env = test_env;
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "b", "rename", "a"]);
-    insta::assert_snapshot!(stdout, @"aaa	(no description set)");
+    insta::assert_snapshot!(stdout, @r"
+    aaa	(no description set)
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "b2", "rename", "a"]);
-    insta::assert_snapshot!(stdout, @"aaa	(no description set)");
+    insta::assert_snapshot!(stdout, @r"
+    aaa	(no description set)
+    [EOF]
+    ");
 }
 
 #[test]
@@ -273,37 +297,55 @@ fn test_remote_names() {
         test_env.env_root(),
         &["--", "jj", "git", "remote", "remove", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @r"
+    origin
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "remote", "rename", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @r"
+    origin
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "remote", "set-url", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @r"
+    origin
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "push", "--remote", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @r"
+    origin
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "git", "fetch", "--remote", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @r"
+    origin
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         test_env.env_root(),
         &["--", "jj", "bookmark", "list", "--remote", "o"],
     );
-    insta::assert_snapshot!(stdout, @r"origin");
+    insta::assert_snapshot!(stdout, @r"
+    origin
+    [EOF]
+    ");
 }
 
 #[test]
@@ -331,7 +373,10 @@ fn test_aliases_are_completed() {
     let test_env = test_env;
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "user-al"]);
-    insta::assert_snapshot!(stdout, @"user-alias");
+    insta::assert_snapshot!(stdout, @r"
+    user-alias
+    [EOF]
+    ");
 
     // make sure --repository flag is respected
     let stdout = test_env.jj_cmd_success(
@@ -344,7 +389,10 @@ fn test_aliases_are_completed() {
             "repo-al",
         ],
     );
-    insta::assert_snapshot!(stdout, @"repo-alias");
+    insta::assert_snapshot!(stdout, @r"
+    repo-alias
+    [EOF]
+    ");
 
     // cannot load aliases from --config flag
     let stdout = test_env.jj_cmd_success(
@@ -426,6 +474,7 @@ fn test_revisions() {
     remote_bookmark@origin	remote_commit
     alias_with_newline	    roots(
     siblings	@-+ ~@
+    [EOF]
     ");
 
     // complete only mutable revisions
@@ -437,6 +486,7 @@ fn test_revisions() {
     zq	remote_commit
     alias_with_newline	    roots(
     siblings	@-+ ~@
+    [EOF]
     ");
 
     // complete args of the default command
@@ -453,6 +503,7 @@ fn test_revisions() {
     remote_bookmark@origin	remote_commit
     alias_with_newline	    roots(
     siblings	@-+ ~@
+    [EOF]
     ");
 }
 
@@ -490,32 +541,57 @@ fn test_operations() {
     insta::assert_snapshot!(stdout, @r"
     5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
     518b588abbc6	(2001-02-03 08:05:09) describe commit 19611c995a342c01f525583e5fcafdd211f6d009
+    [EOF]
     ");
     // make sure global --at-op flag is respected
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["--", "jj", "--at-op", "518b588abbc6", "op", "show", "5"],
     );
-    insta::assert_snapshot!(stdout, @"518b588abbc6	(2001-02-03 08:05:09) describe commit 19611c995a342c01f525583e5fcafdd211f6d009");
+    insta::assert_snapshot!(stdout, @r"
+    518b588abbc6	(2001-02-03 08:05:09) describe commit 19611c995a342c01f525583e5fcafdd211f6d009
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "--at-op", "5b"]);
-    insta::assert_snapshot!(stdout, @"5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710");
+    insta::assert_snapshot!(stdout, @r"
+    5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "abandon", "5b"]);
-    insta::assert_snapshot!(stdout, @"5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710");
+    insta::assert_snapshot!(stdout, @r"
+    5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "diff", "--op", "5b"]);
-    insta::assert_snapshot!(stdout, @"5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710");
+    insta::assert_snapshot!(stdout, @r"
+    5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "diff", "--from", "5b"]);
-    insta::assert_snapshot!(stdout, @"5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710");
+    insta::assert_snapshot!(stdout, @r"
+    5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "diff", "--to", "5b"]);
-    insta::assert_snapshot!(stdout, @"5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710");
+    insta::assert_snapshot!(stdout, @r"
+    5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "restore", "5b"]);
-    insta::assert_snapshot!(stdout, @"5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710");
+    insta::assert_snapshot!(stdout, @r"
+    5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "undo", "5b"]);
-    insta::assert_snapshot!(stdout, @"5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710");
+    insta::assert_snapshot!(stdout, @r"
+    5bbb4ca536a8	(2001-02-03 08:05:12) describe commit 968261075dddabf4b0e333c1cc9a49ce26a3f710
+    [EOF]
+    ");
 }
 
 #[test]
@@ -541,6 +617,7 @@ fn test_workspaces() {
     insta::assert_snapshot!(stdout, @r"
     def-second	(no description set)
     default	initial
+    [EOF]
     ");
 }
 
@@ -554,6 +631,7 @@ fn test_config() {
     insta::assert_snapshot!(stdout, @r"
     core.fsmonitor	Whether to use an external filesystem monitor, useful for large repos
     core.watchman.register_snapshot_trigger	Whether to use triggers to monitor for changes in the background.
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(dir, &["--", "jj", "config", "list", "c"]);
@@ -563,12 +641,14 @@ fn test_config() {
     core.fsmonitor	Whether to use an external filesystem monitor, useful for large repos
     core.watchman
     core.watchman.register_snapshot_trigger	Whether to use triggers to monitor for changes in the background.
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(dir, &["--", "jj", "log", "--config", "c"]);
     insta::assert_snapshot!(stdout, @r"
     core.fsmonitor=	Whether to use an external filesystem monitor, useful for large repos
     core.watchman.register_snapshot_trigger=	Whether to use triggers to monitor for changes in the background.
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(
@@ -579,12 +659,16 @@ fn test_config() {
     ui.conflict-marker-style=diff
     ui.conflict-marker-style=snapshot
     ui.conflict-marker-style=git
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(
         dir,
         &["--", "jj", "log", "--config", "ui.conflict-marker-style=g"],
     );
-    insta::assert_snapshot!(stdout, @"ui.conflict-marker-style=git");
+    insta::assert_snapshot!(stdout, @r"
+    ui.conflict-marker-style=git
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         dir,
@@ -599,6 +683,7 @@ fn test_config() {
     insta::assert_snapshot!(stdout, @r"
     git.abandon-unreachable-commits=false
     git.abandon-unreachable-commits=true
+    [EOF]
     ");
 }
 
@@ -626,6 +711,7 @@ fn test_template_alias() {
     description_placeholder
     email_placeholder
     name_placeholder
+    [EOF]
     ");
 }
 
@@ -742,7 +828,7 @@ fn test_files() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "--summary"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     @  wqnwkozp test.user@example.com 2001-02-03 08:05:20 working_copy 45c3a621
     │  working_copy
     │  A f_added_2
@@ -778,7 +864,8 @@ fn test_files() {
     │    A f_interdiff_only_from
     │    A f_interdiff_same
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     let mut test_env = test_env;
     test_env.add_env_var("COMPLETE", "fish");
@@ -793,6 +880,7 @@ fn test_files() {
     f_not_yet_renamed
     f_renamed
     f_unchanged
+    [EOF]
     ");
 
     let stdout =
@@ -804,6 +892,7 @@ fn test_files() {
     f_not_yet_renamed
     f_renamed
     f_unchanged
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "diff", "-r", "@-", "f_"]);
     insta::assert_snapshot!(stdout.normalize_backslash(), @r"
@@ -812,6 +901,7 @@ fn test_files() {
     f_dir/
     f_modified	Modified
     f_renamed	Added
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(
@@ -829,6 +919,7 @@ fn test_files() {
     f_dir/dir_file_1	Added
     f_dir/dir_file_2	Added
     f_dir/dir_file_3	Added
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(
@@ -842,6 +933,7 @@ fn test_files() {
     f_not_yet_renamed	Added
     f_renamed	Added
     f_unchanged	Added
+    [EOF]
     ");
 
     // interdiff has a different behavior with --from and --to flags
@@ -861,6 +953,7 @@ fn test_files() {
     f_interdiff_same	Added
     f_interdiff_only_to	Added
     f_interdiff_same	Added
+    [EOF]
     ");
 
     // squash has a different behavior with --from and --to flags
@@ -870,6 +963,7 @@ fn test_files() {
     f_modified	Added
     f_not_yet_renamed	Added
     f_unchanged	Added
+    [EOF]
     ");
 
     let stdout =
@@ -877,6 +971,7 @@ fn test_files() {
     insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_dir/
     f_modified
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "log", "f_"]);
@@ -888,6 +983,7 @@ fn test_files() {
     f_not_yet_renamed
     f_renamed
     f_unchanged
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -908,6 +1004,7 @@ fn test_files() {
     f_modified
     f_not_yet_renamed
     f_unchanged
+    [EOF]
     ");
 
     let outside_repo = test_env.env_root();

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -215,9 +215,13 @@ fn test_completions_are_generated() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &[]);
     // cannot use assert_snapshot!, output contains path to binary that depends
     // on environment
-    assert!(stdout.starts_with("complete --keep-order --exclusive --command jj --arguments"));
+    assert!(stdout
+        .raw()
+        .starts_with("complete --keep-order --exclusive --command jj --arguments"));
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["--"]);
-    assert!(stdout.starts_with("complete --keep-order --exclusive --command jj --arguments"));
+    assert!(stdout
+        .raw()
+        .starts_with("complete --keep-order --exclusive --command jj --arguments"));
 }
 
 #[test]
@@ -472,7 +476,14 @@ fn test_operations() {
     let test_env = test_env;
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "show", ""]);
-    let add_workspace_id = stdout.lines().nth(5).unwrap().split('\t').next().unwrap();
+    let add_workspace_id = stdout
+        .raw()
+        .lines()
+        .nth(5)
+        .unwrap()
+        .split('\t')
+        .next()
+        .unwrap();
     insta::assert_snapshot!(add_workspace_id, @"eac759b9ab75");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "op", "show", "5"]);
@@ -731,7 +742,7 @@ fn test_files() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "--summary"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     @  wqnwkozp test.user@example.com 2001-02-03 08:05:20 working_copy 45c3a621
     │  working_copy
     │  A f_added_2
@@ -774,7 +785,7 @@ fn test_files() {
     let test_env = test_env;
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "file", "show", "f_"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_added
     f_added_2
     f_dir/
@@ -786,7 +797,7 @@ fn test_files() {
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["--", "jj", "file", "annotate", "-r@-", "f_"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_added
     f_dir/
     f_modified
@@ -795,7 +806,7 @@ fn test_files() {
     f_unchanged
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "diff", "-r", "@-", "f_"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_added	Added
     f_deleted	Deleted
     f_dir/
@@ -814,7 +825,7 @@ fn test_files() {
             &format!("f_dir{}", std::path::MAIN_SEPARATOR),
         ],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_dir/dir_file_1	Added
     f_dir/dir_file_2	Added
     f_dir/dir_file_3	Added
@@ -824,7 +835,7 @@ fn test_files() {
         &repo_path,
         &["--", "jj", "diff", "--from", "root()", "--to", "@-", "f_"],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_added	Added
     f_dir/
     f_modified	Added
@@ -845,7 +856,7 @@ fn test_files() {
             "f_",
         ],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_interdiff_only_from	Added
     f_interdiff_same	Added
     f_interdiff_only_to	Added
@@ -854,7 +865,7 @@ fn test_files() {
 
     // squash has a different behavior with --from and --to flags
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "squash", "-f=first", "f_"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_deleted	Added
     f_modified	Added
     f_not_yet_renamed	Added
@@ -863,13 +874,13 @@ fn test_files() {
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["--", "jj", "resolve", "-r=conflicted", "f_"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_dir/
     f_modified
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["--", "jj", "log", "f_"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_added
     f_added_2
     f_dir/
@@ -890,7 +901,7 @@ fn test_files() {
             "f_",
         ],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     f_added_2
     f_deleted
     f_dir/

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 use itertools::Itertools as _;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -81,7 +82,7 @@ fn test_concurrent_operations_auto_rebase() {
     │  add workspace 'default'
     ○  000000000000 root()
     "#);
-    let op_id_hex = stdout[3..15].to_string();
+    let op_id_hex = stdout.raw()[3..15].to_string();
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "rewritten"]);
     test_env.jj_cmd_ok(
@@ -111,7 +112,7 @@ fn test_concurrent_operations_wc_modified() {
     std::fs::write(repo_path.join("file"), "contents\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    let op_id_hex = stdout[3..15].to_string();
+    let op_id_hex = stdout.raw()[3..15].to_string();
 
     test_env.jj_cmd_ok(
         &repo_path,
@@ -200,7 +201,7 @@ fn test_concurrent_snapshot_wc_reloadable() {
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
     "#);
-    let op_log_lines = op_log_stdout.lines().collect_vec();
+    let op_log_lines = op_log_stdout.raw().lines().collect_vec();
     let current_op_id = op_log_lines[0].split_once("  ").unwrap().1;
     let previous_op_id = op_log_lines[6].split_once("  ").unwrap().1;
 
@@ -234,7 +235,10 @@ fn test_concurrent_snapshot_wc_reloadable() {
     "###);
 }
 
-fn get_log_output_with_stderr(test_env: &TestEnvironment, cwd: &Path) -> (String, String) {
+fn get_log_output_with_stderr(
+    test_env: &TestEnvironment,
+    cwd: &Path,
+) -> (CommandOutputString, CommandOutputString) {
     let template = r#"commit_id ++ " " ++ description"#;
     test_env.jj_cmd_ok(cwd, &["log", "-T", template])
 }

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -36,30 +36,34 @@ fn test_concurrent_operation_divergence() {
     insta::assert_snapshot!(stderr, @r#"
     Error: The "@" expression resolved to more than one operation
     Hint: Try specifying one of the operations by ID: 0162305507cc, d74dff64472e
+    [EOF]
     "#);
 
     // "op log --at-op" should work without merging the head operations
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "--at-op=d74dff64472e"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  d74dff64472e test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     │  args: jj describe -m 'message 2' --at-op @-
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    [EOF]
+    ");
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  message 1
     │ ○  message 2
     ├─╯
     ◆
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -71,7 +75,7 @@ fn test_concurrent_operations_auto_rebase() {
     std::fs::write(repo_path.join("file"), "contents").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  c62ace5c0522 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
@@ -81,7 +85,8 @@ fn test_concurrent_operations_auto_rebase() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    [EOF]
+    ");
     let op_id_hex = stdout.raw()[3..15].to_string();
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "rewritten"]);
@@ -92,15 +97,17 @@ fn test_concurrent_operations_auto_rebase() {
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  db141860e12c2d5591c56fde4fc99caf71cec418 new child
     @  07c3641e495cce57ea4ca789123b52f421c57aa2 rewritten
     ◆  0000000000000000000000000000000000000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -126,18 +133,20 @@ fn test_concurrent_operations_wc_modified() {
 
     // We should be informed about the concurrent modification
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  4eadcf3df11f46ef3d825c776496221cc8303053 new child1
     │ ○  68119f1643b7e3c301c5f7c2b6c9bf4ccba87379 new child2
     ├─╯
     ○  2ff7ae858a3a11837fdf9d1a76be295ef53f1bb3 initial
     ◆  0000000000000000000000000000000000000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file b/file
     index 12f00e90b6..2e0996000b 100644
     --- a/file
@@ -145,11 +154,12 @@ fn test_concurrent_operations_wc_modified() {
     @@ -1,1 +1,1 @@
     -contents
     +modified
-    "###);
+    [EOF]
+    ");
 
     // The working copy should be committed after merging the operations
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  snapshot working copy
     ○    reconcile divergent operations
     ├─╮
@@ -160,7 +170,8 @@ fn test_concurrent_operations_wc_modified() {
     ○  snapshot working copy
     ○  add workspace 'default'
     ○
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -183,7 +194,7 @@ fn test_concurrent_snapshot_wc_reloadable() {
 
     let template = r#"id ++ "\n" ++ description ++ "\n" ++ tags"#;
     let op_log_stdout = test_env.jj_cmd_success(&repo_path, &["op", "log", "-T", template]);
-    insta::assert_snapshot!(op_log_stdout, @r#"
+    insta::assert_snapshot!(op_log_stdout, @r"
     @  ec6bf266624bbaed55833a34ae62fa95c0e9efa651b94eb28846972da645845052dcdc8580332a5628849f23f48b9e99fc728dc3fb13106df8d0666d746f8b85
     │  commit 554d22b2c43c1c47e279430197363e8daabe2fd6
     │  args: jj commit -m 'new child1'
@@ -200,7 +211,8 @@ fn test_concurrent_snapshot_wc_reloadable() {
     │  add workspace 'default'
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-    "#);
+    [EOF]
+    ");
     let op_log_lines = op_log_stdout.raw().lines().collect_vec();
     let current_op_id = op_log_lines[0].split_once("  ").unwrap().1;
     let previous_op_id = op_log_lines[6].split_once("  ").unwrap().1;
@@ -215,16 +227,17 @@ fn test_concurrent_snapshot_wc_reloadable() {
     std::fs::write(repo_path.join("child2"), "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "new child2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 1795621b new child2
     Parent commit      : rlvkpnrz 86f54245 new child1
-    "###);
+    [EOF]
+    ");
 
     // Since the repo can be reloaded before snapshotting, "child2" should be
     // a child of "child1", not of "initial".
     let template = r#"commit_id ++ " " ++ description"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template, "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  1795621b54f4ebb435978b65d66bc0f90d8f20b6 new child2
     │  A child2
     ○  86f54245e13f850f8275b5541e56da996b6a47b7 new child1
@@ -232,7 +245,8 @@ fn test_concurrent_snapshot_wc_reloadable() {
     ○  84f07f6bca2ffeddac84a8b09f60c6b81112375c initial
     │  A base
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output_with_stderr(

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -152,7 +152,7 @@ fn test_config_list_all() {
 
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["config", "list"]);
     insta::assert_snapshot!(
-        find_stdout_lines(r"(test-val|test-table\b[^=]*)", &stdout),
+        find_stdout_lines(r"(test-val|test-table\b[^=]*)", stdout.raw()),
         @r###"
     test-val = [1, 2, 3]
     test-table.x = true
@@ -1269,7 +1269,7 @@ fn test_config_author_change_warning() {
     log_cmd.assert().success();
 
     let (stdout, _) = test_env.jj_cmd_ok(&repo_path, &["log"]);
-    assert!(stdout.contains("Foo"));
+    assert!(stdout.raw().contains("Foo"));
 }
 
 #[test]

--- a/cli/tests/test_copy_detection.rs
+++ b/cli/tests/test_copy_detection.rs
@@ -27,7 +27,7 @@ fn test_simple_rename() {
     std::fs::remove_file(repo_path.join("original")).unwrap();
     std::fs::write(repo_path.join("modified"), "original").unwrap();
     std::fs::write(repo_path.join("something"), "changed").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["debug", "copy-detection"]).replace('\\', "/"),
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["debug", "copy-detection"]).normalize_backslash(),
     @r###"
     original -> modified
     "###);

--- a/cli/tests/test_copy_detection.rs
+++ b/cli/tests/test_copy_detection.rs
@@ -27,8 +27,9 @@ fn test_simple_rename() {
     std::fs::remove_file(repo_path.join("original")).unwrap();
     std::fs::write(repo_path.join("modified"), "original").unwrap();
     std::fs::write(repo_path.join("something"), "changed").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["debug", "copy-detection"]).normalize_backslash(),
-    @r###"
+    insta::assert_snapshot!(
+        test_env.jj_cmd_success(&repo_path, &["debug", "copy-detection"]).normalize_backslash(), @r"
     original -> modified
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_debug_command.rs
+++ b/cli/tests/test_debug_command.rs
@@ -25,16 +25,17 @@ fn test_debug_fileset() {
     let workspace_path = test_env.env_root().join("repo");
 
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "fileset", "all()"]);
-    assert_snapshot!(stdout, @r###"
+    assert_snapshot!(stdout, @r"
     -- Parsed:
     All
 
     -- Matcher:
     EverythingMatcher
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&workspace_path, &["debug", "fileset", "cwd:.."]);
-    assert_snapshot!(stderr.normalize_backslash(), @r###"
+    assert_snapshot!(stderr.normalize_backslash(), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -45,7 +46,8 @@ fn test_debug_fileset() {
       = Invalid file pattern
     2: Path ".." is not in the repo "."
     3: Invalid component ".." in repo-relative path "../"
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -80,6 +82,7 @@ fn test_debug_revset() {
 
         -- Commit IDs:
         0000000000000000000000000000000000000000
+        [EOF]
         ");
     });
 }
@@ -90,7 +93,7 @@ fn test_debug_index() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let workspace_path = test_env.env_root().join("repo");
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "index"]);
-    assert_snapshot!(filter_index_stats(stdout), @r###"
+    assert_snapshot!(filter_index_stats(stdout), @r"
     Number of commits: 2
     Number of merges: 0
     Max generation number: 1
@@ -100,7 +103,8 @@ fn test_debug_index() {
       Level 0:
         Number of commits: 2
         Name: [hash]
-    "###
+    [EOF]
+    "
     );
 }
 
@@ -112,7 +116,7 @@ fn test_debug_reindex() {
     test_env.jj_cmd_ok(&workspace_path, &["new"]);
     test_env.jj_cmd_ok(&workspace_path, &["new"]);
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "index"]);
-    assert_snapshot!(filter_index_stats(stdout), @r###"
+    assert_snapshot!(filter_index_stats(stdout), @r"
     Number of commits: 4
     Number of merges: 0
     Max generation number: 3
@@ -125,15 +129,17 @@ fn test_debug_reindex() {
       Level 1:
         Number of commits: 1
         Name: [hash]
-    "###
+    [EOF]
+    "
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["debug", "reindex"]);
     assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Finished indexing 4 commits.
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "index"]);
-    assert_snapshot!(filter_index_stats(stdout), @r###"
+    assert_snapshot!(filter_index_stats(stdout), @r"
     Number of commits: 4
     Number of merges: 0
     Max generation number: 3
@@ -143,7 +149,8 @@ fn test_debug_reindex() {
       Level 0:
         Number of commits: 4
         Name: [hash]
-    "###
+    [EOF]
+    "
     );
 }
 
@@ -160,24 +167,27 @@ fn test_debug_tree() {
 
     // Defaults to showing the tree at the current commit
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "tree"]);
-    assert_snapshot!(stdout.normalize_backslash(), @r###"
+    assert_snapshot!(stdout.normalize_backslash(), @r#"
     dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    [EOF]
+    "#
     );
 
     // Can show the tree at another commit
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "tree", "-r@-"]);
-    assert_snapshot!(stdout.normalize_backslash(), @r###"
+    assert_snapshot!(stdout.normalize_backslash(), @r#"
     dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
-    "###
+    [EOF]
+    "#
     );
 
     // Can filter by paths
     let stdout = test_env.jj_cmd_success(&workspace_path, &["debug", "tree", "dir/subdir/file2"]);
-    assert_snapshot!(stdout.normalize_backslash(), @r###"
+    assert_snapshot!(stdout.normalize_backslash(), @r#"
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    [EOF]
+    "#
     );
 
     // Can a show the root tree by id
@@ -189,10 +199,11 @@ fn test_debug_tree() {
             "--id=0958358e3f80e794f032b25ed2be96cf5825da6c",
         ],
     );
-    assert_snapshot!(stdout.normalize_backslash(), @r###"
+    assert_snapshot!(stdout.normalize_backslash(), @r#"
     dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    [EOF]
+    "#
     );
 
     // Can a show non-root tree by id
@@ -205,10 +216,11 @@ fn test_debug_tree() {
             "--id=6ac232efa713535ae518a1a898b77e76c0478184",
         ],
     );
-    assert_snapshot!(stdout.normalize_backslash(), @r###"
+    assert_snapshot!(stdout.normalize_backslash(), @r#"
     dir/subdir/file1: Ok(Resolved(Some(File { id: FileId("498e9b01d79cb8d31cdf0df1a663cc1fcefd9de3"), executable: false })))
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    [EOF]
+    "#
     );
 
     // Can filter by paths when showing non-root tree (matcher applies from root)
@@ -222,9 +234,10 @@ fn test_debug_tree() {
             "dir/subdir/file2",
         ],
     );
-    assert_snapshot!(stdout.normalize_backslash(), @r###"
+    assert_snapshot!(stdout.normalize_backslash(), @r#"
     dir/subdir/file2: Ok(Resolved(Some(File { id: FileId("b2496eaffe394cd50a9db4de5787f45f09fd9722"), executable: false })))
-    "###
+    [EOF]
+    "#
     );
 }
 
@@ -235,9 +248,10 @@ fn test_debug_operation_id() {
     let workspace_path = test_env.env_root().join("repo");
     let stdout =
         test_env.jj_cmd_success(&workspace_path, &["debug", "operation", "--display", "id"]);
-    assert_snapshot!(filter_index_stats(stdout), @r#"
+    assert_snapshot!(filter_index_stats(stdout), @r"
     eac759b9ab75793fd3da96e60939fb48f2cd2b2a9c1f13ffe723cf620f3005b8d3e7e923634a07ea39513e4f2f360c87b9ad5d331cf90d7a844864b83b72eba1
-    "#
+    [EOF]
+    "
     );
 }
 

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use indoc::indoc;
 
 use crate::common::get_stderr_string;
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -849,7 +850,7 @@ fn test_edit_cannot_be_used_with_no_edit() {
     ");
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"commit_id.short() ++ " " ++ description"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -33,27 +33,30 @@ fn test_describe() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description from CLI"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 95979928 (empty) description from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Set the same description using `-m` flag, but with explicit newline
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description from CLI\n"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 
     // Check that the text file gets initialized with the current description and
     // make no changes
     std::fs::write(&edit_script, "dump editor0").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     description from CLI
@@ -65,10 +68,11 @@ fn test_describe() {
     std::fs::write(&edit_script, "write\ndescription from editor").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 94fcb906 (empty) description from editor
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Lines in editor starting with "JJ: " are ignored
     std::fs::write(
@@ -78,64 +82,72 @@ fn test_describe() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 7a348923 (empty) description among comment
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Multi-line description
     std::fs::write(&edit_script, "write\nline1\nline2\n\nline4\n\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 749361b5 (empty) line1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     line1
     line2
 
     line4
-    "###);
+    [EOF]
+    ");
 
     // Multi-line description again with CRLF, which should make no changes
     std::fs::write(&edit_script, "write\nline1\r\nline2\r\n\r\nline4\r\n\r\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 
     // Multi-line description starting with newlines
     std::fs::write(&edit_script, "write\n\n\nline1\nline2").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm dc44dbee (empty) line1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     line1
     line2
-    "#);
+    [EOF]
+    ");
 
     // Clear description
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-m", ""]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 6296963b (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     std::fs::write(&edit_script, "write\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 
     // Fails if the editor fails
     std::fs::write(&edit_script, "fail").unwrap();
@@ -151,6 +163,7 @@ fn test_describe() {
         Error: Failed to edit description
         Caused by: Editor '<redacted>' exited with exit status: 1
         Hint: Edited description is left in $TEST_ENV/repo/.jj/repo/editor-<redacted>.jjdescription
+        [EOF]
         ");
     });
 
@@ -171,17 +184,19 @@ fn test_describe() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 10fa2dc7 (empty) description from editor
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "#);
+    [EOF]
+    ");
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     description from editor
 
     content of message from editor
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -236,12 +251,13 @@ fn test_describe_multiple_commits() {
     // Initial setup
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c6349e79bbfd
     ○  65b6b74e0897
     ○  230dd059e1b0
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Set the description of multiple commits using `-m` flag
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -249,18 +265,20 @@ fn test_describe_multiple_commits() {
         &["describe", "-r@", "-r@--", "-m", "description from CLI"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Updated 2 commits
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 41659b84 (empty) description from CLI
     Parent commit      : rlvkpnrz 8d650510 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  41659b846096 description from CLI
     ○  8d650510daad
     ○  a42f5755e688 description from CLI
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Check that the text file gets initialized with the current description of
     // each commit and doesn't update commits if no changes are made.
@@ -268,9 +286,10 @@ fn test_describe_multiple_commits() {
     std::fs::write(&edit_script, "dump editor0").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "-r@", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
@@ -311,12 +330,13 @@ fn test_describe_multiple_commits() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "@", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Updated 2 commits
     Working copy now at: kkmpptxz f203494a (empty) description from editor of @
     Parent commit      : rlvkpnrz 0d76a92c (empty) description from editor of @-
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f203494a4507 description from editor of @
     │
     │  further commit message of @
@@ -325,7 +345,8 @@ fn test_describe_multiple_commits() {
     │  further commit message of @-
     ○  a42f5755e688 description from CLI
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Fails if the edited message has a commit with multiple descriptions
     std::fs::write(
@@ -352,9 +373,10 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The following commits were found in the edited message multiple times: 0d76a92ca7cc
-    "###);
+    [EOF]
+    ");
 
     // Fails if the edited message has unexpected commit IDs
     std::fs::write(
@@ -379,9 +401,10 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The following commits were not being edited, but were found in the edited message: 000000000000
-    "###);
+    [EOF]
+    ");
 
     // Fails if the edited message has missing commit messages
     std::fs::write(
@@ -398,9 +421,10 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The description for the following commits were not found in the edited message: 0d76a92ca7cc
-    "###);
+    [EOF]
+    ");
 
     // Fails if the edited message has a line which does not have any preceding
     // `JJ: describe` headers
@@ -418,9 +442,10 @@ fn test_describe_multiple_commits() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["describe", "@", "@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: Found the following line without a commit header: "description from editor of @-"
-    "###);
+    [EOF]
+    "#);
 
     // Fails if the editor fails
     std::fs::write(&edit_script, "fail").unwrap();
@@ -436,6 +461,7 @@ fn test_describe_multiple_commits() {
         Error: Failed to edit description
         Caused by: Editor '<redacted>' exited with exit status: 1
         Hint: Edited description is left in $TEST_ENV/repo/.jj/repo/editor-<redacted>.jjdescription
+        [EOF]
         ");
     });
 
@@ -460,20 +486,22 @@ fn test_describe_multiple_commits() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "@--"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Updated 2 commits
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 1d7701ee (empty) description from editor of @
     Parent commit      : rlvkpnrz 5389926e (empty) description from editor for @-
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  1d7701eec9bc description from editor of @
     │
     │  further commit message of @
     ○  5389926ebed6 description from editor for @-
     ○  eaa8547ae37a description from editor for @--
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -494,18 +522,20 @@ fn test_multiple_message_args() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 99a36a50 (empty) First Paragraph from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     First Paragraph from CLI
 
     Second Paragraph from CLI
-    "###);
+    [EOF]
+    ");
 
     // Set the same description, with existing newlines
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -519,9 +549,10 @@ fn test_multiple_message_args() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 
     // Use an empty -m flag between paragraphs to insert an extra blank line
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -537,19 +568,21 @@ fn test_multiple_message_args() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 01ac40b3 (empty) First Paragraph from CLI
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-r@", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     First Paragraph from CLI
 
 
     Second Paragraph from CLI
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -565,10 +598,11 @@ fn test_describe_default_description() {
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["describe"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 573b6df5 TESTED=TODO
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
     TESTED=TODO
@@ -627,7 +661,7 @@ fn test_describe_author() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    insta::assert_snapshot!(get_signatures(), @r###"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Test User test.user@example.com 2001-02-03 04:05:10.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:10.000 +07:00
     ○  Test User test.user@example.com 2001-02-03 04:05:09.000 +07:00
@@ -637,7 +671,8 @@ fn test_describe_author() {
     ○  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     ~
-    "###);
+    [EOF]
+    ");
 
     // Change the author for the latest commit (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -648,7 +683,7 @@ fn test_describe_author() {
             "Super Seeder <super.seeder@example.com>",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Super Seeder super.seeder@example.com 2001-02-03 04:05:12.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:12.000 +07:00
     ○  Test User test.user@example.com 2001-02-03 04:05:09.000 +07:00
@@ -658,7 +693,8 @@ fn test_describe_author() {
     ○  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:07.000 +07:00
     ~
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
     JJ: Author: Super Seeder <super.seeder@example.com> (2001-02-03 08:05:12)
@@ -681,7 +717,7 @@ fn test_describe_author() {
             "Super Seeder <super.seeder@example.com>",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Super Seeder super.seeder@example.com 2001-02-03 04:05:12.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:14.000 +07:00
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
@@ -691,7 +727,8 @@ fn test_describe_author() {
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:14.000 +07:00
     ~
-    "#);
+    [EOF]
+    ");
 
     // Reset the author for the latest commit (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -704,7 +741,7 @@ fn test_describe_author() {
             "--reset-author",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:16.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:16.000 +07:00
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
@@ -714,7 +751,8 @@ fn test_describe_author() {
     ○  Super Seeder super.seeder@example.com 2001-02-03 04:05:14.000 +07:00
     │  Test User test.user@example.com 2001-02-03 04:05:14.000 +07:00
     ~
-    "#);
+    [EOF]
+    ");
 
     // Reset the author for multiple commits (the committer is always reset)
     test_env.jj_cmd_ok(
@@ -728,7 +766,7 @@ fn test_describe_author() {
             "--reset-author",
         ],
     );
-    insta::assert_snapshot!(get_signatures(), @r#"
+    insta::assert_snapshot!(get_signatures(), @r"
     @  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     ○  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
@@ -738,7 +776,8 @@ fn test_describe_author() {
     ○  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     │  Ove Ridder ove.ridder@example.com 2001-02-03 04:05:18.000 +07:00
     ~
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
@@ -798,6 +837,7 @@ fn test_describe_with_edit_and_message_args_opens_editor() {
     insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 61ece7a9 (empty) message from command line
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
@@ -825,6 +865,7 @@ fn test_describe_change_with_existing_message_with_edit_and_message_args_opens_e
     insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm de694560 (empty) new message
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
@@ -847,6 +888,7 @@ fn test_edit_cannot_be_used_with_no_edit() {
     Usage: jj describe --no-edit [REVSETS]...
 
     For more information, try '--help'.
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -34,7 +34,7 @@ fn test_diff_basic() {
     std::fs::write(repo_path.join("file4"), "1\n2\n3\n4\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: 1
        2    2: 25
@@ -42,10 +42,11 @@ fn test_diff_basic() {
        4     : 4
     Modified regular file file3 (file1 => file3):
     Modified regular file file4 (file2 => file4):
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=0"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: 1
        2    2: 25
@@ -53,10 +54,11 @@ fn test_diff_basic() {
        4     : 4
     Modified regular file file3 (file1 => file3):
     Modified regular file file4 (file2 => file4):
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3m<<diff header::Modified regular file file2:>>[39m
     [38;5;1m<<diff removed line_number::   1>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: 1>>
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;1m<<diff removed token::2>>[38;5;2m<<diff added token::5>>[24m[39m<<diff::>>
@@ -64,27 +66,31 @@ fn test_diff_basic() {
     [38;5;1m<<diff removed line_number::   4>>[39m<<diff::     : >>[4m[38;5;1m<<diff removed token::4>>[24m[39m
     [38;5;3m<<diff header::Modified regular file file3 (file1 => file3):>>[39m
     [38;5;3m<<diff header::Modified regular file file4 (file2 => file4):>>[39m
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
     R {file1 => file3}
     C {file2 => file4}
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--types"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     FF file2
     FF {file1 => file3}
     FF {file2 => file4}
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--types", "glob:file[12]"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     F- file1
     FF file2
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "file1"]);
     insta::assert_snapshot!(stdout, @r"
@@ -95,10 +101,11 @@ fn test_diff_basic() {
     +++ /dev/null
     @@ -1,1 +0,0 @@
     -foo
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file2 b/file2
     index 94ebaf9001..1ffc51b472 100644
     --- a/file2
@@ -115,7 +122,8 @@ fn test_diff_basic() {
     diff --git a/file2 b/file4
     copy from file2
     copy to file4
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=0"]);
     insta::assert_snapshot!(stdout, @r"
@@ -134,10 +142,11 @@ fn test_diff_basic() {
     diff --git a/file2 b/file4
     copy from file2
     copy to file4
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m<<diff file_header::diff --git a/file2 b/file2>>[0m
     [1m<<diff file_header::index 94ebaf9001..1ffc51b472 100644>>[0m
     [1m<<diff file_header::--- a/file2>>[0m
@@ -154,10 +163,11 @@ fn test_diff_basic() {
     [1m<<diff file_header::diff --git a/file2 b/file4>>[0m
     [1m<<diff file_header::copy from file2>>[0m
     [1m<<diff file_header::copy to file4>>[0m
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
     R {file1 => file3}
     C {file2 => file4}
@@ -177,22 +187,25 @@ fn test_diff_basic() {
     diff --git a/file2 b/file4
     copy from file2
     copy to file4
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2            | 3 +--
     {file1 => file3} | 0
     {file2 => file4} | 0
     3 files changed, 1 insertion(+), 2 deletions(-)
-    "###);
+    [EOF]
+    ");
 
     // Filter by glob pattern
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "glob:file[12]"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     M file2
-    "###);
+    [EOF]
+    ");
 
     // Unmatched paths should generate warnings
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -207,14 +220,16 @@ fn test_diff_basic() {
             "repo/y/z",
         ],
     );
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     M repo/file2
     R repo/{file1 => file3}
     C repo/{file2 => file4}
-    "###);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r"
     Warning: No matching entries for paths: repo/x, repo/y/z
-    "###);
+    [EOF]
+    ");
 
     // Unmodified paths shouldn't generate warnings
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["diff", "-s", "--from=@", "file2"]);
@@ -230,24 +245,27 @@ fn test_diff_empty() {
 
     std::fs::write(repo_path.join("file1"), "").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added regular file file1:
         (empty)
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::remove_file(repo_path.join("file1")).unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Removed regular file file1:
         (empty)
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 0
     1 file changed, 0 insertions(+), 0 deletions(-)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -281,7 +299,7 @@ fn test_diff_file_mode() {
     std::fs::remove_file(repo_path.join("file4")).unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@--"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Added executable file file1:
         (empty)
     Added executable file file2:
@@ -290,18 +308,20 @@ fn test_diff_file_mode() {
             1: 1
     Added regular file file4:
         (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Executable file became non-executable at file1:
             1: 2
     Executable file became non-executable at file2:
     Non-executable file became executable at file3:
        1    1: 12
     Non-executable file became executable at file4:
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Removed regular file file1:
        1     : 2
     Removed regular file file2:
@@ -310,7 +330,8 @@ fn test_diff_file_mode() {
        1     : 2
     Removed executable file file4:
         (empty)
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@--", "--git"]);
     insta::assert_snapshot!(stdout, @r"
@@ -334,6 +355,7 @@ fn test_diff_file_mode() {
     diff --git a/file4 b/file4
     new file mode 100644
     index 0000000000..e69de29bb2
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@-", "--git"]);
     insta::assert_snapshot!(stdout, @r"
@@ -360,6 +382,7 @@ fn test_diff_file_mode() {
     diff --git a/file4 b/file4
     old mode 100644
     new mode 100755
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-r@", "--git"]);
     insta::assert_snapshot!(stdout, @r"
@@ -387,6 +410,7 @@ fn test_diff_file_mode() {
     diff --git a/file4 b/file4
     deleted file mode 100755
     index e69de29bb2..0000000000
+    [EOF]
     ");
 }
 
@@ -438,24 +462,29 @@ fn test_diff_types() {
             ],
         )
     };
-    insta::assert_snapshot!(diff("missing", "file"), @r###"
+    insta::assert_snapshot!(diff("missing", "file"), @r"
     -F foo
-    "###);
-    insta::assert_snapshot!(diff("file", "conflict"), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(diff("file", "conflict"), @r"
     FC foo
-    "###);
-    insta::assert_snapshot!(diff("conflict", "missing"), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(diff("conflict", "missing"), @r"
     C- foo
-    "###);
+    [EOF]
+    ");
 
     #[cfg(unix)]
     {
-        insta::assert_snapshot!(diff("symlink", "file"), @r###"
+        insta::assert_snapshot!(diff("symlink", "file"), @r"
         LF foo
-        "###);
-        insta::assert_snapshot!(diff("missing", "executable"), @r###"
+        [EOF]
+        ");
+        insta::assert_snapshot!(diff("missing", "executable"), @r"
         -F foo
-        "###);
+        [EOF]
+        ");
     }
 }
 
@@ -468,10 +497,11 @@ fn test_diff_name_only() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("deleted"), "d").unwrap();
     std::fs::write(repo_path.join("modified"), "m").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]), @r"
     deleted
     modified
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["commit", "-mfirst"]);
     std::fs::remove_file(repo_path.join("deleted")).unwrap();
     std::fs::write(repo_path.join("modified"), "mod").unwrap();
@@ -479,12 +509,13 @@ fn test_diff_name_only() {
     std::fs::create_dir(repo_path.join("sub")).unwrap();
     std::fs::write(repo_path.join("sub/added"), "sub/add").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]).normalize_backslash(),
-    @r###"
+    @r"
     added
     deleted
     modified
     sub/added
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -494,22 +525,24 @@ fn test_diff_bad_args() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["diff", "-s", "--types"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--summary' cannot be used with '--types'
 
     Usage: jj diff --summary [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["diff", "--color-words", "--git"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--color-words' cannot be used with '--git'
 
     Usage: jj diff --color-words [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -540,7 +573,7 @@ fn test_diff_relative_paths() {
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: foo2bar2
     Modified regular file subdir1/file3:
@@ -549,9 +582,10 @@ fn test_diff_relative_paths() {
        1    1: foo4bar4
     Modified regular file ../file1:
        1    1: foo1bar1
-    "###);
+    [EOF]
+    ");
     #[cfg(windows)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: foo2bar2
     Modified regular file subdir1\file3:
@@ -560,42 +594,47 @@ fn test_diff_relative_paths() {
        1    1: foo4bar4
     Modified regular file ..\file1:
        1    1: foo1bar1
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "-s"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
     M subdir1/file3
     M ../dir2/file4
     M ../file1
-    "###);
+    [EOF]
+    ");
     #[cfg(windows)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
     M subdir1\file3
     M ..\dir2\file4
     M ..\file1
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "--types"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     FF file2
     FF subdir1/file3
     FF ../dir2/file4
     FF ../file1
-    "###);
+    [EOF]
+    ");
     #[cfg(windows)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     FF file2
     FF subdir1\file3
     FF ..\dir2\file4
     FF ..\file1
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/dir1/file2 b/dir1/file2
     index 54b060eee9..1fe912cdd8 100644
     --- a/dir1/file2
@@ -624,25 +663,28 @@ fn test_diff_relative_paths() {
     @@ -1,1 +1,1 @@
     -foo1
     +bar1
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path.join("dir1"), &["diff", "--stat"]);
     #[cfg(unix)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2         | 2 +-
     subdir1/file3 | 2 +-
     ../dir2/file4 | 2 +-
     ../file1      | 2 +-
     4 files changed, 4 insertions(+), 4 deletions(-)
-    "###);
+    [EOF]
+    ");
     #[cfg(windows)]
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2         | 2 +-
     subdir1\file3 | 2 +-
     ..\dir2\file4 | 2 +-
     ..\file1      | 2 +-
     4 files changed, 4 insertions(+), 4 deletions(-)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -662,7 +704,7 @@ fn test_diff_hunks() {
     std::fs::write(repo_path.join("file3"), "foo\nbar\nbaz quux blah blah\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
             1: foo
     Modified regular file file2:
@@ -671,10 +713,11 @@ fn test_diff_hunks() {
        1    1: foo
             2: bar
        2    3: baz quxquux blah blah
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3m<<diff header::Modified regular file file1:>>[39m
     <<diff::     >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::foo>>[24m[39m
     [38;5;3m<<diff header::Modified regular file file2:>>[39m
@@ -683,7 +726,8 @@ fn test_diff_hunks() {
     [38;5;1m<<diff removed line_number::   1>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: foo>>
     <<diff::     >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::bar>>[24m[39m
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   3>>[39m<<diff::: baz >>[4m[38;5;1m<<diff removed token::qux>>[38;5;2m<<diff added token::quux>>[24m[39m<<diff:: blah blah>>
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
     insta::assert_snapshot!(stdout, @r"
@@ -708,6 +752,7 @@ fn test_diff_hunks() {
     -baz qux blah blah
     +bar
     +baz quux blah blah
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--color=debug"]);
@@ -733,6 +778,7 @@ fn test_diff_hunks() {
     [38;5;1m<<diff removed::-baz >>[4m<<diff removed token::qux>>[24m<<diff removed:: blah blah>>[39m
     [38;5;2m<<diff added::+>>[4m<<diff added token::bar>>[24m[39m
     [38;5;2m<<diff added::+baz >>[4m<<diff added token::quux>>[24m<<diff added:: blah blah>>[39m
+    [EOF]
     ");
 }
 
@@ -852,7 +898,7 @@ fn test_diff_color_words_inlining_threshold() {
 
     // default
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -895,10 +941,11 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    [EOF]
+    ");
 
     // -1: inline all
-    insta::assert_snapshot!(render_diff(-1, &[]), @r###"
+    insta::assert_snapshot!(render_diff(-1, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -937,10 +984,11 @@ fn test_diff_color_words_inlining_threshold() {
       13   13: X a Y b
       14   13: c d
       14   14: Z e f g
-    "###);
+    [EOF]
+    ");
 
     // 0: no inlining
-    insta::assert_snapshot!(render_diff(0, &[]), @r###"
+    insta::assert_snapshot!(render_diff(0, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2     : a b c
@@ -994,10 +1042,11 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    [EOF]
+    ");
 
     // 1: inline adds-only or removes-only lines
-    insta::assert_snapshot!(render_diff(1, &[]), @r###"
+    insta::assert_snapshot!(render_diff(1, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1047,10 +1096,11 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    [EOF]
+    ");
 
     // 2: inline up to adds + removes lines
-    insta::assert_snapshot!(render_diff(2, &[]), @r###"
+    insta::assert_snapshot!(render_diff(2, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1095,10 +1145,11 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    [EOF]
+    ");
 
     // 3: inline up to adds + removes + adds lines
-    insta::assert_snapshot!(render_diff(3, &[]), @r###"
+    insta::assert_snapshot!(render_diff(3, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1141,10 +1192,11 @@ fn test_diff_color_words_inlining_threshold() {
       14     : c d e f g
            13: X a Y b d
            14: Z e
-    "###);
+    [EOF]
+    ");
 
     // 4: inline up to adds + removes + adds + removes lines
-    insta::assert_snapshot!(render_diff(4, &[]), @r###"
+    insta::assert_snapshot!(render_diff(4, &[]), @r"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1183,10 +1235,11 @@ fn test_diff_color_words_inlining_threshold() {
       13   13: X a Y b
       14   13: c d
       14   14: Z e f g
-    "###);
+    [EOF]
+    ");
 
     // context words in added/removed lines should be labeled as such
-    insta::assert_snapshot!(render_diff(2, &["--color=always"]), @r###"
+    insta::assert_snapshot!(render_diff(2, &["--color=always"]), @r"
     [38;5;3mModified regular file file1-single-line:[39m
     [38;5;1m   1[39m [38;5;2m   1[39m: == adds ==
     [38;5;1m   2[39m [38;5;2m   2[39m: a [4m[38;5;2mX [24m[39mb [4m[38;5;2mY Z [24m[39mc
@@ -1231,8 +1284,9 @@ fn test_diff_color_words_inlining_threshold() {
     [38;5;1m  14[39m     : [4m[38;5;1mc[24m d e[4m f g[24m[39m
          [38;5;2m  13[39m: [4m[38;5;2mX [24ma [4mY [24mb d[4m[24m[39m
          [38;5;2m  14[39m: [4m[38;5;2mZ[24m e[39m
-    "###);
-    insta::assert_snapshot!(render_diff(2, &["--color=debug"]), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(render_diff(2, &["--color=debug"]), @r"
     [38;5;3m<<diff header::Modified regular file file1-single-line:>>[39m
     [38;5;1m<<diff removed line_number::   1>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   1>>[39m<<diff::: == adds ==>>
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: a >>[4m[38;5;2m<<diff added token::X >>[24m[39m<<diff::b >>[4m[38;5;2m<<diff added token::Y Z >>[24m[39m<<diff::c>>
@@ -1277,7 +1331,8 @@ fn test_diff_color_words_inlining_threshold() {
     [38;5;1m<<diff removed line_number::  14>>[39m<<diff::     : >>[4m[38;5;1m<<diff removed token::c>>[24m<<diff removed:: d e>>[4m<<diff removed token:: f g>>[24m<<diff removed::>>[39m
     <<diff::     >>[38;5;2m<<diff added line_number::  13>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::X >>[24m<<diff added::a >>[4m<<diff added token::Y >>[24m<<diff added::b d>>[4m<<diff added token::>>[24m[39m
     <<diff::     >>[38;5;2m<<diff added line_number::  14>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::Z>>[24m<<diff added:: e>>[39m
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1293,17 +1348,18 @@ fn test_diff_missing_newline() {
     std::fs::write(repo_path.join("file2"), "foo").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: foo
             2: bar
     Modified regular file file2:
        1    1: foo
        2     : bar
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1910281566..a907ec3f43 100644
     --- a/file1
@@ -1324,14 +1380,16 @@ fn test_diff_missing_newline() {
     \ No newline at end of file
     +foo
     \ No newline at end of file
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 3 ++-
     file2 | 3 +--
     2 files changed, 3 insertions(+), 3 deletions(-)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1367,7 +1425,7 @@ fn test_color_words_diff_missing_newline() {
             "--reversed",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Empty
     Added regular file file1:
         (empty)
@@ -1432,7 +1490,8 @@ fn test_color_words_diff_missing_newline() {
        7     : g
        8     : h
        9     : I
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -1445,7 +1504,7 @@ fn test_color_words_diff_missing_newline() {
             "--reversed",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Empty
     Added regular file file1:
         (empty)
@@ -1515,7 +1574,8 @@ fn test_color_words_diff_missing_newline() {
        7     : g
        8     : h
        9     : I
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1551,7 +1611,7 @@ fn test_diff_ignore_whitespace() {
 
     // Git diff as reference output
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--ignore-all-space"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index f532aa68ad..033c4a6168 100644
     --- a/file1
@@ -1563,9 +1623,10 @@ fn test_diff_ignore_whitespace() {
          }
     +}
      baz {  }
-    "#);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--ignore-space-change"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index f532aa68ad..033c4a6168 100644
     --- a/file1
@@ -1579,26 +1640,29 @@ fn test_diff_ignore_whitespace() {
      }
     -baz {}
     +baz {  }
-    "#);
+    [EOF]
+    ");
 
     // Diff-stat should respects the whitespace options
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat", "--ignore-all-space"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 2 ++
     1 file changed, 2 insertions(+), 0 deletions(-)
-    "#);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat", "--ignore-space-change"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 6 ++++--
     1 file changed, 4 insertions(+), 2 deletions(-)
-    "#);
+    [EOF]
+    ");
 
     // Word-level changes are still highlighted
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["diff", "--color=always", "--ignore-all-space"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3mModified regular file file1:[39m
          [38;5;2m   1[39m: [4m[38;5;2m{[24m[39m
     [38;5;1m   1[39m [38;5;2m   2[39m: [4m[38;5;2m    [24m[39mfoo {
@@ -1606,12 +1670,13 @@ fn test_diff_ignore_whitespace() {
     [38;5;1m   3[39m [38;5;2m   4[39m: [4m[38;5;2m    [24m[39m}
          [38;5;2m   5[39m: [4m[38;5;2m}[24m[39m
     [38;5;1m   4[39m [38;5;2m   6[39m: baz {[4m[38;5;2m  [24m[39m}
-    "#);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["diff", "--color=always", "--ignore-space-change"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;3mModified regular file file1:[39m
          [38;5;2m   1[39m: [4m[38;5;2m{[24m[39m
     [38;5;1m   1[39m [38;5;2m   2[39m: [4m[38;5;2m    [24m[39mfoo {
@@ -1619,7 +1684,8 @@ fn test_diff_ignore_whitespace() {
          [38;5;2m   4[39m: [4m[38;5;2m    }[24m[39m
     [38;5;1m   3[39m [38;5;2m   5[39m: }
     [38;5;1m   4[39m [38;5;2m   6[39m: baz {[4m[38;5;2m  [24m[39m}
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1648,7 +1714,7 @@ fn test_diff_skipped_context() {
         &repo_path,
         &["log", "-Tdescription", "-p", "--no-graph", "--reversed"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Left side of diffs
     Added regular file file1:
             1: a
@@ -1730,7 +1796,8 @@ fn test_diff_skipped_context() {
        8    8: h
        9    9: i
       10   10: j
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1756,7 +1823,7 @@ context = 0
         &repo_path,
         &["log", "-Tdescription", "-p", "--no-graph", "--reversed"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     === First commit
     Added regular file file1:
             1: a
@@ -1769,7 +1836,8 @@ context = 0
         ...
        3    3: cC
         ...
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1824,6 +1892,7 @@ context = 0
     @@ -3,1 +3,1 @@
     -c
     +C
+    [EOF]
     ");
 }
 
@@ -1858,7 +1927,7 @@ fn test_diff_skipped_context_nondefault() {
             "--context=0",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     === Left side of diffs
     Added regular file file1:
             1: a
@@ -1892,7 +1961,8 @@ fn test_diff_skipped_context_nondefault() {
         ...
        3    3: cC
        4    4: d
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1916,7 +1986,7 @@ fn test_diff_leading_trailing_context() {
 
     // N=5 <= num_context_lines + 1: No room to skip.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=4"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: 1
        2    2: 2
@@ -1931,12 +2001,13 @@ fn test_diff_leading_trailing_context() {
       10   10: 9
       11   11: 10
       12   12: 11
-    "###);
+    [EOF]
+    ");
 
     // N=5 <= 2 * num_context_lines + 1: The last hunk wouldn't be split if
     // trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
         ...
        3    3: 3
@@ -1949,12 +2020,13 @@ fn test_diff_leading_trailing_context() {
        9    9: 8
       10   10: 9
         ...
-    "###);
+    [EOF]
+    ");
 
     // N=5 > 2 * num_context_lines + 1: The last hunk should be split no matter
     // if trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--context=1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
         ...
        5    5: 5
@@ -1963,11 +2035,12 @@ fn test_diff_leading_trailing_context() {
             7: R
        8    8: 7
         ...
-    "###);
+    [EOF]
+    ");
 
     // N=5 <= num_context_lines: No room to skip.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=5"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1bf57dee4a..69b3e1865c 100644
     --- a/file1
@@ -1986,12 +2059,13 @@ fn test_diff_leading_trailing_context() {
      9
      10
      11
-    "###);
+    [EOF]
+    ");
 
     // N=5 <= 2 * num_context_lines: The last hunk wouldn't be split if
     // trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1bf57dee4a..69b3e1865c 100644
     --- a/file1
@@ -2006,12 +2080,13 @@ fn test_diff_leading_trailing_context() {
      7
      8
      9
-    "###);
+    [EOF]
+    ");
 
     // N=5 > 2 * num_context_lines: The last hunk should be split no matter
     // if trailing diff existed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git", "--context=2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1 b/file1
     index 1bf57dee4a..69b3e1865c 100644
     --- a/file1
@@ -2024,7 +2099,8 @@ fn test_diff_leading_trailing_context() {
     +R
      7
      8
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2052,9 +2128,10 @@ fn test_diff_external_tool() {
     insta_settings.add_filter("exit (status|code)", "<exit status>");
     insta_settings.bind(|| {
         insta::assert_snapshot!(stdout, @r"");
-        insta::assert_snapshot!(stderr, @r#"
+        insta::assert_snapshot!(stderr, @r"
         Warning: Tool exited with <exit status>: 1 (run with --debug to see the exact invocation)
-        "#);
+        [EOF]
+        ");
     });
 
     // nonzero exit codes should not print a warning if it's an expected exit code
@@ -2079,23 +2156,25 @@ fn test_diff_external_tool() {
 
     // diff without file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r"
     file1
     file2
     --
     file2
     file3
-    "###);
+    [EOF]
+    ");
 
     // diff with file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor", "file1"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor", "file1"]), @r"
     file1
     --
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["log", "-p", "--tool=fake-diff-editor"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["log", "-p", "--tool=fake-diff-editor"]), @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 39d9055d
     │  (no description set)
     │  file1
@@ -2110,10 +2189,11 @@ fn test_diff_external_tool() {
     │  file2
     ◆  zzzzzzzz root() 00000000
        --
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["show", "--tool=fake-diff-editor"]), @r#"
+        test_env.jj_cmd_success(&repo_path, &["show", "--tool=fake-diff-editor"]), @r"
     Commit ID: 39d9055d70873099fd924b9af218289d5663eac8
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -2126,41 +2206,45 @@ fn test_diff_external_tool() {
     --
     file2
     file3
-    "#);
+    [EOF]
+    ");
 
     // Enabled by default, looks up the merge-tools table
     let config = "--config=ui.diff.tool=fake-diff-editor";
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", config]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", config]), @r"
     file1
     file2
     --
     file2
     file3
-    "###);
+    [EOF]
+    ");
 
     // Inlined command arguments
     let command_toml = to_toml_value(fake_diff_editor_path());
     let config = format!("--config=ui.diff.tool=[{command_toml}, '$right', '$left']");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", &config]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", &config]), @r"
     file2
     file3
     --
     file1
     file2
-    "###);
+    [EOF]
+    ");
 
     // Output of external diff tool shouldn't be escaped
     std::fs::write(&edit_script, "print \x1b[1;31mred").unwrap();
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["diff", "--color=always", "--tool=fake-diff-editor"]),
-        @r###"
+        @r"
     [1;31mred
-    "###);
+    [EOF]
+    ");
 
     // Non-zero exit code isn't an error
     std::fs::write(&edit_script, "print diff\0fail").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["show", "--tool=fake-diff-editor"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: 39d9055d70873099fd924b9af218289d5663eac8
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -2169,18 +2253,21 @@ fn test_diff_external_tool() {
         (no description set)
 
     diff
-    "#);
-    insta::assert_snapshot!(stderr.normalize_exit_status(), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r"
     Warning: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "###);
+    [EOF]
+    ");
 
     // --tool=:builtin shouldn't be ignored
     let stderr = test_env.jj_cmd_failure(&repo_path, &["diff", "--tool=:builtin"]);
-    insta::assert_snapshot!(stderr.strip_last_line(), @r###"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r"
     Error: Failed to generate diff
     Caused by:
     1: Error executing ':builtin' (run with --debug to see the exact invocation)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2212,7 +2299,7 @@ fn test_diff_external_file_by_file_tool() {
 
     // diff without file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["diff"], configs].concat()), @r###"
+        test_env.jj_cmd_success(&repo_path, &[&["diff"], configs].concat()), @r"
     ==
     file2
     --
@@ -2225,19 +2312,21 @@ fn test_diff_external_file_by_file_tool() {
     file1
     --
     file4
-    "###);
+    [EOF]
+    ");
 
     // diff with file patterns
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["diff", "file1"], configs].concat()), @r###"
+        test_env.jj_cmd_success(&repo_path, &[&["diff", "file1"], configs].concat()), @r"
     ==
     file1
     --
     file1
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["log", "-p"], configs].concat()), @r###"
+        test_env.jj_cmd_success(&repo_path, &[&["log", "-p"], configs].concat()), @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 7b01704a
     │  (no description set)
     │  ==
@@ -2263,10 +2352,11 @@ fn test_diff_external_file_by_file_tool() {
     │  --
     │  file2
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &[&["show"], configs].concat()), @r#"
+        test_env.jj_cmd_success(&repo_path, &[&["show"], configs].concat()), @r"
     Commit ID: 7b01704a670bc77d11ed117d362855cff1d4513b
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -2286,7 +2376,8 @@ fn test_diff_external_file_by_file_tool() {
     file1
     --
     file4
-    "#);
+    [EOF]
+    ");
 }
 
 #[cfg(unix)]
@@ -2317,13 +2408,14 @@ fn test_diff_external_tool_symlink() {
 
     // Shouldn't try to change permission of symlinks
     insta::assert_snapshot!(
-        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r###"
+        test_env.jj_cmd_success(&repo_path, &["diff", "--tool=fake-diff-editor"]), @r"
     dead
     file
     --
     dead
     file
-    "###);
+    [EOF]
+    ");
 
     // External file should be intact
     assert_eq!(
@@ -2447,25 +2539,30 @@ fn test_diff_stat() {
     std::fs::write(repo_path.join("file1"), "foo\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 1 +
     1 file changed, 1 insertion(+), 0 deletions(-)
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @"0 files changed, 0 insertions(+), 0 deletions(-)");
+    insta::assert_snapshot!(stdout, @r"
+    0 files changed, 0 insertions(+), 0 deletions(-)
+    [EOF]
+    ");
 
     std::fs::write(repo_path.join("file1"), "foo\nbar\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file1"), "bar\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1 | 1 -
     1 file changed, 0 insertions(+), 1 deletion(-)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2489,97 +2586,114 @@ fn test_diff_stat_long_name_or_stat() {
         test_env.jj_cmd_success(&repo_path, &["diff", "--stat"])
     };
 
-    insta::assert_snapshot!(get_stat(&test_env, 1, 1), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 1, 1), @r"
     1   | 1 +
     一  | 1 +
     2 files changed, 2 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r"
     1   | 10 ++++++++++
     一  | 10 ++++++++++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 1, 100), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 1, 100), @r"
     1   | 100 +++++++++++++++++
     一  | 100 +++++++++++++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 10, 1), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 10, 1), @r"
     1234567890      | 1 +
     ...五六七八九十 | 1 +
     2 files changed, 2 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r"
     1234567890     | 10 +++++++
     ...六七八九十  | 10 +++++++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 10, 100), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 10, 100), @r"
     1234567890     | 100 ++++++
     ...六七八九十  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 50, 1), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 50, 1), @r"
     ...901234567890 | 1 +
     ...五六七八九十 | 1 +
     2 files changed, 2 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 50, 10), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 50, 10), @r"
     ...01234567890 | 10 +++++++
     ...六七八九十  | 10 +++++++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 50, 100), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 50, 100), @r"
     ...01234567890 | 100 ++++++
     ...六七八九十  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
+    [EOF]
+    ");
 
     // Lengths around where we introduce the ellipsis
-    insta::assert_snapshot!(get_stat(&test_env, 13, 100), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 13, 100), @r"
     1234567890123  | 100 ++++++
     ...九十一二三  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 14, 100), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 14, 100), @r"
     12345678901234 | 100 ++++++
     ...十一二三四  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 15, 100), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 15, 100), @r"
     ...56789012345 | 100 ++++++
     ...一二三四五  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 16, 100), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 16, 100), @r"
     ...67890123456 | 100 ++++++
     ...二三四五六  | 100 ++++++
     2 files changed, 200 insertions(+), 0 deletions(-)
-    "###);
+    [EOF]
+    ");
 
     // Very narrow terminal (doesn't have to fit, just don't crash)
     test_env.add_env_var("COLUMNS", "10");
-    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r"
     ... | 10 ++
     ... | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
+    [EOF]
+    ");
     test_env.add_env_var("COLUMNS", "3");
-    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r###"
+    insta::assert_snapshot!(get_stat(&test_env, 10, 10), @r"
     ... | 10 ++
     ... | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 3, 10), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 3, 10), @r"
     123 | 10 ++
     ... | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
-    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_stat(&test_env, 1, 10), @r"
     1   | 10 ++
     一  | 10 ++
     2 files changed, 20 insertions(+), 0 deletions(-)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2598,7 +2712,7 @@ fn test_diff_binary() {
     std::fs::write(repo_path.join("file4.png"), b"\0\0\0").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Removed regular file file1.png:
         (binary)
     Modified regular file file2.png:
@@ -2607,10 +2721,11 @@ fn test_diff_binary() {
         (binary)
     Added regular file file4.png:
         (binary)
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file1.png b/file1.png
     deleted file mode 100644
     index 2b65b23c22..0000000000
@@ -2626,14 +2741,16 @@ fn test_diff_binary() {
     new file mode 100644
     index 0000000000..4227ca4e87
     Binary files /dev/null and b/file4.png differ
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "--stat"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1.png | 3 ---
     file2.png | 5 ++---
     file3.png | 3 +++
     file4.png | 1 +
     4 files changed, 6 insertions(+), 6 deletions(-)
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -16,7 +16,6 @@ use indoc::indoc;
 use itertools::Itertools;
 
 use crate::common::fake_diff_editor_path;
-use crate::common::strip_last_line;
 use crate::common::to_toml_value;
 use crate::common::TestEnvironment;
 
@@ -208,12 +207,12 @@ fn test_diff_basic() {
             "repo/y/z",
         ],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     M repo/file2
     R repo/{file1 => file3}
     C repo/{file2 => file4}
     "###);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
     Warning: No matching entries for paths: repo/x, repo/y/z
     "###);
 
@@ -479,7 +478,7 @@ fn test_diff_name_only() {
     std::fs::write(repo_path.join("added"), "add").unwrap();
     std::fs::create_dir(repo_path.join("sub")).unwrap();
     std::fs::write(repo_path.join("sub/added"), "sub/add").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]).replace('\\', "/"),
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--name-only"]).normalize_backslash(),
     @r###"
     added
     deleted
@@ -2171,13 +2170,13 @@ fn test_diff_external_tool() {
 
     diff
     "#);
-    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r###"
     Warning: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     "###);
 
     // --tool=:builtin shouldn't be ignored
     let stderr = test_env.jj_cmd_failure(&repo_path, &["diff", "--tool=:builtin"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r###"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r###"
     Error: Failed to generate diff
     Caused by:
     1: Error executing ':builtin' (run with --debug to see the exact invocation)

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -105,8 +105,8 @@ fn test_diffedit() {
 
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
-    let stderr = &test_env.jj_cmd_failure(&repo_path, &["diffedit"]);
-    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
+    let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit"]);
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r###"
     Error: Failed to edit diff
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     "###);
@@ -631,7 +631,7 @@ fn test_diffedit_old_restore_interactive_tests() {
     // Nothing happens if the diff-editor exits with an error
     std::fs::write(&edit_script, "rm file2\0fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["diffedit", "--from", "@-"]);
-    insta::assert_snapshot!(stderr.replace("exit code:", "exit status:"), @r###"
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r###"
     Error: Failed to edit diff
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     "###);

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
@@ -2394,12 +2395,12 @@ fn test_rebase_duplicates() {
     "#);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"commit_id.short() ++ "   " ++ description.first_line()"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
-fn get_log_output_with_ts(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output_with_ts(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"
     commit_id.short() ++ "   " ++ description.first_line() ++ " @ " ++ committer.timestamp()
     "#;

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -39,31 +39,35 @@ fn test_duplicate() {
     create_commit(&test_env, &repo_path, "b", &[]);
     create_commit(&test_env, &repo_path, "c", &["a", "b"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    17a00fc21654   c
     ├─╮
     │ ○  d370aee184ba   b
     ○ │  2443ea76b0b1   a
     ├─╯
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["duplicate", "all()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Cannot duplicate the root commit
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "none()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     No revisions to duplicate.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 2443ea76b0b1 as kpqxywon f5b1e687 a
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    17a00fc21654   c
     ├─╮
     │ ○  d370aee184ba   b
@@ -72,17 +76,22 @@ fn test_duplicate() {
     │ ○  f5b1e68729d6   a
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Undid operation: 01373b278eae (2001-02-03 08:05:17) duplicate 1 commit(s)");
+    insta::assert_snapshot!(stderr, @r"
+    Undid operation: 01373b278eae (2001-02-03 08:05:17) duplicate 1 commit(s)
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate" /* duplicates `c` */]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 17a00fc21654 as lylxulpl ef3b0f3d c
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    17a00fc21654   c
     ├─╮
     │ │ ○  ef3b0f3d1046   c
@@ -91,7 +100,8 @@ fn test_duplicate() {
     ○ │  2443ea76b0b1   a
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -106,7 +116,7 @@ fn test_duplicate_many() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["b", "d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -115,15 +125,17 @@ fn test_duplicate_many() {
     ├─╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b::"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 1394f625cbbd as wqnwkozp 3b74d969 b
     Duplicated 921dde6e55c0 as mouksmqu 8348ddce e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     ○ │  1394f625cbbd   b
@@ -136,16 +148,18 @@ fn test_duplicate_many() {
     ├───╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // Try specifying the same commit twice directly
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 1394f625cbbd as nkmrtpmo 0276d3d7 b
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -156,18 +170,20 @@ fn test_duplicate_many() {
     ├─╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // Try specifying the same commit twice indirectly
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "b::", "d::"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 1394f625cbbd as xtnwkqum fa167d18 b
     Duplicated ebd06dba20ec as pqrnrkux 2181781b d
     Duplicated 921dde6e55c0 as ztxkyksq 0f7430f2 e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -182,11 +198,12 @@ fn test_duplicate_many() {
     ├───╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // Reminder of the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -195,15 +212,17 @@ fn test_duplicate_many() {
     ├─╯
     ○  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "d::", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 2443ea76b0b1 as nlrtlrxv c6f7f8c4 a
     Duplicated ebd06dba20ec as plymsszl d94e4c55 d
     Duplicated 921dde6e55c0 as urrlptpw 9bd4389f e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -218,20 +237,22 @@ fn test_duplicate_many() {
     │ ○  c6f7f8c4512e   a
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // Check for BUG -- makes too many 'a'-s, etc.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a::"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 2443ea76b0b1 as uuuvxpvw 0fe67a05 a
     Duplicated 1394f625cbbd as nmpuuozl e13ac0ad b
     Duplicated c0cb3a0b73e7 as kzpokyyw df53fa58 c
     Duplicated ebd06dba20ec as yxrlprzz 2f2442db d
     Duplicated 921dde6e55c0 as mvkzkxrl ee8fe64e e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    921dde6e55c0   e
     ├─╮
     │ ○  ebd06dba20ec   d
@@ -248,7 +269,8 @@ fn test_duplicate_many() {
     │ ○  0fe67a05989e   a
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -266,7 +288,7 @@ fn test_duplicate_destination() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7550bb42c6f   d
     │ ○  b75b7aa4b90e   c
     ├─╯
@@ -277,12 +299,16 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // Duplicate a single commit onto a single destination.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Duplicated 9e85a474f005 as nkmrtpmo 2944a632 a1");
+    insta::assert_snapshot!(stderr, @r"
+    Duplicated 9e85a474f005 as nkmrtpmo 2944a632 a1
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7550bb42c6f   d
     │ ○  2944a6324f14   a1
@@ -295,6 +321,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -302,7 +329,10 @@ fn test_duplicate_destination() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "-d", "c", "-d", "d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Duplicated 9e85a474f005 as xtnwkqum 155f6a01 a1");
+    insta::assert_snapshot!(stderr, @r"
+    Duplicated 9e85a474f005 as xtnwkqum 155f6a01 a1
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    155f6a012334   a1
     ├─╮
@@ -316,6 +346,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -325,6 +356,7 @@ fn test_duplicate_destination() {
     insta::assert_snapshot!(stderr, @r"
     Warning: Duplicating commit 9e85a474f005 as a descendant of itself
     Duplicated 9e85a474f005 as wvuyspvk 95585bb2 (empty) a1
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7550bb42c6f   d
@@ -338,6 +370,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -349,6 +382,7 @@ fn test_duplicate_destination() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as xlzxqlsl da0996fd a1
     Duplicated 9a27d5939bef as vnkwvqxw 0af91ca8 b
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7550bb42c6f   d
@@ -364,6 +398,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -377,6 +412,7 @@ fn test_duplicate_destination() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as oupztwtk 2f519daa a1
     Duplicated 9a27d5939bef as yxsqzptr c219a744 b
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    c219a744e19c   b
@@ -393,6 +429,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -403,6 +440,7 @@ fn test_duplicate_destination() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as wtszoswq 806f2b56 a1
     Duplicated 17072aa2b823 as qmykwtmu 161ce874 a3
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7550bb42c6f   d
@@ -417,6 +455,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -428,6 +467,7 @@ fn test_duplicate_destination() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as rkoyqlrv 02cbff23 a1
     Duplicated 17072aa2b823 as zxvrqtmq ddcfb95f a3
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  ddcfb95ff7d8   a3
@@ -443,6 +483,7 @@ fn test_duplicate_destination() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -465,7 +506,7 @@ fn test_duplicate_insert_after() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
     │ ○  09560d60cac4   c2
@@ -480,7 +521,8 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // Duplicate a single commit after a single commit with no direct relationship.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "--after", "b1"]);
@@ -488,6 +530,7 @@ fn test_duplicate_insert_after() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as pzsxstzt b71e23da a1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -505,6 +548,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -515,6 +559,7 @@ fn test_duplicate_insert_after() {
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Duplicated 17072aa2b823 as qmkrwlvp fd3c891b a3
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -532,6 +577,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -542,6 +588,7 @@ fn test_duplicate_insert_after() {
     Warning: Duplicating commit 9e85a474f005 as a descendant of itself
     Duplicated 9e85a474f005 as qwyusntz a4d0b771 (empty) a1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -559,6 +606,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -572,6 +620,7 @@ fn test_duplicate_insert_after() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as soqnvnyz 3449bde2 a1
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -591,6 +640,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -604,6 +654,7 @@ fn test_duplicate_insert_after() {
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Duplicated 17072aa2b823 as nsrwusvy 48764702 a3
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -622,6 +673,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -635,6 +687,7 @@ fn test_duplicate_insert_after() {
     Warning: Duplicating commit 9e85a474f005 as a descendant of itself
     Duplicated 9e85a474f005 as xpnwykqz 43bcb4dc (empty) a1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -653,6 +706,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -665,6 +719,7 @@ fn test_duplicate_insert_after() {
     Duplicated 9e85a474f005 as sryyqqkq 44f57f24 a1
     Duplicated dcc98bc8bbea as pxnqtknr bcee4b60 b1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -685,6 +740,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -698,6 +754,7 @@ fn test_duplicate_insert_after() {
     Duplicated 17072aa2b823 as pyoswmwk 0d11d466 a3
     Duplicated dcc98bc8bbea as yqnpwwmq c32d1ccc b1
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -718,6 +775,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -731,6 +789,7 @@ fn test_duplicate_insert_after() {
     Duplicated 9e85a474f005 as tpmlxquz 213aff50 (empty) a1
     Duplicated dcc98bc8bbea as uukzylyy 67b82bab b1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -751,6 +810,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -769,6 +829,7 @@ fn test_duplicate_insert_after() {
     Parent commit      : knltnxnu ad0a80e9 a1
     Parent commit      : krtqozmx 840bbbe5 b1
     Added 3 files, modified 0 files, removed 0 files
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    9eeade97a2f7   d2
@@ -791,6 +852,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -806,6 +868,7 @@ fn test_duplicate_insert_after() {
     Duplicated 17072aa2b823 as wxzmtyol ade2ae32 a3
     Duplicated dcc98bc8bbea as musouqkq e1eed3f1 b1
     Rebased 4 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -828,6 +891,7 @@ fn test_duplicate_insert_after() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -843,6 +907,7 @@ fn test_duplicate_insert_after() {
     Duplicated 9e85a474f005 as quyylypw c4820edd (empty) a1
     Duplicated dcc98bc8bbea as prukwozq 20cfd11e b1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -864,6 +929,7 @@ fn test_duplicate_insert_after() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -875,6 +941,7 @@ fn test_duplicate_insert_after() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as vvvtksvt b44d23b4 a1
     Duplicated 17072aa2b823 as yvrnrpnw ca8f08f6 a3
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -893,6 +960,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -901,13 +969,14 @@ fn test_duplicate_insert_after() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["duplicate", "a2", "a3", "--after", "a1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Warning: Duplicating commit 47df67757a64 as an ancestor of itself
     Duplicated 47df67757a64 as sukptuzs 4324d289 a2
     Duplicated 17072aa2b823 as rxnrppxl 47586b09 a3
     Rebased 3 commits onto duplicated commits
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -925,6 +994,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -939,6 +1009,7 @@ fn test_duplicate_insert_after() {
     Duplicated 9e85a474f005 as rwkyzntp b68b9a00 (empty) a1
     Duplicated 47df67757a64 as nqtyztop 0dd00ded (empty) a2
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -957,6 +1028,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -970,6 +1042,7 @@ fn test_duplicate_insert_after() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as nwmqwkzz eb455287 a1
     Duplicated 17072aa2b823 as uwrrnrtx 94a1bd80 a3
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  94a1bd8080c6   a3
@@ -989,6 +1062,7 @@ fn test_duplicate_insert_after() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1005,6 +1079,7 @@ fn test_duplicate_insert_after() {
     Duplicated 17072aa2b823 as wunttkrp 1ce432e1 a3
     Duplicated 196bc1f0efc1 as puxpuzrm 14728ee8 a4
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1024,6 +1099,7 @@ fn test_duplicate_insert_after() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1040,6 +1116,7 @@ fn test_duplicate_insert_after() {
     Duplicated 9e85a474f005 as zwvplpop 67dd65d3 (empty) a1
     Duplicated 47df67757a64 as znsksvls 7536fd44 (empty) a2
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1059,6 +1136,7 @@ fn test_duplicate_insert_after() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1067,9 +1145,10 @@ fn test_duplicate_insert_after() {
         &repo_path,
         &["duplicate", "a1", "--after", "b1", "--after", "b2"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to create a loop: commit 7b44470918f4 would be both an ancestor and a descendant of the duplicated commits
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1091,7 +1170,7 @@ fn test_duplicate_insert_before() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
     │ ○  09560d60cac4   c2
@@ -1106,7 +1185,8 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // Duplicate a single commit before a single commit with no direct relationship.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "--before", "b2"]);
@@ -1114,6 +1194,7 @@ fn test_duplicate_insert_before() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as pzsxstzt b71e23da a1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1131,6 +1212,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1141,6 +1223,7 @@ fn test_duplicate_insert_before() {
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Duplicated 17072aa2b823 as qmkrwlvp 2108707c a3
     Rebased 4 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1158,6 +1241,7 @@ fn test_duplicate_insert_before() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1168,6 +1252,7 @@ fn test_duplicate_insert_before() {
     Warning: Duplicating commit 9e85a474f005 as a descendant of itself
     Duplicated 9e85a474f005 as qwyusntz 2fe2d212 (empty) a1
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1185,6 +1270,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1198,6 +1284,7 @@ fn test_duplicate_insert_before() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as soqnvnyz 3449bde2 a1
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1217,6 +1304,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1230,6 +1318,7 @@ fn test_duplicate_insert_before() {
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Duplicated 17072aa2b823 as nsrwusvy 8648c1c8 a3
     Rebased 4 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1249,6 +1338,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1262,6 +1352,7 @@ fn test_duplicate_insert_before() {
     Warning: Duplicating commit 9e85a474f005 as a descendant of itself
     Duplicated 9e85a474f005 as xpnwykqz 72cf8983 (empty) a1
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1281,6 +1372,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1289,11 +1381,12 @@ fn test_duplicate_insert_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["duplicate", "a1", "b1", "--before", "c1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as sryyqqkq fa625d74 a1
     Duplicated dcc98bc8bbea as pxnqtknr 2233b9a8 b1
     Rebased 2 commits onto duplicated commits
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -1313,6 +1406,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1326,6 +1420,7 @@ fn test_duplicate_insert_before() {
     Duplicated 17072aa2b823 as pyoswmwk cad067c7 a3
     Duplicated dcc98bc8bbea as yqnpwwmq 6675be66 b1
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1346,6 +1441,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1359,6 +1455,7 @@ fn test_duplicate_insert_before() {
     Duplicated 9e85a474f005 as tpmlxquz 4d4dc78c (empty) a1
     Duplicated dcc98bc8bbea as uukzylyy a065abc9 b1
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1379,6 +1476,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1389,15 +1487,16 @@ fn test_duplicate_insert_before() {
         &["duplicate", "a1", "b1", "--before", "c1", "--before", "d1"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as knltnxnu 056a0cb3 a1
     Duplicated dcc98bc8bbea as krtqozmx fb68a539 b1
     Rebased 4 commits onto duplicated commits
     Working copy now at: nmzmmopx 89f9b379 d2 | d2
     Parent commit      : xznxytkn 771d0e16 d1 | d1
     Added 2 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  89f9b37923a9   d2
     ○    771d0e16b40c   d1
     ├─╮
@@ -1416,7 +1515,8 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Duplicate multiple commits without a direct ancestry relationship before
@@ -1431,6 +1531,7 @@ fn test_duplicate_insert_before() {
     Duplicated 17072aa2b823 as wxzmtyol 31ca96b8 a3
     Duplicated dcc98bc8bbea as musouqkq 4748cf83 b1
     Rebased 6 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1451,6 +1552,7 @@ fn test_duplicate_insert_before() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1466,6 +1568,7 @@ fn test_duplicate_insert_before() {
     Duplicated 9e85a474f005 as quyylypw 3eefd57d (empty) a1
     Duplicated dcc98bc8bbea as prukwozq ed86e70f b1
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1488,6 +1591,7 @@ fn test_duplicate_insert_before() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1500,6 +1604,7 @@ fn test_duplicate_insert_before() {
     Duplicated 9e85a474f005 as vvvtksvt baee09af a1
     Duplicated 17072aa2b823 as yvrnrpnw c17818c1 a3
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1518,6 +1623,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1532,6 +1638,7 @@ fn test_duplicate_insert_before() {
     Duplicated 9e85a474f005 as sukptuzs ad0234a3 a1
     Duplicated 17072aa2b823 as rxnrppxl e64dcdd1 a3
     Rebased 4 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1550,6 +1657,7 @@ fn test_duplicate_insert_before() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1564,6 +1672,7 @@ fn test_duplicate_insert_before() {
     Duplicated 9e85a474f005 as rwkyzntp e614bda1 (empty) a1
     Duplicated 47df67757a64 as nqtyztop 5de52186 (empty) a2
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1582,6 +1691,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1599,6 +1709,7 @@ fn test_duplicate_insert_before() {
     Working copy now at: nmzmmopx 8161bbbc d2 | d2
     Parent commit      : uwrrnrtx a5eee87f a3
     Added 3 files, modified 0 files, removed 0 files
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  8161bbbc1341   d2
@@ -1619,6 +1730,7 @@ fn test_duplicate_insert_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1635,6 +1747,7 @@ fn test_duplicate_insert_before() {
     Duplicated 17072aa2b823 as wunttkrp 11fcc721 a3
     Duplicated 196bc1f0efc1 as puxpuzrm 3a0d76b0 a4
     Rebased 4 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1655,6 +1768,7 @@ fn test_duplicate_insert_before() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1671,6 +1785,7 @@ fn test_duplicate_insert_before() {
     Duplicated 9e85a474f005 as zwvplpop 311e39e4 (empty) a1
     Duplicated 47df67757a64 as znsksvls fdaa673d (empty) a2
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1691,6 +1806,7 @@ fn test_duplicate_insert_before() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1699,9 +1815,10 @@ fn test_duplicate_insert_before() {
         &repo_path,
         &["duplicate", "a1", "--before", "b1", "--before", "b2"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to create a loop: commit dcc98bc8bbea would be both an ancestor and a descendant of the duplicated commits
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1723,7 +1840,7 @@ fn test_duplicate_insert_after_before() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
     │ ○  09560d60cac4   c2
@@ -1738,7 +1855,8 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     // Duplicate a single commit in between commits with no direct relationship.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1749,6 +1867,7 @@ fn test_duplicate_insert_after_before() {
     insta::assert_snapshot!(stderr, @r"
     Duplicated 9e85a474f005 as pzsxstzt afc97ea4 a1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1767,6 +1886,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1780,6 +1900,7 @@ fn test_duplicate_insert_after_before() {
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Duplicated 17072aa2b823 as qmkrwlvp fd3c891b a3
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1797,6 +1918,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1811,6 +1933,7 @@ fn test_duplicate_insert_after_before() {
     Warning: Duplicating commit 17072aa2b823 as an ancestor of itself
     Duplicated 17072aa2b823 as qwyusntz 4d69f69c a3
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1829,6 +1952,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1842,6 +1966,7 @@ fn test_duplicate_insert_after_before() {
     Warning: Duplicating commit 9e85a474f005 as a descendant of itself
     Duplicated 9e85a474f005 as soqnvnyz 00811f7c (empty) a1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1859,6 +1984,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1873,6 +1999,7 @@ fn test_duplicate_insert_after_before() {
     Warning: Duplicating commit 9e85a474f005 as a descendant of itself
     Duplicated 9e85a474f005 as nsrwusvy 0b89e8a3 (empty) a1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -1892,6 +2019,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1902,10 +2030,11 @@ fn test_duplicate_insert_after_before() {
         &["duplicate", "a2", "--after", "a1", "--before", "a4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 47df67757a64 as xpnwykqz 54cc0161 a2
     Rebased 1 commits onto duplicated commits
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -1924,6 +2053,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1943,6 +2073,7 @@ fn test_duplicate_insert_after_before() {
     Parent commit      : sryyqqkq 44f57f24 a1
     Parent commit      : pxnqtknr bcee4b60 b1
     Added 3 files, modified 0 files, removed 0 files
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @      6a5a099f8a03   d2
@@ -1964,6 +2095,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -1979,6 +2111,7 @@ fn test_duplicate_insert_after_before() {
     Duplicated 17072aa2b823 as pyoswmwk 0d11d466 a3
     Duplicated dcc98bc8bbea as yqnpwwmq c32d1ccc b1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -2000,6 +2133,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2016,6 +2150,7 @@ fn test_duplicate_insert_after_before() {
     Duplicated 9e85a474f005 as tpmlxquz 213aff50 (empty) a1
     Duplicated dcc98bc8bbea as uukzylyy 67b82bab b1
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -2037,6 +2172,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2056,6 +2192,7 @@ fn test_duplicate_insert_after_before() {
     Parent commit      : knltnxnu a2d38733 a1
     Parent commit      : krtqozmx 2512c935 b1
     Added 3 files, modified 0 files, removed 0 files
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @      4678ad489eeb   d2
@@ -2077,6 +2214,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2095,6 +2233,7 @@ fn test_duplicate_insert_after_before() {
     Parent commit      : xznxytkn 0f21c5e1 d1 | d1
     Parent commit      : musouqkq fb14bc1e a3
     Added 3 files, modified 0 files, removed 0 files
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    21321795f72f   d2
@@ -2115,6 +2254,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2126,11 +2266,12 @@ fn test_duplicate_insert_after_before() {
         &["duplicate", "a3", "a4", "--after", "a2", "--before", "c2"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 17072aa2b823 as quyylypw d4d3c907 a3
     Duplicated 196bc1f0efc1 as prukwozq 96798f1b a4
     Rebased 1 commits onto duplicated commits
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -2150,6 +2291,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2165,6 +2307,7 @@ fn test_duplicate_insert_after_before() {
     Duplicated 9e85a474f005 as vvvtksvt b44d23b4 a1
     Duplicated 47df67757a64 as yvrnrpnw 4d0d41e2 a2
     Rebased 2 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -2184,6 +2327,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  dcc98bc8bbea   b1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2200,6 +2344,7 @@ fn test_duplicate_insert_after_before() {
     Duplicated 17072aa2b823 as sukptuzs 8678104c a3
     Duplicated 196bc1f0efc1 as rxnrppxl b6580274 a4
     Rebased 3 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -2218,6 +2363,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2234,6 +2380,7 @@ fn test_duplicate_insert_after_before() {
     Duplicated 9e85a474f005 as rwkyzntp b68b9a00 (empty) a1
     Duplicated 47df67757a64 as nqtyztop 0dd00ded (empty) a2
     Rebased 1 commits onto duplicated commits
+    [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
@@ -2252,6 +2399,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2262,11 +2410,12 @@ fn test_duplicate_insert_after_before() {
         &["duplicate", "a2", "a3", "--after", "a1", "--before", "a4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 47df67757a64 as nwmqwkzz 8517eaa7 a2
     Duplicated 17072aa2b823 as uwrrnrtx 3ce18231 a3
     Rebased 1 commits onto duplicated commits
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  0cdd923e993a   d2
     ○  0f21c5e185c5   d1
@@ -2286,6 +2435,7 @@ fn test_duplicate_insert_after_before() {
     │ ○  9e85a474f005   a1
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
@@ -2294,9 +2444,10 @@ fn test_duplicate_insert_after_before() {
         &repo_path,
         &["duplicate", "a1", "--after", "b2", "--before", "b1"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to create a loop: commit 7b44470918f4 would be both an ancestor and a descendant of the duplicated commits
-    "#);
+    [EOF]
+    ");
 }
 
 // https://github.com/jj-vcs/jj/issues/1050
@@ -2307,30 +2458,37 @@ fn test_undo_after_duplicate() {
     let repo_path = test_env.env_root().join("repo");
 
     create_commit(&test_env, &repo_path, "a", &[]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 2443ea76b0b1 as mzvwutvl f5cefcbb a
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1   a
     │ ○  f5cefcbb65a4   a
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Undid operation: 7e9bd644ad7a (2001-02-03 08:05:11) duplicate 1 commit(s)");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @r"
+    Undid operation: 7e9bd644ad7a (2001-02-03 08:05:11) duplicate 1 commit(s)
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  2443ea76b0b1   a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 // https://github.com/jj-vcs/jj/issues/694
@@ -2344,24 +2502,27 @@ fn test_rebase_duplicates() {
     create_commit(&test_env, &repo_path, "b", &["a"]);
     create_commit(&test_env, &repo_path, "c", &["b"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r"
     @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
     ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
     ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 7e4fbf4f2759 as yostqsxw 0ac2063b c
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["duplicate", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Duplicated 7e4fbf4f2759 as znkkpsqq ce5f4eeb c
-    "###);
-    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r"
     @  7e4fbf4f2759   c @ 2001-02-03 04:05:13.000 +07:00
     │ ○  ce5f4eeb69d1   c @ 2001-02-03 04:05:16.000 +07:00
     ├─╯
@@ -2370,19 +2531,21 @@ fn test_rebase_duplicates() {
     ○  1394f625cbbd   b @ 2001-02-03 04:05:11.000 +07:00
     ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
-    "#);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Working copy now at: royxmykx ed671a3c c | c
     Parent commit      : zsuskuln 4c6f1569 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "#);
+    [EOF]
+    ");
     // Some of the duplicate commits' timestamps were changed a little to make them
     // have distinct commit ids.
-    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_with_ts(&test_env, &repo_path), @r"
     @  ed671a3cbf35   c @ 2001-02-03 04:05:18.000 +07:00
     │ ○  b86e9f27d085   c @ 2001-02-03 04:05:16.000 +07:00
     ├─╯
@@ -2392,7 +2555,8 @@ fn test_rebase_duplicates() {
     │ ○  2443ea76b0b1   a @ 2001-02-03 04:05:09.000 +07:00
     ├─╯
     ◆  000000000000    @ 1970-01-01 00:00:00.000 +00:00
-    "#);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -29,43 +29,48 @@ fn test_edit() {
 
     // Errors out without argument
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["edit"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <REVSET>
 
     Usage: jj edit <REVSET>
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Makes the specified commit the working-copy commit
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 73383c0b first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  2c910ae2d628 second
     @  73383c0b6439 first
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
     insta::assert_snapshot!(read_file(&repo_path.join("file1")), @"0");
 
     // Changes in the working copy are amended into the commit
     std::fs::write(repo_path.join("file2"), "0").unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  b384b2cc1883 second
     @  ff3f7b0dc386 first
     ◆  000000000000
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits onto updated working copy
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -82,9 +83,12 @@ fn test_edit_current_wc_commit_missing() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
 
-    let wc_id = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T=commit_id", "-r=@"]);
-    let wc_child_id =
-        test_env.jj_cmd_success(&repo_path, &["log", "--no-graph", "-T=commit_id", "-r=@+"]);
+    let wc_id = test_env
+        .jj_cmd_success(&repo_path, &["log", "--no-graph", "-T=commit_id", "-r=@"])
+        .into_raw();
+    let wc_child_id = test_env
+        .jj_cmd_success(&repo_path, &["log", "--no-graph", "-T=commit_id", "-r=@+"])
+        .into_raw();
     // Make the Git backend fail to read the current working copy commit
     let commit_object_path = repo_path
         .join(".jj")
@@ -114,7 +118,10 @@ fn read_file(path: &Path) -> String {
     String::from_utf8(std::fs::read(path).unwrap()).unwrap()
 }
 
-fn get_log_output_with_stderr(test_env: &TestEnvironment, cwd: &Path) -> (String, String) {
+fn get_log_output_with_stderr(
+    test_env: &TestEnvironment,
+    cwd: &Path,
+) -> (CommandOutputString, CommandOutputString) {
     let template = r#"commit_id.short() ++ " " ++ description"#;
     test_env.jj_cmd_ok(cwd, &["log", "-T", template])
 }

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -29,7 +29,7 @@ fn test_evolog_with_or_without_diff() {
     std::fs::write(repo_path.join("file1"), "resolved\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
@@ -38,11 +38,12 @@ fn test_evolog_with_or_without_diff() {
     │  my description
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
-    "###);
+    [EOF]
+    ");
 
     // Color
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "evolog"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m6[38;5;8m6b42ad3[39m[0m
     │  [1mmy description[0m
     [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m07[0m[38;5;8mb18245[39m [38;5;1mconflict[39m
@@ -51,12 +52,13 @@ fn test_evolog_with_or_without_diff() {
     │  my description
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m2b[0m[38;5;8m023b5f[39m
        [38;5;2m(empty)[39m my description
-    "###);
+    [EOF]
+    ");
 
     // There should be no diff caused by the rebase because it was a pure rebase
     // (even even though it resulted in a conflict).
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "-p"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     │  Resolved conflict in file1:
@@ -78,20 +80,22 @@ fn test_evolog_with_or_without_diff() {
     │          1: foo
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
-    "###);
+    [EOF]
+    ");
 
     // Test `--limit`
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--limit=2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
     │  my description
-    "###);
+    [EOF]
+    ");
 
     // Test `--no-graph`
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     my description
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
@@ -100,11 +104,12 @@ fn test_evolog_with_or_without_diff() {
     my description
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
     (empty) my description
-    "###);
+    [EOF]
+    ");
 
     // Test `--git` format, and that it implies `-p`
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--no-graph", "--git"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     my description
     diff --git a/file1 b/file1
@@ -140,7 +145,8 @@ fn test_evolog_with_or_without_diff() {
     +foo
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
     (empty) my description
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -159,7 +165,7 @@ fn test_evolog_with_custom_symbols() {
     let config = "templates.log_node='if(current_working_copy, \"$\", \"┝\")'";
     let stdout = test_env.jj_cmd_success(&repo_path, &["evolog", "--config", config]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 66b42ad3
     │  my description
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 07b18245 conflict
@@ -168,7 +174,8 @@ fn test_evolog_with_custom_symbols() {
     │  my description
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 2b023b5f
        (empty) my description
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -264,7 +271,7 @@ fn test_evolog_squash() {
 
     let stdout =
         test_env.jj_cmd_success(&repo_path, &["evolog", "-p", "-r", "description('squash')"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:15 d49749bf
     ├─┬─╮  squashed 3
     │ │ ○  vruxwmqv hidden test.user@example.com 2001-02-03 08:05:15 8f2ae2b5
@@ -316,7 +323,8 @@ fn test_evolog_squash() {
     │  (empty) first
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:07 230dd059
        (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -347,6 +355,7 @@ fn test_evolog_with_no_template() {
     - description_placeholder
     - email_placeholder
     - name_placeholder
+    [EOF]
     ");
 }
 
@@ -369,6 +378,7 @@ fn test_evolog_reversed_no_graph() {
     (empty) b
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 5cb22a87
     (empty) c
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(
@@ -380,6 +390,7 @@ fn test_evolog_reversed_no_graph() {
     (empty) b
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 5cb22a87
     (empty) c
+    [EOF]
     ");
 }
 
@@ -425,6 +436,7 @@ fn test_evolog_reverse_with_graph() {
     ├─╯  (empty) e
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 a177c2f2
        (empty) c+d+e
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(
@@ -438,5 +450,6 @@ fn test_evolog_reverse_with_graph() {
     ├─╯  (empty) e
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 a177c2f2
        (empty) c+d+e
+    [EOF]
     ");
 }

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -44,6 +44,7 @@ fn test_annotate_linear() {
     insta::assert_snapshot!(stdout, @r"
     qpvuntsm foo      2001-02-03 08:05:08    1: line1
     kkmpptxz test.use 2001-02-03 08:05:10    2: new text from new commit
+    [EOF]
     ");
 }
 
@@ -79,6 +80,7 @@ fn test_annotate_merge() {
     qpvuntsm test.use 2001-02-03 08:05:08    1: line1
     zsuskuln test.use 2001-02-03 08:05:11    2: new text from new commit 1
     royxmykx test.use 2001-02-03 08:05:13    3: new text from new commit 2
+    [EOF]
     ");
 }
 
@@ -113,6 +115,7 @@ fn test_annotate_conflicted() {
     yostqsxw test.use 2001-02-03 08:05:15    5: +++++++ Contents of side #2
     royxmykx test.use 2001-02-03 08:05:13    6: new text from new commit 2
     yostqsxw test.use 2001-02-03 08:05:15    7: >>>>>>> Conflict 1 of 1 ends
+    [EOF]
     ");
 }
 
@@ -147,6 +150,7 @@ fn test_annotate_merge_one_sided_conflict_resolution() {
     insta::assert_snapshot!(stdout, @r"
     qpvuntsm test.use 2001-02-03 08:05:08    1: line1
     zsuskuln test.use 2001-02-03 08:05:11    2: new text from new commit 1
+    [EOF]
     ");
 }
 
@@ -186,7 +190,7 @@ fn test_annotate_with_template() {
         &repo_path,
         &["file", "annotate", "file.txt", "-T", template],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     qpvuntsm initial
     2001-02-03 08:05:08 Test User <test.user@example.com>
        1: line1
@@ -201,5 +205,6 @@ fn test_annotate_with_template() {
        4: new text from new commit 2
        5: also continuing on a second line
        6: and a third!
-    "#);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -55,7 +55,7 @@ fn test_chmod_regular_conflict() {
     create_commit(&test_env, &repo_path, "conflict", &["x", "n"], &[]);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  n
@@ -63,15 +63,17 @@ fn test_chmod_regular_conflict() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r#"
     file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -79,18 +81,20 @@ fn test_chmod_regular_conflict() {
     +++++++ Contents of side #2
     n
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
 
     // Test chmodding a conflict
     test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "x", "file"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r#"
     file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: true })]))
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -98,16 +102,18 @@ fn test_chmod_regular_conflict() {
     +++++++ Contents of side #2
     n
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "n", "file"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r#"
     file: Ok(Conflicted([Some(File { id: FileId("587be6b4c3f93f93c489c0111bba5596147a26cb"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("8ba3a16384aacc37d01564b28401755ce8053f51"), executable: false })]))
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file"]);
     insta::assert_snapshot!(stdout, 
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -115,12 +121,13 @@ fn test_chmod_regular_conflict() {
     +++++++ Contents of side #2
     n
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
 
     // Unmatched paths should generate warnings
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "x", "nonexistent", "file"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No matching entries for paths: nonexistent
     Working copy now at: yostqsxw 2b11d002 conflict | (conflict) conflict
     Parent commit      : royxmykx 427fbd2f x | x
@@ -128,7 +135,8 @@ fn test_chmod_regular_conflict() {
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict including an executable
-    "###);
+    [EOF]
+    ");
 }
 
 // TODO: Test demonstrating that conflicts whose *base* is not a file are
@@ -161,7 +169,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
         &["file", "deletion"],
         &[],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    file_deletion
     ├─╮
     │ ○  deletion
@@ -173,50 +181,56 @@ fn test_chmod_file_dir_deletion_conflicts() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
 
     // The file-dir conflict cannot be chmod-ed
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_dir"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r#"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(Tree(TreeId("133bb38fc4e4bf6b551f1f04db7e48f04cac2877")))]))
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_dir", "file"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r"
     Conflict:
       Removing file with id df967b96a579e45a18b8251732d16804b2e56a55
       Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877
-    "###);
+    [EOF]
+    ");
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["file", "chmod", "x", "file", "-r=file_dir"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Some of the sides of the conflict are not files at 'file'.
-    "###);
+    [EOF]
+    ");
 
     // The file_deletion conflict can be chmod-ed
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r#"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), None]))
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     a
     %%%%%%% Changes from base to side #2
     -base
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["file", "chmod", "x", "file", "-r=file_deletion"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kmkuslsw 139dee15 file_deletion | (conflict) file_deletion
     Parent commit      : zsuskuln c51c9c55 file | file
     Parent commit      : royxmykx 6b18b3c1 deletion | deletion
@@ -230,20 +244,23 @@ fn test_chmod_file_dir_deletion_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r#"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), None]))
-    "###);
+    [EOF]
+    "#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=file_deletion", "file"]);
     insta::assert_snapshot!(stdout,
-    @r###"
+    @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     a
     %%%%%%% Changes from base to side #2
     -base
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn create_commit(
@@ -36,7 +37,7 @@ fn create_commit(
     test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     test_env.jj_cmd_success(repo_path, &["log", "-T", "bookmarks"])
 }
 

--- a/cli/tests/test_file_show_command.rs
+++ b/cli/tests/test_file_show_command.rs
@@ -28,15 +28,17 @@ fn test_show() {
 
     // Can print the contents of a file in a commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
 
     // Defaults to printing the working-copy version
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
 
     // Can print a file in a subdirectory
     let subdir_file = if cfg!(unix) {
@@ -45,45 +47,51 @@ fn test_show() {
         "dir\\file2"
     };
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", subdir_file]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 
     // Error if the path doesn't exist
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "nonexistent"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No such path: nonexistent
-    "###);
+    [EOF]
+    ");
 
     // Can print files under the specified directory
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 
     // Can print multiple files
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "."]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
     b
-    "###);
+    [EOF]
+    ");
 
     // Unmatched paths should generate warnings
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["file", "show", "file1", "non-existent"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Warning: No matching entries for paths: non-existent
-    "###);
+    [EOF]
+    ");
 
     // Can print a conflict
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "@", "-d", "@--"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -b
@@ -91,7 +99,8 @@ fn test_show() {
     +++++++ Contents of side #2
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
 }
 
 #[cfg(unix)]
@@ -108,11 +117,13 @@ fn test_show_symlink() {
 
     // Can print multiple files
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "show", "."]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
     a
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Warning: Path 'symlink1' exists but is not a file
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_file_track_untrack_commands.rs
+++ b/cli/tests/test_file_track_untrack_commands.rs
@@ -35,7 +35,9 @@ fn test_track_untrack() {
     // patterns
     test_env.jj_cmd_ok(&repo_path, &["st"]);
     std::fs::write(repo_path.join(".gitignore"), "*.bak\n").unwrap();
-    let files_before = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
+    let files_before = test_env
+        .jj_cmd_success(&repo_path, &["file", "list"])
+        .into_raw();
 
     // Errors out when not run at the head operation
     let stderr =
@@ -61,7 +63,9 @@ fn test_track_untrack() {
     Hint: Files that are not ignored will be added back by the next command.
     Make sure they're ignored, then try again.
     "###);
-    let files_after = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
+    let files_after = test_env
+        .jj_cmd_success(&repo_path, &["file", "list"])
+        .into_raw();
     // There should be no changes to the state when there was an error
     assert_eq!(files_after, files_before);
 
@@ -73,7 +77,9 @@ fn test_track_untrack() {
     Warning: `jj untrack` is deprecated; use `jj file untrack` instead, which is equivalent
     Warning: `jj untrack` will be removed in a future version, and this will be a hard error
     "###);
-    let files_after = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
+    let files_after = test_env
+        .jj_cmd_success(&repo_path, &["file", "list"])
+        .into_raw();
     // The file is no longer tracked
     assert!(!files_after.contains("file1.bak"));
     // Other files that match the ignore pattern are not untracked
@@ -85,7 +91,7 @@ fn test_track_untrack() {
     // Errors out when multiple specified files are not ignored
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "untrack", "target"]);
     assert_eq!(
-        stderr,
+        stderr.raw(),
         format!(
             "Error: '{}' and 1 other files are not ignored.\nHint: Files that are not ignored \
              will be added back by the next command.\nMake sure they're ignored, then try again.\n",
@@ -98,7 +104,9 @@ fn test_track_untrack() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "untrack", "target"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    let files_after = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
+    let files_after = test_env
+        .jj_cmd_success(&repo_path, &["file", "list"])
+        .into_raw();
     assert!(!files_after.contains("target"));
 }
 
@@ -178,7 +186,7 @@ fn test_auto_track() {
     std::fs::create_dir(&subdir).unwrap();
     std::fs::write(subdir.join("file1.rs"), "initial").unwrap();
     let stdout = test_env.jj_cmd_success(&subdir, &["file", "list"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     ../file1.rs
     "###);
 
@@ -186,7 +194,7 @@ fn test_auto_track() {
     let stdout = test_env.jj_cmd_success(&subdir, &["file", "track", "file1.rs"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&subdir, &["file", "list"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     ../file1.rs
     file1.rs
     "###);

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -57,10 +57,14 @@ fn test_config_no_tools() {
     insta::assert_snapshot!(stderr, @r"
     Config error: No `fix.tools` are configured
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content\n");
+    insta::assert_snapshot!(content, @r"
+    content
+    [EOF]
+    ");
 }
 
 #[test]
@@ -90,11 +94,20 @@ fn test_config_multiple_tools() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @r"
+    FOO
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @"bar\n");
+    insta::assert_snapshot!(content, @r"
+    bar
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "baz", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Baz\n");
+    insta::assert_snapshot!(content, @r"
+    Baz
+    [EOF]
+    ");
 }
 
 #[test]
@@ -135,13 +148,20 @@ fn test_config_multiple_tools_with_same_name() {
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     test_env.set_config_path("/dev/null");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Foo\n");
+    insta::assert_snapshot!(content, @r"
+    Foo
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Bar\n");
+    insta::assert_snapshot!(content, @r"
+    Bar
+    [EOF]
+    ");
 }
 
 #[test]
@@ -178,11 +198,20 @@ fn test_config_disabled_tools() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @r"
+    FOO
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @"bar\n");
+    insta::assert_snapshot!(content, @r"
+    bar
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "baz", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Baz\n");
+    insta::assert_snapshot!(content, @r"
+    Baz
+    [EOF]
+    ");
 }
 
 #[test]
@@ -205,10 +234,11 @@ fn test_config_disabled_tools_warning_when_all_tools_are_disabled() {
     std::fs::write(repo_path.join("bar"), "Bar\n").unwrap();
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["fix"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Config error: At least one entry of `fix.tools` must be enabled.
     For help, see https://jj-vcs.github.io/jj/latest/config/.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -239,21 +269,21 @@ fn test_config_tables_overlapping_patterns() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     foo
-    tool-1
-    "###);
+    tool-1[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "bar", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     bar
     tool-1
-    tool-2
-    "###);
+    tool-2[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "baz", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     baz
-    tool-2
-    "###);
+    tool-2[EOF]
+    ");
 }
 
 #[test]
@@ -280,10 +310,14 @@ fn test_config_tables_all_commands_missing() {
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"foo\n");
+    insta::assert_snapshot!(content, @r"
+    foo
+    [EOF]
+    ");
 }
 
 #[test]
@@ -314,10 +348,14 @@ fn test_config_tables_some_commands_missing() {
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"foo\n");
+    insta::assert_snapshot!(content, @r"
+    foo
+    [EOF]
+    ");
 }
 
 #[test]
@@ -340,13 +378,17 @@ fn test_config_tables_empty_patterns_list() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
-      Fixed 0 commits of 1 checked.
-      Nothing changed.
-      "###);
+    insta::assert_snapshot!(stderr, @r"
+    Fixed 0 commits of 1 checked.
+    Nothing changed.
+    [EOF]
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo", "-r", "@"]);
-    insta::assert_snapshot!(content, @"foo\n");
+    insta::assert_snapshot!(content, @r"
+    foo
+    [EOF]
+    ");
 }
 
 #[test]
@@ -380,11 +422,20 @@ fn test_config_filesets() {
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"A1\n");
+    insta::assert_snapshot!(content, @r"
+    A1
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"1b\n");
+    insta::assert_snapshot!(content, @r"
+    1b
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"2b\n");
+    insta::assert_snapshot!(content, @r"
+    2b
+    [EOF]
+    ");
 }
 
 #[test]
@@ -413,30 +464,48 @@ fn test_relative_paths() {
     // filesets.
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path.join("dir"), &["fix", "foo3"]);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @r"
+    unfixed
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @r"
+    unfixed
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir/foo3", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @r"
+    unfixed
+    [EOF]
+    ");
 
     // Positional arguments can specify a subset of the configured fileset.
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path.join("dir"), &["fix", "../foo1"]);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Fixed!\n");
+    insta::assert_snapshot!(content, @"Fixed![EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @r"
+    unfixed
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir/foo3", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @r"
+    unfixed
+    [EOF]
+    ");
 
     // The current directory does not change the interpretation of the config, so
     // foo2 is fixed but not dir/foo3.
     let (_stdout, _stderr) = test_env.jj_cmd_ok(&repo_path.join("dir"), &["fix"]);
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo1", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Fixed!\n");
+    insta::assert_snapshot!(content, @"Fixed![EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "foo2", "-r", "@"]);
-    insta::assert_snapshot!(content, @"Fixed!\n");
+    insta::assert_snapshot!(content, @"Fixed![EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "dir/foo3", "-r", "@"]);
-    insta::assert_snapshot!(content, @"unfixed\n");
+    insta::assert_snapshot!(content, @r"
+    unfixed
+    [EOF]
+    ");
 }
 
 #[test]
@@ -447,6 +516,7 @@ fn test_fix_empty_commit() {
     insta::assert_snapshot!(stderr, @r"
     Fixed 0 commits of 1 checked.
     Nothing changed.
+    [EOF]
     ");
 }
 
@@ -464,11 +534,15 @@ fn test_fix_leaf_commit() {
     Working copy now at: rlvkpnrz 85ce8924 (no description set)
     Parent commit      : qpvuntsm b2ca2bc5 (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@-"]);
-    insta::assert_snapshot!(content, @"unaffected");
+    insta::assert_snapshot!(content, @"unaffected[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"AFFECTED");
+    insta::assert_snapshot!(content, @r"
+    AFFECTED
+    [EOF]
+    ");
 }
 
 #[test]
@@ -491,13 +565,23 @@ fn test_fix_parent_commit() {
     Working copy now at: mzvwutvl d30c8ae2 child2 | (no description set)
     Parent commit      : qpvuntsm 70a4dae2 parent | (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "parent"]);
-    insta::assert_snapshot!(content, @"PARENT");
+    insta::assert_snapshot!(content, @r"
+    PARENT
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child1"]);
-    insta::assert_snapshot!(content, @"CHILD1");
+    insta::assert_snapshot!(content, @r"
+    CHILD1
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child2"]);
-    insta::assert_snapshot!(content, @"CHILD2");
+    insta::assert_snapshot!(content, @r"
+    CHILD2
+    [EOF]
+    ");
 }
 
 #[test]
@@ -514,13 +598,19 @@ fn test_fix_sibling_commit() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix", "-s", "child1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Fixed 1 commits of 1 checked.");
+    insta::assert_snapshot!(stderr, @r"
+    Fixed 1 commits of 1 checked.
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "parent"]);
-    insta::assert_snapshot!(content, @"parent");
+    insta::assert_snapshot!(content, @"parent[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child1"]);
-    insta::assert_snapshot!(content, @"CHILD1");
+    insta::assert_snapshot!(content, @r"
+    CHILD1
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "child2"]);
-    insta::assert_snapshot!(content, @"child2");
+    insta::assert_snapshot!(content, @"child2[EOF]");
 }
 
 #[test]
@@ -556,19 +646,29 @@ fn test_default_revset() {
     Working copy now at: yostqsxw dabc47b2 bar2 | (no description set)
     Parent commit      : yqosqzyt 984b5924 bar1 | (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "trunk1"]);
-    insta::assert_snapshot!(content, @"trunk1");
+    insta::assert_snapshot!(content, @"trunk1[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "trunk2"]);
-    insta::assert_snapshot!(content, @"trunk2");
+    insta::assert_snapshot!(content, @"trunk2[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "foo"]);
-    insta::assert_snapshot!(content, @"foo");
+    insta::assert_snapshot!(content, @"foo[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar1"]);
-    insta::assert_snapshot!(content, @"BAR1");
+    insta::assert_snapshot!(content, @r"
+    BAR1
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar2"]);
-    insta::assert_snapshot!(content, @"BAR2");
+    insta::assert_snapshot!(content, @r"
+    BAR2
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar3"]);
-    insta::assert_snapshot!(content, @"BAR3");
+    insta::assert_snapshot!(content, @r"
+    BAR3
+    [EOF]
+    ");
 }
 
 #[test]
@@ -588,11 +688,17 @@ fn test_custom_default_revset() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Fixed 1 commits of 1 checked.");
+    insta::assert_snapshot!(stderr, @r"
+    Fixed 1 commits of 1 checked.
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "foo"]);
-    insta::assert_snapshot!(content, @"foo");
+    insta::assert_snapshot!(content, @"foo[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "bar"]);
-    insta::assert_snapshot!(content, @"BAR");
+    insta::assert_snapshot!(content, @r"
+    BAR
+    [EOF]
+    ");
 }
 
 #[test]
@@ -610,11 +716,12 @@ fn test_fix_immutable_commit() {
     Error: Commit e4b41a3ce243 is immutable
     Hint: Could not modify commit: qpvuntsm e4b41a3c immutable | (no description set)
     Hint: Pass `--ignore-immutable` or configure the set of immutable commits via `revset-aliases.immutable_heads()`.
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "immutable"]);
-    insta::assert_snapshot!(content, @"immutable");
+    insta::assert_snapshot!(content, @"immutable[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "mutable"]);
-    insta::assert_snapshot!(content, @"mutable");
+    insta::assert_snapshot!(content, @"mutable[EOF]");
 }
 
 #[test]
@@ -627,6 +734,7 @@ fn test_fix_empty_file() {
     insta::assert_snapshot!(stderr, @r"
     Fixed 0 commits of 1 checked.
     Nothing changed.
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(content, @"");
@@ -645,13 +753,15 @@ fn test_fix_some_paths() {
     Working copy now at: qpvuntsm 54a90d2b (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     FOO
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(content, @"bar");
+    insta::assert_snapshot!(content, @"bar[EOF]");
 }
 
 #[test]
@@ -666,9 +776,13 @@ fn test_fix_cyclic() {
     Working copy now at: qpvuntsm bf5e6a5a (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"tnetnoc\n");
+    insta::assert_snapshot!(content, @r"
+    tnetnoc
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix"]);
     insta::assert_snapshot!(stdout, @"");
@@ -677,9 +791,13 @@ fn test_fix_cyclic() {
     Working copy now at: qpvuntsm 0e2d20d6 (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content\n");
+    insta::assert_snapshot!(content, @r"
+    content
+    [EOF]
+    ");
 }
 
 #[test]
@@ -710,15 +828,28 @@ fn test_deduplication() {
     Working copy now at: yqosqzyt cf770245 d | (no description set)
     Parent commit      : mzvwutvl 370615a5 c | (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "a"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @r"
+    FOO
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "b"]);
-    insta::assert_snapshot!(content, @"BAR\n");
+    insta::assert_snapshot!(content, @r"
+    BAR
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "c"]);
-    insta::assert_snapshot!(content, @"BAR\n");
+    insta::assert_snapshot!(content, @r"
+    BAR
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "d"]);
-    insta::assert_snapshot!(content, @"FOO\n");
+    insta::assert_snapshot!(content, @r"
+    FOO
+    [EOF]
+    ");
 
     // Each new content string only appears once in the log, because all the other
     // inputs (like file name) were identical, and so the results were reused. We
@@ -748,9 +879,13 @@ fn test_executed_but_nothing_changed() {
     insta::assert_snapshot!(stderr, @r"
     Fixed 0 commits of 1 checked.
     Nothing changed.
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content\n");
+    insta::assert_snapshot!(content, @r"
+    content
+    [EOF]
+    ");
     let copy_content = std::fs::read_to_string(repo_path.join("file-copy").as_os_str()).unwrap();
     insta::assert_snapshot!(copy_content, @"content\n");
 }
@@ -765,9 +900,10 @@ fn test_failure() {
     insta::assert_snapshot!(stderr, @r"
     Fixed 0 commits of 1 checked.
     Nothing changed.
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content");
+    insta::assert_snapshot!(content, @"content[EOF]");
 }
 
 #[test]
@@ -785,9 +921,10 @@ fn test_stderr_success() {
     Working copy now at: qpvuntsm 487808ba (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"new content");
+    insta::assert_snapshot!(content, @"new content[EOF]");
 }
 
 #[test]
@@ -801,9 +938,10 @@ fn test_stderr_failure() {
     insta::assert_snapshot!(stderr, @r"
     errorFixed 0 commits of 1 checked.
     Nothing changed.
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"old content");
+    insta::assert_snapshot!(content, @"old content[EOF]");
 }
 
 #[test]
@@ -824,6 +962,7 @@ fn test_missing_command() {
     insta::assert_snapshot!(stderr, @r"
     Fixed 0 commits of 1 checked.
     Nothing changed.
+    [EOF]
     ");
 }
 
@@ -841,9 +980,13 @@ fn test_fix_file_types() {
     Working copy now at: qpvuntsm 6836a9e4 (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"CONTENT");
+    insta::assert_snapshot!(content, @r"
+    CONTENT
+    [EOF]
+    ");
 }
 
 #[cfg(unix)]
@@ -863,9 +1006,13 @@ fn test_fix_executable() {
     Working copy now at: qpvuntsm fee78e99 (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @"CONTENT");
+    insta::assert_snapshot!(content, @r"
+    CONTENT
+    [EOF]
+    ");
     let executable = std::fs::metadata(&path).unwrap().permissions().mode() & 0o111;
     assert_eq!(executable, 0o111);
 }
@@ -889,13 +1036,14 @@ fn test_fix_trivial_merge_commit() {
     insta::assert_snapshot!(stderr, @r"
     Fixed 0 commits of 1 checked.
     Nothing changed.
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_a", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content a");
+    insta::assert_snapshot!(content, @"content a[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_b", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content b");
+    insta::assert_snapshot!(content, @"content b[EOF]");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_c", "-r", "@"]);
-    insta::assert_snapshot!(content, @"content c");
+    insta::assert_snapshot!(content, @"content c[EOF]");
 }
 
 #[test]
@@ -924,15 +1072,28 @@ fn test_fix_adding_merge_commit() {
     Parent commit      : qpvuntsm 6e64e7a7 a | (no description set)
     Parent commit      : kkmpptxz c536f264 b | (no description set)
     Added 0 files, modified 4 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_a", "-r", "@"]);
-    insta::assert_snapshot!(content, @"CHANGE A");
+    insta::assert_snapshot!(content, @r"
+    CHANGE A
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_b", "-r", "@"]);
-    insta::assert_snapshot!(content, @"CHANGE B");
+    insta::assert_snapshot!(content, @r"
+    CHANGE B
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_c", "-r", "@"]);
-    insta::assert_snapshot!(content, @"CHANGE C");
+    insta::assert_snapshot!(content, @r"
+    CHANGE C
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file_d", "-r", "@"]);
-    insta::assert_snapshot!(content, @"CHANGE D");
+    insta::assert_snapshot!(content, @r"
+    CHANGE D
+    [EOF]
+    ");
 }
 
 #[test]
@@ -957,24 +1118,28 @@ fn test_fix_both_sides_of_conflict() {
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "a"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     CONTENT A
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "b"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     CONTENT B
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     +CONTENT A
     +++++++ Contents of side #2
     CONTENT B
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -999,11 +1164,13 @@ fn test_fix_resolve_conflict() {
     Parent commit      : qpvuntsm dd2721f1 a | (no description set)
     Parent commit      : kkmpptxz 07c27a8e b | (no description set)
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     CONTENT
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1058,96 +1225,108 @@ fn test_all_files() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Fixed 2 commits of 2 checked.
     Working copy now at: rlvkpnrz c098d165 child
     Parent commit      : qpvuntsm 0bb31627 parent
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    [EOF]
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent aaa
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
-    fixed
-    "###);
+    fixed[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent ccc
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent ddd
-    "###);
+    [EOF]
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     child aaa
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
-    fixed
-    "###);
+    fixed[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent ccc
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     child ddd
-    "###);
+    [EOF]
+    ");
 
     // Not specifying files means all files will be fixed in each revision.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["fix", "--include-unchanged-files"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Fixed 2 commits of 2 checked.
     Working copy now at: rlvkpnrz c5d0aa1d child
     Parent commit      : qpvuntsm b4d02ca9 parent
     Added 0 files, modified 2 files, removed 0 files
-    "###);
+    [EOF]
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent aaa
-    fixed
-    "###);
+    fixed[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
     fixed
-    fixed
-    "###);
+    fixed[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent ccc
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@-"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent ddd
-    "###);
+    [EOF]
+    ");
 
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "a/a", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     child aaa
-    fixed
-    "###);
+    fixed[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "b/b", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent bbb
     fixed
-    fixed
-    "###);
+    fixed[EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "c/c", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     parent ccc
-    "###);
+    [EOF]
+    ");
     let content = test_env.jj_cmd_success(&repo_path, &["file", "show", "ddd", "-r", "@"]);
-    insta::assert_snapshot!(content, @r###"
+    insta::assert_snapshot!(content, @r"
     child ddd
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -274,7 +274,7 @@ fn test_config_tables_all_commands_missing() {
     std::fs::write(repo_path.join("foo"), "foo\n").unwrap();
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["fix"]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r"
     Config error: Invalid type or value for fix.tools.my-tool-missing-command-1
     Caused by: missing field `command`
 
@@ -308,7 +308,7 @@ fn test_config_tables_some_commands_missing() {
     std::fs::write(repo_path.join("foo"), "foo\n").unwrap();
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["fix"]);
-    insta::assert_snapshot!(stderr.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r"
     Config error: Invalid type or value for fix.tools.my-tool-missing-command
     Caused by: missing field `command`
 

--- a/cli/tests/test_generate_md_cli_help.rs
+++ b/cli/tests/test_generate_md_cli_help.rs
@@ -25,8 +25,11 @@ const PREAMBLE: &str = r#"
 fn test_generate_markdown_docs_in_docs_dir() {
     let test_env = TestEnvironment::default();
     let mut markdown_help = PREAMBLE.to_string();
-    markdown_help
-        .push_str(&test_env.jj_cmd_success(test_env.env_root(), &["util", "markdown-help"]));
+    markdown_help.push_str(
+        test_env
+            .jj_cmd_success(test_env.env_root(), &["util", "markdown-help"])
+            .raw(),
+    );
 
     insta::with_settings!({
         snapshot_path => ".",

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -68,10 +68,11 @@ fn test_git_clone(subprocess: bool) {
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "clone", "source", "empty"]);
     insta::allow_duplicates! { insta::assert_snapshot!(stdout, @""); }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/empty"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
 
     set_up_non_empty_git_repo(&git_repo);
@@ -90,6 +91,7 @@ fn test_git_clone(subprocess: bool) {
     Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
     assert!(test_env.env_root().join("clone").join("file").exists());
@@ -101,9 +103,10 @@ fn test_git_clone(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 
     // Failed clone should clean up the destination directory
@@ -122,11 +125,13 @@ fn test_git_clone(subprocess: bool) {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: Could not find repository at '$TEST_ENV/bad'
+        [EOF]
         "#);
     } else {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
+        [EOF]
         "#);
     }
     assert!(!test_env.env_root().join("failed").exists());
@@ -147,11 +152,13 @@ fn test_git_clone(subprocess: bool) {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: Could not find repository at '$TEST_ENV/bad'
+        [EOF]
         "#);
     } else {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
+        [EOF]
         "#);
     }
     assert!(test_env.env_root().join("failed").exists());
@@ -160,36 +167,40 @@ fn test_git_clone(subprocess: bool) {
     // Failed clone (if attempted) shouldn't remove the existing workspace
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "bad", "clone"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
     assert!(test_env.env_root().join("clone").join(".jj").exists());
 
     // Try cloning into an existing workspace
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "clone"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
 
     // Try cloning into an existing file
     std::fs::write(test_env.env_root().join("file"), "contents").unwrap();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "file"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
 
     // Try cloning into non-empty, non-workspace directory
     std::fs::remove_dir_all(test_env.env_root().join("clone").join(".jj")).unwrap();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "clone"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
 
     // Clone into a nested path
@@ -208,6 +219,7 @@ fn test_git_clone(subprocess: bool) {
     Working copy now at: uuzqqzqu df8acbac (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
 }
@@ -222,7 +234,10 @@ fn test_git_clone_bad_source(subprocess: bool) {
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["git", "clone", "", "dest"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"Error: local path "" does not specify a path to a repository"#);
+    insta::assert_snapshot!(stderr, @r#"
+    Error: local path "" does not specify a path to a repository
+    [EOF]
+    "#);
     }
 
     // Invalid port number
@@ -234,6 +249,7 @@ fn test_git_clone_bad_source(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r#"
     Error: URL "https://example.net:bad-port/bar" can not be parsed as valid URL
     Caused by: invalid port number
+    [EOF]
     "#);
     }
 }
@@ -258,10 +274,11 @@ fn test_git_clone_colocate(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/empty"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
 
     // git_target path should be relative to the store
@@ -293,6 +310,7 @@ fn test_git_clone_colocate(subprocess: bool) {
     Working copy now at: uuqppmxq 1f0b881a (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
     assert!(test_env.env_root().join("clone").join("file").exists());
@@ -334,11 +352,12 @@ fn test_git_clone_colocate(subprocess: bool) {
     // The old default bookmark "master" shouldn't exist.
     insta::allow_duplicates! {
     insta::assert_snapshot!(
-        get_bookmark_output(&test_env, &test_env.env_root().join("clone")), @r###"
+        get_bookmark_output(&test_env, &test_env.env_root().join("clone")), @r"
     main: mzyxwzks 9f01a0e0 message
       @git: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    [EOF]
+    ");
     }
 
     // Subsequent fetch should just work even if the source path was relative
@@ -348,9 +367,10 @@ fn test_git_clone_colocate(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 
     // Failed clone should clean up the destination directory
@@ -372,11 +392,13 @@ fn test_git_clone_colocate(subprocess: bool) {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: Could not find repository at '$TEST_ENV/bad'
+        [EOF]
         "#);
     } else {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
+        [EOF]
         "#);
     }
     assert!(!test_env.env_root().join("failed").exists());
@@ -400,11 +422,13 @@ fn test_git_clone_colocate(subprocess: bool) {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: Could not find repository at '$TEST_ENV/bad'
+        [EOF]
         "#);
     } else {
         insta::assert_snapshot!(stderr, @r#"
         Fetching into new repo in "$TEST_ENV/failed"
         Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
+        [EOF]
         "#);
     }
     assert!(test_env.env_root().join("failed").exists());
@@ -417,9 +441,10 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "--colocate", "bad", "clone"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
     assert!(test_env.env_root().join("clone").join(".git").exists());
     assert!(test_env.env_root().join("clone").join(".jj").exists());
@@ -430,9 +455,10 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "source", "clone", "--colocate"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
 
     // Try cloning into an existing file
@@ -442,9 +468,10 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "source", "file", "--colocate"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
 
     // Try cloning into non-empty, non-workspace directory
@@ -454,9 +481,10 @@ fn test_git_clone_colocate(subprocess: bool) {
         &["git", "clone", "source", "clone", "--colocate"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Destination path exists and is not an empty directory
-    "###);
+    [EOF]
+    ");
     }
 
     // Clone into a nested path
@@ -481,6 +509,7 @@ fn test_git_clone_colocate(subprocess: bool) {
     Working copy now at: vzqnnsmr 9407107f (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
 }
@@ -518,16 +547,18 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     Working copy now at: sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 feature1 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(
-        get_bookmark_output(&test_env, &test_env.env_root().join("clone1")), @r###"
+        get_bookmark_output(&test_env, &test_env.env_root().join("clone1")), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
     main: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    [EOF]
+    ");
     }
 
     // "trunk()" alias should be set to default bookmark "main"
@@ -536,9 +567,10 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
         &["config", "list", "--repo", "revset-aliases.'trunk()'"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     revset-aliases.'trunk()' = "main@origin"
-    "###);
+    [EOF]
+    "#);
     }
 
     // Only the default bookmark will be imported if auto-local-bookmark is off
@@ -554,15 +586,17 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     Working copy now at: rzvqmyuk cc8a5041 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 feature1@origin main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(
-        get_bookmark_output(&test_env, &test_env.env_root().join("clone2")), @r###"
+        get_bookmark_output(&test_env, &test_env.env_root().join("clone2")), @r"
     feature1@origin: mzyxwzks 9f01a0e0 message
     main: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    [EOF]
+    ");
     }
 
     // Change the default bookmark in remote
@@ -578,6 +612,7 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     Working copy now at: nppvrztz b8a8a17b (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 feature1 main@origin | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
     insta::allow_duplicates! {
@@ -586,6 +621,7 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
     main@origin: mzyxwzks 9f01a0e0 message
+    [EOF]
     ");
     }
 
@@ -595,9 +631,10 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
         &["config", "list", "--repo", "revset-aliases.'trunk()'"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     revset-aliases.'trunk()' = "feature1@origin"
-    "###);
+    [EOF]
+    "#);
     }
 }
 
@@ -631,6 +668,7 @@ fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
     Working copy now at: sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 " | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
 
@@ -640,7 +678,10 @@ fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
         &["config", "list", "--repo", "revset-aliases.'trunk()'"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r#"revset-aliases.'trunk()' = '"\""@origin'"#);
+    insta::assert_snapshot!(stdout, @r#"
+    revset-aliases.'trunk()' = '"\""@origin'
+    [EOF]
+    "#);
     }
 }
 
@@ -665,17 +706,19 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
     Fetching into new repo in "$TEST_ENV/clone"
     bookmark: main@origin [new] untracked
     Setting the revset alias `trunk()` to `main@origin`
+    [EOF]
     "#);
     }
     let clone_path = test_env.env_root().join("clone");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["status", "--ignore-working-copy"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     Working copy : sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit: mzyxwzks 9f01a0e0 main | message
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @"");
@@ -684,11 +727,12 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
     // TODO: Correct, but might be better to check out the root commit?
     let stderr = test_env.jj_cmd_failure(&clone_path, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation eac759b9ab75).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    [EOF]
+    ");
     }
 }
 
@@ -708,9 +752,10 @@ fn test_git_clone_at_operation(subprocess: bool) {
         &["git", "clone", "--at-op=@-", "source", "clone"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --at-op is not respected
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -742,6 +787,7 @@ fn test_git_clone_with_remote_name(subprocess: bool) {
     Working copy now at: sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
 }
@@ -764,6 +810,7 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     }
 }
@@ -786,6 +833,7 @@ fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remotes with slashes are incompatible with jj: slash/origin
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     }
 }
@@ -815,6 +863,7 @@ fn test_git_clone_trunk_deleted(subprocess: bool) {
     Working copy now at: sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     }
 
@@ -826,28 +875,31 @@ fn test_git_clone_trunk_deleted(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
     Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
-    "#);
+    [EOF]
+    ");
     }
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["log"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 cad212e1
     │  (empty) (no description set)
     ○  mzyxwzks some.one@example.com 1970-01-01 11:00:00 9f01a0e0
     │  message
     ◆  zzzzzzzz root() 00000000
-    "#);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r"
     Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
+    [EOF]
     ");
     }
 }
@@ -900,6 +952,7 @@ fn test_git_clone_conditional_config() {
     @  base@old-repo new empty commit
     ○  base@base add workspace 'default'
     ○  @
+    [EOF]
     ");
 
     // Clone repo at the old workspace directory.
@@ -914,6 +967,7 @@ fn test_git_clone_conditional_config() {
     Working copy now at: zxsnswpr 5695b5e5 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
     jj_cmd_ok(&new_workspace_root, &["new"]);
     let (stdout, _stderr) = jj_cmd_ok(&new_workspace_root, &["log", "-T", log_template]);
@@ -923,6 +977,7 @@ fn test_git_clone_conditional_config() {
     ◆  some.one@example.com message
     │
     ~
+    [EOF]
     ");
     let (stdout, _stderr) = jj_cmd_ok(&new_workspace_root, &["op", "log", "-T", op_log_template]);
     insta::assert_snapshot!(stdout, @r"
@@ -931,6 +986,7 @@ fn test_git_clone_conditional_config() {
     ○  new-repo@base fetch from git remote into empty repo
     ○  new-repo@base add workspace 'default'
     ○  @
+    [EOF]
     ");
 }
 
@@ -954,6 +1010,7 @@ fn test_git_clone_with_depth_git2() {
     insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/clone"
     Error: shallow fetch is not supported by the local transport; class=Net (12)
+    [EOF]
     "#);
 }
 
@@ -980,6 +1037,7 @@ fn test_git_clone_with_depth_subprocess() {
     Working copy now at: sqpuoqvx cad212e1 (empty) (no description set)
     Parent commit      : mzyxwzks 9f01a0e0 main | message
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     "#);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["log"]);
@@ -989,6 +1047,7 @@ fn test_git_clone_with_depth_subprocess() {
     ◆  mzyxwzks some.one@example.com 1970-01-01 11:00:00 main 9f01a0e0
     │  message
     ~
+    [EOF]
     ");
     insta::assert_snapshot!(stderr, @"");
 }
@@ -1018,6 +1077,7 @@ fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     Config error: Invalid `revset-aliases.immutable_heads()`
     Caused by: Revision `unknown` doesn't exist
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     "#);
     }
 }
@@ -1046,27 +1106,30 @@ fn test_git_clone_malformed(subprocess: bool) {
     Setting the revset alias `trunk()` to `main@origin`
     Internal error: Failed to check out commit 039a1eae03465fd3be0fbad87c9ca97303742677
     Caused by: Reserved path component .jj in $TEST_ENV/clone/.jj
+    [EOF]
     "#);
     }
 
     // The cloned workspace isn't usable.
     let stderr = test_env.jj_cmd_failure(&clone_path, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation 4a8ddda0ff63).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    [EOF]
+    ");
     }
 
     // The error can be somehow recovered.
     // TODO: add an update-stale flag to reset the working-copy?
     let stderr = test_env.jj_cmd_internal_error(&clone_path, &["workspace", "update-stale"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Internal error: Failed to check out commit 039a1eae03465fd3be0fbad87c9ca97303742677
     Caused by: Reserved path component .jj in $TEST_ENV/clone/.jj
-    "#);
+    [EOF]
+    ");
     }
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&clone_path, &["new", "root()", "--ignore-working-copy"]);
@@ -1075,11 +1138,12 @@ fn test_git_clone_malformed(subprocess: bool) {
     }
     let stdout = test_env.jj_cmd_success(&clone_path, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     Working copy : zsuskuln f652c321 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1095,6 +1159,7 @@ fn test_git_clone_no_git_executable() {
     insta::assert_snapshot!(stderr.strip_last_line(), @r#"
     Fetching into new repo in "$TEST_ENV/clone"
     Error: Could not execute the git process, found in the OS path 'jj-test-missing-program'
+    [EOF]
     "#);
 }
 
@@ -1114,6 +1179,7 @@ fn test_git_clone_no_git_executable_with_path() {
     insta::assert_snapshot!(stderr.strip_last_line(), @r#"
     Fetching into new repo in "$TEST_ENV/clone"
     Error: Could not execute git process at specified path '$TEST_ENV/invalid/path'
+    [EOF]
     "#);
 }
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -21,8 +21,8 @@ use test_case::test_case;
 
 use crate::common::get_stderr_string;
 use crate::common::get_stdout_string;
-use crate::common::strip_last_line;
 use crate::common::to_toml_value;
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn set_up_non_empty_git_repo(git_repo: &git2::Repository) {
@@ -112,8 +112,8 @@ fn test_git_clone(subprocess: bool) {
         .jj_cmd(test_env.env_root(), &["git", "clone", "bad", "failed"])
         .assert()
         .code(1);
-    let stdout = test_env.normalize_output(&get_stdout_string(&assert));
-    let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+    let stdout = test_env.normalize_output(get_stdout_string(&assert));
+    let stderr = test_env.normalize_output(get_stderr_string(&assert));
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
@@ -137,8 +137,8 @@ fn test_git_clone(subprocess: bool) {
         .jj_cmd(test_env.env_root(), &["git", "clone", "bad", "failed"])
         .assert()
         .code(1);
-    let stdout = test_env.normalize_output(&get_stdout_string(&assert));
-    let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+    let stdout = test_env.normalize_output(get_stdout_string(&assert));
+    let stderr = test_env.normalize_output(get_stderr_string(&assert));
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
@@ -362,8 +362,8 @@ fn test_git_clone_colocate(subprocess: bool) {
         )
         .assert()
         .code(1);
-    let stdout = test_env.normalize_output(&get_stdout_string(&assert));
-    let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+    let stdout = test_env.normalize_output(get_stdout_string(&assert));
+    let stderr = test_env.normalize_output(get_stderr_string(&assert));
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
@@ -390,8 +390,8 @@ fn test_git_clone_colocate(subprocess: bool) {
         )
         .assert()
         .code(1);
-    let stdout = test_env.normalize_output(&get_stdout_string(&assert));
-    let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+    let stdout = test_env.normalize_output(get_stdout_string(&assert));
+    let stderr = test_env.normalize_output(get_stderr_string(&assert));
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
@@ -867,8 +867,8 @@ fn test_git_clone_conditional_config() {
         cmd.env_remove("JJ_OP_HOSTNAME");
         cmd.env_remove("JJ_OP_USERNAME");
         let assert = cmd.assert().success();
-        let stdout = test_env.normalize_output(&get_stdout_string(&assert));
-        let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+        let stdout = test_env.normalize_output(get_stdout_string(&assert));
+        let stderr = test_env.normalize_output(get_stderr_string(&assert));
         (stdout, stderr)
     };
     let log_template = r#"separate(' ', author.email(), description.first_line()) ++ "\n""#;
@@ -1092,7 +1092,7 @@ fn test_git_clone_no_git_executable() {
     set_up_non_empty_git_repo(&git_repo);
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "clone"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r#"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r#"
     Fetching into new repo in "$TEST_ENV/clone"
     Error: Could not execute the git process, found in the OS path 'jj-test-missing-program'
     "#);
@@ -1111,12 +1111,12 @@ fn test_git_clone_no_git_executable_with_path() {
     set_up_non_empty_git_repo(&git_repo);
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "source", "clone"]);
-    insta::assert_snapshot!(strip_last_line(&stderr), @r#"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r#"
     Fetching into new repo in "$TEST_ENV/clone"
     Error: Could not execute git process at specified path '$TEST_ENV/invalid/path'
     "#);
 }
 
-fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes"])
 }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 
 use git2::Oid;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -338,10 +339,12 @@ fn test_git_colocated_bookmarks() {
     );
 
     // Update the bookmark in Git
-    let target_id = test_env.jj_cmd_success(
-        &workspace_root,
-        &["log", "--no-graph", "-T=commit_id", "-r=description(foo)"],
-    );
+    let target_id = test_env
+        .jj_cmd_success(
+            &workspace_root,
+            &["log", "--no-graph", "-T=commit_id", "-r=description(foo)"],
+        )
+        .into_raw();
     git_repo
         .reference(
             "refs/heads/master",
@@ -1127,7 +1130,7 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     "#);
 }
 
-fn get_log_output_divergence(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output_divergence(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"
     separate(" ",
       change_id.short(),
@@ -1141,7 +1144,7 @@ fn get_log_output_divergence(test_env: &TestEnvironment, repo_path: &Path) -> St
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
-fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> CommandOutputString {
     let template = r#"
     separate(" ",
       commit_id,
@@ -1156,7 +1159,7 @@ fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
 fn get_log_output_with_stderr(
     test_env: &TestEnvironment,
     workspace_root: &Path,
-) -> (String, String) {
+) -> (CommandOutputString, CommandOutputString) {
     let template = r#"
     separate(" ",
       commit_id,
@@ -1277,7 +1280,7 @@ fn test_git_colocated_unreachable_commits() {
     insta::assert_snapshot!(stderr, @"Error: Revision `8e713ff77b54928dd4a82aaabeca44b1ae91722c` doesn't exist");
 }
 
-fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     // --quiet to suppress deleted bookmarks hint
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes", "--quiet"])
 }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -58,11 +58,12 @@ fn test_git_colocated() {
 
     // Import the repo
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  3e9369cd54227eb88455e1834dbc08aad6a16ac4
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"e61b6729ff4292870702f2f72b2a60165679ef37"
@@ -71,11 +72,12 @@ fn test_git_colocated() {
     // Modify the working copy. The working-copy commit should changed, but the Git
     // HEAD commit should not
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  4f546c80f30abc0803fb83e5032a4d49fede4d68
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"e61b6729ff4292870702f2f72b2a60165679ef37"
@@ -83,12 +85,13 @@ fn test_git_colocated() {
 
     // Create a new change from jj and check that it's reflected in Git
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  0e2301a42b288b9568344e32cfdd8c76d1e56a83
     ○  4f546c80f30abc0803fb83e5032a4d49fede4d68 git_head()
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"4f546c80f30abc0803fb83e5032a4d49fede4d68"
@@ -120,67 +123,74 @@ fn test_git_colocated_unborn_bookmark() {
         git_repo.find_reference("HEAD").unwrap().symbolic_target(),
         Some("refs/heads/master")
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Stage some change, and check out root. This shouldn't clobber the HEAD.
     add_file_to_index("file0", "");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz fcdbbd73 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     assert!(git_repo.head().is_err());
     assert_eq!(
         git_repo.find_reference("HEAD").unwrap().symbolic_target(),
         Some("refs/heads/master")
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  fcdbbd731496cae17161cd6be9b6cf1f759655a8
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
     // Staged change shouldn't persist.
     checkout_index();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r"
     The working copy has no changes.
     Working copy : kkmpptxz fcdbbd73 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Stage some change, and create new HEAD. This shouldn't move the default
     // bookmark.
     add_file_to_index("file1", "");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: royxmykx 0e146103 (empty) (no description set)
     Parent commit      : kkmpptxz e3e01407 (no description set)
-    "###);
+    [EOF]
+    ");
     assert!(git_repo.head().unwrap().symbolic_target().is_none());
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"e3e01407bd3539722ae4ffff077700d97c60cb11"
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  0e14610343ef50775f5c44db5aeef19aee45d9ad
     ○  e3e01407bd3539722ae4ffff077700d97c60cb11 git_head()
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
     // Staged change shouldn't persist.
     checkout_index();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r"
     The working copy has no changes.
     Working copy : royxmykx 0e146103 (empty) (no description set)
     Parent commit: kkmpptxz e3e01407 (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Assign the default bookmark. The bookmark is no longer "unborn".
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@-", "master"]);
@@ -190,13 +200,14 @@ fn test_git_colocated_unborn_bookmark() {
     add_file_to_index("file2", "");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: znkkpsqq 10dd328b (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 2 files
-    "###);
+    [EOF]
+    ");
     assert!(git_repo.head().is_err());
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  10dd328bb906e15890e55047740eab2812a3b2f7
     │ ○  ef75c0b0dcc9b080e00226908c21316acaa84dc6
     │ ○  e3e01407bd3539722ae4ffff077700d97c60cb11 master
@@ -204,24 +215,27 @@ fn test_git_colocated_unborn_bookmark() {
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
     // Staged change shouldn't persist.
     checkout_index();
-    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&workspace_root, &["status"]), @r"
     The working copy has no changes.
     Working copy : znkkpsqq 10dd328b (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // New snapshot and commit can be created after the HEAD got unset.
     std::fs::write(workspace_root.join("file3"), "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["new"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: wqnwkozp 101e2723 (empty) (no description set)
     Parent commit      : znkkpsqq fc8af934 (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  101e272377a9daff75358f10dbd078df922fe68c
     ○  fc8af9345b0830dcb14716e04cd2af26e2d19f63 git_head()
     │ ○  ef75c0b0dcc9b080e00226908c21316acaa84dc6
@@ -230,7 +244,8 @@ fn test_git_colocated_unborn_bookmark() {
     │ ○  993600f1189571af5bbeb492cf657dc7d0fde48a
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -246,18 +261,20 @@ fn test_git_colocated_export_bookmarks_on_snapshot() {
     // Create bookmark pointing to the initial commit
     std::fs::write(workspace_root.join("file"), "initial").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "foo"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7 foo
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // The bookmark gets updated when we modify the working copy, and it should get
     // exported to Git without requiring any other changes
     std::fs::write(workspace_root.join("file"), "modified").unwrap();
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf foo
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(git_repo
         .find_reference("refs/heads/foo")
         .unwrap()
@@ -295,19 +312,21 @@ fn test_git_colocated_rebase_on_import() {
     let commit1 = commit2.parents().next().unwrap();
     git_repo.branch("master", &commit1, true).unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  15b1d70c5e33b5d2b18383292b85324d5153ffed
     ○  47fe984daf66f7bf3ebf31b9cb3513c995afb857 master git_head() add a file
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Abandoned 1 commits that are no longer reachable.
     Rebased 1 descendant commits off of commits rewritten from git
     Working copy now at: zsuskuln 15b1d70c (empty) (no description set)
     Parent commit      : qpvuntsm 47fe984d master | add a file
     Added 0 files, modified 1 files, removed 0 files
     Done importing changes from the underlying Git repo.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -318,13 +337,14 @@ fn test_git_colocated_bookmarks() {
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m", "foo"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "@-", "-m", "bar"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  3560559274ab431feea00b7b7e0b9250ecce951f bar
     │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda foo
     ├─╯
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Create a bookmark in jj. It should be exported to Git even though it points
     // to the working- copy commit.
@@ -354,19 +374,21 @@ fn test_git_colocated_bookmarks() {
         )
         .unwrap();
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &workspace_root);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  096dc80da67094fbaa6683e2a205dddffa31f9a8
     │ ○  1e6f0b403ed2ff9713b5d6b1dc601e4804250cda master foo
     ├─╯
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Abandoned 1 commits that are no longer reachable.
     Working copy now at: yqosqzyt 096dc80d (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     Done importing changes from the underlying Git repo.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -377,25 +399,28 @@ fn test_git_colocated_bookmark_forget() {
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "foo"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  65b6b74e08973b88d38404430f119c8c79465250 foo
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     foo: rlvkpnrz 65b6b74e (empty) (no description set)
       @git: rlvkpnrz 65b6b74e (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_root,
         &["bookmark", "forget", "--include-remotes", "foo"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
-    "#);
+    [EOF]
+    ");
     // A forgotten bookmark is deleted in the git repo. For a detailed demo
     // explaining this, see `test_bookmark_forget_export` in
     // `test_bookmark_command.rs`.
@@ -410,16 +435,18 @@ fn test_git_colocated_bookmark_at_root() {
 
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "foo", "-r=root()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to zzzzzzzz 00000000 foo | (empty) (no description set)
     Warning: Failed to export some bookmarks:
       foo: Ref cannot point to the root commit in Git
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "move", "foo", "--to=@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to qpvuntsm 230dd059 foo | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -431,11 +458,12 @@ fn test_git_colocated_bookmark_at_root() {
             "--to=root()",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Moved 1 bookmarks to zzzzzzzz 00000000 foo* | (empty) (no description set)
     Warning: Failed to export some bookmarks:
       foo: Ref cannot point to the root commit in Git
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -449,14 +477,15 @@ fn test_git_colocated_conflicting_git_refs() {
         test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "main/sub"]);
     insta::assert_snapshot!(stdout, @"");
     insta::with_settings!({filters => vec![("Failed to set: .*", "Failed to set: ...")]}, {
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r#"
         Created 1 bookmarks pointing to qpvuntsm 230dd059 main main/sub | (empty) (no description set)
         Warning: Failed to export some bookmarks:
           main/sub: Failed to set: ...
         Hint: Git doesn't allow a branch name that looks like a parent directory of
         another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
         export or their "parent" bookmarks.
-        "###);
+        [EOF]
+        "#);
     });
 }
 
@@ -503,23 +532,25 @@ fn test_git_colocated_checkout_non_empty_working_copy() {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "two"]);
     test_env.jj_cmd_ok(&workspace_root, &["new", "@-"]);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "new"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 149cc31c (empty) new
     Parent commit      : lnksqltp e61b6729 master | initial
-    "###);
+    [EOF]
+    ");
 
     let git_head = git_repo.find_reference("HEAD").unwrap();
     let git_head_target = git_head.symbolic_target().unwrap();
 
     assert_eq!(git_head_target, "refs/heads/master");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  149cc31cb08a1589e6c5ee2cb2061559dc758ecb new
     │ ○  4ec6f6506bd1903410f15b80058a7f0d8f62deea two
     ├─╯
     ○  e61b6729ff4292870702f2f72b2a60165679ef37 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -540,7 +571,7 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
     git2::Repository::clone(origin_path.to_str().unwrap(), &clone_path).unwrap();
     test_env.jj_cmd_ok(&clone_path, &["git", "init", "--git-repo=."]);
     test_env.jj_cmd_ok(&clone_path, &["new", "A"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r"
     @  9c2de797c3c299a40173c5af724329012b77cbdd
     │ ○  4a191a9013d3f3398ccf5e172792a61439dbcf3a C_to_move original C
     ├─╯
@@ -548,27 +579,30 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
     ├─╯
     ◆  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A git_head() A
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "delete", "B_to_delete"]);
     // Move bookmark C sideways
     test_env.jj_cmd_ok(&origin_path, &["describe", "C_to_move", "-m", "moved C"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&clone_path, &["git", "fetch"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: B_to_delete@origin [deleted] untracked
     bookmark: C_to_move@origin   [updated] tracked
     Abandoned 2 commits that are no longer reachable.
-    "###);
+    [EOF]
+    ");
     // "original C" and "B_to_delete" are abandoned, as the corresponding bookmarks
     // were deleted or moved on the remote (#864)
-    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &clone_path), @r"
     @  9c2de797c3c299a40173c5af724329012b77cbdd
     │ ○  4f3d13296f978cbc351c46a43b4619c91b888475 C_to_move moved C
     ├─╯
     ◆  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 A git_head() A
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -594,7 +628,7 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     // Because the working copy is dirty, the new working-copy commit will be
     // diverged. Therefore, the feature bookmark has change-delete conflict.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : rlvkpnrz 6bad94b1 feature?? | (no description set)
@@ -602,17 +636,20 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     These bookmarks have conflicts:
       feature
       Use `jj bookmark list` to see details. Use `jj bookmark set <name> -r <rev>` to resolve.
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Warning: Failed to export some bookmarks:
       feature: Modified ref had been deleted in Git
     Done importing changes from the underlying Git repo.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6bad94b10401f5fafc8a91064661224650d10d1b feature??
     ○  3230d52258f6de7e9afbd10da8d64503cc7cdca5 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // The working-copy content shouldn't be lost.
     insta::assert_snapshot!(
@@ -637,13 +674,14 @@ fn test_git_colocated_external_checkout() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
     // Checked out anonymous bookmark
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f8a23336e41840ed1757ef323402a770427dc89a
     ○  eccedddfa5152d99fc8ddd1081b375387a8a382a git_head() B
     │ ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Check out another bookmark by external command
     git_check_out_ref("refs/heads/master");
@@ -651,35 +689,38 @@ fn test_git_colocated_external_checkout() {
     // The old working-copy commit gets abandoned, but the whole bookmark should not
     // be abandoned. (#1042)
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  8bb9e8d42a37c2a4e8dcfad97fce0b8f49bc7afa
     ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master git_head() A
     │ ○  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Reset the working copy parent to the new Git HEAD.
-    "###);
+    [EOF]
+    ");
 
     // Edit non-head commit
     test_env.jj_cmd_ok(&repo_path, &["new", "description(B)"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m=C", "--no-edit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
     @  81e086b7f9b1dd7fde252e28bdcf4ba4abd86ce5
     ○  eccedddfa5152d99fc8ddd1081b375387a8a382a git_head() B
     │ ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Check out another bookmark by external command
     git_check_out_ref("refs/heads/master");
 
     // The old working-copy commit shouldn't be abandoned. (#3747)
     let (stdout, stderr) = get_log_output_with_stderr(&test_env, &repo_path);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  ca2a4e32f08688c6fb795c4c034a0a7e09c0d804
     ○  a7e4cec4256b7995129b9d1e1bda7e1df6e60678 master git_head() A
     │ ○  99a813753d6db988d8fc436b0d6b30a54d6b2707 C
@@ -687,10 +728,12 @@ fn test_git_colocated_external_checkout() {
     │ ○  eccedddfa5152d99fc8ddd1081b375387a8a382a B
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Reset the working copy parent to the new Git HEAD.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -701,26 +744,29 @@ fn test_git_colocated_squash_undo() {
     test_env.jj_cmd_ok(&repo_path, &["git", "init", "--git-repo=."]);
     test_env.jj_cmd_ok(&repo_path, &["ci", "-m=A"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r"
     @  rlvkpnrzqnoo 9670380ac379
     ○  qpvuntsmwlqt a7e4cec4256b A git_head()
     ◆  zzzzzzzzzzzz 000000000000
-    "#);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r"
     @  zsuskulnrvyr 6ee662324e5a
     ○  qpvuntsmwlqt 13ab6b96d82e A git_head()
     ◆  zzzzzzzzzzzz 000000000000
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // TODO: There should be no divergence here; 2f376ea1478c should be hidden
     // (#922)
-    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output_divergence(&test_env, &repo_path), @r"
     @  rlvkpnrzqnoo 9670380ac379
     ○  qpvuntsmwlqt a7e4cec4256b A git_head()
     ◆  zzzzzzzzzzzz 000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -735,29 +781,32 @@ fn test_git_colocated_undo_head_move() {
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  65b6b74e08973b88d38404430f119c8c79465250
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // HEAD should be unset
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     assert!(git_repo.head().is_err());
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Create commit on non-root commit
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  69b19f73cf584f162f078fb0d91c55ca39d10bc7
     ○  eb08b363bb5ef8ee549314260488980d7bbe8f63 git_head()
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"eb08b363bb5ef8ee549314260488980d7bbe8f63");
@@ -765,19 +814,21 @@ fn test_git_colocated_undo_head_move() {
     // HEAD should be moved back
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Undid operation: b50ec983d1c1 (2001-02-03 08:05:13) new empty commit
     Working copy now at: royxmykx eb08b363 (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().target().unwrap().to_string(),
         @"230dd059e1b059aefc0da06a2e5a7dbf22362f22");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  eb08b363bb5ef8ee549314260488980d7bbe8f63
     ○  230dd059e1b059aefc0da06a2e5a7dbf22362f22 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -800,12 +851,13 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "commit2"]);
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  051508d190ffd04fe2d79367ad8e9c3713ac2375
     ○  563dbc583c0d82eb10c40d3f3276183ea28a0fa7 commit2 git_head()
     ○  3c270b473dd871b20d196316eb038f078f80c219 commit1
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=0:0 mtime=0:0 size=0 file1.txt
@@ -828,11 +880,12 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     // touching the working copy
     test_env.jj_cmd_ok(&repo_path, &["edit", "commit2"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  563dbc583c0d82eb10c40d3f3276183ea28a0fa7 commit2
     ○  3c270b473dd871b20d196316eb038f078f80c219 commit1 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Index should contain stat for unchanged file still.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
@@ -844,13 +897,14 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     // Create sibling commit, causing working copy to match index
     test_env.jj_cmd_ok(&repo_path, &["new", "commit1"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  ccb1b1807383dba5ff4d335fd9fb92aa540f4632
     │ ○  563dbc583c0d82eb10c40d3f3276183ea28a0fa7 commit2
     ├─╯
     ○  3c270b473dd871b20d196316eb038f078f80c219 commit1 git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Index should contain stat for unchanged file still.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
@@ -897,7 +951,7 @@ fn test_git_colocated_update_index_merge_conflict() {
     // Create merge conflict
     test_env.jj_cmd_ok(&repo_path, &["new", "left", "right"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    aea7acd77752c3f74914de1fe327075a579bf7c6
     ├─╮
     │ ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right
@@ -905,7 +959,8 @@ fn test_git_colocated_update_index_merge_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Conflict should be added in index with correct blob IDs. The stat for
     // base.txt should not change.
@@ -920,7 +975,7 @@ fn test_git_colocated_update_index_merge_conflict() {
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  cae33b49a8a514996983caaf171c5edbf0d70e78
     ×    aea7acd77752c3f74914de1fe327075a579bf7c6 git_head()
     ├─╮
@@ -929,7 +984,8 @@ fn test_git_colocated_update_index_merge_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Index should be the same after `jj new`.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
@@ -965,13 +1021,14 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     test_env.jj_cmd_ok(&repo_path, &["edit", "left"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  68cc2177623364e4f0719d6ec8da1d6ea8d6087e left
     │ ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base git_head()
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 base.txt
@@ -989,12 +1046,13 @@ fn test_git_colocated_update_index_rebase_conflict() {
     // Create rebase conflict
     test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "left", "-d", "right"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  233cb41e128e74aa2fcbf01c85d69b33a118faa8 left
     ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right git_head()
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Index should contain files from parent commit, so there should be no conflict
     // in conflict.txt yet. The stat for base.txt should not change.
@@ -1006,13 +1064,14 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6d84b9021f9e07b69770687071c4e8e71113e688
     ×  233cb41e128e74aa2fcbf01c85d69b33a118faa8 left git_head()
     ○  df62ad35fc873e89ade730fa9a407cd5cfa5e6ba right
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Now the working copy commit's parent is conflicted, so the index should have
     // a conflict with correct blob IDs.
@@ -1068,7 +1127,7 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     // Create 3-sided merge conflict
     test_env.jj_cmd_ok(&repo_path, &["new", "side-1", "side-2", "side-3"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @      faee07ad76218d193f2784f4988daa2ac46db30c
     ├─┬─╮
     │ │ ○  86e722ea6a9da2551f1e05bc9aa914acd1cb2304 side-3
@@ -1078,7 +1137,8 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // We can't add conflicts with more than 2 sides to the index, so we add a dummy
     // conflict instead. The stat for base.txt should not change.
@@ -1093,7 +1153,7 @@ fn test_git_colocated_update_index_3_sided_conflict() {
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b0e5644063c2a12fb265e5f65cd88c6a2e1cf865
     ×      faee07ad76218d193f2784f4988daa2ac46db30c git_head()
     ├─┬─╮
@@ -1104,7 +1164,8 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ├─╯
     ○  14b3ff6c73a234ab2a26fc559512e0f056a46bd9 base
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
 
     // Index should be the same after `jj new`.
     insta::assert_snapshot!(get_index_state(&repo_path), @r#"
@@ -1265,11 +1326,12 @@ fn test_git_colocated_unreachable_commits() {
 
     // Import the repo while there is no path to the second commit
     test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  66ae47cee4f8c28ee8d7e4f5d9401b03c07e22f2
     ○  2ee37513d2b5e549f7478c671a780053614bff19 master git_head() initial
     ◆  0000000000000000000000000000000000000000
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         git_repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         @"2ee37513d2b5e549f7478c671a780053614bff19"
@@ -1277,7 +1339,10 @@ fn test_git_colocated_unreachable_commits() {
 
     // Check that trying to look up the second commit fails gracefully
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["show", &oid2.to_string()]);
-    insta::assert_snapshot!(stderr, @"Error: Revision `8e713ff77b54928dd4a82aaabeca44b1ae91722c` doesn't exist");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revision `8e713ff77b54928dd4a82aaabeca44b1ae91722c` doesn't exist
+    [EOF]
+    ");
 }
 
 fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use test_case::test_case;
 
 use crate::common::get_stderr_string;
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn add_commit_to_branch(git_repo: &git2::Repository, branch: &str) -> git2::Oid {
@@ -63,7 +64,7 @@ fn add_git_remote(test_env: &TestEnvironment, repo_path: &Path, remote: &str) ->
     repo
 }
 
-fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     // --quiet to suppress deleted bookmarks hint
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes", "--quiet"])
 }
@@ -81,7 +82,7 @@ fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, paren
     test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
-fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, workspace_root: &Path) -> CommandOutputString {
     let template = r#"commit_id.short() ++ " " ++ description.first_line() ++ " " ++ bookmarks"#;
     test_env.jj_cmd_success(workspace_root, &["log", "-T", template, "-r", "all()"])
 }
@@ -1195,7 +1196,7 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
         .env("LANGUAGE", "zh_TW")
         .assert()
         .success();
-    let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+    let stderr = test_env.normalize_output(get_stderr_string(&assert));
     insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `unknown` found on any specified/configured remote
     Nothing changed.

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -128,9 +128,10 @@ fn test_git_fetch_with_default_config(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin@origin: oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -148,10 +149,11 @@ fn test_git_fetch_default_remote(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -169,16 +171,18 @@ fn test_git_fetch_single_remote(subprocess: bool) {
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Hint: Fetching from the only existing remote: rem1
     bookmark: rem1@rem1 [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -199,10 +203,11 @@ fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
         .assert()
         .success();
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -220,10 +225,11 @@ fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote", "rem1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -242,10 +248,11 @@ fn test_git_fetch_single_remote_from_config(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -267,12 +274,13 @@ fn test_git_fetch_multiple_remotes(subprocess: bool) {
         &["git", "fetch", "--remote", "rem1", "--remote", "rem2"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -295,12 +303,13 @@ fn test_git_fetch_all_remotes(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--all-remotes"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -320,12 +329,13 @@ fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: qxosxrvv 6a211027 message
       @rem1: qxosxrvv 6a211027 message
     rem2: yszkquru 2497a8a0 message
       @rem2: yszkquru 2497a8a0 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -345,7 +355,10 @@ fn test_git_fetch_nonexistent_remote(subprocess: bool) {
         &["git", "fetch", "--remote", "rem1", "--remote", "rem2"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @"Error: No git remote named 'rem2'");
+    insta::assert_snapshot!(stderr, @r"
+    Error: No git remote named 'rem2'
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
     // No remote should have been fetched as part of the failing transaction
@@ -367,7 +380,10 @@ fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
 
     let stderr = &test_env.jj_cmd_failure(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @"Error: No git remote named 'rem2'");
+    insta::assert_snapshot!(stderr, @r"
+    Error: No git remote named 'rem2'
+    [EOF]
+    ");
     }
     // No remote should have been fetched as part of the failing transaction
     insta::allow_duplicates! {
@@ -395,11 +411,12 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     // Try fetching from the remote named 'git'.
     let stderr = &test_env.jj_cmd_failure(&repo_path, &["git", "fetch", "--remote=git"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to import refs from underlying Git repo
     Caused by: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give different name.
-    "###);
+    [EOF]
+    ");
     }
 
     // Implicit import shouldn't fail because of the remote ref.
@@ -412,27 +429,30 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
 
     // Explicit import is an error.
     // (This could be warning if we add mechanism to report ignored refs.)
-    insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["git", "import"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["git", "import"]), @r"
     Error: Failed to import refs from underlying Git repo
     Caused by: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give different name.
-    "###);
+    [EOF]
+    ");
     }
 
     // The remote can be renamed, and the ref can be imported.
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "git", "bar"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "list", "--all-remotes"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     git: mrylzrtu 76fc7466 message
       @bar: mrylzrtu 76fc7466 message
       @git: mrylzrtu 76fc7466 message
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Done importing changes from the underlying Git repo.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -459,6 +479,7 @@ fn test_git_fetch_from_remote_with_slashes(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remotes with slashes are incompatible with jj: slash/origin
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     }
 }
@@ -476,10 +497,11 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     let git_repo = add_git_remote(&test_env, &repo_path, "origin");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 
     // Remove origin bookmark in git repo and create origin/subname
@@ -491,10 +513,11 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin/subname: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -514,9 +537,10 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "rem1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: kkmpptxz fcdbbd73 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(
@@ -525,12 +549,13 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     );
     // This should result in a CONFLICTED bookmark
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1 (conflicted):
       + kkmpptxz fcdbbd73 (empty) (no description set)
       + qxosxrvv 6a211027 message
       @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -555,10 +580,11 @@ fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "rem1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1: zsuskuln f652c321 (empty) (no description set)
       @git: zsuskuln f652c321 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(
@@ -568,13 +594,14 @@ fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     // This should result in a CONFLICTED bookmark
     // See https://github.com/jj-vcs/jj/pull/1146#discussion_r1112372340 for the bug this tests for.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     rem1 (conflicted):
       + zsuskuln f652c321 (empty) (no description set)
       + qxosxrvv 6a211027 message
       @git (behind by 1 commits): zsuskuln f652c321 (empty) (no description set)
       @rem1 (behind by 1 commits): qxosxrvv 6a211027 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -626,17 +653,18 @@ fn test_git_fetch_all(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -645,15 +673,17 @@ fn test_git_fetch_all(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
 
     // Nothing in our repo before the fetch
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @"");
@@ -663,15 +693,16 @@ fn test_git_fetch_all(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
         }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
-    "###);
+    [EOF]
+    ");
         }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: nknoxmzm 359a9a02 descr_for_a1
       @origin: nknoxmzm 359a9a02 descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
@@ -680,10 +711,11 @@ fn test_git_fetch_all(subprocess: bool) {
       @origin: vpupmnsl c7d4bdcb descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
       @origin: zowqyktl ff36dc55 descr_for_trunk1
-    "###);
+    [EOF]
+    ");
         }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -693,14 +725,15 @@ fn test_git_fetch_all(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     ○  babc49226c14 descr_for_b b
     │ ○  91e46b4b2653 descr_for_a2 a2
@@ -710,7 +743,8 @@ fn test_git_fetch_all(subprocess: bool) {
     @  8f1f14fbbf42 descr_for_trunk2 trunk2
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -720,7 +754,7 @@ fn test_git_fetch_all(subprocess: bool) {
 
     // Our repo before and after fetch
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  061eddbb43ab new_descr_for_b_to_create_conflict b*
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -730,10 +764,11 @@ fn test_git_fetch_all(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: nknoxmzm 359a9a02 descr_for_a1
       @origin: nknoxmzm 359a9a02 descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
@@ -742,23 +777,25 @@ fn test_git_fetch_all(subprocess: bool) {
       @origin (ahead by 1 commits, behind by 1 commits): vpupmnsl hidden c7d4bdcb descr_for_b
     trunk1: zowqyktl ff36dc55 descr_for_trunk1
       @origin: zowqyktl ff36dc55 descr_for_trunk1
-    "###);
+    [EOF]
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [updated] tracked
     bookmark: a2@origin     [updated] tracked
     bookmark: b@origin      [updated] tracked
     bookmark: trunk2@origin [new] tracked
     Abandoned 2 commits that are no longer reachable.
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: quxllqov 0424f6df descr_for_a1
       @origin: quxllqov 0424f6df descr_for_a1
     a2: osusxwst 91e46b4b descr_for_a2
@@ -772,10 +809,11 @@ fn test_git_fetch_all(subprocess: bool) {
       @origin: zowqyktl ff36dc55 descr_for_trunk1
     trunk2: umznmzko 8f1f14fb descr_for_trunk2
       @origin: umznmzko 8f1f14fb descr_for_trunk2
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  babc49226c14 descr_for_b b?? b@origin
     │ │ ○  91e46b4b2653 descr_for_a2 a2
@@ -788,7 +826,8 @@ fn test_git_fetch_all(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -811,17 +850,18 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -830,7 +870,8 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
 
     // Test an error message
@@ -839,22 +880,27 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
         &["git", "fetch", "--branch", "glob:^:a*"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @"Error: Invalid branch pattern provided. When fetching, branch names and globs may not contain the characters `:`, `^`, `?`, `[`, `]`");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Invalid branch pattern provided. When fetching, branch names and globs may not contain the characters `:`, `^`, `?`, `[`, `]`
+    [EOF]
+    ");
     }
     let stderr = test_env.jj_cmd_failure(&target_jj_repo_path, &["git", "fetch", "--branch", "a*"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r"
     Error: Branch names may not include `*`.
     Hint: Prefix the pattern with `glob:` to expand `*` as a glob
+    [EOF]
     ");
     }
 
     // Nothing in our repo before the fetch
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
     // Fetch one bookmark...
     let (stdout, stderr) =
@@ -863,25 +909,28 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: b@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     // ...check what the intermediate state looks like...
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     b: vpupmnsl c7d4bdcb descr_for_b
       @origin: vpupmnsl c7d4bdcb descr_for_b
-    "###);
+    [EOF]
+    ");
     }
     // ...then fetch two others with a glob.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -892,13 +941,14 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin [new] tracked
     bookmark: a2@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  decaa3966c83 descr_for_a2 a2
     │ │ ○  359a9a02457d descr_for_a1 a1
@@ -908,7 +958,8 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     // Fetching the same bookmark again
     let (stdout, stderr) =
@@ -917,10 +968,11 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  decaa3966c83 descr_for_a2 a2
     │ │ ○  359a9a02457d descr_for_a1 a1
@@ -930,14 +982,15 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     ○  01d115196c39 descr_for_b b
     │ ○  31c7d94b1f29 descr_for_a2 a2
@@ -947,7 +1000,8 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     @  2bb3ebd2bba3 descr_for_trunk2 trunk2
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     test_env.jj_cmd_ok(
@@ -957,7 +1011,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
 
     // Our repo before and after fetch of two bookmarks
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  6ebd41dc4f13 new_descr_for_b_to_create_conflict b*
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -967,7 +1021,8 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &target_jj_repo_path,
@@ -977,14 +1032,15 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  01d115196c39 descr_for_b b?? b@origin
     │ │ ○  6df2d34cf0da descr_for_a1 a1
@@ -997,12 +1053,13 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 
     // We left a2 where it was before, let's see how `jj bookmark list` sees this.
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: ypowunwp 6df2d34c descr_for_a1
       @origin: ypowunwp 6df2d34c descr_for_a1
     a2: qkvnknrk decaa396 descr_for_a2
@@ -1012,7 +1069,8 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
       + vpupmnsl 6ebd41dc new_descr_for_b_to_create_conflict
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
-    "###);
+    [EOF]
+    ");
     }
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
     // anything.
@@ -1024,13 +1082,14 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a2@origin [updated] tracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  31c7d94b1f29 descr_for_a2 a2
     │ │ ○  01d115196c39 descr_for_b b?? b@origin
@@ -1043,10 +1102,11 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &target_jj_repo_path), @r"
     a1: ypowunwp 6df2d34c descr_for_a1
       @origin: ypowunwp 6df2d34c descr_for_a1
     a2: qrmzolkr 31c7d94b descr_for_a2
@@ -1056,7 +1116,8 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
       + vpupmnsl 6ebd41dc new_descr_for_b_to_create_conflict
       + nxrpswuq 01d11519 descr_for_b
       @origin (behind by 1 commits): nxrpswuq 01d11519 descr_for_b
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1079,10 +1140,11 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--branch", "noexist"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `noexist` found on any specified/configured remote
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
@@ -1096,11 +1158,12 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
         ],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `noexist1` found on any specified/configured remote
     Warning: No branch matching `noexist2` found on any specified/configured remote
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
@@ -1109,15 +1172,17 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     // single existing bookmark, implicit remotes (@origin)
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--branch", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: origin@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: oputwtnw ffecd2d6 message
       @origin: oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 
     // multiple existing bookmark, explicit remotes, each bookmark is only in one
@@ -1134,19 +1199,21 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     bookmark: rem1@rem1 [new] tracked
     bookmark: rem2@rem2 [new] tracked
     bookmark: rem3@rem3 [new] tracked
+    [EOF]
     ");
     }
     insta::allow_duplicates! {
      insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
-    origin: oputwtnw ffecd2d6 message
-      @origin: oputwtnw ffecd2d6 message
-    rem1: qxosxrvv 6a211027 message
-      @rem1: qxosxrvv 6a211027 message
-    rem2: yszkquru 2497a8a0 message
-      @rem2: yszkquru 2497a8a0 message
-    rem3: lvsrtwwm 4ffdff2b message
-      @rem3: lvsrtwwm 4ffdff2b message
-    ");
+     origin: oputwtnw ffecd2d6 message
+       @origin: oputwtnw ffecd2d6 message
+     rem1: qxosxrvv 6a211027 message
+       @rem1: qxosxrvv 6a211027 message
+     rem2: yszkquru 2497a8a0 message
+       @rem2: yszkquru 2497a8a0 message
+     rem3: lvsrtwwm 4ffdff2b message
+       @rem3: lvsrtwwm 4ffdff2b message
+     [EOF]
+     ");
     }
 
     // multiple bookmarks, one exists, one doesn't
@@ -1157,10 +1224,11 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
         ],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `notexist` found on any specified/configured remote
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
@@ -1172,6 +1240,7 @@ fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
       @rem2: yszkquru 2497a8a0 message
     rem3: lvsrtwwm 4ffdff2b message
       @rem3: lvsrtwwm 4ffdff2b message
+    [EOF]
     ");
     }
 }
@@ -1200,6 +1269,7 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
     insta::assert_snapshot!(stderr, @r"
     Warning: No branch matching `unknown` found on any specified/configured remote
     Nothing changed.
+    [EOF]
     ");
 }
 
@@ -1223,17 +1293,18 @@ fn test_git_fetch_undo(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1242,7 +1313,8 @@ fn test_git_fetch_undo(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
 
     // Fetch 2 bookmarks
@@ -1254,11 +1326,12 @@ fn test_git_fetch_undo(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin [new] tracked
     bookmark: b@origin  [new] tracked
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  359a9a02457d descr_for_a1 a1
@@ -1266,21 +1339,24 @@ fn test_git_fetch_undo(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&target_jj_repo_path, &["undo"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Undid operation: eb2029853b02 (2001-02-03 08:05:18) fetch from git remote(s) origin
-    "#);
+    [EOF]
+    ");
     // The undo works as expected
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
     // Now try to fetch just one bookmark
     let (stdout, stderr) =
@@ -1289,16 +1365,18 @@ fn test_git_fetch_undo(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: b@origin [new] tracked
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1322,17 +1400,18 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
     let repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1341,7 +1420,8 @@ fn test_fetch_undo_what(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
 
     // Initial state we will try to return to after `op restore`. There are no
@@ -1357,24 +1437,27 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: b@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     b: vpupmnsl c7d4bdcb descr_for_b
       @origin: vpupmnsl c7d4bdcb descr_for_b
-    "###);
+    [EOF]
+    ");
     }
 
     // We can undo the change in the repo without moving the remote-tracking
@@ -1387,26 +1470,29 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
-    "#);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     b (deleted)
       @origin: vpupmnsl hidden c7d4bdcb descr_for_b
-    "###);
+    [EOF]
+    ");
     }
 
     // Now, let's demo restoring just the remote-tracking bookmark. First, let's
     // change our local repo state...
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "newbookmark"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     b (deleted)
       @origin: vpupmnsl hidden c7d4bdcb descr_for_b
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     }
     // Restoring just the remote-tracking state will not affect `newbookmark`, but
     // will eliminate `b@origin`.
@@ -1424,14 +1510,16 @@ fn test_fetch_undo_what(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
-    "#);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1449,28 +1537,31 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "remove", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "remote", "add", "origin", "../origin"]);
@@ -1481,17 +1572,19 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: origin@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1509,19 +1602,21 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @origin (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(
@@ -1529,12 +1624,13 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
         &["git", "remote", "rename", "origin", "upstream"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + oputwtnw ffecd2d6 message
       @upstream (behind by 1 commits): oputwtnw ffecd2d6 message
-    "###);
+    [EOF]
+    ");
     }
 
     // Check that jj indicates that nothing has changed
@@ -1544,9 +1640,10 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1568,17 +1665,18 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1587,7 +1685,8 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
 
     // Fetch all bookmarks
@@ -1596,15 +1695,16 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1614,7 +1714,8 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 
     // Remove a2 bookmark in origin
@@ -1630,12 +1731,13 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1645,7 +1747,8 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 
     // Fetch bookmarks a2 from origin, and check that it has been removed locally
@@ -1655,11 +1758,12 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a2@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  359a9a02457d descr_for_a1 a1
@@ -1667,7 +1771,8 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1689,17 +1794,18 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
-    "###);
+    [EOF]
+    "#);
     }
     let target_jj_repo_path = test_env.env_root().join("target");
 
     let source_log =
         create_colocated_repo_and_bookmarks_from_trunk1(&test_env, &source_git_repo_path);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(source_log, @r###"
+    insta::assert_snapshot!(source_log, @r"
        ===== Source git repo contents =====
     @  c7d4bdcbc215 descr_for_b b
     │ ○  decaa3966c83 descr_for_a2 a2
@@ -1708,7 +1814,8 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     ├─╯
     ○  ff36dc55760e descr_for_trunk1 trunk1
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     }
 
     // Fetch all bookmarks
@@ -1717,15 +1824,16 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [new] tracked
     bookmark: a2@origin     [new] tracked
     bookmark: b@origin      [new] tracked
     bookmark: trunk1@origin [new] tracked
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1735,7 +1843,8 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1 trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 
     // Remove all bookmarks in origin.
@@ -1757,15 +1866,16 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a1@origin     [deleted] untracked
     bookmark: trunk1@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
     Warning: No branch matching `master` found on any specified/configured remote
-    "###);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &target_jj_repo_path), @r"
     @  230dd059e1b0
     │ ○  c7d4bdcbc215 descr_for_b b
     │ │ ○  decaa3966c83 descr_for_a2 a2
@@ -1773,7 +1883,8 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     │ ○  ff36dc55760e descr_for_trunk1
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1818,10 +1929,11 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
-    "###);
+    [EOF]
+    ");
     }
 
     git_repo
@@ -1839,19 +1951,21 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     test_env.add_config("git.auto-local-bookmark = false");
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch", "--remote=origin"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  230dd059e1b0
     │ ◆  9f01a0e04879 message feature1 feature2@origin
     ├─╯
     ◆  000000000000
-    "#);
+    [EOF]
+    ");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: mzyxwzks 9f01a0e0 message
       @origin: mzyxwzks 9f01a0e0 message
     feature2@origin: mzyxwzks 9f01a0e0 message
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1888,6 +2002,7 @@ fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     │ ○  05ae9cbbe5c7 message upstream
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     }
     insta::allow_duplicates! {
@@ -1897,6 +2012,7 @@ fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     upstream: tzqqlonq 05ae9cbb message
       @fork: tzqqlonq 05ae9cbb message
       @upstream: tzqqlonq 05ae9cbb message
+    [EOF]
     ");
     }
 
@@ -1952,6 +2068,7 @@ fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     │ ○  05ae9cbbe5c7 message upstream@fork
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
     }
     insta::allow_duplicates! {
@@ -1959,6 +2076,7 @@ fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     upstream: qzsuxvvx 407a9966 merge
       @fork (behind by 2 commits): tzqqlonq 05ae9cbb message
       @upstream: qzsuxvvx 407a9966 merge
+    [EOF]
     ");
     }
 }

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -34,10 +34,11 @@ fn test_resolution_of_git_tracking_bookmarks() {
     insta::assert_snapshot!(stderr, @"");
     // Move the local bookmark somewhere else
     test_env.jj_cmd_ok(&repo_path, &["describe", "-r", "main", "-m", "new_message"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm b61d21b6 (empty) new_message
       @git (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 03757d22 (empty) old_message
-    "###);
+    [EOF]
+    ");
 
     // Test that we can address both revisions
     let query = |expr| {
@@ -47,12 +48,14 @@ fn test_resolution_of_git_tracking_bookmarks() {
             &["log", "-r", expr, "-T", template, "--no-graph"],
         )
     };
-    insta::assert_snapshot!(query("main"), @r###"
+    insta::assert_snapshot!(query("main"), @r"
     b61d21b660c17a7191f3f73873bfe7d3f7938628 new_message
-    "###);
-    insta::assert_snapshot!(query("main@git"), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(query("main@git"), @r"
     03757d2212d89990ec158e97795b612a38446652 old_message
-    "###);
+    [EOF]
+    ");
     // Can't be selected by remote_bookmarks()
     insta::assert_snapshot!(query(r#"remote_bookmarks(exact:"main", exact:"git")"#), @"");
 }
@@ -68,13 +71,14 @@ fn test_git_export_conflicting_git_refs() {
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::with_settings!({filters => vec![("Failed to set: .*", "Failed to set: ...")]}, {
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r#"
         Warning: Failed to export some bookmarks:
           main/sub: Failed to set: ...
         Hint: Git doesn't allow a branch name that looks like a parent directory of
         another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
         export or their "parent" bookmarks.
-        "###);
+        [EOF]
+        "#);
     });
 }
 
@@ -86,23 +90,28 @@ fn test_git_export_undo() {
     let git_repo = git::open(repo_path.join(".jj/repo/store/git"));
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "a"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 a 230dd059
     │  (empty) (no description set)
     ~
-    "###);
+    [EOF]
+    ");
 
     // Exported refs won't be removed by undoing the export, but the git-tracking
     // bookmark is. This is the same as remote-tracking bookmarks.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "undo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Undid operation: edb40232c741 (2001-02-03 08:05:10) export git refs");
+    insta::assert_snapshot!(stderr, @r"
+    Undid operation: edb40232c741 (2001-02-03 08:05:10) export git refs
+    [EOF]
+    ");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
     [
         (
@@ -116,17 +125,19 @@ fn test_git_export_undo() {
     insta::assert_snapshot!(test_env.jj_cmd_failure(&repo_path, &["log", "-ra@git"]), @r"
     Error: Revision `a@git` doesn't exist
     Hint: Did you mean `a`?
+    [EOF]
     ");
 
     // This would re-export bookmark "a" and create git-tracking bookmark.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-ra@git"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 a 230dd059
     │  (empty) (no description set)
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -156,31 +167,36 @@ fn test_git_import_undo() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // "git import" can be undone by default.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
     // Try "git import" again, which should re-import the bookmark "a".
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -211,39 +227,44 @@ fn test_git_import_move_export_with_default_undo() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: qpvuntsm 230dd059 (empty) (no description set)
       @git: qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Move bookmark "a" and export to git repo
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "set", "a", "--to=@"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: yqosqzyt 096dc80d (empty) (no description set)
       @git (behind by 1 commits): qpvuntsm 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "export"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: yqosqzyt 096dc80d (empty) (no description set)
       @git: yqosqzyt 096dc80d (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // "git import" can be undone with the default `restore` behavior, as shown in
     // the previous test. However, "git export" can't: the bookmarks in the git
     // repo stay where they were.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     Working copy now at: qpvuntsm 230dd059 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
     [
@@ -260,13 +281,15 @@ fn test_git_import_move_export_with_default_undo() {
     // intuitive result here.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "import"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     bookmark: a [new] tracked
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     a: yqosqzyt 096dc80d (empty) (no description set)
       @git: yqosqzyt 096dc80d (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -17,6 +17,7 @@ use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 
 use crate::common::git;
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -136,8 +137,9 @@ fn test_git_import_undo() {
     let git_repo = git::open(repo_path.join(".jj/repo/store/git"));
 
     // Create bookmark "a" in git repo
-    let commit_id =
-        test_env.jj_cmd_success(&repo_path, &["log", "-Tcommit_id", "--no-graph", "-r@"]);
+    let commit_id = test_env
+        .jj_cmd_success(&repo_path, &["log", "-Tcommit_id", "--no-graph", "-r@"])
+        .into_raw();
     let commit_id = gix::ObjectId::from_hex(commit_id.as_bytes()).unwrap();
     git_repo
         .reference(
@@ -189,8 +191,9 @@ fn test_git_import_move_export_with_default_undo() {
     let git_repo = git::open(repo_path.join(".jj/repo/store/git"));
 
     // Create bookmark "a" in git repo
-    let commit_id =
-        test_env.jj_cmd_success(&repo_path, &["log", "-Tcommit_id", "--no-graph", "-r@"]);
+    let commit_id = test_env
+        .jj_cmd_success(&repo_path, &["log", "-Tcommit_id", "--no-graph", "-r@"])
+        .into_raw();
     let commit_id = gix::ObjectId::from_hex(commit_id.as_bytes()).unwrap();
     git_repo
         .reference(
@@ -266,7 +269,7 @@ fn test_git_import_move_export_with_default_undo() {
     "###);
 }
 
-fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes"])
 }
 

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -70,9 +70,10 @@ fn test_git_init_internal() {
     let test_env = TestEnvironment::default();
     let (stdout, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Initialized repo in "repo"
-    "###);
+    [EOF]
+    "#);
 
     let workspace_root = test_env.env_root().join("repo");
     let jj_path = workspace_root.join(".jj");
@@ -96,9 +97,10 @@ fn test_git_init_internal_ignore_working_copy() {
 
     let stderr =
         test_env.jj_cmd_cli_error(&workspace_root, &["git", "init", "--ignore-working-copy"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --ignore-working-copy is not respected
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -108,9 +110,10 @@ fn test_git_init_internal_at_operation() {
     std::fs::create_dir(&workspace_root).unwrap();
 
     let stderr = test_env.jj_cmd_cli_error(&workspace_root, &["git", "init", "--at-op=@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --at-op is not respected
-    "###);
+    [EOF]
+    ");
 }
 
 #[test_case(false; "full")]
@@ -138,6 +141,7 @@ fn test_git_init_external(bare: bool) {
         Parent commit      : nntyzxmz e80a42cc my-bookmark | My commit message
         Added 1 files, modified 0 files, removed 0 files
         Initialized repo in "repo"
+        [EOF]
         "#);
     }
 
@@ -163,6 +167,7 @@ fn test_git_init_external(bare: bool) {
         @  0bd37cef2051
         ○  e80a42cccd06 my-bookmark git_head() My commit message
         ◆  000000000000
+        [EOF]
         ");
     }
 }
@@ -216,6 +221,7 @@ fn test_git_init_external_import_trunk(bare: bool) {
         Parent commit      : nntyzxmz e80a42cc my-bookmark trunk@origin | My commit message
         Added 1 files, modified 0 files, removed 0 files
         Initialized repo in "repo"
+        [EOF]
         "#);
     }
 
@@ -225,9 +231,10 @@ fn test_git_init_external_import_trunk(bare: bool) {
         &["config", "list", "--repo", "revset-aliases.\"trunk()\""],
     );
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r#"
         revset-aliases."trunk()" = "trunk@origin"
-        "###);
+        [EOF]
+        "#);
     }
 }
 
@@ -251,9 +258,10 @@ fn test_git_init_external_ignore_working_copy() {
             git_repo_path.to_str().unwrap(),
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --ignore-working-copy is not respected
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -274,9 +282,10 @@ fn test_git_init_external_at_operation() {
             git_repo_path.to_str().unwrap(),
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --at-op is not respected
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -286,11 +295,12 @@ fn test_git_init_external_non_existent_directory() {
         test_env.env_root(),
         &["git", "init", "repo", "--git-repo", "non-existent"],
     );
-    insta::assert_snapshot!(stderr.strip_last_line(), @r###"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r"
     Error: Failed to access the repository
     Caused by:
     1: Cannot access $TEST_ENV/non-existent
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -302,13 +312,14 @@ fn test_git_init_external_non_existent_git_directory() {
         &["git", "init", "repo", "--git-repo", "repo"],
     );
 
-    insta::assert_snapshot!(&stderr, @r###"
+    insta::assert_snapshot!(&stderr, @r#"
     Error: Failed to access the repository
     Caused by:
     1: Failed to open git repository
     2: "$TEST_ENV/repo" does not appear to be a git repository
     3: Missing HEAD at '.git/HEAD'
-    "###);
+    [EOF]
+    "#);
     let jj_path = workspace_root.join(".jj");
     assert!(!jj_path.exists());
 }
@@ -320,10 +331,11 @@ fn test_git_init_colocated_via_git_repo_path() {
     init_git_repo(&workspace_root, false);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    [EOF]
+    "#);
 
     let jj_path = workspace_root.join(".jj");
     let repo_path = jj_path.join("repo");
@@ -342,6 +354,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     @  5f169ecc57b8
     ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
+    [EOF]
     ");
 
     // Check that the Git repo's HEAD moves
@@ -351,6 +364,7 @@ fn test_git_init_colocated_via_git_repo_path() {
     ○  5f169ecc57b8 git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -367,10 +381,11 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     assert!(workspace_root.join(".git").is_file());
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    [EOF]
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
@@ -378,6 +393,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     @  5f169ecc57b8
     ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
+    [EOF]
     ");
 
     // Check that the Git repo's HEAD moves
@@ -387,6 +403,7 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     ○  5f169ecc57b8 git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -402,10 +419,11 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     std::os::unix::fs::symlink(git_repo_path.join(".git"), workspace_root.join(".git")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    [EOF]
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
@@ -413,6 +431,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     @  5f169ecc57b8
     ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
+    [EOF]
     ");
 
     // Check that the Git repo's HEAD moves
@@ -422,6 +441,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     ○  5f169ecc57b8 git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -441,10 +461,11 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     std::os::unix::fs::symlink(&git_repo_path, workspace_root.join(".git")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    [EOF]
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
@@ -452,6 +473,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     @  5f169ecc57b8
     ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
+    [EOF]
     ");
 
     // Check that the Git repo's HEAD moves
@@ -461,6 +483,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     ○  5f169ecc57b8 git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -480,10 +503,11 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     std::os::unix::fs::symlink(git_workdir_path.join(".git"), workspace_root.join(".git")).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    [EOF]
+    "#);
     insta::assert_snapshot!(read_git_target(&workspace_root), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
@@ -491,6 +515,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     @  5f169ecc57b8
     ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
+    [EOF]
     ");
 
     // Check that the Git repo's HEAD moves
@@ -500,6 +525,7 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     ○  5f169ecc57b8 git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -538,37 +564,41 @@ fn test_git_init_colocated_via_git_repo_path_imported_refs() {
     let local_path = test_env.env_root().join("local1");
     set_up_local_repo(&local_path);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["git", "init", "--git-repo=."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r###"
+    [EOF]
+    "#);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r"
     local-remote: vvkvtnvv 230dd059 (empty) (no description set)
       @git: vvkvtnvv 230dd059 (empty) (no description set)
       @origin: vvkvtnvv 230dd059 (empty) (no description set)
     remote-only: vvkvtnvv 230dd059 (empty) (no description set)
       @git: vvkvtnvv 230dd059 (empty) (no description set)
       @origin: vvkvtnvv 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // With git.auto-local-bookmark = false
     test_env.add_config("git.auto-local-bookmark = false");
     let local_path = test_env.env_root().join("local2");
     set_up_local_repo(&local_path);
     let (_stdout, stderr) = test_env.jj_cmd_ok(&local_path, &["git", "init", "--git-repo=."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Hint: The following remote bookmarks aren't associated with the existing local bookmarks:
       local-remote@origin
     Hint: Run `jj bookmark track local-remote@origin` to keep local bookmarks updated on future pulls.
     Initialized repo in "."
-    "###);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r###"
+    [EOF]
+    "#);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &local_path), @r"
     local-remote: vvkvtnvv 230dd059 (empty) (no description set)
       @git: vvkvtnvv 230dd059 (empty) (no description set)
     local-remote@origin: vvkvtnvv 230dd059 (empty) (no description set)
     remote-only@origin: vvkvtnvv 230dd059 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -609,10 +639,11 @@ fn test_git_init_colocated_dirty_working_copy() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "init", "--git-repo", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    "###);
+    [EOF]
+    "#);
 
     // Working-copy changes should have been snapshotted.
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-s", "--ignore-working-copy"]);
@@ -626,6 +657,7 @@ fn test_git_init_colocated_dirty_working_copy() {
     │  My commit message
     │  A some-file
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 
     // Git index should be consistent with the working copy parent. With the
@@ -685,9 +717,10 @@ fn test_git_init_colocated_ignore_working_copy() {
         &workspace_root,
         &["git", "init", "--ignore-working-copy", "--colocate"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --ignore-working-copy is not respected
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -700,9 +733,10 @@ fn test_git_init_colocated_at_operation() {
         &workspace_root,
         &["git", "init", "--at-op=@-", "--colocate"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --at-op is not respected
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -717,23 +751,26 @@ fn test_git_init_external_but_git_dir_exists() {
         &["git", "init", "--git-repo", git_repo_path.to_str().unwrap()],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Initialized repo in "."
-    "###);
+    [EOF]
+    "#);
 
     // The local ".git" repository is unrelated, so no commits should be imported
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Check that Git HEAD is not set because this isn't a colocated repo
     test_env.jj_cmd_ok(&workspace_root, &["new"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  4db490c88528
     ○  230dd059e1b0
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -745,16 +782,18 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "--colocate", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Done importing changes from the underlying Git repo.
     Initialized repo in "repo"
-    "###);
+    [EOF]
+    "#);
 
     // Check that the Git repo's HEAD got checked out
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  5f169ecc57b8
     ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
+    [EOF]
     ");
 
     // Check that the Git repo's HEAD moves
@@ -764,6 +803,7 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     ○  5f169ecc57b8 git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -774,14 +814,16 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "--colocate", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Initialized repo in "repo"
-    "###);
+    [EOF]
+    "#);
     // No HEAD ref is available yet
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b0
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Create the default bookmark (create both in case we change the default)
     test_env.jj_cmd_ok(
@@ -791,10 +833,11 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
 
     // If .git/HEAD pointed to the default bookmark, new working-copy commit would
     // be created on top.
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_root), @r"
     @  230dd059e1b0 main master
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -842,23 +885,29 @@ fn test_git_init_conditional_config() {
     @  base@old-repo new empty commit
     ○  base@base add workspace 'default'
     ○  @
+    [EOF]
     ");
 
     // Create new repo at the old workspace directory.
     let (_stdout, stderr) = jj_cmd_ok(&old_workspace_root, &["git", "init", "../new"]);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"Initialized repo in "../new""#);
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
+    Initialized repo in "../new"
+    [EOF]
+    "#);
     jj_cmd_ok(&new_workspace_root, &["new"]);
     let (stdout, _stderr) = jj_cmd_ok(&new_workspace_root, &["log", "-T", log_template]);
     insta::assert_snapshot!(stdout, @r"
     @  new-repo@example.org
     ○  new-repo@example.org
     ◆
+    [EOF]
     ");
     let (stdout, _stderr) = jj_cmd_ok(&new_workspace_root, &["op", "log", "-T", op_log_template]);
     insta::assert_snapshot!(stdout, @r"
     @  new-repo@base new empty commit
     ○  new-repo@base add workspace 'default'
     ○  @
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -92,18 +92,20 @@ fn test_git_private_commits_block_pushing() {
     Error: Won't push commit aa3058ff8663 since it is private
     Hint: Rejected commit: yqosqzyt aa3058ff main* | (empty) private 1
     Hint: Configured git.private-commits: 'description(glob:'private*')'
+    [EOF]
     ");
 
     // May push when the commit is removed from git.private-commits
     test_env.add_config(r#"git.private-commits = "none()""#);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to aa3058ff8663
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: znkkpsqq 2e1adf47 (empty) (no description set)
     Parent commit      : yqosqzyt aa3058ff main | (empty) private 1
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -120,6 +122,7 @@ fn test_git_private_commits_can_be_overridden() {
     Error: Won't push commit aa3058ff8663 since it is private
     Hint: Rejected commit: yqosqzyt aa3058ff main* | (empty) private 1
     Hint: Configured git.private-commits: 'description(glob:'private*')'
+    [EOF]
     ");
 
     // May push when the commit is removed from git.private-commits
@@ -127,13 +130,14 @@ fn test_git_private_commits_can_be_overridden() {
         &workspace_root,
         &["git", "push", "--all", "--allow-private"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to aa3058ff8663
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: znkkpsqq 2e1adf47 (empty) (no description set)
     Parent commit      : yqosqzyt aa3058ff main | (empty) private 1
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -146,13 +150,14 @@ fn test_git_private_commits_are_not_checked_if_immutable() {
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "all()""#);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to aa3058ff8663
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: yostqsxw dce4a15c (empty) (no description set)
     Parent commit      : yqosqzyt aa3058ff main | (empty) private 1
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -174,6 +179,7 @@ fn test_git_private_commits_not_directly_in_line_block_pushing() {
     Error: Won't push commit f1253a9b1ea9 since it is private
     Hint: Rejected commit: yqosqzyt f1253a9b (empty) private 1
     Hint: Configured git.private-commits: 'description(glob:'private*')'
+    [EOF]
     ");
 }
 
@@ -187,10 +193,11 @@ fn test_git_private_commits_descending_from_commits_pushed_do_not_block_pushing(
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-b=main"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to 05ef53bc99ec
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -212,14 +219,15 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &workspace_root,
         &["git", "push", "--allow-new", "-b=main", "-b=bookmark1"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to fbb352762352
       Add bookmark bookmark1 to 7eb97bf230ad
     Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy now at: kpqxywon a7b08364 (empty) (no description set)
     Parent commit      : yostqsxw fbb35276 main | (empty) public 3
-    "#);
+    [EOF]
+    ");
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
 
@@ -229,10 +237,11 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &["bookmark", "set", "bookmark1", "-r=main"],
     );
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark1 from 7eb97bf230ad to fbb352762352
-    "#);
+    [EOF]
+    ");
 
     // Ensure that the already-pushed commit doesn't block a new bookmark from
     // being pushed
@@ -245,10 +254,11 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
         &workspace_root,
         &["git", "push", "--allow-new", "-b=bookmark2"],
     );
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark2 to ee5b808b0b95
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -263,10 +273,11 @@ fn test_git_private_commits_are_evaluated_separately_for_each_remote() {
     test_env.jj_cmd_ok(&workspace_root, &["new", "-m=public 3"]);
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "set", "main", "-r@"]);
     let (_, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-b=main"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark main from 7eb97bf230ad to d8632ce893ab
-    "#);
+    [EOF]
+    ");
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
 
@@ -280,5 +291,6 @@ fn test_git_private_commits_are_evaluated_separately_for_each_remote() {
     Error: Won't push commit 36b7ecd11ad9 since it is private
     Hint: Rejected commit: znkkpsqq 36b7ecd1 (empty) private 1
     Hint: Configured git.private-commits: 'description(glob:'private*')'
+    [EOF]
     ");
 }

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -59,12 +59,13 @@ fn test_git_push_nothing(subprocess: bool) {
     }
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: xtvrqkyv d13ecdbd (empty) description 1
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
     // No bookmarks to push yet
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
@@ -72,9 +73,10 @@ fn test_git_push_nothing(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -101,13 +103,14 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: xtvrqkyv 0f8dc656 (empty) modified bookmark1 commit
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
     bookmark2: yostqsxw bc7610b6 (empty) foo
       @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
     my-bookmark: yostqsxw bc7610b6 (empty) foo
-    "###);
+    [EOF]
+    ");
     }
     // First dry-run. `bookmark1` should not get pushed.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -118,31 +121,34 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to bc7610b65a91
       Add bookmark my-bookmark to bc7610b65a91
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to bc7610b65a91
       Add bookmark my-bookmark to bc7610b65a91
-    "#);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: xtvrqkyv 0f8dc656 (empty) modified bookmark1 commit
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
     bookmark2: yostqsxw bc7610b6 (empty) foo
       @origin: yostqsxw bc7610b6 (empty) foo
     my-bookmark: yostqsxw bc7610b6 (empty) foo
       @origin: yostqsxw bc7610b6 (empty) foo
-    "###);
+    [EOF]
+    ");
     }
 
     // Try pushing backwards
@@ -163,10 +169,11 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     // We can move a bookmark backwards
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-bbookmark2"]);
@@ -174,10 +181,11 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move backward bookmark bookmark2 from bc7610b65a91 to 8476341eb395
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -201,10 +209,11 @@ fn test_git_push_parent_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to e612d524a5c6
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -221,10 +230,11 @@ fn test_git_push_no_matching_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -241,10 +251,11 @@ fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -285,10 +296,11 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to a657f1b61b94
-    "#);
+    [EOF]
+    ");
     }
     // Since it's already pushed to origin, nothing will happen if push again
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -296,10 +308,11 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     // The bookmark was moved on the "other" remote as well (since it's actually the
     // same remote), but `jj` is not aware of that since it thinks this is a
@@ -317,10 +330,11 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to other:
       Add bookmark bookmark1 to a657f1b61b94
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -347,12 +361,13 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     // Pushing should fail
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -370,12 +385,13 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     std::fs::write(origin_path.join("remote"), "remote").unwrap();
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "set", "bookmark1", "-r@"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r"
     bookmark1: vruxwmqv 80284bec remote
       @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
     bookmark2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
@@ -387,22 +403,24 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
         &["bookmark", "set", "bookmark1", "--allow-backwards", "-r@"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: kmkuslsw 0f8bf988 local
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
 
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -422,35 +440,38 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     std::fs::write(origin_path.join("remote"), "remote").unwrap();
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "set", "bookmark1", "-r@"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r"
     bookmark1: vruxwmqv 80284bec remote
       @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
     bookmark2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
     // Delete bookmark1 locally
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
 
     let stderr =
         test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--bookmark", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -466,12 +487,13 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     let origin_path = test_env.env_root().join("origin");
     test_env.jj_cmd_ok(&origin_path, &["bookmark", "delete", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &origin_path), @r"
     bookmark1 (deleted)
       @git: qpvuntsm d13ecdbd (empty) description 1
     bookmark2: zsuskuln 8476341e (empty) description 2
       @git: zsuskuln 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
     test_env.jj_cmd_ok(&origin_path, &["git", "export"]);
 
@@ -483,33 +505,36 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
         &["bookmark", "set", "bookmark1", "--allow-backwards", "-r@"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: kpqxywon 1ebe27ba local
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
 
     // Pushing a moved bookmark fails if deleted on remote
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    [EOF]
+    ");
     }
 
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "delete", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
 
     if subprocess {
@@ -521,16 +546,18 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
           Delete bookmark bookmark1 from d13ecdbda2a2
         Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
         Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
         ");
     } else {
         // Pushing a *deleted* bookmark succeeds if deleted on remote, even if we expect
         // bookmark1@origin to exist and point somewhere.
         let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "-bbookmark1"]);
         insta::assert_snapshot!(stdout, @"");
-        insta::assert_snapshot!(stderr, @r#"
+        insta::assert_snapshot!(stderr, @r"
         Changes to push to origin:
           Delete bookmark bookmark1 from d13ecdbda2a2
-        "#);
+        [EOF]
+        ");
     }
 }
 
@@ -553,21 +580,23 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     std::fs::write(workspace_root.join("local"), "local").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: yostqsxw cb17dcdc new bookmark1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
 
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark1 to cb17dcdc74d5
     Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -590,6 +619,7 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     Warning: Refusing to create new remote bookmark my@origin
     Hint: Use --allow-new to push new bookmark. Use --remote to specify the remote to push to.
     Nothing changed.
+    [EOF]
     ");
     }
     // Either --allow-new or git.push-new-bookmarks=true should work
@@ -602,6 +632,7 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     Changes to push to origin:
       Add bookmark my to fcc999921ce9
     Dry-run requested, not pushing.
+    [EOF]
     ");
     }
     let (_stdout, stderr) = test_env.jj_cmd_ok(
@@ -609,10 +640,11 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
         &["git", "push", "--config=git.push-new-bookmarks=true"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my to fcc999921ce9
-    "#);
+    [EOF]
+    ");
     }
 
     // Rewrite it and push again, which would fail if the pushed bookmark weren't
@@ -626,6 +658,7 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
       @origin: rlzusymt 8476341e (empty) description 2
     my: vruxwmqv 423bb660 (empty) local 2
       @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv hidden fcc99992 (empty) local 1
+    [EOF]
     ");
     }
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
@@ -633,6 +666,7 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark my from fcc999921ce9 to 423bb66069e7
+    [EOF]
     ");
     }
 }
@@ -656,13 +690,14 @@ fn test_git_push_multiple(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "foo"]);
     // Check the setup
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2: yqosqzyt c4a3c310 (empty) foo
       @origin (ahead by 1 commits, behind by 1 commits): rlzusymt 8476341e (empty) description 2
     my-bookmark: yqosqzyt c4a3c310 (empty) foo
-    "###);
+    [EOF]
+    ");
     }
     // First dry-run
     let (stdout, stderr) =
@@ -671,13 +706,14 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Move sideways bookmark bookmark2 from 8476341eb395 to c4a3c3105d92
       Add bookmark my-bookmark to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
     // Dry run requesting two specific bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -695,12 +731,13 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Add bookmark my-bookmark to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
     // Dry run requesting two specific bookmarks twice
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -720,12 +757,13 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Add bookmark my-bookmark to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
     // Dry run with glob pattern
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -736,29 +774,32 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Move sideways bookmark bookmark2 from 8476341eb395 to c4a3c3105d92
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
 
     // Unmatched bookmark name is error
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "-b=foo"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No such bookmark: foo
-    "###);
+    [EOF]
+    ");
     }
     let stderr = test_env.jj_cmd_failure(
         &workspace_root,
         &["git", "push", "-b=foo", "-b=glob:?bookmark"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No matching bookmarks for patterns: foo, ?bookmark
-    "###);
+    [EOF]
+    ");
     }
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
@@ -766,22 +807,24 @@ fn test_git_push_multiple(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
       Move sideways bookmark bookmark2 from 8476341eb395 to c4a3c3105d92
       Add bookmark my-bookmark to c4a3c3105d92
-    "#);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark2: yqosqzyt c4a3c310 (empty) foo
       @origin: yqosqzyt c4a3c310 (empty) foo
     my-bookmark: yqosqzyt c4a3c310 (empty) foo
       @origin: yqosqzyt c4a3c310 (empty) foo
-    "###);
+    [EOF]
+    ");
     }
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 bookmark2 my-bookmark c4a3c310
     │  (empty) foo
     │ ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 8476341e
@@ -789,7 +832,8 @@ fn test_git_push_multiple(subprocess: bool) {
     │ ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -810,11 +854,12 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark push-yostqsxwqrlt for revision yostqsxwqrlt
     Changes to push to origin:
       Add bookmark push-yostqsxwqrlt to cf1a53a8800a
-    "#);
+    [EOF]
+    ");
     }
     // test pushing two changes at once
     std::fs::write(workspace_root.join("file"), "modified2").unwrap();
@@ -826,6 +871,7 @@ fn test_git_push_changes(subprocess: bool) {
       yostqsxw 16c16966 push-yostqsxwqrlt* | bar
       yqosqzyt a050abf4 foo
     Hint: Prefix the expression with `all:` to allow any number of revisions (i.e. `all:(@|@-)`).
+    [EOF]
     ");
     }
     // test pushing two changes at once, part 2
@@ -834,12 +880,13 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from cf1a53a8800a to 16c169664e9f
       Add bookmark push-yqosqzytrlsw to a050abf4ff07
-    "#);
+    [EOF]
+    ");
     }
     // specifying the same change twice doesn't break things
     std::fs::write(workspace_root.join("file"), "modified3").unwrap();
@@ -848,10 +895,11 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from 16c169664e9f to ef6313d50ac1
-    "#);
+    [EOF]
+    ");
     }
 
     // specifying the same bookmark with --change/--bookmark doesn't break things
@@ -864,10 +912,11 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from ef6313d50ac1 to c1e65d3a64ce
-    "#);
+    [EOF]
+    ");
     }
 
     // try again with --change that moves the bookmark forward
@@ -884,12 +933,13 @@ fn test_git_push_changes(subprocess: bool) {
     );
     let stdout = test_env.jj_cmd_success(&workspace_root, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : yostqsxw 38cb417c bar
     Parent commit: yqosqzyt a050abf4 push-yostqsxwqrlt* push-yqosqzytrlsw | foo
-    "###);
+    [EOF]
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_root,
@@ -899,19 +949,21 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from c1e65d3a64ce to 38cb417ce3a6
-    "#);
+    [EOF]
+    ");
     }
     let stdout = test_env.jj_cmd_success(&workspace_root, &["status"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : yostqsxw 38cb417c push-yostqsxwqrlt | bar
     Parent commit: yqosqzyt a050abf4 push-yqosqzytrlsw | foo
-    "###);
+    [EOF]
+    ");
     }
 
     // Test changing `git.push-bookmark-prefix`. It causes us to push again.
@@ -928,11 +980,12 @@ fn test_git_push_changes(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark test-yostqsxwqrlt for revision yostqsxwqrlt
     Changes to push to origin:
       Add bookmark test-yostqsxwqrlt to 38cb417ce3a6
-    "#);
+    [EOF]
+    ");
     }
 
     // Test deprecation warning for `git.push-branch-prefix`
@@ -954,6 +1007,7 @@ fn test_git_push_changes(subprocess: bool) {
     Creating bookmark branch-yostqsxwqrlt for revision yostqsxwqrlt
     Changes to push to origin:
       Add bookmark branch-yostqsxwqrlt to 38cb417ce3a6
+    [EOF]
     ");
     }
 }
@@ -990,10 +1044,11 @@ fn test_git_push_revisions(subprocess: bool) {
         &["git", "push", "--allow-new", "-r=none()"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks point to the specified revisions: none()
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     // Push a revision with no bookmarks
     let (stdout, stderr) =
@@ -1002,10 +1057,11 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks point to the specified revisions: @--
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     // Push a revision with a single bookmark
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1016,11 +1072,12 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark-1 to 5f432a855e59
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
     // Push multiple revisions of which some have bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1031,12 +1088,13 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: No bookmarks point to the specified revisions: @--
     Changes to push to origin:
       Add bookmark bookmark-1 to 5f432a855e59
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
     // Push a revision with a multiple bookmarks
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1047,12 +1105,13 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark-2a to 84f499037f5c
       Add bookmark bookmark-2b to 84f499037f5c
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
     // Repeating a commit doesn't result in repeated messages about the bookmark
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -1063,11 +1122,12 @@ fn test_git_push_revisions(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark bookmark-1 to 5f432a855e59
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1113,6 +1173,7 @@ fn test_git_push_mixed(subprocess: bool) {
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
     Error: Refusing to create new remote bookmark bookmark-1@origin
     Hint: Use --allow-new to push new bookmark. Use --remote to specify the remote to push to.
+    [EOF]
     ");
     }
 
@@ -1131,14 +1192,15 @@ fn test_git_push_mixed(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
     Changes to push to origin:
       Add bookmark push-yqosqzytrlsw to a050abf4ff07
       Add bookmark bookmark-1 to 5f432a855e59
       Add bookmark bookmark-2a to 84f499037f5c
       Add bookmark bookmark-2b to 84f499037f5c
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1166,10 +1228,11 @@ fn test_git_push_existing_long_bookmark(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark push-19b790168e73f7a73a98deae21e807c0 to a050abf4ff07
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1207,10 +1270,11 @@ fn test_git_push_conflict(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["describe", "-m", "third"]);
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--all"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit e2221a796300 since it has conflicts
     Hint: Rejected commit: yostqsxw e2221a79 my-bookmark | (conflict) third
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1234,6 +1298,7 @@ fn test_git_push_no_description(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 5b36783cd11c since it has no description
     Hint: Rejected commit: yqosqzyt 5b36783c my-bookmark | (empty) (no description set)
+    [EOF]
     ");
     }
     test_env.jj_cmd_ok(
@@ -1279,6 +1344,7 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 5b36783cd11c since it has no description
     Hint: Rejected commit: yqosqzyt 5b36783c imm | (empty) (no description set)
+    [EOF]
     ");
     }
 
@@ -1297,11 +1363,12 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my-bookmark to ea7373507ad9
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1329,6 +1396,7 @@ fn test_git_push_missing_author(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 944313939bbd since it has no author and/or committer set
     Hint: Rejected commit: vruxwmqv 94431393 missing-name | (empty) initial
+    [EOF]
     ");
     }
     run_without_var("JJ_EMAIL", &["new", "root()", "-m=initial"]);
@@ -1341,6 +1409,7 @@ fn test_git_push_missing_author(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 59354714f789 since it has no author and/or committer set
     Hint: Rejected commit: kpqxywon 59354714 missing-email | (empty) initial
+    [EOF]
     ");
     }
 }
@@ -1383,6 +1452,7 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 011f740bf8b5 since it has no author and/or committer set
     Hint: Rejected commit: yostqsxw 011f740b imm | (empty) no author email
+    [EOF]
     ");
     }
 
@@ -1401,11 +1471,12 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my-bookmark to 68fdae89de4f
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1436,6 +1507,7 @@ fn test_git_push_missing_committer(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 4fd190283d1a since it has no author and/or committer set
     Hint: Rejected commit: yqosqzyt 4fd19028 missing-name | (empty) no committer name
+    [EOF]
     ");
     }
     test_env.jj_cmd_ok(&workspace_root, &["new", "root()"]);
@@ -1452,6 +1524,7 @@ fn test_git_push_missing_committer(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit eab97428a6ec since it has no author and/or committer set
     Hint: Rejected commit: kpqxywon eab97428 missing-email | (empty) no committer email
+    [EOF]
     ");
     }
 
@@ -1466,6 +1539,7 @@ fn test_git_push_missing_committer(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 1143ed607f54 since it has no description and it has no author and/or committer set
     Hint: Rejected commit: kpqxywon 1143ed60 missing-email | (empty) (no description set)
+    [EOF]
     ");
     }
 }
@@ -1509,6 +1583,7 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stderr, @r"
     Error: Won't push commit 7e61dc727a8f since it has no author and/or committer set
     Hint: Rejected commit: yostqsxw 7e61dc72 imm | (empty) no committer email
+    [EOF]
     ");
     }
 
@@ -1527,11 +1602,12 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Add bookmark my-bookmark to c79f85e90b4a
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1549,14 +1625,15 @@ fn test_git_push_deleted(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
-    "#);
+    [EOF]
+    ");
     }
     let stdout = test_env.jj_cmd_success(&workspace_root, &["log", "-rall()"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 5b36783c
     │  (empty) (no description set)
     │ ○  rlzusymt test.user@example.com 2001-02-03 08:05:10 bookmark2 8476341e
@@ -1564,16 +1641,18 @@ fn test_git_push_deleted(subprocess: bool) {
     │ ○  xtvrqkyv test.user@example.com 2001-02-03 08:05:08 d13ecdbd
     ├─╯  (empty) description 1
     ◆  zzzzzzzz root() 00000000
-    "#);
+    [EOF]
+    ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--deleted"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1602,14 +1681,15 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "bookmark2"]);
     test_env.jj_cmd_ok(&workspace_root, &["git", "fetch"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: xtvrqkyv d13ecdbd (empty) description 1
       @origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2 (conflicted):
       + yostqsxw 8e670e2d (empty) description 3
       + rlzusymt 8476341e (empty) description 2
       @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
-    "###);
+    [EOF]
+    ");
     }
 
     let bump_bookmark1 = || {
@@ -1623,11 +1703,12 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 
     // --bookmark should be blocked by conflicting bookmark
@@ -1636,10 +1717,11 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
         &["git", "push", "--allow-new", "--bookmark", "bookmark2"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
-    "###);
+    [EOF]
+    ");
     }
 
     // --all shouldn't be blocked by conflicting bookmark
@@ -1649,12 +1731,13 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Changes to push to origin:
       Move forward bookmark bookmark1 from d13ecdbda2a2 to 8df52121b022
-    "#);
+    [EOF]
+    ");
     }
 
     // --revisions shouldn't be blocked by conflicting bookmark
@@ -1665,12 +1748,13 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     insta::assert_snapshot!(stdout, @"");
     }
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Bookmark bookmark2 is conflicted
     Hint: Run `jj bookmark list` to inspect, and use `jj bookmark set` to fix it up.
     Changes to push to origin:
       Move forward bookmark bookmark1 from 8df52121b022 to 345e1f64a64d
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1691,15 +1775,17 @@ fn test_git_push_deleted_untracked(subprocess: bool) {
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--deleted"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
     let stderr = test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--bookmark=bookmark1"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No such bookmark: bookmark1
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1720,13 +1806,14 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     );
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "bookmark3"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: vruxwmqv db059e3f (empty) moved bookmark1
     bookmark1@origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2 (deleted)
       @origin: rlzusymt 8476341e (empty) description 2
     bookmark3: znkkpsqq 1aa4f1f2 (empty) moved bookmark2
-    "###);
+    [EOF]
+    ");
     }
 
     // At this point, only bookmark2 is still tracked. `jj git push --tracked` would
@@ -1734,11 +1821,12 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--tracked", "--dry-run"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Delete bookmark bookmark2 from 8476341eb395
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     }
 
     // Untrack the last remaining tracked bookmark.
@@ -1747,20 +1835,22 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
         &["bookmark", "untrack", "bookmark2@origin"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &workspace_root), @r"
     bookmark1: vruxwmqv db059e3f (empty) moved bookmark1
     bookmark1@origin: xtvrqkyv d13ecdbd (empty) description 1
     bookmark2@origin: rlzusymt 8476341e (empty) description 2
     bookmark3: znkkpsqq 1aa4f1f2 (empty) moved bookmark2
-    "###);
+    [EOF]
+    ");
     }
 
     // Now, no bookmarks are tracked. --tracked does not push anything
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--tracked"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 
     // All bookmarks are still untracked.
@@ -1781,12 +1871,13 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     //   bookmark2@origin` instead of showing an error here.
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--all"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Non-tracking remote bookmark bookmark1@origin exists
     Hint: Run `jj bookmark track bookmark1@origin` to import the remote bookmark.
     Changes to push to origin:
       Add bookmark bookmark3 to 1aa4f1f2ef7f
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1806,11 +1897,12 @@ fn test_git_push_moved_forward_untracked(subprocess: bool) {
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Non-tracking remote bookmark bookmark1@origin exists
     Hint: Run `jj bookmark track bookmark1@origin` to import the remote bookmark.
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1833,11 +1925,12 @@ fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     );
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--allow-new"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Non-tracking remote bookmark bookmark1@origin exists
     Hint: Run `jj bookmark track bookmark1@origin` to import the remote bookmark.
     Nothing changed.
-    "###);
+    [EOF]
+    ");
     }
 }
 
@@ -1858,12 +1951,13 @@ fn test_git_push_to_remote_named_git(subprocess: bool) {
     let stderr =
         test_env.jj_cmd_failure(&workspace_root, &["git", "push", "--all", "--remote=git"]);
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to git:
       Add bookmark bookmark1 to d13ecdbda2a2
       Add bookmark bookmark2 to 8476341eb395
     Error: Git remote named 'git' is reserved for local Git repository
-    "#);
+    [EOF]
+    ");
     }
 }
 
@@ -1892,6 +1986,7 @@ fn test_git_push_to_remote_with_slashes(subprocess: bool) {
       Add bookmark bookmark2 to 8476341eb395
     Error: Git remotes with slashes are incompatible with jj: slash/origin
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     }
 }
@@ -1927,7 +2022,7 @@ fn test_git_push_sign_on_push() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template]);
     // There should be no signed commits initially
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ○  commit which should not be signed 1
     ○  commit to be signed 2
@@ -1936,7 +2031,8 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
     test_env.add_config(
         r#"
@@ -1947,14 +2043,15 @@ fn test_git_push_sign_on_push() {
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push", "--dry-run"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to 8710e91a14a1
     Dry-run requested, not pushing.
-    "#);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template]);
     // There should be no signed commits after performing a dry run
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ○  commit which should not be signed 1
     ○  commit to be signed 2
@@ -1963,21 +2060,23 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Updated signatures of 2 commits
     Rebased 2 descendant commits
     Changes to push to origin:
       Move forward bookmark bookmark2 from 8476341eb395 to a6259c482040
     Working copy now at: kmkuslsw b5f47345 (empty) commit which should not be signed 2
     Parent commit      : kpqxywon 90df08d3 (empty) commit which should not be signed 1
-    "#);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template]);
     // Only commits which are being pushed should be signed
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ○  commit which should not be signed 1
     ○  commit to be signed 2
@@ -1988,7 +2087,8 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Immutable commits should not be signed
@@ -2003,25 +2103,32 @@ fn test_git_push_sign_on_push() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Created 1 bookmarks pointing to kpqxywon 90df08d3 bookmark3 | (empty) commit which should not be signed 1");
+    insta::assert_snapshot!(stderr, @r"
+    Created 1 bookmarks pointing to kpqxywon 90df08d3 bookmark3 | (empty) commit which should not be signed 1
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_root,
         &["bookmark", "move", "bookmark2", "--to", "bookmark3"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Moved 1 bookmarks to kpqxywon 90df08d3 bookmark2* bookmark3 | (empty) commit which should not be signed 1");
+    insta::assert_snapshot!(stderr, @r"
+    Moved 1 bookmarks to kpqxywon 90df08d3 bookmark2* bookmark3 | (empty) commit which should not be signed 1
+    [EOF]
+    ");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmark3""#);
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["git", "push"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Refusing to create new remote bookmark bookmark3@origin
     Hint: Use --allow-new to push new bookmark. Use --remote to specify the remote to push to.
     Changes to push to origin:
       Move forward bookmark bookmark2 from a6259c482040 to 90df08d3d612
-    "#);
+    [EOF]
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&workspace_root, &["log", "-T", template, "-r", "::"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  commit which should not be signed 2
     ◆  commit which should not be signed 1
     ◆  commit to be signed 2
@@ -2032,7 +2139,8 @@ fn test_git_push_sign_on_push() {
     │ ○  description 1
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 
 use test_case::test_case;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn set_up() -> (TestEnvironment, PathBuf) {
@@ -2035,7 +2036,7 @@ fn test_git_push_sign_on_push() {
     insta::assert_snapshot!(stderr, @"");
 }
 
-fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     // --quiet to suppress deleted bookmarks hint
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes", "--quiet"])
 }

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -39,20 +39,24 @@ fn test_git_remotes() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar http://example.com/repo/bar
     foo http://example.com/repo/foo
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["git", "remote", "remove", "foo"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @"bar http://example.com/repo/bar
-");
+    insta::assert_snapshot!(stdout, @r"
+    bar http://example.com/repo/bar
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "remove", "nonexistent"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No git remote named 'nonexistent'
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -75,9 +79,10 @@ fn test_git_remote_add() {
             "http://example.com/repo/foo2",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'foo' already exists
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["git", "remote", "add", "git", "http://example.com/repo/git"],
@@ -85,11 +90,13 @@ fn test_git_remote_add() {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     foo http://example.com/repo/foo
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -112,9 +119,10 @@ fn test_git_remote_set_url() {
             "http://example.com/repo/bar",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No git remote named 'bar'
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &[
@@ -128,6 +136,7 @@ fn test_git_remote_set_url() {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -142,9 +151,10 @@ fn test_git_remote_set_url() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     foo http://example.com/repo/bar
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -160,7 +170,10 @@ fn test_git_remote_relative_path() {
         &["git", "remote", "add", "foo", path.to_str().unwrap()],
     );
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @"foo $TEST_ENV/native/sep");
+    insta::assert_snapshot!(stdout, @r"
+    foo $TEST_ENV/native/sep
+    [EOF]
+    ");
 
     // Relative path using UNIX separator
     test_env.jj_cmd_ok(
@@ -168,7 +181,10 @@ fn test_git_remote_relative_path() {
         &["-Rrepo", "git", "remote", "set-url", "foo", "unix/sep"],
     );
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @"foo $TEST_ENV/unix/sep");
+    insta::assert_snapshot!(stdout, @r"
+    foo $TEST_ENV/unix/sep
+    [EOF]
+    ");
 }
 
 #[test]
@@ -186,27 +202,31 @@ fn test_git_remote_rename() {
         &["git", "remote", "add", "baz", "http://example.com/repo/baz"],
     );
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "bar", "foo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No git remote named 'bar'
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "foo", "baz"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'baz' already exists
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "foo", "git"]);
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "foo", "bar"]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar http://example.com/repo/foo
     baz http://example.com/repo/baz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -228,22 +248,25 @@ fn test_git_remote_named_git() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar http://example.com/repo/repo
-    "###);
+    [EOF]
+    ");
     // @git bookmark shouldn't be renamed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rmain@git", "-Tbookmarks"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  main
     │
     ~
-    "###);
+    [EOF]
+    ");
 
     // The remote cannot be renamed back by jj.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "bar", "git"]);
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
 
     // Reinitialize the repo with remote named 'git'.
@@ -260,11 +283,12 @@ fn test_git_remote_named_git() {
     "###);
     // @git bookmark shouldn't be removed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rmain@git", "-Tbookmarks"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  main
     │
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -294,11 +318,13 @@ fn test_git_remote_with_slashes() {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remotes with slashes are incompatible with jj: another/origin
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     slash/origin http://example.com/repo/repo
-    "###);
+    [EOF]
+    ");
 
     // The remote can be renamed.
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -308,9 +334,10 @@ fn test_git_remote_with_slashes() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     origin http://example.com/repo/repo
-    "###);
+    [EOF]
+    ");
 
     // The remote cannot be renamed back by jj.
     let stderr = test_env.jj_cmd_failure(
@@ -320,6 +347,7 @@ fn test_git_remote_with_slashes() {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remotes with slashes are incompatible with jj: slash/origin
     Hint: Run `jj git remote rename` to give a different name.
+    [EOF]
     ");
 
     // Reinitialize the repo with remote with slashes
@@ -337,9 +365,10 @@ fn test_git_remote_with_slashes() {
     "###);
     // @git bookmark shouldn't be removed.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rmain@git", "-Tbookmarks"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  main
     │
     ~
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_git_submodule.rs
+++ b/cli/tests/test_git_submodule.rs
@@ -48,19 +48,23 @@ fn test_gitsubmodule_print_gitmodules() {
         &workspace_root,
         &["git", "submodule", "print-gitmodules", "-r", "@-"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     name:old
     url:https://github.com/old/old.git
     path:old
 
 
-    "###);
+    [EOF]
+    ");
 
     let stdout =
         test_env.jj_cmd_success(&workspace_root, &["git", "submodule", "print-gitmodules"]);
-    insta::assert_snapshot!(stdout, @r###"
-	name:new
-	url:https://github.com/new/new.git
-	path:new
-    "###);
+    insta::assert_snapshot!(stdout, @r"
+    name:new
+    url:https://github.com/new/new.git
+    path:new
+
+
+    [EOF]
+    ");
 }

--- a/cli/tests/test_gitignores.rs
+++ b/cli/tests/test_gitignores.rs
@@ -87,11 +87,11 @@ fn test_gitignores_relative_excludes_file_path() {
     // to the cwd.
     std::fs::create_dir(workspace_root.join("sub")).unwrap();
     let stdout = test_env.jj_cmd_success(&workspace_root.join("sub"), &["diff", "-s"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     A ../not-ignored
     "###);
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["-Rrepo", "diff", "-s"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     A repo/not-ignored
     "###);
 }
@@ -106,10 +106,12 @@ fn test_gitignores_ignored_file_in_target_commit() {
     // Create a commit with file "ignored" in it
     std::fs::write(workspace_root.join("ignored"), "committed contents\n").unwrap();
     test_env.jj_cmd_ok(&workspace_root, &["bookmark", "create", "-r@", "with-file"]);
-    let target_commit_id = test_env.jj_cmd_success(
-        &workspace_root,
-        &["log", "--no-graph", "-T=commit_id", "-r=@"],
-    );
+    let target_commit_id = test_env
+        .jj_cmd_success(
+            &workspace_root,
+            &["log", "--no-graph", "-T=commit_id", "-r=@"],
+        )
+        .into_raw();
 
     // Create another commit where we ignore that path
     test_env.jj_cmd_ok(&workspace_root, &["new", "root()"]);

--- a/cli/tests/test_gitignores.rs
+++ b/cli/tests/test_gitignores.rs
@@ -58,11 +58,12 @@ fn test_gitignores() {
     std::fs::write(workspace_root.join("file3"), "contents").unwrap();
 
     let stdout = test_env.jj_cmd_success(&workspace_root, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     A .gitignore
     A file0
     A file3
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -87,13 +88,15 @@ fn test_gitignores_relative_excludes_file_path() {
     // to the cwd.
     std::fs::create_dir(workspace_root.join("sub")).unwrap();
     let stdout = test_env.jj_cmd_success(&workspace_root.join("sub"), &["diff", "-s"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     A ../not-ignored
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["-Rrepo", "diff", "-s"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     A repo/not-ignored
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -121,19 +124,20 @@ fn test_gitignores_ignored_file_in_target_commit() {
     // Update to the commit with the "ignored" file
     let (stdout, stderr) = test_env.jj_cmd_ok(&workspace_root, &["edit", "with-file"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm 5ada929e with-file | (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 1 files, modified 0 files, removed 0 files
     Warning: 1 of those updates were skipped because there were conflicting changes in the working copy.
     Hint: Inspect the changes compared to the intended target with `jj diff --from 5ada929e5d2e`.
     Discard the conflicting changes with `jj restore --from 5ada929e5d2e`.
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(
         &workspace_root,
         &["diff", "--git", "--from", &target_commit_id],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/ignored b/ignored
     index 8a69467466..4d9be5127b 100644
     --- a/ignored
@@ -141,5 +145,6 @@ fn test_gitignores_ignored_file_in_target_commit() {
     @@ -1,1 +1,1 @@
     -committed contents
     +contents in working copy
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -73,17 +73,19 @@ fn test_no_subcommand() {
 
     // Outside of a repo.
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &[]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Hint: Use `jj -h` for a list of available commands.
     Run `jj config set --user ui.default-command log` to disable this message.
     Error: There is no jj repo in "."
-    "###);
+    [EOF]
+    "#);
 
     test_env.add_config(r#"ui.default-command="log""#);
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &[]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
-    "###);
+    [EOF]
+    "#);
 
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["--help"]);
     insta::assert_snapshot!(
@@ -108,16 +110,18 @@ fn test_no_subcommand() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "log"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "show"]);
     // TODO: test_env.jj_cmd_ok(&repo_path, &["-r", "help"])
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "log"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "log"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 help log show 230dd059
     │  (empty) (no description set)
     ~
-    "###);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "show"]), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["-r", "show"]), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 help log show 230dd059
     │  (empty) (no description set)
     ~
-    "###);
+    [EOF]
+    ");
 
     // Multiple default command strings work.
     test_env.add_config(r#"ui.default-command=["commit", "-m", "foo"]"#);
@@ -125,10 +129,11 @@ fn test_no_subcommand() {
     std::fs::write(repo_path.join("file.txt"), "file").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &[]);
     assert_eq!(stdout.raw(), "");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kxryzmor 89c70edf (empty) (no description set)
     Parent commit      : lylxulpl 51bd3589 foo
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -140,10 +145,11 @@ fn test_ignore_working_copy() {
 
     std::fs::write(repo_path.join("file"), "initial").unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  b15ef4cdd277d2c63cce6d67c1916f53a36141f7
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Modify the file. With --ignore-working-copy, we still get the same commit
     // ID.
@@ -156,28 +162,31 @@ fn test_ignore_working_copy() {
 
     // But without --ignore-working-copy, we get a new commit ID.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  4d2c49a8f8e2f1ba61f48ba79e5f4a5faa6512cf
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
 fn test_repo_arg_with_init() {
     let test_env = TestEnvironment::default();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["init", "-R=.", "repo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
 fn test_repo_arg_with_git_clone() {
     let test_env = TestEnvironment::default();
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["git", "clone", "-R=.", "remote"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -190,31 +199,35 @@ fn test_resolve_workspace_directory() {
 
     // Ancestor of cwd
     let stdout = test_env.jj_cmd_success(&subdir, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     Working copy : qpvuntsm 230dd059 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Explicit subdirectory path
     let stderr = test_env.jj_cmd_failure(&subdir, &["status", "-R", "."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
-    "###);
+    [EOF]
+    "#);
 
     // Valid explicit path
     let stdout = test_env.jj_cmd_success(&subdir, &["status", "-R", "../.."]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     Working copy : qpvuntsm 230dd059 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // "../../..".ancestors() contains "../..", but it should never be looked up.
     let stderr = test_env.jj_cmd_failure(&subdir, &["status", "-R", "../../.."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "../../.."
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -224,22 +237,25 @@ fn test_no_workspace_directory() {
     std::fs::create_dir(&repo_path).unwrap();
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["status"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
-    "###);
+    [EOF]
+    "#);
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["status", "-R", "repo"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "repo"
-    "###);
+    [EOF]
+    "#);
 
     std::fs::create_dir(repo_path.join(".git")).unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["status"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
     Hint: It looks like this is a git repo. You can create a jj repo backed by it by running this:
     jj git init --colocate
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -252,7 +268,7 @@ fn test_bad_path() {
 
     // cwd == workspace_root
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "../out"]);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -263,11 +279,12 @@ fn test_bad_path() {
       = Invalid file pattern
     2: Path "../out" is not in the repo "."
     3: Invalid component ".." in repo-relative path "../out"
-    "###);
+    [EOF]
+    "#);
 
     // cwd != workspace_root, can't be parsed as repo-relative path
     let stderr = test_env.jj_cmd_failure(&subdir, &["file", "show", "../.."]);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -278,11 +295,12 @@ fn test_bad_path() {
       = Invalid file pattern
     2: Path "../.." is not in the repo "../"
     3: Invalid component ".." in repo-relative path "../"
-    "###);
+    [EOF]
+    "#);
 
     // cwd != workspace_root, can be parsed as repo-relative path
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["file", "show", "-Rrepo", "out"]);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Error: Failed to parse fileset: Invalid file pattern
     Caused by:
     1:  --> 1:1
@@ -294,7 +312,8 @@ fn test_bad_path() {
     2: Path "out" is not in the repo "repo"
     3: Invalid component ".." in repo-relative path "../out"
     Hint: Consider using root:"out" to specify repo-relative path
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -304,7 +323,7 @@ fn test_invalid_filesets_looking_like_filepaths() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["file", "show", "abc~"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse fileset: Syntax error
     Caused by:  --> 1:5
       |
@@ -313,7 +332,8 @@ fn test_invalid_filesets_looking_like_filepaths() {
       |
       = expected `~` or <primary>
     Hint: See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -327,43 +347,47 @@ fn test_broken_repo_structure() {
     // Test the error message when the git repository can't be located.
     std::fs::remove_file(store_path.join("git_target")).unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(stderr.strip_last_line(), @r###"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r"
     Internal error: The repository appears broken or inaccessible
     Caused by:
     1: Cannot access $TEST_ENV/repo/.jj/repo/store/git_target
-    "###);
+    [EOF]
+    ");
 
     // Test the error message when the commit backend is of unknown type.
     std::fs::write(&store_type_path, "unknown").unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Internal error: This version of the jj binary doesn't support this type of repo
     Caused by: Unsupported commit backend type 'unknown'
-    "###);
+    [EOF]
+    ");
 
     // Test the error message when the file indicating the commit backend type
     // cannot be read.
     std::fs::remove_file(&store_type_path).unwrap();
     std::fs::create_dir(&store_type_path).unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(stderr.strip_last_line(), @r###"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r"
     Internal error: The repository appears broken or inaccessible
     Caused by:
     1: Failed to read commit backend type
     2: Cannot access $TEST_ENV/repo/.jj/repo/store/type
-    "###);
+    [EOF]
+    ");
 
     // Test when the .jj directory is empty. The error message is identical to
     // the previous one, but writing the default type file would also fail.
     std::fs::remove_dir_all(repo_path.join(".jj")).unwrap();
     std::fs::create_dir(repo_path.join(".jj")).unwrap();
     let stderr = test_env.jj_cmd_internal_error(&repo_path, &["log"]);
-    insta::assert_snapshot!(stderr.strip_last_line(), @r###"
+    insta::assert_snapshot!(stderr.strip_last_line(), @r"
     Internal error: The repository appears broken or inaccessible
     Caused by:
     1: Failed to read commit backend type
     2: Cannot access $TEST_ENV/repo/.jj/repo/store/type
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -375,42 +399,47 @@ fn test_color_config() {
 
     // Test that --color=always is respected.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    [EOF]
+    ");
 
     // Test that color is used if it's requested in the config file
     test_env.add_config(r#"ui.color="always""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    [EOF]
+    ");
 
     // Test that --color=never overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=never", "log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Test that --color=auto overrides the config.
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=auto", "log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Test that --config 'ui.color=never' overrides the config.
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["--config=ui.color=never", "log", "-T", "commit_id"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // --color overrides --config 'ui.color=...'.
     let stdout = test_env.jj_cmd_success(
@@ -424,18 +453,20 @@ fn test_color_config() {
             "commit_id",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Test that NO_COLOR does NOT override the request for color in the config file
     test_env.add_env_var("NO_COLOR", "1");
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [38;5;4m230dd059e1b059aefc0da06a2e5a7dbf22362f22[39m
     [1m[38;5;14m◆[0m  [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    [EOF]
+    ");
 
     // Test that per-repo config overrides the user config.
     std::fs::write(
@@ -444,10 +475,11 @@ fn test_color_config() {
     )
     .unwrap();
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "commit_id"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Invalid --color
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["log", "--color=foo"]);
@@ -456,6 +488,7 @@ fn test_color_config() {
       [possible values: always, never, debug, auto]
 
     For more information, try '--help'.
+    [EOF]
     ");
     // Invalid ui.color
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "--config=ui.color=true"]);
@@ -464,6 +497,7 @@ fn test_color_config() {
     Caused by: wanted string or table
 
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 }
 
@@ -476,15 +510,16 @@ fn test_color_ui_messages() {
 
     // hint and error
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["-R."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     [1m[38;5;6mHint: [0m[39mUse `jj -h` for a list of available commands.[39m
     [39mRun `jj config set --user ui.default-command log` to disable this message.[39m
     [1m[38;5;1mError: [39mThere is no jj repo in "."[0m
-    "###);
+    [EOF]
+    "#);
 
     // error source
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", ".."]);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     [1m[38;5;1mError: [39mFailed to parse fileset: Invalid file pattern[0m
     [1m[39mCaused by:[0m
     [1m[39m1: [0m[39m --> 1:1[39m
@@ -495,13 +530,15 @@ fn test_color_ui_messages() {
     [39m  = Invalid file pattern[39m
     [1m[39m2: [0m[39mPath ".." is not in the repo "."[39m
     [1m[39m3: [0m[39mInvalid component ".." in repo-relative path "../"[39m
-    "###);
+    [EOF]
+    "#);
 
     // warning
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     [1m[38;5;3mWarning: [39mThe argument "@" is being interpreted as a fileset expression. To specify a revset, pass -r "@" instead.[0m
-    "###);
+    [EOF]
+    "#);
 
     // error inlined in template output
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -514,11 +551,12 @@ fn test_color_ui_messages() {
             "-Tdescription",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [38;5;4m167f90e7600a50f85c4f909b53eaf546faa82879[39m
     [1m[39m<[38;5;1mError: [39mNo Commit available>[0m  [38;5;8m(elided revisions)[39m
     [38;5;4m0000000000000000000000000000000000000000[39m
-    "###);
+    [EOF]
+    ");
 
     // formatted hint
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", ".."]);
@@ -528,15 +566,17 @@ fn test_color_ui_messages() {
     [39m  [1m[38;5;5mm[0m[38;5;8mzvwutvl[39m [1m[38;5;4m1[0m[38;5;8m67f90e7[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
     [39m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [1m[38;5;4m2[0m[38;5;8m30dd059[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
     [1m[38;5;6mHint: [0m[39mPrefix the expression with `all:` to allow any number of revisions (i.e. `all:..`).[39m
+    [EOF]
     ");
 
     // debugging colors
     let (stdout, _stderr) = test_env.jj_cmd_ok(&repo_path, &["st", "--color", "debug"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     Working copy : [1m[38;5;13m<<working_copy change_id shortest prefix::m>>[38;5;8m<<working_copy change_id shortest rest::zvwutvl>>[39m<<working_copy:: >>[38;5;12m<<working_copy commit_id shortest prefix::1>>[38;5;8m<<working_copy commit_id shortest rest::67f90e7>>[39m<<working_copy:: >>[38;5;10m<<working_copy empty::(empty)>>[39m<<working_copy:: >>[38;5;10m<<working_copy empty description placeholder::(no description set)>>[0m
     Parent commit: [1m[38;5;5m<<change_id shortest prefix::q>>[0m[38;5;8m<<change_id shortest rest::pvuntsm>>[39m [1m[38;5;4m<<commit_id shortest prefix::2>>[0m[38;5;8m<<commit_id shortest rest::30dd059>>[39m [38;5;2m<<empty::(empty)>>[39m [38;5;2m<<empty description placeholder::(no description set)>>[39m
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -621,13 +661,20 @@ fn test_config_args() {
     .unwrap();
 
     let stdout = list_config(&["--config=test.key1=arg1"]);
-    insta::assert_snapshot!(stdout, @r#"test.key1 = "arg1""#);
+    insta::assert_snapshot!(stdout, @r#"
+    test.key1 = "arg1"
+    [EOF]
+    "#);
     let stdout = list_config(&["--config-toml=test.key1='arg1'"]);
-    insta::assert_snapshot!(stdout, @"test.key1 = 'arg1'");
+    insta::assert_snapshot!(stdout, @r"
+    test.key1 = 'arg1'
+    [EOF]
+    ");
     let stdout = list_config(&["--config-file=file1.toml"]);
     insta::assert_snapshot!(stdout, @r"
     test.key1 = 'file1'
     test.key2 = 'file1'
+    [EOF]
     ");
 
     // --config items are inserted to a single layer internally
@@ -639,6 +686,7 @@ fn test_config_args() {
     insta::assert_snapshot!(stdout, @r#"
     test.key1 = "arg3"
     test.key2.sub = true
+    [EOF]
     "#);
 
     // --config* arguments are processed in order of appearance
@@ -654,21 +702,29 @@ fn test_config_args() {
     # test.key2 = 'file1'
     test.key2 = 'arg3'
     test.key3 = 'file2'
+    [EOF]
     "##);
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         test_env.env_root(),
         &["config", "list", "foo", "--config-toml=foo='bar'"],
     );
-    insta::assert_snapshot!(stdout, @"foo = 'bar'");
+    insta::assert_snapshot!(stdout, @r"
+    foo = 'bar'
+    [EOF]
+    ");
     insta::assert_snapshot!(
         stderr,
-        @"Warning: --config-toml is deprecated; use --config or --config-file instead.");
+        @r"
+    Warning: --config-toml is deprecated; use --config or --config-file instead.
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["config", "list", "--config=foo"]);
     insta::assert_snapshot!(stderr, @r"
     Config error: --config must be specified as NAME=VALUE
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(
@@ -684,6 +740,7 @@ fn test_config_args() {
         1: Cannot access unknown.toml
         2: <redacted>
         For help, see https://jj-vcs.github.io/jj/latest/config/.
+        [EOF]
         ");
     });
 }
@@ -706,6 +763,7 @@ fn test_invalid_config() {
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 }
 
@@ -723,6 +781,7 @@ fn test_invalid_config_value() {
     Caused by: invalid type: sequence, expected a string
 
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 }
 
@@ -747,7 +806,10 @@ fn test_conditional_config() {
         test_env.env_root(),
         &["config", "list", "--include-overridden", "aliases"],
     );
-    insta::assert_snapshot!(stdout, @"aliases.foo = ['new', 'root()', '-mglobal']");
+    insta::assert_snapshot!(stdout, @r"
+    aliases.foo = ['new', 'root()', '-mglobal']
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(
         &test_env.home_dir().join("repo1"),
         &["config", "list", "--include-overridden", "aliases"],
@@ -756,6 +818,7 @@ fn test_conditional_config() {
     # aliases.foo = ['new', 'root()', '-mglobal']
     # aliases.foo = ['new', 'root()', '-mhome']
     aliases.foo = ['new', 'root()', '-mrepo1']
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(
         &test_env.home_dir().join("repo2"),
@@ -764,6 +827,7 @@ fn test_conditional_config() {
     insta::assert_snapshot!(stdout, @r"
     # aliases.foo = ['new', 'root()', '-mglobal']
     aliases.foo = ['new', 'root()', '-mhome']
+    [EOF]
     ");
 
     // Aliases can be expanded by using the conditional tables
@@ -771,11 +835,13 @@ fn test_conditional_config() {
     insta::assert_snapshot!(stderr, @r"
     Working copy now at: royxmykx 82899b03 (empty) repo1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
     let (_stdout, stderr) = test_env.jj_cmd_ok(&test_env.home_dir().join("repo2"), &["foo"]);
     insta::assert_snapshot!(stderr, @r"
     Working copy now at: yqosqzyt 3bd315a9 (empty) home
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
 }
 
@@ -842,13 +908,17 @@ fn test_default_config() {
     insta::assert_snapshot!(stdout, @r"
     operation.hostname
     operation.username
+    [EOF]
     ");
     insta::assert_snapshot!(stderr, @"");
 
     let repo_path = test_env.env_root().join("repo");
     let (stdout, stderr) = jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"Initialized repo in "repo""#);
+    insta::assert_snapshot!(stderr, @r#"
+    Initialized repo in "repo"
+    [EOF]
+    "#);
 
     let (stdout, stderr) = jj_cmd_ok(&repo_path, &["new"]);
     insta::assert_snapshot!(stdout, @"");
@@ -858,6 +928,7 @@ fn test_default_config() {
     Warning: Name and email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes. To configure, run:
       jj config set --user user.name "Some One"
       jj config set --user user.email "<user>@<host>"
+    [EOF]
     "#);
 
     let (stdout, stderr) = jj_cmd_ok(&repo_path, &["log"]);
@@ -867,6 +938,7 @@ fn test_default_config() {
     ○  <change-id> (no email set) <date-time> <id>
     │  (empty) (no description set)
     ◆  <change-id> root() <id>
+    [EOF]
     ");
     insta::assert_snapshot!(stderr, @"");
 
@@ -881,6 +953,7 @@ fn test_default_config() {
         ○  <id> <user>@<host> <date-time>
         │  add workspace 'default'
         ○  <id> root()
+        [EOF]
         ");
     }
     insta::assert_snapshot!(stderr, @"");
@@ -961,6 +1034,7 @@ fn test_help() {
           --no-pager                     Disable the pager
           --config <NAME=VALUE>          Additional configuration options (can be repeated)
           --config-file <PATH>           Additional configuration files (can be repeated)
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_help_command.rs
+++ b/cli/tests/test_help_command.rs
@@ -37,22 +37,25 @@ fn test_help() {
 
     // Help command should not work recursively
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["workspace", "help", "root"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: unrecognized subcommand 'help'
 
     Usage: jj workspace [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "#);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["workspace", "add", "help"]);
     insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
+    [EOF]
     "#);
 
     let stderr = test_env.jj_cmd_failure(test_env.env_root(), &["new", "help", "main"]);
     insta::assert_snapshot!(stderr, @r#"
     Error: There is no jj repo in "."
+    [EOF]
     "#);
 
     // Help command should output the same as --help for nonexistent commands
@@ -67,7 +70,7 @@ fn test_help() {
     assert_eq!(help_cmd_stdout.raw(), help_flag_stdout.raw());
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "unknown"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     error: unrecognized subcommand 'unknown'
 
       tip: a similar subcommand exists: 'undo'
@@ -75,14 +78,16 @@ fn test_help() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "#);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "log", "--", "-r"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--revisions <REVSETS>' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -102,38 +107,41 @@ fn test_help_keyword() {
 
     // It should give hints if a similar keyword is present
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "-k", "rev"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r###"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: invalid value 'rev' for '--keyword <KEYWORD>'
       [possible values: bookmarks, config, filesets, glossary, revsets, templates, tutorial]
 
       tip: a similar value exists: 'revsets'
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // It should give error with a hint if no similar keyword is found
     let help_cmd_stderr =
         test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "-k", "<no-similar-keyword>"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r###"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: invalid value '<no-similar-keyword>' for '--keyword <KEYWORD>'
       [possible values: bookmarks, config, filesets, glossary, revsets, templates, tutorial]
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // The keyword flag with no argument should error with a hint
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "-k"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r###"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: a value is required for '--keyword <KEYWORD>' but none was supplied
       [possible values: bookmarks, config, filesets, glossary, revsets, templates, tutorial]
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // It shouldn't show help for a certain keyword if the `--keyword` is not
     // present
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "revsets"]);
-    insta::assert_snapshot!(help_cmd_stderr, @r#"
+    insta::assert_snapshot!(help_cmd_stderr, @r"
     error: unrecognized subcommand 'revsets'
 
       tip: some similar subcommands exist: 'resolve', 'prev', 'restore', 'rebase', 'revert'
@@ -141,5 +149,6 @@ fn test_help_keyword() {
     Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
-    "#);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_help_command.rs
+++ b/cli/tests/test_help_command.rs
@@ -21,19 +21,19 @@ fn test_help() {
     let help_cmd_stdout = test_env.jj_cmd_success(test_env.env_root(), &["help"]);
     // The help command output should be equal to the long --help flag
     let help_flag_stdout = test_env.jj_cmd_success(test_env.env_root(), &["--help"]);
-    assert_eq!(help_cmd_stdout, help_flag_stdout);
+    assert_eq!(help_cmd_stdout.raw(), help_flag_stdout.raw());
 
     // Help command should work with commands
     let help_cmd_stdout = test_env.jj_cmd_success(test_env.env_root(), &["help", "log"]);
     let help_flag_stdout = test_env.jj_cmd_success(test_env.env_root(), &["log", "--help"]);
-    assert_eq!(help_cmd_stdout, help_flag_stdout);
+    assert_eq!(help_cmd_stdout.raw(), help_flag_stdout.raw());
 
     // Help command should work with subcommands
     let help_cmd_stdout =
         test_env.jj_cmd_success(test_env.env_root(), &["help", "workspace", "root"]);
     let help_flag_stdout =
         test_env.jj_cmd_success(test_env.env_root(), &["workspace", "root", "--help"]);
-    assert_eq!(help_cmd_stdout, help_flag_stdout);
+    assert_eq!(help_cmd_stdout.raw(), help_flag_stdout.raw());
 
     // Help command should not work recursively
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["workspace", "help", "root"]);
@@ -59,12 +59,12 @@ fn test_help() {
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "nonexistent"]);
     let help_flag_stderr =
         test_env.jj_cmd_cli_error(test_env.env_root(), &["nonexistent", "--help"]);
-    assert_eq!(help_cmd_stderr, help_flag_stderr);
+    assert_eq!(help_cmd_stderr.raw(), help_flag_stderr.raw());
 
     // Some edge cases
     let help_cmd_stdout = test_env.jj_cmd_success(test_env.env_root(), &["help", "help"]);
     let help_flag_stdout = test_env.jj_cmd_success(test_env.env_root(), &["help", "--help"]);
-    assert_eq!(help_cmd_stdout, help_flag_stdout);
+    assert_eq!(help_cmd_stdout.raw(), help_flag_stdout.raw());
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "unknown"]);
     insta::assert_snapshot!(stderr, @r#"
@@ -93,12 +93,12 @@ fn test_help_keyword() {
     let help_cmd_stdout =
         test_env.jj_cmd_success(test_env.env_root(), &["help", "--keyword", "revsets"]);
     // It should be equal to the docs
-    assert_eq!(help_cmd_stdout, include_str!("../../docs/revsets.md"));
+    assert_eq!(help_cmd_stdout.raw(), include_str!("../../docs/revsets.md"));
 
     // It should show help for a certain keyword if the `-k` flag is present
     let help_cmd_stdout = test_env.jj_cmd_success(test_env.env_root(), &["help", "-k", "revsets"]);
     // It should be equal to the docs
-    assert_eq!(help_cmd_stdout, include_str!("../../docs/revsets.md"));
+    assert_eq!(help_cmd_stdout.raw(), include_str!("../../docs/revsets.md"));
 
     // It should give hints if a similar keyword is present
     let help_cmd_stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["help", "-k", "rev"]);

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -18,11 +18,12 @@ use crate::common::TestEnvironment;
 fn test_init_local_disallowed() {
     let test_env = TestEnvironment::default();
     let stdout = test_env.jj_cmd_failure(test_env.env_root(), &["init", "repo"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Error: The native backend is disallowed by default.
     Hint: Did you mean to call `jj git init`?
     Set `ui.allow-init-native` to allow initializing a repo with the native backend.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -31,9 +32,10 @@ fn test_init_local() {
     test_env.add_config(r#"ui.allow-init-native = true"#);
     let (stdout, stderr) = test_env.jj_cmd_ok(test_env.env_root(), &["init", "repo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     Initialized repo in "repo"
-    "###);
+    [EOF]
+    "#);
 
     let workspace_root = test_env.env_root().join("repo");
     let jj_path = workspace_root.join(".jj");
@@ -54,12 +56,14 @@ fn test_init_local() {
         test_env.env_root(),
         &["init", "--ignore-working-copy", "repo2"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --ignore-working-copy is not respected
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_cli_error(test_env.env_root(), &["init", "--at-op=@-", "repo3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --at-op is not respected
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -33,11 +33,12 @@ fn test_interdiff_basic() {
 
     // implicit --to
     let stdout = test_env.jj_cmd_success(&repo_path, &["interdiff", "--from", "left"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: foo
             2: bar
-    "###);
+    [EOF]
+    ");
 
     // explicit --to
     test_env.jj_cmd_ok(&repo_path, &["new", "@-"]);
@@ -45,11 +46,12 @@ fn test_interdiff_basic() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file2:
        1    1: foo
             2: bar
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // formats specifiers
@@ -57,15 +59,16 @@ fn test_interdiff_basic() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "-s"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     M file2
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file2 b/file2
     index 257cc5642c..3bd1f0e297 100644
     --- a/file2
@@ -73,7 +76,8 @@ fn test_interdiff_basic() {
     @@ -1,1 +1,2 @@
      foo
     +bar
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -101,10 +105,11 @@ fn test_interdiff_paths() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "file1"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: barbaz
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -118,12 +123,13 @@ fn test_interdiff_paths() {
             "file2",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Modified regular file file1:
        1    1: barbaz
     Modified regular file file2:
        1    1: barbaz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -147,7 +153,7 @@ fn test_interdiff_conflicting() {
         &repo_path,
         &["interdiff", "--from", "left", "--to", "right", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     diff --git a/file b/file
     index 0000000000..24c5735c3e 100644
     --- a/file
@@ -161,5 +167,6 @@ fn test_interdiff_conflicting() {
     -bar
     ->>>>>>> Conflict 1 of 1 ends
     +def
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -22,11 +22,12 @@ fn test_log_with_empty_revision() {
     let repo_path = test_env.env_root().join("repo");
 
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["log", "-r="]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: a value is required for '--revisions <REVSETS>' but none was supplied
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -57,6 +58,7 @@ fn test_log_with_no_template() {
     - description_placeholder
     - email_placeholder
     - name_placeholder
+    [EOF]
     ");
 }
 
@@ -72,14 +74,15 @@ fn test_log_with_or_without_diff() {
     std::fs::write(repo_path.join("file1"), "foo\nbar\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     ○  add a file
     ◆
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  Modified regular file file1:
     │     1    1: foo
@@ -88,17 +91,19 @@ fn test_log_with_or_without_diff() {
     │  Added regular file file1:
     │          1: foo
     ◆
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--no-graph"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     add a file
-    "###);
+    [EOF]
+    ");
 
     // `-p` for default diff output, `-s` for summary
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-p", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  M file1
     │  Modified regular file file1:
@@ -109,7 +114,8 @@ fn test_log_with_or_without_diff() {
     │  Added regular file file1:
     │          1: foo
     ◆
-    "###);
+    [EOF]
+    ");
 
     // `-s` for summary, `--git` for git diff (which implies `-p`)
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-s", "--git"]);
@@ -133,6 +139,7 @@ fn test_log_with_or_without_diff() {
     │  @@ -0,0 +1,1 @@
     │  +foo
     ◆
+    [EOF]
     ");
 
     // `-p` enables default "summary" output, so `-s` is noop
@@ -147,20 +154,21 @@ fn test_log_with_or_without_diff() {
             "--config=ui.diff.format=summary",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  M file1
     ○  add a file
     │  A file1
     ◆
-    "###);
+    [EOF]
+    ");
 
     // `-p` enables default "color-words" diff output, so `--color-words` is noop
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-p", "--color-words"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  Modified regular file file1:
     │     1    1: foo
@@ -169,7 +177,8 @@ fn test_log_with_or_without_diff() {
     │  Added regular file file1:
     │          1: foo
     ◆
-    "###);
+    [EOF]
+    ");
 
     // `--git` enables git diff, so `-p` is noop
     let stdout = test_env.jj_cmd_success(
@@ -193,6 +202,7 @@ fn test_log_with_or_without_diff() {
     +++ b/file1
     @@ -0,0 +1,1 @@
     +foo
+    [EOF]
     ");
 
     // Cannot use both `--git` and `--color-words`
@@ -208,40 +218,43 @@ fn test_log_with_or_without_diff() {
             "--color-words",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--git' cannot be used with '--color-words'
 
     Usage: jj log --template <TEMPLATE> --no-graph --patch --git [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // `-s` with or without graph
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  M file1
     ○  add a file
     │  A file1
     ◆
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "--no-graph", "-s"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     M file1
     add a file
     A file1
-    "###);
+    [EOF]
+    ");
 
     // `--git` implies `-p`, with or without graph
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-r", "@", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  diff --git a/file1 b/file1
     ~  index 257cc5642c..3bd1f0e297 100644
@@ -250,12 +263,13 @@ fn test_log_with_or_without_diff() {
        @@ -1,1 +1,2 @@
         foo
        +bar
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-r", "@", "--no-graph", "--git"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     diff --git a/file1 b/file1
     index 257cc5642c..3bd1f0e297 100644
@@ -264,19 +278,21 @@ fn test_log_with_or_without_diff() {
     @@ -1,1 +1,2 @@
      foo
     +bar
-    "###);
+    [EOF]
+    ");
 
     // `--color-words` implies `-p`, with or without graph
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-r", "@", "--color-words"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  a new commit
     │  Modified regular file file1:
     ~     1    1: foo
                2: bar
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -289,12 +305,13 @@ fn test_log_with_or_without_diff() {
             "--color-words",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
     Modified regular file file1:
        1    1: foo
             2: bar
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -356,7 +373,7 @@ fn test_log_shortest_accessors() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "original"]);
     insta::assert_snapshot!(
         render("original", r#"format_id(change_id) ++ " " ++ format_id(commit_id)"#),
-        @"q[pvuntsmwlqt] e[0e22b9fae75]");
+        @"q[pvuntsmwlqt] e[0e22b9fae75][EOF]");
 
     // Create a chain of 10 commits
     for i in 1..10 {
@@ -370,11 +387,11 @@ fn test_log_shortest_accessors() {
 
     insta::assert_snapshot!(
         render("original", r#"format_id(change_id) ++ " " ++ format_id(commit_id)"#),
-        @"qpv[untsmwlqt] e0[e22b9fae75]");
+        @"qpv[untsmwlqt] e0[e22b9fae75][EOF]");
 
     insta::assert_snapshot!(
         render("::@", r#"change_id.shortest() ++ " " ++ commit_id.shortest() ++ "\n""#),
-        @r###"
+        @r"
     wq ed
     km ef3
     kp af
@@ -386,11 +403,12 @@ fn test_log_shortest_accessors() {
     mz 1b
     qpv e0
     zzz 00
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
-        @r###"
+        @r"
     wq[nwkozpkust] ed[e204633421]
     km[kuslswpqwq] ef3[d013266cd]
     kp[qxywonksrl] af[95b841712d]
@@ -402,13 +420,14 @@ fn test_log_shortest_accessors() {
     mz[vwutvlkqwt] 1b[7b715afc3f]
     qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
-    "###);
+    [EOF]
+    ");
 
     // Can get shorter prefixes in configured revset
     test_env.add_config(r#"revsets.short-prefixes = "(@----)::""#);
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
-        @r###"
+        @r"
     w[qnwkozpkust] ed[e204633421]
     km[kuslswpqwq] ef[3d013266cd]
     kp[qxywonksrl] a[f95b841712d]
@@ -420,13 +439,14 @@ fn test_log_shortest_accessors() {
     mz[vwutvlkqwt] 1b[7b715afc3f]
     qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
-    "###);
+    [EOF]
+    ");
 
     // Can disable short prefixes by setting to empty string
     test_env.add_config(r#"revsets.short-prefixes = """#);
     insta::assert_snapshot!(
         render("::@", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#),
-        @r###"
+        @r"
     wq[nwkozpkust] ed[e204633421]
     km[kuslswpqwq] ef3[d013266cd]
     kp[qxywonksrl] af[95b841712d]
@@ -438,7 +458,8 @@ fn test_log_shortest_accessors() {
     mz[vwutvlkqwt] 1b[7b715afc3f]
     qpv[untsmwlqt] e0[e22b9fae75]
     zzz[zzzzzzzzz] 00[0000000000]
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -463,15 +484,17 @@ fn test_log_bad_short_prefixes() {
       |
       = expected <strict_identifier> or <expression>
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     // Warn on resolution of short prefixes
     test_env.add_config("revsets.short-prefixes = 'missing'");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-Tcommit_id.shortest()"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  2
     ◆  0
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @r"
     Warning: In template expression
      --> 1:11
@@ -482,6 +505,7 @@ fn test_log_bad_short_prefixes() {
       = Failed to load short-prefixes index
     Failed to resolve short-prefixes disambiguation revset
     Revision `missing` doesn't exist
+    [EOF]
     ");
 
     // Error on resolution of short prefixes
@@ -490,6 +514,7 @@ fn test_log_bad_short_prefixes() {
     insta::assert_snapshot!(stderr, @r"
     Error: Failed to resolve short-prefixes disambiguation revset
     Caused by: Revision `missing` doesn't exist
+    [EOF]
     ");
 }
 
@@ -519,11 +544,12 @@ fn test_log_prefix_highlight_styled() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "original"]);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
-        @r###"
+        @r"
     @  Change qpvuntsmwlqt initial e0e22b9fae75 original
     │
     ~
-    "###
+    [EOF]
+    "
     );
 
     // Create a chain of 10 commits
@@ -538,11 +564,12 @@ fn test_log_prefix_highlight_styled() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "original", "-T", &prefix_format(Some(12))]),
-        @r###"
+        @r"
     ○  Change qpvuntsmwlqt initial e0e22b9fae75 original
     │
     ~
-    "###
+    [EOF]
+    "
     );
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -556,7 +583,7 @@ fn test_log_prefix_highlight_styled() {
         ],
     );
     insta::assert_snapshot!(stdout,
-        @r###"
+        @r"
     [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4med[0m[38;5;8me204633421[39m
     ○  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4mef3[0m[38;5;8md013266cd[39m
     ○  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4maf[0m[38;5;8m95b841712d[39m
@@ -568,7 +595,8 @@ fn test_log_prefix_highlight_styled() {
     ○  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7b715afc3f[39m
     ○  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4me0[0m[38;5;8me22b9fae75[39m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
-    "###
+    [EOF]
+    "
     );
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -582,7 +610,7 @@ fn test_log_prefix_highlight_styled() {
         ],
     );
     insta::assert_snapshot!(stdout,
-        @r###"
+        @r"
     [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4med[0m[38;5;8me[39m
     ○  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4mef3[0m
     ○  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4maf[0m[38;5;8m9[39m
@@ -594,7 +622,8 @@ fn test_log_prefix_highlight_styled() {
     ○  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m1b[0m[38;5;8m7[39m
     ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m[38;5;8me[39m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
-    "###
+    [EOF]
+    "
     );
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -608,7 +637,7 @@ fn test_log_prefix_highlight_styled() {
         ],
     );
     insta::assert_snapshot!(stdout,
-        @r###"
+        @r"
     [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m commit9 [1m[38;5;4med[0m
     ○  Change [1m[38;5;5mkm[0m commit8 [1m[38;5;4mef3[0m
     ○  Change [1m[38;5;5mkp[0m commit7 [1m[38;5;4maf[0m
@@ -620,7 +649,8 @@ fn test_log_prefix_highlight_styled() {
     ○  Change [1m[38;5;5mmz[0m commit1 [1m[38;5;4m1b[0m
     ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4me0[0m [38;5;5moriginal[39m
     [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m
-    "###
+    [EOF]
+    "
     );
 }
 
@@ -653,10 +683,11 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "c", "-r@", "original"]);
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "all()", "-T", prefix_format]),
-        @r###"
+        @r"
     @  Change q[pvuntsmwlqt] initial e0[e22b9fae75] original
     ◆  Change z[zzzzzzzzzzz] 0[00000000000]
-    "###
+    [EOF]
+    "
     );
 
     // Create 2^7 hidden commits
@@ -669,24 +700,29 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     // The unique prefixes became longer.
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", prefix_format]),
-        @r###"
+        @r"
     @  Change wq[nwkozpkust] 44[4c3c5066d3]
     │ ○  Change qpv[untsmwlqt] initial e0e[22b9fae75] original
     ├─╯
     ◆  Change zzz[zzzzzzzzz] 00[0000000000]
-    "###
+    [EOF]
+    "
     );
     insta::assert_snapshot!(
         test_env.jj_cmd_failure(&repo_path, &["log", "-r", "4", "-T", prefix_format]),
-        @"Error: Commit ID prefix `4` is ambiguous"
+        @r"
+    Error: Commit ID prefix `4` is ambiguous
+    [EOF]
+    "
     );
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-r", "44", "-T", prefix_format]),
-        @r###"
+        @r"
     @  Change wq[nwkozpkust] 44[4c3c5066d3]
     │
     ~
-    "###
+    [EOF]
+    "
     );
 }
 
@@ -698,25 +734,29 @@ fn test_log_short_shortest_length_parameter() {
     let render = |template| test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
 
     insta::assert_snapshot!(
-        render(r#"commit_id.short(0) ++ "|" ++ commit_id.shortest(0)"#), @r###"
+        render(r#"commit_id.short(0) ++ "|" ++ commit_id.shortest(0)"#), @r"
     @  |2
     ◆  |0
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
-        render(r#"commit_id.short(-0) ++ "|" ++ commit_id.shortest(-0)"#), @r###"
+        render(r#"commit_id.short(-0) ++ "|" ++ commit_id.shortest(-0)"#), @r"
     @  |2
     ◆  |0
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
-        render(r#"commit_id.short(-100) ++ "|" ++ commit_id.shortest(-100)"#), @r###"
+        render(r#"commit_id.short(-100) ++ "|" ++ commit_id.shortest(-100)"#), @r"
     @  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
     ◆  <Error: out of range integral type conversion attempted>|<Error: out of range integral type conversion attempted>
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
-        render(r#"commit_id.short(100) ++ "|" ++ commit_id.shortest(100)"#), @r###"
+        render(r#"commit_id.short(100) ++ "|" ++ commit_id.shortest(100)"#), @r"
     @  230dd059e1b059aefc0da06a2e5a7dbf22362f22|230dd059e1b059aefc0da06a2e5a7dbf22362f22
     ◆  0000000000000000000000000000000000000000|0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -727,11 +767,12 @@ fn test_log_author_format() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "--revisions=@"]),
-        @r###"
+        @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
-    "###
+    [EOF]
+    "
     );
 
     let decl = "template-aliases.'format_short_signature(signature)'";
@@ -745,11 +786,12 @@ fn test_log_author_format() {
                 "--revisions=@",
             ],
         ),
-        @r###"
+        @r"
     @  qpvuntsm test.user 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ~
-    "###
+    [EOF]
+    "
     );
 }
 
@@ -764,10 +806,11 @@ fn test_log_divergence() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "description 1"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
     // No divergence
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  description 1
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Create divergence
     test_env.jj_cmd_ok(
@@ -775,15 +818,17 @@ fn test_log_divergence() {
         &["describe", "-m", "description 2", "--at-operation", "@-"],
     );
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  description 1 !divergence!
     │ ○  description 2 !divergence!
     ├─╯
     ◆
-    "#);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -796,20 +841,22 @@ fn test_log_reversed() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "second"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--reversed"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆
     ○  first
     @  second
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "--reversed", "--no-graph"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     first
     second
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -825,48 +872,53 @@ fn test_log_filtered_by_path() {
     std::fs::write(repo_path.join("file2"), "baz\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     ○  first
     │
     ~
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     │
     ~
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "-s", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     │  M file1
     ○  first
     │  A file1
     ~
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "-s", "file2", "--no-graph"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     second
     A file2
-    "###);
+    [EOF]
+    ");
 
     // empty revisions are filtered out by "all()" fileset.
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-Tdescription", "-s", "all()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  second
     │  M file1
     │  A file2
     ○  first
     │  A file1
     ~
-    "###);
+    [EOF]
+    ");
 
     // "root:<path>" is resolved relative to the workspace root.
     let stdout = test_env.jj_cmd_success(
@@ -880,13 +932,14 @@ fn test_log_filtered_by_path() {
             "root:file1",
         ],
     );
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     @  second
     │  M repo/file1
     ○  first
     │  A repo/file1
     ~
-    "###);
+    [EOF]
+    ");
 
     // files() revset doesn't filter the diff.
     let stdout = test_env.jj_cmd_success(
@@ -900,11 +953,12 @@ fn test_log_filtered_by_path() {
             "--no-graph",
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     second
     M file1
     A file2
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -925,30 +979,33 @@ fn test_log_limit() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--limit=3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    d
     ├─╮
     │ ○  b
     ○ │  c
     ├─╯
-    "###);
+    [EOF]
+    ");
 
     // Applied on sorted DAG
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description", "--limit=2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    d
     ├─╮
     │ ○  b
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &["log", "-T", "description", "--limit=2", "--no-graph"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     d
     c
-    "###);
+    [EOF]
+    ");
 
     // Applied on reversed DAG: Because the node "a" is omitted, "b" and "c" are
     // rendered as roots.
@@ -961,6 +1018,7 @@ fn test_log_limit() {
     │ ○  b
     ├─╯
     @  d
+    [EOF]
     ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
@@ -977,6 +1035,7 @@ fn test_log_limit() {
     b
     c
     d
+    [EOF]
     ");
 
     // Applied on filtered commits
@@ -984,11 +1043,12 @@ fn test_log_limit() {
         &repo_path,
         &["log", "-T", "description", "--limit=1", "b", "c"],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  c
     │
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1001,21 +1061,26 @@ fn test_log_warn_path_might_be_revset() {
 
     // Don't warn if the file actually exists.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "file1", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @
     │
     ~
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // Warn for `jj log .` specifically, for former Mercurial users.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", ".", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @
     │
     ~
-    "###);
-    insta::assert_snapshot!(stderr, @r#"Warning: The argument "." is being interpreted as a fileset expression, but this is often not useful because all non-empty commits touch '.'. If you meant to show the working copy commit, pass -r '@' instead."#);
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: The argument "." is being interpreted as a fileset expression, but this is often not useful because all non-empty commits touch '.'. If you meant to show the working copy commit, pass -r '@' instead.
+    [EOF]
+    "#);
 
     // ...but checking `jj log .` makes sense in a subdirectory.
     let subdir = repo_path.join("dir");
@@ -1027,12 +1092,18 @@ fn test_log_warn_path_might_be_revset() {
     // Warn for `jj log @` instead of `jj log -r @`.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "@", "-T", "description"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"Warning: The argument "@" is being interpreted as a fileset expression. To specify a revset, pass -r "@" instead."#);
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: The argument "@" is being interpreted as a fileset expression. To specify a revset, pass -r "@" instead.
+    [EOF]
+    "#);
 
     // Warn when there's no path with the provided name.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "file2", "-T", "description"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"Warning: The argument "file2" is being interpreted as a fileset expression. To specify a revset, pass -r "file2" instead."#);
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: The argument "file2" is being interpreted as a fileset expression. To specify a revset, pass -r "file2" instead.
+    [EOF]
+    "#);
 
     // If an explicit revision is provided, then suppress the warning.
     let (stdout, stderr) =
@@ -1068,11 +1139,12 @@ fn test_default_revset() {
     // The default revset is not used if a path is specified
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "file1", "-T", "description"]),
-        @r###"
+        @r"
     @  add a file
     │
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1118,27 +1190,30 @@ fn test_multiple_revsets() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "bookmarks", "-rfoo"]),
-        @r###"
+        @r"
     ○  foo
     │
     ~
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "bookmarks", "-rfoo", "-rbar", "-rbaz"]),
-        @r###"
+        @r"
     @  baz
     ○  bar
     ○  foo
     │
     ~
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["log", "-T", "bookmarks", "-rfoo", "-rfoo"]),
-        @r###"
+        @r"
     ○  foo
     │
     ~
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1164,29 +1239,32 @@ fn test_graph_template_color() {
     // First test without color for comparison
     let template = r#"label(if(current_working_copy, "working_copy"), description)"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  single line
     ○  first line
     │  second line
     │  third line
     ◆
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=always", "log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m@[0m  [1m[38;5;2msingle line[0m
     ○  [38;5;1mfirst line[39m
     │  [38;5;1msecond line[39m
     │  [38;5;1mthird line[39m
     [1m[38;5;14m◆[0m
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["--color=debug", "log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     [1m[38;5;2m<<node working_copy::@>>[0m  [1m[38;5;2m<<log working_copy description::single line>>[0m
     <<node::○>>  [38;5;1m<<log description::first line>>[39m
     │  [38;5;1m<<log description::second line>>[39m
     │  [38;5;1m<<log description::third line>>[39m
     [1m[38;5;14m<<node immutable::◆>>[0m
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1216,7 +1294,7 @@ fn test_graph_styles() {
 
     // Default (curved) style
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     ├─╮
     │ ○  side bookmark
@@ -1228,12 +1306,13 @@ fn test_graph_styles() {
     ○  main bookmark 1
     ○  initial
     ◆
-    "###);
+    [EOF]
+    ");
 
     // ASCII style
     test_env.add_config(r#"ui.graph.style = "ascii""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     |\
     | o  side bookmark
@@ -1245,12 +1324,13 @@ fn test_graph_styles() {
     o  main bookmark 1
     o  initial
     +
-    "###);
+    [EOF]
+    ");
 
     // Large ASCII style
     test_env.add_config(r#"ui.graph.style = "ascii-large""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @     merge
     |\
     | \
@@ -1264,12 +1344,13 @@ fn test_graph_styles() {
     o  main bookmark 1
     o  initial
     +
-    "###);
+    [EOF]
+    ");
 
     // Curved style
     test_env.add_config(r#"ui.graph.style = "curved""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     ├─╮
     │ ○  side bookmark
@@ -1281,12 +1362,13 @@ fn test_graph_styles() {
     ○  main bookmark 1
     ○  initial
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Square style
     test_env.add_config(r#"ui.graph.style = "square""#);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T=description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    merge
     ├─┐
     │ ○  side bookmark
@@ -1298,7 +1380,8 @@ fn test_graph_styles() {
     ○  main bookmark 1
     ○  initial
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Invalid style name
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "--config=ui.graph.style=unknown"]);
@@ -1307,6 +1390,7 @@ fn test_graph_styles() {
     Caused by: unknown variant `unknown`, expected one of `ascii`, `ascii-large`, `curved`, `square`
 
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 }
 
@@ -1484,7 +1568,7 @@ fn test_elided() {
     };
 
     // Test the setup
-    insta::assert_snapshot!(get_log("::"), @r###"
+    insta::assert_snapshot!(get_log("::"), @r"
     @    merge
     ├─╮
     │ ○  side bookmark 2
@@ -1498,12 +1582,13 @@ fn test_elided() {
     ○  initial
     │
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Elide some commits from each side of the merge. It's unclear that a revision
     // was skipped on the left side.
     test_env.add_config("ui.log-synthetic-elided-nodes = false");
-    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r"
     @    merge
     ├─╮
     │ ○  side bookmark 2
@@ -1513,23 +1598,25 @@ fn test_elided() {
     ○  initial
     │
     ~
-    "###);
+    [EOF]
+    ");
 
     // Elide shared commits. It's unclear that a revision was skipped on the right
     // side (#1252).
-    insta::assert_snapshot!(get_log("@-- | root()"), @r###"
+    insta::assert_snapshot!(get_log("@-- | root()"), @r"
     ○  side bookmark 1
     ╷
     ╷ ○  main bookmark 1
     ╭─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Now test the same thing with synthetic nodes for elided commits
 
     // Elide some commits from each side of the merge
     test_env.add_config("ui.log-synthetic-elided-nodes = true");
-    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial)"), @r"
     @    merge
     ├─╮
     │ ○  side bookmark 2
@@ -1542,11 +1629,12 @@ fn test_elided() {
     ○  initial
     │
     ~
-    "###);
+    [EOF]
+    ");
 
     // Elide shared commits. To keep the implementation simple, it still gets
     // rendered as two synthetic nodes.
-    insta::assert_snapshot!(get_log("@-- | root()"), @r###"
+    insta::assert_snapshot!(get_log("@-- | root()"), @r"
     ○  side bookmark 1
     │
     ~  (elided revisions)
@@ -1555,7 +1643,8 @@ fn test_elided() {
     │ ~  (elided revisions)
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1595,7 +1684,7 @@ fn test_log_with_custom_symbols() {
         templates.log_node = 'if(self, if(current_working_copy, "$", if(root, "┴", "┝")), "🮀")'
         "###,
     );
-    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r"
     $    merge
     ├─╮
     │ ┝  side bookmark 2
@@ -1608,7 +1697,8 @@ fn test_log_with_custom_symbols() {
     ┝  initial
     │
     ┴
-    "###);
+    [EOF]
+    ");
 
     // Simple test with showing default and elided nodes, ascii style.
     test_env.add_config(
@@ -1618,7 +1708,7 @@ fn test_log_with_custom_symbols() {
         templates.log_node = 'if(self, if(current_working_copy, "$", if(root, "^", "*")), ":")'
         "###,
     );
-    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r###"
+    insta::assert_snapshot!(get_log("@ | @- | description(initial) | root()"), @r"
     $    merge
     |\
     | *  side bookmark 2
@@ -1631,7 +1721,8 @@ fn test_log_with_custom_symbols() {
     *  initial
     |
     ^
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1653,12 +1744,13 @@ fn test_log_full_description_template() {
         &repo_path,
         &["log", "-T", "builtin_log_compact_full_description"],
     );
-    insta::assert_snapshot!(log, @r#"
+    insta::assert_snapshot!(log, @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 1c504ec6
     │  (empty) this is commit with a multiline description
     │
     │  <full description>
     │
     ◆  zzzzzzzz root() 00000000
-    "#);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -328,7 +328,7 @@ fn test_log_null_terminate_multiline_descriptions() {
         ],
     );
     insta::assert_debug_snapshot!(
-        stdout,
+        stdout.normalized(),
         @r###""commit 3 line 1\n\ncommit 3 line 2\n\0commit 2 line 1\n\ncommit 2 line 2\n\0commit 1 line 1\n\ncommit 1 line 2\n\0""###
     );
 }
@@ -880,7 +880,7 @@ fn test_log_filtered_by_path() {
             "root:file1",
         ],
     );
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
     @  second
     │  M repo/file1
     ○  first
@@ -1060,6 +1060,7 @@ fn test_default_revset() {
         1,
         test_env
             .jj_cmd_success(&repo_path, &["log", "-T", "commit_id"])
+            .raw()
             .lines()
             .count()
     );
@@ -1096,6 +1097,7 @@ fn test_default_revset_per_repo() {
         1,
         test_env
             .jj_cmd_success(&repo_path, &["log", "-T", "commit_id"])
+            .raw()
             .lines()
             .count()
     );
@@ -1474,7 +1476,7 @@ fn test_elided() {
         ],
     );
 
-    let get_log = |revs: &str| -> String {
+    let get_log = |revs: &str| {
         test_env.jj_cmd_success(
             &repo_path,
             &["log", "-T", r#"description ++ "\n""#, "-r", revs],
@@ -1579,7 +1581,7 @@ fn test_log_with_custom_symbols() {
         ],
     );
 
-    let get_log = |revs: &str| -> String {
+    let get_log = |revs: &str| {
         test_env.jj_cmd_success(
             &repo_path,
             &["log", "-T", r#"description ++ "\n""#, "-r", revs],

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -686,12 +687,12 @@ fn setup_before_insertion(test_env: &TestEnvironment, repo_path: &Path) {
     test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", "F"]);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"commit_id ++ " " ++ description"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
-fn get_short_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_short_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"if(description, description, "root")"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -26,42 +26,46 @@ fn test_new() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "add a file"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "a new commit"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
     ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Start a new change off of a specific commit (the root commit in this case).
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "off of root", "root()"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  026537ddb96b801b9cb909985d5443aab44616c1 off of root
     │ ○  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
     │ ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // --edit is a no-op
     test_env.jj_cmd_ok(&repo_path, &["new", "--edit", "-m", "yet another commit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  101cbec5cae8049cb9850a906ef3675631ed48fa yet another commit
     ○  026537ddb96b801b9cb909985d5443aab44616c1 off of root
     │ ○  34f3c770f1db22ac5c58df21d587aed1a030201f a new commit
     │ ○  bf8753cb48b860b68386c5c8cc997e8e37122485 add a file
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // --edit cannot be used with --no-edit
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["new", "--edit", "B", "--no-edit", "D"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--edit' cannot be used with '--no-edit'
 
     Usage: jj new <REVSETS>...
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -78,63 +82,72 @@ fn test_new_merge() {
 
     // Create a merge commit
     test_env.jj_cmd_ok(&repo_path, &["new", "main", "@"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    2f9a61ea1fef257eca52fcee2feec1cbd2e41660
     ├─╮
     │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
     ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @"a");
+    insta::assert_snapshot!(stdout, @"a[EOF]");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @"b");
+    insta::assert_snapshot!(stdout, @"b[EOF]");
 
     // Same test with `--no-edit`
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "main", "@", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created new commit znkkpsqq 496490a6 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    496490a66cebb31730c4103b7b22a1098d49af91
     ├─╮
     │ @  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
     ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // Same test with `jj new`
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "main", "@"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    114023233c454e2eca22b8b209f9e42f755eb28c
     ├─╮
     │ ○  f399209d9dda06e8a25a0c8e9a0cde9f421ff35d add file2
     ○ │  8d996e001c23e298d0d353ab455665c81bf2080c add file1
     ├─╯
     ◆  0000000000000000000000000000000000000000
-    "###);
+    [EOF]
+    ");
 
     // merge with non-unique revisions
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "@", "3a44e"]);
-    insta::assert_snapshot!(stderr, @"Error: Revision `3a44e` doesn't exist");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revision `3a44e` doesn't exist
+    [EOF]
+    ");
     // if prefixed with all:, duplicates are allowed
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "@", "all:visible_heads()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: nkmrtpmo ed2dc1d9 (empty) (no description set)
     Parent commit      : wqnwkozp 11402323 (empty) (no description set)
-    "#);
+    [EOF]
+    ");
 
     // merge with root
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "@", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -143,7 +156,7 @@ fn test_new_insert_after() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -154,7 +167,8 @@ fn test_new_insert_after() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     // --insert-after can be repeated; --after is an alias
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -162,13 +176,14 @@ fn test_new_insert_after() {
         &["new", "-m", "G", "--insert-after", "B", "--after", "D"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kxryzmor 1fc93fd1 (empty) G
     Parent commit      : kkmpptxz bfd4157e B | (empty) B
     Parent commit      : vruxwmqv c9257eff D | (empty) D
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○  C
     │ ○  F
     ╭─┤
@@ -181,17 +196,19 @@ fn test_new_insert_after() {
     │ ○  E
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["new", "-m", "H", "--insert-after", "D"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 descendant commits
     Working copy now at: uyznsvlq fcf8281b (empty) H
     Parent commit      : vruxwmqv c9257eff D | (empty) D
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○  C
     │ ○  F
     ╭─┤
@@ -205,17 +222,19 @@ fn test_new_insert_after() {
     │ ○  E
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     // --after cannot be used with revisions
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["new", "--after", "B", "D"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--insert-after <REVSETS>' cannot be used with '[REVSETS]...'
 
     Usage: jj new --insert-after <REVSETS> [REVSETS]...
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -224,7 +243,7 @@ fn test_new_insert_after_children() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -235,7 +254,8 @@ fn test_new_insert_after_children() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     // Check that inserting G after A and C doesn't try to rebase B (which is
     // initially a child of A) onto G as that would create a cycle since B is
@@ -253,12 +273,13 @@ fn test_new_insert_after_children() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kxryzmor 6d63e17b (empty) G
     Parent commit      : qpvuntsm 5ef24e4b A | (empty) A
     Parent commit      : mzvwutvl 83376b27 C | (empty) C
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    G
     ├─╮
     │ ○  C
@@ -272,7 +293,8 @@ fn test_new_insert_after_children() {
     │ ○  D
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -281,7 +303,7 @@ fn test_new_insert_before() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -292,7 +314,8 @@ fn test_new_insert_before() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -307,14 +330,15 @@ fn test_new_insert_before() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kxryzmor 7ed2d6ff (empty) G
     Parent commit      : kkmpptxz bfd4157e B | (empty) B
     Parent commit      : vruxwmqv c9257eff D | (empty) D
     Parent commit      : znkkpsqq 41a89ffc E | (empty) E
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○  F
     │ ○  C
     ├─╯
@@ -327,17 +351,19 @@ fn test_new_insert_before() {
     ○ │  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     // --before cannot be used with revisions
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["new", "--before", "B", "D"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--insert-before <REVSETS>' cannot be used with '[REVSETS]...'
 
     Usage: jj new --insert-before <REVSETS> [REVSETS]...
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -346,7 +372,7 @@ fn test_new_insert_before_root_successors() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -357,7 +383,8 @@ fn test_new_insert_before_root_successors() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -372,12 +399,13 @@ fn test_new_insert_before_root_successors() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 5 descendant commits
     Working copy now at: kxryzmor 36541977 (empty) G
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○    F
     ├─╮
     │ ○  E
@@ -389,7 +417,8 @@ fn test_new_insert_before_root_successors() {
     @ │  G
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -400,7 +429,7 @@ fn test_new_insert_before_no_loop() {
     setup_before_insertion(&test_env, &repo_path);
     let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    7705d353bf5d F
     ├─╮
     │ ○  41a89ffcbba2 E
@@ -411,7 +440,8 @@ fn test_new_insert_before_no_loop() {
     │ ○  5ef24e4bf2be A
     ├─╯
     ◆  000000000000 root
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
@@ -425,9 +455,10 @@ fn test_new_insert_before_no_loop() {
             "C",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to create a loop: commit bfd4157e6ea4 would be both an ancestor and a descendant of the new commit
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -436,7 +467,7 @@ fn test_new_insert_before_no_root_merge() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -447,7 +478,8 @@ fn test_new_insert_before_no_root_merge() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
@@ -461,9 +493,10 @@ fn test_new_insert_before_no_root_merge() {
             "D",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -472,7 +505,7 @@ fn test_new_insert_before_root() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -483,13 +516,15 @@ fn test_new_insert_before_root() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     let stderr =
         test_env.jj_cmd_failure(&repo_path, &["new", "-m", "G", "--insert-before", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The root commit 000000000000 is immutable
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -498,7 +533,7 @@ fn test_new_insert_after_before() {
     test_env.jj_cmd_ok(test_env.env_root(), &["git", "init", "repo"]);
     let repo_path = test_env.env_root().join("repo");
     setup_before_insertion(&test_env, &repo_path);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     @    F
     ├─╮
     │ ○  E
@@ -509,19 +544,21 @@ fn test_new_insert_after_before() {
     │ ○  A
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["new", "-m", "G", "--after", "C", "--before", "F"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: kxryzmor 78a97058 (empty) G
     Parent commit      : mzvwutvl 83376b27 C | (empty) C
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○      F
     ├─┬─╮
     │ │ @  G
@@ -533,19 +570,21 @@ fn test_new_insert_after_before() {
     ○ │  D
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["new", "-m", "H", "--after", "D", "--before", "B"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 descendant commits
     Working copy now at: uyznsvlq fcf8281b (empty) H
     Parent commit      : vruxwmqv c9257eff D | (empty) D
-    "###);
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
     ○      F
     ├─┬─╮
     │ │ ○  G
@@ -560,7 +599,8 @@ fn test_new_insert_after_before() {
     │ ○  E
     ├─╯
     ◆  root
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -571,7 +611,7 @@ fn test_new_insert_after_before_no_loop() {
     setup_before_insertion(&test_env, &repo_path);
     let template = r#"commit_id.short() ++ " " ++ if(description, description, "root")"#;
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", template]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    7705d353bf5d F
     ├─╮
     │ ○  41a89ffcbba2 E
@@ -582,7 +622,8 @@ fn test_new_insert_after_before_no_loop() {
     │ ○  5ef24e4bf2be A
     ├─╯
     ◆  000000000000 root
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
@@ -596,9 +637,10 @@ fn test_new_insert_after_before_no_loop() {
             "C",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to create a loop: commit 83376b270925 would be both an ancestor and a descendant of the new commit
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -633,6 +675,7 @@ fn test_new_conflicting_bookmarks() {
       kkmpptxz 66c6502d foo?? | (empty) two
       qpvuntsm 876f4b7e foo?? | (empty) one
     Hint: Set which revision the bookmark points to with `jj bookmark set foo -r <REVISION>`.
+    [EOF]
     ");
 }
 
@@ -655,6 +698,7 @@ fn test_new_conflicting_change_ids() {
       qpvuntsm?? 66c6502d (empty) two
       qpvuntsm?? 876f4b7e (empty) one
     Hint: Some of these commits have the same change id. Abandon one of them with `jj abandon -r <REVISION>`.
+    [EOF]
     ");
 }
 
@@ -668,7 +712,10 @@ fn test_new_error_revision_does_not_exist() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "two"]);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "this"]);
-    insta::assert_snapshot!(stderr, @"Error: Revision `this` doesn't exist");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revision `this` doesn't exist
+    [EOF]
+    ");
 }
 
 fn setup_before_insertion(test_env: &TestEnvironment, repo_path: &Path) {

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 
 use crate::common::get_stderr_string;
 use crate::common::get_stdout_string;
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -354,7 +355,7 @@ fn test_next_fails_on_bookmarking_children_no_stdin() {
 
     // Try to advance the working copy commit.
     let assert = test_env.jj_cmd(&repo_path, &["next"]).assert().code(1);
-    let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+    let stderr = test_env.normalize_output(get_stderr_string(&assert));
     insta::assert_snapshot!(stderr,@r###"
     Error: Cannot prompt for input since the output is not connected to a terminal
     "###);
@@ -386,8 +387,8 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
         .jj_cmd_stdin(&repo_path, &["next"], "q\n")
         .assert()
         .code(1);
-    let stdout = test_env.normalize_output(&get_stdout_string(&assert));
-    let stderr = test_env.normalize_output(&get_stderr_string(&assert));
+    let stdout = test_env.normalize_output(get_stdout_string(&assert));
+    let stderr = test_env.normalize_output(get_stderr_string(&assert));
     insta::assert_snapshot!(stdout,@r###"
     ambiguous next commit, choose one to target:
     1: zsuskuln 5f24490d (empty) third
@@ -1181,7 +1182,7 @@ fn test_next_offset_when_wc_has_descendants() {
     "###);
 }
 
-fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     let template = r#"separate(" ", change_id.short(), local_bookmarks, if(conflict, "conflict"), description)"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -36,40 +36,44 @@ fn test_next_simple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     // Move to `first`
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 0c7d7732 (empty) (no description set)
     Parent commit      : kkmpptxz 30056b0c (empty) third
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -84,7 +88,7 @@ fn test_next_multiple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@---"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  zsuskulnrvyr fourth
     │ ○  kkmpptxzrspx third
@@ -92,24 +96,27 @@ fn test_next_multiple() {
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "2"]);
     // We should now be the child of the fourth commit.
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 41cc776d (empty) (no description set)
     Parent commit      : zsuskuln 9d7e5e99 (empty) fourth
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -121,29 +128,32 @@ fn test_prev_simple() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: royxmykx 6db74f64 (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -156,23 +166,25 @@ fn test_prev_multiple_without_root() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: yqosqzyt 794ffd20 (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yqosqzytrlsw
     │ ○  zsuskulnrvyr fourth
     │ ○  kkmpptxzrspx third
@@ -180,7 +192,8 @@ fn test_prev_multiple_without_root() {
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -194,19 +207,21 @@ fn test_next_exceeding_history() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "-r", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "3"]);
     // `jj next` beyond existing history fails.
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No other descendant found 3 commit(s) forward from the working copy parent(s)
     Hint: Working copy parent: qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 }
 
 // The working copy commit is a child of a "fork" with two children on each
@@ -222,29 +237,32 @@ fn test_next_parent_has_multiple_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["new", "root()", "-m", "3"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  mzvwutvlkqwt 4
     @  zsuskulnrvyr 3
     │ ○  kkmpptxzrspx 2
     │ ○  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
     insta::assert_snapshot!(stdout,@r###""###);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: mzvwutvl 1b8531ce (empty) 4
     Parent commit      : zsuskuln b1394455 (empty) 3
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt 4
     ○  zsuskulnrvyr 3
     │ ○  kkmpptxzrspx 2
     │ ○  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -261,7 +279,7 @@ fn test_next_with_merge_commit_parent() {
     );
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["prev", "0"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  mzvwutvlkqwt 4
     ├─╯
@@ -271,15 +289,17 @@ fn test_next_with_merge_commit_parent() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout,@r###""###);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: vruxwmqv e2cefcb7 (empty) (no description set)
     Parent commit      : mzvwutvl b54bbdea (empty) 4
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     ○  mzvwutvlkqwt 4
     ○    zsuskulnrvyr 3
@@ -288,7 +308,8 @@ fn test_next_with_merge_commit_parent() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -305,7 +326,7 @@ fn test_next_on_merge_commit() {
     );
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "4"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(3)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  mzvwutvlkqwt 4
     @    zsuskulnrvyr 3
     ├─╮
@@ -313,15 +334,17 @@ fn test_next_on_merge_commit() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
     insta::assert_snapshot!(stdout,@r###""###);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: mzvwutvl b54bbdea (empty) 4
     Parent commit      : zsuskuln 5542f0b4 (empty) 3
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt 4
     ○    zsuskulnrvyr 3
     ├─╮
@@ -329,7 +352,8 @@ fn test_next_on_merge_commit() {
     ○ │  qpvuntsmwlqt 1
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -343,7 +367,7 @@ fn test_next_fails_on_bookmarking_children_no_stdin() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  zsuskulnrvyr third
     ├─╯
@@ -351,14 +375,16 @@ fn test_next_fails_on_bookmarking_children_no_stdin() {
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     // Try to advance the working copy commit.
     let assert = test_env.jj_cmd(&repo_path, &["next"]).assert().code(1);
     let stderr = test_env.normalize_output(get_stderr_string(&assert));
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Error: Cannot prompt for input since the output is not connected to a terminal
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -372,7 +398,7 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  zsuskulnrvyr third
     ├─╯
@@ -380,7 +406,8 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     // Try to advance the working copy commit.
     let assert = test_env
@@ -389,15 +416,17 @@ fn test_next_fails_on_bookmarking_children_quit_prompt() {
         .code(1);
     let stdout = test_env.normalize_output(get_stdout_string(&assert));
     let stderr = test_env.normalize_output(get_stderr_string(&assert));
-    insta::assert_snapshot!(stdout,@r###"
+    insta::assert_snapshot!(stdout,@r"
     ambiguous next commit, choose one to target:
     1: zsuskuln 5f24490d (empty) third
     2: rlvkpnrz 9ed53a4a (empty) second
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Error: ambiguous target commit
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -414,17 +443,19 @@ fn test_next_choose_bookmarking_child() {
     test_env.jj_cmd_ok(&repo_path, &["new", "@--"]);
     // Advance the working copy commit.
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["next"], "2\n");
-    insta::assert_snapshot!(stdout,@r###"
+    insta::assert_snapshot!(stdout,@r"
     ambiguous next commit, choose one to target:
     1: royxmykx d00fe885 (empty) fourth
     2: zsuskuln 5f24490d (empty) third
     3: rlvkpnrz 9ed53a4a (empty) second
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: yostqsxw 5c8fa96d (empty) (no description set)
     Parent commit      : zsuskuln 5f24490d (empty) third
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -439,34 +470,38 @@ fn test_prev_on_merge_commit() {
     test_env.jj_cmd_ok(&repo_path, &["new", "left", "right"]);
 
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    royxmykxtrkr
     ├─╮
     │ ○  zsuskulnrvyr right second
     ○ │  qpvuntsmwlqt left first
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Working copy now at: vruxwmqv 41658cf4 (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev", "--edit"], "2\n");
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ambiguous prev commit, choose one to target:
     1: zsuskuln b0d21db3 right | (empty) second
     2: qpvuntsm fa15625b left | (empty) first
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: qpvuntsm fa15625b left | (empty) first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -487,7 +522,7 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     );
 
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    royxmykxtrkr M
     ├─╮
     │ ○  mzvwutvlkqwt 1
@@ -498,34 +533,39 @@ fn test_prev_on_merge_commit_with_parent_merge() {
     ○ │  qpvuntsmwlqt x
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev"], "2\n");
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ambiguous prev commit, choose one to target:
     1: kkmpptxz 146d5c67 (empty) y
     2: qpvuntsm 6799aaa2 (empty) x
     3: zzzzzzzz 00000000 (empty) (no description set)
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: vruxwmqv e5a6794c (empty) (no description set)
     Parent commit      : qpvuntsm 6799aaa2 (empty) x
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev", "--edit"], "2\n");
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ambiguous prev commit, choose one to target:
     1: mzvwutvl 89b8a355 (empty) 1
     2: zsuskuln a83fc061 (empty) z
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: zsuskuln a83fc061 (empty) z
     Parent commit      : qpvuntsm 6799aaa2 (empty) x
     Parent commit      : kkmpptxz 146d5c67 (empty) y
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -544,7 +584,7 @@ fn test_prev_prompts_on_multiple_parents() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "merge+1"]);
 
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yostqsxwqrlt
     ○  vruxwmqvtpmx merge+1
     ○      yqosqzytrlsw merge
@@ -555,23 +595,26 @@ fn test_prev_prompts_on_multiple_parents() {
     ○ │  mzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     // Move @ backwards.
     let (stdout, stderr) = test_env.jj_cmd_stdin_ok(&repo_path, &["prev", "2"], "3\n");
-    insta::assert_snapshot!(stdout,@r###"
+    insta::assert_snapshot!(stdout,@r"
     ambiguous prev commit, choose one to target:
     1: mzvwutvl bc4f4fe3 (empty) third
     2: kkmpptxz b0d21db3 (empty) second
     3: qpvuntsm fa15625b (empty) first
     q: quit the prompt
-    "###);
-    insta::assert_snapshot!(stderr,@r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr,@r"
     enter the index of the commit you want to target: Working copy now at: kpqxywon ddac00b0 (empty) (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kpqxywonksrl
     │ ○  vruxwmqvtpmx merge+1
     │ ○    yqosqzytrlsw merge
@@ -582,12 +625,13 @@ fn test_prev_prompts_on_multiple_parents() {
     │ ○  mzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["next"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  vruxwmqvtpmx merge+1
     @      yqosqzytrlsw merge
     ├─┬─╮
@@ -597,15 +641,17 @@ fn test_prev_prompts_on_multiple_parents() {
     ○ │  mzvwutvlkqwt third
     ├─╯
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "--no-edit"]);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Error: No other descendant found 1 commit(s) forward from the working copy parent(s)
     Hint: Working copy parent: mzvwutvl bc4f4fe3 (empty) third
     Hint: Working copy parent: kkmpptxz b0d21db3 (empty) second
     Hint: Working copy parent: qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -617,20 +663,22 @@ fn test_prev_beyond_root_fails() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  mzvwutvlkqwt
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
     // @- is at "fourth", and there is no parent 5 commits behind it.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "5"]);
-    insta::assert_snapshot!(stderr,@r###"
+    insta::assert_snapshot!(stderr,@r"
     Error: No ancestor found 5 commit(s) back from the working copy parents(s)
     Hint: Working copy parent: zsuskuln 9d7e5e99 (empty) fourth
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -646,28 +694,31 @@ fn test_prev_editing() {
     // Edit the "fourth" commit, which becomes the leaf.
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     // Check that the graph looks the way we expect.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--edit"]);
     insta::assert_snapshot!(stdout, @r"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr fourth
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -682,28 +733,31 @@ fn test_next_editing() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     test_env.jj_cmd_ok(&repo_path, &["edit", "@---"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr fourth
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr fourth
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -724,16 +778,17 @@ fn test_prev_conflict() {
     test_env.jj_cmd_ok(&repo_path, &["new", "description(third)"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "fourth"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yqosqzytrlsw conflict
     ×  royxmykxtrkr conflict fourth
     ×  kkmpptxzrspx conflict third
     ×  rlvkpnrzqnoo conflict second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["prev", "--conflict"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  yostqsxwqrlt conflict
     │ ×  royxmykxtrkr conflict fourth
     ├─╯
@@ -741,7 +796,8 @@ fn test_prev_conflict() {
     ×  rlvkpnrzqnoo conflict second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -760,21 +816,23 @@ fn test_prev_conflict_editing() {
     std::fs::write(&file_path, "first text").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "description(third)"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr conflict
     ×  kkmpptxzrspx conflict third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["prev", "--conflict", "--edit"]);
     // We now should be editing the third commit.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx conflict third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -795,22 +853,24 @@ fn test_next_conflict() {
     std::fs::write(&file_path, "first v2").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["squash", "--into", "description(third)"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ×  kkmpptxzrspx conflict third
     │ ○  rlvkpnrzqnoo second
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["next", "--conflict"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx conflict
     ×  kkmpptxzrspx conflict third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -830,19 +890,21 @@ fn test_next_conflict_editing() {
     std::fs::write(&file_path, "modified second").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ×  kkmpptxzrspx conflict
     ○  rlvkpnrzqnoo second
     @  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["next", "--conflict", "--edit"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx conflict
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -857,22 +919,25 @@ fn test_next_conflict_head() {
     std::fs::write(&file_path, "second").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["abandon", "@-"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  rlvkpnrzqnoo conflict
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "--conflict"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy parent(s) have no other descendants with conflicts
     Hint: Working copy parent: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next", "--conflict", "--edit"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy has no descendants with conflicts
     Hint: Working copy: rlvkpnrz 0273eeab (conflict) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -886,121 +951,137 @@ fn test_movement_edit_mode_true() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["prev"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 9ed53a4a (empty) second
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: qpvuntsm fa15625b (empty) first
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     @  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The root commit 000000000000 is immutable
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 9ed53a4a (empty) second
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: uyznsvlq 7ad57fb8 (empty) (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  uyznsvlquzzm
     │ ○  kkmpptxzrspx third
     │ ○  rlvkpnrzqnoo second
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: xtnwkqum 7ac7a1c4 (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  xtnwkqumpolk
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["next"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No descendant found 1 commit(s) forward from the working copy
     Hint: Working copy: xtnwkqum 7ac7a1c4 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1014,97 +1095,109 @@ fn test_movement_edit_mode_false() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "first"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "second"]);
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "third"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  zsuskulnrvyr
     ○  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["prev"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  royxmykxtrkr
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 087a65b1 (empty) (no description set)
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  vruxwmqvtpmx
     │ ○  kkmpptxzrspx third
     │ ○  rlvkpnrzqnoo second
     ├─╯
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["prev", "3"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: No ancestor found 3 commit(s) back from the working copy parents(s)
     Hint: Working copy parent: qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kpqxywon d06750fb (empty) (no description set)
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kpqxywonksrl
     │ ○  kkmpptxzrspx third
     ├─╯
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--no-edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: wqnwkozp 10fa181f (empty) (no description set)
     Parent commit      : kkmpptxz 30056b0c (empty) third
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["prev", "--edit", "2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 9ed53a4a (empty) second
     Parent commit      : qpvuntsm fa15625b (empty) first
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  kkmpptxzrspx third
     @  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["next", "--edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 30056b0c (empty) third
     Parent commit      : rlvkpnrz 9ed53a4a (empty) second
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kkmpptxzrspx third
     ○  rlvkpnrzqnoo second
     ○  qpvuntsmwlqt first
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1126,7 +1219,7 @@ fn test_next_offset_when_wc_has_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m", "left-2"]);
 
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(right-wc)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  zsuskulnrvyr right-2
     ○  kkmpptxzrspx right-1
     @  rlvkpnrzqnoo right-wc
@@ -1136,10 +1229,11 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "#);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["next", "2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  kmkuslswpqwq
     │ ○  vruxwmqvtpmx left-2
     ├─╯
@@ -1151,10 +1245,11 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["edit", "description(left-wc)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  vruxwmqvtpmx left-2
     ○  yqosqzytrlsw left-1
     @  royxmykxtrkr left-wc
@@ -1164,10 +1259,11 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["next"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  nkmrtpmomlro
     │ ○  zsuskulnrvyr right-2
     │ ○  kkmpptxzrspx right-1
@@ -1179,7 +1275,8 @@ fn test_next_offset_when_wc_has_descendants() {
     ├─╯
     ○  qpvuntsmwlqt base
     ◆  zzzzzzzzzzzz
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -631,7 +632,7 @@ fn test_parallelize_complex_nonlinear_target() {
     "###);
 }
 
-fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     let template = r#"
     separate(" ",
         commit_id.short(),

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -27,7 +27,7 @@ fn test_parallelize_no_descendants() {
         test_env.jj_cmd_ok(&workspace_path, &["commit", &format!("-m{n}")]);
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  02b7709cc4e9 6 parents: 5
     ○  1b2f08d76b66 5 parents: 4
     ○  e5c4cf44e237 4 parents: 3
@@ -35,10 +35,11 @@ fn test_parallelize_no_descendants() {
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4850b4629edb 6 parents:
     │ ○  87627fbb7d29 5 parents:
     ├─╯
@@ -51,7 +52,8 @@ fn test_parallelize_no_descendants() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 // Only the head commit has descendants.
@@ -65,7 +67,7 @@ fn test_parallelize_with_descendants_simple() {
         test_env.jj_cmd_ok(&workspace_path, &["commit", &format!("-m{n}")]);
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=6"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  02b7709cc4e9 6 parents: 5
     ○  1b2f08d76b66 5 parents: 4
     ○  e5c4cf44e237 4 parents: 3
@@ -73,13 +75,14 @@ fn test_parallelize_with_descendants_simple() {
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(4)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  9bc057f8b6e3 6 parents: 5
     ○        9e36a8afe793 5 parents: 1 2 3 4
     ├─┬─┬─╮
@@ -91,7 +94,8 @@ fn test_parallelize_with_descendants_simple() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 // One of the commits being parallelized has a child that isn't being
@@ -108,7 +112,7 @@ fn test_parallelize_where_interior_has_non_target_children() {
     }
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(2)", "-m=2c"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(5)", "-m=6"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  2508ea92308a 6 parents: 5
     ○  1b2f08d76b66 5 parents: 4
     ○  e5c4cf44e237 4 parents: 3
@@ -118,13 +122,14 @@ fn test_parallelize_where_interior_has_non_target_children() {
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(4)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  c9525dff9d03 6 parents: 5
     ○        b3ad09518546 5 parents: 1 2 3 4
     ├─┬─┬─╮
@@ -138,7 +143,8 @@ fn test_parallelize_where_interior_has_non_target_children() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -152,7 +158,7 @@ fn test_parallelize_where_root_has_non_target_children() {
     }
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(1)", "-m=1c"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m=4"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  9132691e6256 4 parents: 3
     ○  4cd999dfaac0 3 parents: 2
     ○  d3902619fade 2 parents: 1
@@ -160,12 +166,13 @@ fn test_parallelize_where_root_has_non_target_children() {
     ├─╯
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(3)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @      3397916989e7 4 parents: 1 2 3
     ├─┬─╮
     │ │ ○  1f768c1bc591 3 parents:
@@ -176,7 +183,8 @@ fn test_parallelize_where_root_has_non_target_children() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 // One of the commits being parallelized has a child that is a merge commit.
@@ -196,7 +204,7 @@ fn test_parallelize_with_merge_commit_child() {
         &["new", "description(2)", "description(a)", "-m", "2a-c"],
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(3)", "-m", "4"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  99ffaf5b3984 4 parents: 3
     ○  4cd999dfaac0 3 parents: 2
     │ ○  4313cc3b476f 2a-c parents: 2 a
@@ -206,14 +214,15 @@ fn test_parallelize_with_merge_commit_child() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     // After this finishes, child-2a will have three parents: "1", "2", and "a".
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(3)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @      3ee9279847a6 4 parents: 1 2 3
     ├─┬─╮
     │ │ ○  bb1bb465ccc2 3 parents:
@@ -226,7 +235,8 @@ fn test_parallelize_with_merge_commit_child() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -239,27 +249,30 @@ fn test_parallelize_disconnected_target_commits() {
         test_env.jj_cmd_ok(&workspace_path, &["commit", &format!("-m{n}")]);
     }
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4cd999dfaac0 3 parents: 2
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)", "description(3)"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4cd999dfaac0 3 parents: 2
     ○  d3902619fade 2 parents: 1
     ○  8b64ddff700d 1 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -277,7 +290,7 @@ fn test_parallelize_head_is_a_merge() {
         &workspace_path,
         &["new", "description(2)", "description(b)", "-m=merged-head"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    1fb53c45237e merged-head parents: 2 b
     ├─╮
     │ ○  a7bf5001cfd8 b parents: a
@@ -287,10 +300,11 @@ fn test_parallelize_head_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    82131a679769 merged-head parents: 0 b
     ├─╮
     │ ○  a7bf5001cfd8 b parents: a
@@ -302,7 +316,8 @@ fn test_parallelize_head_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -318,7 +333,7 @@ fn test_parallelize_interior_target_is_a_merge() {
         &["new", "description(1)", "description(a)", "-m=2"],
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  9b77792c77ac 3 parents: 2
     ○    1e29145c95fd 2 parents: 1 a
     ├─╮
@@ -327,10 +342,11 @@ fn test_parallelize_interior_target_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(1)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    042fc3f4315c 3 parents: 0 a
     ├─╮
     │ │ ○  80603361bb48 2 parents: 0 a
@@ -341,7 +357,8 @@ fn test_parallelize_interior_target_is_a_merge() {
     ○ │  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -357,7 +374,7 @@ fn test_parallelize_root_is_a_merge() {
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=2"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  cc239b744d01 3 parents: 2
     ○  2bf00c2ad44c 2 parents: 1
     ○    1c6853121f3c 1 parents: y x
@@ -366,13 +383,14 @@ fn test_parallelize_root_is_a_merge() {
     ○ │  ca57511e158f y parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(1)::description(2)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    2c7fdfa00b38 3 parents: 1 2
     ├─╮
     │ ○    3acbd32944d6 2 parents: y x
@@ -383,7 +401,8 @@ fn test_parallelize_root_is_a_merge() {
       ○ │  ca57511e158f y parents:
       ├─╯
       ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -394,23 +413,25 @@ fn test_parallelize_multiple_heads() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=0"]);
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=1"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  97d7522f40e8 2 parents: 0
     │ ○  0c058af014a6 1 parents: 0
     ├─╯
     ○  745bea8029c1 0 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "description(0)::"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  e84481c26195 2 parents:
     │ ○  6270540ee067 1 parents:
     ├─╯
     │ ○  745bea8029c1 0 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 // All heads must have the same children as the other heads, but only if they
@@ -424,25 +445,27 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=0"]);
     test_env.jj_cmd_ok(&workspace_path, &["describe", "-m=1"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "description(0)", "-m=2"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  97d7522f40e8 2 parents: 0
     │ ○  0c058af014a6 1 parents: 0
     ├─╯
     ○  745bea8029c1 0 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(0)", "description(1)"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  97d7522f40e8 2 parents: 0
     ○  745bea8029c1 0 parents:
     │ ○  6270540ee067 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -457,7 +480,7 @@ fn test_parallelize_multiple_roots() {
         &["new", "description(1)", "description(a)", "-m=2"],
     );
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  34da938ad94a 3 parents: 2
     ○    85d5043b881d 2 parents: 1 a
     ├─╮
@@ -465,11 +488,12 @@ fn test_parallelize_multiple_roots() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     // Succeeds because the roots have the same parents.
     test_env.jj_cmd_ok(&workspace_path, &["parallelize", "root().."]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  3c90598481cd 3 parents:
     │ ○  b96aa55582e5 2 parents:
     ├─╯
@@ -478,7 +502,8 @@ fn test_parallelize_multiple_roots() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -493,7 +518,7 @@ fn test_parallelize_multiple_heads_with_different_children() {
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=a"]);
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=b"]);
     test_env.jj_cmd_ok(&workspace_path, &["commit", "-m=c"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  4bc4dace0e65 parents: c
     ○  63b0da9212c0 c parents: b
     ○  a7bf5001cfd8 b parents: a
@@ -503,7 +528,8 @@ fn test_parallelize_multiple_heads_with_different_children() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
@@ -513,7 +539,7 @@ fn test_parallelize_multiple_heads_with_different_children() {
             "description(a)::description(b)",
         ],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  f6c9d9ee3db8 parents: c
     ○    62661d5f0c77 c parents: a b
     ├─╮
@@ -527,7 +553,8 @@ fn test_parallelize_multiple_heads_with_different_children() {
     │ ○  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -544,7 +571,7 @@ fn test_parallelize_multiple_roots_with_different_parents() {
         &workspace_path,
         &["new", "description(2)", "description(b)", "-m=merged-head"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    ba4297d53c1a merged-head parents: 2 b
     ├─╮
     │ ○  6577defaca2d b parents: a
@@ -553,13 +580,14 @@ fn test_parallelize_multiple_roots_with_different_parents() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(2)::", "description(b)::"],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    0943ed52b3ed merged-head parents: 1 a
     ├─╮
     │ │ ○  6577defaca2d b parents: a
@@ -570,7 +598,8 @@ fn test_parallelize_multiple_roots_with_different_parents() {
     ○ │  8b64ddff700d 1 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -586,7 +615,7 @@ fn test_parallelize_complex_nonlinear_target() {
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=1c", "description(1)"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=2c", "description(2)"]);
     test_env.jj_cmd_ok(&workspace_path, &["new", "-m=3c", "description(3)"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  b043eb81416c 3c parents: 3
     │ ○    48277ee9afe0 4 parents: 3 2 1
     ╭─┼─╮
@@ -601,18 +630,20 @@ fn test_parallelize_complex_nonlinear_target() {
     ├─╯
     ○  745bea8029c1 0 parents:
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 
     let (_stdout, stderr) = test_env.jj_cmd_ok(
         &workspace_path,
         &["parallelize", "description(0)::description(4)"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: yostqsxw 59a216e5 (empty) 3c
     Parent commit      : rlvkpnrz 745bea80 (empty) 0
     Parent commit      : mzvwutvl cb944786 (empty) 3
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @    59a216e537c4 3c parents: 0 3
     ├─╮
     │ ○  cb9447869bf0 3 parents:
@@ -629,7 +660,8 @@ fn test_parallelize_complex_nonlinear_target() {
     │ ○  14ca4df576b3 4 parents:
     ├─╯
     ◆  000000000000 parents:
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 fn create_commit(test_env: &TestEnvironment, repo_path: &Path, name: &str, parents: &[&str]) {
@@ -2802,12 +2803,12 @@ fn test_rebase_skip_if_on_destination() {
     "###);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = "bookmarks ++ surround(': ', '', parents.map(|c| c.bookmarks()))";
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
 
-fn get_long_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_long_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = "bookmarks ++ '  ' ++ change_id.shortest(8) ++ '  ' ++ commit_id.shortest(8) \
                     ++ surround(':  ', '', parents.map(|c| c.bookmarks()))";
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -40,80 +40,88 @@ fn test_rebase_invalid() {
 
     // Missing destination
     let stderr = test_env.jj_cmd_cli_error(&repo_path, &["rebase"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the following required arguments were not provided:
       <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     Usage: jj rebase <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Both -r and -s
     let stderr =
         test_env.jj_cmd_cli_error(&repo_path, &["rebase", "-r", "a", "-s", "a", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--revisions <REVSETS>' cannot be used with '--source <REVSETS>'
 
     Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Both -b and -s
     let stderr =
         test_env.jj_cmd_cli_error(&repo_path, &["rebase", "-b", "a", "-s", "a", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--branch <REVSETS>' cannot be used with '--source <REVSETS>'
 
     Usage: jj rebase --branch <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Both -d and --after
     let stderr = test_env.jj_cmd_cli_error(
         &repo_path,
         &["rebase", "-r", "a", "-d", "b", "--after", "b"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--destination <REVSETS>' cannot be used with '--insert-after <REVSETS>'
 
     Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Both -d and --before
     let stderr = test_env.jj_cmd_cli_error(
         &repo_path,
         &["rebase", "-r", "a", "-d", "b", "--before", "b"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     error: the argument '--destination <REVSETS>' cannot be used with '--insert-before <REVSETS>'
 
     Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 
     // Rebase onto self with -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "a"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Cannot rebase 2443ea76b0b1 onto itself
-    "###);
+    [EOF]
+    ");
 
     // Rebase root with -r
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "root()", "-d", "a"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The root commit 000000000000 is immutable
-    "###);
+    [EOF]
+    ");
 
     // Rebase onto descendant with -s
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s", "a", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Cannot rebase 2443ea76b0b1 onto descendant 1394f625cbbd
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -128,15 +136,27 @@ fn test_rebase_empty_sets() {
     // TODO: Make all of these say "Nothing changed"?
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r=none()", "-d=b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Nothing changed.");
+    insta::assert_snapshot!(stderr, @r"
+    Nothing changed.
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-s=none()", "-d=b"]);
-    insta::assert_snapshot!(stderr, @"Error: Revset `none()` didn't resolve to any revisions");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revset `none()` didn't resolve to any revisions
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-b=none()", "-d=b"]);
-    insta::assert_snapshot!(stderr, @"Error: Revset `none()` didn't resolve to any revisions");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revset `none()` didn't resolve to any revisions
+    [EOF]
+    ");
     // Empty because "b..a" is empty
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b=a", "-d=b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Nothing changed.");
+    insta::assert_snapshot!(stderr, @r"
+    Nothing changed.
+    [EOF]
+    ");
 }
 
 #[test]
@@ -151,7 +171,7 @@ fn test_rebase_bookmark() {
     create_commit(&test_env, &repo_path, "d", &["b"]);
     create_commit(&test_env, &repo_path, "e", &["a"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: a
     │ ○  d: b
     │ │ ○  c: b
@@ -160,12 +180,16 @@ fn test_rebase_bookmark() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Rebased 3 commits onto destination");
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(stderr, @r"
+    Rebased 3 commits onto destination
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  d: b
     │ ○  c: b
     ├─╯
@@ -173,20 +197,22 @@ fn test_rebase_bookmark() {
     @  e: a
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Test rebasing multiple bookmarks at once
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b=e", "-b=d", "-d=b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 1 commits onto destination
     Working copy now at: znkkpsqq 9ca2a154 e | e
     Parent commit      : zsuskuln 1394f625 b | b
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: b
     │ ○  d: b
     ├─╯
@@ -195,7 +221,8 @@ fn test_rebase_bookmark() {
     ○  b: a
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Same test but with more than one revision per argument
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -206,17 +233,19 @@ fn test_rebase_bookmark() {
       znkkpsqq e52756c8 e | e
       vruxwmqv 514fa6b2 d | d
     Hint: Prefix the expression with `all:` to allow any number of revisions (i.e. `all:e|d`).
+    [EOF]
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b=all:e|d", "-d=b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 1 commits onto destination
     Working copy now at: znkkpsqq 817e3fb0 e | e
     Parent commit      : zsuskuln 1394f625 b | b
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: b
     │ ○  d: b
     ├─╯
@@ -225,7 +254,8 @@ fn test_rebase_bookmark() {
     ○  b: a
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -240,7 +270,7 @@ fn test_rebase_bookmark_with_merge() {
     create_commit(&test_env, &repo_path, "d", &["c"]);
     create_commit(&test_env, &repo_path, "e", &["a", "d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: a d
     ├─╮
     │ ○  d: c
@@ -250,18 +280,20 @@ fn test_rebase_bookmark_with_merge() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: znkkpsqq 5f8a3db2 e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : vruxwmqv 1677f795 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: a d
     ├─╮
     │ ○  d: c
@@ -270,19 +302,21 @@ fn test_rebase_bookmark_with_merge() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: znkkpsqq a331ac11 e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : vruxwmqv 3d0f3644 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: a d
     ├─╮
     │ ○  d: c
@@ -291,7 +325,8 @@ fn test_rebase_bookmark_with_merge() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -306,7 +341,7 @@ fn test_rebase_single_revision() {
     create_commit(&test_env, &repo_path, "d", &["b", "c"]);
     create_commit(&test_env, &repo_path, "e", &["d"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: d
     ○    d: b c
     ├─╮
@@ -315,20 +350,22 @@ fn test_rebase_single_revision() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Descendants of the rebased commit "c" should be rebased onto parents. First
     // we test with a non-merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: znkkpsqq 2668ffbe e | e
     Parent commit      : vruxwmqv 7b370c85 d | d
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e: d
     ○    d: b a
     ├─╮
@@ -338,22 +375,24 @@ fn test_rebase_single_revision() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Now, let's try moving the merge commit. After, both parents of "d" ("b" and
     // "c") should become parents of "e".
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: znkkpsqq ed210c15 e | e
     Parent commit      : zsuskuln 1394f625 b | b
     Parent commit      : royxmykx c0cb3a0b c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    e: b c
     ├─╮
     │ ○  c: a
@@ -363,7 +402,8 @@ fn test_rebase_single_revision() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -377,7 +417,7 @@ fn test_rebase_single_revision_merge_parent() {
     create_commit(&test_env, &repo_path, "c", &["b"]);
     create_commit(&test_env, &repo_path, "d", &["a", "c"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    d: a c
     ├─╮
     │ ○  c: b
@@ -385,21 +425,23 @@ fn test_rebase_single_revision_merge_parent() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Descendants of the rebased commit should be rebased onto parents, and if
     // the descendant is a merge commit, it shouldn't forget its other parents.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: vruxwmqv a37531e8 d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Parent commit      : zsuskuln d370aee1 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    d: a b
     ├─╮
     │ ○  b
@@ -408,7 +450,8 @@ fn test_rebase_single_revision_merge_parent() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -427,7 +470,7 @@ fn test_rebase_multiple_revisions() {
     create_commit(&test_env, &repo_path, "h", &["g"]);
     create_commit(&test_env, &repo_path, "i", &["f"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  i: f
     │ ○  h: g
     │ ○  g: f
@@ -441,20 +484,22 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Test with two non-related non-merge commits.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-r", "e", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 016685dc i | i
     Parent commit      : kmkuslsw e04d3932 f | f
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  i: f
     │ ○  h: g
     │ ○  g: f
@@ -470,7 +515,8 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test with two related non-merge commits. Since "b" is a parent of "c", when
@@ -479,14 +525,15 @@ fn test_rebase_multiple_revisions() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b", "-r", "c", "-d", "e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 94538385 i | i
     Parent commit      : kmkuslsw dae8d293 f | f
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  i: f
     │ ○  h: g
     │ ○  g: f
@@ -501,7 +548,8 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test with a subgraph containing a merge commit. Since the merge commit "f"
@@ -511,15 +559,16 @@ fn test_rebase_multiple_revisions() {
     // a descendant of any new children.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e::g", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 1868ded4 i | i
     Parent commit      : royxmykx 7e4fbf4f c | c
     Parent commit      : vruxwmqv 4cc44fbf d | d
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    i: c d
     ├─╮
     │ │ ○  h: c d
@@ -535,7 +584,8 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test with commits in a disconnected subgraph. The subgraph has the
@@ -548,15 +598,16 @@ fn test_rebase_multiple_revisions() {
         &["rebase", "-r", "d", "-r", "f", "-r", "h", "-d", "b"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn 9cfd1635 i | i
     Parent commit      : royxmykx 7e4fbf4f c | c
     Parent commit      : znkkpsqq ecf9a1d5 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    i: c e
     ├─╮
     │ │ ○  g: c e
@@ -572,20 +623,22 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
 
     // Test rebasing a subgraph onto its descendants.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d::e", "-d", "i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 5d911e5c i | i
     Parent commit      : kmkuslsw d1bfda8c f | f
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: d
     ○  d: i
     @  i: f
@@ -599,7 +652,8 @@ fn test_rebase_multiple_revisions() {
     ├─╯
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -613,7 +667,7 @@ fn test_rebase_revision_onto_descendant() {
     create_commit(&test_env, &repo_path, "b", &["base"]);
     create_commit(&test_env, &repo_path, "merge", &["b", "a"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    merge: b a
     ├─╮
     │ ○  a: base
@@ -621,21 +675,23 @@ fn test_rebase_revision_onto_descendant() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Simpler example
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: vruxwmqv bff4a4eb merge | merge
     Parent commit      : royxmykx c84e900d b | b
     Parent commit      : zsuskuln d57db87b a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    merge: b a
     ├─╮
     ○ │  b
@@ -644,7 +700,8 @@ fn test_rebase_revision_onto_descendant() {
     │ ○  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Now, let's rebase onto the descendant merge
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
@@ -655,18 +712,20 @@ fn test_rebase_revision_onto_descendant() {
     Parent commit      : royxmykx cea87a87 b | b
     Parent commit      : zsuskuln 2c5b7858 a | a
     Added 1 files, modified 0 files, removed 0 files
+    [EOF]
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "merge"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: vruxwmqv 986b7a49 merge | merge
     Parent commit      : royxmykx c07c677c b | b
     Parent commit      : zsuskuln abc90087 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  base: merge
     @    merge: b a
     ├─╮
@@ -674,7 +733,8 @@ fn test_rebase_revision_onto_descendant() {
     ○ │  b
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // TODO(ilyagr): These will be good tests for `jj rebase --insert-after` and
     // `--insert-before`, once those are implemented.
@@ -690,29 +750,32 @@ fn test_rebase_multiple_destinations() {
     create_commit(&test_env, &repo_path, "b", &[]);
     create_commit(&test_env, &repo_path, "c", &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c
     │ ○  b
     ├─╯
     │ ○  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    a: b c
     ├─╮
     │ @  c
     ○ │  b
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b|c"]);
     insta::assert_snapshot!(stderr, @r"
@@ -721,22 +784,25 @@ fn test_rebase_multiple_destinations() {
       royxmykx fe2e8e8b c | c
       zsuskuln d370aee1 b | b
     Hint: Prefix the expression with `all:` to allow any number of revisions (i.e. `all:b|c`).
+    [EOF]
     ");
 
     // try with 'all:' and succeed
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "all:b|c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    a: c b
     ├─╮
     │ ○  b
     @ │  c
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // undo and do it again, but with 'ui.always-allow-large-revsets'
     let (_, _) = test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -749,36 +815,40 @@ fn test_rebase_multiple_destinations() {
             "-d=b|c",
         ],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    a: c b
     ├─╮
     │ ○  b
     @ │  c
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "a", "-d", "b", "-d", "b"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: More than one revset resolved to revision d370aee184ba
-    "###);
+    [EOF]
+    ");
 
     // Same error with 'all:' if there is overlap.
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["rebase", "-r", "a", "-d", "all:b|c", "-d", "b"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: More than one revset resolved to revision d370aee184ba
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &repo_path,
         &["rebase", "-r", "a", "-d", "b", "-d", "root()"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -792,7 +862,7 @@ fn test_rebase_with_descendants() {
     create_commit(&test_env, &repo_path, "c", &["a", "b"]);
     create_commit(&test_env, &repo_path, "d", &["c"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: c
     ○    c: a b
     ├─╮
@@ -800,16 +870,18 @@ fn test_rebase_with_descendants() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "b", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: vruxwmqv 705832bd d | d
     Parent commit      : royxmykx 57c7246a c | c
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: c
     ○    c: a b
     ├─╮
@@ -817,19 +889,21 @@ fn test_rebase_with_descendants() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Rebase several subtrees at once.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=c", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Working copy now at: vruxwmqv 92c2bc9a d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: a
     │ ○  c: a
     ├─╯
@@ -837,11 +911,12 @@ fn test_rebase_with_descendants() {
     │ ○  b
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     // Reminder of the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: c
     ○    c: a b
     ├─╮
@@ -849,19 +924,21 @@ fn test_rebase_with_descendants() {
     ○ │  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // `d` was a descendant of `b`, and both are moved to be direct descendants of
     // `a`. `c` remains a descendant of `b`.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=b", "-s=d", "-d=a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: vruxwmqv f1e71cb7 d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: a
     │ ○  c: a b
     ╭─┤
@@ -869,7 +946,8 @@ fn test_rebase_with_descendants() {
     ├─╯
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
 
     // Same test as above, but with multiple commits per argument
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -880,16 +958,18 @@ fn test_rebase_with_descendants() {
       vruxwmqv df54a9fd d | d
       zsuskuln d370aee1 b | b
     Hint: Prefix the expression with `all:` to allow any number of revisions (i.e. `all:b|d`).
+    [EOF]
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=all:b|d", "-d=a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: vruxwmqv d17539f7 d | d
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  d: a
     │ ○  c: a b
     ╭─┤
@@ -897,7 +977,8 @@ fn test_rebase_with_descendants() {
     ├─╯
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -911,10 +992,16 @@ fn test_rebase_error_revision_does_not_exist() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-r", "@-", "-m", "two"]);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-b", "b-one", "-d", "this"]);
-    insta::assert_snapshot!(stderr, @"Error: Revision `this` doesn't exist");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revision `this` doesn't exist
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-b", "this", "-d", "b-one"]);
-    insta::assert_snapshot!(stderr, @"Error: Revision `this` doesn't exist");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revision `this` doesn't exist
+    [EOF]
+    ");
 }
 
 // This behavior illustrates https://github.com/jj-vcs/jj/issues/2600
@@ -932,7 +1019,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -941,18 +1028,20 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     // ===================== rebase -s tests =================
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "base", "-d", "notroot"]);
     insta::assert_snapshot!(stdout, @"");
     // This should be a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -961,17 +1050,19 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "a", "-d", "base"]);
     insta::assert_snapshot!(stdout, @"");
     // This should be a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 3 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -980,19 +1071,21 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "a", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: znkkpsqq cf8ecff5 c | c
     Parent commit      : vruxwmqv 24e1a270 b | b
-    "#);
+    [EOF]
+    ");
     // Commit "a" should be rebased onto the root commit. Commit "b" should have
     // "base" and "a" as parents as before.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1001,12 +1094,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○ │  notroot
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // ===================== rebase -b tests =================
     // ====== Reminder of the setup =========
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1015,17 +1109,19 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "base"]);
     insta::assert_snapshot!(stdout, @"");
     // The commits in roots(base..c), i.e. commit "a" should be rebased onto "base",
     // which is a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 3 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1034,36 +1130,40 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Working copy now at: znkkpsqq 76914dcc c | c
     Parent commit      : vruxwmqv f73f03c7 b | b
-    "#);
+    [EOF]
+    ");
     // The commits in roots(a..c), i.e. commit "b" should be rebased onto "a",
     // which means "b" loses its "base" parent
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○  b: a
     ○  a: base
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "a", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
     // This should be a no-op
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 5 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1072,12 +1172,13 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     // ===================== rebase -r tests =================
     // ====== Reminder of the setup =========
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1086,20 +1187,22 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq 45371aaf c | c
     Parent commit      : vruxwmqv c0a76bf4 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     // The user would expect unsimplified ancestry here.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: notroot a
     ├─╮
@@ -1109,21 +1212,23 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     │ ○  base
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq e28fa972 c | c
     Parent commit      : vruxwmqv 8d0eeb6a b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     │ ○  base: b
     ├─╯
@@ -1133,21 +1238,23 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ├─╯
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "base", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq a9da974c c | c
     Parent commit      : vruxwmqv 0072139c b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: notroot a
     ├─╮
@@ -1157,11 +1264,12 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ├─╯
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // ====== Reminder of the setup =========
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○    b: base a
     ├─╮
@@ -1170,20 +1278,22 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "a", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: znkkpsqq 7210b05e c | c
     Parent commit      : vruxwmqv da3f7511 b | b
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     // In this case, it is unclear whether the user would always prefer unsimplified
     // ancestry (whether `b` should also be a direct child of the root commit).
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: b
     ○  b: base
     ○  base: notroot
@@ -1191,21 +1301,23 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     │ ○  a
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b", "-d", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: znkkpsqq f280545e c | c
     Parent commit      : zsuskuln 0a7fb8f6 base | base
     Parent commit      : royxmykx 86a06598 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     // The user would expect unsimplified ancestry here.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    c: base a
     ├─╮
     │ ○  a: base
@@ -1215,22 +1327,24 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     │ ○  b
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
 
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: znkkpsqq c0a7cd80 c | c
     Parent commit      : zsuskuln 0a7fb8f6 base | base
     Parent commit      : royxmykx 86a06598 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  b: c
     @    c: base a
     ├─╮
@@ -1239,20 +1353,22 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 
     // In this test, the commit with weird ancestry is not rebased (neither directly
     // nor indirectly).
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: znkkpsqq 7a3bc050 c | c
     Parent commit      : royxmykx 86a06598 a | a
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  c: a
     │ ○  b: base a
     ╭─┤
@@ -1261,7 +1377,8 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ○  base: notroot
     ○  notroot
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1280,7 +1397,7 @@ fn test_rebase_after() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1294,7 +1411,8 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Rebasing a commit after its parents should be a no-op.
@@ -1303,11 +1421,12 @@ fn test_rebase_after() {
         &["rebase", "-r", "c", "--after", "b2", "--after", "b4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1321,16 +1440,18 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Rebasing a commit after itself should be a no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1344,19 +1465,21 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Rebase a commit after another commit. "c" has parents "b2" and "b4", so its
     // children "d" and "e" should be rebased onto "b2" and "b4" respectively.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--after", "e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn e0e873c8 f | f
     Parent commit      : kmkuslsw 754793f3 c | c
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     ○  c: e
     ○    e: b2 b4
@@ -1370,20 +1493,22 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after a leaf commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e", "--after", "f"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: xznxytkn 9804b742 f | f
     Parent commit      : kmkuslsw cd86b3e4 c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: f
     @  f: c
     │ ○  d: c
@@ -1397,20 +1522,22 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after a commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--after", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 80c27408 f | f
     Parent commit      : zsuskuln 072d5ae1 b1 | b1
     Added 0 files, modified 0 files, removed 5 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1424,20 +1551,22 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after the last commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--after", "b2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn ebbc24b1 f | f
     Parent commit      : royxmykx 2b8e1148 b2 | b2
     Added 0 files, modified 0 files, removed 4 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1451,7 +1580,8 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after a commit with multiple children.
@@ -1459,14 +1589,15 @@ fn test_rebase_after() {
     // two children.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 8f8c91d3 f | f
     Parent commit      : kmkuslsw cd86b3e4 c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: f
     │ ○  d: f
     ├─╯
@@ -1480,7 +1611,8 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after multiple commits.
@@ -1489,14 +1621,15 @@ fn test_rebase_after() {
         &["rebase", "-r", "f", "--after", "e", "--after", "d"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: xznxytkn 7784e5a0 f | f
     Parent commit      : nkmrtpmo 858693f7 e | e
     Parent commit      : lylxulpl 7d0512e5 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    f: e d
     ├─╮
     │ ○  d: c
@@ -1511,7 +1644,8 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase two unrelated commits.
@@ -1520,14 +1654,15 @@ fn test_rebase_after() {
         &["rebase", "-r", "d", "-r", "e", "--after", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn 0b53613e f | f
     Parent commit      : kmkuslsw 193687bb c | c
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     ○    c: b2 b4
     ├─╮
@@ -1542,7 +1677,8 @@ fn test_rebase_after() {
       ├─╯
       ○  a
       ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with merge commit and two parents, which should preserve
@@ -1552,14 +1688,15 @@ fn test_rebase_after() {
         &["rebase", "-r", "b2", "-r", "b4", "-r", "c", "--after", "f"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn eaf1d6b8 f | f
     Parent commit      : nkmrtpmo 0d7e4ce9 e | e
     Added 0 files, modified 0 files, removed 3 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    c: b2 b4
     ├─╮
     │ ○  b4: f
@@ -1575,21 +1712,23 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with four commits after one of the commits itself.
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b1::d", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 9bc7e54c f | f
     Parent commit      : nkmrtpmo 0f80251b e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: d
     ○  d: c
@@ -1603,7 +1742,8 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph before the parents of one of the commits in the subgraph.
@@ -1612,14 +1752,15 @@ fn test_rebase_after() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b2::d", "--after", "root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn 0875aabc f | f
     Parent commit      : nkmrtpmo d429661b e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b1 b4
     ├─╮
@@ -1632,7 +1773,8 @@ fn test_rebase_after() {
     ○  c: b2
     ○  b2
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with disconnected commits. Since "b2" is an ancestor of
@@ -1642,14 +1784,15 @@ fn test_rebase_after() {
         &["rebase", "-r", "e", "-r", "b2", "--after", "d"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn 3238a418 f | f
     Parent commit      : kmkuslsw 6a51bd41 c | c
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     │ ○  e: b2
     │ ○  b2: d
@@ -1663,17 +1806,19 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of commit "c" and its descendants after itself should be a no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "c", "--after", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1687,7 +1832,8 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of a commit and its descendants after multiple commits.
@@ -1696,14 +1842,15 @@ fn test_rebase_after() {
         &["rebase", "-s", "c", "--after", "b1", "--after", "b3"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn a4ace41c f | f
     Parent commit      : nkmrtpmo c7744d08 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    b4: d f
     ├─╮
     │ │ ○  b2: d f
@@ -1719,7 +1866,8 @@ fn test_rebase_after() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -b` of commit "b3" after "b1" moves its descendants which are not
@@ -1727,14 +1875,15 @@ fn test_rebase_after() {
     // child "b2".
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "b3", "--after", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 6 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: xznxytkn b4078b57 f | f
     Parent commit      : nkmrtpmo 1b95558f e | e
     Added 0 files, modified 0 files, removed 1 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    b2: d f
     ├─╮
     │ @  f: e
@@ -1747,7 +1896,8 @@ fn test_rebase_after() {
     ○  b1: a
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Should error if a loop will be created.
@@ -1755,9 +1905,10 @@ fn test_rebase_after() {
         &repo_path,
         &["rebase", "-r", "e", "--after", "a", "--after", "b2"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to create a loop: commit 2b8e1148290f would be both an ancestor and a descendant of the rebased commits
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1776,7 +1927,7 @@ fn test_rebase_before() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1790,7 +1941,8 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Rebasing a commit before its children should be a no-op.
@@ -1799,11 +1951,12 @@ fn test_rebase_before() {
         &["rebase", "-r", "c", "--before", "d", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1817,16 +1970,18 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Rebasing a commit before itself should be a no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--before", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -1840,25 +1995,28 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     // Rebasing a commit before the root commit should error.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["rebase", "-r", "c", "--before", "root()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The root commit 000000000000 is immutable
-    "###);
+    [EOF]
+    ");
 
     // Rebase a commit before another commit. "c" has parents "b2" and "b4", so its
     // children "d" and "e" should be rebased onto "b2" and "b4" respectively.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "c", "--before", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 8 descendant commits
     Working copy now at: xznxytkn 24335685 f | f
     Parent commit      : nkmrtpmo e9a28d4b e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b2 b4
     ├─╮
@@ -1872,20 +2030,22 @@ fn test_rebase_before() {
     ○  a: c
     ○  c
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before its parent.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: xznxytkn 8e3b728a f | f
     Parent commit      : kmkuslsw cd86b3e4 c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: f
     @  f: c
     │ ○  d: c
@@ -1899,20 +2059,22 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before a commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "b2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: xznxytkn 2b4f48f8 f | f
     Parent commit      : zsuskuln 072d5ae1 b1 | b1
     Added 0 files, modified 0 files, removed 5 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1926,20 +2088,22 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before the first commit in a bookmark of a merge commit.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 5 descendant commits
     Working copy now at: xznxytkn 488ebb95 f | f
     Parent commit      : rlvkpnrz 2443ea76 a | a
     Added 0 files, modified 0 files, removed 6 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1953,7 +2117,8 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before a merge commit. "c" has two parents "b2" and "b4", so
@@ -1961,15 +2126,16 @@ fn test_rebase_before() {
     // parents.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "f", "--before", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn aae1bc10 f | f
     Parent commit      : royxmykx 2b8e1148 b2 | b2
     Parent commit      : znkkpsqq a52a83a4 b4 | b4
     Added 0 files, modified 0 files, removed 2 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -1983,7 +2149,8 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before multiple commits.
@@ -1992,13 +2159,14 @@ fn test_rebase_before() {
         &["rebase", "-r", "b1", "--before", "d", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 5 descendant commits
     Working copy now at: xznxytkn 8268ec4d f | f
     Parent commit      : nkmrtpmo fd26fbd4 e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: b1
     │ ○  d: b1
@@ -2012,7 +2180,8 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit before two commits in separate bookmarks to create a merge
@@ -2022,15 +2191,16 @@ fn test_rebase_before() {
         &["rebase", "-r", "f", "--before", "b2", "--before", "b4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 5 descendant commits
     Working copy now at: xznxytkn 7ba8014f f | f
     Parent commit      : zsuskuln 072d5ae1 b1 | b1
     Parent commit      : vruxwmqv 523e6a8b b3 | b3
     Added 0 files, modified 0 files, removed 4 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  e: c
     │ ○  d: c
     ├─╯
@@ -2046,7 +2216,8 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase two unrelated commits "b2" and "b4" before a single commit "a". This
@@ -2056,13 +2227,14 @@ fn test_rebase_before() {
         &["rebase", "-r", "b2", "-r", "b4", "--before", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 7 descendant commits
     Working copy now at: xznxytkn fabd8dd7 f | f
     Parent commit      : nkmrtpmo b5933877 e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2078,7 +2250,8 @@ fn test_rebase_before() {
     ○ │  b2
     ├─╯
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with a merge commit and two parents.
@@ -2087,13 +2260,14 @@ fn test_rebase_before() {
         &["rebase", "-r", "b2", "-r", "b4", "-r", "c", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: xznxytkn cbe2be58 f | f
     Parent commit      : nkmrtpmo e31053d1 e | e
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     ○    c: b2 b4
@@ -2109,7 +2283,8 @@ fn test_rebase_before() {
       ├─╯
       ○  a
       ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph with disconnected commits. Since "b1" is an ancestor of
@@ -2119,13 +2294,14 @@ fn test_rebase_before() {
         &["rebase", "-r", "b1", "-r", "e", "--before", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Rebased 7 descendant commits
     Working copy now at: xznxytkn 1c48b514 f | f
     Parent commit      : kmkuslsw c0fd979a c | c
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: c
     │ ○  d: c
     ├─╯
@@ -2139,7 +2315,8 @@ fn test_rebase_before() {
     ○  e: b1
     ○  b1
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph before the parents of one of the commits in the subgraph.
@@ -2148,14 +2325,15 @@ fn test_rebase_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b2::d", "--before", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn f5991dc7 f | f
     Parent commit      : nkmrtpmo 37894e3c e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b1 b4
     ├─╮
@@ -2168,7 +2346,8 @@ fn test_rebase_before() {
     ○  c: b2
     ○  b2
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a subgraph before the parents of one of the commits in the subgraph.
@@ -2177,14 +2356,15 @@ fn test_rebase_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "b2::d", "--before", "a"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 6 descendant commits
     Working copy now at: xznxytkn 308a31e9 f | f
     Parent commit      : nkmrtpmo 538444a5 e | e
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○    e: b1 b4
     ├─╮
@@ -2197,18 +2377,20 @@ fn test_rebase_before() {
     ○  c: b2
     ○  b2
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of commit "c" and its descendants before itself should be a
     // no-op.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "c", "--before", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2222,7 +2404,8 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of a commit and its descendants before multiple commits.
@@ -2231,14 +2414,15 @@ fn test_rebase_before() {
         &["rebase", "-s", "c", "--before", "b2", "--before", "b4"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 84704387 f | f
     Parent commit      : nkmrtpmo cff61821 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○    b4: d f
     ├─╮
     │ │ ○  b2: d f
@@ -2254,7 +2438,8 @@ fn test_rebase_before() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -b` of commit "b3" before "b2" moves its descendants which are not
@@ -2263,15 +2448,16 @@ fn test_rebase_before() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "b3", "--before", "b1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 2 commits that were already in place
     Rebased 4 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: xznxytkn 16422f85 f | f
     Parent commit      : nkmrtpmo ef9dea83 e | e
     Added 0 files, modified 0 files, removed 2 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○  b2: b1
     ○    b1: d f
     ├─╮
@@ -2284,7 +2470,8 @@ fn test_rebase_before() {
     ○  b3: a
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Should error if a loop will be created.
@@ -2292,9 +2479,10 @@ fn test_rebase_before() {
         &repo_path,
         &["rebase", "-r", "e", "--before", "b2", "--before", "c"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Refusing to create a loop: commit 2b8e1148290f would be both an ancestor and a descendant of the rebased commits
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2314,7 +2502,7 @@ fn test_rebase_after_before() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2330,7 +2518,8 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Rebase a commit after another commit and before that commit's child to
@@ -2340,14 +2529,15 @@ fn test_rebase_after_before() {
         &["rebase", "-r", "d", "--after", "e", "--before", "f"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx 56c81c6d f | f
     Parent commit      : nkmrtpmo ff196f69 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: d
     ○  d: e
     ○  e: c
@@ -2362,7 +2552,8 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase a commit after another commit and before that commit's descendant to
@@ -2372,15 +2563,16 @@ fn test_rebase_after_before() {
         &["rebase", "-r", "d", "--after", "a", "--before", "f"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx 398173ed f | f
     Parent commit      : xznxytkn b3e6aadf e | e
     Parent commit      : nkmrtpmo db529447 d | d
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    f: e d
     ├─╮
     │ ○  d: a
@@ -2397,7 +2589,8 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // "c" has parents "b1" and "b2", so when it is rebased, its children "d" and
@@ -2409,14 +2602,15 @@ fn test_rebase_after_before() {
         &["rebase", "-r", "c", "--after", "d", "--before", "e"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 3 descendant commits
     Working copy now at: nmzmmopx 2be98daf f | f
     Parent commit      : xznxytkn 911fc846 e | e
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○      e: b1 b2 c
     ├─┬─╮
@@ -2432,7 +2626,8 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Rebase multiple commits and preserve their ancestry. Apart from the heads of
@@ -2446,7 +2641,7 @@ fn test_rebase_after_before() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx bee09b10 f | f
@@ -2455,8 +2650,9 @@ fn test_rebase_after_before() {
     Parent commit      : nkmrtpmo 4a8ca156 d | d
     Parent commit      : xznxytkn 0cc1825e e | e
     Added 1 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @        f: b1 b2 d e
     ├─┬─┬─╮
     │ │ │ ○  e: c
@@ -2473,7 +2669,8 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -s` of a commit and its descendants.
@@ -2482,14 +2679,15 @@ fn test_rebase_after_before() {
         &["rebase", "-s", "c", "--before", "b1", "--after", "b2"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 4 commits onto destination
     Rebased 1 descendant commits
     Working copy now at: nmzmmopx 951204cf f | f
     Parent commit      : xznxytkn fe8ec4e2 e | e
     Added 0 files, modified 0 files, removed 1 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     ○      b1: a d f
     ├─┬─╮
     │ │ @  f: e
@@ -2505,7 +2703,8 @@ fn test_rebase_after_before() {
     │ ○  x
     ├─╯
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // `rebase -b` of a commit "y" to a destination after "a" will rebase all
@@ -2516,14 +2715,15 @@ fn test_rebase_after_before() {
         &["rebase", "-b", "y", "--after", "a", "--before", "c"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Rebased 4 descendant commits
     Working copy now at: nmzmmopx 4496f88e f | f
     Parent commit      : xznxytkn a85404a6 e | e
     Added 3 files, modified 0 files, removed 0 files
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f: e
     ○  e: c
     │ ○  d: c
@@ -2539,7 +2739,8 @@ fn test_rebase_after_before() {
     ├─╯
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
 
     // Should error if a loop will be created.
@@ -2547,7 +2748,10 @@ fn test_rebase_after_before() {
         &repo_path,
         &["rebase", "-r", "e", "--after", "c", "--before", "a"],
     );
-    insta::assert_snapshot!(stderr, @"Error: Refusing to create a loop: commit 31b84afe1c8f would be both an ancestor and a descendant of the rebased commits");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Refusing to create a loop: commit 31b84afe1c8f would be both an ancestor and a descendant of the rebased commits
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2565,7 +2769,7 @@ fn test_rebase_skip_emptied() {
     let setup_opid = test_env.current_operation_id(&repo_path);
 
     // Test the setup
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  will become empty
@@ -2573,30 +2777,33 @@ fn test_rebase_skip_emptied() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=b", "--skip-emptied"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 commits onto destination
     Abandoned 1 newly emptied commits
     Working copy now at: yostqsxw bc4222f2 (empty) also already empty
     Parent commit      : vruxwmqv 6b41ecb2 (empty) already empty
-    "#);
+    [EOF]
+    ");
 
     // The parent commit became empty and was dropped, but the already empty commits
     // were kept
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  b
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &setup_opid]);
     // Test the setup
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r###"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  will become empty
@@ -2604,7 +2811,8 @@ fn test_rebase_skip_emptied() {
     ├─╯
     ○  a
     ◆
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
@@ -2616,24 +2824,26 @@ fn test_rebase_skip_emptied() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Abandoned 1 newly emptied commits
     Working copy now at: yostqsxw 74149b9b (empty) also already empty
     Parent commit      : vruxwmqv 3bdb2801 (empty) already empty
     Added 0 files, modified 0 files, removed 1 files
-    "#);
+    [EOF]
+    ");
 
     // Rebasing a single commit which becomes empty abandons that commit, whilst its
     // already empty descendants were kept
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     │ ○  b
     ├─╯
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2651,7 +2861,7 @@ fn test_rebase_skip_emptied_descendants() {
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "also already empty"]);
 
     // Test the setup
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  c (will become empty)
@@ -2659,30 +2869,33 @@ fn test_rebase_skip_emptied_descendants() {
     ├─╯
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["rebase", "-r", "b", "--before", "c", "--skip-emptied"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 3 descendant commits
     Working copy now at: znkkpsqq 353bac5c (empty) also already empty
     Parent commit      : yostqsxw 0a3f76fd (empty) already empty
-    "#);
+    [EOF]
+    ");
 
     // Commits not in the rebase target set should not be abandoned even if they
     // were emptied.
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]), @r"
     @  also already empty
     ○  already empty
     ○  c (will become empty)
     ○  b
     ○  a
     ◆
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -2699,7 +2912,7 @@ fn test_rebase_skip_if_on_destination() {
     create_commit(&test_env, &repo_path, "e", &["c"]);
     create_commit(&test_env, &repo_path, "f", &["e"]);
     // Test the setup
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2711,16 +2924,18 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-b", "d", "-d", "a"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase with -b
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 6 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2732,17 +2947,19 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s", "c", "-d", "b1", "-d", "b2"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase with -s
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 4 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2754,16 +2971,18 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "d", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase with -r since commit has no children
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  88f778c5:  e
     ○  e  kmkuslsw  48dd9e3f:  c
     │ ○  d  znkkpsqq  92438fc9:  c
@@ -2775,19 +2994,21 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-r", "e", "-d", "c"]);
     insta::assert_snapshot!(stdout, @"");
     // Skip rebase of commit, but rebases children onto destination with -r
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Skipped rebase of 1 commits that were already in place
     Rebased 1 descendant commits
     Working copy now at: lylxulpl 77cb229f f | f
     Parent commit      : vruxwmqv c41e416e c | c
     Added 0 files, modified 0 files, removed 1 files
-    "###);
-    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_long_log_output(&test_env, &repo_path), @r"
     @  f  lylxulpl  77cb229f:  c
     │ ○  e  kmkuslsw  48dd9e3f:  c
     ├─╯
@@ -2800,7 +3021,8 @@ fn test_rebase_skip_if_on_destination() {
     ├─╯
     ○  a  rlvkpnrz  2443ea76
     ◆    zzzzzzzz  00000000
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -30,7 +30,7 @@ fn test_report_conflicts() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln f8a2c4e0 (conflict) (empty) (no description set)
     Parent commit      : kkmpptxz 2271a49e (conflict) C
@@ -45,11 +45,12 @@ fn test_report_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln d70c003d (empty) (no description set)
     Parent commit      : kkmpptxz 43e94449 C
@@ -57,13 +58,14 @@ fn test_report_conflicts() {
     Existing conflicts were resolved or abandoned from these commits:
       kkmpptxz hidden 2271a49e (conflict) C
       rlvkpnrz hidden b7d83633 (conflict) B
-    "###);
+    [EOF]
+    ");
 
     // Can get hint about multiple root commits
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-r=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Rebased 2 descendant commits
     Working copy now at: zsuskuln 588bd15c (conflict) (empty) (no description set)
@@ -80,27 +82,30 @@ fn test_report_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
 
     // Resolve one of the conflicts by (mostly) following the instructions
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["new", "rlvkpnrzqnoo"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 0485e30f (conflict) (empty) (no description set)
     Parent commit      : rlvkpnrz b42f84eb (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
-    "###);
+    [EOF]
+    ");
     std::fs::write(repo_path.join("file"), "resolved\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: yostqsxw f5a0cf8c (empty) (no description set)
     Parent commit      : rlvkpnrz 87370844 B
     Existing conflicts were resolved or abandoned from these commits:
       rlvkpnrz hidden b42f84eb (conflict) B
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -121,7 +126,7 @@ fn test_report_conflicts_with_divergent_commits() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(B)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln?? 4ca807ad (conflict) C2
@@ -138,11 +143,12 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 3 commits onto destination
     Working copy now at: zsuskuln?? f2d7a228 C2
     Parent commit      : kkmpptxz db069a22 B
@@ -151,13 +157,14 @@ fn test_report_conflicts_with_divergent_commits() {
       zsuskuln hidden 1db43f23 (conflict) C3
       zsuskuln hidden 4ca807ad (conflict) C2
       kkmpptxz hidden b42f84eb (conflict) B
-    "###);
+    [EOF]
+    ");
 
     // Same thing when rebasing the divergent commits one at a time
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(C2)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: zsuskuln?? 3c36afc9 (conflict) C2
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
@@ -171,12 +178,13 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["rebase", "-s=description(C3)", "-d=root()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     New conflicts appeared in these commits:
       zsuskuln?? e3ff827e (conflict) C3
@@ -185,30 +193,33 @@ fn test_report_conflicts_with_divergent_commits() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["rebase", "-s=description(C2)", "-d=description(B)"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Working copy now at: zsuskuln?? 1f9680bd C2
     Parent commit      : kkmpptxz db069a22 B
     Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from these commits:
       zsuskuln hidden 3c36afc9 (conflict) C2
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &["rebase", "-s=description(C3)", "-d=description(B)"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 commits onto destination
     Existing conflicts were resolved or abandoned from these commits:
       zsuskuln hidden e3ff827e (conflict) C3
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -54,7 +54,7 @@ fn test_resolution() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -62,11 +62,13 @@ fn test_resolution() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -88,18 +90,19 @@ fn test_resolution() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv e069f073 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
     --- a/file
@@ -113,11 +116,13 @@ fn test_resolution() {
     -b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     Error: No conflicts found at this revision
-    "###);
+    [EOF]
+    ");
 
     // Try again with --tool=<name>
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -131,15 +136,16 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 1a70c7c6 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]),
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
     --- a/file
@@ -153,11 +159,13 @@ fn test_resolution() {
     -b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]),
-    @r###"
+    @r"
     Error: No conflicts found at this revision
-    "###);
+    [EOF]
+    ");
 
     // Check that the output file starts with conflict markers if
     // `merge-tool-edits-conflict-markers=true`
@@ -187,7 +195,7 @@ fn test_resolution() {
     >>>>>>> Conflict 1 of 1 ends
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
     --- a/file
@@ -201,7 +209,8 @@ fn test_resolution() {
     -b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
-    "###);
+    [EOF]
+    ");
 
     // Check that if merge tool leaves conflict markers in output file and
     // `merge-tool-edits-conflict-markers=true`, these markers are properly parsed.
@@ -234,7 +243,7 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 608a2310 conflict | (conflict) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -249,7 +258,8 @@ fn test_resolution() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
     <<<<<<< Conflict 1 of 1
@@ -262,7 +272,7 @@ fn test_resolution() {
     "###);
     // Note the "Modified" below
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -277,11 +287,13 @@ fn test_resolution() {
     -b
     +conflict
      >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
 
     // Check that if merge tool leaves conflict markers in output file but
     // `merge-tool-edits-conflict-markers=false` or is not specified,
@@ -309,19 +321,20 @@ fn test_resolution() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 3166dfd2 conflict | conflict
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx db6a4daf b | b
     Added 0 files, modified 1 files, removed 0 files
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor3")).unwrap(), @r###"
     "###);
     // Note the "Resolved" below
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/file b/file
     index 0000000000..0610716cc1 100644
     --- a/file
@@ -341,11 +354,13 @@ fn test_resolution() {
     ++++++++
     +conflict
     +>>>>>>>
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     Error: No conflicts found at this revision
-    "###);
+    [EOF]
+    ");
 
     // Check that merge tool can override conflict marker style setting, and that
     // the merge tool can output Git-style conflict markers
@@ -379,7 +394,7 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 8e03fefa conflict | (conflict) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -394,7 +409,8 @@ fn test_resolution() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor4")).unwrap(), @r##"
     <<<<<<< Side #1 (Conflict 1 of 1)
@@ -406,7 +422,7 @@ fn test_resolution() {
     >>>>>>> Side #2 (Conflict 1 of 1 ends)
     "##);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -421,11 +437,13 @@ fn test_resolution() {
     -b
     +conflict
      >>>>>>> Conflict 1 of 1 ends
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
 
     // Check that merge tool can leave conflict markers by returning exit code 1
     // when using `merge-conflict-exit-codes = [1]`. The Git "diff3" conflict
@@ -460,7 +478,7 @@ fn test_resolution() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv a786ac2f conflict | (conflict) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -475,11 +493,12 @@ fn test_resolution() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor5")).unwrap(), @"");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -494,11 +513,13 @@ fn test_resolution() {
     -b
     +conflict
      >>>>>>> Conflict 1 of 1 ends
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
 
     // Check that an error is reported if a merge tool indicated it would leave
     // conflict markers, but the output file didn't contain valid conflict markers.
@@ -528,11 +549,12 @@ fn test_resolution() {
             "--config=merge-tools.fake-editor.merge-conflict-exit-codes=[1]",
         ],
     );
-    insta::assert_snapshot!(stderr.normalize_exit_status(), @r#"
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r"
     Resolving conflicts in: file
     Error: Failed to resolve conflicts
     Caused by: Tool exited with exit status: 1, but did not produce valid conflict markers (run with --debug to see the exact invocation)
-    "#);
+    [EOF]
+    ");
 
     // TODO: Check that running `jj new` and then `jj resolve -r conflict` works
     // correctly.
@@ -580,7 +602,7 @@ fn test_normal_conflict_input_files() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -588,11 +610,13 @@ fn test_normal_conflict_input_files() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -621,7 +645,7 @@ fn test_baseless_conflict_input_files() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -629,11 +653,13 @@ fn test_baseless_conflict_input_files() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -662,21 +688,24 @@ fn test_too_many_parents() {
     create_commit(&test_env, &repo_path, "c", &["base"], &[("file", "c\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b", "c"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    3-sided conflict
-    "###);
+    [EOF]
+    ");
     // Test warning color
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
-    @r###"
+    @r"
     file    [38;5;1m3-sided[38;5;3m conflict[39m
-    "###);
+    [EOF]
+    ");
 
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(error, @r###"
+    insta::assert_snapshot!(error, @r#"
     Hint: Using default editor ':builtin'; run `jj config set --user ui.merge-editor :builtin` to disable this message.
     Error: Failed to resolve conflicts
     Caused by: The conflict at "file" has 3 sides. At most 2 sides are supported.
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -712,15 +741,17 @@ fn test_simplify_conflict_sides() {
     // Even though the tree-level conflict is a 4-sided conflict, each file is
     // materialized as a 2-sided conflict.
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["debug", "tree"]),
-    @r###"
+    @r#"
     fileA: Ok(Conflicted([Some(File { id: FileId("d00491fd7e5bb6fa28c517a0bb32b8b506539d4d"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("0cfbf08886fca9a91cb753ec8734c84fcbe52c9f"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false })]))
     fileB: Ok(Conflicted([Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("d00491fd7e5bb6fa28c517a0bb32b8b506539d4d"), executable: false }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: false }), Some(File { id: FileId("0cfbf08886fca9a91cb753ec8734c84fcbe52c9f"), executable: false })]))
-    "###);
+    [EOF]
+    "#);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-    @r###"
+    @r"
     fileA    2-sided conflict
     fileB    2-sided conflict
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("fileA")).unwrap(), @r###"
     <<<<<<< Conflict 1 of 1
@@ -776,7 +807,7 @@ fn test_simplify_conflict_sides() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: fileB
     Working copy now at: nkmrtpmo 69cc0c2d conflict | (conflict) conflict
     Parent commit      : kmkuslsw 4601566f conflictA | (conflict) (empty) conflictA
@@ -792,7 +823,8 @@ fn test_simplify_conflict_sides() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r###"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
@@ -803,10 +835,11 @@ fn test_simplify_conflict_sides() {
     >>>>>>> Conflict 1 of 1 ends
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-    @r###"
+    @r"
     fileA    2-sided conflict
     fileB    2-sided conflict
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -821,7 +854,7 @@ fn test_edit_delete_conflict_input_files() {
     std::fs::remove_file(repo_path.join("file")).unwrap();
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -829,11 +862,13 @@ fn test_edit_delete_conflict_input_files() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict including 1 deletion
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -864,7 +899,7 @@ fn test_file_vs_dir() {
     // Without a placeholder file, `jj` ignores an empty directory
     std::fs::write(repo_path.join("file").join("placeholder"), "").unwrap();
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -872,14 +907,16 @@ fn test_file_vs_dir() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    2-sided conflict including a directory
-    "###);
+    [EOF]
+    ");
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(error, @r###"
+    insta::assert_snapshot!(error, @r#"
     Hint: Using default editor ':builtin'; run `jj config set --user ui.merge-editor :builtin` to disable this message.
     Error: Failed to resolve conflicts
     Caused by: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
@@ -888,7 +925,8 @@ fn test_file_vs_dir() {
       Adding file with id 78981922613b2afb6025042ff6bd878ac1994e85
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877
 
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -913,7 +951,7 @@ fn test_description_with_dir_and_deletion() {
         &["edit", "dir", "del"],
         &[],
     );
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @      conflict
     ├─┬─╮
     │ │ ○  del
@@ -923,19 +961,22 @@ fn test_description_with_dir_and_deletion() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     file    3-sided conflict including 1 deletion and a directory
-    "###);
+    [EOF]
+    ");
     // Test warning color. The deletion is fine, so it's not highlighted
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
-    @r###"
+    @r"
     file    [38;5;1m3-sided[38;5;3m conflict including 1 deletion and [38;5;1ma directory[39m
-    "###);
+    [EOF]
+    ");
     let error = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(error, @r###"
+    insta::assert_snapshot!(error, @r#"
     Hint: Using default editor ':builtin'; run `jj config set --user ui.merge-editor :builtin` to disable this message.
     Error: Failed to resolve conflicts
     Caused by: Only conflicts that involve normal files (not symlinks, not executable, etc.) are supported. Conflict summary for "file":
@@ -945,7 +986,8 @@ fn test_description_with_dir_and_deletion() {
       Adding file with id 61780798228d17af2d34fce4cfbdf35556832472
       Adding tree with id 133bb38fc4e4bf6b551f1f04db7e48f04cac2877
 
-    "###);
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -981,10 +1023,11 @@ fn test_resolve_conflicts_with_executable() {
     test_env.jj_cmd_ok(&repo_path, &["file", "chmod", "x", "file2"]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r#"
+    @r"
     file1    2-sided conflict including an executable
     file2    2-sided conflict including an executable
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file1")).unwrap(),
         @r##"
@@ -1015,7 +1058,7 @@ fn test_resolve_conflicts_with_executable() {
     std::fs::write(&editor_script, b"write\nresolution1\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "file1"]);
     insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file1
     Working copy now at: znkkpsqq eb159d56 conflict | (conflict) conflict
     Parent commit      : mzvwutvl 08932848 a | a
@@ -1030,9 +1073,10 @@ fn test_resolve_conflicts_with_executable() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100755
     --- a/file1
@@ -1046,10 +1090,14 @@ fn test_resolve_conflicts_with_executable() {
     -b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @"file2    2-sided conflict including an executable"
+        @r"
+    file2    2-sided conflict including an executable
+    [EOF]
+    "
     );
 
     // Test resolving the conflict in "file2", which should produce an executable
@@ -1057,7 +1105,7 @@ fn test_resolve_conflicts_with_executable() {
     std::fs::write(&editor_script, b"write\nresolution2\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "file2"]);
     insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file2
     Working copy now at: znkkpsqq 4dccbb3c conflict | (conflict) conflict
     Parent commit      : mzvwutvl 08932848 a | a
@@ -1072,9 +1120,10 @@ fn test_resolve_conflicts_with_executable() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file2 b/file2
     index 0000000000..775f078581 100755
     --- a/file2
@@ -1088,10 +1137,14 @@ fn test_resolve_conflicts_with_executable() {
     -b2
     ->>>>>>> Conflict 1 of 1 ends
     +resolution2
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @"file1    2-sided conflict including an executable"
+        @r"
+    file1    2-sided conflict including an executable
+    [EOF]
+    "
     );
 }
 
@@ -1128,7 +1181,10 @@ fn test_resolve_long_conflict_markers() {
     );
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @"file    2-sided conflict");
+    @r"
+    file    2-sided conflict
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file")).unwrap(),
         @r##"
@@ -1166,7 +1222,7 @@ fn test_resolve_long_conflict_markers() {
     .unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 2b985546 conflict | (conflict) conflict
     Parent commit      : zsuskuln 64177fd4 a | a
@@ -1181,9 +1237,10 @@ fn test_resolve_long_conflict_markers() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -1204,10 +1261,14 @@ fn test_resolve_long_conflict_markers() {
     ++++++++ Contents of side #2
     +B
     +>>>>>>> Conflict 1 of 1 ends
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @"file    2-sided conflict"
+        @r"
+    file    2-sided conflict
+    [EOF]
+    "
     );
 
     // If the merge tool edits the output file with materialized markers, the
@@ -1237,7 +1298,7 @@ fn test_resolve_long_conflict_markers() {
         ],
     );
     insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv fac9406d conflict | (conflict) conflict
     Parent commit      : zsuskuln 64177fd4 a | a
@@ -1252,7 +1313,8 @@ fn test_resolve_long_conflict_markers() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r##"
     <<<<<<<<<<< Conflict 1 of 1
@@ -1265,7 +1327,7 @@ fn test_resolve_long_conflict_markers() {
     >>>>>>>>>>> Conflict 1 of 1 ends
     "##);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -1281,10 +1343,14 @@ fn test_resolve_long_conflict_markers() {
     ->>>>>>> b
     +>>>>>>> B
      >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @"file    2-sided conflict"
+        @r"
+    file    2-sided conflict
+    [EOF]
+    "
     );
 
     // If the merge tool accepts the marker length as an argument, then the conflict
@@ -1314,7 +1380,7 @@ fn test_resolve_long_conflict_markers() {
         ],
     );
     insta::assert_snapshot!(stdout, @r#""#);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: file
     Working copy now at: vruxwmqv 1b29631a conflict | (conflict) conflict
     Parent commit      : zsuskuln 64177fd4 a | a
@@ -1329,9 +1395,10 @@ fn test_resolve_long_conflict_markers() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -1347,10 +1414,14 @@ fn test_resolve_long_conflict_markers() {
     ->>>>>>> b
     +>>>>>>> B
      >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @"file    2-sided conflict"
+        @r"
+    file    2-sided conflict
+    [EOF]
+    "
     );
 }
 
@@ -1401,7 +1472,7 @@ fn test_multiple_conflicts() {
     );
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -1409,7 +1480,8 @@ fn test_multiple_conflicts() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("this_file_has_a_very_long_name_to_test_padding")).unwrap()
         , @r###"
@@ -1433,16 +1505,18 @@ fn test_multiple_conflicts() {
     >>>>>>> Conflict 1 of 1 ends
     "###);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     another_file                        2-sided conflict
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
-    "###);
+    [EOF]
+    ");
     // Test colors
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list", "--color=always"]), 
-    @r###"
+    @r"
     another_file                        [38;5;3m2-sided conflict[39m
     this_file_has_a_very_long_name_to_test_padding [38;5;3m2-sided conflict[39m
-    "###);
+    [EOF]
+    ");
 
     let editor_script = test_env.set_up_fake_editor();
 
@@ -1450,7 +1524,7 @@ fn test_multiple_conflicts() {
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["resolve", "another_file"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Resolving conflicts in: another_file
     Working copy now at: vruxwmqv 309e981c conflict | (conflict) conflict
     Parent commit      : zsuskuln de7553ef a | a
@@ -1465,9 +1539,10 @@ fn test_multiple_conflicts() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/another_file b/another_file
     index 0000000000..a9fcc7d486 100644
     --- a/another_file
@@ -1481,11 +1556,13 @@ fn test_multiple_conflicts() {
     -second b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution another_file
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
-    "###);
+    [EOF]
+    ");
 
     // Repeat the above with the `--quiet` option.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -1512,7 +1589,7 @@ fn test_multiple_conflicts() {
     .unwrap();
     test_env.jj_cmd_ok(&repo_path, &["resolve"]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r###"
+    @r"
     diff --git a/another_file b/another_file
     index 0000000000..7903e1c1c7 100644
     --- a/another_file
@@ -1539,16 +1616,19 @@ fn test_multiple_conflicts() {
     -first b
     ->>>>>>> Conflict 1 of 1 ends
     +second resolution for auto-chosen file
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve", "--list"]), 
-    @r###"
+    @r"
     Error: No conflicts found at this revision
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_cli_error(&repo_path, &["resolve"]), 
-    @r###"
+    @r"
     Error: No conflicts found at this revision
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1585,10 +1665,11 @@ fn test_multiple_conflicts_with_error() {
     );
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]), 
-    @r#"
+    @r"
     file1    2-sided conflict
     file2    2-sided conflict
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file1")).unwrap(),
         @r##"
@@ -1622,7 +1703,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(stderr.normalize_exit_status(), @r#"
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r"
     Resolving conflicts in: file1
     Resolving conflicts in: file2
     Working copy now at: vruxwmqv d2f3f858 conflict | (conflict) conflict
@@ -1640,9 +1721,10 @@ fn test_multiple_conflicts_with_error() {
     Then run `jj squash` to move the resolution into the conflicted commit.
     Error: Stopped due to error after resolving 1 conflicts
     Caused by: The output file is either unchanged or empty after the editor quit (run with --debug to see the exact invocation).
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644
     --- a/file1
@@ -1656,10 +1738,14 @@ fn test_multiple_conflicts_with_error() {
     -b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @"file2    2-sided conflict"
+        @r"
+    file2    2-sided conflict
+    [EOF]
+    "
     );
 
     // Test resolving one conflict, then failing during the second resolution
@@ -1670,7 +1756,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(stderr.normalize_exit_status(), @r#"
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r"
     Resolving conflicts in: file1
     Resolving conflicts in: file2
     Working copy now at: vruxwmqv 0a54e8ed conflict | (conflict) conflict
@@ -1688,9 +1774,10 @@ fn test_multiple_conflicts_with_error() {
     Then run `jj squash` to move the resolution into the conflicted commit.
     Error: Stopped due to error after resolving 1 conflicts
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), 
-    @r##"
+    @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644
     --- a/file1
@@ -1704,27 +1791,33 @@ fn test_multiple_conflicts_with_error() {
     -b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
-    "##);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @"file2    2-sided conflict"
+        @r"
+    file2    2-sided conflict
+    [EOF]
+    "
     );
 
     // Test immediately failing to resolve any conflict
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&editor_script, "fail").unwrap();
     let stderr = test_env.jj_cmd_failure(&repo_path, &["resolve"]);
-    insta::assert_snapshot!(stderr.normalize_exit_status(), @r#"
+    insta::assert_snapshot!(stderr.normalize_exit_status(), @r"
     Resolving conflicts in: file1
     Error: Failed to resolve conflicts
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @"");
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["resolve", "--list"]),
-        @r#"
+        @r"
     file1    2-sided conflict
     file2    2-sided conflict
-    "#
+    [EOF]
+    "
     );
 }

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -33,33 +33,36 @@ fn test_restore() {
 
     // There is no `-r` argument
     let stderr = test_env.jj_cmd_failure(&repo_path, &["restore", "-r=@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: `jj restore` does not have a `--revision`/`-r` option. If you'd like to modify
     the *current* revision, use `--from`. If you'd like to modify a *different* revision,
     use `--into` or `--changes-in`.
-    "###);
+    [EOF]
+    ");
 
     // Restores from parent by default
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 370d81ea (empty) (no description set)
     Working copy now at: kkmpptxz 370d81ea (empty) (no description set)
     Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 1 files, modified 1 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
 
     // Can restore another revision from its parents
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     A file2
-    "###);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "-c=@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz b9b6011e (empty) (no description set)
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 5b361547 (conflict) (no description set)
@@ -74,7 +77,8 @@ fn test_restore() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r=@-"]);
     insta::assert_snapshot!(stdout, @"");
 
@@ -82,70 +86,78 @@ fn test_restore() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 1154634b (no description set)
     Working copy now at: kkmpptxz 1154634b (no description set)
     Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 1 files, modified 0 files, removed 2 files
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file2
-    "###);
+    [EOF]
+    ");
 
     // Can restore into other revision
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "--into", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz ad805965 (no description set)
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 3fcdcbf2 (empty) (no description set)
     Parent commit      : rlvkpnrz ad805965 (no description set)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     A file2
     A file3
-    "###);
+    [EOF]
+    ");
 
     // Can combine `--from` and `--into`
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["restore", "--from", "@", "--into", "@-"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created rlvkpnrz f256040a (no description set)
     Rebased 1 descendant commits
     Working copy now at: kkmpptxz 9c6f2083 (empty) (no description set)
     Parent commit      : rlvkpnrz f256040a (no description set)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
     insta::assert_snapshot!(stdout, @"");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s", "-r", "@-"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
     A file2
     A file3
-    "###);
+    [EOF]
+    ");
 
     // Can restore only specified paths
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "file2", "file3"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created kkmpptxz 4ad35a2f (no description set)
     Working copy now at: kkmpptxz 4ad35a2f (no description set)
     Parent commit      : rlvkpnrz ef160660 (no description set)
     Added 0 files, modified 1 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["diff", "-s"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     D file1
-    "###);
+    [EOF]
+    ");
 }
 
 // Much of this test is copied from test_resolve_command
@@ -160,7 +172,7 @@ fn test_restore_conflicted_merge() {
     create_commit(&test_env, &repo_path, "b", &["base"], &[("file", "b\n")]);
     create_commit(&test_env, &repo_path, "conflict", &["a", "b"], &[]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    conflict
     ├─╮
     │ ○  b
@@ -168,7 +180,8 @@ fn test_restore_conflicted_merge() {
     ├─╯
     ○  base
     ◆
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -184,7 +197,7 @@ fn test_restore_conflicted_merge() {
     // Overwrite the file...
     std::fs::write(repo_path.join("file"), "resolution").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
-    @r###"
+    @r"
     Resolved conflict in file:
        1     : <<<<<<< Conflict 1 of 1
        2     : %%%%%%% Changes from base to side #1
@@ -194,12 +207,13 @@ fn test_restore_conflicted_merge() {
        6     : b
        7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
-    "###);
+    [EOF]
+    ");
 
     // ...and restore it back again.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore", "file"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created vruxwmqv 25a37060 conflict | (conflict) (empty) conflict
     Working copy now at: vruxwmqv 25a37060 conflict | (conflict) (empty) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -207,7 +221,8 @@ fn test_restore_conflicted_merge() {
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -225,7 +240,7 @@ fn test_restore_conflicted_merge() {
     // The same, but without the `file` argument. Overwrite the file...
     std::fs::write(repo_path.join("file"), "resolution").unwrap();
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff"]), 
-    @r###"
+    @r"
     Resolved conflict in file:
        1     : <<<<<<< Conflict 1 of 1
        2     : %%%%%%% Changes from base to side #1
@@ -235,12 +250,13 @@ fn test_restore_conflicted_merge() {
        6     : b
        7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
-    "###);
+    [EOF]
+    ");
 
     // ... and restore it back again.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["restore"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created vruxwmqv f2c82b9c conflict | (conflict) (empty) conflict
     Working copy now at: vruxwmqv f2c82b9c conflict | (conflict) (empty) conflict
     Parent commit      : zsuskuln aa493daf a | a
@@ -248,7 +264,8 @@ fn test_restore_conflicted_merge() {
     Added 0 files, modified 1 files, removed 0 files
     There are unresolved conflicts at these paths:
     file    2-sided conflict
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
         , @r###"
@@ -285,7 +302,7 @@ fn test_restore_restore_descendants() {
         &[("file", "ab\n")],
     );
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    ab
     ├─╮
     │ ○  b
@@ -293,7 +310,8 @@ fn test_restore_restore_descendants() {
     ├─╯
     ○  base
     ◆
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap(), @r#"
     ab
@@ -306,13 +324,14 @@ fn test_restore_restore_descendants() {
         &["restore", "-c", "b", "file", "--restore-descendants"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Created royxmykx 3fd5aa05 b | b
     Rebased 1 descendant commits (while preserving their content)
     Working copy now at: vruxwmqv bf5491a0 ab | ab
     Parent commit      : zsuskuln aa493daf a | a
     Parent commit      : royxmykx 3fd5aa05 b | b
-    "#);
+    [EOF]
+    ");
 
     // Check that "a", "b", and "ab" have their expected content by diffing them.
     // "ab" must have kept its content.
@@ -331,8 +350,9 @@ fn test_restore_restore_descendants() {
     +++ b/file2
     @@ -0,0 +1,1 @@
     +b
+    [EOF]
     ");
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--from=b", "--to=ab", "--git"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--from=b", "--to=ab", "--git"]), @r"
     diff --git a/file b/file
     index df967b96a5..81bf396956 100644
     --- a/file
@@ -340,7 +360,8 @@ fn test_restore_restore_descendants() {
     @@ -1,1 +1,1 @@
     -base
     +ab
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -375,6 +396,7 @@ fn test_restore_interactive() {
     │  A file1
     │  A file2
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 
     let diff_editor = test_env.set_up_fake_diff_editor();
@@ -394,6 +416,7 @@ fn test_restore_interactive() {
     Working copy now at: zsuskuln bccde490 b | b
     Parent commit      : rlvkpnrz 186caaef a | a
     Added 0 files, modified 1 files, removed 1 files
+    [EOF]
     ");
 
     insta::assert_snapshot!(
@@ -415,6 +438,7 @@ fn test_restore_interactive() {
     │  A file1
     │  A file2
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 
     // Try again with --tool, which should imply --interactive
@@ -425,6 +449,7 @@ fn test_restore_interactive() {
     Working copy now at: zsuskuln 5921de19 b | b
     Parent commit      : rlvkpnrz 186caaef a | a
     Added 0 files, modified 1 files, removed 1 files
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--summary"]);
@@ -437,6 +462,7 @@ fn test_restore_interactive() {
     │  A file1
     │  A file2
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 }
 
@@ -469,6 +495,7 @@ fn test_restore_interactive_merge() {
     ├─╯  a
     │    A file1
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 
     let diff_editor = test_env.set_up_fake_diff_editor();
@@ -489,6 +516,7 @@ fn test_restore_interactive_merge() {
     Parent commit      : rlvkpnrz 79c1b823 a | a
     Parent commit      : zsuskuln 29e70804 b | b
     Added 0 files, modified 1 files, removed 1 files
+    [EOF]
     ");
 
     insta::assert_snapshot!(
@@ -513,6 +541,7 @@ fn test_restore_interactive_merge() {
     ├─╯  a
     │    A file1
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 }
 
@@ -548,6 +577,7 @@ fn test_restore_interactive_with_paths() {
     │  A file1
     │  A file2
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 
     let diff_editor = test_env.set_up_fake_diff_editor();
@@ -566,6 +596,7 @@ fn test_restore_interactive_with_paths() {
     Working copy now at: zsuskuln 7187da33 b | b
     Parent commit      : rlvkpnrz 186caaef a | a
     Added 0 files, modified 1 files, removed 0 files
+    [EOF]
     ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--summary"]);
@@ -579,6 +610,7 @@ fn test_restore_interactive_with_paths() {
     │  A file1
     │  A file2
     ◆  zzzzzzzz root() 00000000
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -601,6 +602,6 @@ fn create_commit(
     test_env.jj_cmd_ok(repo_path, &["bookmark", "create", "-r@", name]);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     test_env.jj_cmd_success(repo_path, &["log", "-T", "bookmarks"])
 }

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -30,10 +30,11 @@ fn test_syntax_error() {
       |
       = `:` is not a prefix operator
     Hint: Did you mean `::` for ancestors?
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "x &"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Syntax error
     Caused by:  --> 1:4
       |
@@ -41,7 +42,8 @@ fn test_syntax_error() {
       |    ^---
       |
       = expected `::`, `..`, `~`, or <primary>
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "x - y"]);
     insta::assert_snapshot!(stderr, @r"
@@ -53,6 +55,7 @@ fn test_syntax_error() {
       |
       = `-` is not an infix operator
     Hint: Did you mean `~` for difference?
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "HEAD^"]);
@@ -65,6 +68,7 @@ fn test_syntax_error() {
       |
       = `^` is not a postfix operator
     Hint: Did you mean `-` for parents?
+    [EOF]
     ");
 }
 
@@ -83,6 +87,7 @@ fn test_bad_function_call() {
       |     ^---------^
       |
       = Function `all`: Expected 0 arguments
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "parents()"]);
@@ -94,6 +99,7 @@ fn test_bad_function_call() {
       |         ^
       |
       = Function `parents`: Expected 1 arguments
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "parents(foo, bar)"]);
@@ -105,6 +111,7 @@ fn test_bad_function_call() {
       |         ^------^
       |
       = Function `parents`: Expected 1 arguments
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "heads(foo, bar)"]);
@@ -116,10 +123,11 @@ fn test_bad_function_call() {
       |       ^------^
       |
       = Function `heads`: Expected 1 arguments
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "latest(a, not_an_integer)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Expected expression of type integer
     Caused by:  --> 1:11
       |
@@ -127,7 +135,8 @@ fn test_bad_function_call() {
       |           ^------------^
       |
       = Expected expression of type integer
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "files()"]);
     insta::assert_snapshot!(stderr, @r"
@@ -138,10 +147,11 @@ fn test_bad_function_call() {
       |       ^
       |
       = Function `files`: Expected at least 1 arguments
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "files(not::a-fileset)"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: In fileset expression
     Caused by:
     1:  --> 1:7
@@ -157,7 +167,8 @@ fn test_bad_function_call() {
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
     Hint: See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
-    "#);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", r#"files(foo:"bar")"#]);
     insta::assert_snapshot!(stderr, @r#"
@@ -176,10 +187,11 @@ fn test_bad_function_call() {
       |
       = Invalid file pattern
     3: Invalid file pattern kind `foo:`
+    [EOF]
     "#);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", r#"files(a, "../out")"#]);
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Error: Failed to parse revset: In fileset expression
     Caused by:
     1:  --> 1:10
@@ -196,7 +208,8 @@ fn test_bad_function_call() {
       = Invalid file pattern
     3: Path "../out" is not in the repo "."
     4: Invalid component ".." in repo-relative path "../out"
-    "###);
+    [EOF]
+    "#);
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "bookmarks(bad:pattern)"]);
     insta::assert_snapshot!(stderr, @r"
@@ -210,10 +223,11 @@ fn test_bad_function_call() {
       = Invalid string pattern
     2: Invalid string pattern kind `bad:`
     Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, or `substring:`
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "bookmarks(regex:'(')"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Invalid string pattern
     Caused by:
     1:  --> 1:11
@@ -226,7 +240,8 @@ fn test_bad_function_call() {
         (
         ^
     error: unclosed group
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root()::whatever()"]);
     insta::assert_snapshot!(stderr, @r"
@@ -237,6 +252,7 @@ fn test_bad_function_call() {
       |         ^------^
       |
       = Function `whatever` doesn't exist
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(
@@ -251,6 +267,7 @@ fn test_bad_function_call() {
       |                        ^------^
       |
       = Function `remote_bookmarks`: Got multiple values for keyword "remote"
+    [EOF]
     "#);
 
     let stderr =
@@ -263,6 +280,7 @@ fn test_bad_function_call() {
       |                            ^
       |
       = Function `remote_bookmarks`: Positional argument follows keyword argument
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_bookmarks(=foo)"]);
@@ -274,10 +292,11 @@ fn test_bad_function_call() {
       |                  ^---
       |
       = expected <strict_identifier> or <expression>
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "remote_bookmarks(remote=)"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to parse revset: Syntax error
     Caused by:  --> 1:25
       |
@@ -285,7 +304,8 @@ fn test_bad_function_call() {
       |                         ^---
       |
       = expected <expression>
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -304,7 +324,7 @@ fn test_parse_warning() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: In revset expression
      --> 1:1
       |
@@ -333,11 +353,12 @@ fn test_parse_warning() {
       |                                                              ^-----------------------^
       |
       = untracked_remote_branches() is deprecated; use untracked_remote_bookmarks() instead
-    "#);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "files(foo, bar)"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Warning: In revset expression
      --> 1:7
       |
@@ -345,7 +366,8 @@ fn test_parse_warning() {
       |       ^------^
       |
       = Multi-argument patterns syntax is deprecated; separate them with |
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -375,6 +397,7 @@ fn test_function_name_hint() {
       |
       = Function `bookmark` doesn't exist
     Hint: Did you mean `bookmarks`, `remote_bookmarks`?
+    [EOF]
     ");
 
     // Both builtin function and function alias should be suggested
@@ -387,6 +410,7 @@ fn test_function_name_hint() {
       |
       = Function `author_` doesn't exist
     Hint: Did you mean `author`, `author_date`, `author_email`, `author_name`, `my_author`?
+    [EOF]
     ");
 
     insta::assert_snapshot!(evaluate_err("my_bookmarks"), @r"
@@ -405,6 +429,7 @@ fn test_function_name_hint() {
       |
       = Function `bookmark` doesn't exist
     Hint: Did you mean `bookmarks`, `remote_bookmarks`?
+    [EOF]
     ");
 }
 
@@ -429,14 +454,16 @@ fn test_alias() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "my-root"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "identity(my-root)"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root() & syntax-error"]);
     insta::assert_snapshot!(stderr, @r"
@@ -454,6 +481,7 @@ fn test_alias() {
       |           ^---
       |
       = expected `::`, `..`, `~`, or <primary>
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "identity()"]);
@@ -465,6 +493,7 @@ fn test_alias() {
       |          ^
       |
       = Function `identity`: Expected 1 arguments
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "my_author(none())"]);
@@ -489,6 +518,7 @@ fn test_alias() {
       |           ^----^
       |
       = Expected expression of string pattern
+    [EOF]
     ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["log", "-r", "root() & recurse"]);
@@ -519,6 +549,7 @@ fn test_alias() {
       | ^-----^
       |
       = Alias `recurse` expanded recursively
+    [EOF]
     ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "deprecated()"]);
@@ -537,6 +568,7 @@ fn test_alias() {
       | ^------^
       |
       = branches() is deprecated; use bookmarks() instead
+    [EOF]
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "all:deprecated()"]);
     insta::assert_snapshot!(stdout, @"");
@@ -554,6 +586,7 @@ fn test_alias() {
       | ^------^
       |
       = branches() is deprecated; use bookmarks() instead
+    [EOF]
     ");
 }
 
@@ -576,7 +609,10 @@ fn test_alias_override() {
         &repo_path,
         &["log", "-r", "f(_)", "--config=revset-aliases.'f(a)'=arg"],
     );
-    insta::assert_snapshot!(stderr, @"Error: Revision `arg` doesn't exist");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Revision `arg` doesn't exist
+    [EOF]
+    ");
 }
 
 #[test]
@@ -596,9 +632,10 @@ fn test_bad_alias_decl() {
 
     // Invalid declaration should be warned and ignored.
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["log", "-r", "my-root"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @r#"
     Warning: Failed to load `revset-aliases."bad"`:  --> 1:1
       |
@@ -612,6 +649,7 @@ fn test_bad_alias_decl() {
       |       ^--^
       |
       = Redefinition of function parameter
+    [EOF]
     "#);
 }
 
@@ -629,39 +667,45 @@ fn test_all_modifier() {
       qpvuntsm 230dd059 (empty) (no description set)
       zzzzzzzz 00000000 (empty) (no description set)
     Hint: Prefix the expression with `all:` to allow any number of revisions (i.e. `all:all()`).
+    [EOF]
     ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "all:all()"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
-    "###);
+    [EOF]
+    ");
 
     // Command that accepts multiple revisions by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-rall:all()"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     // Command that accepts only single revision
     let (_stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-rall:@", "x"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Created 1 bookmarks pointing to qpvuntsm 230dd059 x | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["bookmark", "set", "-rall:all()", "x"]);
     insta::assert_snapshot!(stderr, @r"
     Error: Revset `all:all()` resolved to more than one revision
     Hint: The revset `all:all()` resolved to these revisions:
       qpvuntsm 230dd059 x | (empty) (no description set)
       zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
 
     // Template expression that accepts multiple revisions by default
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-Tself.contained_in('all:all()')"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  true
     ◆  true
-    "###);
+    [EOF]
+    ");
 
     // Typo
     let stderr = test_env.jj_cmd_failure(&repo_path, &["new", "ale:x"]);
@@ -673,6 +717,7 @@ fn test_all_modifier() {
       | ^-^
       |
       = Modifier `ale` doesn't exist
+    [EOF]
     ");
 
     // Modifier shouldn't be allowed in sub expression
@@ -695,6 +740,7 @@ fn test_all_modifier() {
       | ^-^
       |
       = Modifier `all:` is not allowed in sub expression
+    [EOF]
     ");
 
     // immutable_heads() alias may be parsed as a top-level expression, but
@@ -716,6 +762,7 @@ fn test_all_modifier() {
       |
       = Modifier `all:` is not allowed in sub expression
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 }
 
@@ -797,43 +844,53 @@ fn test_revset_committer_date_with_time_zone() {
 
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-25 12:00", "2023-02-01T00:00:00-05:00", NEW_YORK);
-    insta::assert_snapshot!(before_log, @r###"
+    insta::assert_snapshot!(before_log, @r"
     first 2023-01-25 11:30:00.000 -05:00
-    "###);
-    insta::assert_snapshot!(after_log, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(after_log, @r"
     third 2023-01-25 13:30:00.000 -05:00
     second 2023-01-25 12:30:00.000 -05:00
-    "###);
+    [EOF]
+    ");
 
     // Switch to DST and ensure we get the same results, because it should
     // evaluate 12:00 on commit date, not the current date
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-25 12:00", "2023-06-01T00:00:00-04:00", NEW_YORK);
-    insta::assert_snapshot!(before_log, @r###"
+    insta::assert_snapshot!(before_log, @r"
     first 2023-01-25 11:30:00.000 -05:00
-    "###);
-    insta::assert_snapshot!(after_log, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(after_log, @r"
     third 2023-01-25 13:30:00.000 -05:00
     second 2023-01-25 12:30:00.000 -05:00
-    "###);
+    [EOF]
+    ");
 
     // Change the local time zone and ensure the result changes
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-25 12:00", "2023-06-01T00:00:00-06:00", CHICAGO);
-    insta::assert_snapshot!(before_log, @r###"
+    insta::assert_snapshot!(before_log, @r"
     second 2023-01-25 12:30:00.000 -05:00
     first 2023-01-25 11:30:00.000 -05:00
-    "###);
-    insta::assert_snapshot!(after_log, @"third 2023-01-25 13:30:00.000 -05:00");
+    [EOF]
+    ");
+    insta::assert_snapshot!(after_log, @r"
+    third 2023-01-25 13:30:00.000 -05:00
+    [EOF]
+    ");
 
     // Time zone far outside USA with no DST
     let (before_log, after_log) =
         log_commits_before_and_after("2023-01-26 03:00", "2023-06-01T00:00:00+10:00", AUSTRALIA);
-    insta::assert_snapshot!(before_log, @r###"
+    insta::assert_snapshot!(before_log, @r"
     first 2023-01-25 11:30:00.000 -05:00
-    "###);
-    insta::assert_snapshot!(after_log, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(after_log, @r"
     third 2023-01-25 13:30:00.000 -05:00
     second 2023-01-25 12:30:00.000 -05:00
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_root.rs
+++ b/cli/tests/test_root.rs
@@ -36,7 +36,8 @@ fn test_root(backend: TestRepoBackend) {
 fn test_root_outside_a_repo() {
     let test_env = TestEnvironment::default();
     let stdout = test_env.jj_cmd_failure(Path::new("/"), &["root"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r#"
     Error: There is no jj repo in "."
-    "###);
+    [EOF]
+    "#);
 }

--- a/cli/tests/test_root.rs
+++ b/cli/tests/test_root.rs
@@ -29,7 +29,7 @@ fn test_root(backend: TestRepoBackend) {
     let subdir = root.join("subdir");
     std::fs::create_dir(&subdir).unwrap();
     let stdout = test_env.jj_cmd_success(&subdir, &["root"]);
-    assert_eq!(&stdout, &[root.to_str().unwrap(), "\n"].concat());
+    assert_eq!(stdout.raw(), &[root.to_str().unwrap(), "\n"].concat());
 }
 
 #[test]

--- a/cli/tests/test_shell_completion.rs
+++ b/cli/tests/test_shell_completion.rs
@@ -23,10 +23,11 @@ fn test_deprecated_flags() {
         test_env.jj_cmd_ok(test_env.env_root(), &["util", "completion", "--bash"]);
     assert_snapshot!(
         stderr,
-        @r###"
+        @r"
     Warning: `jj util completion --bash` will be removed in a future version, and this will be a hard error
     Hint: Use `jj util completion bash` instead
-    "###
+    [EOF]
+    "
     );
     assert!(stdout.raw().contains("COMPREPLY"));
 }

--- a/cli/tests/test_shell_completion.rs
+++ b/cli/tests/test_shell_completion.rs
@@ -28,5 +28,5 @@ fn test_deprecated_flags() {
     Hint: Use `jj util completion bash` instead
     "###
     );
-    assert!(stdout.contains("COMPREPLY"));
+    assert!(stdout.raw().contains("COMPREPLY"));
 }

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -25,12 +25,14 @@ fn test_show() {
     let stdout = test_env.jj_cmd_success(&repo_path, &["show"]);
     let stdout = stdout.normalize_with(|s| s.split_inclusive('\n').skip(2).collect());
 
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:07)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:07)
 
         (no description set)
-    "#);
+
+    [EOF]
+    ");
 }
 
 #[test]
@@ -47,7 +49,7 @@ fn test_show_basic() {
     std::fs::write(repo_path.join("file3"), "foo\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -60,10 +62,11 @@ fn test_show_basic() {
             2: bar
        2    3: baz quxquux
     Modified regular file file3 (file1 => file3):
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--context=0"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -76,10 +79,11 @@ fn test_show_basic() {
             2: bar
        2    3: baz quxquux
     Modified regular file file3 (file1 => file3):
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: [38;5;4m<<commit_id::e34f04317a81edc6ba41fef239c0d0180f10656f>>[39m
     Change ID: [38;5;5m<<change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m
     Author   : [38;5;3m<<author name::Test User>>[39m <[38;5;3m<<author email local::test.user>><<author email::@>><<author email domain::example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
@@ -92,10 +96,11 @@ fn test_show_basic() {
     <<diff::     >>[38;5;2m<<diff added line_number::   2>>[39m<<diff::: >>[4m[38;5;2m<<diff added token::bar>>[24m[39m
     [38;5;1m<<diff removed line_number::   2>>[39m<<diff:: >>[38;5;2m<<diff added line_number::   3>>[39m<<diff::: baz >>[4m[38;5;1m<<diff removed token::qux>>[38;5;2m<<diff added token::quux>>[24m[39m<<diff::>>
     [38;5;3m<<diff header::Modified regular file file3 (file1 => file3):>>[39m
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-s"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -105,10 +110,11 @@ fn test_show_basic() {
 
     M file2
     R {file1 => file3}
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--types"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -118,10 +124,11 @@ fn test_show_basic() {
 
     FF file2
     FF {file1 => file3}
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -141,10 +148,11 @@ fn test_show_basic() {
     diff --git a/file1 b/file3
     rename from file1
     rename to file3
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--git", "--context=0"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -163,10 +171,11 @@ fn test_show_basic() {
     diff --git a/file1 b/file3
     rename from file1
     rename to file3
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--git", "--color=debug"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: [38;5;4m<<commit_id::e34f04317a81edc6ba41fef239c0d0180f10656f>>[39m
     Change ID: [38;5;5m<<change_id::rlvkpnrzqnoowoytxnquwvuryrwnrmlp>>[39m
     Author   : [38;5;3m<<author name::Test User>>[39m <[38;5;3m<<author email local::test.user>><<author email::@>><<author email domain::example.com>>[39m> ([38;5;6m<<author timestamp local format::2001-02-03 08:05:09>>[39m)
@@ -186,10 +195,11 @@ fn test_show_basic() {
     [1m<<diff file_header::diff --git a/file1 b/file3>>[0m
     [1m<<diff file_header::rename from file1>>[0m
     [1m<<diff file_header::rename to file3>>[0m
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-s", "--git"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -211,10 +221,11 @@ fn test_show_basic() {
     diff --git a/file1 b/file3
     rename from file1
     rename to file3
-    "#);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "--stat"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Commit ID: e34f04317a81edc6ba41fef239c0d0180f10656f
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
@@ -225,7 +236,8 @@ fn test_show_basic() {
     file2            | 3 ++-
     {file1 => file3} | 0
     2 files changed, 2 insertions(+), 1 deletion(-)
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -237,9 +249,10 @@ fn test_show_with_template() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["show", "-T", "description"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a new commit
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -270,6 +283,7 @@ fn test_show_with_no_template() {
     - description_placeholder
     - email_placeholder
     - name_placeholder
+    [EOF]
     ");
 }
 
@@ -295,10 +309,12 @@ fn test_show_relative_timestamps() {
             .collect()
     });
 
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Author   : Test User <test.user@example.com> (...timestamp...)
     Committer: Test User <test.user@example.com> (...timestamp...)
 
         (no description set)
-    "#);
+
+    [EOF]
+    ");
 }

--- a/cli/tests/test_sparse_command.rs
+++ b/cli/tests/test_sparse_command.rs
@@ -31,16 +31,18 @@ fn test_sparse_manage_patterns() {
 
     // By default, all files are tracked
     let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     .
-    "###);
+    [EOF]
+    ");
 
     // Can stop tracking all files
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["sparse", "set", "--remove", "."]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Added 0 files, modified 0 files, removed 3 files
-    "###);
+    [EOF]
+    ");
     // The list is now empty
     let stdout = test_env.jj_cmd_success(&repo_path, &["sparse", "list"]);
     insta::assert_snapshot!(stdout, @"");
@@ -50,11 +52,12 @@ fn test_sparse_manage_patterns() {
     assert!(!repo_path.join("file3").exists());
     // But they're still in the commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1
     file2
     file3
-    "###);
+    [EOF]
+    ");
 
     // Run commands in sub directory to ensure that patterns are parsed as
     // workspace-relative paths, not cwd-relative ones.
@@ -63,11 +66,12 @@ fn test_sparse_manage_patterns() {
 
     // Not a workspace-relative path
     let stderr = test_env.jj_cmd_cli_error(&sub_dir, &["sparse", "set", "--add=../file2"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r#"
     error: invalid value '../file2' for '--add <ADD>': Invalid component ".." in repo-relative path "../file2"
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    "#);
 
     // Can `--add` a few files
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -75,14 +79,16 @@ fn test_sparse_manage_patterns() {
         &["sparse", "set", "--add", "file2", "--add", "file3"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Added 2 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2
     file3
-    "###);
+    [EOF]
+    ");
     assert!(!repo_path.join("file1").exists());
     assert!(repo_path.join("file2").exists());
     assert!(repo_path.join("file3").exists());
@@ -95,13 +101,15 @@ fn test_sparse_manage_patterns() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Added 1 files, modified 0 files, removed 2 files
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1
-    "###);
+    [EOF]
+    ");
     assert!(repo_path.join("file1").exists());
     assert!(!repo_path.join("file2").exists());
     assert!(!repo_path.join("file3").exists());
@@ -110,13 +118,15 @@ fn test_sparse_manage_patterns() {
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&sub_dir, &["sparse", "set", "--clear", "--add", "file2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Added 1 files, modified 0 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2
-    "###);
+    [EOF]
+    ");
     assert!(!repo_path.join("file1").exists());
     assert!(repo_path.join("file2").exists());
     assert!(!repo_path.join("file3").exists());
@@ -124,13 +134,15 @@ fn test_sparse_manage_patterns() {
     // Can reset back to all files
     let (stdout, stderr) = test_env.jj_cmd_ok(&sub_dir, &["sparse", "reset"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Added 2 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     .
-    "###);
+    [EOF]
+    ");
     assert!(repo_path.join("file1").exists());
     assert!(repo_path.join("file2").exists());
     assert!(repo_path.join("file3").exists());
@@ -149,30 +161,34 @@ fn test_sparse_manage_patterns() {
     edit_patterns(&["file1"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&sub_dir, &["sparse", "edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Added 0 files, modified 0 files, removed 2 files
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(read_patterns(), @".");
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file1
-    "###);
+    [EOF]
+    ");
 
     // Can edit with multiple files
     edit_patterns(&["file3", "file2", "file3"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&sub_dir, &["sparse", "edit"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Added 2 files, modified 0 files, removed 1 files
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(read_patterns(), @r###"
     file1
     "###);
     let stdout = test_env.jj_cmd_success(&sub_dir, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     file2
     file3
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -17,19 +17,20 @@ use std::path::PathBuf;
 
 use test_case::test_case;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
-fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     let template = r#"separate(" ", change_id.short(), empty, local_bookmarks, description)"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template])
 }
 
-fn get_workspace_log_output(test_env: &TestEnvironment, cwd: &Path) -> String {
+fn get_workspace_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {
     let template = r#"separate(" ", change_id.short(), working_copies, description)"#;
     test_env.jj_cmd_success(cwd, &["log", "-T", template, "-r", "all()"])
 }
 
-fn get_recorded_dates(test_env: &TestEnvironment, cwd: &Path, revset: &str) -> String {
+fn get_recorded_dates(test_env: &TestEnvironment, cwd: &Path, revset: &str) -> CommandOutputString {
     let template = r#"separate("\n", "Author date:  " ++ author.timestamp(), "Committer date: " ++ committer.timestamp())"#;
     test_env.jj_cmd_success(cwd, &["log", "--no-graph", "-T", template, "-r", revset])
 }

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -1001,7 +1002,7 @@ fn test_squash_from_multiple_partial_no_op() {
     "###);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"separate(
         " ",
         commit_id.short(),
@@ -1225,14 +1226,17 @@ fn test_squash_use_destination_message_and_message_mutual_exclusion() {
     "###);
 }
 
-fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> String {
+fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> CommandOutputString {
     test_env.jj_cmd_success(
         repo_path,
         &["log", "--no-graph", "-T", "description", "-r", rev],
     )
 }
 
-fn get_log_output_with_description(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output_with_description(
+    test_env: &TestEnvironment,
+    repo_path: &Path,
+) -> CommandOutputString {
     let template = r#"separate(" ", commit_id.short(), description)"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -33,53 +33,61 @@ fn test_squash() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  382c9bad7d42 c
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     // Squashes the working copy into the parent by default
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv f7bb78d8 (empty) (no description set)
     Parent commit      : kkmpptxz 59f44460 b c | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  f7bb78d8da62 (empty)
     ○  59f4446070a0 b c
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 
     // Can squash a given commit into its parent
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl 1d70f50a c | (no description set)
     Parent commit      : qpvuntsm 9146bcc8 a b | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  1d70f50afa6d c
     ○  9146bcc8d996 a b
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 
     // Cannot squash a merge commit (because it's unclear which parent it should go
     // into)
@@ -90,7 +98,7 @@ fn test_squash() {
     std::fs::write(repo_path.join("file2"), "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "c", "d"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "e"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    41219719ab5f e (empty)
     ├─╮
     │ ○  f86e2b3af3e3 d
@@ -99,23 +107,26 @@ fn test_squash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Error: Cannot squash merge commits without a specified destination
     Hint: Use `--into` to specify which parent to squash into
-    "#);
+    [EOF]
+    ");
 
     // Can squash into a merge commit
     test_env.jj_cmd_ok(&repo_path, &["new", "e"]);
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: xlzxqlsl b50b843d (empty) (no description set)
     Parent commit      : nmzmmopx 338cbc05 e | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b50b843d8555 (empty)
     ○    338cbc05e4e6 e
     ├─╮
@@ -125,11 +136,13 @@ fn test_squash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "e"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     e
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -150,12 +163,13 @@ fn test_squash_partial() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a0b1a272ebc4 c
     ○  d117da276a0f b
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     // If we don't make any changes in the diff-editor, the whole change is moved
     // into the parent
@@ -163,11 +177,12 @@ fn test_squash_partial() {
     std::fs::write(&edit_script, "dump JJ-INSTRUCTIONS instrs").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl 3c633226 c | (no description set)
     Parent commit      : qpvuntsm 38ffd8b9 a b | (no description set)
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
@@ -183,48 +198,56 @@ fn test_squash_partial() {
     from the source will be moved into the destination.
     "###);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  3c6332267ea8 c
     ○  38ffd8b98578 a b
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
 
     // Can squash only some changes in interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&edit_script, "reset file1").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: mzvwutvl 57c3cf20 c | (no description set)
     Parent commit      : kkmpptxz c4925e01 b | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  57c3cf20d0b1 c
     ○  c4925e01d298 b
     ○  1fc159063ed3 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
 
     // Can squash only some changes in non-interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -232,41 +255,48 @@ fn test_squash_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "file2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: mzvwutvl 64d7ad7c c | (no description set)
     Parent commit      : kkmpptxz 60a26452 b | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  64d7ad7c43c1 c
     ○  60a264527aee b
     ○  7314692d32e3 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
 
     // If we specify only a non-existent file, then nothing changes.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 
     // We get a warning if we pass a positional argument that looks like a revset
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -274,6 +304,7 @@ fn test_squash_partial() {
     insta::assert_snapshot!(stderr, @r#"
     Warning: The argument "b" is being interpreted as a fileset expression. To specify a revset, pass -r "b" instead.
     Nothing changed.
+    [EOF]
     "#);
     insta::assert_snapshot!(stdout, @"");
 }
@@ -294,31 +325,35 @@ fn test_squash_keep_emptied() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  382c9bad7d42 c
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-r", "b", "--keep-emptied"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: mzvwutvl 7ee7f18a c | (no description set)
     Parent commit      : kkmpptxz 9490bd7f b | (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     // With --keep-emptied, b remains even though it is now empty.
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  7ee7f18a5223 c
     ○  9490bd7f1e6a b (empty)
     ○  53bf93080518 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -359,7 +394,7 @@ fn test_squash_from_to() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "f"]);
     std::fs::write(repo_path.join("file2"), "f\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a847ab4967fe f
     ○  c2f9de87325d e
     ○  e0dac715116f d
@@ -368,23 +403,26 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     // Errors out if source and destination are the same
     let stderr = test_env.jj_cmd_failure(&repo_path, &["squash", "--into", "@"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Source and destination cannot be the same
-    "###);
+    [EOF]
+    ");
 
     // Can squash from sibling, which results in the source being abandoned
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kmkuslsw b902d1dd f | (no description set)
     Parent commit      : znkkpsqq c2f9de87 e | (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b902d1dd59d9 f
     ○  c2f9de87325d e
     ○  e0dac715116f d
@@ -392,29 +430,33 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     // File `file2`, which was not changed in source, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     f
-    "###);
+    [EOF]
+    ");
 
     // Can squash from ancestor
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "@--"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kmkuslsw cfc5eb87 f | (no description set)
     Parent commit      : znkkpsqq 4dc7c279 e | (no description set)
-    "###);
+    [EOF]
+    ");
     // The change has been removed from the source (the change pointed to by 'd'
     // became empty and was abandoned)
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  cfc5eb876eb1 f
     ○  4dc7c27994bd e
     │ ○  59597b34a0d8 c
@@ -422,27 +464,30 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a d
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The change from the source has been applied (the file contents were already
     // "f", as is typically the case when moving changes from an ancestor)
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     f
-    "###);
+    [EOF]
+    ");
 
     // Can squash from descendant
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "e", "--into", "d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: kmkuslsw 6de62c22 f | (no description set)
     Parent commit      : vruxwmqv 32196a11 d e | (no description set)
-    "###);
+    [EOF]
+    ");
     // The change has been removed from the source (the change pointed to by 'e'
     // became empty and was abandoned)
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6de62c22fa07 f
     ○  32196a117ee3 d e
     │ ○  59597b34a0d8 c
@@ -450,12 +495,14 @@ fn test_squash_from_to() {
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "d"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     e
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -486,80 +533,91 @@ fn test_squash_from_to_partial() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "d"]);
     std::fs::write(repo_path.join("file3"), "d\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e0dac715116f d
     │ ○  087591be5a01 c
     │ ○  12d6103dc0c8 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     let edit_script = test_env.set_up_fake_diff_editor();
 
     // If we don't make any changes in the diff-editor, the whole change is moved
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 987bcfb2 d | (no description set)
     Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 2 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  987bcfb2eb62 d
     │ ○  12d6103dc0c8 b c
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The changes from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     // File `file3`, which was not changed in source, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     d
-    "###);
+    [EOF]
+    ");
 
     // Can squash only part of the change in interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(&edit_script, "reset file2").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "-i", "--from", "c"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 576244e8 d | (no description set)
     Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  576244e87883 d
     │ ○  6f486f2f4539 c
     │ ○  12d6103dc0c8 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     // The unselected change from the source has not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     // File `file3`, which was changed in source's parent, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     d
-    "###);
+    [EOF]
+    ");
 
     // Can squash only part of the change from a sibling in non-interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -567,34 +625,39 @@ fn test_squash_from_to_partial() {
     std::fs::write(&edit_script, "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: vruxwmqv 5b407c24 d | (no description set)
     Parent commit      : qpvuntsm b7b76717 a | (no description set)
     Added 0 files, modified 1 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  5b407c249fa7 d
     │ ○  724d64da1487 c
     │ ○  12d6103dc0c8 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     // The unselected change from the source has not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     // File `file3`, which was changed in source's parent, is unchanged
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file3"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     d
-    "###);
+    [EOF]
+    ");
 
     // Can squash only part of the change from a descendant in non-interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -605,36 +668,41 @@ fn test_squash_from_to_partial() {
         &["squash", "--from", "c", "--into", "b", "file1"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r#"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e0dac715116f d
     │ ○  d2a587ae205d c
     │ ○  a53394306362 b
     ├─╯
     ○  b7b767179c44 a
     ◆  000000000000 (empty)
-    "#);
+    [EOF]
+    ");
     // The selected change from the source has been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     // The unselected change from the source has not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
 
     // If we specify only a non-existent file, then nothing changes.
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from", "c", "nonexistent"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -670,7 +738,7 @@ fn test_squash_from_multiple() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "f"]);
     std::fs::write(&file, "f\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  94e57ecb8d4f f
     ○      78ed28eb87b8 e
     ├─┬─╮
@@ -681,13 +749,14 @@ fn test_squash_from_multiple() {
     ├─╯
     ○  3b1673b6370c a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     // Squash a few commits sideways
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b", "--from=c", "--into=d"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kpqxywon 7ea39167 f | (no description set)
     Parent commit      : yostqsxw acfbf2a0 e | (no description set)
@@ -698,8 +767,9 @@ fn test_squash_from_multiple() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  7ea391676d52 f
     ○    acfbf2a0600d e
     ├─╮
@@ -707,10 +777,11 @@ fn test_squash_from_multiple() {
     ├─╯
     ○  3b1673b6370c a b c
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The changes from the sources have been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
     -a
@@ -721,18 +792,20 @@ fn test_squash_from_multiple() {
     +++++++ Contents of side #3
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
 
     // Squash a few commits up an down
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b|c|f", "--into=e"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: xznxytkn 6a670d1a (empty) (no description set)
     Parent commit      : yostqsxw c1293ff7 e f | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  6a670d1ac76e (empty)
     ○    c1293ff7be51 e f
     ├─╮
@@ -740,19 +813,22 @@ fn test_squash_from_multiple() {
     ├─╯
     ○  3b1673b6370c a b c
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The changes from the sources have been applied to the destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=e", "file"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     f
-    "###);
+    [EOF]
+    ");
 
     // Empty squash shouldn't crash
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash", "--from=none()"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -795,7 +871,7 @@ fn test_squash_from_multiple_partial() {
     std::fs::write(&file1, "f\n").unwrap();
     std::fs::write(&file2, "f\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  30980b9045f7 f
     ○      5326a04aac1f e
     ├─┬─╮
@@ -806,13 +882,14 @@ fn test_squash_from_multiple_partial() {
     ├─╯
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     // Partially squash a few commits sideways
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b|c", "--into=d", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 2 descendant commits
     Working copy now at: kpqxywon a8530305 f | (no description set)
     Parent commit      : yostqsxw 0a3637fc e | (no description set)
@@ -823,8 +900,9 @@ fn test_squash_from_multiple_partial() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a8530305127c f
     ○      0a3637fca632 e
     ├─┬─╮
@@ -835,19 +913,22 @@ fn test_squash_from_multiple_partial() {
     ├─╯
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=c", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     // The selected changes from the sources have been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
     -a
@@ -858,25 +939,28 @@ fn test_squash_from_multiple_partial() {
     +++++++ Contents of side #3
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    [EOF]
+    ");
     // The unselected change from the sources have not been applied to the
     // destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     d
-    "###);
+    [EOF]
+    ");
 
     // Partially squash a few commits up an down
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["squash", "--from=b|c|f", "--into=e", "file1"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: kpqxywon 3b7559b8 f | (no description set)
     Parent commit      : yostqsxw a3b1714c e | (no description set)
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  3b7559b89a57 f
     ○      a3b1714cdfb2 e
     ├─┬─╮
@@ -887,30 +971,36 @@ fn test_squash_from_multiple_partial() {
     ├─╯
     ○  54d3c1c0e9fd a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     // The selected changes have been removed from the sources
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=b", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=c", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=f", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     f
-    "###);
+    [EOF]
+    ");
     // The selected changes from the sources have been applied to the destination
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=e", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     f
-    "###);
+    [EOF]
+    ");
     // The unselected changes from the sources have not been applied
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "-r=d", "file2"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     d
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -936,7 +1026,7 @@ fn test_squash_from_multiple_partial_no_op() {
     test_env.jj_cmd_ok(&repo_path, &["new", "@-", "-m=d"]);
     std::fs::write(file_d, "d\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b37ca1ee3306 d
     │ ○  f40b442af3e8 c
     ├─╯
@@ -944,7 +1034,8 @@ fn test_squash_from_multiple_partial_no_op() {
     ├─╯
     ○  2443ea76b0b1 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 
     // Source commits that didn't match the paths are not rewritten
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -952,18 +1043,20 @@ fn test_squash_from_multiple_partial_no_op() {
         &["squash", "--from=@-+ ~ @", "--into=@", "-m=d", "b"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: mzvwutvl e178068a d
     Parent commit      : qpvuntsm 2443ea76 a
     Added 1 files, modified 0 files, removed 0 files
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  e178068add8c d
     │ ○  f40b442af3e8 c
     ├─╯
     ○  2443ea76b0b1 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(
         &repo_path,
         &[
@@ -972,14 +1065,15 @@ fn test_squash_from_multiple_partial_no_op() {
             r#"separate(" ", commit_id.short(), description)"#,
         ],
     );
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @    e178068add8c d
     ├─╮
     │ ○  b73077b08c59 b
     │ ○  a786561e909f b
     ○  b37ca1ee3306 d
     ○  1d9eb34614c9 d
-    "###);
+    [EOF]
+    ");
 
     // If no source commits match the paths, then the whole operation is a no-op
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -988,10 +1082,11 @@ fn test_squash_from_multiple_partial_no_op() {
         &["squash", "--from=@-+ ~ @", "--into=@", "-m=d", "a"],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b37ca1ee3306 d
     │ ○  f40b442af3e8 c
     ├─╯
@@ -999,7 +1094,8 @@ fn test_squash_from_multiple_partial_no_op() {
     ├─╯
     ○  2443ea76b0b1 a
     ◆  000000000000 (empty)
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
@@ -1036,36 +1132,40 @@ fn test_squash_description() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "source"]);
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     source
-    "###);
+    [EOF]
+    ");
 
     // If the destination description is non-empty and the source's description is
     // empty, the resulting description is from the destination
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", "@--"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "destination"]);
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     destination
-    "###);
+    [EOF]
+    ");
 
     // An explicit description on the command-line overrides this
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["squash", "-m", "custom"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     custom
-    "###);
+    [EOF]
+    ");
 
     // If both descriptions were non-empty, we get asked for a combined description
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "source"]);
     std::fs::write(&edit_script, "dump editor0").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     destination
 
     source
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the combined commit.
@@ -1086,20 +1186,23 @@ fn test_squash_description() {
     // editor
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["squash", "-m", "custom"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     custom
-    "###);
+    [EOF]
+    ");
 
     // If the source's *content* doesn't become empty, then the source remains and
     // both descriptions are unchanged
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["squash", "file1"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     destination
-    "###);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r"
     source
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1138,22 +1241,25 @@ fn test_squash_empty() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz adece6e8 (empty) (no description set)
     Parent commit      : qpvuntsm 5076fc41 (empty) parent
-    "###);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     parent
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "child"]);
     test_env.set_up_fake_editor();
     test_env.jj_cmd_ok(&repo_path, &["squash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     parent
 
     child
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1166,21 +1272,23 @@ fn test_squash_use_destination_message() {
     test_env.jj_cmd_ok(&repo_path, &["commit", "-m=b"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m=c"]);
     // Test the setup
-    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r"
     @  8aac283daeac c
     ○  017c7f689ed7 b
     ○  d8d5f980a897 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Squash the current revision using the short name for the option.
     test_env.jj_cmd_ok(&repo_path, &["squash", "-u"]);
-    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r"
     @  fd33e4bc332b
     ○  3a17aa5dcce9 b
     ○  d8d5f980a897 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Undo and squash again, but this time squash both "b" and "c" into "a".
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -1195,11 +1303,12 @@ fn test_squash_use_destination_message() {
             "description(a)",
         ],
     );
-    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output_with_description(&test_env, &repo_path), @r"
     @  7c832accbf60
     ○  688660377651 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 // The --use-destination-message and --message options are incompatible.
@@ -1217,13 +1326,14 @@ fn test_squash_use_destination_message_and_message_mutual_exclusion() {
             "--message=123",
             "--use-destination-message",
         ],
-    ), @r###"
+    ), @r"
     error: the argument '--message <MESSAGE>' cannot be used with '--use-destination-message'
 
     Usage: jj squash --message <MESSAGE> [FILESETS]...
 
     For more information, try '--help'.
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> CommandOutputString {

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -59,14 +59,15 @@ fn test_status_copies() {
     std::fs::write(repo_path.join("rename-target"), "rename").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M copy-source
     C {copy-source => copy-target}
     R {rename-source => rename-target}
     Working copy : rlvkpnrz a96c3086 (no description set)
     Parent commit: qpvuntsm e3e2c703 (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -85,12 +86,13 @@ fn test_status_merge() {
     // The output should mention each parent, and the diff should be empty (compared
     // to the auto-merged parents)
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     Working copy : mzvwutvl a538c72d (empty) (no description set)
     Parent commit: rlvkpnrz d3dd19f1 left | (empty) left
     Parent commit: zsuskuln 705a356d right
-    "###);
+    [EOF]
+    ");
 }
 
 // See https://github.com/jj-vcs/jj/issues/2051.
@@ -110,12 +112,13 @@ fn test_status_ignored_gitignore() {
     std::fs::write(repo_path.join(".gitignore"), "untracked/\n!dummy\n").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A .gitignore
     Working copy : qpvuntsm 3cef2183 (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -129,12 +132,13 @@ fn test_status_filtered() {
 
     // The output filtered to file_1 should not list the addition of file_2.
     let stdout = test_env.jj_cmd_success(&repo_path, &["status", "file_1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A file_1
     Working copy : qpvuntsm c8fb8395 (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 // See <https://github.com/jj-vcs/jj/issues/3108>
@@ -179,7 +183,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 dcb25635 conflict
     │  (empty) boom-cont-2
     ×  royxmykx test.user@example.com 2001-02-03 08:05:12 664a4c6c conflict
@@ -193,11 +197,12 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     There are unresolved conflicts at these paths:
     conflicted.txt    2-sided conflict
@@ -208,7 +213,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
 
     // Resolve conflict
     test_env.jj_cmd_ok(&repo_path, &["new", "--message", "fixed 1"]);
@@ -221,7 +227,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     // wc is now conflict free, parent is also conflict free
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  kpqxywon test.user@example.com 2001-02-03 08:05:18 d313f2e1
     │  fixed 2
     ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 23e58975
@@ -239,23 +245,25 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M conflicted.txt
     Working copy : kpqxywon d313f2e1 fixed 2
     Parent commit: znkkpsqq 23e58975 fixed 1
-    "###);
+    [EOF]
+    ");
 
     // Step back one.
     // wc is still conflict free, parent has a conflict.
     test_env.jj_cmd_ok(&repo_path, &["edit", "@-"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  kpqxywon test.user@example.com 2001-02-03 08:05:18 d313f2e1
     │  fixed 2
     @  znkkpsqq test.user@example.com 2001-02-03 08:05:17 23e58975
@@ -273,17 +281,19 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M conflicted.txt
     Working copy : znkkpsqq 23e58975 fixed 1
     Parent commit: yqosqzyt dcb25635 (conflict) (empty) boom-cont-2
     Conflict in parent commit has been resolved in working copy
-    "###);
+    [EOF]
+    ");
 
     // Step back to all the way to `root()+` so that wc has no conflict, even though
     // there is a conflict later in the tree. So that we can confirm
@@ -291,7 +301,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     test_env.jj_cmd_ok(&repo_path, &["edit", "root()+"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-r", "::"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     ○  kpqxywon test.user@example.com 2001-02-03 08:05:18 d313f2e1
     │  fixed 2
     ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 23e58975
@@ -309,16 +319,18 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 aade7195
     │  Initial contents
     ◆  zzzzzzzz root() 00000000
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
 
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A conflicted.txt
     Working copy : qpvuntsm aade7195 Initial contents
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -352,7 +364,7 @@ fn test_status_simplify_conflict_sides() {
     );
 
     insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["status"]),
-    @r###"
+    @r"
     The working copy has no changes.
     There are unresolved conflicts at these paths:
     fileA    2-sided conflict
@@ -366,7 +378,8 @@ fn test_status_simplify_conflict_sides() {
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -392,6 +405,7 @@ fn test_status_untracked_files() {
     ? sub/initially-untracked
     Working copy : qpvuntsm 230dd059 (empty) (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
 
     test_env.jj_cmd_success(
@@ -414,6 +428,7 @@ fn test_status_untracked_files() {
     ? sub/always-untracked
     Working copy : qpvuntsm 99798fcd (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -425,6 +440,7 @@ fn test_status_untracked_files() {
     ? sub/always-untracked
     Working copy : mzvwutvl 30e53c74 (empty) (no description set)
     Parent commit: qpvuntsm 99798fcd (no description set)
+    [EOF]
     ");
 
     test_env.jj_cmd_success(
@@ -448,6 +464,7 @@ fn test_status_untracked_files() {
     ? sub/initially-untracked
     Working copy : mzvwutvl bb362aaf (no description set)
     Parent commit: qpvuntsm 99798fcd (no description set)
+    [EOF]
     ");
 
     test_env.jj_cmd_ok(&repo_path, &["new"]);
@@ -461,5 +478,6 @@ fn test_status_untracked_files() {
     ? sub/initially-untracked
     Working copy : yostqsxw 8e8c02fe (empty) (no description set)
     Parent commit: mzvwutvl bb362aaf (no description set)
+    [EOF]
     ");
 }

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -384,7 +384,7 @@ fn test_status_untracked_files() {
     std::fs::write(repo_path.join("sub").join("initially-untracked"), "...").unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file
@@ -405,7 +405,7 @@ fn test_status_untracked_files() {
     );
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     Working copy changes:
     A initially-untracked-file
     A sub/initially-untracked
@@ -419,7 +419,7 @@ fn test_status_untracked_files() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     Untracked paths:
     ? always-untracked-file
     ? sub/always-untracked
@@ -437,7 +437,7 @@ fn test_status_untracked_files() {
         ],
     );
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     Working copy changes:
     D initially-untracked-file
     D sub/initially-untracked
@@ -453,7 +453,7 @@ fn test_status_untracked_files() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["status"]);
-    insta::assert_snapshot!(stdout.replace('\\', "/"), @r"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -57,38 +57,42 @@ fn test_tag_list() {
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list"]),
-        @r###"
+        @r"
     conflicted_tag (conflicted):
       - rlvkpnrz caf975d0 (empty) commit1
       + zsuskuln 3db783e0 (empty) commit2
       + royxmykx 68d950ce (empty) commit3
     test_tag: rlvkpnrz caf975d0 (empty) commit1
     test_tag2: zsuskuln 3db783e0 (empty) commit2
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "--color=always"]),
-        @r###"
+        @r"
     [38;5;5mconflicted_tag[39m [38;5;1m(conflicted)[39m:
       - [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4mc[0m[38;5;8maf975d0[39m [38;5;2m(empty)[39m commit1
       + [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m3[0m[38;5;8mdb783e0[39m [38;5;2m(empty)[39m commit2
       + [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m6[0m[38;5;8m8d950ce[39m [38;5;2m(empty)[39m commit3
     [38;5;5mtest_tag[39m: [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4mc[0m[38;5;8maf975d0[39m [38;5;2m(empty)[39m commit1
     [38;5;5mtest_tag2[39m: [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m3[0m[38;5;8mdb783e0[39m [38;5;2m(empty)[39m commit2
-    "###);
+    [EOF]
+    ");
 
     // Test pattern matching.
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "test_tag2"]),
-        @r###"
+        @r"
     test_tag2: zsuskuln 3db783e0 (empty) commit2
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "glob:test_tag?"]),
-        @r###"
+        @r"
     test_tag2: zsuskuln 3db783e0 (empty) commit2
-    "###);
+    [EOF]
+    ");
 
     let template = r#"
     concat(
@@ -102,7 +106,7 @@ fn test_tag_list() {
     "#;
     insta::assert_snapshot!(
         test_env.jj_cmd_success(&repo_path, &["tag", "list", "-T", template]),
-        @r###"
+        @r"
     [conflicted_tag]
     present: true
     conflict: true
@@ -121,5 +125,6 @@ fn test_tag_list() {
     normal_target: commit2
     removed_targets:
     added_targets: commit2
-    "###);
+    [EOF]
+    ");
 }

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 use indoc::indoc;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -527,7 +528,7 @@ fn get_template_output(
     repo_path: &Path,
     rev: &str,
     template: &str,
-) -> String {
+) -> CommandOutputString {
     test_env.jj_cmd_success(repo_path, &["log", "--no-graph", "-r", rev, "-T", template])
 }
 
@@ -536,7 +537,7 @@ fn get_colored_template_output(
     repo_path: &Path,
     rev: &str,
     template: &str,
-) -> String {
+) -> CommandOutputString {
     test_env.jj_cmd_success(
         repo_path,
         &[

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -31,21 +31,23 @@ fn test_undo_rewrite_with_child() {
     let op_id_hex = stdout.raw()[3..15].to_string();
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "child"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  child
     ○  modified
     ◆
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["undo", &op_id_hex]);
 
     // Since we undid the description-change, the child commit should now be on top
     // of the initial commit
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  child
     ○  initial
     ◆
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -70,10 +72,11 @@ fn test_git_push_undo() {
     //   ------------------------------------------
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
@@ -82,10 +85,11 @@ fn test_git_push_undo() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
 
     // Undo the push
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &pre_push_opid]);
@@ -95,10 +99,11 @@ fn test_git_push_undo() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
@@ -110,13 +115,14 @@ fn test_git_push_undo() {
     // One option to solve this would be to have undo not restore remote-tracking
     // bookmarks, but that also has undersired consequences: the second fetch in
     // `jj git fetch && jj undo && jj git fetch` would become a no-op.
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main (conflicted):
       - qpvuntsm hidden 2080bdb8 (empty) AA
       + qpvuntsm?? 20b2cc4b (empty) CC
       + qpvuntsm?? 75e78001 (empty) BB
       @origin (behind by 1 commits): qpvuntsm?? 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
 }
 
 /// This test is identical to the previous one, except for one additional
@@ -143,10 +149,11 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local `main`     | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
@@ -155,10 +162,11 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
 
     // Undo the push
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &pre_push_opid]);
@@ -168,10 +176,11 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | AA      |   AA   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
 
     // PROBLEM: inserting this import changes the outcome compared to previous test
     // TODO: decide if this is the better behavior, and whether import of
@@ -183,19 +192,21 @@ fn test_git_push_undo_with_import() {
     //   ------------------------------------------
     //    local  `main`    | BB      |   --   | --
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     // There is not a conflict. This seems like a good outcome; undoing `git push`
     // was essentially a no-op.
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 20b2cc4b (empty) CC
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
 }
 
 // This test is currently *identical* to `test_git_push_undo` except the repo
@@ -224,11 +235,12 @@ fn test_git_push_undo_colocated() {
     //   ------------------------------------------
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @git: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
     //                     | jj refs | jj's   | git
@@ -237,11 +249,12 @@ fn test_git_push_undo_colocated() {
     //   ------------------------------------------
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | BB      |   BB   | BB
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @git: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
 
     // Undo the push
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", &pre_push_opid]);
@@ -259,24 +272,26 @@ fn test_git_push_undo_colocated() {
     //   ------------------------------------------
     //    local `main`     | BB      |   BB   | BB
     //    remote-tracking  | AA      |   AA   | AA
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @git: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     // We have the same conflict as `test_git_push_undo`. TODO: why did we get the
     // same result in a seemingly different way?
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main (conflicted):
       - qpvuntsm hidden 2080bdb8 (empty) AA
       + qpvuntsm?? 20b2cc4b (empty) CC
       + qpvuntsm?? 75e78001 (empty) BB
       @git (behind by 1 commits): qpvuntsm?? 20b2cc4b (empty) CC
       @origin (behind by 1 commits): qpvuntsm?? 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
 }
 
 // This test is currently *identical* to `test_git_push_undo` except
@@ -295,16 +310,18 @@ fn test_git_push_undo_repo_only() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "main"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "AA"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 2080bdb8 (empty) AA
       @origin: qpvuntsm 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "BB"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 2080bdb8 (empty) AA
-    "###);
+    [EOF]
+    ");
     let pre_push_opid = test_env.current_operation_id(&repo_path);
     test_env.jj_cmd_ok(&repo_path, &["git", "push"]);
 
@@ -313,18 +330,20 @@ fn test_git_push_undo_repo_only() {
         &repo_path,
         &["op", "restore", "--what=repo", &pre_push_opid],
     );
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 75e78001 (empty) BB
       @origin: qpvuntsm 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "CC"]);
     test_env.jj_cmd_ok(&repo_path, &["git", "fetch"]);
     // This currently gives an identical result to `test_git_push_undo_import`.
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     main: qpvuntsm 20b2cc4b (empty) CC
       @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm hidden 75e78001 (empty) BB
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -343,52 +362,58 @@ fn test_bookmark_track_untrack_undo() {
     );
     test_env.jj_cmd_ok(&repo_path, &["git", "push", "--allow-new"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "delete", "feature2"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
       @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2 (deleted)
       @origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     // Track/untrack can be undone so long as states can be trivially merged.
     test_env.jj_cmd_ok(
         &repo_path,
         &["bookmark", "untrack", "feature1@origin", "feature2@origin"],
     );
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
     feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
       @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2 (deleted)
       @origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
     feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "track", "feature1@origin"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
       @origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
     feature1: qpvuntsm 8da1cfc8 (empty) commit
     feature1@origin: qpvuntsm 8da1cfc8 (empty) commit
     feature2@origin: qpvuntsm 8da1cfc8 (empty) commit
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -408,6 +433,7 @@ fn test_shows_a_warning_when_undoing_an_undo_operation_as_bare_jj_undo() {
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     Hint: This action reverted an 'undo' operation. The repository is now in the same state as it was before the original 'undo'.
     Hint: If your goal is to undo multiple operations, consider using `jj op log` to see past states, and `jj op restore` to restore one of these states.
+    [EOF]
     ");
 
     // Double-undo creation of sibling
@@ -421,6 +447,7 @@ fn test_shows_a_warning_when_undoing_an_undo_operation_as_bare_jj_undo() {
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
     Hint: This action reverted an 'undo' operation. The repository is now in the same state as it was before the original 'undo'.
     Hint: If your goal is to undo multiple operations, consider using `jj op log` to see past states, and `jj op restore` to restore one of these states.
+    [EOF]
     ");
 }
 
@@ -440,6 +467,7 @@ fn test_shows_no_warning_when_undoing_a_specific_undo_change() {
     Undid operation: 2d5b73a97567 (2001-02-03 08:05:09) undo operation 289cb69a8458456474a77cc432e8009b99f039cdcaf19ba4526753e97d70fee3fd0f410ff2b7c1d10cf0c2501702e7a85d58f9d813cdca567c377431ec4d2b97
     Working copy now at: rlvkpnrz 65b6b74e (empty) (no description set)
     Parent commit      : qpvuntsm 230dd059 (empty) (no description set)
+    [EOF]
     ");
 }
 

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -14,6 +14,7 @@
 use std::path::Path;
 
 use crate::common::git;
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -27,7 +28,7 @@ fn test_undo_rewrite_with_child() {
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "modified"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    let op_id_hex = stdout[3..15].to_string();
+    let op_id_hex = stdout.raw()[3..15].to_string();
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "child"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["log", "-T", "description"]);
     insta::assert_snapshot!(stdout, @r###"
@@ -432,7 +433,7 @@ fn test_shows_no_warning_when_undoing_a_specific_undo_change() {
     test_env.jj_cmd_ok(&repo_path, &["new"]);
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    let op_id_hex = stdout[3..15].to_string();
+    let op_id_hex = stdout.raw()[3..15].to_string();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["undo", &op_id_hex]);
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r"
@@ -442,7 +443,7 @@ fn test_shows_no_warning_when_undoing_a_specific_undo_change() {
     ");
 }
 
-fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_bookmark_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     // --quiet to suppress deleted bookmarks hint
     test_env.jj_cmd_success(repo_path, &["bookmark", "list", "--all-remotes", "--quiet"])
 }

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -33,56 +33,64 @@ fn test_unsquash() {
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "c"]);
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  382c9bad7d42 c
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Unsquashes into the working copy from its parent by default
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: mzvwutvl 9177132c c | (no description set)
     Parent commit      : qpvuntsm 184ddbcc a b | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  9177132cfbb9 c
     ○  184ddbcce5a9 a b
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 
     // Can unsquash into a given commit from its parent
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash", "-r", "b"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl b353b29c c | (no description set)
     Parent commit      : kkmpptxz 27772b15 b | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  b353b29c423d c
     ○  27772b156771 b
     ◆  000000000000 a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 
     // Cannot unsquash into a merge commit (because it's unclear which parent it
     // should come from)
@@ -93,7 +101,7 @@ fn test_unsquash() {
     std::fs::write(repo_path.join("file2"), "d\n").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["new", "-m", "merge", "c", "d"]);
     test_env.jj_cmd_ok(&repo_path, &["bookmark", "create", "-r@", "e"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    b780e7469252 e
     ├─╮
     │ ○  f86e2b3af3e3 d
@@ -102,27 +110,30 @@ fn test_unsquash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Error: Cannot unsquash merge commits
-    "#);
+    [EOF]
+    ");
 
     // Can unsquash from a merge commit
     test_env.jj_cmd_ok(&repo_path, &["new", "e"]);
     std::fs::write(repo_path.join("file1"), "e\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: pzsxstzt bd05eb69 merge
     Parent commit      : mzvwutvl 382c9bad c e?? | (no description set)
     Parent commit      : xznxytkn f86e2b3a d e?? | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @    bd05eb698d1e
     ├─╮
     │ ○  f86e2b3af3e3 d e??
@@ -131,11 +142,13 @@ fn test_unsquash() {
     ○  d5d59175b481 b
     ○  184ddbcce5a9 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     e
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -156,12 +169,13 @@ fn test_unsquash_partial() {
     std::fs::write(repo_path.join("file1"), "c\n").unwrap();
     std::fs::write(repo_path.join("file2"), "c\n").unwrap();
     // Test the setup
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a0b1a272ebc4 c
     ○  d117da276a0f b
     ○  54d3c1c0e9fd a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // If we don't make any changes in the diff-editor, the whole change is moved
     // from the parent
@@ -169,13 +183,14 @@ fn test_unsquash_partial() {
     std::fs::write(&edit_script, "dump JJ-INSTRUCTIONS instrs").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash", "-r", "b", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl 8802263d c | (no description set)
     Parent commit      : kkmpptxz 5bd83140 b | (no description set)
-    "#);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
@@ -190,50 +205,58 @@ fn test_unsquash_partial() {
     aborted.
     "###);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  8802263dbd92 c
     ○  5bd83140fd47 b
     ○  c93de9257191 a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "a"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
 
     // Can unsquash only some changes in interactive mode
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     std::fs::write(edit_script, "reset file1").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["unsquash", "-i"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: mzvwutvl a896ffde c | (no description set)
     Parent commit      : kkmpptxz 904111b4 b | (no description set)
-    "#);
-    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  a896ffdebb85 c
     ○  904111b4d3c4 b
     ○  54d3c1c0e9fd a
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 
     // Try again with --tool=<name>, which implies --interactive
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
@@ -246,28 +269,33 @@ fn test_unsquash_partial() {
         ],
     );
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
     Working copy now at: mzvwutvl aaca9268 c | (no description set)
     Parent commit      : kkmpptxz fe8eb117 b | (no description set)
-    "#);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     a
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "b"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     b
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file1", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["file", "show", "file2", "-r", "c"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     c
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
@@ -298,29 +326,32 @@ fn test_unsquash_description() {
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "source"]);
     test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r"
     source
-    "###);
+    [EOF]
+    ");
 
     // If the destination description is non-empty and the source's description is
     // empty, the resulting description is from the destination
     test_env.jj_cmd_ok(&repo_path, &["op", "restore", "@--"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "destination"]);
     test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r"
     destination
-    "###);
+    [EOF]
+    ");
 
     // If both descriptions were non-empty, we get asked for a combined description
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
     test_env.jj_cmd_ok(&repo_path, &["describe", "@-", "-m", "source"]);
     std::fs::write(&edit_script, "dump editor0").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["unsquash"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r"
     destination
 
     source
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
     JJ: Enter a description for the combined commit.
@@ -336,12 +367,14 @@ fn test_unsquash_description() {
     // If the source's *content* doesn't become empty, then the source remains and
     // both descriptions are unchanged
     test_env.jj_cmd_ok(&repo_path, &["undo"]);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r###"
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@-"), @r"
     source
-    "###);
-    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_description(&test_env, &repo_path, "@"), @r"
     destination
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -269,7 +270,7 @@ fn test_unsquash_partial() {
     "###);
 }
 
-fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> String {
+fn get_log_output(test_env: &TestEnvironment, repo_path: &Path) -> CommandOutputString {
     let template = r#"commit_id.short() ++ " " ++ bookmarks"#;
     test_env.jj_cmd_success(repo_path, &["log", "-T", template])
 }
@@ -369,7 +370,7 @@ fn test_unsquash_description_editor_avoids_unc() {
     assert_eq!(edited_path, dunce::simplified(&edited_path));
 }
 
-fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> String {
+fn get_description(test_env: &TestEnvironment, repo_path: &Path, rev: &str) -> CommandOutputString {
     test_env.jj_cmd_success(
         repo_path,
         &["log", "--no-graph", "-T", "description", "-r", rev],

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -14,7 +14,6 @@
 
 use insta::assert_snapshot;
 
-use crate::common::strip_last_line;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -140,5 +139,5 @@ fn test_util_exec_fail() {
         test_env.env_root(),
         &["util", "exec", "--", "jj-test-missing-program"],
     );
-    insta::assert_snapshot!(strip_last_line(&err), @"Error: Failed to execute external command 'jj-test-missing-program'");
+    insta::assert_snapshot!(err.strip_last_line(), @"Error: Failed to execute external command 'jj-test-missing-program'");
 }

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -22,7 +22,7 @@ fn test_util_config_schema() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["util", "config-schema"]);
     // Validate partial snapshot, redacting any lines nested 2+ indent levels.
     insta::with_settings!({filters => vec![(r"(?m)(^        .*$\r?\n)+", "        [...]\n")]}, {
-        assert_snapshot!(stdout, @r###"
+        assert_snapshot!(stdout, @r#"
         {
             "$schema": "http://json-schema.org/draft-04/schema",
             "$comment": "`taplo` and the corresponding VS Code plugins only support draft-04 verstion of JSON Schema, see <https://taplo.tamasfe.dev/configuration/developing-schemas.html>. draft-07 is mostly compatible with it, newer versions may not be.",
@@ -33,7 +33,8 @@ fn test_util_config_schema() {
                 [...]
             }
         }
-        "###);
+        [EOF]
+        "#);
     });
 }
 
@@ -51,14 +52,16 @@ fn test_gc_args() {
     insta::assert_snapshot!(stderr, @"");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["util", "gc", "--at-op=@-"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Cannot garbage collect from a non-head operation
-    "###);
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(&repo_path, &["util", "gc", "--expire=foobar"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: --expire only accepts 'now'
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -91,6 +94,7 @@ fn test_gc_operation_log() {
     let stderr = test_env.jj_cmd_failure(&repo_path, &["debug", "operation", &op_to_remove]);
     insta::assert_snapshot!(stderr, @r#"
     Error: No operation ID matching "8382f401329617b0c91a63354b86ca48fc28dee8d7a916fdad5310030f9a1260e969c43ed2b13d1d48eaf38f6f45541ecf593bcb6105495d514d21b3b6a98846"
+    [EOF]
     "#);
 }
 
@@ -127,7 +131,7 @@ fn test_util_exec() {
             "hello",
         ],
     );
-    insta::assert_snapshot!(out, @"hello");
+    insta::assert_snapshot!(out, @"hello[EOF]");
     // Ensures only stdout contains text
     assert!(err.is_empty());
 }
@@ -139,5 +143,8 @@ fn test_util_exec_fail() {
         test_env.env_root(),
         &["util", "exec", "--", "jj-test-missing-program"],
     );
-    insta::assert_snapshot!(err.strip_last_line(), @"Error: Failed to execute external command 'jj-test-missing-program'");
+    insta::assert_snapshot!(err.strip_last_line(), @r"
+    Error: Failed to execute external command 'jj-test-missing-program'
+    [EOF]
+    ");
 }

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -15,6 +15,7 @@
 use indoc::indoc;
 use regex::Regex;
 
+use crate::common::CommandOutputString;
 use crate::common::TestEnvironment;
 
 #[test]
@@ -358,8 +359,9 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // or `false`, so we want to remove it from the output as well
     let executable_regex = Regex::new("executable: [^ ]+").unwrap();
 
-    let redact_output = |output: &str| {
-        let output = timestamp_regex.replace_all(output, "<timestamp>");
+    let redact_output = |output: &CommandOutputString| {
+        let output = output.to_string();
+        let output = timestamp_regex.replace_all(&output, "<timestamp>");
         let output = executable_regex.replace_all(&output, "<executable>");
         output.into_owned()
     };

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -30,8 +30,11 @@ fn test_snapshot_large_file() {
     std::fs::write(repo_path.join("empty"), "").unwrap();
     std::fs::write(repo_path.join("large"), "a lot of text").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @"empty");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stdout, @r"
+    empty
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Warning: Refused to snapshot some files:
       large: 13.0B (13 bytes); the maximum size allowed is 10.0B (10 bytes)
     Hint: This is to prevent large files from being added by accident. You can fix this by:
@@ -40,15 +43,19 @@ fn test_snapshot_large_file() {
         This will increase the maximum file size allowed for new files, in this repository only.
       - Run `jj --config snapshot.max-new-file-size=13 st`
         This will increase the maximum file size allowed for new files, for this command only.
-    "#);
+    [EOF]
+    ");
 
     // test with a larger file using 'KB' human-readable syntax
     test_env.add_config(r#"snapshot.max-new-file-size = "10KB""#);
     let big_string = vec![0; 1024 * 11];
     std::fs::write(repo_path.join("large"), &big_string).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout, @"empty");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stdout, @r"
+    empty
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Warning: Refused to snapshot some files:
       large: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
     Hint: This is to prevent large files from being added by accident. You can fix this by:
@@ -57,13 +64,14 @@ fn test_snapshot_large_file() {
         This will increase the maximum file size allowed for new files, in this repository only.
       - Run `jj --config snapshot.max-new-file-size=11264 st`
         This will increase the maximum file size allowed for new files, for this command only.
-    "#);
+    [EOF]
+    ");
 
     // test with file track for hint formatting
     std::fs::write(repo_path.join("large2"), big_string).unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "track", "large", "large2"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Refused to snapshot some files:
       large: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
       large2: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
@@ -81,7 +89,8 @@ fn test_snapshot_large_file() {
         This will increase the maximum file size allowed for new files, in this repository only.
       - Run `jj --config snapshot.max-new-file-size=11264 file track large large2`
         This will increase the maximum file size allowed for new files, for this command only.
-    "#);
+    [EOF]
+    ");
 
     // test invalid configuration
     let stderr = test_env.jj_cmd_failure(
@@ -92,6 +101,7 @@ fn test_snapshot_large_file() {
     Config error: Invalid type or value for snapshot.max-new-file-size
     Caused by: Expected a positive integer or a string in '<number><unit>' form
     For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
     ");
 
     // No error if we disable auto-tracking of the path
@@ -99,7 +109,10 @@ fn test_snapshot_large_file() {
         &repo_path,
         &["file", "list", "--config=snapshot.auto-track='none()'"],
     );
-    insta::assert_snapshot!(stdout, @"empty");
+    insta::assert_snapshot!(stdout, @r"
+    empty
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // max-new-file-size=0 means no limit
@@ -107,11 +120,12 @@ fn test_snapshot_large_file() {
         &repo_path,
         &["file", "list", "--config=snapshot.max-new-file-size=0"],
     );
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     empty
     large
     large2
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 }
 
@@ -131,7 +145,7 @@ fn test_snapshot_large_file_restore() {
     std::fs::write(repo_path.join("file"), "a lot of text").unwrap();
     let (_stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["restore", "--from=description(committed)"]);
-    insta::assert_snapshot!(stderr, @r#"
+    insta::assert_snapshot!(stderr, @r"
     Warning: Refused to snapshot some files:
       file: 13.0B (13 bytes); the maximum size allowed is 10.0B (10 bytes)
     Hint: This is to prevent large files from being added by accident. You can fix this by:
@@ -147,7 +161,8 @@ fn test_snapshot_large_file_restore() {
     Warning: 1 of those updates were skipped because there were conflicting changes in the working copy.
     Hint: Inspect the changes compared to the intended target with `jj diff --from e3eb7e819de5`.
     Discard the conflicting changes with `jj restore --from e3eb7e819de5`.
-    "#);
+    [EOF]
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(repo_path.join("file")).unwrap(),
         @"a lot of text");
@@ -160,6 +175,7 @@ fn test_snapshot_large_file_restore() {
     A file
     Working copy : kkmpptxz b75eed09 (no description set)
     Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
     insta::assert_snapshot!(stderr, @"");
 }
@@ -248,7 +264,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
     .unwrap();
 
     // Git-style markers should be parsed, then rendered with new config
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r##"
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -261,7 +277,8 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
      ------- Contents of base
      line 2
      line 3
-    "##);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -273,21 +290,23 @@ fn test_snapshot_invalid_ignore_pattern() {
 
     // Test invalid pattern in .gitignore
     std::fs::write(&gitignore_path, " []\n").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r#"
+    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r"
     Internal error: Failed to snapshot the working copy
     Caused by:
     1: Failed to parse ignore patterns from file $TEST_ENV/repo/.gitignore
     2: error parsing glob ' []': unclosed character class; missing ']'
-    "#);
+    [EOF]
+    ");
 
     // Test invalid UTF-8 in .gitignore
     std::fs::write(&gitignore_path, b"\xff\n").unwrap();
-    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r##"
+    insta::assert_snapshot!(test_env.jj_cmd_internal_error(&repo_path, &["st"]), @r"
     Internal error: Failed to snapshot the working copy
     Caused by:
     1: Invalid UTF-8 for ignore pattern in $TEST_ENV/repo/.gitignore on line #1: �
     2: invalid utf-8 sequence of 1 bytes from index 0
-    "##);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -372,6 +391,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     Current operation: OperationId("6feb53603f9f7324085d2d89dca19a6dac93fef6795cfd5d57090ff803d404ab1196b45d5b97faa641f6a78302ac0fbd149f5e5a880d1fd64d6520c31beab213")
     Current tree: Merge(Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]))
     Normal { <executable> }           249 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
+    [EOF]
     "#);
 
     // Update the conflict with more fake markers, and it should still parse
@@ -400,7 +420,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
 
     // The file should still be conflicted, and the new content should be saved
     let stdout = test_env.jj_cmd_success(&repo_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     There are unresolved conflicts at these paths:
@@ -408,8 +428,9 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     Working copy : mzvwutvl 3a981880 (conflict) (no description set)
     Parent commit: rlvkpnrz ce613b49 side-a
     Parent commit: zsuskuln 7b2b03ab side-b
-    "#);
-    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r##"
+    [EOF]
+    ");
+    insta::assert_snapshot!(test_env.jj_cmd_success(&repo_path, &["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
     +++ b/file
@@ -425,7 +446,8 @@ fn test_conflict_marker_length_stored_in_working_copy() {
      line 3
     +>>>>>>> fake marker
      >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    [EOF]
+    ");
 
     // Working copy should still contain conflict marker length
     let stdout = test_env.jj_cmd_success(&repo_path, &["debug", "local-working-copy"]);
@@ -433,6 +455,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     Current operation: OperationId("205bc702428a522e0b175938a51c51b59741c854a609ba63c89de76ffda6e5eff6fcc00725328b1a91f448401769773cefcff01fac3448190d2cea4e137d2166")
     Current tree: Merge(Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]))
     Normal { <executable> }           289 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
+    [EOF]
     "#);
 
     // Resolve the conflict
@@ -452,13 +475,14 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     .unwrap();
 
     let stdout = test_env.jj_cmd_success(&repo_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     M file
     Working copy : mzvwutvl 1aefd866 (no description set)
     Parent commit: rlvkpnrz ce613b49 side-a
     Parent commit: zsuskuln 7b2b03ab side-b
-    "#);
+    [EOF]
+    ");
 
     // When the file is resolved, the conflict marker length is removed from the
     // working copy
@@ -467,5 +491,6 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     Current operation: OperationId("2206ce3c108b1573df0841138c226bba1ab3cff900a5899ed31ac69162c7d6f30d37fb5ab43da60dba88047b8ab22d453887fff688f26dfcf04f2c99420a5563")
     Current tree: Merge(Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")))
     Normal { <executable> }           130 <timestamp> None "file"
+    [EOF]
     "#);
 }

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -31,21 +31,23 @@ fn test_workspaces_add_second_workspace() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "initial"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 8183d0fc (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &main_path,
         &["workspace", "add", "--name", "second", "../secondary"],
     );
     insta::assert_snapshot!(stdout.normalize_backslash(), @"");
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "../secondary"
     Working copy now at: rzvqmyuk 5ed2222c (empty) (no description set)
     Parent commit      : qpvuntsm 751b12b7 initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    "#);
 
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
@@ -55,21 +57,24 @@ fn test_workspaces_add_second_workspace() {
     ├─╯
     ○  751b12b7b981
     ◆  000000000000
+    [EOF]
     ");
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  5ed2222c28e2 second@
     │ ○  8183d0fcaa4c default@
     ├─╯
     ○  751b12b7b981
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 8183d0fc (empty) (no description set)
     second: rzvqmyuk 5ed2222c (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 /// Test how sparse patterns are inherited
@@ -87,34 +92,38 @@ fn test_workspaces_sparse_patterns() {
     test_env.jj_cmd_ok(&ws1_path, &["sparse", "set", "--clear", "--add=foo"]);
     test_env.jj_cmd_ok(&ws1_path, &["workspace", "add", "../ws2"]);
     let stdout = test_env.jj_cmd_success(&ws2_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     foo
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&ws2_path, &["sparse", "set", "--add=bar"]);
     test_env.jj_cmd_ok(&ws2_path, &["workspace", "add", "../ws3"]);
     let stdout = test_env.jj_cmd_success(&ws3_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar
     foo
-    "###);
+    [EOF]
+    ");
     // --sparse-patterns behavior
     test_env.jj_cmd_ok(
         &ws3_path,
         &["workspace", "add", "--sparse-patterns=copy", "../ws4"],
     );
     let stdout = test_env.jj_cmd_success(&ws4_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     bar
     foo
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(
         &ws3_path,
         &["workspace", "add", "--sparse-patterns=full", "../ws5"],
     );
     let stdout = test_env.jj_cmd_success(&ws5_path, &["sparse", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     .
-    "###);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(
         &ws3_path,
         &["workspace", "add", "--sparse-patterns=empty", "../ws6"],
@@ -136,9 +145,10 @@ fn test_workspaces_add_second_workspace_on_merge() {
     test_env.jj_cmd_ok(&main_path, &["new", "all:@-+", "-m=merge"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: zsuskuln 35e47bff (empty) merge
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &main_path,
@@ -155,6 +165,7 @@ fn test_workspaces_add_second_workspace_on_merge() {
     ○ │  1694f2ddf8ec
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -170,11 +181,12 @@ fn test_workspaces_add_ignore_working_copy() {
         &main_path,
         &["workspace", "add", "--ignore-working-copy", "../secondary"],
     );
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "../secondary"
     Error: This command must be able to update the working copy.
     Hint: Don't use --ignore-working-copy.
-    "###);
+    [EOF]
+    "#);
 }
 
 /// Test that --at-op is respected
@@ -186,17 +198,19 @@ fn test_workspaces_add_at_operation() {
 
     std::fs::write(main_path.join("file1"), "").unwrap();
     let (_stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["commit", "-m1"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: rlvkpnrz 18d8b994 (empty) (no description set)
     Parent commit      : qpvuntsm 3364a7ed 1
-    "###);
+    [EOF]
+    ");
 
     std::fs::write(main_path.join("file2"), "").unwrap();
     let (_stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["commit", "-m2"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: kkmpptxz 2e7dc5ab (empty) (no description set)
     Parent commit      : rlvkpnrz 0dbaa19a 2
-    "###);
+    [EOF]
+    ");
 
     // --at-op should disable snapshot in the main workspace, but the newly
     // created workspace should still be writable.
@@ -205,29 +219,32 @@ fn test_workspaces_add_at_operation() {
         &main_path,
         &["workspace", "add", "--at-op=@-", "../secondary"],
     );
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "../secondary"
     Working copy now at: rzvqmyuk a4d1cbc9 (empty) (no description set)
     Parent commit      : qpvuntsm 3364a7ed 1
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    "#);
     let secondary_path = test_env.env_root().join("secondary");
 
     // New snapshot can be taken in the secondary workspace.
     std::fs::write(secondary_path.join("file4"), "").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["status"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     Working copy changes:
     A file4
     Working copy : rzvqmyuk 2ba74f85 (no description set)
     Parent commit: qpvuntsm 3364a7ed 1
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&secondary_path, &["op", "log", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  snapshot working copy
     ○    reconcile divergent operations
     ├─╮
@@ -240,7 +257,8 @@ fn test_workspaces_add_at_operation() {
     ○  snapshot working copy
     ○  add workspace 'default'
     ○
-    "#);
+    [EOF]
+    ");
 }
 
 /// Test adding a workspace, but at a specific revision using '-r'
@@ -258,9 +276,10 @@ fn test_workspaces_add_workspace_at_revision() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "second"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: kkmpptxz dadeedb4 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let (_, stderr) = test_env.jj_cmd_ok(
         &main_path,
@@ -274,12 +293,13 @@ fn test_workspaces_add_workspace_at_revision() {
             "@--",
         ],
     );
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "../secondary"
     Working copy now at: zxsnswpr e374e74a (empty) (no description set)
     Parent commit      : qpvuntsm f6097c2f first
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    "#);
 
     // Can see the working-copy commit in each workspace in the log output. The "@"
     // node in the graph indicates the current workspace's working-copy commit.
@@ -290,15 +310,17 @@ fn test_workspaces_add_workspace_at_revision() {
     ├─╯
     ○  f6097c2f7cac
     ◆  000000000000
+    [EOF]
     ");
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  e374e74aa0c8 second@
     │ ○  dadeedb493e8 default@
     │ ○  c420244c6398
     ├─╯
     ○  f6097c2f7cac
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 /// Test multiple `-r` flags to `workspace add` to create a workspace
@@ -321,7 +343,7 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "third"]);
     test_env.jj_cmd_ok(&main_path, &["new", "-r", "root()"]);
 
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  5b36783cd11c
     │ ○  6c843d62ca29
     ├─╯
@@ -330,7 +352,8 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     │ ○  f6097c2f7cac
     ├─╯
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     let (_, stderr) = test_env.jj_cmd_ok(
         &main_path,
@@ -344,14 +367,15 @@ fn test_workspaces_add_workspace_multiple_revisions() {
             "-r=description(first)",
         ],
     );
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "../merged"
     Working copy now at: wmwvqwsz f4fa64f4 (empty) (no description set)
     Parent commit      : mzvwutvl 6c843d62 third
     Parent commit      : kkmpptxz 544cd61f second
     Parent commit      : qpvuntsm f6097c2f first
     Added 3 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    "#);
 
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  5b36783cd11c default@
@@ -364,6 +388,7 @@ fn test_workspaces_add_workspace_multiple_revisions() {
     │ ○  6c843d62ca29
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -380,27 +405,30 @@ fn test_workspaces_add_workspace_from_subdir() {
     test_env.jj_cmd_ok(&main_path, &["commit", "-m", "initial"]);
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz e1038e77 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Create workspace while in sub-directory of current workspace
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&subdir_path, &["workspace", "add", "../../secondary"]);
     insta::assert_snapshot!(stdout.normalize_backslash(), @"");
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "../../secondary"
     Working copy now at: rzvqmyuk 7ad84461 (empty) (no description set)
     Parent commit      : qpvuntsm a3a43d9e initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    "#);
 
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz e1038e77 (empty) (no description set)
     secondary: rzvqmyuk 7ad84461 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -415,47 +443,52 @@ fn test_workspaces_add_workspace_in_current_workspace() {
     // Try to create workspace using name instead of path
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "add", "secondary"]);
     insta::assert_snapshot!(stdout.normalize_backslash(), @"");
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "secondary"
     Warning: Workspace created inside current directory. If this was unintentional, delete the "secondary" directory and run `jj workspace forget secondary` to remove it.
     Working copy now at: pmmvwywv 0a77a39d (empty) (no description set)
     Parent commit      : qpvuntsm 751b12b7 initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    "#);
 
     // Workspace created despite warning
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 46d9ba8b (no description set)
     secondary: pmmvwywv 0a77a39d (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Use explicit path instead (no warning)
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "add", "./third"]);
     insta::assert_snapshot!(stdout.normalize_backslash(), @"");
-    insta::assert_snapshot!(stderr.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stderr.normalize_backslash(), @r#"
     Created workspace in "third"
     Working copy now at: zxsnswpr 64746d4b (empty) (no description set)
     Parent commit      : qpvuntsm 751b12b7 initial
     Added 1 files, modified 0 files, removed 0 files
-    "###);
+    [EOF]
+    "#);
 
     // Both workspaces created
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 477c647f (no description set)
     secondary: pmmvwywv 0a77a39d (empty) (no description set)
     third: zxsnswpr 64746d4b (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Can see files from the other workspaces in main workspace, since they are
     // child directories and will therefore be snapshotted
     let stdout = test_env.jj_cmd_success(&main_path, &["file", "list"]);
-    insta::assert_snapshot!(stdout.normalize_backslash(), @r###"
+    insta::assert_snapshot!(stdout.normalize_backslash(), @r"
     file
     secondary/file
     third/file
-    "###);
+    [EOF]
+    ");
 }
 
 /// Test making changes to the working copy in a workspace as it gets rewritten
@@ -478,6 +511,7 @@ fn test_workspaces_conflicting_edits() {
     ├─╯
     ○  506f4ec3c2c6
     ◆  000000000000
+    [EOF]
     ");
 
     // Make changes in both working copies
@@ -487,47 +521,52 @@ fn test_workspaces_conflicting_edits() {
     // running any command in the secondary workspace
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
     Parent commit      : qpvuntsm d4124476 (no description set)
-    "###);
+    [EOF]
+    ");
 
     // The secondary workspace's working-copy commit was updated
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  a58c9a9b19ce default@
     │ ○  e82cd4ee8faa secondary@
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation c81af45155a2).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    [EOF]
+    ");
     // Same error on second run, and from another command
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["log"]);
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation c81af45155a2).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     // It was detected that the working copy is now stale.
     // Since there was an uncommitted change in the working copy, it should
     // have been committed first (causing divergence)
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
     Working copy now at: pmmvwywv?? e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit e82cd4ee8faa
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
-    @r###"
+    @r"
     @  e82cd4ee8faa secondary@ (divergent)
     │ ×  30816012e0da (divergent)
     ├─╯
@@ -535,11 +574,12 @@ fn test_workspaces_conflicting_edits() {
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     // The stale working copy should have been resolved by the previous command
     let stdout = get_log_output(&test_env, &secondary_path);
     assert!(!stdout.raw().starts_with("The working copy is stale"));
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     @  e82cd4ee8faa secondary@ (divergent)
     │ ×  30816012e0da (divergent)
     ├─╯
@@ -547,7 +587,8 @@ fn test_workspaces_conflicting_edits() {
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 /// Test a clean working copy that gets rewritten from another workspace
@@ -569,41 +610,46 @@ fn test_workspaces_updated_by_other() {
     ├─╯
     ○  506f4ec3c2c6
     ◆  000000000000
+    [EOF]
     ");
 
     // Rewrite the check-out commit in one workspace.
     std::fs::write(main_path.join("file"), "changed in main\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
     Parent commit      : qpvuntsm d4124476 (no description set)
-    "###);
+    [EOF]
+    ");
 
     // The secondary workspace's working-copy commit was updated.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  a58c9a9b19ce default@
     │ ○  e82cd4ee8faa secondary@
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
-    insta::assert_snapshot!(stderr, @r##"
+    insta::assert_snapshot!(stderr, @r"
     Error: The working copy is stale (not updated since operation c81af45155a2).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-    "##);
+    [EOF]
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     // It was detected that the working copy is now stale, but clean. So no
     // divergent commit should be created.
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: pmmvwywv e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit e82cd4ee8faa
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r"
     @  e82cd4ee8faa secondary@
@@ -611,6 +657,7 @@ fn test_workspaces_updated_by_other() {
     ├─╯
     ○  d41244767d45
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -635,39 +682,44 @@ fn test_workspaces_updated_by_other_automatic() {
     ├─╯
     ○  506f4ec3c2c6
     ◆  000000000000
+    [EOF]
     ");
 
     // Rewrite the check-out commit in one workspace.
     std::fs::write(main_path.join("file"), "changed in main\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["squash"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Rebased 1 descendant commits
     Working copy now at: mzvwutvl a58c9a9b (empty) (no description set)
     Parent commit      : qpvuntsm d4124476 (no description set)
-    "###);
+    [EOF]
+    ");
 
     // The secondary workspace's working-copy commit was updated.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  a58c9a9b19ce default@
     │ ○  e82cd4ee8faa secondary@
     ├─╯
     ○  d41244767d45
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // The first working copy gets automatically updated.
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     The working copy has no changes.
     Working copy : pmmvwywv e82cd4ee (empty) (no description set)
     Parent commit: qpvuntsm d4124476 (no description set)
-    "###);
-    insta::assert_snapshot!(stderr, @r###"
+    [EOF]
+    ");
+    insta::assert_snapshot!(stderr, @r"
     Working copy now at: pmmvwywv e82cd4ee (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit e82cd4ee8faa
-    "###);
+    [EOF]
+    ");
 
     insta::assert_snapshot!(get_log_output(&test_env, &secondary_path),
     @r"
@@ -676,6 +728,7 @@ fn test_workspaces_updated_by_other_automatic() {
     ├─╯
     ○  d41244767d45
     ◆  000000000000
+    [EOF]
     ");
 }
 
@@ -733,7 +786,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ],
     );
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r#"
+        insta::assert_snapshot!(stdout, @r"
         @  757bc1140b abandon commit 20dd439c4bd12c6ad56c187ac490bd0141804618f638dc5c4dc92ff9aecba20f152b23160db9dcf61beb31a5cb14091d9def5a36d11c9599cc4d2e5689236af1
         ○  8d4abed655 create initial working-copy commit in workspace secondary
         ○  3de27432e5 add workspace 'secondary'
@@ -743,7 +796,8 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ○  829c93f6a3 snapshot working copy
         ○  2557266dd2 add workspace 'default'
         ○  0000000000
-        "#);
+        [EOF]
+        ");
     }
 
     // Abandon ops, including the one the secondary workspace is currently on.
@@ -757,6 +811,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ├─╯
         ○  7c5b25a4fc8f
         ◆  000000000000
+        [EOF]
         ");
     }
 
@@ -765,31 +820,35 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         test_env.jj_cmd_success(&secondary_path, &["help"]);
 
         let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["st"]);
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Working copy changes:
         A added
         D deleted
         M modified
         Working copy : kmkuslsw 15df8cb5 RECOVERY COMMIT FROM `jj workspace update-stale`
         Parent commit: rzvqmyuk 96b31daf (empty) (no description set)
-        "###);
-        insta::assert_snapshot!(stderr, @r###"
+        [EOF]
+        ");
+        insta::assert_snapshot!(stderr, @r"
         Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 8d4abed655badb70b1bab62aa87136619dbc3c8015a8ce8dfb7abfeca4e2f36c713d8f84e070a0613907a6cee7e1cc05323fe1205a319b93fe978f11a060c33c of type operation not found
         Created and checked out recovery commit 76d0126b3e5c
-        "###);
+        [EOF]
+        ");
     } else {
         let stderr = test_env.jj_cmd_failure(&secondary_path, &["st"]);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r"
         Error: Could not read working copy's operation.
         Hint: Run `jj workspace update-stale` to recover.
         See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
-        "###);
+        [EOF]
+        ");
 
         let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
-        insta::assert_snapshot!(stderr, @r###"
+        insta::assert_snapshot!(stderr, @r"
         Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 8d4abed655badb70b1bab62aa87136619dbc3c8015a8ce8dfb7abfeca4e2f36c713d8f84e070a0613907a6cee7e1cc05323fe1205a319b93fe978f11a060c33c of type operation not found
         Created and checked out recovery commit 76d0126b3e5c
-        "###);
+        [EOF]
+        ");
         insta::assert_snapshot!(stdout, @"");
     }
 
@@ -801,31 +860,34 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ├─╯
         ○  7c5b25a4fc8f
         ◆  000000000000
+        [EOF]
         ");
     }
 
     // The sparse patterns should remain
     let stdout = test_env.jj_cmd_success(&secondary_path, &["sparse", "list"]);
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         added
         deleted
         modified
-        "###);
+        [EOF]
+        ");
     }
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["st"]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(stderr, @"");
     }
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         Working copy changes:
         A added
         D deleted
         M modified
         Working copy : kmkuslsw 15df8cb5 RECOVERY COMMIT FROM `jj workspace update-stale`
         Parent commit: rzvqmyuk 96b31daf (empty) (no description set)
-        "###);
+        [EOF]
+        ");
     }
     insta::allow_duplicates! {
         // The modified file should have the same contents it had before (not reset to
@@ -840,12 +902,13 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         insta::assert_snapshot!(stderr, @"");
     }
     insta::allow_duplicates! {
-        insta::assert_snapshot!(stdout, @r###"
+        insta::assert_snapshot!(stdout, @r"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 15df8cb5
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
         ○  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 76d0126b
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-        "###);
+        [EOF]
+        ");
     }
 }
 
@@ -857,22 +920,27 @@ fn test_workspaces_update_stale_noop() {
 
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "update-stale"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @"Attempted recovery, but the working copy is not stale");
+    insta::assert_snapshot!(stderr, @r"
+    Attempted recovery, but the working copy is not stale
+    [EOF]
+    ");
 
     let stderr = test_env.jj_cmd_failure(
         &main_path,
         &["workspace", "update-stale", "--ignore-working-copy"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: This command must be able to update the working copy.
     Hint: Don't use --ignore-working-copy.
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "-Tdescription"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  add workspace 'default'
     ○
-    "#);
+    [EOF]
+    ");
 }
 
 /// Test "update-stale" in a dirty, but not stale working copy.
@@ -895,19 +963,21 @@ fn test_workspaces_update_stale_snapshot() {
     std::fs::write(secondary_path.join("file"), "changed in second\n").unwrap();
     let (stdout, stderr) = test_env.jj_cmd_ok(&secondary_path, &["workspace", "update-stale"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Concurrent modification detected, resolving automatically.
     Attempted recovery, but the working copy is not stale
-    "###);
+    [EOF]
+    ");
 
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  e672fd8fefac secondary@
     │ ○  ea37b073f5ab default@
     │ ○  b13c81dedc64
     ├─╯
     ○  e6e9989f1179
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 /// Test forgetting workspaces
@@ -927,37 +997,44 @@ fn test_workspaces_forget() {
 
     // When listing workspaces, only the secondary workspace shows up
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     secondary: pmmvwywv 18463f43 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // `jj status` tells us that there's no working copy here
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["st"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     No working copy
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(stderr, @"");
 
     // The old working copy doesn't get an "@" in the log output
     // TODO: It seems useful to still have the "secondary@" marker here even though
     // there's only one workspace. We should show it when the command is not run
     // from that workspace.
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  18463f438cc9
     ○  4e8f9d2be039
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // Revision "@" cannot be used
     let stderr = test_env.jj_cmd_failure(&main_path, &["log", "-r", "@"]);
-    insta::assert_snapshot!(stderr, @"Error: Workspace `default` doesn't have a working-copy commit");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Workspace `default` doesn't have a working-copy commit
+    [EOF]
+    ");
 
     // Try to add back the workspace
     // TODO: We should make this just add it back instead of failing
     let stderr = test_env.jj_cmd_failure(&main_path, &["workspace", "add", "."]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Workspace already exists
-    "###);
+    [EOF]
+    ");
 
     // Add a third workspace...
     test_env.jj_cmd_ok(&main_path, &["workspace", "add", "../third"]);
@@ -985,37 +1062,41 @@ fn test_workspaces_forget_multi_transaction() {
 
     // there should be three workspaces
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 909d51b1 (empty) (no description set)
     second: pmmvwywv 18463f43 (empty) (no description set)
     third: rzvqmyuk cc383fa2 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // delete two at once, in a single tx
     test_env.jj_cmd_ok(&main_path, &["workspace", "forget", "second", "third"]);
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 909d51b1 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // the op log should have multiple workspaces forgotten in a single tx
     let stdout = test_env.jj_cmd_success(&main_path, &["op", "log", "--limit", "1"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  60b2b5a71a84 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third
-    "#);
+    [EOF]
+    ");
 
     // now, undo, and that should restore both workspaces
     test_env.jj_cmd_ok(&main_path, &["op", "undo"]);
 
     // finally, there should be three workspaces at the end
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: rlvkpnrz 909d51b1 (empty) (no description set)
     second: pmmvwywv 18463f43 (empty) (no description set)
     third: rzvqmyuk cc383fa2 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1036,45 +1117,50 @@ fn test_workspaces_forget_abandon_commits() {
 
     // there should be four workspaces, three of which are at the same empty commit
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: qpvuntsm 4e8f9d2b (no description set)
     fourth: uuqppmxq 57d63245 (empty) (no description set)
     second: uuqppmxq 57d63245 (empty) (no description set)
     third: uuqppmxq 57d63245 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     @  4e8f9d2be039 default@
     │ ○  57d63245a308 fourth@ second@ third@
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
 
     // delete the default workspace (should not abandon commit since not empty)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "default"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  57d63245a308 fourth@ second@ third@
     │ ○  4e8f9d2be039
     ├─╯
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // delete the second workspace (should not abandon commit since other workspaces
     // still have commit checked out)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "second"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  57d63245a308 fourth@ third@
     │ ○  4e8f9d2be039
     ├─╯
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 
     // delete the last 2 workspaces (commit should be abandoned now even though
     // forgotten in same tx)
     test_env.jj_cmd_success(&main_path, &["workspace", "forget", "third", "fourth"]);
-    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
     ○  4e8f9d2be039
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 /// Test context of commit summary template
@@ -1100,16 +1186,18 @@ fn test_list_workspaces_template() {
 
     // "current_working_copy" should point to the workspace we operate on
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: 8183d0fcaa4c  (current)
     second: 0a77a39d7d6f 
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: 8183d0fcaa4c 
     second: 0a77a39d7d6f  (current)
-    "###);
+    [EOF]
+    ");
 }
 
 /// Test getting the workspace root from primary and secondary workspaces
@@ -1121,30 +1209,34 @@ fn test_workspaces_root() {
     let secondary_path = test_env.env_root().join("secondary");
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     $TEST_ENV/main
-    "###);
+    [EOF]
+    ");
     let main_subdir_path = main_path.join("subdir");
     std::fs::create_dir(&main_subdir_path).unwrap();
     let stdout = test_env.jj_cmd_success(&main_subdir_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     $TEST_ENV/main
-    "###);
+    [EOF]
+    ");
 
     test_env.jj_cmd_ok(
         &main_path,
         &["workspace", "add", "--name", "secondary", "../secondary"],
     );
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     $TEST_ENV/secondary
-    "###);
+    [EOF]
+    ");
     let secondary_subdir_path = secondary_path.join("subdir");
     std::fs::create_dir(&secondary_subdir_path).unwrap();
     let stdout = test_env.jj_cmd_success(&secondary_subdir_path, &["workspace", "root"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     $TEST_ENV/secondary
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1156,17 +1248,18 @@ fn test_debug_snapshot() {
     std::fs::write(repo_path.join("file"), "contents").unwrap();
     test_env.jj_cmd_ok(&repo_path, &["debug", "snapshot"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  c55ebc67e3db test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    [EOF]
+    ");
     test_env.jj_cmd_ok(&repo_path, &["describe", "-m", "initial"]);
     let stdout = test_env.jj_cmd_success(&repo_path, &["op", "log"]);
-    insta::assert_snapshot!(stdout, @r#"
+    insta::assert_snapshot!(stdout, @r"
     @  c9a40b951848 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit 4e8f9d2be039994f589b4e57ac5e9488703e604d
     │  args: jj describe -m initial
@@ -1176,7 +1269,8 @@ fn test_debug_snapshot() {
     ○  eac759b9ab75 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
-    "#);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1186,9 +1280,10 @@ fn test_workspaces_rename_nothing_changed() {
     let main_path = test_env.env_root().join("main");
     let (stdout, stderr) = test_env.jj_cmd_ok(&main_path, &["workspace", "rename", "default"]);
     insta::assert_snapshot!(stdout, @"");
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Nothing changed.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1201,10 +1296,11 @@ fn test_workspaces_rename_new_workspace_name_already_used() {
         &["workspace", "add", "--name", "second", "../secondary"],
     );
     let stderr = test_env.jj_cmd_failure(&main_path, &["workspace", "rename", "second"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Failed to rename a workspace
     Caused by: Workspace second already exists
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1219,9 +1315,10 @@ fn test_workspaces_rename_forgotten_workspace() {
     test_env.jj_cmd_ok(&main_path, &["workspace", "forget", "second"]);
     let secondary_path = test_env.env_root().join("secondary");
     let stderr = test_env.jj_cmd_failure(&secondary_path, &["workspace", "rename", "third"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: The current workspace 'second' is not tracked in the repo.
-    "###);
+    [EOF]
+    ");
 }
 
 #[test]
@@ -1237,19 +1334,21 @@ fn test_workspaces_rename_workspace() {
 
     // Both workspaces show up when we list them
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: qpvuntsm 230dd059 (empty) (no description set)
     second: uuqppmxq 57d63245 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     let stdout = test_env.jj_cmd_success(&secondary_path, &["workspace", "rename", "third"]);
     insta::assert_snapshot!(stdout, @"");
 
     let stdout = test_env.jj_cmd_success(&main_path, &["workspace", "list"]);
-    insta::assert_snapshot!(stdout, @r###"
+    insta::assert_snapshot!(stdout, @r"
     default: qpvuntsm 230dd059 (empty) (no description set)
     third: uuqppmxq 57d63245 (empty) (no description set)
-    "###);
+    [EOF]
+    ");
 
     // Can see the working-copy commit in each workspace in the log output.
     insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"
@@ -1257,13 +1356,15 @@ fn test_workspaces_rename_workspace() {
     │ ○  57d63245a308 third@
     ├─╯
     ◆  000000000000
+    [EOF]
     ");
-    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r###"
+    insta::assert_snapshot!(get_log_output(&test_env, &secondary_path), @r"
     @  57d63245a308 third@
     │ ○  230dd059e1b0 default@
     ├─╯
     ◆  000000000000
-    "###);
+    [EOF]
+    ");
 }
 
 fn get_log_output(test_env: &TestEnvironment, cwd: &Path) -> CommandOutputString {


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
