### PR TITLE
docs: record contributors whose employer pays for contributions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,10 +66,12 @@ so you can address any remaining minor comments and then merge the PR yourself
 when you're ready. If you realize that some comments require non-trivial
 changes, please ask your reviewer to take another look.
 
+If your employer pays anyone (not necessarily you) to contribute to Jujutsu,
+please make sure your GitHub username is [recorded](paid_contributors.md).
 To avoid conflicts of interest, please don't merge a PR that has only been
-approved by someone from the same organization. Similarly, as a reviewer,
-there is no need to approve your coworkers' PRs, since the author should await
-an approval from someone else anyway. It is of course still appreciated if you
+approved by someone from the same organization. Similarly, as a reviewer, there
+is no need to approve your coworkers' PRs, since the author should await an
+approval from someone else anyway. It is of course still appreciated if you
 review and comment on their PRs. Also, if the PR seems completely unrelated to
 your company's interests, do feel free to approve it.
 

--- a/docs/paid_contributors.md
+++ b/docs/paid_contributors.md
@@ -1,0 +1,34 @@
+# Paying employers and their employees
+
+This is the list companies paying for contributions to Jujutsu. For each
+company, all contributors are listed, whether it's part of their job to
+contribute or not.
+
+## Google
+
+* AM5800
+* algmyr
+* aspotashev
+* edre
+* emesterhazy
+* essiene
+* daehyeok
+* drieber
+* durin42
+* honglooker
+* hooper
+* incognito124
+* jonathantanmy
+* kevincliao
+* lukegb
+* martinvonz
+* matts1
+* mlcui-corp
+* qfel
+* Ralith
+* rdamazio
+* solson
+* spectral54
+* steadmon
+* torquestomp
+* zygoloid


### PR DESCRIPTION
This adds a record of all contributing employees of companies who pay for contributions. The purpose is to help make possible conflicts of interest easier to spot. As far as we know, only Google currently pays right now.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
