### PR TITLE
cli split: Make `jj split --parallel` set @ to the first revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `ui.allow-filesets` configuration option has been removed.
   [The "fileset" language](docs/filesets.md) has been enabled by default since v0.20.
 
+* `jj split --parallel` now sets the working copy revision (`@`) to the first
+  revision created by the split instead of the second. As a result, `@` remains on
+  the same change id before and after the split.
+  
+
 ### Deprecations
 
 * This release takes the first steps to make target revision required in

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -221,11 +221,20 @@ The remainder will be in the second commit.
             rewriter.rebase()?.write()?;
             Ok(())
         })?;
-    // Move the working copy commit (@) to the second commit for any workspaces
-    // where the target commit is the working copy commit.
+    // Change the working copy commit as needed.
     for (workspace_id, working_copy_commit) in tx.base_repo().clone().view().wc_commit_ids() {
         if working_copy_commit == commit.id() {
-            tx.repo_mut().edit(workspace_id.clone(), &second_commit)?;
+            // TODO: https://github.com/jj-vcs/jj/issues/3419 - Delete this
+            //   branch when the config setting is removed.
+            if args.parallel && legacy_bookmark_behavior {
+                // We need to do this manually since the legacy behavior
+                // rewrites the target to the second commit.
+                tx.repo_mut().edit(workspace_id.clone(), &first_commit)?;
+            } else if !args.parallel {
+                // Move the working copy commit (@) to the second commit for any
+                // workspaces where the target commit is the working copy commit.
+                tx.repo_mut().edit(workspace_id.clone(), &second_commit)?;
+            }
         }
     }
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -369,13 +369,13 @@ fn test_split_siblings_no_descendants() {
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 48018df6 TESTED=TODO
     Second part: kkmpptxz 7eddbf93 (no description set)
-    Working copy now at: kkmpptxz 7eddbf93 (no description set)
+    Working copy now at: qpvuntsm 48018df6 TESTED=TODO
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r###"
-    @  kkmpptxzrspx false
-    │ ○  qpvuntsmwlqt false TESTED=TODO
+    @  qpvuntsmwlqt false TESTED=TODO
+    │ ○  kkmpptxzrspx false
     ├─╯
     ◆  zzzzzzzzzzzz true
     "###);
@@ -451,7 +451,7 @@ fn test_split_siblings_with_descendants() {
     Rebased 2 descendant commits
     First part: qpvuntsm 84df941d Add file1
     Second part: vruxwmqv 94753be3 Add file2
-    Working copy now at: vruxwmqv 94753be3 Add file2
+    Working copy now at: qpvuntsm 84df941d Add file1
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     "###);
@@ -459,8 +459,8 @@ fn test_split_siblings_with_descendants() {
     ○  kkmpptxzrspx false Add file4
     ○    rlvkpnrzqnoo false Add file3
     ├─╮
-    │ @  vruxwmqvtpmx false Add file2
-    ○ │  qpvuntsmwlqt false Add file1
+    │ ○  vruxwmqvtpmx false Add file2
+    @ │  qpvuntsmwlqt false Add file1
     ├─╯
     ◆  zzzzzzzzzzzz true
     "###);
@@ -765,8 +765,8 @@ fn test_split_with_multiple_workspaces_same_working_copy() {
     .unwrap();
     test_env.jj_cmd_ok(&main_path, &["split", "file2", "--parallel"]);
     insta::assert_snapshot!(get_workspace_log_output(&test_env, &main_path), @r###"
-    @  yostqsxwqrlt default@ second@ second-commit
-    │ ○  qpvuntsmwlqt first-commit
+    @  qpvuntsmwlqt default@ second@ first-commit
+    │ ○  yostqsxwqrlt second-commit
     ├─╯
     ◆  zzzzzzzzzzzz
     "###);
@@ -823,8 +823,8 @@ fn test_split_with_multiple_workspaces_different_working_copy() {
     .unwrap();
     test_env.jj_cmd_ok(&main_path, &["split", "file2", "--parallel"]);
     insta::assert_snapshot!(get_workspace_log_output(&test_env, &main_path), @r###"
-    @  vruxwmqvtpmx default@ second-commit
-    │ ○  qpvuntsmwlqt first-commit
+    @  qpvuntsmwlqt default@ first-commit
+    │ ○  vruxwmqvtpmx second-commit
     ├─╯
     │ ○  pmmvwywvzvvn second@
     ├─╯
@@ -928,8 +928,8 @@ fn test_split_with_bookmarks(bookmark_behavior: BookmarkBehavior) {
         BookmarkBehavior::Modern => {
             insta::allow_duplicates! {
             insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-            @  vruxwmqvtpmx false second-commit
-            │ ○  qpvuntsmwlqt false *le-signet* first-commit
+            @  qpvuntsmwlqt false *le-signet* first-commit
+            │ ○  vruxwmqvtpmx false second-commit
             ├─╯
             ◆  zzzzzzzzzzzz true
             "###);
@@ -938,8 +938,8 @@ fn test_split_with_bookmarks(bookmark_behavior: BookmarkBehavior) {
         BookmarkBehavior::Default | BookmarkBehavior::Legacy => {
             insta::allow_duplicates! {
             insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r###"
-            @  vruxwmqvtpmx false *le-signet* second-commit
-            │ ○  qpvuntsmwlqt false first-commit
+            @  qpvuntsmwlqt false first-commit
+            │ ○  vruxwmqvtpmx false *le-signet* second-commit
             ├─╯
             ◆  zzzzzzzzzzzz true
             "###);


### PR DESCRIPTION
`jj split --parallel` now sets the working copy revision (`@`) to the first revision created by the split instead of the second. As a result, `@` remains on the same change id before and after the split.

There is no good reason to choose the second commit as the working copy commit after a --parallel split. The only reason it works that way today is because doing that didn't require any code changes compared to the non parallel split.

Martin proposed this change in the review for https://github.com/jj-vcs/jj/pull/5618.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
