### PR TITLE
cli split: Recommend `jj config set --user` instead of `--repo` in deprecation warning

### DIFF
--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -263,7 +263,7 @@ fn read_legacy_bookmark_behavior_setting(
             )?;
             writeln!(
                 ui.warning_default(),
-                "Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this \
+                "Run `jj config set --user split.legacy-bookmark-behavior false` to silence this \
                  message and use the new behavior."
             )?;
             writeln!(

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -63,7 +63,7 @@ fn test_split_by_paths() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 65569ca7 (no description set)
     Second part: zsuskuln 709756f0 (no description set)
@@ -115,7 +115,7 @@ fn test_split_by_paths() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: All changes have been selected, so the second commit will be empty
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: qpvuntsm 9da0eea0 (no description set)
@@ -146,7 +146,7 @@ fn test_split_by_paths() {
     insta::assert_snapshot!(stderr, @r###"
     Warning: No changes have been selected, so the first commit will be empty
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: qpvuntsm bd42f95a (empty) (no description set)
@@ -195,7 +195,7 @@ fn test_split_with_non_empty_description() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 231a3c00 part 1
     Second part: kkmpptxz e96291aa part 2
@@ -250,7 +250,7 @@ fn test_split_with_default_description() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 02ee5d60 TESTED=TODO
     Second part: rlvkpnrz 33cd046b (no description set)
@@ -318,7 +318,7 @@ fn test_split_with_merge_child() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
@@ -365,7 +365,7 @@ fn test_split_siblings_no_descendants() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 48018df6 TESTED=TODO
     Second part: kkmpptxz 7eddbf93 (no description set)
@@ -446,7 +446,7 @@ fn test_split_siblings_with_descendants() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 2 descendant commits
     First part: qpvuntsm 84df941d Add file1
@@ -527,7 +527,7 @@ fn test_split_siblings_with_merge_child() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     Rebased 1 descendant commits
     First part: kkmpptxz e8006b47 Add file1
@@ -626,7 +626,7 @@ fn test_split_interactive() {
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: qpvuntsm 0e15949e (no description set)
     Second part: rlvkpnrz 9ed12e4c (no description set)
@@ -674,7 +674,7 @@ fn test_split_interactive_with_paths() {
     let (_stdout, stderr) = test_env.jj_cmd_ok(&workspace_path, &["split", "-i", "file1", "file2"]);
     insta::assert_snapshot!(stderr, @r###"
     Warning: `jj split` will leave bookmarks on the first commit in the next release.
-    Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+    Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
     Warning: See https://github.com/jj-vcs/jj/issues/3419
     First part: rlvkpnrz e3d766b8 (no description set)
     Second part: kkmpptxz 4cf22d3b (no description set)
@@ -898,7 +898,7 @@ fn test_split_with_bookmarks(bookmark_behavior: BookmarkBehavior) {
             insta::allow_duplicates! {
             insta::assert_snapshot!(stderr, @r###"
             Warning: `jj split` will leave bookmarks on the first commit in the next release.
-            Warning: Run `jj config set --repo split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
+            Warning: Run `jj config set --user split.legacy-bookmark-behavior false` to silence this message and use the new behavior.
             Warning: See https://github.com/jj-vcs/jj/issues/3419
             First part: qpvuntsm 63d0c5ed first-commit
             Second part: mzvwutvl a9f5665f *le-signet* | second-commit


### PR DESCRIPTION
It only occurred to me after I rebuilt jj and actually had to run the command that we should probably recommend a change to the user config instead of the repo config.

#3419

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
