### PR TITLE
config-schema: validate default configs in tests with taplo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         target: ${{ matrix.target }}
     - uses: taiki-e/install-action@995f97569c4a8ae84dcd7e1a0107f65ca6ebf139
       with:
-        tool: nextest
+        tool: nextest,taplo-cli
     - name: Build
       run: cargo build --target ${{ matrix.target }} --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
     - name: Test

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -21,6 +21,7 @@ mod test_commit_template;
 mod test_completion;
 mod test_concurrent_operations;
 mod test_config_command;
+mod test_config_schema;
 mod test_copy_detection;
 mod test_debug_command;
 mod test_describe_command;

--- a/cli/tests/test_config_schema.rs
+++ b/cli/tests/test_config_schema.rs
@@ -1,0 +1,71 @@
+use std::process::Command;
+use std::process::Stdio;
+
+fn taplo_check_config(file: &str) {
+    if Command::new("taplo")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .status()
+        .is_err()
+    {
+        eprintln!("Skipping test because taplo is not installed on the system");
+        return;
+    }
+
+    // Taplo requires an absolute URL to the schema :/
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let taplo_res = Command::new("taplo")
+        .args([
+            "check",
+            "--schema",
+            &format!("file://{}/src/config-schema.json", root.display()),
+            file,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap()
+        .wait_with_output()
+        .unwrap();
+
+    if !taplo_res.status.success() {
+        eprintln!("Failed to validate {file}:");
+        eprintln!("{}", String::from_utf8_lossy(&taplo_res.stderr));
+        panic!("Validation failed");
+    }
+}
+
+#[test]
+fn test_taplo_check_colors_config() {
+    taplo_check_config("src/config/colors.toml");
+}
+
+#[test]
+fn test_taplo_check_merge_tools_config() {
+    taplo_check_config("src/config/merge_tools.toml");
+}
+
+#[test]
+fn test_taplo_check_misc_config() {
+    taplo_check_config("src/config/misc.toml");
+}
+
+#[test]
+fn test_taplo_check_revsets_config() {
+    taplo_check_config("src/config/revsets.toml");
+}
+
+#[test]
+fn test_taplo_check_templates_config() {
+    taplo_check_config("src/config/templates.toml");
+}
+
+#[test]
+fn test_taplo_check_unix_config() {
+    taplo_check_config("src/config/unix.toml");
+}
+
+#[test]
+fn test_taplo_check_windows_config() {
+    taplo_check_config("src/config/windows.toml");
+}

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,9 @@
 
         # for git subprocess test
         git
+
+        # for schema tests
+        taplo
       ];
 
       env = {


### PR DESCRIPTION
An example failure (after intentionally breaking `cli/src/config/windows.toml`) can be found here:
https://github.com/steadmon/jj/actions/runs/13318732695/job/37198937640#step:7:323

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
