### PR TITLE
fix: add simple debugging logs

### DIFF
--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -383,8 +383,9 @@ fn run_tool(
     // associated with.
     let mut vars: HashMap<&str, &str> = HashMap::new();
     vars.insert("path", tool_input.repo_path.as_internal_file_string());
-    let mut child = tool_command
-        .to_command_with_variables(&vars)
+    let mut command = tool_command.to_command_with_variables(&vars);
+    tracing::debug!(?command, ?tool_input.repo_path, "spawning fix tool");
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
@@ -397,6 +398,7 @@ fn run_tool(
         Some(child.wait_with_output().or(Err(())))
     })
     .unwrap()?;
+    tracing::debug!(?command, ?output.status, "fix tool exited:");
     if output.status.success() {
         Ok(output.stdout)
     } else {


### PR DESCRIPTION
https://discord.com/channels/968932220549103686/1339741938324340927/1339741938324340927

There's currently no way to tell what `jj fix` is doing. This adds some traces such that `jj fix --debug` will at least tell you what's being run and what it's exit code is, similar to other subprocessing code.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
