### PR TITLE
cli: warn when command differs after --config, including when subcommand not found

### DIFF
--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -381,4 +381,16 @@ fn test_alias_in_config_arg() {
     Warning: Command aliases cannot be loaded from -R/--repository path or --config/--config-file arguments.
     [EOF]
     ");
+    // should print warning about aliases even if cli parsing fails
+    let alias_arg = r#"--config=aliases.this-command-not-exist=['log', '-r@', '--no-graph', '-T"arg alias\n"']"#;
+    let stderr = test_env.jj_cmd_cli_error(&repo_path, &[alias_arg, "this-command-not-exist"]);
+    insta::assert_snapshot!(stderr, @r#"
+    Warning: Command aliases cannot be loaded from -R/--repository path or --config/--config-file arguments.
+    error: unrecognized subcommand 'this-command-not-exist'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    [EOF]
+    "#);
 }


### PR DESCRIPTION
Aliases and `ui.default-command` are loaded before `--config` and `--config-file` arguments are parsed (#5282).

There is supposed to be a warning when the result of these arguments would change the parsed args: #5286.

However, that warning was not being printed if the arguments failed to parse due to an unrecognized subcommand. Example:

```bash
# correct:
$ jj --config ui.default-command=nonsense
Warning: Command aliases cannot be loaded from -R/--repository path or --config/--config-file arguments.

# previous, confusing:
$ jj --config aliases.some-alias=nonsense some-alias
error: unrecognized subcommand 'some-alias'

# now:
$ jj --config aliases.some-alias=nonsense some-alias
Warning: Command aliases cannot be loaded from -R/--repository path or --config/--config-file arguments.
error: unrecognized subcommand 'some-alias'
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
