### PR TITLE
cli `git push`: new `--named NAME=REVISION` argument to create and immediately push bookmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj diff -r` now allows multiple revisions (as long as there are no gaps in
   the revset), such as `jj diff -r 'mutable()'`.
 
+* `jj git push` now accepts a `--named NAME=REVISION` argument to create a named
+  bookmark and immediately push it.
+
 * The 'how to resolve conflicts' hint that is shown when conflicts appear can
   be hidden by setting `hints.resolving-conflicts = false`.
 

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -205,6 +205,13 @@ pub fn cli_error(err: impl Into<Box<dyn error::Error + Send + Sync>>) -> Command
     CommandError::new(CommandErrorKind::Cli, err)
 }
 
+pub fn cli_error_with_message(
+    message: impl Into<String>,
+    source: impl Into<Box<dyn error::Error + Send + Sync>>,
+) -> CommandError {
+    CommandError::with_message(CommandErrorKind::Cli, message, source)
+}
+
 pub fn internal_error(err: impl Into<Box<dyn error::Error + Send + Sync>>) -> CommandError {
     CommandError::new(CommandErrorKind::Internal, err)
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1259,6 +1259,9 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 * `-c`, `--change <REVSETS>` — Push this commit by creating a bookmark based on its change ID (can be repeated)
 
    The created bookmark will be tracked automatically. Use the `git.push-bookmark-prefix` setting to change the prefix for generated names.
+* `--named <NAME=REVISION>` — Specify a new bookmark name and a revision to push under that name, e.g. '--named myfeature=@'
+
+   Does not require --allow-new.
 * `--dry-run` — Only display what will change on the remote
 
 


### PR DESCRIPTION
Fixes https://github.com/jj-vcs/jj/issues/5472

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md` (todo)
- [x] I have updated the documentation (README.md, docs/, demos/)
- (n/a) I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
