### PR TITLE
ui: add color to help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates now have `format_short_operation_id(id)` function for users to
   customize the default operation id representation.
 
+* Help text is now colored (when stdout is a terminal).
+
 ### Fixed bugs
 
 * `jj status` now shows untracked files under untracked directories.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -59,6 +59,8 @@ mod workspace;
 
 use std::fmt::Debug;
 
+use clap::builder::styling::AnsiColor;
+use clap::builder::Styles;
 use clap::CommandFactory;
 use clap::FromArgMatches;
 use clap::Subcommand;
@@ -72,7 +74,14 @@ use crate::command_error::CommandError;
 use crate::complete;
 use crate::ui::Ui;
 
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Yellow.on_default().bold())
+    .usage(AnsiColor::Yellow.on_default().bold())
+    .literal(AnsiColor::Green.on_default().bold())
+    .placeholder(AnsiColor::Green.on_default());
+
 #[derive(clap::Parser, Clone, Debug)]
+#[command(styles = STYLES)]
 #[command(disable_help_subcommand = true)]
 #[command(after_long_help = help::show_keyword_hint_after_help())]
 #[command(add = SubcommandCandidates::new(complete::aliases))]

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -607,23 +607,23 @@ fn test_early_args() {
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["--color=always", "help"]);
     insta::assert_snapshot!(
         stdout.normalized().lines().find(|l| l.contains("Commands:")).unwrap(),
-        @"[1m[4mCommands:[0m");
+        @"[1m[33mCommands:[0m");
 
     // Check that early args are accepted after the help command
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["help", "--color=always"]);
     insta::assert_snapshot!(
         stdout.normalized().lines().find(|l| l.contains("Commands:")).unwrap(),
-        @"[1m[4mCommands:[0m");
+        @"[1m[33mCommands:[0m");
 
     // Check that early args are accepted after -h/--help
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["-h", "--color=always"]);
     insta::assert_snapshot!(
         stdout.normalized().lines().find(|l| l.contains("Usage:")).unwrap(),
-        @"[1m[4mUsage:[0m [1mjj[0m [OPTIONS] <COMMAND>");
+        @"[1m[33mUsage:[0m [1m[32mjj[0m [32m[OPTIONS][0m [32m<COMMAND>[0m");
     let stdout = test_env.jj_cmd_success(test_env.env_root(), &["log", "--help", "--color=always"]);
     insta::assert_snapshot!(
         stdout.normalized().lines().find(|l| l.contains("Usage:")).unwrap(),
-        @"[1m[4mUsage:[0m [1mjj log[0m [OPTIONS] [FILESETS]...");
+        @"[1m[33mUsage:[0m [1m[32mjj log[0m [32m[OPTIONS][0m [32m[FILESETS]...[0m");
 
     // Early args are parsed with clap's ignore_errors(), but there is a known
     // bug that causes defaults to be unpopulated. Test that the early args are


### PR DESCRIPTION
I appreciate that this might not be to everyone's taste, but I find help text output more readable with colours.

I chose the [default clap v3 colours](https://docs.rs/clap_builder/4.5.29/clap_builder/builder/styling/struct.Styles.html#example) since that's what I've become used to with Rust tools, but happy to tweak as desired, or close this PR entirely if the plain appearance is the `jj` maintainers' preference.

## Before

![image](https://github.com/user-attachments/assets/63775d06-915e-4324-bfa2-f10ad877f13f)

## After

![image](https://github.com/user-attachments/assets/a2d840bb-bcbd-4cd2-9335-90634cae6811)

## Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
