### PR TITLE
templates: add hook points for users to customize the default operation id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Provides `self.commit()`, `.content()`, `.line_number()`, and
   `.first_line_in_hunk()`.
 
+* Templates now have `format_short_operation_id(id)` function for users to
+  customize the default operation id representation.
+
 ### Fixed bugs
 
 * `jj status` now shows untracked files under untracked directories.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -184,6 +184,7 @@ commit_summary_separator = 'label("separator", " | ")'
 'format_short_id(id)' = 'id.shortest(8)'
 'format_short_change_id(id)' = 'format_short_id(id)'
 'format_short_commit_id(id)' = 'format_short_id(id)'
+'format_short_operation_id(id)' = 'id.short()'
 'format_short_signature(signature)' = '''
   coalesce(signature.email(), email_placeholder)'''
 'format_detailed_signature(signature)' = '''
@@ -251,7 +252,7 @@ if(ref.tracking_present(), surround("(", ")", separate(", ",
 
 'format_operation(op)' = '''
 concat(
-  separate(" ", op.id().short(), op.user(), format_time_range(op.time())), "\n",
+  separate(" ", format_short_operation_id(op.id()), op.user(), format_time_range(op.time())), "\n",
   op.description().first_line(), "\n",
   if(op.tags(), op.tags() ++ "\n"),
 )
@@ -262,7 +263,7 @@ concat(
 
 'format_operation_oneline(op)' = '''
 separate(" ",
-  op.id().short(), op.user(), format_time_range(op.time()),
+  format_short_operation_id(op.id()), op.user(), format_time_range(op.time()),
   op.description().first_line(),
   if(op.tags(), op.tags()),
 ) ++ "\n"

--- a/docs/config.md
+++ b/docs/config.md
@@ -465,6 +465,14 @@ To customize these separately, use the `format_short_commit_id()` and
 'format_short_change_id(id)' = 'format_short_id(id).upper()'
 ```
 
+Operation ids can be customized by the `format_short_operation_id()` alias:
+
+```toml
+[template-aliases]
+# Always show 12 characters
+'format_short_operation_id(id)' = 'id.short(12)'
+```
+
 To get shorter prefixes for certain revisions, set `revsets.short-prefixes`:
 
 ```toml


### PR DESCRIPTION
Same as `format_short_change_id`.

We can't use `format_short_id` because `operation.id()` does not have `shortest()` method.


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
