### PR TITLE
working_copy: adjust max-size hint to fit all configurations

### DIFF
--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -18,6 +18,7 @@ use tracing::instrument;
 
 use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::CommandHelper;
+use crate::cli_util::SnapshotContext;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -58,6 +59,11 @@ pub(crate) fn cmd_file_track(
     }
     let repo = tx.commit("track paths")?;
     locked_ws.finish(repo.op_id().clone())?;
-    print_snapshot_stats(ui, &stats, workspace_command.env().path_converter())?;
+    print_snapshot_stats(
+        ui,
+        &stats,
+        workspace_command.env().path_converter(),
+        SnapshotContext::Track,
+    )?;
     Ok(())
 }

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -23,6 +23,7 @@ use tracing::instrument;
 
 use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::CommandHelper;
+use crate::cli_util::SnapshotContext;
 use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::complete;
@@ -111,6 +112,11 @@ Make sure they're ignored, then try again.",
     }
     let repo = tx.commit("untrack paths")?;
     locked_ws.finish(repo.op_id().clone())?;
-    print_snapshot_stats(ui, &stats, workspace_command.env().path_converter())?;
+    print_snapshot_stats(
+        ui,
+        &stats,
+        workspace_command.env().path_converter(),
+        SnapshotContext::Untrack,
+    )?;
     Ok(())
 }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Fixes #5718

This is one of the proposed fixes, the other option needs more discussion I think.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
