### PR TITLE
cli: accept remote bookmark patterns in `bookmark forget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Use the `--sparse-patterns` option to control this behavior (evaluated
   per each `jj run` invocation).
 
+* `jj bookmark forget` can now also accept remote bookmarks as arguments. For
+  instance, `jj bookmark forget bookmark@remote` will forget the target of
+  `bookmark@remote` until the next `jj git fetch` from the remote.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/cli/src/commands/bookmark/forget.rs
+++ b/cli/src/commands/bookmark/forget.rs
@@ -18,7 +18,10 @@ use jj_lib::op_store::LocalRemoteRefTarget;
 use jj_lib::op_store::RefTarget;
 use jj_lib::op_store::RemoteRef;
 use jj_lib::ref_name::RefName;
+use jj_lib::ref_name::RemoteRefSymbol;
+use jj_lib::ref_name::RemoteRefSymbolBuf;
 use jj_lib::repo::Repo as _;
+use jj_lib::str_util::StringExpression;
 use jj_lib::view::View;
 
 use super::warn_unmatched_local_or_remote_bookmarks;
@@ -26,7 +29,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::default_ignored_remote_name;
 use crate::command_error::CommandError;
 use crate::complete;
-use crate::revset_util::parse_union_name_patterns;
+use crate::revset_util::parse_name_patterns_or_remote_symbols;
 use crate::ui::Ui;
 
 /// Forget a bookmark without marking it as a deletion to be pushed
@@ -34,15 +37,25 @@ use crate::ui::Ui;
 /// If a local bookmark is forgotten, any corresponding remote bookmarks will
 /// become untracked to ensure that the forgotten bookmark will not impact
 /// remotes on future pushes.
+///
+/// Remote bookmarks can also be forgotten using the normal `bookmark@remote`
+/// syntax. If a remote bookmark is forgotten, it will be recreated on future
+/// fetches if it still exists on the remote.
+///
+/// Git-tracking bookmarks (e.g. `bookmark@git`) can also be forgotten. If a
+/// Git-tracking bookmark is forgotten, it will be deleted from the underlying
+/// Git repo on the next `jj git export`. Otherwise, the bookmark will be
+/// recreated on the next `jj git import` if it still exists in the underlying
+/// Git repo. In colocated repos, `jj git export` is run automatically after
+/// every command, so forgetting a Git-tracking bookmark has no effect in a
+/// colocated repo.
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkForgetArgs {
     /// When forgetting a local bookmark, also forget any corresponding remote
     /// bookmarks
     ///
-    /// A forgotten remote bookmark will not impact remotes on future pushes. It
-    /// will be recreated on future fetches if it still exists on the remote. If
-    /// there is a corresponding Git-tracking remote bookmark, it will also be
-    /// forgotten.
+    /// If there is a corresponding Git-tracking remote bookmark, it will also
+    /// be forgotten.
     #[arg(long)]
     include_remotes: bool,
 
@@ -51,10 +64,12 @@ pub struct BookmarkForgetArgs {
     /// By default, the specified pattern matches bookmark names with glob
     /// syntax. You can also use other [string pattern syntax].
     ///
+    /// `BOOKMARK@REMOTE` resolves to a remote bookmark exactly.
+    ///
     /// [string pattern syntax]:
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
-    #[arg(required = true)]
-    #[arg(add = ArgValueCandidates::new(complete::bookmarks))]
+    #[arg(required = true, value_name = "BOOKMARK[@REMOTE]")]
+    #[arg(add = ArgValueCandidates::new(complete::local_and_remote_bookmarks))]
     names: Vec<String>,
 }
 
@@ -65,16 +80,32 @@ pub async fn cmd_bookmark_forget(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui).await?;
     let repo = workspace_command.repo().clone();
-    let ignored_remote = default_ignored_remote_name(repo.store());
-    let matched_bookmarks = find_forgettable_bookmarks(ui, repo.view(), &args.names)?;
-    if matched_bookmarks.is_empty() {
+    let (bookmark_exprs, remote_symbols) = parse_name_patterns_or_remote_symbols(ui, &args.names)?;
+    let bookmark_expr = StringExpression::union_all(bookmark_exprs);
+    let matched_bookmarks = find_forgettable_bookmarks(ui, repo.view(), &bookmark_expr)?;
+    let matched_remote_bookmarks = find_remote_bookmarks(ui, repo.view(), &remote_symbols)?;
+
+    if matched_bookmarks.is_empty() && matched_remote_bookmarks.is_empty() {
         writeln!(ui.status(), "No bookmarks to forget.")?;
         return Ok(());
     }
 
+    let ignored_remote = default_ignored_remote_name(repo.store());
     let mut tx = workspace_command.start_transaction();
     let mut forgotten_local: usize = 0;
     let mut forgotten_remote: usize = 0;
+
+    for &(symbol, remote_ref) in &matched_remote_bookmarks {
+        // If the remote bookmark was already deleted explicitly, there is
+        // nothing left for `forget` to do.
+        if remote_ref.is_absent() {
+            continue;
+        }
+        tx.repo_mut()
+            .set_remote_bookmark(symbol, RemoteRef::absent());
+        forgotten_remote += 1;
+    }
+
     for (name, bookmark_target) in &matched_bookmarks {
         if bookmark_target.local_target.is_present() {
             forgotten_local += 1;
@@ -83,30 +114,42 @@ pub async fn cmd_bookmark_forget(
             .set_local_bookmark_target(name, RefTarget::absent());
         for (remote, _) in &bookmark_target.remote_refs {
             let symbol = name.to_remote_symbol(remote);
-            // If `--include-remotes` is specified, we forget the corresponding remote
-            // bookmarks instead of untracking them
+            // If the remote bookmark was already deleted explicitly, skip it.
+            if tx.repo().get_remote_bookmark(symbol).is_absent() {
+                continue;
+            }
+            // If `--include-remotes` is specified, we forget the corresponding
+            // remote bookmarks instead of untracking them.
             if args.include_remotes {
                 tx.repo_mut()
                     .set_remote_bookmark(symbol, RemoteRef::absent());
                 forgotten_remote += 1;
                 continue;
             }
-            // Git-tracking remote bookmarks cannot be untracked currently, so skip them
+            // Git-tracking remote bookmarks cannot be untracked currently, so
+            // skip them.
             if ignored_remote.is_some_and(|ignored| symbol.remote == ignored) {
                 continue;
             }
             tx.repo_mut().untrack_remote_bookmark(symbol);
         }
     }
+
     if forgotten_local != 0 {
         writeln!(ui.status(), "Forgot {forgotten_local} local bookmarks.")?;
     }
     if forgotten_remote != 0 {
         writeln!(ui.status(), "Forgot {forgotten_remote} remote bookmarks.")?;
     }
+
     let forgotten_bookmarks = matched_bookmarks
         .iter()
-        .map(|(name, _)| name.as_symbol())
+        .map(|(name, _)| name.as_symbol().to_string())
+        .chain(
+            matched_remote_bookmarks
+                .iter()
+                .map(|(symbol, _)| symbol.to_string()),
+        )
         .join(", ");
     tx.finish(ui, format!("forget bookmark {forgotten_bookmarks}"))
         .await?;
@@ -116,14 +159,44 @@ pub async fn cmd_bookmark_forget(
 fn find_forgettable_bookmarks<'a>(
     ui: &Ui,
     view: &'a View,
-    name_patterns: &[String],
+    name_expr: &StringExpression,
 ) -> Result<Vec<(&'a RefName, LocalRemoteRefTarget<'a>)>, CommandError> {
-    let name_expr = parse_union_name_patterns(ui, name_patterns)?;
     let name_matcher = name_expr.to_matcher();
     let matched_bookmarks = view
         .bookmarks()
         .filter(|(name, _)| name_matcher.is_match(name.as_str()))
         .collect();
-    warn_unmatched_local_or_remote_bookmarks(ui, view, &name_expr)?;
+    warn_unmatched_local_or_remote_bookmarks(ui, view, name_expr)?;
     Ok(matched_bookmarks)
+}
+
+fn find_remote_bookmarks<'a>(
+    ui: &Ui,
+    view: &'a View,
+    symbols: &'a [RemoteRefSymbolBuf],
+) -> Result<Vec<(RemoteRefSymbol<'a>, &'a RemoteRef)>, CommandError> {
+    let mut matched = Vec::new();
+    let mut unmatched = Vec::new();
+    for symbol in symbols {
+        let symbol = symbol.as_ref();
+        let remote_ref = view.get_remote_bookmark(symbol);
+        let has_entry = view
+            .get_remote_view(symbol.remote)
+            .is_some_and(|remote_view| remote_view.bookmarks.contains_key(symbol.name));
+        if remote_ref.is_present() || has_entry {
+            matched.push((symbol, remote_ref));
+        } else {
+            unmatched.push(symbol);
+        }
+    }
+    matched.sort_unstable_by_key(|(symbol, _)| *symbol);
+    matched.dedup_by(|(symbol1, _), (symbol2, _)| symbol1 == symbol2);
+    if !unmatched.is_empty() {
+        writeln!(
+            ui.warning_default(),
+            "No matching remote bookmarks for names: {}",
+            unmatched.iter().join(", ")
+        )?;
+    }
+    Ok(matched)
 }

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -85,7 +85,7 @@ pub struct BookmarkListArgs {
     ///
     /// [string pattern syntax]:
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
-    #[arg(add = ArgValueCandidates::new(complete::bookmarks))]
+    #[arg(add = ArgValueCandidates::new(complete::bookmark_names))]
     names: Option<Vec<String>>,
 
     /// Show bookmarks whose local targets are in the given revisions

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -80,14 +80,8 @@ pub struct GitFetchArgs {
     ///
     /// [logical operators]:
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
-    #[arg(
-        long = "branch",
-        short,
-        alias = "bookmark",
-        group = "specific",
-        value_name = "BRANCH"
-    )]
-    #[arg(add = ArgValueCandidates::new(complete::bookmarks))]
+    #[arg(long = "branch", short, alias = "bookmark", value_name = "BRANCH")]
+    #[arg(add = ArgValueCandidates::new(complete::bookmark_names))]
     branches: Option<Vec<String>>,
 
     /// Fetch only some of the tags (can be repeated)

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -191,7 +191,7 @@ pub fn untracked_bookmarks() -> Vec<CompletionCandidate> {
     })
 }
 
-pub fn bookmarks() -> Vec<CompletionCandidate> {
+fn bookmark_completions(hide_remote_part: bool) -> Vec<CompletionCandidate> {
     with_jj(|jj, _settings| {
         let output = jj
             .build()
@@ -209,10 +209,18 @@ pub fn bookmarks() -> Vec<CompletionCandidate> {
             .map_err(user_error)?;
         let stdout = String::from_utf8_lossy(&output.stdout);
 
-        Ok((&stdout
+        Ok(stdout
             .lines()
             .map(split_help_text)
-            .chunk_by(|(name, _)| name.split_once('@').map(|t| t.0).unwrap_or(name)))
+            .chunk_by(|&(bookmark, _)| {
+                if hide_remote_part {
+                    bookmark
+                        .split_once('@')
+                        .map_or(bookmark, |(name, _remote)| name)
+                } else {
+                    bookmark
+                }
+            })
             .into_iter()
             .map(|(bookmark, mut refs)| {
                 let help = refs.find_map(|(_, help)| help);
@@ -248,6 +256,14 @@ pub fn local_tags() -> Vec<CompletionCandidate> {
             .map(|(name, help)| CompletionCandidate::new(name).help(help))
             .collect())
     })
+}
+
+pub fn local_and_remote_bookmarks() -> Vec<CompletionCandidate> {
+    bookmark_completions(false)
+}
+
+pub fn bookmark_names() -> Vec<CompletionCandidate> {
+    bookmark_completions(true)
 }
 
 pub fn git_remotes() -> Vec<CompletionCandidate> {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -494,15 +494,21 @@ Forget a bookmark without marking it as a deletion to be pushed
 
 If a local bookmark is forgotten, any corresponding remote bookmarks will become untracked to ensure that the forgotten bookmark will not impact remotes on future pushes.
 
-**Usage:** `jj bookmark forget [OPTIONS] <NAMES>...`
+Remote bookmarks can also be forgotten using the normal `bookmark@remote` syntax. If a remote bookmark is forgotten, it will be recreated on future fetches if it still exists on the remote.
+
+Git-tracking bookmarks (e.g. `bookmark@git`) can also be forgotten. If a Git-tracking bookmark is forgotten, it will be deleted from the underlying Git repo on the next `jj git export`. Otherwise, the bookmark will be recreated on the next `jj git import` if it still exists in the underlying Git repo. In colocated repos, `jj git export` is run automatically after every command, so forgetting a Git-tracking bookmark has no effect in a colocated repo.
+
+**Usage:** `jj bookmark forget [OPTIONS] <BOOKMARK[@REMOTE]>...`
 
 **Command Alias:** `f`
 
 ###### **Arguments:**
 
-* `<NAMES>` — The bookmarks to forget
+* `<BOOKMARK[@REMOTE]>` — The bookmarks to forget
 
    By default, the specified pattern matches bookmark names with glob syntax. You can also use other [string pattern syntax].
+
+   `BOOKMARK@REMOTE` resolves to a remote bookmark exactly.
 
    [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
@@ -510,7 +516,7 @@ If a local bookmark is forgotten, any corresponding remote bookmarks will become
 
 * `--include-remotes` — When forgetting a local bookmark, also forget any corresponding remote bookmarks
 
-   A forgotten remote bookmark will not impact remotes on future pushes. It will be recreated on future fetches if it still exists on the remote. If there is a corresponding Git-tracking remote bookmark, it will also be forgotten.
+   If there is a corresponding Git-tracking remote bookmark, it will also be forgotten.
 
 
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1150,7 +1150,7 @@ fn test_bookmark_forget_glob() {
     let output = work_dir.run_jj(["bookmark", "forget", "glob:'foo-[1-3'"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Failed to parse name pattern: Invalid string pattern
+    Error: Failed to parse name pattern or remote symbol: Invalid string pattern
     Caused by:
     1:  --> 1:1
       |
@@ -1283,7 +1283,7 @@ fn test_bookmark_delete_glob() -> TestResult {
     let output = work_dir.run_jj(["bookmark", "forget", "whatever:bookmark"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Failed to parse name pattern: Invalid string pattern
+    Error: Failed to parse name pattern or remote symbol: Invalid string pattern
     Caused by:
     1:  --> 1:1
       |
@@ -1511,6 +1511,33 @@ fn test_bookmark_forget_fetched_bookmark() {
     feature1@origin: tyvxnvqr 9175cb32 (empty) another message
     [EOF]
     ");
+
+    // TEST 5: Explicitly naming the remote bookmarks has the same behavior as
+    // --include-remotes (same as test 1)
+    work_dir
+        .run_jj(["bookmark", "forget", "feature1", "feature1@origin"])
+        .success();
+    insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
+    let output = work_dir.run_jj(["git", "export"]);
+    insta::assert_snapshot!(output, @"");
+    let output = work_dir.run_jj(["git", "import"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    "#);
+    insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
+    let output = work_dir.run_jj(["git", "fetch", "--remote=origin"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    bookmark: feature1@origin [new] tracked
+    [EOF]
+    "#);
+    insta::assert_snapshot!(get_bookmark_output(&work_dir), @r#"
+    feature1: tyvxnvqr 9175cb32 (empty) another message
+      @origin: tyvxnvqr 9175cb32 (empty) another message
+    [EOF]
+    "#);
 }
 
 #[test]

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -258,7 +258,9 @@ fn test_bookmark_names() {
     insta::assert_snapshot!(output, @"
     aaa-local	x
     aaa-tracked	x
-    aaa-untracked
+    aaa-tracked@origin
+    aaa-tracked@upstream
+    aaa-untracked@origin
     [EOF]
     ");
 


### PR DESCRIPTION
Follow-up to #5621. Allows `BOOKMARK@REMOTE` patterns in `bookmark forget`. Another alternative might be `--remote REMOTE`.

TODO: add tests for forgetting `BOOKMARK@REMOTE` without forgetting `BOOKMARK`.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
