### PR TITLE
track: only print snapshot stats and hints once

### DIFF
--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -23,7 +23,6 @@ use tracing::instrument;
 
 use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::CommandHelper;
-use crate::cli_util::SnapshotContext;
 use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::complete;
@@ -112,11 +111,6 @@ Make sure they're ignored, then try again.",
     }
     let repo = tx.commit("untrack paths")?;
     locked_ws.finish(repo.op_id().clone())?;
-    print_snapshot_stats(
-        ui,
-        &stats,
-        workspace_command.env().path_converter(),
-        SnapshotContext::Untrack,
-    )?;
+    print_snapshot_stats(ui, &stats, workspace_command.env().path_converter())?;
     Ok(())
 }

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -24,7 +24,6 @@ use tracing::instrument;
 use crate::cli_util::print_conflicted_paths;
 use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::CommandHelper;
-use crate::cli_util::SnapshotContext;
 use crate::command_error::CommandError;
 use crate::diff_util::get_copy_records;
 use crate::diff_util::DiffFormat;
@@ -59,7 +58,6 @@ pub(crate) fn cmd_status(
         ui,
         &snapshot_stats,
         workspace_command.env().path_converter(),
-        SnapshotContext::Automatic,
     )?;
     let repo = workspace_command.repo();
     let maybe_wc_commit = workspace_command

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -22,7 +22,9 @@ use jj_lib::revset::RevsetFilterPredicate;
 use tracing::instrument;
 
 use crate::cli_util::print_conflicted_paths;
+use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::CommandHelper;
+use crate::cli_util::SnapshotContext;
 use crate::command_error::CommandError;
 use crate::diff_util::get_copy_records;
 use crate::diff_util::DiffFormat;
@@ -53,6 +55,12 @@ pub(crate) fn cmd_status(
     args: &StatusArgs,
 ) -> Result<(), CommandError> {
     let (workspace_command, snapshot_stats) = command.workspace_helper_with_stats(ui)?;
+    print_snapshot_stats(
+        ui,
+        &snapshot_stats,
+        workspace_command.env().path_converter(),
+        SnapshotContext::Automatic,
+    )?;
     let repo = workspace_command.repo();
     let maybe_wc_commit = workspace_command
         .get_wc_commit_id()

--- a/cli/src/commands/workspace/update_stale.rs
+++ b/cli/src/commands/workspace/update_stale.rs
@@ -14,7 +14,9 @@
 
 use tracing::instrument;
 
+use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::CommandHelper;
+use crate::cli_util::SnapshotContext;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -33,7 +35,13 @@ pub fn cmd_workspace_update_stale(
     command: &CommandHelper,
     _args: &WorkspaceUpdateStaleArgs,
 ) -> Result<(), CommandError> {
-    command.recover_stale_working_copy(ui)?;
+    let (workspace_command, stats) = command.recover_stale_working_copy(ui)?;
+    print_snapshot_stats(
+        ui,
+        &stats,
+        workspace_command.env().path_converter(),
+        SnapshotContext::Automatic,
+    )?;
 
     Ok(())
 }

--- a/cli/src/commands/workspace/update_stale.rs
+++ b/cli/src/commands/workspace/update_stale.rs
@@ -16,7 +16,6 @@ use tracing::instrument;
 
 use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::CommandHelper;
-use crate::cli_util::SnapshotContext;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -36,12 +35,7 @@ pub fn cmd_workspace_update_stale(
     _args: &WorkspaceUpdateStaleArgs,
 ) -> Result<(), CommandError> {
     let (workspace_command, stats) = command.recover_stale_working_copy(ui)?;
-    print_snapshot_stats(
-        ui,
-        &stats,
-        workspace_command.env().path_converter(),
-        SnapshotContext::Automatic,
-    )?;
+    print_snapshot_stats(ui, &stats, workspace_command.env().path_converter())?;
 
     Ok(())
 }

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -67,9 +67,18 @@ fn test_snapshot_large_file() {
     [EOF]
     ");
 
-    // test with file track for hint formatting
+    // test with file track for hint formatting, both files should appear in
+    // warnings even though they were snapshotted separately
     std::fs::write(repo_path.join("large2"), big_string).unwrap();
-    let (stdout, stderr) = test_env.jj_cmd_ok(&repo_path, &["file", "track", "large", "large2"]);
+    let (stdout, stderr) = test_env.jj_cmd_ok(
+        &repo_path,
+        &[
+            "file",
+            "--config=snapshot.auto-track='large'",
+            "track",
+            "large2",
+        ],
+    );
     insta::assert_snapshot!(stdout, @"");
     insta::assert_snapshot!(stderr, @r"
     Warning: Refused to snapshot some files:
@@ -77,14 +86,6 @@ fn test_snapshot_large_file() {
       large2: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
     Hint: This is to prevent large files from being added by accident. You can fix this by:
       - Adding the file to `.gitignore`
-      - Run `jj config set --repo snapshot.max-new-file-size 11264`
-        This will increase the maximum file size allowed for new files, in this repository only.
-      - Run `jj --config snapshot.max-new-file-size=11264 st`
-        This will increase the maximum file size allowed for new files, for this command only.
-    Warning: Refused to snapshot some files:
-      large: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
-      large2: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
-    Hint: This is to prevent large files from being added by accident. You can fix this by:
       - Run `jj config set --repo snapshot.max-new-file-size 11264`
         This will increase the maximum file size allowed for new files, in this repository only.
       - Run `jj --config snapshot.max-new-file-size=11264 file track large large2`


### PR DESCRIPTION
Since every command first runs an automatic snapshot, we don't need to explicitly snapshot a file that would've been matched by the auto-matcher previously. This would in some cases lead to double hints being printed (see snapshot test case).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This is a quick followup to https://github.com/jj-vcs/jj/pull/5722#discussion_r1958525279

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
