### PR TITLE
merge_tools: use `ExternalToolError` for external tools

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -424,11 +424,7 @@ impl From<DiffRenderError> for CommandError {
 
 impl From<ConflictResolveError> for CommandError {
     fn from(err: ConflictResolveError) -> Self {
-        match err {
-            ConflictResolveError::Backend(err) => err.into(),
-            ConflictResolveError::Io(err) => err.into(),
-            _ => user_error_with_message("Failed to resolve conflicts", err),
-        }
+        user_error_with_message("Failed to resolve conflicts", err)
     }
 }
 


### PR DESCRIPTION
I think this is what was suggested in https://github.com/jj-vcs/jj/pull/5111#discussion_r1904820097

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
