### PR TITLE
git: handle multi-component remotes

### DIFF
--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
@@ -239,7 +240,11 @@ pub fn maybe_set_repository_level_trunk_alias(
     let git_repo = get_git_repo(workspace_command.repo().store())?;
     if let Ok(reference) = git_repo.find_reference("refs/remotes/origin/HEAD") {
         if let Some(reference_name) = reference.symbolic_target() {
-            if let Some(RefName::RemoteBranch { branch, .. }) = parse_git_ref(reference_name) {
+            let mut remote_names = BTreeSet::new();
+            remote_names.insert("origin");
+            if let Some(RefName::RemoteBranch { branch, .. }) =
+                parse_git_ref(reference_name, &remote_names)
+            {
                 write_repository_level_trunk_alias(
                     ui,
                     workspace_command.repo_path(),


### PR DESCRIPTION
`jj` assumes that remotes don't have slashes in them Hence, a reference like `refs/remotes/test/jj/some/branch` will always be parsed into `jj/some/branch@test`, even if the user explicitely created the remote via `jj git remote add test/jj <URL>`.

This does not match the git behaviour, where such remotes accepted, and as such creates confusion with the `jj git` commands.

This commit fixes this problem, by adding the current known remotes to the ref parsing function. Note that if the remote reference doesn't match any of the known remotes, then the remote is parsed assuming it has no slashes.

Fixes #5731

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
