### PR TITLE
git: reject remotes with forward slashes

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -537,6 +537,10 @@ jj currently does not support partial clones. To use jj with this repository, tr
             }
             match err {
                 GitFetchError::NoSuchRemote(_) => user_error(err),
+                GitFetchError::RemoteWithSlash(_) => user_error_with_hint(
+                    err,
+                    "Run `jj git remote rename` to give a different name.",
+                ),
                 GitFetchError::InvalidBranchPattern(_) => user_error(err),
                 GitFetchError::InternalGitError(err) => map_git2_error(err),
                 GitFetchError::Subprocess(_) => user_error(err),
@@ -557,6 +561,10 @@ jj currently does not support partial clones. To use jj with this repository, tr
         fn from(err: GitPushError) -> Self {
             match err {
                 GitPushError::NoSuchRemote(_) => user_error(err),
+                GitPushError::RemoteWithSlash(_) => user_error_with_hint(
+                    err,
+                    "Run `jj git remote rename` to give a different name.",
+                ),
                 GitPushError::RemoteReservedForLocalGitRepo => user_error(err),
                 GitPushError::RefInUnexpectedLocation(refs) => user_error_with_hint(
                     format!(
@@ -580,7 +588,8 @@ jj currently does not support partial clones. To use jj with this repository, tr
             match err {
                 GitRemoteManagementError::NoSuchRemote(_) => user_error(err),
                 GitRemoteManagementError::RemoteAlreadyExists(_) => user_error(err),
-                GitRemoteManagementError::RemoteReservedForLocalGitRepo => user_error_with_hint(
+                GitRemoteManagementError::RemoteReservedForLocalGitRepo
+                | GitRemoteManagementError::RemoteWithSlash(_) => user_error_with_hint(
                     err,
                     "Run `jj git remote rename` to give a different name.",
                 ),

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -577,7 +577,15 @@ jj currently does not support partial clones. To use jj with this repository, tr
 
     impl From<GitRemoteManagementError> for CommandError {
         fn from(err: GitRemoteManagementError) -> Self {
-            user_error(err)
+            match err {
+                GitRemoteManagementError::NoSuchRemote(_) => user_error(err),
+                GitRemoteManagementError::RemoteAlreadyExists(_) => user_error(err),
+                GitRemoteManagementError::RemoteReservedForLocalGitRepo => user_error_with_hint(
+                    err,
+                    "Run `jj git remote rename` to give a different name.",
+                ),
+                GitRemoteManagementError::InternalGitError(err) => map_git2_error(err),
+            }
         }
     }
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -761,7 +761,10 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
         &["git", "clone", "--remote=git", "source", "dest"],
     );
     insta::allow_duplicates! {
-    insta::assert_snapshot!(stderr, @"Error: Git remote named 'git' is reserved for local Git repository");
+    insta::assert_snapshot!(stderr, @r"
+    Error: Git remote named 'git' is reserved for local Git repository
+    Hint: Run `jj git remote rename` to give a different name.
+    ");
     }
 }
 

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -82,9 +82,10 @@ fn test_git_remote_add() {
         &repo_path,
         &["git", "remote", "add", "git", "http://example.com/repo/git"],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    Hint: Run `jj git remote rename` to give a different name.
+    ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
     insta::assert_snapshot!(stdout, @r###"
     foo http://example.com/repo/foo
@@ -124,9 +125,10 @@ fn test_git_remote_set_url() {
             "http://example.com/repo/git",
         ],
     );
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    Hint: Run `jj git remote rename` to give a different name.
+    ");
     let (stdout, stderr) = test_env.jj_cmd_ok(
         &repo_path,
         &[
@@ -192,9 +194,10 @@ fn test_git_remote_rename() {
     Error: Git remote named 'baz' already exists
     "###);
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "foo", "git"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    Hint: Run `jj git remote rename` to give a different name.
+    ");
     let (stdout, stderr) =
         test_env.jj_cmd_ok(&repo_path, &["git", "remote", "rename", "foo", "bar"]);
     insta::assert_snapshot!(stdout, @"");
@@ -238,9 +241,10 @@ fn test_git_remote_named_git() {
 
     // The remote cannot be renamed back by jj.
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "bar", "git"]);
-    insta::assert_snapshot!(stderr, @r###"
+    insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    "###);
+    Hint: Run `jj git remote rename` to give a different name.
+    ");
 
     // Reinitialize the repo with remote named 'git'.
     fs::remove_dir_all(repo_path.join(".jj")).unwrap();


### PR DESCRIPTION
Although this behaviour is accepted by git, it's a degenerate case. Especially because we implicitely rely on being able to parse out the remote from the refname (i.e., `refs/remotes/<remote>/<branch>`).

Branches can have forward slashes, but if remotes can also have them, parsing the refname becomes ambiguous, and a pain. Especially because it would be totally legal to have a branch "c" on remote "a/b" and a branch "b" on remote "a".

Fixes #5731

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
