### PR TITLE
cli: remove error hint for invalid remote names

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -585,16 +585,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
 
     impl From<GitRemoteManagementError> for CommandError {
         fn from(err: GitRemoteManagementError) -> Self {
-            match err {
-                GitRemoteManagementError::NoSuchRemote(_) => user_error(err),
-                GitRemoteManagementError::RemoteAlreadyExists(_) => user_error(err),
-                GitRemoteManagementError::RemoteReservedForLocalGitRepo
-                | GitRemoteManagementError::RemoteWithSlash(_) => user_error_with_hint(
-                    err,
-                    "Run `jj git remote rename` to give a different name.",
-                ),
-                GitRemoteManagementError::InternalGitError(err) => map_git2_error(err),
-            }
+            user_error(err)
         }
     }
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -809,7 +809,6 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
     }
@@ -832,7 +831,6 @@ fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(stderr, @r"
     Error: Git remotes with slashes are incompatible with jj: slash/origin
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
     }

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -89,7 +89,6 @@ fn test_git_remote_add() {
     );
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
@@ -135,7 +134,6 @@ fn test_git_remote_set_url() {
     );
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
     let (stdout, stderr) = test_env.jj_cmd_ok(
@@ -214,7 +212,6 @@ fn test_git_remote_rename() {
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "foo", "git"]);
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
     let (stdout, stderr) =
@@ -265,7 +262,6 @@ fn test_git_remote_named_git() {
     let stderr = test_env.jj_cmd_failure(&repo_path, &["git", "remote", "rename", "bar", "git"]);
     insta::assert_snapshot!(stderr, @r"
     Error: Git remote named 'git' is reserved for local Git repository
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
 
@@ -317,7 +313,6 @@ fn test_git_remote_with_slashes() {
     );
     insta::assert_snapshot!(stderr, @r"
     Error: Git remotes with slashes are incompatible with jj: another/origin
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
     let stdout = test_env.jj_cmd_success(&repo_path, &["git", "remote", "list"]);
@@ -346,7 +341,6 @@ fn test_git_remote_with_slashes() {
     );
     insta::assert_snapshot!(stderr, @r"
     Error: Git remotes with slashes are incompatible with jj: slash/origin
-    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     ");
 


### PR DESCRIPTION
Existing hint suggests using `jj git remote rename`, but that's not applicable to `jj git clone`.

This commit removes that hint
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
