### PR TITLE
cli/tests: move bookmark_command test to gitoxide

### DIFF
--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -2126,7 +2126,7 @@ fn test_bookmark_move_with_default_target_revision() {
 
     // Set up remote
     let git_repo_path = test_env.env_root().join("git-repo");
-    git2::Repository::init_bare(git_repo_path).unwrap();
+    git::init_bare(git_repo_path);
     test_env.jj_cmd_ok(
         &repo_path,
         &["git", "remote", "add", "origin", "../git-repo"],


### PR DESCRIPTION
An in-flight PR snuck in another git2 usage, moved to gitoxide

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
