### PR TITLE
fix: invoke tools from the workspace root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `split.legacy-bookmark-behavior = true`, but this will likely be removed in a
   future release. [#3419](https://github.com/jj-vcs/jj/issues/3419)
 
+* `jj fix` now always sets the working directory of invoked tools to be the
+  workspace root, instead of the working directory of the `jj fix`.
+
 ### Deprecations
 
 * This release takes the first steps to make target revision required in


### PR DESCRIPTION
Motivating discord discussion: https://discord.com/channels/968932220549103686/1339369275915501599

Previously, tools invoked by `jj fix` did not have their `.current_dir()` set, and would just run from whatever directory the user was in.

Now, the tools will always be invoked from the same directory that `jj root` gives.

As a motivating example, consider a configuration path that's always at the workspace root:

```toml
[fix.tools.something]
# previous:
command = ["cmd", "--config", "$root/tool.toml"]
#                              ^^^^^^ not possible
# now:
command = ["cmd", "--config", "./tool.toml"]
#                              ^^ now, just use a relative path
```

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
