### PR TITLE
lib/tests: port lib tests to gitoxide

### DIFF
--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -22,6 +22,7 @@ use jj_lib::repo::Repo;
 use jj_lib::settings::UserSettings;
 use jj_lib::workspace::Workspace;
 use test_case::test_case;
+use testutils::git;
 use testutils::write_random_commit;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
@@ -109,7 +110,7 @@ fn test_init_external_git() {
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
     let git_repo_path = uncanonical.join("git");
-    git2::Repository::init(&git_repo_path).unwrap();
+    git::init(&git_repo_path);
     std::fs::create_dir(uncanonical.join("jj")).unwrap();
     let (workspace, repo) = Workspace::init_external_git(
         &settings,


### PR DESCRIPTION
As per #5548, this moves the majority of the tests in lib/test over to gitoxide

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
