### PR TITLE
cli: restore: Fix `--into` placeholder

### DIFF
--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -65,7 +65,7 @@ pub(crate) struct RestoreArgs {
     #[arg(
         long, short = 't',
         visible_alias = "to",
-        value_name = "REVSETS",
+        value_name = "REVSET",
         add = ArgValueCandidates::new(complete::mutable_revisions)
     )]
     into: Option<RevisionArg>,

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2155,7 +2155,7 @@ See `jj diffedit` if you'd like to restore portions of files rather than entire 
 ###### **Options:**
 
 * `-f`, `--from <REVSET>` — Revision to restore from (source)
-* `-t`, `--into <REVSETS>` — Revision to restore into (destination)
+* `-t`, `--into <REVSET>` — Revision to restore into (destination)
 * `-c`, `--changes-in <REVSET>` — Undo the changes in a revision as compared to the merge of its parents.
 
    This undoes the changes that can be seen with `jj diff -r REVSET`. If `REVSET` only has a single parent, this option is equivalent to `jj restore --into REVSET --from REVSET-`.


### PR DESCRIPTION
`jj restore --into` accepts a single revision, not multiple.