### PR TITLE
merge_tools: add "ours" and "theirs" merge tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   which branch in the `jj log` graph is displayed on the left instead of `@`
   (e.g. `coalesce(description("megamerge\n"), trunk())`)
 
+* `jj resolve` now accepts new built-in merge tools `:ours` and `:theirs`.
+  These merge tools accept side #1 and side #2 of the conflict respectively.
+
 ### Fixed bugs
 
 * `jj log -p --stat` now shows diff stats as well as the default color-words/git

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -59,6 +59,9 @@ pub(crate) struct ResolveArgs {
     #[arg(long, short)]
     list: bool,
     /// Specify 3-way merge tool to be used
+    ///
+    /// The built-in merge tools `:ours` and `:theirs` can be used to choose
+    /// side #1 and side #2 of the conflict respectively.
     #[arg(long, conflicts_with = "list", value_name = "NAME")]
     tool: Option<String>,
     /// Only resolve conflicts in these paths. You can use the `--list` argument

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2135,6 +2135,8 @@ Note that conflicts can also be resolved without using this command. You may edi
 * `-l`, `--list` — Instead of resolving conflicts, list all the conflicts
 * `--tool <NAME>` — Specify 3-way merge tool to be used
 
+   The built-in merge tools `:ours` and `:theirs` can be used to choose side #1 and side #2 of the conflict respectively.
+
 
 
 ## `jj restore`


### PR DESCRIPTION
This is a bit of a hack, but it would be useful to have these available for users until a proper solution is implemented.

Related to #1027.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
