### PR TITLE
github: fix invalid permission settings for scorecards workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,6 +14,10 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-24.04
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      id-token: write
 
     steps:
       - name: "Checkout code"
@@ -45,7 +49,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
         with:
           sarif_file: results.sarif
-        permissions:
-          # Needed to upload the results to code-scanning dashboard.
-          security-events: write
-          id-token: write


### PR DESCRIPTION
In https://github.com/jj-vcs/jj/actions/runs/13490171888, we got this error:

```
Invalid workflow file: .github/workflows/scorecards.yml#L48
The workflow is not valid. .github/workflows/scorecards.yml (Line: 48, Col: 9): Unexpected value 'permissions'
```

It looks like permissions can be set per job but not per step, so I moved the permission setting to the job level.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
