### PR TITLE
git: forward unknown messages to the user

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -270,6 +270,11 @@ pub fn with_remote_git_callbacks<T>(ui: &Ui, f: impl FnOnce(git::RemoteCallbacks
     };
     callbacks.sideband_progress = Some(&mut sideband_progress_callback);
 
+    let mut stderr = |message: &[u8]| {
+        _ = ui.stderr().write(message);
+    };
+    callbacks.stderr = Some(&mut stderr);
+
     let mut get_ssh_keys = get_ssh_keys; // Coerce to unit fn type
     callbacks.get_ssh_keys = Some(&mut get_ssh_keys);
     let mut get_pw =

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2242,6 +2242,7 @@ fn allow_push(
 pub struct RemoteCallbacks<'a> {
     pub progress: Option<&'a mut dyn FnMut(&Progress)>,
     pub sideband_progress: Option<&'a mut dyn FnMut(&[u8])>,
+    pub stderr: Option<&'a mut dyn FnMut(&[u8])>,
     pub get_ssh_keys: Option<&'a mut dyn FnMut(&str) -> Vec<PathBuf>>,
     pub get_password: Option<&'a mut dyn FnMut(&str, &str) -> Option<String>>,
     pub get_username_password: Option<&'a mut dyn FnMut(&str) -> Option<(String, String)>>,


### PR DESCRIPTION
We cannot hope to parse everything `git(1)` outputs. In particular, custom OpenSSH setups can print authentication related text, for instance, to confirm user presence for keys (#5760). This commit forwards unknown git output (lines that would never be touched by parsing) to the user

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
