### PR TITLE
docs workflow: try to fix it again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,5 +36,7 @@ jobs:
           export MKDOCS_SITE_NAME="Jujutsu docs (prerelease)"
           export MKDOCS_PRIMARY_COLOR="blue grey"
           .github/scripts/docs-build-deploy prerelease --push
+        env:
+            GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,5 +146,6 @@ jobs:
           .github/scripts/docs-build-deploy "${RELEASE_TAG_NAME}" latest --update-aliases --push
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"


### PR DESCRIPTION
(See also the commit description)

Some notes:

  - I'm not sure whether the env var should be `GH_PAGES` or `GITHUB_PAGES`, but several places in the docs suggested using the former. We can try this as is, or we can set both.
  - It bothers me that there is no easy way I can think of to test these things after 514a009, or to experiment with it outside of production. WDYT, @thoughtpolice ?

Sample error: https://github.com/jj-vcs/jj/actions/runs/13548628896/job/37866477622