### PR TITLE
docs: Add pointers to usage of `jj help -k <keyword>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ As you become more familiar with Jujutsu, the following resources may be helpful
 - The [FAQ](https://jj-vcs.github.io/jj/latest/FAQ).
 - The [Glossary](https://jj-vcs.github.io/jj/latest/glossary).
 - The `jj help` command (e.g. `jj help rebase`).
+- The `jj help -k <keyword>` command (e.g. `jj help -k config`). Use `jj help --help`
+  to see what keywords are available.
 
 If you are using a **prerelease** version of `jj`, you would want to consult
 [the docs for the prerelease (main branch)

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3064,7 +3064,10 @@ impl fmt::Display for RemoteBookmarkNamePattern {
 
 /// Jujutsu (An experimental VCS)
 ///
-/// To get started, see the tutorial at https://jj-vcs.github.io/jj/latest/tutorial/.
+/// To get started, see the tutorial [`jj help -k tutorial`].
+///
+/// [`jj help -k tutorial`]:
+///     https://jj-vcs.github.io/jj/latest/tutorial/
 #[allow(rustdoc::bare_urls)]
 #[derive(clap::Parser, Clone, Debug)]
 #[command(name = "jj")]

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -778,8 +778,8 @@ fn file_pattern_parse_error_hint(err: &FilePatternParseError) -> Option<String> 
 fn fileset_parse_error_hint(err: &FilesetParseError) -> Option<String> {
     match err.kind() {
         FilesetParseErrorKind::SyntaxError => Some(String::from(
-            "See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to \
-             match file paths.",
+            "See https://jj-vcs.github.io/jj/latest/filesets/ or use `jj help -k filesets` for \
+             filesets syntax and how to match file paths.",
         )),
         FilesetParseErrorKind::NoSuchFunction {
             name: _,
@@ -812,8 +812,8 @@ fn revset_parse_error_hint(err: &RevsetParseError) -> Option<String> {
     let bottom_err = iter::successors(Some(err), |e| e.origin()).last().unwrap();
     match bottom_err.kind() {
         RevsetParseErrorKind::SyntaxError => Some(
-            "See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to \
-             quote symbols."
+            "See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for \
+             revsets syntax and how to quote symbols."
                 .into(),
         ),
         RevsetParseErrorKind::NotPrefixOperator {
@@ -905,7 +905,8 @@ fn try_handle_command_result(
             print_error(ui, "Config error: ", err, hints)?;
             writeln!(
                 ui.stderr_formatter().labeled("hint"),
-                "For help, see https://jj-vcs.github.io/jj/latest/config/."
+                "For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k \
+                 config`."
             )?;
             Ok(ExitCode::from(1))
         }

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -36,9 +36,9 @@ use crate::ui::Ui;
 /// revisions are preceded by a "-" and new target revisions are preceded by a
 /// "+".
 ///
-/// See the [bookmark documentation] for more information.
+/// See [`jj help -k bookmarks`] for more information.
 ///
-/// [bookmark documentation]:
+/// [`jj help -k bookmarks`]:
 ///     https://jj-vcs.github.io/jj/latest/bookmarks
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkListArgs {
@@ -95,14 +95,15 @@ pub struct BookmarkListArgs {
 
     /// Render each bookmark using the given template
     ///
-    /// All 0-argument methods of the [`RefName` type] are available as
-    /// keywords in the [template expression].
-    ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    /// All 0-argument methods of the [`RefName` type] are available as keywords
+    /// in the template expression. See [`jj help -k templates`] for more
+    /// information.
     ///
     /// [`RefName` type]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#refname-type
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -60,9 +60,9 @@ use crate::ui::Ui;
 
 /// Manage bookmarks [default alias: b]
 ///
-/// See the [bookmark documentation] for more information.
+/// See [`jj help -k bookmarks`] for more information.
 ///
-/// [bookmark documentation]:
+/// [`jj help -k bookmarks`]:
 ///     https://jj-vcs.github.io/jj/latest/bookmarks
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum BookmarkCommand {

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -47,13 +47,15 @@ pub struct ConfigListArgs {
     // TODO(#1047): Support --show-origin using StackedConfig.
     /// Render each variable using the given template
     ///
-    /// The following keywords are available in the [template expression]:
+    /// The following keywords are available in the template expression:
     ///
     /// * `name: String`: Config name.
     /// * `value: ConfigValue`: Value to be formatted in TOML syntax.
     /// * `overridden: Boolean`: True if the value is shadowed by other.
     ///
-    /// [template expression]:
+    /// See [`jj help -k templates`] for more information.
+    ///
+    /// [`jj help -k templates`]:
     ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(
         long, short = 'T',

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -118,10 +118,10 @@ impl ConfigLevelArgs {
 /// Operates on jj configuration, which comes from the config file and
 /// environment variables.
 ///
-/// See the [config documentation] for file locations, supported config options,
-/// and other details about `jj config`.
+/// See [`jj help -k config`] to know more about file locations, supported
+/// config options, and other details about `jj config`.
 ///
-/// [config documentation]:
+/// [`jj help -k config`]:
 ///     https://jj-vcs.github.io/jj/latest/config/
 #[derive(clap::Subcommand, Clone, Debug)]
 pub(crate) enum ConfigCommand {

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -68,14 +68,15 @@ pub(crate) struct EvologArgs {
     ///
     /// Run `jj log -T` to list the built-in templates.
     ///
-    /// You can also specify arbitrary [template expressions] using the
-    /// [built-in keywords].
-    ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    /// You can also specify arbitrary template expressions using the
+    /// [built-in keywords]. See [`jj help -k templates`] for more
+    /// information.
     ///
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show patch compared to the previous version of this change

--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -53,16 +53,17 @@ pub(crate) struct FileAnnotateArgs {
     /// Render each line using the given template
     ///
     /// All 0-argument methods of the [`AnnotationLine` type] are available as
-    /// keywords in the [template expression].
+    /// keywords in the template expression. See [`jj help -k templates`] for
+    /// more information.
     ///
     /// If not specified, this defaults to the `templates.file_annotate`
     /// setting.
     ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
-    ///
     /// [`AnnotationLine` type]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#annotationline-type
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }

--- a/cli/src/commands/file/list.rs
+++ b/cli/src/commands/file/list.rs
@@ -38,13 +38,14 @@ pub(crate) struct FileListArgs {
     /// Render each file entry using the given template
     ///
     /// All 0-argument methods of the [`TreeEntry` type] are available as
-    /// keywords in the [template expression].
-    ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    /// keywords in the template expression. See [`jj help -k templates`] for
+    /// more information.
     ///
     /// [`TreeEntry` type]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#treeentry-type
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T')]
     template: Option<String>,
 

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -100,15 +100,17 @@ pub(crate) struct LogArgs {
     ///
     /// Run `jj log -T` to list the built-in templates.
     ///
-    /// You can also specify arbitrary [template expressions] using the
-    /// [built-in keywords].
+    /// You can also specify arbitrary template expressions using the
+    /// [built-in keywords]. See [`jj help -k templates`] for more
+    /// information.
     ///
     /// If not specified, this defaults to the `templates.log` setting.
     ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show patch

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -64,14 +64,15 @@ pub struct OperationLogArgs {
     no_graph: bool,
     /// Render each operation using the given template
     ///
-    /// You can specify arbitrary [template expressions] using the
-    /// [built-in keywords].
-    ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    /// You can specify arbitrary template expressions using the
+    /// [built-in keywords]. See [`jj help -k templates`] for more
+    /// information.
     ///
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show changes to the repository at each operation

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -38,14 +38,14 @@ pub(crate) struct ShowArgs {
     unused_revision: bool,
     /// Render a revision using the given template
     ///
-    /// You can specify arbitrary [template expressions] using the
-    /// [built-in keywords].
-    ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    /// You can specify arbitrary template expressions using the
+    /// [built-in keywords]. See [`jj help -k templates`] for more information.
     ///
     /// [built-in keywords]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     #[command(flatten)]

--- a/cli/src/commands/tag.rs
+++ b/cli/src/commands/tag.rs
@@ -43,14 +43,15 @@ pub struct TagListArgs {
     pub names: Vec<StringPattern>,
     /// Render each tag using the given template
     ///
-    /// All 0-argument methods of the [`RefName` type] are available as
-    /// keywords in the [template expression].
-    ///
-    /// [template expression]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    /// All 0-argument methods of the [`RefName` type] are available as keywords
+    /// in the template expression. See [`jj help -k templates`] for more
+    /// information.
     ///
     /// [`RefName` type]:
     ///     https://jj-vcs.github.io/jj/latest/templates/#refname-type
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://jj-vcs.github.io/jj/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -113,7 +113,9 @@ This document contains the help content for the `jj` command-line program.
 
 Jujutsu (An experimental VCS)
 
-To get started, see the tutorial at https://jj-vcs.github.io/jj/latest/tutorial/.
+To get started, see the tutorial [`jj help -k tutorial`].
+
+[`jj help -k tutorial`]: https://jj-vcs.github.io/jj/latest/tutorial/
 
 **Usage:** `jj [OPTIONS] [COMMAND]`
 
@@ -284,9 +286,9 @@ The description of the new revisions can be customized with the `templates.backo
 
 Manage bookmarks [default alias: b]
 
-See the [bookmark documentation] for more information.
+See [`jj help -k bookmarks`] for more information.
 
-[bookmark documentation]: https://jj-vcs.github.io/jj/latest/bookmarks
+[`jj help -k bookmarks`]: https://jj-vcs.github.io/jj/latest/bookmarks
 
 **Usage:** `jj bookmark <COMMAND>`
 
@@ -370,9 +372,9 @@ List bookmarks and their targets
 
 By default, a tracking remote bookmark will be included only if its target is different from the local target. A non-tracking remote bookmark won't be listed. For a conflicted bookmark (both local and remote), old target revisions are preceded by a "-" and new target revisions are preceded by a "+".
 
-See the [bookmark documentation] for more information.
+See [`jj help -k bookmarks`] for more information.
 
-[bookmark documentation]: https://jj-vcs.github.io/jj/latest/bookmarks
+[`jj help -k bookmarks`]: https://jj-vcs.github.io/jj/latest/bookmarks
 
 **Usage:** `jj bookmark list [OPTIONS] [NAMES]...`
 
@@ -401,11 +403,11 @@ See the [bookmark documentation] for more information.
    Note that `-r deleted_bookmark` will not work since `deleted_bookmark` wouldn't have a local target.
 * `-T`, `--template <TEMPLATE>` — Render each bookmark using the given template
 
-   All 0-argument methods of the [`RefName` type] are available as keywords in the [template expression].
-
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
+   All 0-argument methods of the [`RefName` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
    [`RefName` type]: https://jj-vcs.github.io/jj/latest/templates/#refname-type
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 
 
 
@@ -547,9 +549,9 @@ Manage config options
 
 Operates on jj configuration, which comes from the config file and environment variables.
 
-See the [config documentation] for file locations, supported config options, and other details about `jj config`.
+See [`jj help -k config`] to know more about file locations, supported config options, and other details about `jj config`.
 
-[config documentation]: https://jj-vcs.github.io/jj/latest/config/
+[`jj help -k config`]: https://jj-vcs.github.io/jj/latest/config/
 
 **Usage:** `jj config <COMMAND>`
 
@@ -617,13 +619,15 @@ List variables set in config file, along with their values
 * `--repo` — Target the repo-level config
 * `-T`, `--template <TEMPLATE>` — Render each variable using the given template
 
-   The following keywords are available in the [template expression]:
+   The following keywords are available in the template expression:
 
    * `name: String`: Config name.
    * `value: ConfigValue`: Value to be formatted in TOML syntax.
    * `overridden: Boolean`: True if the value is shadowed by other.
 
-   [template expression]:
+   See [`jj help -k templates`] for more information.
+
+   [`jj help -k templates`]:
        https://jj-vcs.github.io/jj/latest/templates/
 
 
@@ -855,11 +859,11 @@ Lists the previous commits which a change has pointed to. The current commit of 
 
    Run `jj log -T` to list the built-in templates.
 
-   You can also specify arbitrary [template expressions] using the [built-in keywords].
-
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
+   You can also specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
    [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 * `-p`, `--patch` — Show patch compared to the previous version of this change
 
    If the previous version has different parents, it will be temporarily rebased to the parents of the new version, so the diff is not contaminated by unrelated changes.
@@ -914,13 +918,13 @@ Annotates a revision line by line. Each line includes the source change that int
 * `-r`, `--revision <REVSET>` — an optional revision to start at
 * `-T`, `--template <TEMPLATE>` — Render each line using the given template
 
-   All 0-argument methods of the [`AnnotationLine` type] are available as keywords in the [template expression].
+   All 0-argument methods of the [`AnnotationLine` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
    If not specified, this defaults to the `templates.file_annotate` setting.
 
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
-
    [`AnnotationLine` type]: https://jj-vcs.github.io/jj/latest/templates/#annotationline-type
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 
 
 
@@ -969,11 +973,11 @@ List files in a revision
   Default value: `@`
 * `-T`, `--template <TEMPLATE>` — Render each file entry using the given template
 
-   All 0-argument methods of the [`TreeEntry` type] are available as keywords in the [template expression].
-
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
+   All 0-argument methods of the [`TreeEntry` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
    [`TreeEntry` type]: https://jj-vcs.github.io/jj/latest/templates/#treeentry-type
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 
 
 
@@ -1466,11 +1470,13 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
    Run `jj log -T` to list the built-in templates.
 
-   You can also specify arbitrary [template expressions] using the [built-in keywords].
+   You can also specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
    If not specified, this defaults to the `templates.log` setting.
 
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/ [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+   [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 * `-p`, `--patch` — Show patch
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
@@ -1655,11 +1661,11 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
 * `--no-graph` — Don't show the graph, show a flat list of operations
 * `-T`, `--template <TEMPLATE>` — Render each operation using the given template
 
-   You can specify arbitrary [template expressions] using the [built-in keywords].
-
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
+   You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
    [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 * `--op-diff` — Show changes to the repository at each operation
 * `-p`, `--patch` — Show patch of modifications to changes (implies --op-diff)
 
@@ -2195,11 +2201,11 @@ Show commit description and changes in a revision
 
 * `-T`, `--template <TEMPLATE>` — Render a revision using the given template
 
-   You can specify arbitrary [template expressions] using the [built-in keywords].
-
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
+   You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
    [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
 * `--types` — For each path, show only its type before and after
@@ -2421,11 +2427,11 @@ List tags
 
 * `-T`, `--template <TEMPLATE>` — Render each tag using the given template
 
-   All 0-argument methods of the [`RefName` type] are available as keywords in the [template expression].
-
-   [template expression]: https://jj-vcs.github.io/jj/latest/templates/
+   All 0-argument methods of the [`RefName` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
    [`RefName` type]: https://jj-vcs.github.io/jj/latest/templates/#refname-type
+
+   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
 
 
 

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -147,10 +147,12 @@ fn test_alias_calls_help() {
     test_env.add_config(r#"aliases.h = ["--help"]"#);
     let output = test_env.run_jj_in(&repo_path, &["h"]);
     insta::assert_snapshot!(
-        output.normalize_stdout_with(|s| s.split_inclusive('\n').take(5).collect()), @r"
+        output.normalize_stdout_with(|s| s.split_inclusive('\n').take(7).collect()), @r"
     Jujutsu (An experimental VCS)
 
-    To get started, see the tutorial at https://jj-vcs.github.io/jj/latest/tutorial/.
+    To get started, see the tutorial [`jj help -k tutorial`].
+
+    [`jj help -k tutorial`]: https://jj-vcs.github.io/jj/latest/tutorial/
 
     Usage: jj [OPTIONS] <COMMAND>
     [EOF]
@@ -280,7 +282,7 @@ fn test_alias_invalid_definition() {
     Caused by: invalid type: integer `5`, expected a sequence
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -291,7 +293,7 @@ fn test_alias_invalid_definition() {
     Caused by: invalid type: integer `0`, expected a string
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -152,7 +152,7 @@ fn test_bookmark_bad_name() {
       = expected <identifier>, <string_literal>, or <raw_string_literal>
 
     For more information, try '--help'.
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -183,7 +183,7 @@ fn test_bookmark_bad_name() {
       = expected <identifier>, <string_literal>, or <raw_string_literal>
 
     For more information, try '--help'.
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -200,7 +200,7 @@ fn test_bookmark_bad_name() {
       = expected <identifier>, <string_literal>, or <raw_string_literal>
 
     For more information, try '--help'.
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 2]
     ");

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -958,7 +958,7 @@ fn test_log_immutable() {
       | ^--------^
       |
       = Function `unknown_fn` doesn't exist
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1029,7 +1029,7 @@ fn test_config_get() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: Value not found for nonexistent
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1052,7 +1052,7 @@ fn test_config_get() {
     Config error: Invalid type or value for table.list
     Caused by: Expected a value convertible to a string, but is an array
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1063,7 +1063,7 @@ fn test_config_get() {
     Config error: Invalid type or value for table
     Caused by: Expected a value convertible to a string, but is a table
     Hint: Check the config file: $TEST_ENV/config/config0003.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1127,7 +1127,7 @@ fn test_config_path_syntax() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: Value not found for a.'b()'.x
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1406,7 +1406,7 @@ fn test_config_show_paths() {
     Caused by: unknown variant `:builtin`, expected `never` or `auto`
 
     Hint: Check the config file: $TEST_ENV/config/config0001.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -57,7 +57,7 @@ fn test_config_no_tools() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: No `fix.tools` are configured
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -150,7 +150,7 @@ fn test_config_multiple_tools_with_same_name() {
     duplicate key `my-tool` in table `fix.tools`
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -241,7 +241,7 @@ fn test_config_disabled_tools_warning_when_all_tools_are_disabled() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: At least one entry of `fix.tools` must be enabled.
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -316,7 +316,7 @@ fn test_config_tables_all_commands_missing() {
     Caused by: missing field `command`
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -356,7 +356,7 @@ fn test_config_tables_some_commands_missing() {
     Caused by: missing field `command`
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -1018,7 +1018,7 @@ fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     bookmark: main@origin [new] untracked
     Config error: Invalid `revset-aliases.immutable_heads()`
     Caused by: Revision `unknown` doesn't exist
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -352,7 +352,7 @@ fn test_invalid_filesets_looking_like_filepaths() {
       |     ^---
       |
       = expected `~` or <primary>
-    Hint: See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
+    Hint: See https://jj-vcs.github.io/jj/latest/filesets/ or use `jj help -k filesets` for filesets syntax and how to match file paths.
     [EOF]
     [exit status: 1]
     ");
@@ -529,7 +529,7 @@ fn test_color_config() {
     Config error: Invalid type or value for ui.color
     Caused by: wanted string or table
 
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -770,7 +770,7 @@ fn test_config_args() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: --config must be specified as NAME=VALUE
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -785,7 +785,7 @@ fn test_config_args() {
         Caused by:
         1: Cannot access unknown.toml
         2: <redacted>
-        For help, see https://jj-vcs.github.io/jj/latest/config/.
+        For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
         [EOF]
         [exit status: 1]
         ");
@@ -810,7 +810,7 @@ fn test_invalid_config() {
     expected newline, `#`
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -829,7 +829,7 @@ fn test_invalid_config_value() {
     Config error: Invalid type or value for snapshot.auto-track
     Caused by: invalid type: sequence, expected a string
 
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -93,7 +93,7 @@ fn test_rewrite_immutable_generic() {
     ------- stderr -------
     Config error: Invalid `revset-aliases.immutable_heads()`
     Caused by: Revision `bookmark_that_does_not_exist` doesn't exist
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -496,7 +496,7 @@ fn test_log_bad_short_prefixes() {
       | ^---
       |
       = expected <strict_identifier> or <expression>
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1427,7 +1427,7 @@ fn test_graph_styles() {
     Config error: Invalid type or value for ui.graph.style
     Caused by: unknown variant `unknown`, expected one of `ascii`, `ascii-large`, `curved`, `square`
 
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -45,7 +45,7 @@ fn test_syntax_error() {
       |    ^---
       |
       = expected `::`, `..`, `~`, or <primary>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -188,7 +188,7 @@ fn test_bad_function_call() {
       |     ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-    Hint: See https://jj-vcs.github.io/jj/latest/filesets/ for filesets syntax, or for how to match file paths.
+    Hint: See https://jj-vcs.github.io/jj/latest/filesets/ or use `jj help -k filesets` for filesets syntax and how to match file paths.
     [EOF]
     [exit status: 1]
     ");
@@ -329,7 +329,7 @@ fn test_bad_function_call() {
       |                  ^---
       |
       = expected <strict_identifier> or <expression>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -344,7 +344,7 @@ fn test_bad_function_call() {
       |                         ^---
       |
       = expected <expression>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -530,7 +530,7 @@ fn test_alias() {
       |           ^---
       |
       = expected `::`, `..`, `~`, or <primary>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ for revsets syntax, or for how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -831,7 +831,7 @@ fn test_all_modifier() {
       | ^-^
       |
       = Modifier `all:` is not allowed in sub expression
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -99,7 +99,7 @@ fn test_snapshot_large_file() {
     ------- stderr -------
     Config error: Invalid type or value for snapshot.max-new-file-size
     Caused by: Expected a positive integer or a string in '<number><unit>' form
-    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
Relates to #5306

I wasn't aware that `jj help -k <keyword>` exists.



<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
