### PR TITLE
cli: provide better hint on bookmark name parse error

### DIFF
--- a/cli/src/commands/bookmark/create.rs
+++ b/cli/src/commands/bookmark/create.rs
@@ -15,7 +15,6 @@
 use clap_complete::ArgValueCandidates;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::RefTarget;
-use jj_lib::revset;
 
 use super::has_tracked_remote_bookmarks;
 use crate::cli_util::CommandHelper;
@@ -23,6 +22,7 @@ use crate::cli_util::RevisionArg;
 use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::complete;
+use crate::revset_util;
 use crate::ui::Ui;
 
 /// Create a new bookmark
@@ -44,7 +44,7 @@ pub struct BookmarkCreateArgs {
     revision: Option<RevisionArg>,
 
     /// The bookmarks to create
-    #[arg(required = true, value_parser = revset::parse_symbol)]
+    #[arg(required = true, value_parser = revset_util::parse_bookmark_name)]
     names: Vec<String>,
 }
 

--- a/cli/src/commands/bookmark/rename.rs
+++ b/cli/src/commands/bookmark/rename.rs
@@ -14,13 +14,13 @@
 
 use clap_complete::ArgValueCandidates;
 use jj_lib::op_store::RefTarget;
-use jj_lib::revset;
 
 use super::has_tracked_remote_bookmarks;
 use crate::cli_util::CommandHelper;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::complete;
+use crate::revset_util;
 use crate::ui::Ui;
 
 /// Rename `old` bookmark name to `new` bookmark name
@@ -30,13 +30,13 @@ use crate::ui::Ui;
 pub struct BookmarkRenameArgs {
     /// The old name of the bookmark
     #[arg(
-        value_parser = revset::parse_symbol,
+        value_parser = revset_util::parse_bookmark_name,
         add = ArgValueCandidates::new(complete::local_bookmarks),
     )]
     old: String,
 
     /// The new name of the bookmark
-    #[arg(value_parser = revset::parse_symbol)]
+    #[arg(value_parser = revset_util::parse_bookmark_name)]
     new: String,
 }
 

--- a/cli/src/commands/bookmark/set.rs
+++ b/cli/src/commands/bookmark/set.rs
@@ -15,7 +15,6 @@
 use clap_complete::ArgValueCandidates;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::RefTarget;
-use jj_lib::revset;
 
 use super::has_tracked_remote_bookmarks;
 use super::is_fast_forward;
@@ -24,6 +23,7 @@ use crate::cli_util::RevisionArg;
 use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::complete;
+use crate::revset_util;
 use crate::ui::Ui;
 
 /// Create or update a bookmark to point to a certain commit
@@ -49,7 +49,7 @@ pub struct BookmarkSetArgs {
     /// The bookmarks to update
     #[arg(
         required = true,
-        value_parser = revset::parse_symbol,
+        value_parser = revset_util::parse_bookmark_name,
         add = ArgValueCandidates::new(complete::local_bookmarks),
     )]
     names: Vec<String>,

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -352,3 +352,18 @@ fn format_multiple_revisions_error(
     };
     cmd_err
 }
+
+#[derive(Debug, Error)]
+#[error("Failed to parse bookmark name: {}", source.kind())]
+pub struct BookmarkNameParseError {
+    pub input: String,
+    pub source: RevsetParseError,
+}
+
+/// Parses bookmark name specified in revset syntax.
+pub fn parse_bookmark_name(text: &str) -> Result<String, BookmarkNameParseError> {
+    revset::parse_symbol(text).map_err(|source| BookmarkNameParseError {
+        input: text.to_owned(),
+        source,
+    })
+}

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -144,15 +144,16 @@ fn test_bookmark_bad_name() {
     let output = test_env.run_jj_in(&repo_path, ["bookmark", "create", "-r@", ""]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: invalid value '' for '<NAMES>...':  --> 1:1
+    error: invalid value '' for '<NAMES>...': Failed to parse bookmark name: Syntax error
+
+    For more information, try '--help'.
+    Caused by:  --> 1:1
       |
     1 | 
       | ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-
-    For more information, try '--help'.
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -160,14 +161,16 @@ fn test_bookmark_bad_name() {
     let output = test_env.run_jj_in(&repo_path, ["bookmark", "set", "''"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: invalid value '''' for '<NAMES>...':  --> 1:1
+    error: invalid value '''' for '<NAMES>...': Failed to parse bookmark name: Expected non-empty string
+
+    For more information, try '--help'.
+    Caused by:  --> 1:1
       |
     1 | ''
       | ^^
       |
       = Expected non-empty string
-
-    For more information, try '--help'.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -175,15 +178,16 @@ fn test_bookmark_bad_name() {
     let output = test_env.run_jj_in(&repo_path, ["bookmark", "rename", "x", ""]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: invalid value '' for '<NEW>':  --> 1:1
+    error: invalid value '' for '<NEW>': Failed to parse bookmark name: Syntax error
+
+    For more information, try '--help'.
+    Caused by:  --> 1:1
       |
     1 | 
       | ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-
-    For more information, try '--help'.
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -192,15 +196,33 @@ fn test_bookmark_bad_name() {
     let output = test_env.run_jj_in(&repo_path, ["bookmark", "set", "@-", "foo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: invalid value '@-' for '<NAMES>...':  --> 1:1
+    error: invalid value '@-' for '<NAMES>...': Failed to parse bookmark name: Syntax error
+
+    For more information, try '--help'.
+    Caused by:  --> 1:1
       |
     1 | @-
       | ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
+    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let stderr = test_env.run_jj_in(&repo_path, ["bookmark", "set", "-r@-", "foo@bar"]);
+    insta::assert_snapshot!(stderr, @r"
+    ------- stderr -------
+    error: invalid value 'foo@bar' for '<NAMES>...': Failed to parse bookmark name: Syntax error
 
     For more information, try '--help'.
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Caused by:  --> 1:4
+      |
+    1 | foo@bar
+      |    ^---
+      |
+      = expected <EOI>
+    Hint: Looks like remote bookmark. Run `jj bookmark track foo@bar` to track it.
     [EOF]
     [exit status: 2]
     ");

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -54,6 +54,7 @@ use crate::repo::RepoLoaderError;
 use crate::repo_path::RepoPathUiConverter;
 use crate::revset_parser;
 pub use crate::revset_parser::expect_literal;
+pub use crate::revset_parser::parse_program;
 pub use crate::revset_parser::parse_symbol;
 pub use crate::revset_parser::BinaryOp;
 pub use crate::revset_parser::ExpressionKind;
@@ -1191,7 +1192,7 @@ pub fn parse(
     revset_str: &str,
     context: &RevsetParseContext,
 ) -> Result<Rc<UserRevsetExpression>, RevsetParseError> {
-    let node = revset_parser::parse_program(revset_str)?;
+    let node = parse_program(revset_str)?;
     let node = dsl_util::expand_aliases(node, context.aliases_map)?;
     lower_expression(diagnostics, &node, context)
         .map_err(|err| err.extend_function_candidates(context.aliases_map.function_names()))
@@ -1202,7 +1203,7 @@ pub fn parse_with_modifier(
     revset_str: &str,
     context: &RevsetParseContext,
 ) -> Result<(Rc<UserRevsetExpression>, Option<RevsetModifier>), RevsetParseError> {
-    let node = revset_parser::parse_program(revset_str)?;
+    let node = parse_program(revset_str)?;
     let node = dsl_util::expand_aliases(node, context.aliases_map)?;
     revset_parser::expect_program_with(
         diagnostics,

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -462,7 +462,8 @@ fn union_nodes<'i>(lhs: ExpressionNode<'i>, rhs: ExpressionNode<'i>) -> Expressi
     ExpressionNode::new(expr, span)
 }
 
-pub(super) fn parse_program(revset_str: &str) -> Result<ExpressionNode, RevsetParseError> {
+/// Parses text into expression tree. No name resolution is made at this stage.
+pub fn parse_program(revset_str: &str) -> Result<ExpressionNode, RevsetParseError> {
     let mut pairs = RevsetParser::parse(Rule::program, revset_str)?;
     let first = pairs.next().unwrap();
     match first.as_rule() {


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
