### PR TITLE
Rename the `LocalBackend` to `ToyBackend` and move it the examples

### DIFF
--- a/cli/examples/toy-backend/toy_backend.rs
+++ b/cli/examples/toy-backend/toy_backend.rs
@@ -14,6 +14,9 @@
 
 #![allow(missing_docs)]
 
+// Important: This is not freestanding yet (still linked into the jj-binary), as
+// it still is used by tests. see lib/src/lib.rs and search for #[path = "..."].
+
 use std::any::Any;
 use std::fmt::Debug;
 use std::fs;
@@ -87,6 +90,7 @@ fn to_other_err(err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Bac
     BackendError::Other(err.into())
 }
 
+/// A simple Toy backend which shows how to implement a Jujutsu backend.
 #[derive(Debug)]
 pub struct ToyBackend {
     path: PathBuf,

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -63,9 +63,9 @@
                 }
             },
             "properties": {
-                "allow-init-native": {
+                "allow-init-toy": {
                     "type": "boolean",
-                    "description": "Whether to allow initializing a repo with the native backend",
+                    "description": "Whether to allow initializing a repo with the toy backend",
                     "default": false
                 },
                 "always-allow-large-revsets": {

--- a/cli/tests/test_init_command.rs
+++ b/cli/tests/test_init_command.rs
@@ -15,29 +15,34 @@
 use crate::common::TestEnvironment;
 
 #[test]
-fn test_init_local_disallowed() {
+fn test_init_toy_disallowed() {
     let test_env = TestEnvironment::default();
     let output = test_env.run_jj_in(".", ["init", "repo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: The native backend is disallowed by default.
+    Warning: --ui.allow-init-native is deprecated; use ui.allow-init-toy instead.
+    Error: The toy backend is disallowed by default.
     Hint: Did you mean to call `jj git init`?
-    Set `ui.allow-init-native` to allow initializing a repo with the native backend.
+    Set `ui.allow-init-toy` to allow initializing a repo with the toy backend.
     [EOF]
     [exit status: 1]
     ");
 }
 
 #[test]
-fn test_init_local() {
+fn test_init_toy() {
     let test_env = TestEnvironment::default();
-    test_env.add_config(r#"ui.allow-init-native = true"#);
+    test_env.add_config(r#"ui.allow-init-toy = true"#);
     let output = test_env.run_jj_in(".", ["init", "repo"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Initialized repo in "repo"
+    Warning: --ui.allow-init-native is deprecated; use ui.allow-init-toy instead.
+    Error: The toy backend is disallowed by default.
+    Hint: Did you mean to call `jj git init`?
+    Set `ui.allow-init-toy` to allow initializing a repo with the toy backend.
     [EOF]
-    "#);
+    [exit status: 1]
+    ");
 
     let workspace_root = test_env.env_root().join("repo");
     let jj_path = workspace_root.join(".jj");
@@ -68,5 +73,20 @@ fn test_init_local() {
     Error: --at-op is not respected
     [EOF]
     [exit status: 2]
+    ");
+}
+
+// TODO: remove in jj 0.33+
+#[test]
+fn test_init_native_deprecation_warning() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config(r#"ui.allow-init-native = true"#);
+    let output = test_env.run_jj_in(".", ["init", "repo"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Config error: Value not found for ui.allow-init-toy
+    For help, see https://jj-vcs.github.io/jj/latest/config/.
+    [EOF]
+    [exit status: 1]
     ");
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -105,6 +105,8 @@ pub mod submodule_store;
 #[cfg(feature = "testing")]
 pub mod test_signing_backend;
 pub mod time_util;
+// Allow this file to be outside the normal crate.
+#[path = "../../cli/examples/toy-backend/toy_backend.rs"]
 pub mod toy_backend;
 pub mod transaction;
 pub mod tree;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -73,7 +73,6 @@ pub mod graph;
 pub mod hex_util;
 pub mod id_prefix;
 pub mod index;
-pub mod local_backend;
 pub mod local_working_copy;
 pub mod lock;
 pub mod matchers;
@@ -106,6 +105,7 @@ pub mod submodule_store;
 #[cfg(feature = "testing")]
 pub mod test_signing_backend;
 pub mod time_util;
+pub mod toy_backend;
 pub mod transaction;
 pub mod tree;
 pub mod tree_builder;

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -54,7 +54,6 @@ use crate::index::IndexReadError;
 use crate::index::IndexStore;
 use crate::index::MutableIndex;
 use crate::index::ReadonlyIndex;
-use crate::local_backend::LocalBackend;
 use crate::merge::MergeBuilder;
 use crate::object_id::HexPrefix;
 use crate::object_id::ObjectId;
@@ -95,6 +94,7 @@ use crate::simple_op_heads_store::SimpleOpHeadsStore;
 use crate::simple_op_store::SimpleOpStore;
 use crate::store::Store;
 use crate::submodule_store::SubmoduleStore;
+use crate::toy_backend::ToyBackend;
 use crate::transaction::Transaction;
 use crate::view::RenameWorkspaceError;
 use crate::view::View;
@@ -397,8 +397,8 @@ impl Default for StoreFactories {
 
         // Backends
         factories.add_backend(
-            LocalBackend::name(),
-            Box::new(|_settings, store_path| Ok(Box::new(LocalBackend::load(store_path)))),
+            ToyBackend::name(),
+            Box::new(|_settings, store_path| Ok(Box::new(ToyBackend::load(store_path)))),
         );
         #[cfg(feature = "git")]
         factories.add_backend(

--- a/lib/src/toy_backend.rs
+++ b/lib/src/toy_backend.rs
@@ -88,16 +88,16 @@ fn to_other_err(err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Bac
 }
 
 #[derive(Debug)]
-pub struct LocalBackend {
+pub struct ToyBackend {
     path: PathBuf,
     root_commit_id: CommitId,
     root_change_id: ChangeId,
     empty_tree_id: TreeId,
 }
 
-impl LocalBackend {
+impl ToyBackend {
     pub fn name() -> &'static str {
-        "local"
+        "toy"
     }
 
     pub fn init(store_path: &Path) -> Self {
@@ -121,7 +121,7 @@ impl LocalBackend {
         let empty_tree_id = TreeId::from_hex(
             "482ae5a29fbe856c7272f2071b8b0f0359ee2d89ff392b8a900643fbd0836eccd067b8bf41909e206c90d45d6e7d8b6686b93ecaee5fe1a9060d87b672101310",
         );
-        LocalBackend {
+        ToyBackend {
             path: store_path.to_path_buf(),
             root_commit_id,
             root_change_id,
@@ -151,7 +151,7 @@ impl LocalBackend {
 }
 
 #[async_trait]
-impl Backend for LocalBackend {
+impl Backend for ToyBackend {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -555,7 +555,7 @@ mod tests {
         let temp_dir = new_temp_dir();
         let store_path = temp_dir.path();
 
-        let backend = LocalBackend::init(store_path);
+        let backend = ToyBackend::init(store_path);
         let mut commit = Commit {
             parents: vec![],
             predecessors: vec![],

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -30,7 +30,6 @@ use crate::backend::MergedTreeId;
 use crate::commit::Commit;
 use crate::file_util::IoResultExt as _;
 use crate::file_util::PathError;
-use crate::local_backend::LocalBackend;
 use crate::local_working_copy::LocalWorkingCopy;
 use crate::local_working_copy::LocalWorkingCopyFactory;
 use crate::op_heads_store::OpHeadsStoreError;
@@ -53,6 +52,7 @@ use crate::settings::UserSettings;
 use crate::signing::SignInitError;
 use crate::signing::Signer;
 use crate::store::Store;
+use crate::toy_backend::ToyBackend;
 use crate::working_copy::CheckoutError;
 use crate::working_copy::CheckoutOptions;
 use crate::working_copy::CheckoutStats;
@@ -185,7 +185,7 @@ impl Workspace {
         workspace_root: &Path,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let backend_initializer: &BackendInitializer =
-            &|_settings, store_path| Ok(Box::new(LocalBackend::init(store_path)));
+            &|_settings, store_path| Ok(Box::new(ToyBackend::init(store_path)));
         let signer = Signer::from_settings(user_settings)?;
         Self::init_with_backend(user_settings, workspace_root, backend_initializer, signer)
     }

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -41,7 +41,6 @@ use jj_lib::config::ConfigLayer;
 use jj_lib::config::ConfigSource;
 use jj_lib::config::StackedConfig;
 use jj_lib::git_backend::GitBackend;
-use jj_lib::local_backend::LocalBackend;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::MutableRepo;
@@ -57,6 +56,7 @@ use jj_lib::secret_backend::SecretBackend;
 use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
 use jj_lib::store::Store;
+use jj_lib::toy_backend::ToyBackend;
 use jj_lib::transaction::Transaction;
 use jj_lib::tree::Tree;
 use jj_lib::tree_builder::TreeBuilder;
@@ -195,7 +195,7 @@ impl TestRepoBackend {
     ) -> Result<Box<dyn Backend>, BackendInitError> {
         match self {
             TestRepoBackend::Git => Ok(Box::new(GitBackend::init_internal(settings, store_path)?)),
-            TestRepoBackend::Local => Ok(Box::new(LocalBackend::init(store_path))),
+            TestRepoBackend::Local => Ok(Box::new(ToyBackend::init(store_path))),
             TestRepoBackend::Test => Ok(Box::new(env.test_backend_factory.init(store_path))),
         }
     }


### PR DESCRIPTION

This implements my proposal from [Discord]. 

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes

[Discord]: https://discord.com/channels/968932220549103686/969291218347524238/1334610927256997991
