### PR TITLE
Disable the new bookmark behavior for `jj split`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   of forgetting them, since forgetting a remote bookmark can be unintuitive.
   The old behavior is still available with the new `--include-remotes` flag.
 
-* `jj split` no longer moves bookmarks to the second revision created by the
-  split. Instead, local bookmarks associated with the target revision will move
-  to the first revision created by the split (which inherits the target
-  revision's change id). You can opt out of this change by setting
-  `split.legacy-bookmark-behavior = true`, but this will likely be removed in a
-  future release. [#3419](https://github.com/jj-vcs/jj/issues/3419)
-
 * `jj fix` now always sets the working directory of invoked tools to be the
   workspace root, instead of the working directory of the `jj fix`.
 

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -196,7 +196,7 @@ The remainder will be in the second commit.
         commit_builder.write(tx.repo_mut())?
     };
 
-    let legacy_bookmark_behavior = read_legacy_bookmark_behavior_setting(tx.settings(), ui)?;
+    let legacy_bookmark_behavior = tx.settings().get_bool("split.legacy-bookmark-behavior")?;
     if legacy_bookmark_behavior {
         // Mark the commit being split as rewritten to the second commit. This
         // moves any bookmarks pointing to the target commit to the second
@@ -240,29 +240,4 @@ The remainder will be in the second commit.
     }
     tx.finish(ui, format!("split commit {}", commit.id().hex()))?;
     Ok(())
-}
-
-/// Reads and returns 'split.legacy-bookmark-behavior' from settings and prints
-/// a warning if it is set to true to alert the user of the deprecation.
-fn read_legacy_bookmark_behavior_setting(
-    settings: &jj_lib::settings::UserSettings,
-    ui: &Ui,
-) -> Result<bool, CommandError> {
-    let use_legacy_behavior = settings.get_bool("split.legacy-bookmark-behavior")?;
-    if use_legacy_behavior {
-        writeln!(
-            ui.warning_default(),
-            "`jj split` will leave bookmarks on the first commit in the next release."
-        )?;
-        writeln!(
-            ui.warning_default(),
-            "Run `jj config set --user split.legacy-bookmark-behavior false` to silence this \
-             message and use the new behavior."
-        )?;
-        writeln!(
-            ui.warning_default(),
-            "See https://github.com/jj-vcs/jj/issues/3419"
-        )?;
-    }
-    Ok(use_legacy_behavior)
 }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -49,5 +49,7 @@ auto-track = "all()"
 auto-update-stale = false
 
 # TODO: https://github.com/jj-vcs/jj/issues/3419 - Remove when fully deprecated.
+# The behavior when this flag is set to false is experimental and may be changed
+# in the future.
 [split]
-legacy-bookmark-behavior = false
+legacy-bookmark-behavior = true


### PR DESCRIPTION
The consensus about this change, if one ever existed, seems to have dissolved into two cohorts, one which is happy with the change, and one which thinks we should move both the bookmark and change id to the child commit instead of leaving them on the parent.

We may decide to add flags to allow users to choose between the two behaviors, but there are also other concerns such as where @ should go (parent or child). Until we agree on a path forward it seems reasonable to delay the breaking change by disabling it via the config option we added. I don't think it's necessary to fully revert the code and new tests since we aren't announcing the option.


#3419

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
