### PR TITLE
cli split: Rename the "commit" variable to "target_commit"

### DIFF
--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -83,15 +83,18 @@ pub(crate) fn cmd_split(
     args: &SplitArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
-    let commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
-    if commit.is_empty(workspace_command.repo().as_ref())? {
+    let target_commit = workspace_command.resolve_single_rev(ui, &args.revision)?;
+    if target_commit.is_empty(workspace_command.repo().as_ref())? {
         return Err(user_error_with_hint(
-            format!("Refusing to split empty commit {}.", commit.id().hex()),
+            format!(
+                "Refusing to split empty commit {}.",
+                target_commit.id().hex()
+            ),
             "Use `jj new` if you want to create another empty commit.",
         ));
     }
 
-    workspace_command.check_rewritable([commit.id()])?;
+    workspace_command.check_rewritable([target_commit.id()])?;
     let matcher = workspace_command
         .parse_file_patterns(ui, &args.paths)?
         .to_matcher();
@@ -102,8 +105,8 @@ pub(crate) fn cmd_split(
     )?;
     let text_editor = workspace_command.text_editor()?;
     let mut tx = workspace_command.start_transaction();
-    let end_tree = commit.tree()?;
-    let base_tree = commit.parent_tree(tx.repo())?;
+    let end_tree = target_commit.tree()?;
+    let base_tree = target_commit.parent_tree(tx.repo())?;
     let format_instructions = || {
         format!(
             "\
@@ -114,14 +117,14 @@ The diff initially shows the changes in the commit you're splitting.
 Adjust the right side until it shows the contents you want for the first commit.
 The remainder will be in the second commit.
 ",
-            tx.format_commit_summary(&commit)
+            tx.format_commit_summary(&target_commit)
         )
     };
 
     // Prompt the user to select the changes they want for the first commit.
     let selected_tree_id =
         diff_selector.select(&base_tree, &end_tree, matcher.as_ref(), format_instructions)?;
-    if &selected_tree_id == commit.tree_id() {
+    if &selected_tree_id == target_commit.tree_id() {
         // The user selected everything from the original commit.
         writeln!(
             ui.warning_default(),
@@ -138,7 +141,7 @@ The remainder will be in the second commit.
     // Create the first commit, which includes the changes selected by the user.
     let selected_tree = tx.repo().store().get_root_tree(&selected_tree_id)?;
     let first_commit = {
-        let mut commit_builder = tx.repo_mut().rewrite_commit(&commit).detach();
+        let mut commit_builder = tx.repo_mut().rewrite_commit(&target_commit).detach();
         commit_builder.set_tree_id(selected_tree_id);
         if commit_builder.description().is_empty() {
             commit_builder.set_description(tx.settings().get_string("ui.default-description")?);
@@ -167,18 +170,18 @@ The remainder will be in the second commit.
             end_tree
         };
         let parents = if args.parallel {
-            commit.parent_ids().to_vec()
+            target_commit.parent_ids().to_vec()
         } else {
             vec![first_commit.id().clone()]
         };
-        let mut commit_builder = tx.repo_mut().rewrite_commit(&commit).detach();
+        let mut commit_builder = tx.repo_mut().rewrite_commit(&target_commit).detach();
         commit_builder
             .set_parents(parents)
             .set_tree_id(new_tree.id())
             // Generate a new change id so that the commit being split doesn't
             // become divergent.
             .generate_new_change_id();
-        let description = if commit.description().is_empty() {
+        let description = if target_commit.description().is_empty() {
             // If there was no description before, don't ask for one for the
             // second commit.
             "".to_string()
@@ -202,11 +205,11 @@ The remainder will be in the second commit.
         // moves any bookmarks pointing to the target commit to the second
         // commit.
         tx.repo_mut()
-            .set_rewritten_commit(commit.id().clone(), second_commit.id().clone());
+            .set_rewritten_commit(target_commit.id().clone(), second_commit.id().clone());
     }
     let mut num_rebased = 0;
     tx.repo_mut()
-        .transform_descendants(vec![commit.id().clone()], |mut rewriter| {
+        .transform_descendants(vec![target_commit.id().clone()], |mut rewriter| {
             num_rebased += 1;
             if args.parallel && legacy_bookmark_behavior {
                 // The old_parent is the second commit due to the rewrite above.
@@ -223,7 +226,7 @@ The remainder will be in the second commit.
     // Move the working copy commit (@) to the second commit for any workspaces
     // where the target commit is the working copy commit.
     for (workspace_id, working_copy_commit) in tx.base_repo().clone().view().wc_commit_ids() {
-        if working_copy_commit == commit.id() {
+        if working_copy_commit == target_commit.id() {
             tx.repo_mut().edit(workspace_id.clone(), &second_commit)?;
         }
     }
@@ -238,7 +241,7 @@ The remainder will be in the second commit.
         tx.write_commit_summary(formatter.as_mut(), &second_commit)?;
         writeln!(formatter)?;
     }
-    tx.finish(ui, format!("split commit {}", commit.id().hex()))?;
+    tx.finish(ui, format!("split commit {}", target_commit.id().hex()))?;
     Ok(())
 }
 


### PR DESCRIPTION
This has bothered me for a while... It's useful to describe the target of the split command as the "target commit", and it's a little confusing to have a variable named "commit" in the code when we are dealing with several different commits in the command.

I think this improves readability by being more precise.
