### PR TITLE
cli/tests: move remaining tests to gitoxide

### DIFF
--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -622,7 +622,7 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
         .success();
 
     let clone_path = test_env.env_root().join("clone");
-    git::clone(&clone_path, origin_path.to_str().unwrap());
+    git::clone(&clone_path, origin_path.to_str().unwrap(), None);
     test_env
         .run_jj_in(&clone_path, ["git", "init", "--git-repo=."])
         .success();

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -552,7 +552,7 @@ fn test_git_init_colocated_via_git_repo_path_imported_refs() {
 
     let remote_git_path = remote_path.join(PathBuf::from_iter([".jj", "repo", "store", "git"]));
     let set_up_local_repo = |local_path: &Path| {
-        let git_repo = git::clone(local_path, remote_git_path.to_str().unwrap());
+        let git_repo = git::clone(local_path, remote_git_path.to_str().unwrap(), None);
         let git_ref = git_repo
             .find_reference("refs/remotes/origin/local-remote")
             .unwrap();

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use test_case::test_case;
+use testutils::git;
 
 use crate::common::CommandOutput;
 use crate::common::TestEnvironment;
@@ -1800,7 +1801,7 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     let git_repo = {
         let mut git_repo_path = workspace_root.clone();
         git_repo_path.extend([".jj", "repo", "store", "git"]);
-        git2::Repository::open(&git_repo_path).unwrap()
+        git::open(&git_repo_path)
     };
 
     // Forget remote ref, move local ref, then fetch to create conflict.
@@ -2103,12 +2104,12 @@ fn test_git_push_to_remote_named_git(subprocess: bool) {
     if !subprocess {
         test_env.add_config("git.subprocess = false");
     }
-    let git_repo = {
+    let git_repo_path = {
         let mut git_repo_path = workspace_root.clone();
         git_repo_path.extend([".jj", "repo", "store", "git"]);
-        git2::Repository::open(&git_repo_path).unwrap()
+        git_repo_path
     };
-    git_repo.remote_rename("origin", "git").unwrap();
+    git::rename_remote(&git_repo_path, "origin", "git");
 
     let output = test_env.run_jj_in(&workspace_root, ["git", "push", "--all", "--remote=git"]);
     insta::allow_duplicates! {
@@ -2131,12 +2132,12 @@ fn test_git_push_to_remote_with_slashes(subprocess: bool) {
     if !subprocess {
         test_env.add_config("git.subprocess = false");
     }
-    let git_repo = {
+    let git_repo_path = {
         let mut git_repo_path = workspace_root.clone();
         git_repo_path.extend([".jj", "repo", "store", "git"]);
-        git2::Repository::open(&git_repo_path).unwrap()
+        git_repo_path
     };
-    git_repo.remote_rename("origin", "slash/origin").unwrap();
+    git::rename_remote(&git_repo_path, "origin", "slash/origin");
 
     let output = test_env.run_jj_in(
         &workspace_root,

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -15,6 +15,8 @@
 use std::fs;
 use std::path::PathBuf;
 
+use testutils::git;
+
 use crate::common::TestEnvironment;
 
 #[test]
@@ -254,10 +256,8 @@ fn test_git_remote_named_git() {
 
     // Existing remote named 'git' shouldn't block the repo initialization.
     let repo_path = test_env.env_root().join("repo");
-    let git_repo = git2::Repository::init(&repo_path).unwrap();
-    git_repo
-        .remote("git", "http://example.com/repo/repo")
-        .unwrap();
+    git::init(&repo_path);
+    git::add_remote(&repo_path, "git", "http://example.com/repo/repo");
     test_env
         .run_jj_in(&repo_path, ["git", "init", "--git-repo=."])
         .success();
@@ -293,7 +293,7 @@ fn test_git_remote_named_git() {
 
     // Reinitialize the repo with remote named 'git'.
     fs::remove_dir_all(repo_path.join(".jj")).unwrap();
-    git_repo.remote_rename("bar", "git").unwrap();
+    git::rename_remote(&repo_path, "bar", "git");
     test_env
         .run_jj_in(&repo_path, ["git", "init", "--git-repo=."])
         .success();
@@ -320,10 +320,8 @@ fn test_git_remote_with_slashes() {
 
     // Existing remote with slashes shouldn't block the repo initialization.
     let repo_path = test_env.env_root().join("repo");
-    let git_repo = git2::Repository::init(&repo_path).unwrap();
-    git_repo
-        .remote("slash/origin", "http://example.com/repo/repo")
-        .unwrap();
+    git::init(&repo_path);
+    git::add_remote(&repo_path, "slash/origin", "http://example.com/repo/repo");
     test_env
         .run_jj_in(&repo_path, ["git", "init", "--git-repo=."])
         .success();
@@ -380,7 +378,7 @@ fn test_git_remote_with_slashes() {
 
     // Reinitialize the repo with remote with slashes
     fs::remove_dir_all(repo_path.join(".jj")).unwrap();
-    git_repo.remote_rename("origin", "slash/origin").unwrap();
+    git::rename_remote(&repo_path, "origin", "slash/origin");
     test_env
         .run_jj_in(&repo_path, ["git", "init", "--git-repo=."])
         .success();

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -255,7 +255,7 @@ fn test_git_push_undo_colocated() {
     let git_repo_path = test_env.env_root().join("git-repo");
     git::init_bare(git_repo_path.clone());
     let repo_path = test_env.env_root().join("clone");
-    git::clone(&repo_path, git_repo_path.to_str().unwrap());
+    git::clone(&repo_path, git_repo_path.to_str().unwrap(), None);
 
     test_env
         .run_jj_in(&repo_path, ["git", "init", "--git-repo=."])

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1390,7 +1390,8 @@ impl GitRepoData {
         let origin_repo_dir = temp_dir.path().join("source");
         let origin_repo = testutils::git::init_bare(&origin_repo_dir);
         let git_repo_dir = temp_dir.path().join("git");
-        let git_repo = testutils::git::clone(&git_repo_dir, origin_repo_dir.to_str().unwrap());
+        let git_repo =
+            testutils::git::clone(&git_repo_dir, origin_repo_dir.to_str().unwrap(), None);
         let jj_repo_dir = temp_dir.path().join("jj");
         std::fs::create_dir(&jj_repo_dir).unwrap();
         let repo = ReadonlyRepo::init(
@@ -3123,7 +3124,8 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
         "refs/heads/main",
         &[parent_of_initial_git_commit],
     );
-    let clone_repo = testutils::git::clone(&clone_repo_dir, source_repo_dir.to_str().unwrap());
+    let clone_repo =
+        testutils::git::clone(&clone_repo_dir, source_repo_dir.to_str().unwrap(), None);
     std::fs::create_dir(&jj_repo_dir).unwrap();
     let jj_repo = ReadonlyRepo::init(
         settings,

--- a/lib/testutils/src/git.rs
+++ b/lib/testutils/src/git.rs
@@ -69,7 +69,7 @@ pub fn clone(dest_path: &Path, repo_url: &str) -> gix::Repository {
         .unwrap();
     assert!(
         output.status.success(),
-        "git cloning failed with exit code {}:\n{}\n----- stderr -----\n{}",
+        "git cloning failed with {}:\n{}\n----- stderr -----\n{}",
         output.status,
         bstr::BString::from(output.stdout),
         bstr::BString::from(output.stderr),
@@ -349,4 +349,34 @@ impl<'a> IndexManager<'a> {
             .write(gix::index::write::Options::default())
             .unwrap();
     }
+}
+
+pub fn add_remote(repo_dir: impl AsRef<Path>, remote_name: &str, url: &str) {
+    let output = std::process::Command::new("git")
+        .current_dir(repo_dir)
+        .args(["remote", "add", remote_name, url])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git remote add {remote_name} {url} failed with {}:\n{}\n----- stderr -----\n{}",
+        output.status,
+        bstr::BString::from(output.stdout),
+        bstr::BString::from(output.stderr),
+    );
+}
+
+pub fn rename_remote(repo_dir: impl AsRef<Path>, original: &str, new: &str) {
+    let output = std::process::Command::new("git")
+        .current_dir(repo_dir)
+        .args(["remote", "rename", original, new])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git remote rename failed with {}:\n{}\n----- stderr -----\n{}",
+        output.status,
+        bstr::BString::from(output.stdout),
+        bstr::BString::from(output.stderr),
+    );
 }

--- a/lib/testutils/src/git.rs
+++ b/lib/testutils/src/git.rs
@@ -381,3 +381,18 @@ pub fn rename_remote(repo_dir: impl AsRef<Path>, original: &str, new: &str) {
         bstr::BString::from(output.stderr),
     );
 }
+
+pub fn fetch(repo_dir: impl AsRef<Path>, remote: &str) {
+    let output = std::process::Command::new("git")
+        .current_dir(repo_dir)
+        .args(["fetch", remote])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git fetch {remote} failed with {}:\n{}\n----- stderr -----\n{}",
+        output.status,
+        bstr::BString::from(output.stdout),
+        bstr::BString::from(output.stderr),
+    );
+}

--- a/lib/testutils/src/git.rs
+++ b/lib/testutils/src/git.rs
@@ -56,14 +56,15 @@ pub fn init_bare(directory: impl AsRef<Path>) -> gix::Repository {
     .to_thread_local()
 }
 
-pub fn clone(dest_path: &Path, repo_url: &str) -> gix::Repository {
+pub fn clone(dest_path: &Path, repo_url: &str, remote_name: Option<&str>) -> gix::Repository {
+    let remote_name = remote_name.unwrap_or("origin");
     // gitoxide doesn't write the remote HEAD as a symbolic link, which prevents
     // `jj` from getting it.
     //
     // This, plus the fact that the code to clone a repo in gitoxide is non-trivial,
     // makes it appealing to just spawn a git subprocess
     let output = std::process::Command::new("git")
-        .args(["clone", repo_url])
+        .args(["clone", repo_url, "--origin", remote_name])
         .arg(dest_path)
         .output()
         .unwrap();


### PR DESCRIPTION
As per #5548, this concludes the port of the current tests to gitoxide.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
