### PR TITLE
cli_util: extract shared `compute_commit_location` function

### DIFF
--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -13,21 +13,18 @@
 // limitations under the License.
 
 use std::io::Write;
-use std::rc::Rc;
 
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::CommitIteratorExt;
-use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
-use jj_lib::revset::ResolvedRevsetExpression;
-use jj_lib::revset::RevsetExpression;
 use jj_lib::rewrite::duplicate_commits;
 use jj_lib::rewrite::duplicate_commits_onto_parents;
 use jj_lib::rewrite::DuplicateCommitsStats;
 use tracing::instrument;
 
+use crate::cli_util::compute_commit_location;
 use crate::cli_util::short_commit_hash;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
@@ -72,7 +69,7 @@ pub(crate) struct DuplicateArgs {
         value_name = "REVSETS",
         add = ArgValueCandidates::new(complete::all_revisions)
     )]
-    destination: Vec<RevisionArg>,
+    destination: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert after (can be repeated to create a merge
     /// commit)
     #[arg(
@@ -83,7 +80,7 @@ pub(crate) struct DuplicateArgs {
         value_name = "REVSETS",
         add = ArgValueCandidates::new(complete::all_revisions),
     )]
-    insert_after: Vec<RevisionArg>,
+    insert_after: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert before (can be repeated to create a merge
     /// commit)
     #[arg(
@@ -94,7 +91,7 @@ pub(crate) struct DuplicateArgs {
         value_name = "REVSETS",
         add = ArgValueCandidates::new(complete::mutable_revisions)
     )]
-    insert_before: Vec<RevisionArg>,
+    insert_before: Option<Vec<RevisionArg>>,
 }
 
 #[instrument(skip_all)]
@@ -121,127 +118,70 @@ pub(crate) fn cmd_duplicate(
         return Err(user_error("Cannot duplicate the root commit"));
     }
 
-    let parent_commit_ids: Vec<CommitId>;
-    let children_commit_ids: Vec<CommitId>;
-
-    if !args.insert_before.is_empty() && !args.insert_after.is_empty() {
-        let parent_commits = workspace_command
-            .resolve_some_revsets_default_single(ui, &args.insert_after)?
-            .into_iter()
-            .collect_vec();
-        parent_commit_ids = parent_commits.iter().ids().cloned().collect();
-        let children_commits = workspace_command
-            .resolve_some_revsets_default_single(ui, &args.insert_before)?
-            .into_iter()
-            .collect_vec();
-        children_commit_ids = children_commits.iter().ids().cloned().collect();
-        workspace_command.check_rewritable(&children_commit_ids)?;
-        let children_expression = RevsetExpression::commits(children_commit_ids.clone());
-        let parents_expression = RevsetExpression::commits(parent_commit_ids.clone());
-        ensure_no_commit_loop(
-            workspace_command.repo(),
-            &children_expression,
-            &parents_expression,
-        )?;
-    } else if !args.insert_before.is_empty() {
-        let children_commits = workspace_command
-            .resolve_some_revsets_default_single(ui, &args.insert_before)?
-            .into_iter()
-            .collect_vec();
-        children_commit_ids = children_commits.iter().ids().cloned().collect();
-        workspace_command.check_rewritable(&children_commit_ids)?;
-        let children_expression = RevsetExpression::commits(children_commit_ids.clone());
-        let parents_expression = children_expression.parents();
-        ensure_no_commit_loop(
-            workspace_command.repo(),
-            &children_expression,
-            &parents_expression,
-        )?;
-        // Manually collect the parent commit IDs to preserve the order of parents.
-        parent_commit_ids = children_commits
-            .iter()
-            .flat_map(|commit| commit.parent_ids())
-            .unique()
-            .cloned()
-            .collect_vec();
-    } else if !args.insert_after.is_empty() {
-        let parent_commits = workspace_command
-            .resolve_some_revsets_default_single(ui, &args.insert_after)?
-            .into_iter()
-            .collect_vec();
-        parent_commit_ids = parent_commits.iter().ids().cloned().collect();
-        let parents_expression = RevsetExpression::commits(parent_commit_ids.clone());
-        let children_expression = parents_expression.children();
-        children_commit_ids = children_expression
-            .clone()
-            .evaluate(workspace_command.repo().as_ref())
-            .map_err(|err| err.expect_backend_error())?
-            .iter()
-            .try_collect()?;
-        workspace_command.check_rewritable(&children_commit_ids)?;
-        ensure_no_commit_loop(
-            workspace_command.repo(),
-            &children_expression,
-            &parents_expression,
-        )?;
-    } else if !args.destination.is_empty() {
-        let parent_commits = workspace_command
-            .resolve_some_revsets_default_single(ui, &args.destination)?
-            .into_iter()
-            .collect_vec();
-        parent_commit_ids = parent_commits.iter().ids().cloned().collect();
-        children_commit_ids = vec![];
+    let location = if args.destination.is_none()
+        && args.insert_after.is_none()
+        && args.insert_before.is_none()
+    {
+        None
     } else {
-        parent_commit_ids = vec![];
-        children_commit_ids = vec![];
+        let (parent_commits, children_commits) = compute_commit_location(
+            ui,
+            &workspace_command,
+            args.destination.as_deref(),
+            args.insert_after.as_deref(),
+            args.insert_before.as_deref(),
+            "duplicated commits",
+        )?;
+        let parent_commit_ids = parent_commits.iter().ids().cloned().collect_vec();
+        let children_commit_ids = children_commits.iter().ids().cloned().collect_vec();
+
+        Some((parent_commit_ids, children_commit_ids))
     };
 
     let mut tx = workspace_command.start_transaction();
 
-    if !parent_commit_ids.is_empty() {
-        for commit_id in &to_duplicate {
-            for parent_commit_id in &parent_commit_ids {
-                if tx.repo().index().is_ancestor(commit_id, parent_commit_id) {
-                    writeln!(
-                        ui.warning_default(),
-                        "Duplicating commit {} as a descendant of itself",
-                        short_commit_hash(commit_id)
-                    )?;
-                    break;
+    if let Some((parent_commit_ids, children_commit_ids)) = &location {
+        if !parent_commit_ids.is_empty() {
+            for commit_id in &to_duplicate {
+                for parent_commit_id in parent_commit_ids {
+                    if tx.repo().index().is_ancestor(commit_id, parent_commit_id) {
+                        writeln!(
+                            ui.warning_default(),
+                            "Duplicating commit {} as a descendant of itself",
+                            short_commit_hash(commit_id)
+                        )?;
+                        break;
+                    }
                 }
             }
-        }
 
-        for commit_id in &to_duplicate {
-            for child_commit_id in &children_commit_ids {
-                if tx.repo().index().is_ancestor(child_commit_id, commit_id) {
-                    writeln!(
-                        ui.warning_default(),
-                        "Duplicating commit {} as an ancestor of itself",
-                        short_commit_hash(commit_id)
-                    )?;
-                    break;
+            for commit_id in &to_duplicate {
+                for child_commit_id in children_commit_ids {
+                    if tx.repo().index().is_ancestor(child_commit_id, commit_id) {
+                        writeln!(
+                            ui.warning_default(),
+                            "Duplicating commit {} as an ancestor of itself",
+                            short_commit_hash(commit_id)
+                        )?;
+                        break;
+                    }
                 }
             }
         }
     }
-
     let num_to_duplicate = to_duplicate.len();
     let DuplicateCommitsStats {
         duplicated_commits,
         num_rebased,
-    } = if args.destination.is_empty()
-        && args.insert_after.is_empty()
-        && args.insert_before.is_empty()
-    {
-        duplicate_commits_onto_parents(tx.repo_mut(), &to_duplicate)?
-    } else {
+    } = if let Some((parent_commit_ids, children_commit_ids)) = location {
         duplicate_commits(
             tx.repo_mut(),
             &to_duplicate,
             &parent_commit_ids,
             &children_commit_ids,
         )?
+    } else {
+        duplicate_commits_onto_parents(tx.repo_mut(), &to_duplicate)?
     };
 
     if let Some(mut formatter) = ui.status_formatter() {
@@ -258,28 +198,5 @@ pub(crate) fn cmd_duplicate(
         }
     }
     tx.finish(ui, format!("duplicate {num_to_duplicate} commit(s)"))?;
-    Ok(())
-}
-
-/// Ensure that there is no possible cycle between the potential children and
-/// parents of the duplicated commits.
-fn ensure_no_commit_loop(
-    repo: &ReadonlyRepo,
-    children_expression: &Rc<ResolvedRevsetExpression>,
-    parents_expression: &Rc<ResolvedRevsetExpression>,
-) -> Result<(), CommandError> {
-    if let Some(commit_id) = children_expression
-        .dag_range_to(parents_expression)
-        .evaluate(repo)?
-        .iter()
-        .next()
-    {
-        let commit_id = commit_id?;
-        return Err(user_error(format!(
-            "Refusing to create a loop: commit {} would be both an ancestor and a descendant of \
-             the duplicated commits",
-            short_commit_hash(&commit_id),
-        )));
-    }
     Ok(())
 }

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -161,12 +161,12 @@ pub(crate) fn cmd_new(
             .collect_vec();
         parent_commit_ids = parent_commits.iter().ids().cloned().collect();
         let parents_expression = RevsetExpression::commits(parent_commit_ids.clone());
-        // Each child of the targets will be rebased: its set of parents will be updated
-        // so that the targets are replaced by the new commit.
-        // Exclude children that are ancestors of the new commit
-        let children_expression = parents_expression
-            .children()
-            .minus(&parents_expression.ancestors());
+        let children_expression = parents_expression.children();
+        ensure_no_commit_loop(
+            workspace_command.repo(),
+            &children_expression,
+            &parents_expression,
+        )?;
         children_commits = children_expression
             .evaluate(workspace_command.repo().as_ref())?
             .iter()

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -282,9 +282,8 @@ fn test_new_insert_after_children() {
     [EOF]
     ");
 
-    // Check that inserting G after A and C doesn't try to rebase B (which is
-    // initially a child of A) onto G as that would create a cycle since B is
-    // a parent of C which is a parent G.
+    // Attempting to insert G after A and C errors out due to the cycle created
+    // as A is an ancestor of C.
     let output = test_env.run_jj_in(
         &repo_path,
         [
@@ -297,29 +296,12 @@ fn test_new_insert_after_children() {
             "C",
         ],
     );
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Working copy now at: kxryzmor 6d63e17b (empty) G
-    Parent commit      : qpvuntsm 5ef24e4b A | (empty) A
-    Parent commit      : mzvwutvl 83376b27 C | (empty) C
+    Error: Refusing to create a loop: commit 83376b270925 would be both an ancestor and a descendant of the new commit
     [EOF]
-    ");
-    insta::assert_snapshot!(get_short_log_output(&test_env, &repo_path), @r"
-    @    G
-    ├─╮
-    │ ○  C
-    │ ○  B
-    ├─╯
-    ○  A
-    │ ○    F
-    │ ├─╮
-    │ │ ○  E
-    ├───╯
-    │ ○  D
-    ├─╯
-    ◆  root
-    [EOF]
-    ");
+    [exit status: 1]
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This will be used to compute the location to place commits from the
`--destination`, `--insert-after`, and `--insert-before` options. This
is used across the `new`, `duplicate`, and `rebase` commands, and can be
used for further commands as well.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
