### PR TITLE
ci: make sure tests fail in CI if `gpg` or `taplo` binaries are not found

### DIFF
--- a/cli/tests/test_config_schema.rs
+++ b/cli/tests/test_config_schema.rs
@@ -1,6 +1,8 @@
 use std::process::Command;
 use std::process::Stdio;
 
+use testutils::ensure_running_outside_ci;
+
 fn taplo_check_config(file: &str) {
     if Command::new("taplo")
         .arg("--version")
@@ -8,6 +10,7 @@ fn taplo_check_config(file: &str) {
         .status()
         .is_err()
     {
+        ensure_running_outside_ci("`taplo` must be in the PATH");
         eprintln!("Skipping test because taplo is not installed on the system");
         return;
     }

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -12,6 +12,7 @@ use jj_lib::gpg_signing::GpgBackend;
 use jj_lib::signing::SigStatus;
 use jj_lib::signing::SignError;
 use jj_lib::signing::SigningBackend as _;
+use testutils::ensure_running_outside_ci;
 
 static PRIVATE_KEY: &str = r#"-----BEGIN PGP PRIVATE KEY BLOCK-----
 
@@ -81,6 +82,7 @@ impl GpgEnvironment {
 macro_rules! gpg_guard {
     () => {
         if Command::new("gpg").arg("--version").status().is_err() {
+            ensure_running_outside_ci("`gpg` must be in the PATH");
             eprintln!("Skipping test because gpg is not installed on the system");
             return;
         }

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -135,6 +135,16 @@ pub fn user_settings() -> UserSettings {
     UserSettings::from_config(base_user_config()).unwrap()
 }
 
+/// Panic if `CI` environment variable is set to a non-empty value
+///
+/// Most CI environments set this variable automatically. See e.g.
+/// <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables>
+#[track_caller]
+pub fn ensure_running_outside_ci(reason: &str) {
+    let running_in_ci = std::env::var("CI").is_ok_and(|value| !value.is_empty());
+    assert!(!running_in_ci, "Running in CI, {reason}.");
+}
+
 #[derive(Debug)]
 pub struct TestEnvironment {
     temp_dir: TempDir,


### PR DESCRIPTION
Fixes #5696

Example failure: https://github.com/jj-vcs/jj/actions/runs/13611152082/job/38048476201?pr=5854#step:7:1543

(This can wait; since the CI passes on the PR, we know the problem this PR aims to detect is not occurring, at least at the commit the PR is synced to).