### PR TITLE
cli split: Refactor and move tree selection to a function

### DIFF
--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -22,7 +22,7 @@ use jj_lib::matchers::Matcher;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::Repo;
 use jj_lib::rewrite;
-use jj_lib::rewrite::CommitToSquash;
+use jj_lib::rewrite::CommitWithSelection;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -252,7 +252,7 @@ fn select_diff(
     destination: &Commit,
     matcher: &dyn Matcher,
     diff_selector: &DiffSelector,
-) -> Result<Vec<CommitToSquash>, CommandError> {
+) -> Result<Vec<CommitWithSelection>, CommandError> {
     let mut source_commits = vec![];
     for source in sources {
         let parent_tree = source.parent_tree(tx.repo())?;
@@ -277,7 +277,7 @@ fn select_diff(
         let selected_tree_id =
             diff_selector.select(&parent_tree, &source_tree, matcher, format_instructions)?;
         let selected_tree = tx.repo().store().get_root_tree(&selected_tree_id)?;
-        source_commits.push(CommitToSquash {
+        source_commits.push(CommitWithSelection {
             commit: source.clone(),
             selected_tree,
             parent_tree,

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -1037,7 +1037,7 @@ pub struct CommitWithSelection {
 
 impl CommitWithSelection {
     /// Returns true if the selection contains all changes in the commit.
-    fn is_full_selection(&self) -> bool {
+    pub fn is_full_selection(&self) -> bool {
         &self.selected_tree.id() == self.commit.tree_id()
     }
 
@@ -1046,7 +1046,7 @@ impl CommitWithSelection {
     ///
     /// Both `is_full_selection()` and `is_empty_selection()`
     /// can be true if the commit is itself empty.
-    fn is_empty_selection(&self) -> bool {
+    pub fn is_empty_selection(&self) -> bool {
         self.selected_tree.id() == self.parent_tree.id()
     }
 }

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -1029,13 +1029,13 @@ fn compute_commits_heads(
         .collect_vec()
 }
 
-pub struct CommitToSquash {
+pub struct CommitWithSelection {
     pub commit: Commit,
     pub selected_tree: MergedTree,
     pub parent_tree: MergedTree,
 }
 
-impl CommitToSquash {
+impl CommitWithSelection {
     /// Returns true if the selection contains all changes in the commit.
     fn is_full_selection(&self) -> bool {
         &self.selected_tree.id() == self.commit.tree_id()
@@ -1065,12 +1065,12 @@ pub struct SquashedCommit<'repo> {
 /// finishing the commit.
 pub fn squash_commits<'repo>(
     repo: &'repo mut MutableRepo,
-    sources: &[CommitToSquash],
+    sources: &[CommitWithSelection],
     destination: &Commit,
     keep_emptied: bool,
 ) -> BackendResult<Option<SquashedCommit<'repo>>> {
     struct SourceCommit<'a> {
-        commit: &'a CommitToSquash,
+        commit: &'a CommitWithSelection,
         abandon: bool,
     }
     let mut source_commits = vec![];


### PR DESCRIPTION
This change moves the code for prompting the user to select changes for the first commit to a helper function. There are no functional changes.

Resulting from the discussion in https://github.com/jj-vcs/jj/pull/5828 we are planning to add several new flags (-B, -A, and -d) to jj split.

Since this may change how the user selects changes (i.e. they may select changes to remove from the target commit, rather than what stays in the target commit), I want to move the selection logic to a function to make the main split function more readable.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
