### PR TITLE
templates: expose `format_short_signature_oneline` template alias hook

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -91,7 +91,7 @@ if(root,
     concat(
       separate(" ",
         format_short_change_id_with_hidden_and_divergent_info(self),
-        if(author.email(), author.email().local(), email_placeholder),
+        format_short_signature_oneline(author),
         format_timestamp(commit_timestamp(self)),
         bookmarks,
         tags,
@@ -199,6 +199,9 @@ commit_summary_separator = 'label("separator", " | ")'
 'format_short_operation_id(id)' = 'id.short()'
 'format_short_signature(signature)' = '''
   coalesce(signature.email(), email_placeholder)'''
+'format_short_signature_oneline(signature)' = '''
+  coalesce(signature.email().local(), email_placeholder)'''
+
 'format_detailed_signature(signature)' = '''
   coalesce(signature.name(), name_placeholder)
   ++ " <" ++ coalesce(signature.email(), email_placeholder) ++ ">"


### PR DESCRIPTION
For `builtin_log_compact` you can specify how you want signatures to be displayed via `format_short_signature`, but the same wasn't possible for `builtin_log_compact_oneline` which always chose `email().local()`.

Is this worth a changelog entry? 

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
