### PR TITLE
cli `git remote`: add aliases to (a)dd, (l)ist, and (r)e(m)ove

### DIFF
--- a/cli/src/commands/git/remote/mod.rs
+++ b/cli/src/commands/git/remote/mod.rs
@@ -39,8 +39,11 @@ use crate::ui::Ui;
 /// The Git repo will be a bare git repo stored inside the `.jj/` directory.
 #[derive(Subcommand, Clone, Debug)]
 pub enum RemoteCommand {
+    #[command(visible_alias("a"))]
     Add(GitRemoteAddArgs),
+    #[command(visible_alias("l"))]
     List(GitRemoteListArgs),
+    #[command(visible_alias("rm"))]
     Remove(GitRemoteRemoveArgs),
     Rename(GitRemoteRenameArgs),
     SetUrl(GitRemoteSetUrlArgs),


### PR DESCRIPTION
Not sure if there is a decision on when to add alias to a command, but I found myself going for `jj git remote l` and surprised that it didn't exist.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
