### PR TITLE
debug init-local: fixups, docs,remove the `ui.allow-init-native` option

### DIFF
--- a/cli/src/commands/debug/init_local.rs
+++ b/cli/src/commands/debug/init_local.rs
@@ -25,10 +25,15 @@ use crate::command_error::user_error_with_message;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Create a new repo in the given directory
+/// Create a new repo in the given directory using the proof-of-concept native
+/// backend
 ///
-/// If the given directory does not exist, it will be created. If no directory
-/// is given, the current directory is used.
+/// The proof-of-concept backend is called "local" because it does not support
+/// cloning, pushing, or fetching repositories or commits.
+///
+/// This command is otherwise analogous to `jj git init`. If the given directory
+/// does not exist, it will be created. If no directory is given, the current
+/// directory is used.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct DebugInitLocalArgs {
     /// The destination directory

--- a/cli/src/commands/debug/init_local.rs
+++ b/cli/src/commands/debug/init_local.rs
@@ -20,7 +20,6 @@ use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::cli_error;
-use crate::command_error::user_error_with_hint;
 use crate::command_error::user_error_with_message;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
@@ -59,13 +58,6 @@ pub(crate) fn cmd_debug_init_local(
         .and_then(|_| dunce::canonicalize(wc_path))
         .map_err(|e| user_error_with_message("Failed to create workspace", e))?;
 
-    if !command.settings().get_bool("ui.allow-init-native")? {
-        return Err(user_error_with_hint(
-            "The native backend is disallowed by default.",
-            "Did you mean to call `jj git init`?
-Set `ui.allow-init-native` to allow initializing a repo with the native backend.",
-        ));
-    }
     Workspace::init_local(&command.settings_for_new_workspace(&wc_path)?, &wc_path)?;
 
     let relative_wc_path = file_util::relative_path(cwd, &wc_path);

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -63,11 +63,6 @@
                 }
             },
             "properties": {
-                "allow-init-native": {
-                    "type": "boolean",
-                    "description": "Whether to allow initializing a repo with the native backend",
-                    "default": false
-                },
                 "always-allow-large-revsets": {
                     "type": "boolean",
                     "description": "Whether to allow large revsets to be used in all commands without the `all:` modifier",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -20,7 +20,6 @@ push-new-bookmarks = false
 sign-on-push = false
 
 [ui]
-allow-init-native = false
 always-allow-large-revsets = false
 color = "auto"
 default-description = ""

--- a/cli/tests/test_debug_init_local_command.rs
+++ b/cli/tests/test_debug_init_local_command.rs
@@ -15,25 +15,8 @@
 use crate::common::TestEnvironment;
 
 #[test]
-fn test_init_local_disallowed() {
-    // TODO(ilyagr): it is unclear whether `ui.allow-init-native` is useful now
-    // that `jj init` was renamed to `jj debug init-local`.
-    let test_env = TestEnvironment::default();
-    let output = test_env.run_jj_in(".", ["debug", "init-local", "repo"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Error: The native backend is disallowed by default.
-    Hint: Did you mean to call `jj git init`?
-    Set `ui.allow-init-native` to allow initializing a repo with the native backend.
-    [EOF]
-    [exit status: 1]
-    ");
-}
-
-#[test]
 fn test_init_local() {
     let test_env = TestEnvironment::default();
-    test_env.add_config(r#"ui.allow-init-native = true"#);
     let output = test_env.run_jj_in(".", ["debug", "init-local", "repo"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------

--- a/demos/demo_juggle_conflicts.sh
+++ b/demos/demo_juggle_conflicts.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 new_tmp_dir
 (
-    jj init --config ui.allow-init-native=true
+    jj debug init-local
     echo "first" > file
     jj bookmark create first
     jj commit -m 'first'


### PR DESCRIPTION
Not sure whether I should merge this before or after the release, feel free to tell me.

---------------

It is not needed to gate `jj debug init-local` on an option now that the command is no longer called `jj init`.

This also includes a separate fixup to #5845 in demos/


# Checklist

If applicable:
- [ ] ~~I have updated `CHANGELOG.md`~~ (I think it's too minor)
- [ ] ~~I have updated the documentation (README.md, docs/, demos/)~~
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
