### PR TITLE
settings: load signing parameters early, propagate config error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `signing.behavior`. The new option accepts `drop` (never sign), `keep` (preserve
   existing signatures), `own` (sign own commits), or `force` (sign all commits).
   Existing `signing.sign-all = true` translates to `signing.behavior = "own"`, and
-  `false` translates to `"keep"`.
+  `false` translates to `"keep"`. Invalid configuration is now an error.
 
 ### New features
 

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -21,6 +21,8 @@ username = ""
 
 [signing]
 backend = "none"
+behavior = "keep"
+# key = <none>
 
 [signing.backends.gpg]
 allow-expired-keys = false


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
