### PR TITLE
config: rename `core.watchman.register_snapshot_trigger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* `core.watchman.register_snapshot_trigger` has been renamed to `core.watchman.register-snapshot-trigger` for consistency with other configuration options.
+
 ### New features
 
 ### Fixed bugs

--- a/cli/src/commands/debug/watchman.rs
+++ b/cli/src/commands/debug/watchman.rs
@@ -62,7 +62,7 @@ pub fn cmd_debug_watchman(
                     writeln!(ui.stdout(), "Watchman is enabled via `core.fsmonitor`.")?;
                     writeln!(
                         ui.stdout(),
-                        r"Background snapshotting is {}. Use `core.watchman.register_snapshot_trigger` to control it.",
+                        r"Background snapshotting is {}. Use `core.watchman.register-snapshot-trigger` to control it.",
                         if config.register_trigger {
                             "enabled"
                         } else {

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -250,7 +250,7 @@
                 "watchman": {
                     "type": "object",
                     "properties": {
-                      "register_snapshot_trigger": {
+                      "register-snapshot-trigger": {
                         "type": "boolean",
                         "default": false,
                         "description": "Whether to use triggers to monitor for changes in the background."

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -620,6 +620,11 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
                 }
             },
         ),
+        // TODO: Delete in jj 0.34+
+        ConfigMigrationRule::rename_value(
+            "core.watchman.register_snapshot_trigger",
+            "core.watchman.register-snapshot-trigger",
+        ),
     ]
 }
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -680,7 +680,7 @@ fn test_config() {
     let output = test_env.run_jj_in(dir, ["--", "jj", "config", "get", "c"]);
     insta::assert_snapshot!(output, @r"
     core.fsmonitor	Whether to use an external filesystem monitor, useful for large repos
-    core.watchman.register_snapshot_trigger	Whether to use triggers to monitor for changes in the background.
+    core.watchman.register-snapshot-trigger	Whether to use triggers to monitor for changes in the background.
     [EOF]
     ");
 
@@ -690,14 +690,14 @@ fn test_config() {
     core
     core.fsmonitor	Whether to use an external filesystem monitor, useful for large repos
     core.watchman
-    core.watchman.register_snapshot_trigger	Whether to use triggers to monitor for changes in the background.
+    core.watchman.register-snapshot-trigger	Whether to use triggers to monitor for changes in the background.
     [EOF]
     ");
 
     let output = test_env.run_jj_in(dir, ["--", "jj", "log", "--config", "c"]);
     insta::assert_snapshot!(output, @r"
     core.fsmonitor=	Whether to use an external filesystem monitor, useful for large repos
-    core.watchman.register_snapshot_trigger=	Whether to use triggers to monitor for changes in the background.
+    core.watchman.register-snapshot-trigger=	Whether to use triggers to monitor for changes in the background.
     [EOF]
     ");
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1388,7 +1388,7 @@ executable on your system](https://facebook.github.io/watchman/docs/install).
 
 You can configure `jj` to use watchman triggers to automatically create
 snapshots on filesystem changes by setting
-`core.watchman.register_snapshot_trigger = true`.
+`core.watchman.register-snapshot-trigger = true`.
 
 You can check whether Watchman is enabled and whether it is installed correctly
 using `jj debug watchman status`.

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -2,7 +2,7 @@
 fsmonitor = "none"
 
 [core.watchman]
-register_snapshot_trigger = false
+register-snapshot-trigger = false
 
 [debug]
 # commit-timestamp = <now>

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -60,8 +60,7 @@ impl FsmonitorSettings {
         let name = "core.fsmonitor";
         match settings.get_string(name)?.as_ref() {
             "watchman" => Ok(Self::Watchman(WatchmanConfig {
-                // TODO: rename to "register-snapshot-trigger" for consistency?
-                register_trigger: settings.get_bool("core.watchman.register_snapshot_trigger")?,
+                register_trigger: settings.get_bool("core.watchman.register-snapshot-trigger")?,
             })),
             "test" => Err(ConfigGetError::Type {
                 name: name.to_owned(),


### PR DESCRIPTION
This always bugged me, then I spotted the TODO comment while browsing the codebase.