### PR TITLE
config: remove `git.push-branch-prefix` warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Breaking changes
 
 * The minimum supported Rust version (MSRV) is now 1.84.0.
+* The `git.push-branch-prefix` config has been removed in favor of
+  `git.push-bookmark-prefix`.
 
 ### Deprecations
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -604,8 +604,6 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
     vec![
         // TODO: Delete in jj 0.32+
         ConfigMigrationRule::rename_value("git.auto-local-branch", "git.auto-local-bookmark"),
-        // TODO: Delete in jj 0.28+
-        ConfigMigrationRule::rename_value("git.push-branch-prefix", "git.push-bookmark-prefix"),
         // TODO: Delete in jj 0.33+
         ConfigMigrationRule::rename_update_value(
             "signing.sign-all",

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -1064,27 +1064,6 @@ fn test_git_push_changes(subprocess: bool) {
     [EOF]
     ");
     }
-
-    // Test deprecation warning for `git.push-branch-prefix`
-    let output = test_env.run_jj_in(
-        &workspace_root,
-        [
-            "git",
-            "push",
-            "--config=git.push-branch-prefix=branch-",
-            "--change=@",
-        ],
-    );
-    insta::allow_duplicates! {
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: Deprecated config: git.push-branch-prefix is renamed to git.push-bookmark-prefix
-    Creating bookmark branch-yostqsxwqrlt for revision yostqsxwqrlt
-    Changes to push to origin:
-      Add bookmark branch-yostqsxwqrlt to 38cb417ce3a6
-    [EOF]
-    ");
-    }
 }
 
 #[test_case(false; "use git2 for remote calls")]


### PR DESCRIPTION
Since v0.27 was just released, start work on the v0.28 deprecations.