### PR TITLE
Update MSRV to 1.84 and turn on MSRV-aware Cargo resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
       with:
-        toolchain: 1.76
+        toolchain: 1.84
         target: ${{ matrix.target }}
     - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769
       with:
@@ -98,7 +98,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
       with:
-        toolchain: 1.76
+        toolchain: 1.84
     - name: Build
       run: cargo build -p jj-cli --no-default-features --verbose
 
@@ -213,7 +213,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8
         with:
-          toolchain: 1.76
+          toolchain: 1.84
       # NOTE: We need to run `cargo test --doc` separately from normal tests:
       # - `cargo build --all-targets` specifies: "Build all targets"
       # - `cargo test --all-targets` specifies: "Test all targets (does not include doctests)"
@@ -276,9 +276,9 @@ jobs:
         uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231
 
       - name: Run zizmor
-        run: uvx zizmor --format sarif . > results.sarif 
+        run: uvx zizmor --format sarif . > results.sarif
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* The minimum supported Rust version (MSRV) is now 1.84.0.
+
 ### Deprecations
 
 ### New features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 cargo-features = []
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
 [workspace.package]
 version = "0.27.0"
 license = "Apache-2.0"
-rust-version = "1.76" # NOTE: remember to update CI, contributing.md, changelog.md, install-and-setup.md, and flake.nix
+rust-version = "1.84" # NOTE: remember to update CI, contributing.md, changelog.md, and install-and-setup.md
 edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/jj-vcs/jj"

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3169,7 +3169,6 @@ fn ensure_no_commit_loop(
 ///
 /// [`jj help -k tutorial`]:
 ///     https://jj-vcs.github.io/jj/latest/tutorial/
-#[allow(rustdoc::bare_urls)]
 #[derive(clap::Parser, Clone, Debug)]
 #[command(name = "jj")]
 pub struct Args {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -22,7 +22,6 @@ use std::fmt;
 use std::fmt::Debug;
 use std::io;
 use std::io::Write as _;
-use std::iter;
 use std::mem;
 use std::path::Path;
 use std::path::PathBuf;
@@ -3548,7 +3547,7 @@ fn handle_shell_completion(
             // TODO: Maybe we should instead expand args[..index] + [""], adjust
             // the index accordingly, strip the last "", and append remainder?
             let pad_len = usize::saturating_sub(index + 1, orig_args.len());
-            let padded_args = orig_args.chain(iter::repeat(OsString::new()).take(pad_len));
+            let padded_args = orig_args.chain(std::iter::repeat_n(OsString::new(), pad_len));
             expand_args(ui, app, padded_args, config)?
         } else {
             expand_args(ui, app, orig_args, config)?

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -169,7 +169,7 @@ pub fn cmd_bookmark_list(
     let bookmarks_to_list = view.bookmarks().filter(|(name, target)| {
         bookmark_names_to_list
             .as_ref()
-            .map_or(true, |bookmark_names| bookmark_names.contains(name))
+            .is_none_or(|bookmark_names| bookmark_names.contains(name))
             && (!args.conflicted || target.local_target.has_conflict())
     });
     for (name, bookmark_target) in bookmarks_to_list {
@@ -179,7 +179,7 @@ pub fn cmd_bookmark_list(
             .iter()
             .copied()
             .filter(|&(remote_name, _)| {
-                args.remotes.as_ref().map_or(true, |patterns| {
+                args.remotes.as_ref().is_none_or(|patterns| {
                     patterns.iter().any(|pattern| pattern.matches(remote_name))
                 })
             })

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -161,7 +161,7 @@ pub fn cmd_op_diff(
 /// `ReadonlyRepo`s for the operations.
 /// `current_repo` should contain a `Repo` with the indices of both repos merged
 /// into it.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn show_op_diff(
     ui: &Ui,
     formatter: &mut dyn Formatter,

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -120,7 +120,7 @@ pub struct CommitTemplateLanguage<'repo> {
 impl<'repo> CommitTemplateLanguage<'repo> {
     /// Sets up environment where commit template will be transformed to
     /// evaluation tree.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         repo: &'repo dyn Repo,
         path_converter: &'repo RepoPathUiConverter,

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -298,7 +298,7 @@ impl<'a> DiffRenderer<'a> {
     }
 
     /// Generates diff between `from_tree` and `to_tree`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn show_diff(
         &self,
         ui: &Ui, // TODO: remove Ui dependency if possible
@@ -322,7 +322,7 @@ impl<'a> DiffRenderer<'a> {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn show_diff_inner(
         &self,
         ui: &Ui,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -138,7 +138,7 @@ recommended steps.
 One-time setup:
 
     rustup toolchain add nightly  # wanted for 'rustfmt'
-    rustup toolchain add 1.76     # also specified in Cargo.toml
+    rustup toolchain add 1.84     # also specified in Cargo.toml
     cargo install --locked bacon
     cargo install --locked cargo-insta
     cargo install --locked cargo-nextest
@@ -176,7 +176,7 @@ These are listed roughly in order of decreasing importance.
 3. Your code will be rejected if it cannot be compiled with the minimal
    supported version of Rust ("MSRV"). Currently, `jj` follows a rather
    casual MSRV policy: "The current `rustc` stable version, minus one."
-   As of this writing, that version is **1.76.0**.
+   As of this writing, that version is **1.84.0**.
 
 4. Your code needs to pass `cargo clippy`. You can also
    use `cargo +nightly clippy` if you wish to see more warnings.

--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -30,7 +30,7 @@ be compiled from the same source code.
 
 #### From Source
 
-First make sure that you have a Rust version >= 1.76 and that the `libssl-dev`,
+First make sure that you have a Rust version >= 1.84 and that the `libssl-dev`,
 `openssl`, `pkg-config`, and `build-essential` packages are installed by running
 something like this:
 
@@ -109,7 +109,7 @@ emerge -av dev-vcs/jj
 
 #### From Source, Vendored OpenSSL
 
-First make sure that you have a Rust version >= 1.76. You may also need to run:
+First make sure that you have a Rust version >= 1.84. You may also need to run:
 
 ```shell
 xcode-select --install
@@ -132,7 +132,7 @@ cargo install --features vendored-openssl --locked --bin jj jj-cli
 
 #### From Source, Homebrew OpenSSL
 
-First make sure that you have a Rust version >= 1.76. You will also need
+First make sure that you have a Rust version >= 1.84. You will also need
 [Homebrew] installed. You may then need to run some or all of
 these:
 
@@ -179,7 +179,7 @@ sudo port install jujutsu
 
 ### Windows
 
-First make sure that you have a Rust version >= 1.76. Now run either:
+First make sure that you have a Rust version >= 1.84. Now run either:
 
 ```shell
 # To install the *prerelease* version from the main branch

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -160,7 +160,7 @@ impl Commit {
     ///  A commit is hidden if its commit id is not in the change id index.
     pub fn is_hidden(&self, repo: &dyn Repo) -> bool {
         let maybe_entries = repo.resolve_change_id(self.change_id());
-        maybe_entries.map_or(true, |entries| !entries.contains(&self.id))
+        maybe_entries.is_none_or(|entries| !entries.contains(&self.id))
     }
 
     /// A commit is discardable if it has no change from its parent, and an

--- a/lib/src/config_resolver.rs
+++ b/lib/src/config_resolver.rs
@@ -251,12 +251,12 @@ enum MigrationRule {
     RenameUpdateValue {
         old_name: ConfigNamePathBuf,
         new_name: ConfigNamePathBuf,
-        #[allow(clippy::type_complexity)] // type alias wouldn't help readability
+        #[expect(clippy::type_complexity)] // type alias wouldn't help readability
         new_value_fn: Box<dyn Fn(&ConfigValue) -> Result<ConfigValue, DynError>>,
     },
     Custom {
         matches_fn: Box<dyn Fn(&ConfigLayer) -> bool>,
-        #[allow(clippy::type_complexity)] // type alias wouldn't help readability
+        #[expect(clippy::type_complexity)] // type alias wouldn't help readability
         apply_fn: Box<dyn Fn(&mut ConfigLayer) -> Result<String, ConfigMigrateLayerError>>,
     },
 }

--- a/lib/src/dag_walk.rs
+++ b/lib/src/dag_walk.rs
@@ -298,7 +298,7 @@ impl<T: Ord, ID: Hash + Eq + Clone, E> TopoOrderReverseLazyInner<T, ID, E> {
 /// ```
 ///
 /// We assume the graph is (mostly) topologically ordered by `T: Ord`.
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn look_ahead_sub_graph<T, ID, E, NI>(
     start: Vec<T>,
     id_fn: impl Fn(&T) -> ID,

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -175,7 +175,7 @@ mod tests {
         let id_1 = CommitId::from_hex("111111");
         let change_id1 = new_change_id();
         let id_2 = CommitId::from_hex("222222");
-        #[allow(clippy::redundant_clone)] // Work around nightly clippy false positive
+        #[expect(clippy::redundant_clone)] // Work around nightly clippy false positive
         // TODO: Remove the exception after https://github.com/rust-lang/rust-clippy/issues/10577
         // is fixed or file a new bug.
         let change_id2 = change_id1.clone();
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::redundant_clone)] // allow id_n.clone()
+    #[expect(clippy::redundant_clone)] // allow id_n.clone()
     fn neighbor_commit_ids() {
         let temp_dir = new_temp_dir();
         let mut new_change_id = change_id_generator();

--- a/lib/src/default_index/rev_walk.rs
+++ b/lib/src/default_index/rev_walk.rs
@@ -1100,7 +1100,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::redundant_clone)] // allow id_n.clone()
+    #[expect(clippy::redundant_clone)] // allow id_n.clone()
     fn test_walk_ancestors_filtered_by_generation_range_merging() {
         let mut new_change_id = change_id_generator();
         let mut index = DefaultMutableIndex::full(3, 16);

--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -141,7 +141,7 @@ impl<'a> RevsetGraphWalk<'a> {
         index_entry: &IndexEntry,
     ) -> Result<&[IndexGraphEdge], RevsetEvaluationError> {
         let position = index_entry.position();
-        // `if let Some(edges) = ...` doesn't pass lifetime check as of Rust 1.76.0
+        // `if let Some(edges) = ...` doesn't pass lifetime check as of Rust 1.84.0
         if self.edges.contains_key(&position) {
             return Ok(self.edges.get(&position).unwrap());
         }

--- a/lib/src/default_submodule_store.rs
+++ b/lib/src/default_submodule_store.rs
@@ -21,7 +21,7 @@ use crate::submodule_store::SubmoduleStore;
 
 #[derive(Debug)]
 pub struct DefaultSubmoduleStore {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     path: PathBuf,
 }
 

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -625,7 +625,7 @@ impl<'input> Diff<'input> {
         // ignore-whitespace. They are tokenized as [] and [" "] respectively.
         if base_input.is_empty() || other_inputs.iter().any(|input| input.is_empty()) {
             base_token_ranges = vec![];
-            other_token_ranges = iter::repeat(vec![]).take(other_inputs.len()).collect();
+            other_token_ranges = std::iter::repeat_n(vec![], other_inputs.len()).collect();
         } else {
             base_token_ranges = tokenizer(base_input);
             other_token_ranges = other_inputs

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -14,7 +14,6 @@
 
 //! Domain-specific language helpers.
 
-use std::array;
 use std::ascii;
 use std::collections::HashMap;
 use std::fmt;
@@ -149,7 +148,7 @@ impl<'i, T> FunctionCallNode<'i, T> {
     }
 
     /// Extracts N required arguments and remainders.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn expect_some_arguments<const N: usize>(
         &self,
     ) -> Result<(&[ExpressionNode<'i, T>; N], &[ExpressionNode<'i, T>]), InvalidArguments<'i>> {
@@ -163,7 +162,7 @@ impl<'i, T> FunctionCallNode<'i, T> {
     }
 
     /// Extracts N required arguments and M optional arguments.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn expect_arguments<const N: usize, const M: usize>(
         &self,
     ) -> Result<
@@ -194,7 +193,7 @@ impl<'i, T> FunctionCallNode<'i, T> {
     ///
     /// `names` is a list of parameter names. Unnamed positional arguments
     /// should be padded with `""`.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn expect_named_arguments<const N: usize, const M: usize>(
         &self,
         names: &[&str],
@@ -207,8 +206,7 @@ impl<'i, T> FunctionCallNode<'i, T> {
     > {
         if self.keyword_args.is_empty() {
             let (required, optional) = self.expect_arguments::<N, M>()?;
-            // TODO: use .each_ref() if MSRV is bumped to 1.77.0
-            Ok((array::from_fn(|i| &required[i]), optional))
+            Ok((required.each_ref(), optional))
         } else {
             let (required, optional) = self.expect_named_arguments_vec(names, N, N + M)?;
             Ok((
@@ -218,7 +216,7 @@ impl<'i, T> FunctionCallNode<'i, T> {
         }
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn expect_named_arguments_vec(
         &self,
         names: &[&str],

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -17,7 +17,6 @@
 use std::fs;
 use std::fs::File;
 use std::io;
-use std::iter;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
@@ -95,7 +94,7 @@ pub fn relative_path(from: &Path, to: &Path) -> PathBuf {
             if i == 0 && suffix.as_os_str().is_empty() {
                 return ".".into();
             } else {
-                let mut result = PathBuf::from_iter(iter::repeat("..").take(i));
+                let mut result = PathBuf::from_iter(std::iter::repeat_n("..", i));
                 result.push(suffix);
                 return result;
             }

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -92,7 +92,7 @@ pub struct FilesetParseError {
 }
 
 /// Categories of fileset parsing and name resolution error.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum FilesetParseErrorKind {
     #[error("Syntax error")]

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -147,7 +147,7 @@ pub mod watchman {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[derive(Debug, Error)]
     pub enum Error {
         #[error("Could not connect to Watchman")]

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2213,7 +2213,7 @@ fn allow_push(
     // sufficient) for the destination_location to be either a descendant of
     // actual_remote_location or equal to it. Either way, we would know about that
     // commit locally.
-    if !actual_remote_location.map_or(true, |id| index.has_id(id)) {
+    if !actual_remote_location.is_none_or(|id| index.has_id(id)) {
         return Err(());
     }
     let remote_target = RefTarget::resolved(actual_remote_location.cloned());

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2245,7 +2245,7 @@ fn allow_push(
 
 #[non_exhaustive]
 #[derive(Default)]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct RemoteCallbacks<'a> {
     pub progress: Option<&'a mut dyn FnMut(&Progress)>,
     pub sideband_progress: Option<&'a mut dyn FnMut(&[u8])>,

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1335,7 +1335,7 @@ impl Backend for GitBackend {
                     .map_err(|err| to_invalid_utf8_err(err, head_id))?;
 
                 let target = RepoPathBuf::from_internal_string(dest);
-                if !paths.map_or(true, |paths| paths.contains(&target)) {
+                if !paths.is_none_or(|paths| paths.contains(&target)) {
                     return Ok(None);
                 }
 

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -55,7 +55,7 @@ pub struct AllHeadsForGcUnsupported;
 /// Defines the interface for types that provide persistent storage for an
 /// index.
 pub trait IndexStore: Send + Sync + Debug {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     fn as_any(&self) -> &dyn Any;
 
     /// Returns a name representing the type of index that the `IndexStore` is
@@ -136,7 +136,7 @@ pub trait Index: Send + Sync {
     ) -> Result<Box<dyn Revset + 'index>, RevsetEvaluationError>;
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait ReadonlyIndex: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
@@ -148,7 +148,7 @@ pub trait ReadonlyIndex: Send + Sync {
     fn start_modification(&self) -> Box<dyn MutableIndex>;
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub trait MutableIndex {
     fn as_any(&self) -> &dyn Any;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -84,7 +84,7 @@ pub mod op_heads_store;
 pub mod op_store;
 pub mod op_walk;
 pub mod operation;
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod protos;
 pub mod refs;
 pub mod repo;

--- a/lib/src/local_backend.rs
+++ b/lib/src/local_backend.rs
@@ -352,8 +352,7 @@ impl Backend for LocalBackend {
     }
 }
 
-#[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
-#[allow(clippy::assigning_clones)]
+#[expect(clippy::assigning_clones)]
 pub fn commit_to_proto(commit: &Commit) -> crate::protos::local_store::Commit {
     let mut proto = crate::protos::local_store::Commit::default();
     for parent in &commit.parents {

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -847,8 +847,7 @@ impl TreeState {
         Ok(())
     }
 
-    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
-    #[allow(clippy::assigning_clones)]
+    #[expect(clippy::assigning_clones)]
     fn save(&mut self) -> Result<(), TreeStateError> {
         let mut proto: crate::protos::working_copy::TreeState = Default::default();
         match &self.tree_id {
@@ -2218,7 +2217,7 @@ impl WorkingCopyFactory for LocalWorkingCopyFactory {
 /// `finish()` or `discard()`.
 pub struct LockedLocalWorkingCopy {
     wc: LocalWorkingCopy,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     lock: FileLock,
     old_operation_id: OperationId,
     old_tree_id: MergedTreeId,

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -856,7 +856,7 @@ pub struct TreeDiffStreamImpl<'matcher> {
     /// a corresponding entry in `pending_trees`.
     items: BTreeMap<DiffStreamKey, BackendResult<(MergedTreeValue, MergedTreeValue)>>,
     // TODO: Is it better to combine this and `items` into a single map?
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pending_trees: VecDeque<(
         RepoPathBuf,
         BoxFuture<'matcher, BackendResult<(Merge<Tree>, Merge<Tree>)>>,

--- a/lib/src/op_walk.rs
+++ b/lib/src/op_walk.rs
@@ -303,7 +303,7 @@ pub fn reparent_range(
     assert!(
         ops_to_reparent
             .last()
-            .map_or(true, |op| op.id() != op_store.root_operation_id()),
+            .is_none_or(|op| op.id() != op_store.root_operation_id()),
         "root operation cannot be rewritten"
     );
     let mut rewritten_ids = HashMap::new();

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -175,7 +175,7 @@ impl ReadonlyRepo {
         &|_settings, store_path| Ok(Box::new(DefaultSubmoduleStore::init(store_path)))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn init(
         settings: &UserSettings,
         repo_path: &Path,

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1365,7 +1365,7 @@ fn try_transform_expression<St: ExpressionState, E>(
         .map(Rc::new))
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn transform_rec_pair<St: ExpressionState, E>(
         (expression1, expression2): (&Rc<RevsetExpression<St>>, &Rc<RevsetExpression<St>>),
         pre: &mut impl FnMut(&Rc<RevsetExpression<St>>) -> Result<TransformedExpression<St>, E>,
@@ -1578,7 +1578,7 @@ fn internalize_filter<St: ExpressionState>(
     }
 
     // Extracts 'c & f' from intersect_down()-ed node.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn as_filter_intersection<St: ExpressionState>(
         expression: &RevsetExpression<St>,
     ) -> Option<(&Rc<RevsetExpression<St>>, &Rc<RevsetExpression<St>>)> {
@@ -2814,7 +2814,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::redundant_clone)] // allow symbol.clone()
+    #[expect(clippy::redundant_clone)] // allow symbol.clone()
     fn test_revset_expression_building() {
         let settings = insta_settings();
         let _guard = settings.bind_to_scope();

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2191,7 +2191,7 @@ fn resolve_commit_ref(
                 .view()
                 .remote_bookmarks_matching(bookmark_pattern, remote_pattern)
                 .filter(|(_, remote_ref)| {
-                    remote_ref_state.map_or(true, |state| remote_ref.state == state)
+                    remote_ref_state.is_none_or(|state| remote_ref.state == state)
                 })
                 .filter(|&(symbol, _)| !crate::git::is_special_git_remote(symbol.remote))
                 .flat_map(|(_, remote_ref)| remote_ref.target.added_ids())

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -303,10 +303,10 @@ fn rename_rules_in_pest_error(mut err: pest::error::Error<Rule>) -> pest::error:
     // (positive) suggestion.
     let mut known_syms = HashSet::new();
     positives.retain(|rule| {
-        !rule.is_compat() && rule.to_symbol().map_or(true, |sym| known_syms.insert(sym))
+        !rule.is_compat() && rule.to_symbol().is_none_or(|sym| known_syms.insert(sym))
     });
     let mut known_syms = HashSet::new();
-    negatives.retain(|rule| rule.to_symbol().map_or(true, |sym| known_syms.insert(sym)));
+    negatives.retain(|rule| rule.to_symbol().is_none_or(|sym| known_syms.insert(sym)));
     err.renamed_rules(|rule| {
         rule.to_symbol()
             .map(|sym| format!("`{sym}`"))

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -512,7 +512,7 @@ fn view_from_proto(proto: crate::protos::op_store::View) -> View {
     let mut view = View::empty();
     // For compatibility with old repos before we had support for multiple working
     // copies
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if !proto.wc_commit_id.is_empty() {
         view.wc_commit_ids
             .insert(WorkspaceId::default(), CommitId::new(proto.wc_commit_id));
@@ -544,7 +544,7 @@ fn view_from_proto(proto: crate::protos::op_store::View) -> View {
         view.git_refs.insert(git_ref.name, target);
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if proto.git_head.is_some() {
         view.git_head = ref_target_from_proto(proto.git_head);
     } else if !proto.git_head_legacy.is_empty() {
@@ -644,7 +644,7 @@ fn ref_target_to_proto(value: &RefTarget) -> Option<crate::protos::op_store::Ref
     Some(proto)
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cfg(test)]
 fn ref_target_to_proto_legacy(value: &RefTarget) -> Option<crate::protos::op_store::RefTarget> {
     if let Some(id) = value.as_normal() {
@@ -679,12 +679,11 @@ fn ref_target_from_proto(maybe_proto: Option<crate::protos::op_store::RefTarget>
         return RefTarget::absent();
     };
     match proto.value.unwrap() {
-        #[allow(deprecated)]
         crate::protos::op_store::ref_target::Value::CommitId(id) => {
             // Legacy non-conflicting id
             RefTarget::normal(CommitId::new(id))
         }
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         crate::protos::op_store::ref_target::Value::ConflictLegacy(conflict) => {
             // Legacy conflicting ids
             let removes = conflict.removes.into_iter().map(CommitId::new);

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -235,8 +235,6 @@ impl MutableTable {
         other.segment_add_entries_to(self);
     }
 
-    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
-    #[allow(clippy::assigning_clones)]
     fn merge_in(&mut self, other: &Arc<ReadonlyTable>) {
         let mut maybe_own_ancestor = self.parent_file.clone();
         let mut maybe_other_ancestor = Some(other.clone());
@@ -295,8 +293,7 @@ impl MutableTable {
     /// If the MutableTable has more than half the entries of its parent
     /// ReadonlyTable, return MutableTable with the commits from both. This
     /// is done recursively, so the stack of index files has O(log n) files.
-    #[allow(unknown_lints)] // XXX FIXME (aseipp): nightly bogons; re-test this occasionally
-    #[allow(clippy::assigning_clones)]
+    #[expect(clippy::assigning_clones)]
     fn maybe_squash_with_ancestors(self) -> MutableTable {
         let mut num_new_entries = self.entries.len();
         let mut files_to_squash = vec![];

--- a/lib/src/tree_builder.rs
+++ b/lib/src/tree_builder.rs
@@ -136,7 +136,7 @@ impl TreeBuilder {
             store: &Arc<Store>,
             dir: &RepoPath,
         ) -> BackendResult<&'a Tree> {
-            // `if let Some(tree) = ...` doesn't pass lifetime check as of Rust 1.76.0
+            // `if let Some(tree) = ...` doesn't pass lifetime check as of Rust 1.84.0
             if tree_cache.contains_key(dir) {
                 return Ok(tree_cache.get(dir).unwrap());
             }

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -276,7 +276,7 @@ impl Workspace {
         Self::init_with_backend(user_settings, workspace_root, &backend_initializer, signer)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn init_with_factories(
         user_settings: &UserSettings,
         workspace_root: &Path,

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -246,8 +246,7 @@ fn test_from_legacy_tree() {
 
     // Create the merged tree by starting from an empty merged tree and adding
     // entries from the merged tree we created before
-    let empty_merged_id_builder: MergeBuilder<_> = std::iter::repeat(store.empty_tree_id())
-        .take(5)
+    let empty_merged_id_builder: MergeBuilder<_> = std::iter::repeat_n(store.empty_tree_id(), 5)
         .cloned()
         .collect();
     let empty_merged_id = MergedTreeId::Merge(empty_merged_id_builder.build());

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -3392,9 +3392,8 @@ fn test_evaluate_expression_machine_generated_union() {
 
     // This query shouldn't trigger stack overflow. Here we use "x::y" in case
     // we had optimization path for trivial "commit_id|.." expression.
-    let revset_str = iter::repeat(format!("({}::{})", commit1.id(), commit2.id()))
-        .take(5000)
-        .join("|");
+    let revset_str =
+        std::iter::repeat_n(format!("({}::{})", commit1.id(), commit2.id()), 5000).join("|");
     assert_eq!(
         resolve_commit_ids(mut_repo, &revset_str),
         vec![commit2.id().clone(), commit1.id().clone()]


### PR DESCRIPTION
See also #5885

Other options would be to update to 1.82 (conservatively, following Firefox, no MSRV-aware resolver), 1.85 (aggressive, not quite yet in nixpkgs or stable in Gentoo, though should be relatively soon), or to do nothing.

I'm guessing (but not sure) that at least one of our dependencies will require 1.85 in the near future for the 2024 Rust edition. If we use the MSRV-aware resolver, that will almost certainly not be a problem for us.


------------

For reference, we last updated the MSRV to 1.76 in https://github.com/jj-vcs/jj/commit/5b517b542ec6c88357adf92369dda7668131da72. According to https://releases.rs/docs/1.76.0/, this was when it barely became stable.


-------

Re some Discord discussion:

I feel strongly that we should *not* upgrade to Rust 2024 at the same time as we upgrade the MSRV. I tried the auto-upgrade, and it's a bit messy. So, to me it matters little that 1.84 does not support 2024 Rust. I also think that if we try auto-conversion to Rust 2024 later, it might be smarter and/or more polished, since others will have tried it and would have reported bugs. (Though I'm not opposed to somebody else doing the 2024 conversion whenever).

Upgrading 1.84 -> 1.85 in a month or so should be nearly trivial, I think. Most of the work here was in changing lints from `allow` to `expect`. If I change the MSRV to 1.85, running `cargo clippy --workspace --all-targets --fix` results in no changes.