### PR TITLE
tests: run `insta --force-update-snapshots`

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -702,7 +702,7 @@ mod tests {
         };
         // First output is after the initial delay
         assert_snapshot!(update(crate::progress::INITIAL_DELAY - Duration::from_millis(1), 0.1), @"");
-        assert_snapshot!(update(Duration::from_millis(1), 0.10), @"[?25l\r 10% [█▊                ][K");
+        assert_snapshot!(update(Duration::from_millis(1), 0.10), @"\u{1b}[?25l\r 10% [█▊                ]\u{1b}[K");
         // No updates for the next 30 milliseconds
         assert_snapshot!(update(Duration::from_millis(10), 0.11), @"");
         assert_snapshot!(update(Duration::from_millis(10), 0.12), @"");

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -728,7 +728,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -816,7 +816,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
 
         let no_changes_tree_id = apply_diff_builtin(
             store,
@@ -865,7 +865,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -888,7 +888,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree_id = apply_diff_builtin(
             store,
             &left_tree,
@@ -936,7 +936,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -959,7 +959,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree_id = apply_diff_builtin(
             store,
             &left_tree,
@@ -1008,7 +1008,7 @@ mod tests {
             ConflictMarkerStyle::Diff,
         )
         .unwrap();
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -1031,7 +1031,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree_id = apply_diff_builtin(
             store,
             &left_tree,
@@ -1098,7 +1098,7 @@ mod tests {
             .unwrap();
         let merge_result = files::merge(&content);
         let sections = make_merge_sections(merge_result).unwrap();
-        insta::assert_debug_snapshot!(sections, @r###"
+        insta::assert_debug_snapshot!(sections, @r#"
         [
             Changed {
                 lines: [
@@ -1146,6 +1146,6 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
     }
 }

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -703,11 +703,11 @@ mod tests {
         insta::assert_debug_snapshot!(get(":builtin", "").unwrap(), @"Builtin");
 
         // Just program name
-        insta::assert_debug_snapshot!(get("my diff", "").unwrap_err(), @r###"
+        insta::assert_debug_snapshot!(get("my diff", "").unwrap_err(), @r#"
         MergeArgsNotConfigured {
             tool_name: "my diff",
         }
-        "###);
+        "#);
 
         // Pick from merge-tools
         insta::assert_debug_snapshot!(get(
@@ -763,11 +763,11 @@ mod tests {
         insta::assert_debug_snapshot!(get("").unwrap(), @"Builtin");
 
         // Just program name
-        insta::assert_debug_snapshot!(get(r#"ui.merge-editor = "my-merge""#).unwrap_err(), @r###"
+        insta::assert_debug_snapshot!(get(r#"ui.merge-editor = "my-merge""#).unwrap_err(), @r#"
         MergeArgsNotConfigured {
             tool_name: "my-merge",
         }
-        "###);
+        "#);
 
         // String args
         insta::assert_debug_snapshot!(
@@ -871,11 +871,11 @@ mod tests {
 
         // List args should never be a merge-tools key
         insta::assert_debug_snapshot!(
-            get(r#"ui.merge-editor = ["meld"]"#).unwrap_err(), @r###"
+            get(r#"ui.merge-editor = ["meld"]"#).unwrap_err(), @r#"
         MergeArgsNotConfigured {
             tool_name: "meld",
         }
-        "###);
+        "#);
 
         // Invalid type
         assert!(get(r#"ui.merge-editor.k = 0"#).is_err());

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -2106,14 +2106,14 @@ mod tests {
         env.add_keyword("description", || L::wrap_string(Literal("".to_owned())));
         env.add_keyword("empty", || L::wrap_boolean(Literal(true)));
 
-        insta::assert_snapshot!(env.parse_err(r#"description ()"#), @r#"
+        insta::assert_snapshot!(env.parse_err(r#"description ()"#), @r"
          --> 1:13
           |
         1 | description ()
           |             ^---
           |
           = expected <EOI>, `++`, `||`, `&&`, `==`, `!=`, `>=`, `>`, `<=`, or `<`
-        "#);
+        ");
 
         insta::assert_snapshot!(env.parse_err(r#"foo"#), @r"
          --> 1:1
@@ -2132,14 +2132,14 @@ mod tests {
           |
           = Function `foo` doesn't exist
         ");
-        insta::assert_snapshot!(env.parse_err(r#"false()"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"false()"#), @r"
          --> 1:1
           |
         1 | false()
           | ^---^
           |
           = Expected identifier
-        "###);
+        ");
 
         insta::assert_snapshot!(env.parse_err(r#"!foo"#), @r"
          --> 1:2
@@ -2231,14 +2231,14 @@ mod tests {
           = Method `foo` doesn't exist for type `String`
         ");
 
-        insta::assert_snapshot!(env.parse_err(r#"10000000000000000000"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"10000000000000000000"#), @r"
          --> 1:1
           |
         1 | 10000000000000000000
           | ^------------------^
           |
           = Invalid integer literal
-        "###);
+        ");
         insta::assert_snapshot!(env.parse_err(r#"42.foo()"#), @r"
          --> 1:4
           |
@@ -2335,14 +2335,14 @@ mod tests {
           = Expected expression of type `Boolean`, but actual type is `Template`
         "#);
 
-        insta::assert_snapshot!(env.parse_err(r#"|x| description"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"|x| description"#), @r"
          --> 1:1
           |
         1 | |x| description
           | ^-------------^
           |
           = Lambda cannot be defined here
-        "###);
+        ");
     }
 
     #[test]
@@ -2552,31 +2552,31 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#""a\nb\nc".lines().map(identity)"#), @"a b c");
 
         // Not a lambda expression
-        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(empty)"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(empty)"#), @r#"
          --> 1:17
           |
         1 | "a".lines().map(empty)
           |                 ^---^
           |
           = Expected lambda expression
-        "###);
+        "#);
         // Bad lambda parameter count
-        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|| "")"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|| "")"#), @r#"
          --> 1:18
           |
         1 | "a".lines().map(|| "")
           |                  ^
           |
           = Expected 1 lambda parameters
-        "###);
-        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|a, b| "")"#), @r###"
+        "#);
+        insta::assert_snapshot!(env.parse_err(r#""a".lines().map(|a, b| "")"#), @r#"
          --> 1:18
           |
         1 | "a".lines().map(|a, b| "")
           |                  ^--^
           |
           = Expected 1 lambda parameters
-        "###);
+        "#);
         // Bad lambda output
         insta::assert_snapshot!(env.parse_err(r#""a".lines().filter(|s| s ++ "\n")"#), @r#"
          --> 1:24
@@ -2675,10 +2675,10 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#"" \n \r foo  bar \t \r ".trim()"#), @"foo  bar");
 
         insta::assert_snapshot!(env.render_ok(r#"" \n \r    \t \r ".trim_start()"#), @"");
-        insta::assert_snapshot!(env.render_ok(r#"" \n \r foo  bar \t \r ".trim_start()"#), @"foo  bar \t \r ");
+        insta::assert_snapshot!(env.render_ok(r#"" \n \r foo  bar \t \r ".trim_start()"#), @"foo  bar");
 
         insta::assert_snapshot!(env.render_ok(r#"" \n \r    \t \r ".trim_end()"#), @"");
-        insta::assert_snapshot!(env.render_ok(r#"" \n \r foo  bar \t \r ".trim_end()"#), @" \n \r foo  bar");
+        insta::assert_snapshot!(env.render_ok(r#"" \n \r foo  bar \t \r ".trim_end()"#), @" foo  bar");
 
         insta::assert_snapshot!(env.render_ok(r#""foo".substr(0, 0)"#), @"");
         insta::assert_snapshot!(env.render_ok(r#""foo".substr(0, 1)"#), @"f");
@@ -2866,34 +2866,34 @@ mod tests {
             @"19700101 00:00:00");
 
         // Invalid format string
-        insta::assert_snapshot!(env.parse_err(r#"t0.format("%_")"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"t0.format("%_")"#), @r#"
          --> 1:11
           |
         1 | t0.format("%_")
           |           ^--^
           |
           = Invalid time format
-        "###);
+        "#);
 
         // Invalid type
-        insta::assert_snapshot!(env.parse_err(r#"t0.format(0)"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"t0.format(0)"#), @r"
          --> 1:11
           |
         1 | t0.format(0)
           |           ^
           |
           = Expected string literal
-        "###);
+        ");
 
         // Dynamic string isn't supported yet
-        insta::assert_snapshot!(env.parse_err(r#"t0.format("%Y" ++ "%m")"#), @r###"
+        insta::assert_snapshot!(env.parse_err(r#"t0.format("%Y" ++ "%m")"#), @r#"
          --> 1:11
           |
         1 | t0.format("%Y" ++ "%m")
           |           ^----------^
           |
           = Expected string literal
-        "###);
+        "#);
 
         // Literal alias expansion
         env.add_alias("time_format", r#""%Y-%m-%d""#);
@@ -2923,17 +2923,17 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok(r#"fill(20, "The quick fox jumps over the " ++
                                   label("error", "lazy") ++ " dog\n")"#),
-            @r###"
+            @r"
         The quick fox jumps
         over the [38;5;1mlazy[39m dog
-        "###);
+        ");
 
         // A low value will not chop words, but can chop a label by words
         insta::assert_snapshot!(
             env.render_ok(r#"fill(9, "Longlonglongword an some short words " ++
                                   label("error", "longlonglongword and short words") ++
                                   " back out\n")"#),
-            @r###"
+            @r"
         Longlonglongword
         an some
         short
@@ -2942,13 +2942,13 @@ mod tests {
         [38;5;1mand short[39m
         [38;5;1mwords[39m
         back out
-        "###);
+        ");
 
         // Filling to 0 means breaking at every word
         insta::assert_snapshot!(
             env.render_ok(r#"fill(0, "The quick fox jumps over the " ++
                                   label("error", "lazy") ++ " dog\n")"#),
-            @r###"
+            @r"
         The
         quick
         fox
@@ -2957,13 +2957,13 @@ mod tests {
         the
         [38;5;1mlazy[39m
         dog
-        "###);
+        ");
 
         // Filling to -0 is the same as 0
         insta::assert_snapshot!(
             env.render_ok(r#"fill(-0, "The quick fox jumps over the " ++
                                   label("error", "lazy") ++ " dog\n")"#),
-            @r###"
+            @r"
         The
         quick
         fox
@@ -2972,7 +2972,7 @@ mod tests {
         the
         [38;5;1mlazy[39m
         dog
-        "###);
+        ");
 
         // Filling to negative width is an error
         insta::assert_snapshot!(
@@ -2985,23 +2985,23 @@ mod tests {
             env.render_ok(r#""START marker to help insta\n" ++
                              indent("    ", fill(20, "The quick fox jumps over the " ++
                                                  label("error", "lazy") ++ " dog\n"))"#),
-            @r###"
+            @r"
         START marker to help insta
             The quick fox jumps
             over the [38;5;1mlazy[39m dog
-        "###);
+        ");
 
         // Word-wrap indented (no special handling for leading spaces)
         insta::assert_snapshot!(
             env.render_ok(r#""START marker to help insta\n" ++
                              fill(20, indent("    ", "The quick fox jumps over the " ++
                                              label("error", "lazy") ++ " dog\n"))"#),
-            @r###"
+            @r"
         START marker to help insta
             The quick fox
         jumps over the [38;5;1mlazy[39m
         dog
-        "###);
+        ");
     }
 
     #[test]
@@ -3020,36 +3020,36 @@ mod tests {
         // "\n" at end of labeled text
         insta::assert_snapshot!(
             env.render_ok(r#"indent("__", label("error", "a\n") ++ label("warning", "b\n"))"#),
-            @r###"
+            @r"
         [38;5;1m__a[39m
         [38;5;3m__b[39m
-        "###);
+        ");
 
         // "\n" in labeled text
         insta::assert_snapshot!(
             env.render_ok(r#"indent("__", label("error", "a") ++ label("warning", "b\nc"))"#),
-            @r###"
+            @r"
         [38;5;1m__a[39m[38;5;3mb[39m
         [38;5;3m__c[39m
-        "###);
+        ");
 
         // Labeled prefix + unlabeled content
         insta::assert_snapshot!(
             env.render_ok(r#"indent(label("error", "XX"), "a\nb\n")"#),
-            @r###"
+            @r"
         [38;5;1mXX[39ma
         [38;5;1mXX[39mb
-        "###);
+        ");
 
         // Nested indent, silly but works
         insta::assert_snapshot!(
             env.render_ok(r#"indent(label("hint", "A"),
                                     label("warning", indent(label("hint", "B"),
                                                             label("error", "x\n") ++ "y")))"#),
-            @r###"
+            @r"
         [38;5;6mAB[38;5;1mx[39m
         [38;5;6mAB[38;5;3my[39m
-        "###);
+        ");
     }
 
     #[test]
@@ -3156,7 +3156,7 @@ mod tests {
                 ++ "\e\\"
                 ++ "Example"
                 ++ "\x1b]8;;\x1B\\""#),
-            @r#"␛]8;;http://example.com␛\Example␛]8;;␛\"#);
+            @r"␛]8;;http://example.com␛\Example␛]8;;␛\");
 
         // Don't sanitize ANSI escape with raw_escape_sequence
         insta::assert_snapshot!(env.render_ok(r#"raw_escape_sequence("\e")"#), @"");
@@ -3168,7 +3168,7 @@ mod tests {
                 ++ "\e\\"
                 ++ "Example"
                 ++ "\x1b]8;;\x1B\\")"#),
-            @r#"]8;;http://example.com\Example]8;;\"#);
+            @r"]8;;http://example.com\Example]8;;\");
     }
 
     #[test]

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -1410,12 +1410,12 @@ mod tests {
         recorder.pop_label().unwrap();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 7)),
-            @r###"
+            @r"
         [38;5;1mfoo bar[39m
         [38;5;1mbaz[39m
         [38;5;1mqux[39m
         [38;5;1mquux[39m
-        "###
+        "
         );
 
         // Multiple label chunks in a line
@@ -1427,12 +1427,12 @@ mod tests {
         }
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 7)),
-            @r###"
+            @r"
         [38;5;1mfoo [39m[38;5;6mbar[39m
         [38;5;1mbaz[39m
         [38;5;6mqux[39m
         [38;5;1mquux[39m
-        "###
+        "
         );
 
         // Empty lines should not cause panic
@@ -1444,13 +1444,13 @@ mod tests {
         }
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
-            @r###"
+            @r"
         [38;5;1m[39m
         [38;5;6mfoo[39m
         [38;5;1m[39m
         [38;5;6mbar baz[39m
         [38;5;1m[39m
-        "###
+        "
         );
 
         // Split at label boundary
@@ -1464,10 +1464,10 @@ mod tests {
         recorder.pop_label().unwrap();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
-            @r###"
+            @r"
         [38;5;1mfoo bar[39m
         [38;5;6mbaz[39m
-        "###
+        "
         );
 
         // Do not split at label boundary "ba|z" (since it's a single word)
@@ -1480,10 +1480,10 @@ mod tests {
         recorder.pop_label().unwrap();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
-            @r###"
+            @r"
         [38;5;1mfoo bar[39m
         [38;5;1mba[39m[38;5;6mz[39m
-        "###
+        "
         );
     }
 

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -775,7 +775,7 @@ fn test_absorb_immutable() {
 
     // Immutable revisions shouldn't be rewritten
     let output = test_env.run_jj_in(&repo_path, ["absorb", "--into=all()"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit 3619e4e52fce is immutable
     Hint: Could not modify commit: qpvuntsm 3619e4e5 main | 1
@@ -786,7 +786,7 @@ fn test_absorb_immutable() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
 
     insta::assert_snapshot!(get_diffs(&test_env, &repo_path, ".."), @r"
     @  mzvwutvl 3021153d (no description set)

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -943,8 +943,7 @@ fn test_bookmark_delete_export() {
     ");
 
     test_env.run_jj_in(&repo_path, ["git", "export"]).success();
-    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r###"
-    "###);
+    insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
 }
 
 #[test]

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -57,11 +57,11 @@ fn test_commit_with_editor() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     initial
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Check that the editor content includes diff summary
     std::fs::write(workspace_path.join("file1"), "foo\n").unwrap();
@@ -72,7 +72,7 @@ fn test_commit_with_editor() {
     std::fs::write(&edit_script, "dump editor1").unwrap();
     test_env.run_jj_in(&workspace_path, ["commit"]).success();
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     add files
 
     JJ: This commit contains the following changes:
@@ -80,7 +80,7 @@ fn test_commit_with_editor() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]
@@ -125,23 +125,23 @@ fn test_commit_interactive() {
         .success();
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are splitting the working-copy commit: qpvuntsm 4219467e add files
 
     The diff initially shows all changes. Adjust the right side until it shows the
     contents you want for the first commit. The remainder will be included in the
     new working-copy commit.
-    "###);
+    ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     add files
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Try again with --tool=<name>, which implies --interactive
     test_env.run_jj_in(&workspace_path, ["undo"]).success();
@@ -157,14 +157,14 @@ fn test_commit_interactive() {
         .success();
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     add files
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     let output = test_env.run_jj_in(&workspace_path, ["log", "--summary"]);
     insta::assert_snapshot!(output, @r"
@@ -262,7 +262,7 @@ fn test_commit_with_default_description() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     TESTED=TODO
 
     JJ: This commit contains the following changes:
@@ -270,7 +270,7 @@ fn test_commit_with_default_description() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]
@@ -311,7 +311,7 @@ fn test_commit_with_description_template() {
         .run_jj_in(&workspace_path, ["commit", "file1"])
         .success();
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Test User <test.user@example.com> (2001-02-03 08:05:08)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
 
@@ -319,7 +319,7 @@ fn test_commit_with_description_template() {
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Only file2 with modified author should be included in the diff
     test_env
@@ -334,7 +334,7 @@ fn test_commit_with_description_template() {
         )
         .success();
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Another User <another.user@example.com> (2001-02-03 08:05:08)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -342,14 +342,14 @@ fn test_commit_with_description_template() {
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Timestamp after the reset should be available to the template
     test_env
         .run_jj_in(&workspace_path, ["commit", "--reset-author"])
         .success();
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Test User <test.user@example.com> (2001-02-03 08:05:10)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:10)
 
@@ -357,7 +357,7 @@ fn test_commit_with_description_template() {
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -342,23 +342,23 @@ fn test_log_builtin_templates() {
         .run_jj_in(&repo_path, ["bookmark", "create", "-r@", "my-bookmark"])
         .success();
 
-    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r###"
+    insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @r"
     rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark dc315397 (empty) (no description set)
     qpvuntsm test.user 2001-02-03 08:05:07 230dd059 (empty) (no description set)
     zzzzzzzz root() 00000000
     [EOF]
-    "###);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r###"
+    insta::assert_snapshot!(render(r#"builtin_log_compact"#), @r"
     rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark dc315397
     (empty) (no description set)
     qpvuntsm test.user@example.com 2001-02-03 08:05:07 230dd059
     (empty) (no description set)
     zzzzzzzz root() 00000000
     [EOF]
-    "###);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r###"
+    insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @r"
     rlvkpnrz (no email set) 2001-02-03 08:05:08 my-bookmark dc315397
     (empty) (no description set)
 
@@ -368,9 +368,9 @@ fn test_log_builtin_templates() {
     zzzzzzzz root() 00000000
 
     [EOF]
-    "###);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_log_detailed"#), @r"
     Commit ID: dc31539712c7294d1d712cec63cef4504b94ca74
     Change ID: rlvkpnrzqnoowoytxnquwvuryrwnrmlp
     Bookmarks: my-bookmark
@@ -394,7 +394,7 @@ fn test_log_builtin_templates() {
         (no description set)
 
     [EOF]
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1065,5 +1065,5 @@ fn test_files() {
 
     let outside_repo = test_env.env_root();
     let output = test_env.run_jj_in(outside_repo, ["--", "jj", "log", "f_"]);
-    insta::assert_snapshot!(output, @r"");
+    insta::assert_snapshot!(output, @"");
 }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -626,12 +626,12 @@ fn test_config_set_for_repo() {
                 expected_repo_config_path.display()
             )
         });
-    insta::assert_snapshot!(repo_config_toml, @r###"
+    insta::assert_snapshot!(repo_config_toml, @r#"
     test-key = "test-val"
 
     [test-table]
     foo = true
-    "###);
+    "#);
 }
 
 #[test]
@@ -654,7 +654,7 @@ fn test_config_set_toml_types() {
     set_value("test-table.boolean", "true");
     set_value("test-table.string", r#""foo""#);
     set_value("test-table.invalid", r"a + b");
-    insta::assert_snapshot!(std::fs::read_to_string(&user_config_path).unwrap(), @r###"
+    insta::assert_snapshot!(std::fs::read_to_string(&user_config_path).unwrap(), @r#"
     [test-table]
     integer = 42
     float = 3.14
@@ -662,7 +662,7 @@ fn test_config_set_toml_types() {
     boolean = true
     string = "foo"
     invalid = "a + b"
-    "###);
+    "#);
 }
 
 #[test]
@@ -853,9 +853,7 @@ fn test_config_unset_for_user() {
         .success();
 
     let user_config_toml = std::fs::read_to_string(&user_config_path).unwrap();
-    insta::assert_snapshot!(user_config_toml, @r#"
-        [table]
-        "#);
+    insta::assert_snapshot!(user_config_toml, @"[table]");
 }
 
 #[test]

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -55,11 +55,11 @@ fn test_describe() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     description from CLI
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Set a description in editor
     std::fs::write(&edit_script, "write\ndescription from editor").unwrap();
@@ -319,7 +319,7 @@ fn test_describe_multiple_commits() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
     JJ: Warning:
     JJ: - The text you enter will be lost on a syntax error.
@@ -331,7 +331,7 @@ fn test_describe_multiple_commits() {
     description from CLI
 
     JJ: Lines starting with "JJ: " (like this one) will be removed.
-    "###);
+    "#);
 
     // Set the description of multiple commits in the editor
     std::fs::write(
@@ -640,7 +640,7 @@ fn test_describe_default_description() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     TESTED=TODO
 
     JJ: This commit contains the following changes:
@@ -648,7 +648,7 @@ fn test_describe_default_description() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 #[test]
@@ -727,14 +727,14 @@ fn test_describe_author() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Author: Super Seeder <super.seeder@example.com> (2001-02-03 08:05:12)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:12)
 
     JJ: 0 files changed, 0 insertions(+), 0 deletions(-)
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Change the author for multiple commits (the committer is always reset)
     test_env

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -2601,7 +2601,7 @@ fn test_diff_external_tool_conflict_marker_style() {
     insta::assert_snapshot!(output, @"");
     // Conflicts should render using "snapshot" format
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("file")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("file")).unwrap(), @r"
     line 1
     line 2.1
     line 2.2
@@ -2617,7 +2617,7 @@ fn test_diff_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -50,14 +50,14 @@ fn test_diffedit() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are editing changes in: kkmpptxz 3d4cce89 (no description set)
 
     The diff initially shows the commit's changes.
 
     Adjust the right side until it shows the contents you want. If you
     don't make any changes, then the operation will be aborted.
-    "###);
+    ");
     let output = test_env.run_jj_in(&repo_path, ["diff", "-s"]);
     insta::assert_snapshot!(output, @r"
     D file1
@@ -157,9 +157,7 @@ fn test_diffedit() {
     [EOF]
     ");
     let contents = String::from_utf8(std::fs::read(repo_path.join("file3")).unwrap()).unwrap();
-    insta::assert_snapshot!(contents, @r###"
-    modified
-    "###);
+    insta::assert_snapshot!(contents, @"modified");
 
     // Test diffedit --from @--
     test_env.run_jj_in(&repo_path, ["undo"]).success();
@@ -372,7 +370,7 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     ");
     // Conflicts should render using "snapshot" format in diff editor
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("before-file")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("before-file")).unwrap(), @r"
     line 1
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
@@ -394,9 +392,9 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("after-file")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("after-file")).unwrap(), @r"
     line 1
     line 2.1
     line 2.2
@@ -412,10 +410,10 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##);
+    ");
     // Conflicts should be materialized using "diff" format in working copy
     insta::assert_snapshot!(
-        std::fs::read_to_string(&file_path).unwrap(), @r##"
+        std::fs::read_to_string(&file_path).unwrap(), @r"
     line 1
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
@@ -435,7 +433,7 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     line 4.3
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
+    ");
 
     // File should be conflicted with no changes
     let output = test_env.run_jj_in(&repo_path, ["st"]);

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -766,7 +766,7 @@ fn test_fix_immutable_commit() {
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "immutable""#);
 
     let output = test_env.run_jj_in(&repo_path, ["fix", "-s", "immutable"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit e4b41a3ce243 is immutable
     Hint: Could not modify commit: qpvuntsm e4b41a3c immutable | (no description set)
@@ -777,7 +777,7 @@ fn test_fix_immutable_commit() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     let output = test_env.run_jj_in(&repo_path, ["file", "show", "file", "-r", "immutable"]);
     insta::assert_snapshot!(output, @"immutable[EOF]");
     let output = test_env.run_jj_in(&repo_path, ["file", "show", "file", "-r", "mutable"]);
@@ -921,7 +921,10 @@ fn test_deduplication() {
     // Each new content string only appears once in the log, because all the other
     // inputs (like file name) were identical, and so the results were reused. We
     // sort the log because the order of execution inside `jj fix` is undefined.
-    insta::assert_snapshot!(sorted_lines(repo_path.join("file-fixlog")), @"BAR\nFOO\n");
+    insta::assert_snapshot!(sorted_lines(repo_path.join("file-fixlog")), @r"
+    BAR
+    FOO
+    ");
 }
 
 fn sorted_lines(path: PathBuf) -> String {
@@ -954,7 +957,7 @@ fn test_executed_but_nothing_changed() {
     [EOF]
     ");
     let copy_content = std::fs::read_to_string(repo_path.join("file-copy").as_os_str()).unwrap();
-    insta::assert_snapshot!(copy_content, @"content\n");
+    insta::assert_snapshot!(copy_content, @"content");
 
     // fix tools are always run from the workspace root, regardless of working
     // directory at time of invocation.
@@ -968,7 +971,10 @@ fn test_executed_but_nothing_changed() {
     ");
 
     let copy_content = std::fs::read_to_string(repo_path.join("file-copy").as_os_str()).unwrap();
-    insta::assert_snapshot!(copy_content, @"content\ncontent\n");
+    insta::assert_snapshot!(copy_content, @r"
+    content
+    content
+    ");
     assert!(!repo_path.join("dir").join("file-copy").exists());
 }
 

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -945,22 +945,22 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     [EOF]
     ");
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=0:0 mtime=0:0 size=0 file1.txt
     Unconflicted Mode(FILE) 2e0996000b7e ctime=0:0 mtime=0:0 size=0 file2.txt
     Unconflicted Mode(FILE) d5f7fc3f74f7 ctime=0:0 mtime=0:0 size=0 file4.txt
-    "#);
+    ");
 
     // Update index with stats for all files. We may want to do this automatically
     // in the future after we update the index in `git::reset_head` (#3786), but for
     // now, we at least want to preserve existing stat information when possible.
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=[nonzero] mtime=[nonzero] size=18 file1.txt
     Unconflicted Mode(FILE) 2e0996000b7e ctime=[nonzero] mtime=[nonzero] size=9 file2.txt
     Unconflicted Mode(FILE) d5f7fc3f74f7 ctime=[nonzero] mtime=[nonzero] size=6 file4.txt
-    "#);
+    ");
 
     // Edit parent commit, causing the changes to be removed from the index without
     // touching the working copy
@@ -976,11 +976,11 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     ");
 
     // Index should contain stat for unchanged file still.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=[nonzero] mtime=[nonzero] size=18 file1.txt
     Unconflicted Mode(FILE) 28d2718c947b ctime=0:0 mtime=0:0 size=0 file2.txt
     Unconflicted Mode(FILE) 528557ab3a42 ctime=0:0 mtime=0:0 size=0 file3.txt
-    "#);
+    ");
 
     // Create sibling commit, causing working copy to match index
     test_env.run_jj_in(&repo_path, ["new", "commit1"]).success();
@@ -995,11 +995,11 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     ");
 
     // Index should contain stat for unchanged file still.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=[nonzero] mtime=[nonzero] size=18 file1.txt
     Unconflicted Mode(FILE) 28d2718c947b ctime=0:0 mtime=0:0 size=0 file2.txt
     Unconflicted Mode(FILE) 528557ab3a42 ctime=0:0 mtime=0:0 size=0 file3.txt
-    "#);
+    ");
 }
 
 #[test]
@@ -1031,18 +1031,18 @@ fn test_git_colocated_update_index_merge_conflict() {
         .run_jj_in(&repo_path, ["bookmark", "create", "-r@", "right"])
         .success();
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Update index with stat for base.txt
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Create merge conflict
     test_env
@@ -1062,14 +1062,14 @@ fn test_git_colocated_update_index_merge_conflict() {
 
     // Conflict should be added in index with correct blob IDs. The stat for
     // base.txt should not change.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Ours         Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
     Theirs       Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 
     test_env.run_jj_in(&repo_path, ["new"]).success();
 
@@ -1086,14 +1086,14 @@ fn test_git_colocated_update_index_merge_conflict() {
     ");
 
     // Index should be the same after `jj new`.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Ours         Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
     Theirs       Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 }
 
 #[test]
@@ -1136,18 +1136,18 @@ fn test_git_colocated_update_index_rebase_conflict() {
     [EOF]
     ");
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Update index with stat for base.txt
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Create rebase conflict
     test_env
@@ -1164,11 +1164,11 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     // Index should contain files from parent commit, so there should be no conflict
     // in conflict.txt yet. The stat for base.txt should not change.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 
     test_env.run_jj_in(&repo_path, ["new"]).success();
 
@@ -1183,14 +1183,14 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     // Now the working copy commit's parent is conflicted, so the index should have
     // a conflict with correct blob IDs.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Base         Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Ours         Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Theirs       Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) 45cf141ba67d ctime=0:0 mtime=0:0 size=0 left.txt
     Unconflicted Mode(FILE) c376d892e8b1 ctime=0:0 mtime=0:0 size=0 right.txt
-    "#);
+    ");
 }
 
 #[test]
@@ -1229,18 +1229,18 @@ fn test_git_colocated_update_index_3_sided_conflict() {
         .run_jj_in(&repo_path, ["bookmark", "create", "-r@", "side-3"])
         .success();
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Update index with stat for base.txt
     update_git_index(&repo_path);
 
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 conflict.txt
-    "#);
+    ");
 
     // Create 3-sided merge conflict
     test_env
@@ -1262,14 +1262,14 @@ fn test_git_colocated_update_index_3_sided_conflict() {
 
     // We can't add conflicts with more than 2 sides to the index, so we add a dummy
     // conflict instead. The stat for base.txt should not change.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Ours         Mode(FILE) eb8299123d2a ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
     Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
     Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
-    "#);
+    ");
 
     test_env.run_jj_in(&repo_path, ["new"]).success();
 
@@ -1288,27 +1288,27 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ");
 
     // Index should be the same after `jj new`.
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Ours         Mode(FILE) eb8299123d2a ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
     Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
     Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
-    "#);
+    ");
 
     // If we add a file named ".jj-do-not-resolve-this-conflict", it should take
     // precedence over the dummy conflict.
     std::fs::write(repo_path.join(".jj-do-not-resolve-this-conflict"), "file\n").unwrap();
     test_env.run_jj_in(&repo_path, ["new"]).success();
-    insta::assert_snapshot!(get_index_state(&repo_path), @r#"
+    insta::assert_snapshot!(get_index_state(&repo_path), @r"
     Unconflicted Mode(FILE) f73f3093ff86 ctime=0:0 mtime=0:0 size=0 .jj-do-not-resolve-this-conflict
     Unconflicted Mode(FILE) df967b96a579 ctime=[nonzero] mtime=[nonzero] size=5 base.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 conflict.txt
     Unconflicted Mode(FILE) dd8f930010b3 ctime=0:0 mtime=0:0 size=0 side-1.txt
     Unconflicted Mode(FILE) 7b44e11df720 ctime=0:0 mtime=0:0 size=0 side-2.txt
     Unconflicted Mode(FILE) 42f37a71bf20 ctime=0:0 mtime=0:0 size=0 side-3.txt
-    "#);
+    ");
 }
 
 #[must_use]

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -122,7 +122,7 @@ fn test_git_export_undo() {
     Undid operation: edb40232c741 (2001-02-03 08:05:10) export git refs
     [EOF]
     ");
-    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
+    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
     [
         (
             "refs/heads/a",
@@ -131,7 +131,7 @@ fn test_git_export_undo() {
             ),
         ),
     ]
-    "###);
+    "#);
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["log", "-ra@git"]), @r"
     ------- stderr -------
     Error: Revision `a@git` doesn't exist
@@ -282,7 +282,7 @@ fn test_git_import_move_export_with_default_undo() {
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @"");
-    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r###"
+    insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
     [
         (
             "refs/heads/a",
@@ -291,7 +291,7 @@ fn test_git_import_move_export_with_default_undo() {
             ),
         ),
     ]
-    "###);
+    "#);
 
     // The last bookmark "a" state is imported from git. No idea what's the most
     // intuitive result here.

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -302,8 +302,7 @@ fn test_git_remote_named_git() {
     let output = test_env.run_jj_in(&repo_path, ["git", "remote", "remove", "git"]);
     insta::assert_snapshot!(output, @"");
     let output = test_env.run_jj_in(&repo_path, ["git", "remote", "list"]);
-    insta::assert_snapshot!(output, @r###"
-    "###);
+    insta::assert_snapshot!(output, @"");
     // @git bookmark shouldn't be removed.
     let output = test_env.run_jj_in(&repo_path, ["log", "-rmain@git", "-Tbookmarks"]);
     insta::assert_snapshot!(output, @r"
@@ -387,8 +386,7 @@ fn test_git_remote_with_slashes() {
     let output = test_env.run_jj_in(&repo_path, ["git", "remote", "remove", "slash/origin"]);
     insta::assert_snapshot!(output, @"");
     let output = test_env.run_jj_in(&repo_path, ["git", "remote", "list"]);
-    insta::assert_snapshot!(output, @r###"
-    "###);
+    insta::assert_snapshot!(output, @"");
     // @git bookmark shouldn't be removed.
     let output = test_env.run_jj_in(&repo_path, ["log", "-rmain@git", "-Tbookmarks"]);
     insta::assert_snapshot!(output, @r"

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -47,7 +47,7 @@ fn test_rewrite_immutable_generic() {
     // Cannot rewrite a commit in the configured set
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
     let output = test_env.run_jj_in(&repo_path, ["edit", "main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit 72e1b68cbcf2 is immutable
     Hint: Could not modify commit: kkmpptxz 72e1b68c main | b
@@ -58,10 +58,10 @@ fn test_rewrite_immutable_generic() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // Cannot rewrite an ancestor of the configured set
     let output = test_env.run_jj_in(&repo_path, ["edit", "main-"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit b84b821b8a2b is immutable
     Hint: Could not modify commit: qpvuntsm b84b821b a
@@ -72,7 +72,7 @@ fn test_rewrite_immutable_generic() {
     Hint: This operation would rewrite 2 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // Cannot rewrite the root commit even with an empty set of immutable commits
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let output = test_env.run_jj_in(&repo_path, ["edit", "root()"]);
@@ -270,7 +270,7 @@ fn test_rewrite_immutable_commands() {
 
     // abandon
     let output = test_env.run_jj_in(&repo_path, ["abandon", "main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -281,10 +281,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // absorb
     let output = test_env.run_jj_in(&repo_path, ["absorb", "--into=::@-"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit 72e1b68cbcf2 is immutable
     Hint: Could not modify commit: kkmpptxz 72e1b68c b
@@ -295,10 +295,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 2 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // chmod
     let output = test_env.run_jj_in(&repo_path, ["file", "chmod", "-r=main", "x", "file"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -309,10 +309,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // describe
     let output = test_env.run_jj_in(&repo_path, ["describe", "main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -323,10 +323,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // diffedit
     let output = test_env.run_jj_in(&repo_path, ["diffedit", "-r=main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -337,10 +337,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // edit
     let output = test_env.run_jj_in(&repo_path, ["edit", "main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -351,10 +351,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // new --insert-before
     let output = test_env.run_jj_in(&repo_path, ["new", "--insert-before", "main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -365,10 +365,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // new --insert-after parent_of_main
     let output = test_env.run_jj_in(&repo_path, ["new", "--insert-after", "description(b)"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -379,10 +379,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // parallelize
     let output = test_env.run_jj_in(&repo_path, ["parallelize", "description(b)", "main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -393,10 +393,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 2 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // rebase -s
     let output = test_env.run_jj_in(&repo_path, ["rebase", "-s=main", "-d=@"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -407,10 +407,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // rebase -b
     let output = test_env.run_jj_in(&repo_path, ["rebase", "-b=main", "-d=@"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit 77cee210cbf5 is immutable
     Hint: Could not modify commit: zsuskuln 77cee210 c
@@ -421,10 +421,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 2 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // rebase -r
     let output = test_env.run_jj_in(&repo_path, ["rebase", "-r=main", "-d=@"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -435,10 +435,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // resolve
     let output = test_env.run_jj_in(&repo_path, ["resolve", "-r=description(merge)", "file"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -449,10 +449,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // restore -c
     let output = test_env.run_jj_in(&repo_path, ["restore", "-c=main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -463,10 +463,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // restore --into
     let output = test_env.run_jj_in(&repo_path, ["restore", "--into=main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -477,10 +477,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // split
     let output = test_env.run_jj_in(&repo_path, ["split", "-r=main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -491,10 +491,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // squash -r
     let output = test_env.run_jj_in(&repo_path, ["squash", "-r=description(b)"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit 72e1b68cbcf2 is immutable
     Hint: Could not modify commit: kkmpptxz 72e1b68c b
@@ -505,10 +505,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 4 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // squash --from
     let output = test_env.run_jj_in(&repo_path, ["squash", "--from=main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -519,10 +519,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // squash --into
     let output = test_env.run_jj_in(&repo_path, ["squash", "--into=main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: Commit bcab555fc80e is immutable
     Hint: Could not modify commit: mzvwutvl bcab555f main | (conflict) merge
@@ -533,10 +533,10 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // unsquash
     let output = test_env.run_jj_in(&repo_path, ["unsquash", "-r=main"]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Warning: `jj unsquash` is deprecated; use `jj diffedit --restore-descendants` or `jj squash` instead
     Warning: `jj unsquash` will be removed in a future version, and this will be a hard error
@@ -549,7 +549,7 @@ fn test_rewrite_immutable_commands() {
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
-    "##);
+    "#);
     // sign
     let output = test_env.run_jj_in(
         &repo_path,

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -358,7 +358,7 @@ fn test_log_null_terminate_multiline_descriptions() {
         .success();
     insta::assert_debug_snapshot!(
         output.stdout.normalized(),
-        @r###""commit 3 line 1\n\ncommit 3 line 2\n\0commit 2 line 1\n\ncommit 2 line 2\n\0commit 1 line 1\n\ncommit 1 line 2\n\0""###
+        @r#""commit 3 line 1\n\ncommit 3 line 2\n\0commit 2 line 1\n\ncommit 2 line 2\n\0commit 1 line 1\n\ncommit 1 line 2\n\0""#
     );
 }
 
@@ -1134,8 +1134,7 @@ fn test_log_warn_path_might_be_revset() {
 
     // If an explicit revision is provided, then suppress the warning.
     let output = test_env.run_jj_in(&repo_path, ["log", "@", "-r", "@", "-T", "description"]);
-    insta::assert_snapshot!(output, @r###"
-    "###);
+    insta::assert_snapshot!(output, @"");
 }
 
 #[test]

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -296,12 +296,12 @@ fn test_new_insert_after_children() {
             "C",
         ],
     );
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Refusing to create a loop: commit 83376b270925 would be both an ancestor and a descendant of the new commit
     [EOF]
     [exit status: 1]
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -405,7 +405,7 @@ fn test_op_log_builtin_templates() {
         .run_jj_in(&repo_path, ["describe", "-m", "description 0"])
         .success();
 
-    insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r"
     d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     args: jj describe -m 'description 0'
@@ -413,9 +413,9 @@ fn test_op_log_builtin_templates() {
     add workspace 'default'
     000000000000 root()
     [EOF]
-    "#);
+    ");
 
-    insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r#"
+    insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r"
     d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22
     args: jj describe -m 'description 0'
@@ -426,7 +426,7 @@ fn test_op_log_builtin_templates() {
     000000000000 root()
 
     [EOF]
-    "#);
+    ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @r"
     d009cfc04993 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit 230dd059e1b059aefc0da06a2e5a7dbf22362f22 args: jj describe -m 'description 0'

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -77,7 +77,7 @@ fn test_resolution() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -85,7 +85,7 @@ fn test_resolution() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     let editor_script = test_env.set_up_fake_editor();
     // Check that output file starts out empty and resolve the conflict
@@ -105,8 +105,7 @@ fn test_resolution() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
-    "###);
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @"");
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["diff", "--git"]), @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
@@ -192,7 +191,7 @@ fn test_resolution() {
         )
         .success();
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -200,7 +199,7 @@ fn test_resolution() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["diff", "--git"]), @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
@@ -266,7 +265,7 @@ fn test_resolution() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -274,7 +273,7 @@ fn test_resolution() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     // Note the "Modified" below
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["diff", "--git"]), @r"
     diff --git a/file b/file
@@ -332,8 +331,7 @@ fn test_resolution() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor3")).unwrap(), @r###"
-    "###);
+        std::fs::read_to_string(test_env.env_root().join("editor3")).unwrap(), @"");
     // Note the "Resolved" below
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["diff", "--git"]), @r"
     diff --git a/file b/file
@@ -413,7 +411,7 @@ fn test_resolution() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor4")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("editor4")).unwrap(), @r"
     <<<<<<< Side #1 (Conflict 1 of 1)
     a
     ||||||| Base
@@ -421,7 +419,7 @@ fn test_resolution() {
     =======
     b
     >>>>>>> Side #2 (Conflict 1 of 1 ends)
-    "##);
+    ");
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
@@ -614,7 +612,7 @@ fn test_normal_conflict_input_files() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -622,7 +620,7 @@ fn test_normal_conflict_input_files() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "base", "base\n");
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "left", "a\n");
@@ -656,14 +654,14 @@ fn test_baseless_conflict_input_files() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     +a
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "base", "");
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "left", "a\n");
@@ -746,7 +744,7 @@ fn test_simplify_conflict_sides() {
     [EOF]
     ");
     insta::assert_snapshot!(
-    std::fs::read_to_string(repo_path.join("fileA")).unwrap(), @r###"
+    std::fs::read_to_string(repo_path.join("fileA")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -754,9 +752,9 @@ fn test_simplify_conflict_sides() {
     +++++++ Contents of side #2
     2
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(
-    std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r###"
+    std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -764,7 +762,7 @@ fn test_simplify_conflict_sides() {
     +++++++ Contents of side #2
     2
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Conflict should be simplified before being handled by external merge tool.
     check_resolve_produces_input_file(&mut test_env, &repo_path, "fileA", "base", "base\n");
@@ -818,7 +816,7 @@ fn test_simplify_conflict_sides() {
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
     ");
-    insta::assert_snapshot!(std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r###"
+    insta::assert_snapshot!(std::fs::read_to_string(repo_path.join("fileB")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base_edited
@@ -826,7 +824,7 @@ fn test_simplify_conflict_sides() {
     +++++++ Contents of side #2
     2_edited
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["resolve", "--list"]), @r"
     fileA    2-sided conflict
     fileB    2-sided conflict
@@ -862,14 +860,14 @@ fn test_edit_delete_conflict_input_files() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     a
     %%%%%%% Changes from base to side #2
     -base
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "base", "base\n");
     check_resolve_produces_input_file(&mut test_env, &repo_path, "file", "left", "a\n");
@@ -1025,7 +1023,7 @@ fn test_resolve_conflicts_with_executable() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(repo_path.join("file1")).unwrap(), @r##"
+        std::fs::read_to_string(repo_path.join("file1")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base1
@@ -1033,10 +1031,10 @@ fn test_resolve_conflicts_with_executable() {
     +++++++ Contents of side #2
     b1
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     insta::assert_snapshot!(
-        std::fs::read_to_string(repo_path.join("file2")).unwrap(), @r##"
+        std::fs::read_to_string(repo_path.join("file2")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base2
@@ -1044,7 +1042,7 @@ fn test_resolve_conflicts_with_executable() {
     +++++++ Contents of side #2
     b2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     let editor_script = test_env.set_up_fake_editor();
 
@@ -1173,7 +1171,7 @@ fn test_resolve_long_conflict_markers() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(repo_path.join("file")).unwrap(), @r##"
+        std::fs::read_to_string(repo_path.join("file")).unwrap(), @r"
     <<<<<<<<<<< Conflict 1 of 1
     +++++++++++ Contents of side #1
     <<<<<<< a
@@ -1182,7 +1180,7 @@ fn test_resolve_long_conflict_markers() {
     +++++++++++ Contents of side #2
     >>>>>>> b
     >>>>>>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     let editor_script = test_env.set_up_fake_editor();
     // Allow signaling that conflict markers were produced even if not editing
@@ -1299,7 +1297,7 @@ fn test_resolve_long_conflict_markers() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r##"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r"
     <<<<<<<<<<< Conflict 1 of 1
     +++++++++++ Contents of side #1
     <<<<<<< a
@@ -1308,7 +1306,7 @@ fn test_resolve_long_conflict_markers() {
     +++++++++++ Contents of side #2
     >>>>>>> b
     >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
@@ -1461,7 +1459,7 @@ fn test_multiple_conflicts() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(
-        repo_path.join("this_file_has_a_very_long_name_to_test_padding")).unwrap(), @r###"
+        repo_path.join("this_file_has_a_very_long_name_to_test_padding")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -first base
@@ -1469,9 +1467,9 @@ fn test_multiple_conflicts() {
     +++++++ Contents of side #2
     first b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(repo_path.join("another_file")).unwrap(), @r###"
+        std::fs::read_to_string(repo_path.join("another_file")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -second base
@@ -1479,7 +1477,7 @@ fn test_multiple_conflicts() {
     +++++++ Contents of side #2
     second b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(test_env.run_jj_in(&repo_path, ["resolve", "--list"]), @r"
     another_file                        2-sided conflict
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
@@ -1642,7 +1640,7 @@ fn test_multiple_conflicts_with_error() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(repo_path.join("file1")).unwrap(), @r##"
+        std::fs::read_to_string(repo_path.join("file1")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base1
@@ -1650,10 +1648,10 @@ fn test_multiple_conflicts_with_error() {
     +++++++ Contents of side #2
     b1
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     insta::assert_snapshot!(
-        std::fs::read_to_string(repo_path.join("file2")).unwrap(), @r##"
+        std::fs::read_to_string(repo_path.join("file2")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base2
@@ -1661,7 +1659,7 @@ fn test_multiple_conflicts_with_error() {
     +++++++ Contents of side #2
     b2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     let editor_script = test_env.set_up_fake_editor();
 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -185,7 +185,7 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -193,7 +193,7 @@ fn test_restore_conflicted_merge() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Overwrite the file...
     std::fs::write(repo_path.join("file"), "resolution").unwrap();
@@ -225,7 +225,7 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -233,7 +233,7 @@ fn test_restore_conflicted_merge() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     let output = test_env.run_jj_in(&repo_path, ["diff"]);
     insta::assert_snapshot!(output, @"");
 
@@ -267,7 +267,7 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(
     std::fs::read_to_string(repo_path.join("file")).unwrap()
-        , @r###"
+        , @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -base
@@ -275,7 +275,7 @@ fn test_restore_conflicted_merge() {
     +++++++ Contents of side #2
     b
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 }
 
 #[test]
@@ -312,9 +312,7 @@ fn test_restore_restore_descendants() {
     [EOF]
     ");
     insta::assert_snapshot!(
-    std::fs::read_to_string(repo_path.join("file")).unwrap(), @r#"
-    ab
-    "#);
+    std::fs::read_to_string(repo_path.join("file")).unwrap(), @"ab");
 
     // Commit "b" was not supposed to modify "file", restore it from its parent
     // while preserving its child commit content.

--- a/cli/tests/test_sparse_command.rs
+++ b/cli/tests/test_sparse_command.rs
@@ -181,9 +181,7 @@ fn test_sparse_manage_patterns() {
     Added 2 files, modified 0 files, removed 1 files
     [EOF]
     ");
-    insta::assert_snapshot!(read_patterns(), @r###"
-    file1
-    "###);
+    insta::assert_snapshot!(read_patterns(), @"file1");
     let output = test_env.run_jj_in(&sub_dir, ["sparse", "list"]);
     insta::assert_snapshot!(output, @r"
     file2

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -74,14 +74,14 @@ fn test_split_by_paths() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
     JJ: This commit contains the following changes:
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     assert!(!test_env.env_root().join("editor1").exists());
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
@@ -210,7 +210,7 @@ fn test_split_with_non_empty_description() {
     ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
     test
 
@@ -218,9 +218,9 @@ fn test_split_with_non_empty_description() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r#"
     JJ: Enter a description for the second commit.
     test
 
@@ -228,7 +228,7 @@ fn test_split_with_non_empty_description() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  kkmpptxzrspx false part 2
     ○  qpvuntsmwlqt false part 1
@@ -268,7 +268,7 @@ fn test_split_with_default_description() {
     // default value we set. The second commit will inherit the empty
     // description from the commit being split.
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
 
@@ -278,7 +278,7 @@ fn test_split_with_default_description() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     assert!(!test_env.env_root().join("editor2").exists());
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
     @  rlvkpnrzqnoo false
@@ -396,7 +396,7 @@ fn test_split_siblings_no_descendants() {
     // default value we set. The second commit will inherit the empty
     // description from the commit being split.
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
 
@@ -406,7 +406,7 @@ fn test_split_siblings_no_descendants() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     assert!(!test_env.env_root().join("editor2").exists());
 }
 
@@ -489,7 +489,7 @@ fn test_split_siblings_with_descendants() {
     // The commit we're splitting has a description, so the user will be
     // prompted to enter a description for each of the sibling commits.
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
     Add file1 & file2
 
@@ -497,9 +497,9 @@ fn test_split_siblings_with_descendants() {
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r#"
     JJ: Enter a description for the second commit.
     Add file1 & file2
 
@@ -507,7 +507,7 @@ fn test_split_siblings_with_descendants() {
     JJ:     A file2
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 }
 
 // This test makes sure that the children of the commit being split retain any
@@ -644,24 +644,24 @@ fn test_split_interactive() {
     ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r#"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are splitting a commit into two: qpvuntsm 44af2155 (no description set)
 
     The diff initially shows the changes in the commit you're splitting.
 
     Adjust the right side until it shows the contents you want for the first commit.
     The remainder will be in the second commit.
-    "#);
+    ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     let output = test_env.run_jj_in(&workspace_path, ["log", "--summary"]);
     insta::assert_snapshot!(output, @r"
@@ -712,14 +712,14 @@ fn test_split_interactive_with_paths() {
     ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
     JJ: This commit contains the following changes:
     JJ:     A file1
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     let output = test_env.run_jj_in(&workspace_path, ["log", "--summary"]);
     insta::assert_snapshot!(output, @r"
@@ -951,14 +951,14 @@ fn test_split_with_bookmarks(bookmark_behavior: BookmarkBehavior) {
         }
         BookmarkBehavior::Default | BookmarkBehavior::MoveBookmarkToChild => {
             insta::allow_duplicates! {
-            insta::assert_snapshot!(output, @r###"
+            insta::assert_snapshot!(output, @r"
             ------- stderr -------
             First part: qpvuntsm 63d0c5ed first-commit
             Second part: mzvwutvl a9f5665f *le-signet* | second-commit
             Working copy now at: mzvwutvl a9f5665f *le-signet* | second-commit
             Parent commit      : qpvuntsm 63d0c5ed first-commit
             [EOF]
-            "###);
+            ");
             }
             insta::allow_duplicates! {
             insta::assert_snapshot!(get_log_output(&test_env, &main_path), @r"

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -203,7 +203,7 @@ fn test_squash_partial() {
     ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are moving changes from: kkmpptxz d117da27 b | (no description set)
     into commit: qpvuntsm 54d3c1c0 a | (no description set)
 
@@ -214,7 +214,7 @@ fn test_squash_partial() {
     Adjust the right side until the diff shows the changes you want to move
     to the destination. If you don't make any changes, then all the changes
     from the source will be moved into the destination.
-    "###);
+    ");
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  3c6332267ea8 c

--- a/cli/tests/test_unsquash_command.rs
+++ b/cli/tests/test_unsquash_command.rs
@@ -213,7 +213,7 @@ fn test_unsquash_partial() {
     ");
 
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("instrs")).unwrap(), @r"
     You are moving changes from: qpvuntsm 54d3c1c0 a | (no description set)
     into its child: kkmpptxz d117da27 b | (no description set)
 
@@ -223,7 +223,7 @@ fn test_unsquash_partial() {
     the parent commit. The changes you edited out will be moved into the
     child commit. If you don't make any changes, then the operation will be
     aborted.
-    "###);
+    ");
 
     insta::assert_snapshot!(get_log_output(&test_env, &repo_path), @r"
     @  8802263dbd92 c
@@ -382,7 +382,7 @@ fn test_unsquash_description() {
     [EOF]
     ");
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the combined commit.
     JJ: Description from the destination commit:
     destination
@@ -391,7 +391,7 @@ fn test_unsquash_description() {
     source
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // If the source's *content* doesn't become empty, then the source remains and
     // both descriptions are unchanged

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -234,7 +234,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
         .success();
 
     // File should have Git-style conflict markers
-    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r##"
+    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r"
     line 1
     <<<<<<< Side #1 (Conflict 1 of 1)
     line 2 - a
@@ -246,7 +246,7 @@ fn test_materialize_and_snapshot_different_conflict_markers() {
     line 2 - b
     line 3 - b
     >>>>>>> Side #2 (Conflict 1 of 1 ends)
-    "##);
+    ");
 
     // Configure to use JJ-style "snapshot" conflict markers
     test_env.add_config(r#"ui.conflict-marker-style = "snapshot""#);
@@ -374,7 +374,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
         .success();
 
     // File should be materialized with long conflict markers
-    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r##"
+    insta::assert_snapshot!(std::fs::read_to_string(&conflict_file).unwrap(), @r"
     line 1
     <<<<<<<<<<< Conflict 1 of 1
     %%%%%%%%%%% Changes from base to side #1
@@ -388,7 +388,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     ======= fake marker
     line 3
     >>>>>>>>>>> Conflict 1 of 1 ends
-    "##);
+    ");
 
     // The timestamps in the `jj debug local-working-copy` output change, so we want
     // to remove them before asserting the snapshot

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -952,9 +952,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
     insta::allow_duplicates! {
         // The modified file should have the same contents it had before (not reset to
         // the base contents)
-        insta::assert_snapshot!(std::fs::read_to_string(secondary_path.join("modified")).unwrap(), @r###"
-        secondary
-        "###);
+        insta::assert_snapshot!(std::fs::read_to_string(secondary_path.join("modified")).unwrap(), @"secondary");
     }
 
     let output = test_env.run_jj_in(&secondary_path, ["evolog"]);

--- a/lib/src/config_resolver.rs
+++ b/lib/src/config_resolver.rs
@@ -663,7 +663,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         let context = ConfigResolutionContext {
             home_dir: None,
@@ -672,9 +672,9 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 3);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.1 foo'");
-        insta::assert_snapshot!(resolved_config.layers()[2].data, @r"a = 'a #0.2 foo|bar'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.1 foo'");
+        insta::assert_snapshot!(resolved_config.layers()[2].data, @"a = 'a #0.2 foo|bar'");
 
         let context = ConfigResolutionContext {
             home_dir: None,
@@ -683,8 +683,8 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 2);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.2 foo|bar'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.2 foo|bar'");
 
         let context = ConfigResolutionContext {
             home_dir: None,
@@ -693,10 +693,10 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 4);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.1 foo'");
-        insta::assert_snapshot!(resolved_config.layers()[2].data, @r"a = 'a #0.2 foo|bar'");
-        insta::assert_snapshot!(resolved_config.layers()[3].data, @r"a = 'a #0.3 foo baz'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.1 foo'");
+        insta::assert_snapshot!(resolved_config.layers()[2].data, @"a = 'a #0.2 foo|bar'");
+        insta::assert_snapshot!(resolved_config.layers()[3].data, @"a = 'a #0.3 foo baz'");
 
         // "fooqux" shares "foo" prefix, but should *not* match
         let context = ConfigResolutionContext {
@@ -706,7 +706,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
     }
 
     #[test]
@@ -727,7 +727,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         // only repo matches
         let context = ConfigResolutionContext {
@@ -737,7 +737,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         // only command matches
         let context = ConfigResolutionContext {
@@ -747,7 +747,7 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
 
         // both match
         let context = ConfigResolutionContext {
@@ -757,8 +757,8 @@ mod tests {
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 2);
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"a = 'a #0'");
-        insta::assert_snapshot!(resolved_config.layers()[1].data, @r"a = 'a #0.1'");
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+        insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a #0.1'");
     }
 
     #[test]

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -751,20 +751,20 @@ mod tests {
 
         insta::assert_debug_snapshot!(parse("all()").unwrap(), @"All");
         insta::assert_debug_snapshot!(parse("none()").unwrap(), @"None");
-        insta::assert_debug_snapshot!(parse("all(x)").unwrap_err().kind(), @r###"
+        insta::assert_debug_snapshot!(parse("all(x)").unwrap_err().kind(), @r#"
         InvalidArguments {
             name: "all",
             message: "Expected 0 arguments",
         }
-        "###);
-        insta::assert_debug_snapshot!(parse("ale()").unwrap_err().kind(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("ale()").unwrap_err().kind(), @r#"
         NoSuchFunction {
             name: "ale",
             candidates: [
                 "all",
             ],
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -777,13 +777,13 @@ mod tests {
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
-        insta::assert_debug_snapshot!(parse("~x").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("~x").unwrap(), @r#"
         Difference(
             All,
             Pattern(PrefixPath("cur/x")),
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("x|y|root:z").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("x|y|root:z").unwrap(), @r#"
         UnionAll(
             [
                 Pattern(PrefixPath("cur/x")),
@@ -791,8 +791,8 @@ mod tests {
                 Pattern(PrefixPath("z")),
             ],
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("x|y&z").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("x|y&z").unwrap(), @r#"
         UnionAll(
             [
                 Pattern(PrefixPath("cur/x")),
@@ -802,7 +802,7 @@ mod tests {
                 ),
             ],
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -847,22 +847,22 @@ mod tests {
         insta::assert_debug_snapshot!(FilesetExpression::all().to_matcher(), @"EverythingMatcher");
         insta::assert_debug_snapshot!(
             FilesetExpression::file_path(repo_path_buf("foo")).to_matcher(),
-            @r###"
+            @r#"
         FilesMatcher {
             tree: Dir {
                 "foo": File {},
             },
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             FilesetExpression::prefix_path(repo_path_buf("foo")).to_matcher(),
-            @r###"
+            @r#"
         PrefixMatcher {
             tree: Dir {
                 "foo": Prefix {},
             },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -922,7 +922,7 @@ mod tests {
             FilesetExpression::file_path(repo_path_buf("foo")),
             FilesetExpression::file_path(repo_path_buf("foo/bar")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         FilesMatcher {
             tree: Dir {
                 "foo": File {
@@ -930,13 +930,13 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
 
         let expr = FilesetExpression::union_all(vec![
             FilesetExpression::prefix_path(repo_path_buf("bar")),
             FilesetExpression::prefix_path(repo_path_buf("bar/baz")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         PrefixMatcher {
             tree: Dir {
                 "bar": Prefix {
@@ -944,7 +944,7 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -956,7 +956,7 @@ mod tests {
             FilesetExpression::file_path(repo_path_buf("foo")),
             FilesetExpression::prefix_path(repo_path_buf("bar")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         UnionMatcher {
             input1: FilesMatcher {
                 tree: Dir {
@@ -969,7 +969,7 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -982,12 +982,12 @@ mod tests {
 
         let expr =
             FilesetExpression::UnionAll(vec![FilesetExpression::None, FilesetExpression::All]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r"
         UnionMatcher {
             input1: NothingMatcher,
             input2: EverythingMatcher,
         }
-        "###);
+        ");
     }
 
     #[test]
@@ -1001,7 +1001,7 @@ mod tests {
             FilesetExpression::file_path(repo_path_buf("foo")),
             FilesetExpression::prefix_path(repo_path_buf("bar")),
         ]);
-        insta::assert_debug_snapshot!(expr.to_matcher(), @r###"
+        insta::assert_debug_snapshot!(expr.to_matcher(), @r#"
         UnionMatcher {
             input1: UnionMatcher {
                 input1: IntersectionMatcher {
@@ -1026,6 +1026,6 @@ mod tests {
                 },
             },
         }
-        "###);
+        "#);
     }
 }

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -725,13 +725,13 @@ mod tests {
 
     #[test]
     fn test_parse_error() {
-        insta::assert_snapshot!(parse_program("foo|").unwrap_err().to_string(), @r###"
+        insta::assert_snapshot!(parse_program("foo|").unwrap_err().to_string(), @r"
          --> 1:5
           |
         1 | foo|
           |     ^---
           |
           = expected `~` or <primary>
-        "###);
+        ");
     }
 }

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -2250,17 +2250,17 @@ mod tests {
         let sig = commit.secure_sig.expect("failed to read the signature");
         assert_eq!(&sig, &returned_sig);
 
-        insta::assert_snapshot!(std::str::from_utf8(&sig.sig).unwrap(), @r###"
+        insta::assert_snapshot!(std::str::from_utf8(&sig.sig).unwrap(), @r"
         test sig
         hash=9ad9526c3b2103c41a229f2f3c82d107a0ecd902f476a855f0e1dd5f7bef1430663de12749b73e293a877113895a8a2a0f29da4bbc5a5f9a19c3523fb0e53518
-        "###);
-        insta::assert_snapshot!(std::str::from_utf8(&sig.data).unwrap(), @r###"
+        ");
+        insta::assert_snapshot!(std::str::from_utf8(&sig.data).unwrap(), @r"
         tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
         author Someone <someone@example.com> 0 +0000
         committer Someone <someone@example.com> 0 +0000
 
         initial
-        "###);
+        ");
     }
 
     fn git_id(commit_id: &CommitId) -> gix::ObjectId {

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -402,7 +402,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph), @r###"
+        insta::assert_snapshot!(format_graph(graph), @r"
         D    direct(C), indirect(B)
         ├─╮
         C ╷  direct(A)
@@ -412,8 +412,7 @@ mod tests {
         │ ~
         │
         A
-
-        "###);
+        ");
     }
 
     fn topo_grouped<I, E>(graph_iter: I) -> TopoGroupedGraphIterator<char, I::IntoIter>
@@ -431,7 +430,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         C  missing(Y)
         │
         ~
@@ -441,8 +440,8 @@ mod tests {
         ~
 
         A
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         C  missing(Y)
         │
         ~
@@ -452,7 +451,7 @@ mod tests {
         ~
 
         A
-        "###);
+        ");
 
         // All nodes can be lazily emitted.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -472,7 +471,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         E  direct(B)
         │
         │ D  direct(A)
@@ -482,11 +481,10 @@ mod tests {
         B │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
         // D-A is found earlier than B-A, but B is emitted first because it belongs to
         // the emitting branch.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         E  direct(B)
         │
         │ C  direct(B)
@@ -496,8 +494,7 @@ mod tests {
         │ D  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // E can be lazy, then D and C will be queued.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -520,7 +517,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         F  direct(D)
         │
         │ E  direct(C)
@@ -532,9 +529,8 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         F  direct(D)
         │
         D  direct(B)
@@ -546,8 +542,7 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
 
         // F can be lazy, then E will be queued, then C.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -573,7 +568,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         I  direct(E)
         │
         │ H  direct(C)
@@ -591,9 +586,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         I  direct(E)
         │
         │ F  direct(E)
@@ -611,8 +605,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // I can be lazy, then H, G, and F will be queued.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -640,7 +633,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         I  direct(A)
         │
         │ H  direct(C)
@@ -662,9 +655,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         I  direct(A)
         │
         │ B  direct(A)
@@ -686,7 +678,7 @@ mod tests {
         E  missing(Y)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -713,7 +705,7 @@ mod tests {
         )
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         G  direct(A)
         │
         │ F  direct(C)
@@ -727,10 +719,9 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
         // A::F is picked at A, and A will be unblocked. Then, C::D at C, ...
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         G  direct(A)
         │
         │ F  direct(C)
@@ -744,8 +735,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // Two nested fork sub graphs from A
         let graph = itertools::chain!(
@@ -756,7 +746,7 @@ mod tests {
         )
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         L  direct(A)
         │
         │ K  direct(H)
@@ -780,10 +770,9 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
         // A::K is picked at A, and A will be unblocked. Then, H::I at H, ...
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         L  direct(A)
         │
         │ K  direct(H)
@@ -807,8 +796,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // Two nested fork sub graphs from A, interleaved
         let graph = itertools::chain!(
@@ -820,7 +808,7 @@ mod tests {
         .sorted_by(|(id1, _), (id2, _)| id2.cmp(id1))
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         L  direct(A)
         │
         │ K  direct(E)
@@ -844,10 +832,9 @@ mod tests {
         │   B  direct(A)
         ├───╯
         A
-
-        "###);
+        ");
         // A::K is picked at A, and A will be unblocked. Then, E::G at E, ...
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         L  direct(A)
         │
         │ K  direct(E)
@@ -871,8 +858,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // Merged fork sub graphs at K
         let graph = itertools::chain!(
@@ -882,7 +868,7 @@ mod tests {
         )
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         K    direct(E), direct(J)
         ├─╮
         │ J  direct(G)
@@ -908,10 +894,10 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
         // K-E,J is resolved without queuing new heads. Then, G::H, F::I, B::C, and
         // A::D.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         K    direct(E), direct(J)
         ├─╮
         │ J  direct(G)
@@ -937,7 +923,7 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
 
         // Merged fork sub graphs at K, interleaved
         let graph = itertools::chain!(
@@ -948,7 +934,7 @@ mod tests {
         .sorted_by(|(id1, _), (id2, _)| id2.cmp(id1))
         .map(Ok)
         .collect_vec();
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         K    direct(I), direct(J)
         ├─╮
         │ J  direct(D)
@@ -974,10 +960,10 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
         // K-I,J is resolved without queuing new heads. Then, D::F, B::H, C::E, and
         // A::G.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         K    direct(I), direct(J)
         ├─╮
         │ J  direct(D)
@@ -1003,7 +989,7 @@ mod tests {
         A  missing(X)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -1017,7 +1003,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         F  direct(E)
         │
         E    direct(C), direct(D)
@@ -1029,9 +1015,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         F  direct(E)
         │
         E    direct(C), direct(D)
@@ -1043,8 +1028,7 @@ mod tests {
         C │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // F, E, and D can be lazy, then C will be queued, then B.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -1068,7 +1052,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         E  direct(D)
         │
         D    missing(Y), direct(C)
@@ -1084,9 +1068,8 @@ mod tests {
           B  direct(A)
           │
           A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         E  direct(D)
         │
         D    missing(Y), direct(C)
@@ -1102,8 +1085,7 @@ mod tests {
           B  direct(A)
           │
           A
-
-        "###);
+        ");
 
         // All nodes can be lazily emitted.
         let mut iter = topo_grouped(graph.iter().cloned().peekable());
@@ -1129,7 +1111,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         G  direct(E)
         │
         │ F  direct(D)
@@ -1143,9 +1125,8 @@ mod tests {
         B   │  direct(A)
         ├───╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         G  direct(E)
         │
         E    direct(B), direct(C)
@@ -1159,8 +1140,7 @@ mod tests {
         B │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1176,7 +1156,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         H  direct(F)
         │
         │ G  direct(E)
@@ -1192,9 +1172,8 @@ mod tests {
         B │  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         H  direct(F)
         │
         F  direct(D)
@@ -1210,8 +1189,7 @@ mod tests {
         C │  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1223,7 +1201,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         D  direct(C)
         │
         C    direct(B), direct(A)
@@ -1233,10 +1211,9 @@ mod tests {
         ~ │
           │
           A
-
-        "###);
+        ");
         // A is emitted first because it's the second parent.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         D  direct(C)
         │
         C    direct(B), direct(A)
@@ -1246,7 +1223,7 @@ mod tests {
         B  missing(X)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -1267,7 +1244,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         J    direct(I), direct(G)
         ├─╮
         I │    direct(H), direct(E)
@@ -1287,10 +1264,9 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
         // Second branches are visited first.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         J    direct(I), direct(G)
         ├─╮
         │ G  direct(D)
@@ -1310,8 +1286,7 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1329,7 +1304,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         J  direct(F)
         │
         │ I  direct(E)
@@ -1349,9 +1324,8 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         J  direct(F)
         │
         F  direct(C)
@@ -1371,8 +1345,7 @@ mod tests {
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1390,7 +1363,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         J  direct(F)
         │
         │ I  direct(G)
@@ -1412,9 +1385,8 @@ mod tests {
         │ ~
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         J  direct(F)
         │
         F  direct(D)
@@ -1436,8 +1408,7 @@ mod tests {
         │ C  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1450,7 +1421,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         E  direct(C)
         │
         │ D  direct(B)
@@ -1462,9 +1433,8 @@ mod tests {
         │ ~
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         E  direct(C)
         │
         C  direct(A)
@@ -1476,7 +1446,7 @@ mod tests {
         B  missing(X)
         │
         ~
-        "###);
+        ");
     }
 
     #[test]
@@ -1493,7 +1463,7 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         I    direct(H), direct(G)
         ├─╮
         H │  direct(D)
@@ -1511,11 +1481,10 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
         // Topological order must be preserved. Depending on the implementation,
         // E might be requested more than once by paths D->E and B->D->E.
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         I    direct(H), direct(G)
         ├─╮
         │ G  direct(B)
@@ -1533,8 +1502,7 @@ mod tests {
         B  direct(A)
         │
         A
-
-        "###);
+        ");
     }
 
     #[test]
@@ -1835,22 +1803,20 @@ mod tests {
             ('A', vec![]),
         ]
         .map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         C    direct(A), direct(B)
         ├─╮
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         C    direct(A), direct(B)
         ├─╮
         │ B  direct(A)
         ├─╯
         A
-
-        "###);
+        ");
 
         // A is queued once by C-A because B isn't populated at this point. Since
         // B is the second parent, B-A is processed next and A is queued again. So
@@ -1870,18 +1836,16 @@ mod tests {
         // The graph shouldn't have duplicated parent->child edges, but topo-grouped
         // iterator can handle it anyway.
         let graph = [('B', vec![direct('A'), direct('A')]), ('A', vec![])].map(Ok);
-        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r###"
+        insta::assert_snapshot!(format_graph(graph.iter().cloned()), @r"
         B  direct(A), direct(A)
         │
         A
-
-        "###);
-        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r###"
+        ");
+        insta::assert_snapshot!(format_graph(topo_grouped(graph.iter().cloned())), @r"
         B  direct(A), direct(A)
         │
         A
-
-        "###);
+        ");
 
         let mut iter = topo_grouped(graph.iter().cloned());
         assert_eq!(iter.next().unwrap().unwrap().0, 'B');

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2825,94 +2825,94 @@ mod tests {
 
         insta::assert_debug_snapshot!(
             current_wc,
-            @r###"CommitRef(WorkingCopy(WorkspaceId("default")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("default")))"#);
         insta::assert_debug_snapshot!(
             current_wc.heads(),
-            @r###"Heads(CommitRef(WorkingCopy(WorkspaceId("default"))))"###);
+            @r#"Heads(CommitRef(WorkingCopy(WorkspaceId("default"))))"#);
         insta::assert_debug_snapshot!(
             current_wc.roots(),
-            @r###"Roots(CommitRef(WorkingCopy(WorkspaceId("default"))))"###);
+            @r#"Roots(CommitRef(WorkingCopy(WorkspaceId("default"))))"#);
         insta::assert_debug_snapshot!(
-            current_wc.parents(), @r###"
+            current_wc.parents(), @r#"
         Ancestors {
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            current_wc.ancestors(), @r###"
+            current_wc.ancestors(), @r#"
         Ancestors {
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.children(), @r###"
+            foo_symbol.children(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.descendants(), @r###"
+            foo_symbol.descendants(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.dag_range_to(&current_wc), @r###"
+            foo_symbol.dag_range_to(&current_wc), @r#"
         DagRange {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.connected(), @r###"
+            foo_symbol.connected(), @r#"
         DagRange {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("foo")),
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.range(&current_wc), @r###"
+            foo_symbol.range(&current_wc), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(WorkingCopy(WorkspaceId("default"))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             foo_symbol.negated(),
-            @r###"NotIn(CommitRef(Symbol("foo")))"###);
+            @r#"NotIn(CommitRef(Symbol("foo")))"#);
         insta::assert_debug_snapshot!(
-            foo_symbol.union(&current_wc), @r###"
+            foo_symbol.union(&current_wc), @r#"
         Union(
             CommitRef(Symbol("foo")),
             CommitRef(WorkingCopy(WorkspaceId("default"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             UserRevsetExpression::union_all(&[]),
             @"None");
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[current_wc.clone()]),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("default")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("default")))"#);
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[current_wc.clone(), foo_symbol.clone()]),
-            @r###"
+            @r#"
         Union(
             CommitRef(WorkingCopy(WorkspaceId("default"))),
             CommitRef(Symbol("foo")),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[
                 current_wc.clone(),
                 foo_symbol.clone(),
                 bar_symbol.clone(),
             ]),
-            @r###"
+            @r#"
         Union(
             CommitRef(WorkingCopy(WorkspaceId("default"))),
             Union(
@@ -2920,7 +2920,7 @@ mod tests {
                 CommitRef(Symbol("bar")),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             RevsetExpression::union_all(&[
                 current_wc.clone(),
@@ -2928,7 +2928,7 @@ mod tests {
                 bar_symbol.clone(),
                 baz_symbol.clone(),
             ]),
-            @r###"
+            @r#"
         Union(
             Union(
                 CommitRef(WorkingCopy(WorkspaceId("default"))),
@@ -2939,27 +2939,27 @@ mod tests {
                 CommitRef(Symbol("baz")),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.intersection(&current_wc), @r###"
+            foo_symbol.intersection(&current_wc), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(WorkingCopy(WorkspaceId("default"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            foo_symbol.minus(&current_wc), @r###"
+            foo_symbol.minus(&current_wc), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(WorkingCopy(WorkspaceId("default"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             UserRevsetExpression::coalesce(&[]),
             @"None");
         insta::assert_debug_snapshot!(
             RevsetExpression::coalesce(&[current_wc.clone()]),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("default")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("default")))"#);
         insta::assert_debug_snapshot!(
             RevsetExpression::coalesce(&[current_wc.clone(), foo_symbol.clone()]),
             @r#"
@@ -2998,33 +2998,33 @@ mod tests {
             @"WorkingCopyWithoutWorkspace");
         insta::assert_debug_snapshot!(
             parse("main@").unwrap(),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("main")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("main")))"#);
         insta::assert_debug_snapshot!(
             parse_with_workspace("@", &main_workspace_id).unwrap(),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("main")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("main")))"#);
         insta::assert_debug_snapshot!(
             parse_with_workspace("main@", &other_workspace_id).unwrap(),
-            @r###"CommitRef(WorkingCopy(WorkspaceId("main")))"###);
+            @r#"CommitRef(WorkingCopy(WorkspaceId("main")))"#);
         // "@" in function argument must be quoted
         insta::assert_debug_snapshot!(
             parse("author_name(foo@)").unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"author_name("foo@")"#).unwrap(),
             @r#"Filter(AuthorName(Substring("foo@")))"#);
         // Parse a single symbol
         insta::assert_debug_snapshot!(
             parse("foo").unwrap(),
-            @r###"CommitRef(Symbol("foo"))"###);
+            @r#"CommitRef(Symbol("foo"))"#);
         // Default arguments for *bookmarks() are all ""
         insta::assert_debug_snapshot!(
             parse("bookmarks()").unwrap(),
-            @r###"CommitRef(Bookmarks(Substring("")))"###);
+            @r#"CommitRef(Bookmarks(Substring("")))"#);
         // Default argument for tags() is ""
         insta::assert_debug_snapshot!(
             parse("tags()").unwrap(),
-            @r###"CommitRef(Tags(Substring("")))"###);
-        insta::assert_debug_snapshot!(parse("remote_bookmarks()").unwrap(), @r###"
+            @r#"CommitRef(Tags(Substring("")))"#);
+        insta::assert_debug_snapshot!(parse("remote_bookmarks()").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3032,8 +3032,8 @@ mod tests {
                 remote_ref_state: None,
             },
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("tracked_remote_bookmarks()").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("tracked_remote_bookmarks()").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3041,8 +3041,8 @@ mod tests {
                 remote_ref_state: Some(Tracking),
             },
         )
-        "###);
-        insta::assert_debug_snapshot!(parse("untracked_remote_bookmarks()").unwrap(), @r###"
+        "#);
+        insta::assert_debug_snapshot!(parse("untracked_remote_bookmarks()").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3050,46 +3050,46 @@ mod tests {
                 remote_ref_state: Some(New),
             },
         )
-        "###);
+        "#);
         // Parse a quoted symbol
         insta::assert_debug_snapshot!(
             parse("'foo'").unwrap(),
-            @r###"CommitRef(Symbol("foo"))"###);
+            @r#"CommitRef(Symbol("foo"))"#);
         // Parse the "parents" operator
-        insta::assert_debug_snapshot!(parse("foo-").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo-").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         // Parse the "children" operator
-        insta::assert_debug_snapshot!(parse("foo+").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo+").unwrap(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         // Parse the "ancestors" operator
-        insta::assert_debug_snapshot!(parse("::foo").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("::foo").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         // Parse the "descendants" operator
-        insta::assert_debug_snapshot!(parse("foo::").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo::").unwrap(), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         // Parse the "dag range" operator
-        insta::assert_debug_snapshot!(parse("foo::bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo::bar").unwrap(), @r#"
         DagRange {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
         }
-        "###);
+        "#);
         // Parse the nullary "dag range" operator
         insta::assert_debug_snapshot!(parse("::").unwrap(), @"All");
         // Parse the "range" prefix operator
@@ -3107,13 +3107,13 @@ mod tests {
             generation: 0..18446744073709551615,
         }
         "#);
-        insta::assert_debug_snapshot!(parse("foo..bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo..bar").unwrap(), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         // Parse the nullary "range" operator
         insta::assert_debug_snapshot!(parse("..").unwrap(), @r"
         Range {
@@ -3125,28 +3125,28 @@ mod tests {
         // Parse the "negate" operator
         insta::assert_debug_snapshot!(
             parse("~ foo").unwrap(),
-            @r###"NotIn(CommitRef(Symbol("foo")))"###);
+            @r#"NotIn(CommitRef(Symbol("foo")))"#);
         // Parse the "intersection" operator
-        insta::assert_debug_snapshot!(parse("foo & bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo & bar").unwrap(), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
         // Parse the "union" operator
-        insta::assert_debug_snapshot!(parse("foo | bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo | bar").unwrap(), @r#"
         Union(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
         // Parse the "difference" operator
-        insta::assert_debug_snapshot!(parse("foo ~ bar").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parse("foo ~ bar").unwrap(), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3155,17 +3155,17 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse_with_modifier("all:foo").unwrap(), @r###"
+            parse_with_modifier("all:foo").unwrap(), @r#"
         (
             CommitRef(Symbol("foo")),
             Some(All),
         )
-        "###);
+        "#);
 
         // Top-level string pattern can't be parsed, which is an error anyway
         insta::assert_debug_snapshot!(
             parse_with_modifier(r#"exact:"foo""#).unwrap_err().kind(),
-            @r###"NoSuchModifier("exact")"###);
+            @r#"NoSuchModifier("exact")"#);
     }
 
     #[test]
@@ -3175,41 +3175,41 @@ mod tests {
 
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks("foo")"#).unwrap(),
-            @r###"CommitRef(Bookmarks(Substring("foo")))"###);
+            @r#"CommitRef(Bookmarks(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(exact:"foo")"#).unwrap(),
-            @r###"CommitRef(Bookmarks(Exact("foo")))"###);
+            @r#"CommitRef(Bookmarks(Exact("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(substring:"foo")"#).unwrap(),
-            @r###"CommitRef(Bookmarks(Substring("foo")))"###);
+            @r#"CommitRef(Bookmarks(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(bad:"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Invalid string pattern")"###);
+            @r#"Expression("Invalid string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(exact::"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"bookmarks(exact:"foo"+)"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
 
         insta::assert_debug_snapshot!(
             parse(r#"tags("foo")"#).unwrap(),
-            @r###"CommitRef(Tags(Substring("foo")))"###);
+            @r#"CommitRef(Tags(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(exact:"foo")"#).unwrap(),
-            @r###"CommitRef(Tags(Exact("foo")))"###);
+            @r#"CommitRef(Tags(Exact("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(substring:"foo")"#).unwrap(),
-            @r###"CommitRef(Tags(Substring("foo")))"###);
+            @r#"CommitRef(Tags(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(bad:"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Invalid string pattern")"###);
+            @r#"Expression("Invalid string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(exact::"foo")"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse(r#"tags(exact:"foo"+)"#).unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
 
         // String pattern isn't allowed at top level.
         assert_matches!(
@@ -3224,21 +3224,21 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse("parents(foo)").unwrap(), @r###"
+            parse("parents(foo)").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("parents(\"foo\")").unwrap(), @r###"
+            parse("parents(\"foo\")").unwrap(), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("ancestors(parents(foo))").unwrap(), @r###"
+            parse("ancestors(parents(foo))").unwrap(), @r#"
         Ancestors {
             heads: Ancestors {
                 heads: CommitRef(Symbol("foo")),
@@ -3246,30 +3246,30 @@ mod tests {
             },
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("parents(foo,foo)").unwrap_err().kind(), @r###"
+            parse("parents(foo,foo)").unwrap_err().kind(), @r#"
         InvalidFunctionArguments {
             name: "parents",
             message: "Expected 1 arguments",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse("root()").unwrap(),
             @"Root");
         assert!(parse("root(a)").is_err());
         insta::assert_debug_snapshot!(
             parse(r#"description("")"#).unwrap(),
-            @r###"Filter(Description(Substring("")))"###);
+            @r#"Filter(Description(Substring("")))"#);
         insta::assert_debug_snapshot!(
             parse("description(foo)").unwrap(),
-            @r###"Filter(Description(Substring("foo")))"###);
+            @r#"Filter(Description(Substring("foo")))"#);
         insta::assert_debug_snapshot!(
             parse("description(visible_heads())").unwrap_err().kind(),
-            @r###"Expression("Expected expression of string pattern")"###);
+            @r#"Expression("Expected expression of string pattern")"#);
         insta::assert_debug_snapshot!(
             parse("description(\"(foo)\")").unwrap(),
-            @r###"Filter(Description(Substring("(foo)")))"###);
+            @r#"Filter(Description(Substring("(foo)")))"#);
         assert!(parse("mine(foo)").is_err());
         insta::assert_debug_snapshot!(
             parse_with_workspace("empty()", &WorkspaceId::default()).unwrap(),
@@ -3278,15 +3278,15 @@ mod tests {
         assert!(parse_with_workspace("file()", &WorkspaceId::default()).is_err());
         insta::assert_debug_snapshot!(
             parse_with_workspace("file(foo)", &WorkspaceId::default()).unwrap(),
-            @r###"Filter(File(Pattern(PrefixPath("foo"))))"###);
+            @r#"Filter(File(Pattern(PrefixPath("foo"))))"#);
         insta::assert_debug_snapshot!(
             parse_with_workspace("file(all())", &WorkspaceId::default()).unwrap(),
             @"Filter(File(All))");
         insta::assert_debug_snapshot!(
             parse_with_workspace(r#"file(file:"foo")"#, &WorkspaceId::default()).unwrap(),
-            @r###"Filter(File(Pattern(FilePath("foo"))))"###);
+            @r#"Filter(File(Pattern(FilePath("foo"))))"#);
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(foo|bar&baz)", &WorkspaceId::default()).unwrap(), @r###"
+            parse_with_workspace("file(foo|bar&baz)", &WorkspaceId::default()).unwrap(), @r#"
         Filter(
             File(
                 UnionAll(
@@ -3300,9 +3300,9 @@ mod tests {
                 ),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(foo, bar, baz)", &WorkspaceId::default()).unwrap(), @r###"
+            parse_with_workspace("file(foo, bar, baz)", &WorkspaceId::default()).unwrap(), @r#"
         Filter(
             File(
                 UnionAll(
@@ -3314,7 +3314,7 @@ mod tests {
                 ),
             ),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3361,7 +3361,7 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse("remote_bookmarks(remote=foo)").unwrap(), @r###"
+            parse("remote_bookmarks(remote=foo)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
@@ -3369,9 +3369,9 @@ mod tests {
                 remote_ref_state: None,
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("remote_bookmarks(foo, remote=bar)").unwrap(), @r###"
+            parse("remote_bookmarks(foo, remote=bar)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring("foo"),
@@ -3379,9 +3379,9 @@ mod tests {
                 remote_ref_state: None,
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("tracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r###"
+            parse("tracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring("foo"),
@@ -3389,9 +3389,9 @@ mod tests {
                 remote_ref_state: Some(Tracking),
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            parse("untracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r###"
+            parse("untracked_remote_bookmarks(foo, remote=bar)").unwrap(), @r#"
         CommitRef(
             RemoteBookmarks {
                 bookmark_pattern: Substring("foo"),
@@ -3399,39 +3399,39 @@ mod tests {
                 remote_ref_state: Some(New),
             },
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks(remote=foo, bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Positional argument follows keyword argument",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks("", foo, remote=bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Got multiple values for keyword \"remote\"",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks(remote=bar, remote=bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Got multiple values for keyword \"remote\"",
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             parse(r#"remote_bookmarks(unknown=bar)"#).unwrap_err().kind(),
-            @r###"
+            @r#"
         InvalidFunctionArguments {
             name: "remote_bookmarks",
             message: "Unexpected keyword argument \"unknown\"",
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -3440,7 +3440,7 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         insta::assert_debug_snapshot!(
-            parse_with_aliases("AB|c", [("AB", "a|b")]).unwrap(), @r###"
+            parse_with_aliases("AB|c", [("AB", "a|b")]).unwrap(), @r#"
         Union(
             Union(
                 CommitRef(Symbol("a")),
@@ -3448,13 +3448,13 @@ mod tests {
             ),
             CommitRef(Symbol("c")),
         )
-        "###);
+        "#);
 
         // Alias can be substituted to string literal.
         insta::assert_debug_snapshot!(
             parse_with_aliases_and_workspace("file(A)", [("A", "a")], &WorkspaceId::default())
                 .unwrap(),
-            @r###"Filter(File(Pattern(PrefixPath("a"))))"###);
+            @r#"Filter(File(Pattern(PrefixPath("a"))))"#);
 
         // Alias can be substituted to string pattern.
         insta::assert_debug_snapshot!(
@@ -3497,77 +3497,77 @@ mod tests {
         // (e.g. Range -> DagRange) nor reorders arguments unintentionally.
 
         insta::assert_debug_snapshot!(
-            optimize(parse("parents(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("parents(bookmarks() & all())").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Bookmarks(Substring(""))),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("children(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("children(bookmarks() & all())").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Bookmarks(Substring(""))),
             generation: 1..2,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("ancestors(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("ancestors(bookmarks() & all())").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Bookmarks(Substring(""))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("descendants(bookmarks() & all())").unwrap()), @r###"
+            optimize(parse("descendants(bookmarks() & all())").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Bookmarks(Substring(""))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all())..(all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all())..(all() & tags())").unwrap()), @r#"
         Range {
             roots: CommitRef(Bookmarks(Substring(""))),
             heads: CommitRef(Tags(Substring(""))),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all())::(all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all())::(all() & tags())").unwrap()), @r#"
         DagRange {
             roots: CommitRef(Bookmarks(Substring(""))),
             heads: CommitRef(Tags(Substring(""))),
         }
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
             optimize(parse("heads(bookmarks() & all())").unwrap()),
-            @r###"Heads(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"Heads(CommitRef(Bookmarks(Substring(""))))"#);
         insta::assert_debug_snapshot!(
             optimize(parse("roots(bookmarks() & all())").unwrap()),
-            @r###"Roots(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"Roots(CommitRef(Bookmarks(Substring(""))))"#);
 
         insta::assert_debug_snapshot!(
-            optimize(parse("latest(bookmarks() & all(), 2)").unwrap()), @r###"
+            optimize(parse("latest(bookmarks() & all(), 2)").unwrap()), @r#"
         Latest {
             candidates: CommitRef(Bookmarks(Substring(""))),
             count: 2,
         }
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
-            optimize(parse("present(foo ~ bar)").unwrap()), @r###"
+            optimize(parse("present(foo ~ bar)").unwrap()), @r#"
         Present(
             Difference(
                 CommitRef(Symbol("foo")),
                 CommitRef(Symbol("bar")),
             ),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
             optimize(parse("present(bookmarks() & all())").unwrap()),
-            @r###"Present(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"Present(CommitRef(Bookmarks(Substring(""))))"#);
 
         insta::assert_debug_snapshot!(
             optimize(parse("at_operation(@-, bookmarks() & all())").unwrap()), @r#"
@@ -3591,28 +3591,28 @@ mod tests {
 
         insta::assert_debug_snapshot!(
             optimize(parse("~bookmarks() & all()").unwrap()),
-            @r###"NotIn(CommitRef(Bookmarks(Substring(""))))"###);
+            @r#"NotIn(CommitRef(Bookmarks(Substring(""))))"#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all()) | (all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all()) | (all() & tags())").unwrap()), @r#"
         Union(
             CommitRef(Bookmarks(Substring(""))),
             CommitRef(Tags(Substring(""))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all()) & (all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all()) & (all() & tags())").unwrap()), @r#"
         Intersection(
             CommitRef(Bookmarks(Substring(""))),
             CommitRef(Tags(Substring(""))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(
-            optimize(parse("(bookmarks() & all()) ~ (all() & tags())").unwrap()), @r###"
+            optimize(parse("(bookmarks() & all()) ~ (all() & tags())").unwrap()), @r#"
         Difference(
             CommitRef(Bookmarks(Substring(""))),
             CommitRef(Tags(Substring(""))),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3669,19 +3669,19 @@ mod tests {
         let settings = insta_settings();
         let _guard = settings.bind_to_scope();
 
-        insta::assert_debug_snapshot!(optimize(parse("foo & ~bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~foo & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~foo & bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("bar")),
             CommitRef(Symbol("foo")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~foo & bar & ~baz").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~foo & bar & ~baz").unwrap()), @r#"
         Difference(
             Difference(
                 CommitRef(Symbol("bar")),
@@ -3689,46 +3689,46 @@ mod tests {
             ),
             CommitRef(Symbol("baz")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(all() & ~foo) & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(all() & ~foo) & bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("bar")),
             CommitRef(Symbol("foo")),
         )
-        "###);
+        "#);
 
         // Binary difference operation should go through the same optimization passes.
         insta::assert_debug_snapshot!(
             optimize(parse("all() ~ foo").unwrap()),
-            @r###"NotIn(CommitRef(Symbol("foo")))"###);
-        insta::assert_debug_snapshot!(optimize(parse("foo ~ bar").unwrap()), @r###"
+            @r#"NotIn(CommitRef(Symbol("foo")))"#);
+        insta::assert_debug_snapshot!(optimize(parse("foo ~ bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(all() ~ foo) & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(all() ~ foo) & bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("bar")),
             CommitRef(Symbol("foo")),
         )
-        "###);
+        "#);
 
         // Range expression.
-        insta::assert_debug_snapshot!(optimize(parse("::foo & ~::bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("::foo & ~::bar").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("bar")),
             heads: CommitRef(Symbol("foo")),
             generation: 0..18446744073709551615,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~::foo & ::bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~::foo & ::bar").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
         insta::assert_debug_snapshot!(optimize(parse("foo..").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
@@ -3736,41 +3736,41 @@ mod tests {
             generation: 0..18446744073709551615,
         }
         "#);
-        insta::assert_debug_snapshot!(optimize(parse("foo..bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo..bar").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
 
         // Double/triple negates.
-        insta::assert_debug_snapshot!(optimize(parse("foo & ~~bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~~bar").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("foo & ~~~bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("foo & ~~~bar").unwrap()), @r#"
         Difference(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~(all() & ~foo) & bar").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~(all() & ~foo) & bar").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
 
         // Should be better than '(all() & ~foo) & (all() & ~bar)'.
-        insta::assert_debug_snapshot!(optimize(parse("~foo & ~bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("~foo & ~bar").unwrap()), @r#"
         Difference(
             NotIn(CommitRef(Symbol("foo"))),
             CommitRef(Symbol("bar")),
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3810,22 +3810,22 @@ mod tests {
         "#);
 
         // Bounded ancestors shouldn't be substituted.
-        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo, 1)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo, 1)").unwrap()), @r#"
         NotIn(
             Ancestors {
                 heads: CommitRef(Symbol("foo")),
                 generation: 0..1,
             },
         )
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo-, 1)").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("~ancestors(foo-, 1)").unwrap()), @r#"
         NotIn(
             Ancestors {
                 heads: CommitRef(Symbol("foo")),
                 generation: 1..2,
             },
         )
-        "###);
+        "#);
     }
 
     #[test]
@@ -3888,12 +3888,12 @@ mod tests {
             optimize(parse("author_name(foo)").unwrap()),
             @r#"Filter(AuthorName(Substring("foo")))"#);
 
-        insta::assert_debug_snapshot!(optimize(parse("foo & description(bar)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo & description(bar)").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("foo")),
             Filter(Description(Substring("bar"))),
         )
-        "###);
+        "#);
         insta::assert_debug_snapshot!(optimize(parse("author_name(foo) & bar").unwrap()), @r#"
         Intersection(
             CommitRef(Symbol("bar")),
@@ -3954,7 +3954,7 @@ mod tests {
             Filter(AuthorName(Substring("baz"))),
         )
         "#);
-        insta::assert_debug_snapshot!(optimize(parse_with_workspace("foo & file(bar) & baz", &WorkspaceId::default()).unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse_with_workspace("foo & file(bar) & baz", &WorkspaceId::default()).unwrap()), @r#"
         Intersection(
             Intersection(
                 CommitRef(Symbol("foo")),
@@ -3962,7 +3962,7 @@ mod tests {
             ),
             Filter(File(Pattern(PrefixPath("bar")))),
         )
-        "###);
+        "#);
 
         insta::assert_debug_snapshot!(
             optimize(parse("foo & description(bar) & author_name(baz) & qux").unwrap()), @r#"
@@ -4190,27 +4190,27 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         // Typical scenario: fold nested parents()
-        insta::assert_debug_snapshot!(optimize(parse("foo--").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo--").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 2..3,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("::(foo---)").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("::(foo---)").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(::foo)---").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(::foo)---").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
+        "#);
 
         // 'foo-+' is not 'foo'.
-        insta::assert_debug_snapshot!(optimize(parse("foo---+").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo---+").unwrap()), @r#"
         Descendants {
             roots: Ancestors {
                 heads: CommitRef(Symbol("foo")),
@@ -4218,18 +4218,18 @@ mod tests {
             },
             generation: 1..2,
         }
-        "###);
+        "#);
 
         // For 'roots..heads', heads can be folded.
-        insta::assert_debug_snapshot!(optimize(parse("foo..(bar--)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo..(bar--)").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: CommitRef(Symbol("bar")),
             generation: 2..18446744073709551615,
         }
-        "###);
+        "#);
         // roots can also be folded, and the range expression is reconstructed.
-        insta::assert_debug_snapshot!(optimize(parse("(foo--)..(bar---)").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("(foo--)..(bar---)").unwrap()), @r#"
         Range {
             roots: Ancestors {
                 heads: CommitRef(Symbol("foo")),
@@ -4238,10 +4238,10 @@ mod tests {
             heads: CommitRef(Symbol("bar")),
             generation: 3..18446744073709551615,
         }
-        "###);
+        "#);
         // Bounded ancestors shouldn't be substituted to range.
         insta::assert_debug_snapshot!(
-            optimize(parse("~ancestors(foo, 2) & ::bar").unwrap()), @r###"
+            optimize(parse("~ancestors(foo, 2) & ::bar").unwrap()), @r#"
         Difference(
             Ancestors {
                 heads: CommitRef(Symbol("bar")),
@@ -4252,11 +4252,11 @@ mod tests {
                 generation: 0..2,
             },
         )
-        "###);
+        "#);
 
         // If inner range is bounded by roots, it cannot be merged.
         // e.g. '..(foo..foo)' is equivalent to '..none()', not to '..foo'
-        insta::assert_debug_snapshot!(optimize(parse("(foo..bar)--").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("(foo..bar)--").unwrap()), @r#"
         Ancestors {
             heads: Range {
                 roots: CommitRef(Symbol("foo")),
@@ -4265,8 +4265,8 @@ mod tests {
             },
             generation: 2..3,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("foo..(bar..baz)").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("foo..(bar..baz)").unwrap()), @r#"
         Range {
             roots: CommitRef(Symbol("foo")),
             heads: Range {
@@ -4276,24 +4276,24 @@ mod tests {
             },
             generation: 0..18446744073709551615,
         }
-        "###);
+        "#);
 
         // Ancestors of empty generation range should be empty.
         insta::assert_debug_snapshot!(
-            optimize(parse("ancestors(ancestors(foo), 0)").unwrap()), @r###"
+            optimize(parse("ancestors(ancestors(foo), 0)").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 0..0,
         }
-        "###
+        "#
         );
         insta::assert_debug_snapshot!(
-            optimize(parse("ancestors(ancestors(foo, 0))").unwrap()), @r###"
+            optimize(parse("ancestors(ancestors(foo, 0))").unwrap()), @r#"
         Ancestors {
             heads: CommitRef(Symbol("foo")),
             generation: 0..0,
         }
-        "###
+        "#
         );
     }
 
@@ -4303,27 +4303,27 @@ mod tests {
         let _guard = settings.bind_to_scope();
 
         // Typical scenario: fold nested children()
-        insta::assert_debug_snapshot!(optimize(parse("foo++").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo++").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 2..3,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(foo+++)::").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(foo+++)::").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
-        insta::assert_debug_snapshot!(optimize(parse("(foo::)+++").unwrap()), @r###"
+        "#);
+        insta::assert_debug_snapshot!(optimize(parse("(foo::)+++").unwrap()), @r#"
         Descendants {
             roots: CommitRef(Symbol("foo")),
             generation: 3..18446744073709551615,
         }
-        "###);
+        "#);
 
         // 'foo+-' is not 'foo'.
-        insta::assert_debug_snapshot!(optimize(parse("foo+++-").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("foo+++-").unwrap()), @r#"
         Ancestors {
             heads: Descendants {
                 roots: CommitRef(Symbol("foo")),
@@ -4331,12 +4331,12 @@ mod tests {
             },
             generation: 1..2,
         }
-        "###);
+        "#);
 
         // TODO: Inner Descendants can be folded into DagRange. Perhaps, we can rewrite
         // 'x::y' to 'x:: & ::y' first, so the common substitution rule can handle both
         // 'x+::y' and 'x+ & ::y'.
-        insta::assert_debug_snapshot!(optimize(parse("(foo++)::bar").unwrap()), @r###"
+        insta::assert_debug_snapshot!(optimize(parse("(foo++)::bar").unwrap()), @r#"
         DagRange {
             roots: Descendants {
                 roots: CommitRef(Symbol("foo")),
@@ -4344,7 +4344,7 @@ mod tests {
             },
             heads: CommitRef(Symbol("bar")),
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/lib/tests/test_annotate.rs
+++ b/lib/tests/test_annotate.rs
@@ -124,18 +124,18 @@ fn test_annotate_linear() {
     drop(create_commit);
 
     insta::assert_snapshot!(annotate(tx.repo(), &commit1, file_path), @"");
-    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path), @r"
     commit2: 2a
     commit2: 2b
-    "#);
-    insta::assert_snapshot!(annotate(tx.repo(), &commit3, file_path), @r#"
+    ");
+    insta::assert_snapshot!(annotate(tx.repo(), &commit3, file_path), @r"
     commit2: 2b
     commit3: 3
-    "#);
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    ");
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2b
     commit3: 3
-    "#);
+    ");
 }
 
 #[test]
@@ -169,11 +169,11 @@ fn test_annotate_merge_simple() {
     let commit4 = create_commit("commit4", &[commit2.id(), commit3.id()], tree4.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2
     commit1: 1
     commit3: 3
-    "#);
+    ");
 
     // Exclude the fork commit and its ancestors.
     let domain = RevsetExpression::commit(commit1.id().clone())
@@ -243,13 +243,13 @@ fn test_annotate_merge_split() {
     let commit4 = create_commit("commit4", &[commit2.id(), commit3.id()], tree4.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2
     commit1: 1a
     commit1: 1b
     commit3: 3
     commit4: 4
-    "#);
+    ");
 }
 
 #[test]
@@ -293,7 +293,7 @@ fn test_annotate_merge_split_interleaved() {
     let commit6 = create_commit("commit6", &[commit4.id(), commit5.id()], tree6.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit6, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit6, file_path), @r"
     commit1: 1a
     commit4: 4
     commit1: 1b
@@ -301,7 +301,7 @@ fn test_annotate_merge_split_interleaved() {
     commit2: 2a
     commit5: 5
     commit2: 2b
-    "#);
+    ");
 }
 
 #[test]
@@ -338,13 +338,13 @@ fn test_annotate_merge_dup() {
     // Both "1"s can be propagated to commit1 through commit2 and commit3.
     // Alternatively, it's also good to interpret that one of the "1"s was
     // produced at commit2, commit3, or commit4.
-    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r#"
+    insta::assert_snapshot!(annotate(tx.repo(), &commit4, file_path), @r"
     commit2: 2
     commit1: 1
     commit1: 1
     commit3: 3
     commit4: 4
-    "#);
+    ");
 
     // For example, the parent tree of commit4 doesn't contain multiple "1"s.
     // If annotation were computed compared to the parent tree, not trees of the
@@ -373,7 +373,5 @@ fn test_annotate_file_directory_transition() {
     let commit2 = create_commit("commit2", &[commit1.id()], tree2.id());
     drop(create_commit);
 
-    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path2), @r#"
-    commit2: 2
-    "#);
+    insta::assert_snapshot!(annotate(tx.repo(), &commit2, file_path2), @"commit2: 2");
 }

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -79,7 +79,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -93,7 +93,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
     // Swap the positive terms in the conflict. The diff should still use the right
     // side, but now the right side should come first.
@@ -103,7 +103,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -117,7 +117,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
     // Test materializing "snapshot" conflict markers
     let conflict = Merge::from_removes_adds(
@@ -126,7 +126,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot),
-        @r##"
+        @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -141,7 +141,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "##
+    "
     );
     // Test materializing "git" conflict markers
     let conflict = Merge::from_removes_adds(
@@ -150,7 +150,7 @@ fn test_materialize_conflict_basic() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Git),
-        @r##"
+        @r"
     line 1
     line 2
     <<<<<<< Side #1 (Conflict 1 of 1)
@@ -164,7 +164,7 @@ fn test_materialize_conflict_basic() {
     >>>>>>> Side #2 (Conflict 1 of 1 ends)
     line 4
     line 5
-    "##
+    "
     );
 }
 
@@ -234,7 +234,7 @@ fn test_materialize_conflict_three_sides() {
     // Test materializing "diff" conflict markers
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -252,12 +252,12 @@ fn test_materialize_conflict_three_sides() {
     +line 3 c.2
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##
+    "
     );
     // Test materializing "snapshot" conflict markers
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot),
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
@@ -279,13 +279,13 @@ fn test_materialize_conflict_three_sides() {
     line 3 c.2
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##
+    "
     );
     // Test materializing "git" conflict markers (falls back to "snapshot" since
     // "git" conflict markers don't support more than 2 sides)
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Git),
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
@@ -307,7 +307,7 @@ fn test_materialize_conflict_three_sides() {
     line 3 c.2
     >>>>>>> Conflict 1 of 1 ends
     line 5
-    "##
+    "
     );
 }
 
@@ -366,7 +366,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
@@ -382,7 +382,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     +line 2 c.1
     >>>>>>> Conflict 1 of 1 ends
     line 3
-    "###
+    "
     );
     let conflict = Merge::from_removes_adds(
         vec![Some(base_id.clone()), Some(base_id.clone())],
@@ -390,7 +390,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -406,7 +406,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     line 2 a.3
     >>>>>>> Conflict 1 of 1 ends
     line 3
-    "###
+    "
     );
     let conflict = Merge::from_removes_adds(
         vec![Some(base_id.clone()), Some(base_id.clone())],
@@ -414,7 +414,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base #1 to side #1
@@ -430,7 +430,7 @@ fn test_materialize_conflict_multi_rebase_conflicts() {
     +line 2 b.2
     >>>>>>> Conflict 1 of 1 ends
     line 3
-    "###
+    "
     );
 }
 
@@ -483,7 +483,7 @@ fn test_materialize_parse_roundtrip() {
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(
         materialized,
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
     line 1 left
@@ -503,13 +503,13 @@ fn test_materialize_parse_roundtrip() {
     line 4 right
     line 5 right
     >>>>>>> Conflict 2 of 2 ends
-    "###
+    "
     );
 
     // The first add should always be from the left side
     insta::assert_debug_snapshot!(
         parse_conflict(materialized.as_bytes(), conflict.num_sides(), MIN_CONFLICT_MARKER_LEN),
-        @r###"
+        @r#"
     Some(
         [
             Conflicted(
@@ -531,7 +531,7 @@ fn test_materialize_parse_roundtrip() {
             ),
         ],
     )
-    "###);
+    "#);
 }
 
 #[test]
@@ -627,14 +627,14 @@ fn test_materialize_conflict_no_newlines_at_eof() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1 (adds terminating newline)
     -base
     +++++++ Contents of side #2 (no terminating newline)
     right
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     // The conflict markers are parsed with the trailing newline, but it is removed
     // by `update_from_content`
@@ -703,7 +703,7 @@ fn test_materialize_conflict_modify_delete() {
         vec![Some(base_id.clone())],
         vec![Some(modified_id.clone()), Some(deleted_id.clone())],
     );
-    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r###"
+    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -714,7 +714,7 @@ fn test_materialize_conflict_modify_delete() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
 
     // right modifies a line, left deletes the same line.
@@ -722,7 +722,7 @@ fn test_materialize_conflict_modify_delete() {
         vec![Some(base_id.clone())],
         vec![Some(deleted_id.clone()), Some(modified_id.clone())],
     );
-    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r###"
+    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r"
     line 1
     line 2
     <<<<<<< Conflict 1 of 1
@@ -733,7 +733,7 @@ fn test_materialize_conflict_modify_delete() {
     >>>>>>> Conflict 1 of 1 ends
     line 4
     line 5
-    "###
+    "
     );
 
     // modify/delete conflict at the file level
@@ -741,7 +741,7 @@ fn test_materialize_conflict_modify_delete() {
         vec![Some(base_id.clone())],
         vec![Some(modified_id.clone()), None],
     );
-    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r###"
+    insta::assert_snapshot!(&materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
      line 1
@@ -752,7 +752,7 @@ fn test_materialize_conflict_modify_delete() {
      line 5
     +++++++ Contents of side #2
     >>>>>>> Conflict 1 of 1 ends
-    "###
+    "
     );
 }
 
@@ -794,7 +794,7 @@ fn test_materialize_conflict_two_forward_diffs() {
     );
     insta::assert_snapshot!(
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff),
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     A
@@ -807,7 +807,7 @@ fn test_materialize_conflict_two_forward_diffs() {
     ------- Contents of base #3
     E
     >>>>>>> Conflict 1 of 1 ends
-    "###
+    "
     );
 }
 
@@ -848,7 +848,7 @@ fn test_parse_conflict_simple() {
             2,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -866,7 +866,7 @@ fn test_parse_conflict_simple() {
             ),
         ],
     )
-    "###
+    "#
     );
     insta::assert_debug_snapshot!(
         parse_conflict(indoc! {b"
@@ -885,7 +885,7 @@ fn test_parse_conflict_simple() {
             2,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -903,7 +903,7 @@ fn test_parse_conflict_simple() {
             ),
         ],
     )
-    "###
+    "#
     );
     // Test "snapshot" style
     insta::assert_debug_snapshot!(
@@ -1127,7 +1127,7 @@ fn test_parse_conflict_multi_way() {
             3,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -1147,7 +1147,7 @@ fn test_parse_conflict_multi_way() {
             ),
         ],
     )
-    "###
+    "#
     );
     insta::assert_debug_snapshot!(
         parse_conflict(indoc! {b"
@@ -1171,7 +1171,7 @@ fn test_parse_conflict_multi_way() {
             3,
             7
         ),
-        @r###"
+        @r#"
     Some(
         [
             Resolved(
@@ -1191,7 +1191,7 @@ fn test_parse_conflict_multi_way() {
             ),
         ],
     )
-    "###
+    "#
     );
     // Test "snapshot" style
     insta::assert_debug_snapshot!(
@@ -1784,7 +1784,7 @@ fn test_update_conflict_from_content_simplified_conflict() {
     };
     insta::assert_snapshot!(
         materialized,
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 2
     %%%%%%% Changes from base to side #1
     -line 1
@@ -1800,7 +1800,7 @@ fn test_update_conflict_from_content_simplified_conflict() {
     +++++++ Contents of side #2
     right 3
     >>>>>>> Conflict 2 of 2 ends
-    "###
+    "
     );
     assert_eq!(parse(materialized.as_bytes()), conflict);
 
@@ -1892,7 +1892,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     assert!(materialized_marker_len > MIN_CONFLICT_MARKER_LEN);
     let materialized =
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot);
-    insta::assert_snapshot!(materialized, @r##"
+    insta::assert_snapshot!(materialized, @r"
     <<<<<<<<<<<<<<<< Conflict 1 of 2
     ++++++++++++++++ Contents of side #1
     <<<< left 1
@@ -1910,7 +1910,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     ++++++++++++++++ Contents of side #2
     >>>>>>>>>>>> right 3
     >>>>>>>>>>>>>>>> Conflict 2 of 2 ends
-    "##
+    "
     );
 
     // Parse the conflict markers using a different conflict marker style. This is
@@ -1977,21 +1977,21 @@ fn test_update_conflict_from_content_with_long_markers() {
     let [new_left_side, new_base, new_right_side] = new_conflict_terms.as_slice() else {
         unreachable!()
     };
-    insta::assert_snapshot!(new_left_side, @r#"
+    insta::assert_snapshot!(new_left_side, @r"
     <<<< left 1
     line 2
     line 3
-    "#);
-    insta::assert_snapshot!(new_base, @r#"
+    ");
+    insta::assert_snapshot!(new_base, @r"
     line 1
     line 2
     line 3
-    "#);
-    insta::assert_snapshot!(new_right_side, @r#"
+    ");
+    insta::assert_snapshot!(new_right_side, @r"
     >>>>>>> right 1
     line 2
     line 3
-    "#);
+    ");
 
     // The conflict markers should still parse in future snapshots even though
     // they're now longer than necessary
@@ -2009,7 +2009,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     // conflict markers now
     insta::assert_snapshot!(
         materialize_conflict_string(store, path, &new_conflict, ConflictMarkerStyle::Snapshot),
-        @r##"
+        @r"
     <<<<<<<<<<< Conflict 1 of 1
     +++++++++++ Contents of side #1
     <<<< left 1
@@ -2020,7 +2020,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     >>>>>>>>>>> Conflict 1 of 1 ends
     line 2
     line 3
-    "##
+    "
     );
 }
 
@@ -2043,7 +2043,7 @@ fn test_update_conflict_from_content_no_eol() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 2
     %%%%%%% Changes from base to side #1
@@ -2061,7 +2061,7 @@ fn test_update_conflict_from_content_no_eol() {
     -base
     +right
     >>>>>>> Conflict 2 of 2 ends
-    "##
+    "
     );
     // Parse with "snapshot" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2081,7 +2081,7 @@ fn test_update_conflict_from_content_no_eol() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Snapshot);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 2
     +++++++ Contents of side #1
@@ -2101,7 +2101,7 @@ fn test_update_conflict_from_content_no_eol() {
     +++++++ Contents of side #2 (no terminating newline)
     right
     >>>>>>> Conflict 2 of 2 ends
-    "##
+    "
     );
     // Parse with "diff" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2121,7 +2121,7 @@ fn test_update_conflict_from_content_no_eol() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Git);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Side #1 (Conflict 1 of 2)
     line 2 left
@@ -2139,7 +2139,7 @@ fn test_update_conflict_from_content_no_eol() {
     =======
     right
     >>>>>>> Side #2 (Conflict 2 of 2 ends)
-    "##
+    "
     );
     // Parse with "diff" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2193,7 +2193,7 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     <<<<<<< Conflict 1 of 1
     +++++++ Contents of side #1
     side
@@ -2214,7 +2214,7 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
     -line 1
     +line 2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     // Parse with "snapshot" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2250,7 +2250,7 @@ fn test_update_conflict_from_content_only_no_eol_change() {
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     insta::assert_snapshot!(materialized,
-        @r##"
+        @r"
     line 1
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1 (removes terminating newline)
@@ -2258,7 +2258,7 @@ fn test_update_conflict_from_content_only_no_eol_change() {
     +++++++ Contents of side #2
     line 2
     >>>>>>> Conflict 1 of 1 ends
-    "##
+    "
     );
     // Parse with "snapshot" markers to ensure the file is actually parsed
     assert_eq!(
@@ -2330,7 +2330,7 @@ fn test_update_from_content_malformed_conflict() {
 
     let materialized =
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
-    insta::assert_snapshot!(materialized, @r##"
+    insta::assert_snapshot!(materialized, @r"
     line 1
     <<<<<<< Conflict 1 of 2
     %%%%%%% Changes from base to side #1
@@ -2348,7 +2348,7 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##
+    "
     );
 
     let parse = |conflict, content| {
@@ -2400,7 +2400,7 @@ fn test_update_from_content_malformed_conflict() {
     let [new_left_side, new_base, new_right_side] = new_conflict_terms.as_slice() else {
         unreachable!()
     };
-    insta::assert_snapshot!(new_left_side, @r##"
+    insta::assert_snapshot!(new_left_side, @r"
     line 1
     line 2 left
     line 3
@@ -2411,8 +2411,8 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
-    insta::assert_snapshot!(new_base, @r##"
+    ");
+    insta::assert_snapshot!(new_base, @r"
     line 1
     line 2
     line 3
@@ -2423,8 +2423,8 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
-    insta::assert_snapshot!(new_right_side, @r##"
+    ");
+    insta::assert_snapshot!(new_right_side, @r"
     line 1
     line 2 right
     line 3
@@ -2435,7 +2435,7 @@ fn test_update_from_content_malformed_conflict() {
     line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
-    "##);
+    ");
 
     // Even though the file now contains markers of length 7, the materialized
     // markers of length 7 are still parsed

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2497,12 +2497,12 @@ fn test_reset_head_with_index_no_conflict() {
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
-    insta::assert_snapshot!(get_index_state(&workspace_root), @r#"
+    insta::assert_snapshot!(get_index_state(&workspace_root), @r"
     Unconflicted some/dir/commit Mode(DIR | SYMLINK)
     Unconflicted some/dir/executable-file Mode(FILE | FILE_EXECUTABLE)
     Unconflicted some/dir/normal-file Mode(FILE)
     Unconflicted some/dir/symlink Mode(SYMLINK)
-    "#);
+    ");
 }
 
 #[test]
@@ -2627,7 +2627,7 @@ fn test_reset_head_with_index_merge_conflict() {
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
-    insta::assert_snapshot!(get_index_state(&workspace_root), @r#"
+    insta::assert_snapshot!(get_index_state(&workspace_root), @r"
     Base some/dir/commit Mode(DIR | SYMLINK)
     Ours some/dir/commit Mode(DIR | SYMLINK)
     Theirs some/dir/commit Mode(DIR | SYMLINK)
@@ -2640,7 +2640,7 @@ fn test_reset_head_with_index_merge_conflict() {
     Base some/dir/symlink Mode(SYMLINK)
     Ours some/dir/symlink Mode(SYMLINK)
     Theirs some/dir/symlink Mode(SYMLINK)
-    "#);
+    ");
 }
 
 #[test]

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -134,7 +134,7 @@ fn gpg_signing_roundtrip_explicit_key() {
     let data = b"hello world";
     let signature = backend.sign(data, Some("Someone Else")).unwrap();
 
-    assert_debug_snapshot!(backend.verify(data, &signature).unwrap(), @r###"
+    assert_debug_snapshot!(backend.verify(data, &signature).unwrap(), @r#"
     Verification {
         status: Good,
         key: Some(
@@ -144,8 +144,8 @@ fn gpg_signing_roundtrip_explicit_key() {
             "Someone Else (jj test signing key) <someone-else@example.com>",
         ),
     }
-    "###);
-    assert_debug_snapshot!(backend.verify(b"so so bad", &signature).unwrap(), @r###"
+    "#);
+    assert_debug_snapshot!(backend.verify(b"so so bad", &signature).unwrap(), @r#"
     Verification {
         status: Bad,
         key: Some(
@@ -155,7 +155,7 @@ fn gpg_signing_roundtrip_explicit_key() {
             "Someone Else (jj test signing key) <someone-else@example.com>",
         ),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -172,7 +172,7 @@ fn unknown_key() {
     e+U6bvqw3pOBoI53Th35drQ0qPI+jAE=
     =kwsk
     -----END PGP SIGNATURE-----";
-    assert_debug_snapshot!(backend.verify(b"hello world", signature).unwrap(), @r###"
+    assert_debug_snapshot!(backend.verify(b"hello world", signature).unwrap(), @r#"
     Verification {
         status: Unknown,
         key: Some(
@@ -180,8 +180,8 @@ fn unknown_key() {
         ),
         display: None,
     }
-    "###);
-    assert_debug_snapshot!(backend.verify(b"so bad", signature).unwrap(), @r###"
+    "#);
+    assert_debug_snapshot!(backend.verify(b"so bad", signature).unwrap(), @r#"
     Verification {
         status: Unknown,
         key: Some(
@@ -189,7 +189,7 @@ fn unknown_key() {
         ),
         display: None,
     }
-    "###);
+    "#);
 }
 
 #[test]

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -66,7 +66,7 @@ fn test_id_prefix() {
         .map(|(i, commit)| format!("{} {}", &commit.id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(commit_prefixes, @r###"
+    insta::assert_snapshot!(commit_prefixes, @r"
     11a 5
     214 24
     2a6 2
@@ -93,14 +93,14 @@ fn test_id_prefix() {
     eec 15
     efe 7
     fa3 11
-    "###);
+    ");
     let change_prefixes = commits
         .iter()
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.change_id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(change_prefixes, @r###"
+    insta::assert_snapshot!(change_prefixes, @r"
     026 9
     030 13
     1b5 6
@@ -127,7 +127,7 @@ fn test_id_prefix() {
     c24 15
     d64 12
     fee 25
-    "###);
+    ");
 
     let prefix = |x| HexPrefix::new(x).unwrap();
 
@@ -300,21 +300,21 @@ fn test_id_prefix_divergent() {
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.change_id().hex()[..4], i))
         .join("\n");
-    insta::assert_snapshot!(change_prefixes, @r###"
+    insta::assert_snapshot!(change_prefixes, @r"
     a533 0
     a500 1
     a500 2
-    "###);
+    ");
     let commit_prefixes = commits
         .iter()
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.id().hex()[..4], i))
         .join("\n");
-    insta::assert_snapshot!(commit_prefixes, @r###"
+    insta::assert_snapshot!(commit_prefixes, @r"
     eafa 0
     d48d 1
     2fbb 2
-    "###);
+    ");
 
     let prefix = |x| HexPrefix::new(x).unwrap();
 
@@ -423,7 +423,7 @@ fn test_id_prefix_hidden() {
         .map(|(i, commit)| format!("{} {}", &commit.id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(commit_prefixes, @r#"
+    insta::assert_snapshot!(commit_prefixes, @r"
     15e 9
     397 6
     53c 7
@@ -434,14 +434,14 @@ fn test_id_prefix_hidden() {
     c0a 5
     ce9 0
     f10 1
-    "#);
+    ");
     let change_prefixes = commits
         .iter()
         .enumerate()
         .map(|(i, commit)| format!("{} {}", &commit.change_id().hex()[..3], i))
         .sorted()
         .join("\n");
-    insta::assert_snapshot!(change_prefixes, @r#"
+    insta::assert_snapshot!(change_prefixes, @r"
     026 9
     1b5 6
     26b 3
@@ -452,7 +452,7 @@ fn test_id_prefix_hidden() {
     896 5
     a2c 1
     b93 4
-    "#);
+    ");
 
     let hidden_commit = &commits[8];
     tx.repo_mut().record_abandoned_commit(hidden_commit);

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -887,7 +887,7 @@ fn test_materialize_snapshot_conflicted_files() {
     assert_eq!(file2_value.num_sides(), 3);
     insta::assert_snapshot!(
         std::fs::read_to_string(file1_path.to_fs_path_unchecked(&workspace_root)).ok().unwrap(),
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -b
@@ -895,10 +895,10 @@ fn test_materialize_snapshot_conflicted_files() {
     +++++++ Contents of side #2
     c
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(file2_path.to_fs_path_unchecked(&workspace_root)).ok().unwrap(),
-        @r###"
+        @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
     -2
@@ -906,7 +906,7 @@ fn test_materialize_snapshot_conflicted_files() {
     +++++++ Contents of side #2
     4
     >>>>>>> Conflict 1 of 1 ends
-    "###);
+    ");
 
     // Editing a conflicted file should correctly propagate updates to each of
     // the conflicting trees.
@@ -2102,10 +2102,10 @@ fn test_fsmonitor() {
     {
         let mut locked_ws = ws.start_working_copy_mutation().unwrap();
         let tree_id = snapshot(&mut locked_ws, &[foo_path]);
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree d5e38c0a1b0ee5de47c5
           file "foo" (e99c2057c15160add351): "foo\n"
-        "###);
+        "#);
     }
 
     {
@@ -2114,12 +2114,12 @@ fn test_fsmonitor() {
             &mut locked_ws,
             &[foo_path, bar_path, nested_path, ignored_path],
         );
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree f408c8d080414f8e90e1
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "foo" (e99c2057c15160add351): "foo\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
-        "###);
+        "#);
         locked_ws.finish(repo.op_id().clone()).unwrap();
     }
 
@@ -2128,23 +2128,23 @@ fn test_fsmonitor() {
         testutils::write_working_copy_file(&workspace_root, bar_path, "updated bar\n");
         let mut locked_ws = ws.start_working_copy_mutation().unwrap();
         let tree_id = snapshot(&mut locked_ws, &[foo_path]);
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree e994a93c46f41dc91704
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "foo" (e0fbd106147cc04ccd05): "updated foo\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
-        "###);
+        "#);
     }
 
     {
         std::fs::remove_file(foo_path.to_fs_path_unchecked(&workspace_root)).unwrap();
         let mut locked_ws = ws.start_working_copy_mutation().unwrap();
         let tree_id = snapshot(&mut locked_ws, &[foo_path]);
-        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r###"
+        insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree 1df764981d4d74a4ecfa
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
-        "###);
+        "#);
         locked_ws.finish(repo.op_id().clone()).unwrap();
     }
 }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -590,7 +590,7 @@ fn test_resolve_symbol_bookmarks() {
 
     // Remote only (or locally deleted)
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "remote").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "remote").unwrap_err(), @r#"
     NoSuchRevision {
         name: "remote",
         candidates: [
@@ -598,7 +598,7 @@ fn test_resolve_symbol_bookmarks() {
             "remote@origin",
         ],
     }
-    "###);
+    "#);
     assert_eq!(
         resolve_symbol(mut_repo, "remote@origin").unwrap(),
         vec![commit2.id().clone()],
@@ -692,7 +692,7 @@ fn test_resolve_symbol_bookmarks() {
     // "local-remote@mirror" shouldn't be omitted just because it points to the same
     // target as "local-remote".
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "remote@mirror").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "remote@mirror").unwrap_err(), @r#"
     NoSuchRevision {
         name: "remote@mirror",
         candidates: [
@@ -700,11 +700,11 @@ fn test_resolve_symbol_bookmarks() {
             "remote@origin",
         ],
     }
-    "###);
+    "#);
 
     // Typo of remote-only bookmark name
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "emote").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "emote").unwrap_err(), @r#"
     NoSuchRevision {
         name: "emote",
         candidates: [
@@ -712,7 +712,7 @@ fn test_resolve_symbol_bookmarks() {
             "remote@origin",
         ],
     }
-    "###);
+    "#);
     insta::assert_debug_snapshot!(
         resolve_symbol(mut_repo, "emote@origin").unwrap_err(), @r#"
     NoSuchRevision {
@@ -848,12 +848,12 @@ fn test_resolve_symbol_git_refs() {
     );
     // bookmark alone is not recognized
     insta::assert_debug_snapshot!(
-        resolve_symbol(mut_repo, "bookmark").unwrap_err(), @r###"
+        resolve_symbol(mut_repo, "bookmark").unwrap_err(), @r#"
     NoSuchRevision {
         name: "bookmark",
         candidates: [],
     }
-    "###);
+    "#);
     // heads/bookmark does get resolved to the git ref refs/heads/bookmark
     assert_eq!(
         resolve_symbol(mut_repo, "heads/bookmark").unwrap(),


### PR DESCRIPTION
This is a replacement for #5558. See the discussion over there for an explanation of the first commit.

(That commit is a bit cavalier, I may have missed some sport)

Thanks to @yuja 's https://github.com/mitsuhiko/insta/pull/722, the second commit is now easy to generate.

-----

I'm sending this out now with #5887 to front-load various "large-scale changes", so that there is one large hurdle for rebasing different PRs instead of many small ones.