### PR TITLE
cli: Print @ and @- in status and update_working_copy

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2023,13 +2023,18 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
         if Some(new_commit) != maybe_old_commit {
             if let Some(mut formatter) = ui.status_formatter() {
                 let template = self.commit_summary_template();
-                write!(formatter, "Working copy now at: ")?;
+                write!(formatter, "Working copy now ")?;
+                formatter.with_label("node", |fmt| write!(fmt.labeled("working_copy"), "@"))?;
+                write!(formatter, "  ")?;
                 formatter.with_label("working_copy", |fmt| template.format(new_commit, fmt))?;
                 writeln!(formatter)?;
                 for parent in new_commit.parents() {
                     let parent = parent?;
-                    //                "Working copy now at: "
-                    write!(formatter, "Parent commit      : ")?;
+                    //                "Working copy now @  "
+                    //                "Parent commit    @- "
+                    write!(formatter, "Parent commit    ")?;
+                    write!(formatter.labeled("node"), "@-")?;
+                    write!(formatter, " ")?;
                     template.format(&parent, formatter.as_mut())?;
                     writeln!(formatter)?;
                 }

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -113,12 +113,16 @@ pub(crate) fn cmd_status(
         }
 
         let template = workspace_command.commit_summary_template();
-        write!(formatter, "Working copy : ")?;
+        write!(formatter, "Working copy  ")?;
+        formatter.with_label("node", |fmt| write!(fmt.labeled("working_copy"), "@"))?;
+        write!(formatter, "  ")?;
         formatter.with_label("working_copy", |fmt| template.format(wc_commit, fmt))?;
         writeln!(formatter)?;
         for parent in wc_commit.parents() {
             let parent = parent?;
-            write!(formatter, "Parent commit: ")?;
+            write!(formatter, "Parent commit ")?;
+            write!(formatter.labeled("node"), "@-")?;
+            write!(formatter, " ")?;
             template.format(&parent, formatter)?;
             writeln!(formatter)?;
         }


### PR DESCRIPTION
This helps newcomers remember what `@` and `@-` stand for. Fixes #4700.

`jj st` before:

<img width="692" alt="Screenshot 2025-03-06 at 8 26 02 pm" src="https://github.com/user-attachments/assets/1091c6ca-3e75-4e9e-87d7-e8bd934dcf3d" />

```
Working copy : srzktwpv 0eeeada1 (empty) (no description set)
Parent commit: usotzrkt 552b98c3 Print @ and @- in status and update_working_copy
```

after:

<img width="681" alt="Screenshot 2025-03-06 at 8 26 08 pm" src="https://github.com/user-attachments/assets/f4705b6a-1c91-4309-8246-b3f196fe3487" />

```
Working copy  @  srzktwpv 0eeeada1 (empty) (no description set)
Parent commit @- usotzrkt 552b98c3 Print @ and @- in status and update_working_copy
```

And the output after e.g. a `jj commit`:

<img width="747" alt="Screenshot 2025-03-06 at 8 17 25 pm" src="https://github.com/user-attachments/assets/42dd8afb-28f1-4ce8-986f-8ba5578bd7f4" />

Note that I've removed the `:` because:
- I feel like the `@` symbols and whitespace provide enough separation, also having `:` there makes it a bit noisy
- It doesn't take up as much horizontal space

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes

(Not doing^ yet until the format is agreed.)