### PR TITLE
git: reject reserved remote name early in fetch() function

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -540,7 +540,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
             }
             match err {
                 GitFetchError::NoSuchRemote(_) => user_error(err),
-                GitFetchError::RemoteWithSlash(_) => user_error_with_hint(
+                GitFetchError::RemoteName(_) => user_error_with_hint(
                     err,
                     "Run `jj git remote rename` to give a different name.",
                 ),

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -564,11 +564,10 @@ jj currently does not support partial clones. To use jj with this repository, tr
         fn from(err: GitPushError) -> Self {
             match err {
                 GitPushError::NoSuchRemote(_) => user_error(err),
-                GitPushError::RemoteWithSlash(_) => user_error_with_hint(
+                GitPushError::RemoteName(_) => user_error_with_hint(
                     err,
                     "Run `jj git remote rename` to give a different name.",
                 ),
-                GitPushError::RemoteReservedForLocalGitRepo => user_error(err),
                 GitPushError::RefInUnexpectedLocation(refs) => user_error_with_hint(
                     format!(
                         "Refusing to push a bookmark that unexpectedly moved on the remote. \

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -531,13 +531,15 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Failed to import refs from underlying Git repo
-    Caused by: Git remote named 'git' is reserved for local Git repository
-    Hint: Run `jj git remote rename` to give different name.
+    Error: Git remote named 'git' is reserved for local Git repository
+    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     [exit status: 1]
     ");
     }
+
+    // Fetch remote refs by using the git CLI.
+    git::fetch(&repo_path, "git");
 
     // Implicit import shouldn't fail because of the remote ref.
     let output = test_env.run_jj_in(&repo_path, ["bookmark", "list", "--all-remotes"]);

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -2098,6 +2098,7 @@ fn test_git_push_to_remote_named_git(subprocess: bool) {
       Add bookmark bookmark1 to d13ecdbda2a2
       Add bookmark bookmark2 to 8476341eb395
     Error: Git remote named 'git' is reserved for local Git repository
+    Hint: Run `jj git remote rename` to give a different name.
     [EOF]
     [exit status: 1]
     ");

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1914,7 +1914,9 @@ pub fn push_branches(
     targets: &GitBranchPushTargets,
     callbacks: RemoteCallbacks<'_>,
 ) -> Result<(), GitPushError> {
-    if remote.contains("/") {
+    if remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO {
+        return Err(GitPushError::RemoteReservedForLocalGitRepo);
+    } else if remote.contains("/") {
         return Err(GitPushError::RemoteWithSlash(remote.to_owned()));
     }
 
@@ -1954,10 +1956,6 @@ pub fn push_updates(
     updates: &[GitRefUpdate],
     callbacks: RemoteCallbacks<'_>,
 ) -> Result<(), GitPushError> {
-    if remote_name == REMOTE_NAME_FOR_LOCAL_GIT_REPO {
-        return Err(GitPushError::RemoteReservedForLocalGitRepo);
-    }
-
     let mut qualified_remote_refs_expected_locations = HashMap::new();
     let mut refspecs = vec![];
     for update in updates {


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
