### PR TITLE
cli `op log`: short `-d` alias for `--op-diff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The 'how to resolve conflicts' hint that is shown when conflicts appear can
   be hidden by setting `hints.resolving-conflicts = false`.
 
+* `jj op log -d` now has an alias for `jj op log --op-diff`.
+
 ### Fixed bugs
 
 ## [0.27.0] - 2025-03-05

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -76,7 +76,7 @@ pub struct OperationLogArgs {
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show changes to the repository at each operation
-    #[arg(long)]
+    #[arg(long, short = 'd')]
     op_diff: bool,
     /// Show patch of modifications to changes (implies --op-diff)
     ///

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1652,7 +1652,7 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
    [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
 
    [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
-* `--op-diff` — Show changes to the repository at each operation
+* `-d`, `--op-diff` — Show changes to the repository at each operation
 * `-p`, `--patch` — Show patch of modifications to changes (implies --op-diff)
 
    If the previous version has different parents, it will be temporarily rebased to the parents of the new version, so the diff is not contaminated by unrelated changes.


### PR DESCRIPTION
`--op-diff` is often more useful than `-p`/`--patch`.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- ~~[ ] I have updated the documentation (README.md, docs/, demos/)~~
- ~~[ ] I have updated the config schema (cli/src/config-schema.json)~~
- ~~[ ] I have added tests to cover my changes~~
