### PR TITLE
cli: remove `untrack` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj unsquash` has been removed in favor of `jj squash` and
   `jj diffedit --restore-descendants`.
 
+* The `jj untrack` subcommand has been removed in favor of `jj file untrack`.
+
 ### Deprecations
 
 * `core.watchman.register_snapshot_trigger` has been renamed to `core.watchman.register-snapshot-trigger` for consistency with other configuration options.

--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -17,7 +17,7 @@ mod chmod;
 mod list;
 mod show;
 mod track;
-pub mod untrack;
+mod untrack;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -146,9 +146,6 @@ enum Command {
     /// Undo an operation (shortcut for `jj op undo`)
     Undo(operation::undo::OperationUndoArgs),
     Unsign(unsign::UnsignArgs),
-    // TODO: Delete `untrack` in jj 0.27+
-    #[command(hide = true)]
-    Untrack(file::untrack::FileUntrackArgs),
     Version(version::VersionArgs),
     #[command(subcommand)]
     Workspace(workspace::WorkspaceCommand),
@@ -210,10 +207,6 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Tag(args) => tag::cmd_tag(ui, command_helper, args),
         Command::Undo(args) => operation::undo::cmd_op_undo(ui, command_helper, args),
         Command::Unsign(args) => unsign::cmd_unsign(ui, command_helper, args),
-        Command::Untrack(args) => {
-            let cmd = renamed_cmd("untrack", "file untrack", file::untrack::cmd_file_untrack);
-            cmd(ui, command_helper, args)
-        }
         Command::Util(args) => util::cmd_util(ui, command_helper, args),
         Command::Version(args) => version::cmd_version(ui, command_helper, args),
         Command::Workspace(args) => workspace::cmd_workspace(ui, command_helper, args),

--- a/cli/tests/test_file_track_untrack_commands.rs
+++ b/cli/tests/test_file_track_untrack_commands.rs
@@ -72,13 +72,8 @@ fn test_track_untrack() {
 
     // Can untrack a single file
     assert!(files_before.stdout.raw().contains("file1.bak\n"));
-    let output = test_env.run_jj_in(&repo_path, ["untrack", "file1.bak"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: `jj untrack` is deprecated; use `jj file untrack` instead, which is equivalent
-    Warning: `jj untrack` will be removed in a future version, and this will be a hard error
-    [EOF]
-    ");
+    let output = test_env.run_jj_in(&repo_path, ["file", "untrack", "file1.bak"]);
+    insta::assert_snapshot!(output, @r"");
     let files_after = test_env.run_jj_in(&repo_path, ["file", "list"]).success();
     // The file is no longer tracked
     assert!(!files_after.stdout.raw().contains("file1.bak"));


### PR DESCRIPTION
`jj untrack` was scheduled to be removed in v0.27 but slipped through the net, so remove support in v0.28 instead.