### PR TITLE
cleanup: switch to use<'_> capturing syntax

### DIFF
--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -888,10 +888,10 @@ impl JjBuilder {
 /// multiple times, the parsing will pick any of the available ones, while the
 /// actual execution of the command would fail.
 mod parse {
-    pub(super) fn parse_flag<'a>(
+    pub(super) fn parse_flag<'a, I: Iterator<Item = String>>(
         candidates: &'a [&str],
-        mut args: impl Iterator<Item = String> + 'a,
-    ) -> impl Iterator<Item = String> + 'a {
+        mut args: I,
+    ) -> impl Iterator<Item = String> + use<'a, I> {
         std::iter::from_fn(move || {
             for arg in args.by_ref() {
                 // -r REV syntax

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -477,7 +477,7 @@ pub fn get_copy_records<'a>(
     root: &CommitId,
     head: &CommitId,
     matcher: &'a dyn Matcher,
-) -> BackendResult<impl Iterator<Item = BackendResult<CopyRecord>> + 'a> {
+) -> BackendResult<impl Iterator<Item = BackendResult<CopyRecord>> + use<'a>> {
     // TODO: teach backend about matching path prefixes?
     let stream = store.get_copy_records(None, root, head)?;
     // TODO: test record.source as well? should be AND-ed or OR-ed?

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -15,7 +15,7 @@ use crate::ui::Ui;
 pub const UPDATE_HZ: u32 = 30;
 pub const INITIAL_DELAY: Duration = Duration::from_millis(250);
 
-pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + '_> {
+pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + use<>> {
     struct State {
         guard: Option<OutputGuard>,
         output: ProgressOutput<std::io::Stderr>,

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -128,7 +128,7 @@ impl<'repo> RevsetExpressionEvaluator<'repo> {
     pub fn evaluate_to_commits(
         &self,
     ) -> Result<
-        impl Iterator<Item = Result<Commit, RevsetEvaluationError>> + 'repo,
+        impl Iterator<Item = Result<Commit, RevsetEvaluationError>> + use<'repo>,
         UserRevsetEvaluationError,
     > {
         Ok(self.evaluate()?.iter().commits(self.repo.store()))

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -2052,7 +2052,10 @@ mod tests {
         }
     }
 
-    fn new_error_property<O>(message: &str) -> impl TemplateProperty<Output = O> + '_ {
+    // TODO: O doesn't have to be captured, but "currently, all type parameters
+    // are required to be mentioned in the precise captures list" as of rustc
+    // 1.85.0.
+    fn new_error_property<O>(message: &str) -> impl TemplateProperty<Output = O> + use<'_, O> {
         Literal(()).and_then(|()| Err(TemplatePropertyError(message.into())))
     }
 

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -747,7 +747,7 @@ impl<'a> TemplateFormatter<'a> {
     ///
     /// This does not borrow `self` so the underlying formatter can be mutably
     /// borrowed.
-    pub fn rewrap_fn(&self) -> impl Fn(&mut dyn Formatter) -> TemplateFormatter<'_> {
+    pub fn rewrap_fn(&self) -> impl Fn(&mut dyn Formatter) -> TemplateFormatter<'_> + use<> {
         let error_handler = self.error_handler;
         move |formatter| TemplateFormatter::new(formatter, error_handler)
     }
@@ -879,7 +879,10 @@ fn propagate_property_error(
 /// This inherits the error handling strategy from the given `formatter`.
 fn record_non_empty_fn<T: Template + ?Sized>(
     formatter: &TemplateFormatter,
-) -> impl Fn(&T) -> Option<io::Result<FormatRecorder>> {
+    // TODO: T doesn't have to be captured, but "currently, all type parameters
+    // are required to be mentioned in the precise captures list" as of rustc
+    // 1.85.0.
+) -> impl Fn(&T) -> Option<io::Result<FormatRecorder>> + use<T> {
     let rewrap = formatter.rewrap_fn();
     move |template| {
         let mut recorder = FormatRecorder::new();

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -724,7 +724,7 @@ fn duplicate_child_stdin(stdin: &ChildStdin) -> io::Result<std::os::windows::io:
     stdin.as_handle().try_clone_to_owned()
 }
 
-fn format_error_with_sources(err: &dyn error::Error) -> impl fmt::Display + '_ {
+fn format_error_with_sources(err: &dyn error::Error) -> impl fmt::Display + use<'_> {
     iter::successors(Some(err), |&err| err.source()).format(": ")
 }
 

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -93,7 +93,7 @@ impl Commit {
         &self.data.parents
     }
 
-    pub fn parents(&self) -> impl Iterator<Item = BackendResult<Commit>> + '_ {
+    pub fn parents(&self) -> impl Iterator<Item = BackendResult<Commit>> + use<'_> {
         self.data.parents.iter().map(|id| self.store.get_commit(id))
     }
 
@@ -101,7 +101,7 @@ impl Commit {
         &self.data.predecessors
     }
 
-    pub fn predecessors(&self) -> impl Iterator<Item = BackendResult<Commit>> + '_ {
+    pub fn predecessors(&self) -> impl Iterator<Item = BackendResult<Commit>> + use<'_> {
         self.data
             .predecessors
             .iter()

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -665,7 +665,7 @@ pub struct MaterializedTreeDiffEntry {
 pub fn materialized_diff_stream<'a>(
     store: &'a Store,
     tree_diff: BoxStream<'a, CopiesTreeDiffEntry>,
-) -> impl Stream<Item = MaterializedTreeDiffEntry> + 'a {
+) -> impl Stream<Item = MaterializedTreeDiffEntry> + use<'a> {
     tree_diff
         .map(|CopiesTreeDiffEntry { path, values }| async {
             match values {

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -85,7 +85,7 @@ impl CopyRecords {
     }
 
     /// Gets all copy records.
-    pub fn iter(&self) -> impl Iterator<Item = &CopyRecord> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &CopyRecord> {
         self.records.iter()
     }
 }

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -355,12 +355,12 @@ impl CompositeIndex {
         self.heads_pos(result)
     }
 
-    pub(super) fn all_heads(&self) -> impl Iterator<Item = CommitId> + '_ {
+    pub(super) fn all_heads(&self) -> impl Iterator<Item = CommitId> + use<'_> {
         self.all_heads_pos()
             .map(move |pos| self.entry_by_pos(pos).commit_id())
     }
 
-    pub(super) fn all_heads_pos(&self) -> impl Iterator<Item = IndexPosition> {
+    pub(super) fn all_heads_pos(&self) -> impl Iterator<Item = IndexPosition> + use<> {
         // TODO: can be optimized to use bit vec and leading/trailing_ones()
         let num_commits = self.num_commits();
         let mut not_head: Vec<bool> = vec![false; num_commits as usize];

--- a/lib/src/default_index/entry.rs
+++ b/lib/src/default_index/entry.rs
@@ -114,7 +114,7 @@ impl<'a> IndexEntry<'a> {
         self.source.parent_positions(self.local_pos)
     }
 
-    pub fn parents(&self) -> impl ExactSizeIterator<Item = IndexEntry<'a>> {
+    pub fn parents(&self) -> impl ExactSizeIterator<Item = IndexEntry<'a>> + use<'a> {
         let composite = CompositeIndex::new(self.source);
         self.parent_positions()
             .into_iter()

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -432,7 +432,10 @@ impl ReadonlyIndexSegment {
     }
 
     /// Scans graph entry positions stored in the overflow change ids table.
-    fn overflow_changes_from(&self, overflow_pos: u32) -> impl Iterator<Item = LocalPosition> + '_ {
+    fn overflow_changes_from(
+        &self,
+        overflow_pos: u32,
+    ) -> impl Iterator<Item = LocalPosition> + use<'_> {
         let table = &self.data[self.change_overflow_base..];
         let offset = (overflow_pos as usize) * 4;
         table[offset..]

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -127,14 +127,16 @@ impl<I: AsCompositeIndex + Clone> RevsetImpl<I> {
         Self { inner, index }
     }
 
-    fn positions(&self) -> impl Iterator<Item = Result<IndexPosition, RevsetEvaluationError>> + '_ {
+    fn positions(
+        &self,
+    ) -> impl Iterator<Item = Result<IndexPosition, RevsetEvaluationError>> + use<'_, I> {
         self.inner.positions().attach(self.index.as_composite())
     }
 
     pub fn iter_graph_impl(
         &self,
         skip_transitive_edges: bool,
-    ) -> impl Iterator<Item = Result<GraphNode<CommitId>, RevsetEvaluationError>> {
+    ) -> impl Iterator<Item = Result<GraphNode<CommitId>, RevsetEvaluationError>> + use<I> {
         let index = self.index.clone();
         let walk = self.inner.positions();
         let mut graph_walk = RevsetGraphWalk::new(walk, skip_transitive_edges);
@@ -1336,10 +1338,10 @@ fn matches_diff_from_parent(
     .block_on()
 }
 
-fn match_lines<'a: 'b, 'b>(
+fn match_lines<'a, 'b>(
     text: &'a [u8],
     pattern: &'b StringPattern,
-) -> impl Iterator<Item = &'a [u8]> + 'b {
+) -> impl Iterator<Item = &'a [u8]> + use<'a, 'b> {
     // The pattern is matched line by line so that it can be anchored to line
     // start/end. For example, exact:"" will match blank lines.
     text.split_inclusive(|b| *b == b'\n').filter(|line| {

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -76,11 +76,11 @@ pub fn find_nonword_ranges(text: &[u8]) -> Vec<Range<usize>> {
         .collect()
 }
 
-fn bytes_ignore_all_whitespace(text: &[u8]) -> impl Iterator<Item = u8> + '_ {
+fn bytes_ignore_all_whitespace(text: &[u8]) -> impl Iterator<Item = u8> + use<'_> {
     text.iter().copied().filter(|b| !b.is_ascii_whitespace())
 }
 
-fn bytes_ignore_whitespace_amount(text: &[u8]) -> impl Iterator<Item = u8> + '_ {
+fn bytes_ignore_whitespace_amount(text: &[u8]) -> impl Iterator<Item = u8> + use<'_> {
     let mut prev_was_space = false;
     text.iter().filter_map(move |&b| {
         let was_space = prev_was_space;
@@ -295,7 +295,8 @@ impl<'input> LocalDiffSource<'input, '_> {
 
     fn hashed_words(
         &self,
-    ) -> impl DoubleEndedIterator<Item = HashedWord<'input>> + ExactSizeIterator + '_ {
+    ) -> impl DoubleEndedIterator<Item = HashedWord<'input>> + ExactSizeIterator + use<'_, 'input>
+    {
         iter::zip(self.ranges, self.hashes).map(|(range, &hash)| {
             let text = &self.text[range.clone()];
             HashedWord { hash, text }
@@ -779,7 +780,10 @@ impl<'input> Diff<'input> {
     }
 
     /// Returns contents at the unchanged `range`.
-    fn hunk_at<'a>(&'a self, range: &'a UnchangedRange) -> impl Iterator<Item = &'input BStr> + 'a {
+    fn hunk_at<'a, 'b>(
+        &'a self,
+        range: &'b UnchangedRange,
+    ) -> impl Iterator<Item = &'input BStr> + use<'a, 'b, 'input> {
         itertools::chain(
             iter::once(&self.base_input[range.base.clone()]),
             iter::zip(&self.other_inputs, &range.others).map(|(input, r)| &input[r.clone()]),
@@ -787,11 +791,11 @@ impl<'input> Diff<'input> {
     }
 
     /// Returns contents between the `previous` ends and the `current` starts.
-    fn hunk_between<'a>(
+    fn hunk_between<'a, 'b>(
         &'a self,
-        previous: &'a UnchangedRange,
-        current: &'a UnchangedRange,
-    ) -> impl Iterator<Item = &'input BStr> + 'a {
+        previous: &'b UnchangedRange,
+        current: &'b UnchangedRange,
+    ) -> impl Iterator<Item = &'input BStr> + use<'a, 'b, 'input> {
         itertools::chain(
             iter::once(&self.base_input[previous.base.end..current.base.start]),
             itertools::izip!(&self.other_inputs, &previous.others, &current.others)

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -604,7 +604,10 @@ struct AliasFunctionOverloads<'a, V> {
 }
 
 impl<'a, V> AliasFunctionOverloads<'a, V> {
-    fn arities(&self) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator + 'a {
+    // TODO: Perhaps, V doesn't have to be captured, but "currently, all type
+    // parameters are required to be mentioned in the precise captures list" as
+    // of rustc 1.85.0.
+    fn arities(&self) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator + use<'a, V> {
         self.overloads.iter().map(|(params, _)| params.len())
     }
 

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -385,7 +385,7 @@ impl<'a> FileStates<'a> {
     }
 
     /// Iterates sorted file paths.
-    pub fn paths(&self) -> impl ExactSizeIterator<Item = &'a RepoPath> {
+    pub fn paths(&self) -> impl ExactSizeIterator<Item = &'a RepoPath> + use<'a> {
         self.data
             .iter()
             .map(|entry| RepoPath::from_internal_string(&entry.path))

--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -480,10 +480,13 @@ impl<V> RepoPathTree<V> {
 
     /// Walks the tree from the root to the given `dir`, yielding each sub tree
     /// and remaining path.
-    fn walk_to<'a, 'b: 'a>(
+    fn walk_to<'a, 'b>(
         &'a self,
         dir: &'b RepoPath,
-    ) -> impl Iterator<Item = (&'a Self, &'b RepoPath)> + 'a {
+        // TODO: V doesn't have to be captured, but "currently, all type
+        // parameters are required to be mentioned in the precise captures list"
+        // as of rustc 1.85.0.
+    ) -> impl Iterator<Item = (&'a Self, &'b RepoPath)> + use<'a, 'b, V> {
         iter::successors(Some((self, dir)), |(sub, dir)| {
             let mut components = dir.components();
             let name = components.next()?;

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -182,7 +182,9 @@ impl MergedTree {
     /// all sides are trees, so tree/file conflicts will be reported as a single
     /// conflict, not one for each path in the tree.
     // TODO: Restrict this by a matcher (or add a separate method for that).
-    pub fn conflicts(&self) -> impl Iterator<Item = (RepoPathBuf, BackendResult<MergedTreeValue>)> {
+    pub fn conflicts(
+        &self,
+    ) -> impl Iterator<Item = (RepoPathBuf, BackendResult<MergedTreeValue>)> + use<> {
         ConflictIterator::new(self)
     }
 

--- a/lib/src/op_walk.rs
+++ b/lib/src/op_walk.rs
@@ -242,7 +242,9 @@ impl PartialOrd for OperationByEndTime {
 }
 
 /// Walks `head_ops` and their ancestors in reverse topological order.
-pub fn walk_ancestors(head_ops: &[Operation]) -> impl Iterator<Item = OpStoreResult<Operation>> {
+pub fn walk_ancestors(
+    head_ops: &[Operation],
+) -> impl Iterator<Item = OpStoreResult<Operation>> + use<> {
     // Emit the latest head first to stabilize the order.
     let mut head_ops = head_ops
         .iter()

--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -100,7 +100,7 @@ impl Operation {
         &self.data.parents
     }
 
-    pub fn parents(&self) -> impl ExactSizeIterator<Item = OpStoreResult<Operation>> + '_ {
+    pub fn parents(&self) -> impl ExactSizeIterator<Item = OpStoreResult<Operation>> + use<'_> {
         let op_store = &self.op_store;
         self.data.parents.iter().map(|parent_id| {
             let data = op_store.read_operation(parent_id)?;

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1886,7 +1886,7 @@ fn resolve_remote_bookmark(repo: &dyn Repo, symbol: RemoteRefSymbol<'_>) -> Opti
 fn all_formatted_bookmark_symbols(
     repo: &dyn Repo,
     include_synced_remotes: bool,
-) -> impl Iterator<Item = String> + '_ {
+) -> impl Iterator<Item = String> + use<'_> {
     let view = repo.view();
     view.bookmarks().flat_map(move |(name, bookmark_target)| {
         let local_target = bookmark_target.local_target;
@@ -2611,7 +2611,7 @@ impl RevsetExtensions {
         }
     }
 
-    pub fn symbol_resolvers(&self) -> &[impl AsRef<dyn SymbolResolverExtension>] {
+    pub fn symbol_resolvers(&self) -> &[impl AsRef<dyn SymbolResolverExtension> + use<>] {
         &self.symbol_resolvers
     }
 
@@ -2668,7 +2668,7 @@ impl<'a> RevsetParseContext<'a> {
         &self.date_pattern_context
     }
 
-    pub fn symbol_resolvers(&self) -> &[impl AsRef<dyn SymbolResolverExtension>] {
+    pub fn symbol_resolvers(&self) -> &'a [impl AsRef<dyn SymbolResolverExtension> + use<>] {
         self.extensions.symbol_resolvers()
     }
 }

--- a/lib/src/str_util.rs
+++ b/lib/src/str_util.rs
@@ -228,10 +228,10 @@ impl StringPattern {
     }
 
     /// Iterates entries of the given `map` whose keys matches this pattern.
-    pub fn filter_btree_map<'a: 'b, 'b, K: Borrow<str> + Ord, V>(
+    pub fn filter_btree_map<'a, 'b, K: Borrow<str> + Ord, V>(
         &'b self,
         map: &'a BTreeMap<K, V>,
-    ) -> impl Iterator<Item = (&'a K, &'a V)> + 'b {
+    ) -> impl Iterator<Item = (&'a K, &'a V)> + use<'a, 'b, K, V> {
         if let Some(key) = self.as_exact() {
             Either::Left(map.get_key_value(key).into_iter())
         } else {

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -138,20 +138,20 @@ impl View {
 
     /// Iterates local bookmarks `(name, target)` in lexicographical order where
     /// the target adds `commit_id`.
-    pub fn local_bookmarks_for_commit<'a: 'b, 'b>(
+    pub fn local_bookmarks_for_commit<'a, 'b>(
         &'a self,
         commit_id: &'b CommitId,
-    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + 'b {
+    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + use<'a, 'b> {
         self.local_bookmarks()
             .filter(|(_, target)| target.added_ids().contains(commit_id))
     }
 
     /// Iterates local bookmark `(name, target)`s matching the given pattern.
     /// Entries are sorted by `name`.
-    pub fn local_bookmarks_matching<'a: 'b, 'b>(
+    pub fn local_bookmarks_matching<'a, 'b>(
         &'a self,
         pattern: &'b StringPattern,
-    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + 'b {
+    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + use<'a, 'b> {
         pattern
             .filter_btree_map(&self.data.local_bookmarks)
             .map(|(name, target)| (name.as_ref(), target))
@@ -181,7 +181,10 @@ impl View {
 
     /// Iterates over `(name, remote_ref)`s for all remote bookmarks of the
     /// specified remote in lexicographical order.
-    pub fn remote_bookmarks(&self, remote_name: &str) -> impl Iterator<Item = (&str, &RemoteRef)> {
+    pub fn remote_bookmarks(
+        &self,
+        remote_name: &str,
+    ) -> impl Iterator<Item = (&str, &RemoteRef)> + use<'_> {
         let maybe_remote_view = self.data.remote_views.get(remote_name);
         maybe_remote_view
             .map(|remote_view| {
@@ -198,11 +201,11 @@ impl View {
     /// specified remote that match the given pattern.
     ///
     /// Entries are sorted by `symbol`, which is `(name, remote)`.
-    pub fn remote_bookmarks_matching<'a: 'b, 'b>(
+    pub fn remote_bookmarks_matching<'a, 'b>(
         &'a self,
         bookmark_pattern: &'b StringPattern,
         remote_pattern: &'b StringPattern,
-    ) -> impl Iterator<Item = (RemoteRefSymbol<'a>, &'a RemoteRef)> + 'b {
+    ) -> impl Iterator<Item = (RemoteRefSymbol<'a>, &'a RemoteRef)> + use<'a, 'b> {
         // Use kmerge instead of flat_map for consistency with all_remote_bookmarks().
         remote_pattern
             .filter_btree_map(&self.data.remote_views)
@@ -249,10 +252,10 @@ impl View {
     /// Note that this does *not* take into account whether the local bookmark
     /// tracks the remote bookmark or not. Missing values are represented as
     /// RefTarget::absent_ref() or RemoteRef::absent_ref().
-    pub fn local_remote_bookmarks<'a>(
-        &'a self,
+    pub fn local_remote_bookmarks(
+        &self,
         remote_name: &str,
-    ) -> impl Iterator<Item = (&'a str, LocalAndRemoteRef<'a>)> + 'a {
+    ) -> impl Iterator<Item = (&str, LocalAndRemoteRef<'_>)> + use<'_> {
         refs::iter_named_local_remote_refs(
             self.local_bookmarks(),
             self.remote_bookmarks(remote_name),
@@ -275,11 +278,11 @@ impl View {
     /// Note that this does *not* take into account whether the local bookmark
     /// tracks the remote bookmark or not. Missing values are represented as
     /// RefTarget::absent_ref() or RemoteRef::absent_ref().
-    pub fn local_remote_bookmarks_matching<'a: 'b, 'b>(
+    pub fn local_remote_bookmarks_matching<'a, 'b>(
         &'a self,
         bookmark_pattern: &'b StringPattern,
         remote_name: &str,
-    ) -> impl Iterator<Item = (&'a str, LocalAndRemoteRef<'a>)> + 'b {
+    ) -> impl Iterator<Item = (&'a str, LocalAndRemoteRef<'a>)> + use<'a, 'b> {
         // Change remote_name to StringPattern if needed, but merge-join adapter won't
         // be usable.
         let maybe_remote_view = self.data.remote_views.get(remote_name);
@@ -315,10 +318,10 @@ impl View {
 
     /// Iterates tags `(name, target)`s matching the given pattern. Entries
     /// are sorted by `name`.
-    pub fn tags_matching<'a: 'b, 'b>(
+    pub fn tags_matching<'a, 'b>(
         &'a self,
         pattern: &'b StringPattern,
-    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + 'b {
+    ) -> impl Iterator<Item = (&'a str, &'a RefTarget)> + use<'a, 'b> {
         pattern
             .filter_btree_map(&self.data.tags)
             .map(|(name, target)| (name.as_ref(), target))

--- a/lib/tests/test_annotate.rs
+++ b/lib/tests/test_annotate.rs
@@ -35,7 +35,7 @@ use testutils::TestRepo;
 
 fn create_commit_fn(
     mut_repo: &mut MutableRepo,
-) -> impl FnMut(&str, &[&CommitId], MergedTreeId) -> Commit + '_ {
+) -> impl FnMut(&str, &[&CommitId], MergedTreeId) -> Commit + use<'_> {
     // stabilize commit IDs for ease of debugging
     let signature = Signature {
         name: "Some One".to_owned(),


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
