### PR TITLE
revset, templater: remove deprecated "branches" aliases, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `branches()`, `remote_branches()`, `tracked_remote_branches()`, and
     `untracked_remote_branches()`, which were renamed to "bookmarks".
   - `file()` and `conflict()`, which were renamed to plural forms.
+  - `files(x, y, ..)` with multiple patterns. Use `files(x|y|..)` instead.
 
 * The following deprecated template functions have been removed:
   - `branches()`, `local_branches()`, and `remote_branches()`, which were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * The `jj untrack` subcommand has been removed in favor of `jj file untrack`.
 
+* The following deprecated revset functions have been removed:
+  - `branches()`, `remote_branches()`, `tracked_remote_branches()`, and
+    `untracked_remote_branches()`, which were renamed to "bookmarks".
+
+* The following deprecated template functions have been removed:
+  - `branches()`, `local_branches()`, and `remote_branches()`, which were
+    renamed to "bookmarks".
+
 ### Deprecations
 
 * `core.watchman.register_snapshot_trigger` has been renamed to `core.watchman.register-snapshot-trigger` for consistency with other configuration options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The following deprecated revset functions have been removed:
   - `branches()`, `remote_branches()`, `tracked_remote_branches()`, and
     `untracked_remote_branches()`, which were renamed to "bookmarks".
+  - `file()` and `conflict()`, which were renamed to plural forms.
 
 * The following deprecated template functions have been removed:
   - `branches()`, `local_branches()`, and `remote_branches()`, which were

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -879,14 +879,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
     );
     map.insert(
         "bookmarks",
-        |language, diagnostics, _build_ctx, self_property, function| {
-            if function.name != "bookmarks" {
-                // TODO: Remove in jj 0.28+
-                diagnostics.add_warning(TemplateParseError::expression(
-                    "branches() is deprecated; use bookmarks() instead",
-                    function.name_span,
-                ));
-            }
+        |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let index = language
                 .keyword_cache
@@ -905,14 +898,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
     );
     map.insert(
         "local_bookmarks",
-        |language, diagnostics, _build_ctx, self_property, function| {
-            if function.name != "local_bookmarks" {
-                // TODO: Remove in jj 0.28+
-                diagnostics.add_warning(TemplateParseError::expression(
-                    "local_branches() is deprecated; use local_bookmarks() instead",
-                    function.name_span,
-                ));
-            }
+        |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let index = language
                 .keyword_cache
@@ -931,14 +917,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
     );
     map.insert(
         "remote_bookmarks",
-        |language, diagnostics, _build_ctx, self_property, function| {
-            if function.name != "remote_bookmarks" {
-                // TODO: Remove in jj 0.28+
-                diagnostics.add_warning(TemplateParseError::expression(
-                    "remote_branches() is deprecated; use remote_bookmarks() instead",
-                    function.name_span,
-                ));
-            }
+        |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let index = language
                 .keyword_cache
@@ -955,11 +934,6 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             Ok(L::wrap_ref_name_list(out_property))
         },
     );
-    // TODO: Remove the following block after jj 0.28+
-    map.insert("branches", map["bookmarks"]);
-    map.insert("local_branches", map["local_bookmarks"]);
-    map.insert("remote_branches", map["remote_bookmarks"]);
-
     map.insert(
         "tags",
         |language, _diagnostics, _build_ctx, self_property, function| {

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -29,11 +29,6 @@
 "bookmarks" = "magenta"
 "local_bookmarks" = "magenta"
 "remote_bookmarks" = "magenta"
-#  TODO: Remove *branch* in jj 0.28+
-"branch" = "magenta"
-"branches" = "magenta"
-"local_branches" = "magenta"
-"remote_branches" = "magenta"
 "tag" = "magenta"
 "tags" = "magenta"
 "git_refs" = "green"
@@ -62,11 +57,6 @@
 "working_copy bookmarks" = "bright magenta"
 "working_copy local_bookmarks" = "bright magenta"
 "working_copy remote_bookmarks" = "bright magenta"
-#  TODO: Remove *branch* in jj 0.28+
-"working_copy branch" = "bright magenta"
-"working_copy branches" = "bright magenta"
-"working_copy local_branches" = "bright magenta"
-"working_copy remote_branches" = "bright magenta"
 "working_copy tag" = "bright magenta"
 "working_copy tags" = "bright magenta"
 "working_copy git_refs" = "bright green"

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -157,16 +157,17 @@ fn test_bad_function_call() {
     [exit status: 1]
     ");
 
-    let output = test_env.run_jj_in(&repo_path, ["log", "-r", "files()"]);
+    // "N to M arguments"
+    let output = test_env.run_jj_in(&repo_path, ["log", "-r", "ancestors()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Failed to parse revset: Function `files`: Expected at least 1 arguments
-    Caused by:  --> 1:7
+    Error: Failed to parse revset: Function `ancestors`: Expected 1 to 2 arguments
+    Caused by:  --> 1:11
       |
-    1 | files()
-      |       ^
+    1 | ancestors()
+      |           ^
       |
-      = Function `files`: Expected at least 1 arguments
+      = Function `ancestors`: Expected 1 to 2 arguments
     [EOF]
     [exit status: 1]
     ");
@@ -215,15 +216,15 @@ fn test_bad_function_call() {
     [exit status: 1]
     "#);
 
-    let output = test_env.run_jj_in(&repo_path, ["log", "-r", r#"files(a, "../out")"#]);
+    let output = test_env.run_jj_in(&repo_path, ["log", "-r", r#"files("../out")"#]);
     insta::assert_snapshot!(output.normalize_backslash(), @r#"
     ------- stderr -------
     Error: Failed to parse revset: In fileset expression
     Caused by:
-    1:  --> 1:10
+    1:  --> 1:7
       |
-    1 | files(a, "../out")
-      |          ^------^
+    1 | files("../out")
+      |       ^------^
       |
       = In fileset expression
     2:  --> 1:1
@@ -347,26 +348,6 @@ fn test_bad_function_call() {
     Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
-    ");
-}
-
-#[test]
-fn test_parse_warning() {
-    let test_env = TestEnvironment::default();
-    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let repo_path = test_env.env_root().join("repo");
-
-    let output = test_env.run_jj_in(&repo_path, ["log", "-r", "files(foo, bar)"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: In revset expression
-     --> 1:7
-      |
-    1 | files(foo, bar)
-      |       ^------^
-      |
-      = Multi-argument patterns syntax is deprecated; separate them with |
-    [EOF]
     ");
 }
 

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -356,48 +356,6 @@ fn test_parse_warning() {
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let repo_path = test_env.env_root().join("repo");
 
-    let output = test_env.run_jj_in(
-        &repo_path,
-        [
-            "log",
-            "-r",
-            "branches() | remote_branches() | tracked_remote_branches() | \
-             untracked_remote_branches()",
-        ],
-    );
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: In revset expression
-     --> 1:1
-      |
-    1 | branches() | remote_branches() | tracked_remote_branches() | untracked_remote_branches()
-      | ^------^
-      |
-      = branches() is deprecated; use bookmarks() instead
-    Warning: In revset expression
-     --> 1:14
-      |
-    1 | branches() | remote_branches() | tracked_remote_branches() | untracked_remote_branches()
-      |              ^-------------^
-      |
-      = remote_branches() is deprecated; use remote_bookmarks() instead
-    Warning: In revset expression
-     --> 1:34
-      |
-    1 | branches() | remote_branches() | tracked_remote_branches() | untracked_remote_branches()
-      |                                  ^---------------------^
-      |
-      = tracked_remote_branches() is deprecated; use tracked_remote_bookmarks() instead
-    Warning: In revset expression
-     --> 1:62
-      |
-    1 | branches() | remote_branches() | tracked_remote_branches() | untracked_remote_branches()
-      |                                                              ^-----------------------^
-      |
-      = untracked_remote_branches() is deprecated; use untracked_remote_bookmarks() instead
-    [EOF]
-    ");
-
     let output = test_env.run_jj_in(&repo_path, ["log", "-r", "files(foo, bar)"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
@@ -497,7 +455,6 @@ fn test_alias() {
     'recurse2()' = 'recurse'
     'identity(x)' = 'x'
     'my_author(x)' = 'author(x)'
-    'deprecated()' = 'branches()'
     "###,
     );
 
@@ -607,43 +564,6 @@ fn test_alias() {
       = Alias `recurse` expanded recursively
     [EOF]
     [exit status: 1]
-    ");
-
-    let output = test_env.run_jj_in(&repo_path, ["log", "-r", "deprecated()"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: In revset expression
-     --> 1:1
-      |
-    1 | deprecated()
-      | ^----------^
-      |
-      = In alias `deprecated()`
-     --> 1:1
-      |
-    1 | branches()
-      | ^------^
-      |
-      = branches() is deprecated; use bookmarks() instead
-    [EOF]
-    ");
-    let output = test_env.run_jj_in(&repo_path, ["log", "-r", "all:deprecated()"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: In revset expression
-     --> 1:5
-      |
-    1 | all:deprecated()
-      |     ^----------^
-      |
-      = In alias `deprecated()`
-     --> 1:1
-      |
-    1 | branches()
-      | ^------^
-      |
-      = branches() is deprecated; use bookmarks() instead
-    [EOF]
     ");
 }
 

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -122,6 +122,20 @@ fn test_templater_parse_error() {
     [exit status: 1]
     ");
 
+    // "at least N arguments"
+    insta::assert_snapshot!(render("separate()"), @r"
+    ------- stderr -------
+    Error: Failed to parse template: Function `separate`: Expected at least 1 arguments
+    Caused by:  --> 1:10
+      |
+    1 | separate()
+      |          ^
+      |
+      = Function `separate`: Expected at least 1 arguments
+    [EOF]
+    [exit status: 1]
+    ");
+
     // -Tbuiltin shows the predefined builtin_* aliases. This isn't 100%
     // guaranteed, but is nice.
     insta::assert_snapshot!(render(r#"builtin"#), @r"

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -147,58 +147,20 @@ fn test_template_parse_warning() {
 
     let template = indoc! {r#"
         separate(' ',
-          branches,
-          local_branches,
-          remote_branches,
-          self.contained_in('branches()'),
           author.username(),
         )
     "#};
     let output = test_env.run_jj_in(&repo_path, ["log", "-r@", "-T", template]);
     insta::assert_snapshot!(output, @r"
-    @  false test.user
+    @  test.user
     │
     ~
     [EOF]
     ------- stderr -------
     Warning: In template expression
-     --> 2:3
+     --> 2:10
       |
-    2 |   branches,
-      |   ^------^
-      |
-      = branches() is deprecated; use bookmarks() instead
-    Warning: In template expression
-     --> 3:3
-      |
-    3 |   local_branches,
-      |   ^------------^
-      |
-      = local_branches() is deprecated; use local_bookmarks() instead
-    Warning: In template expression
-     --> 4:3
-      |
-    4 |   remote_branches,
-      |   ^-------------^
-      |
-      = remote_branches() is deprecated; use remote_bookmarks() instead
-    Warning: In template expression
-     --> 5:21
-      |
-    5 |   self.contained_in('branches()'),
-      |                     ^----------^
-      |
-      = In revset expression
-     --> 1:1
-      |
-    1 | branches()
-      | ^------^
-      |
-      = branches() is deprecated; use bookmarks() instead
-    Warning: In template expression
-     --> 6:10
-      |
-    6 |   author.username(),
+    2 |   author.username(),
       |          ^------^
       |
       = username() is deprecated; use email().local() instead
@@ -238,7 +200,7 @@ fn test_templater_alias() {
     'recurse2()' = 'recurse'
     'identity(x)' = 'x'
     'coalesce(x, y)' = 'if(x, x, y)'
-    'deprecated()' = 'branches ++ self.contained_in("branches()")'
+    'deprecated()' = 'author.username()'
     'builtin_log_node' = '"#"'
     'builtin_op_log_node' = '"#"'
     "###,
@@ -429,8 +391,8 @@ fn test_templater_alias() {
     ");
 
     let output = test_env.run_jj_in(&repo_path, ["log", "-r@", "-Tdeprecated()"]);
-    insta::assert_snapshot!(output, @r##"
-    #  false
+    insta::assert_snapshot!(output, @r"
+    #  test.user
     │
     ~
     [EOF]
@@ -442,33 +404,14 @@ fn test_templater_alias() {
       | ^----------^
       |
       = In alias `deprecated()`
-     --> 1:1
+     --> 1:8
       |
-    1 | branches ++ self.contained_in("branches()")
-      | ^------^
+    1 | author.username()
+      |        ^------^
       |
-      = branches() is deprecated; use bookmarks() instead
-    Warning: In template expression
-     --> 1:1
-      |
-    1 | deprecated()
-      | ^----------^
-      |
-      = In alias `deprecated()`
-     --> 1:31
-      |
-    1 | branches ++ self.contained_in("branches()")
-      |                               ^----------^
-      |
-      = In revset expression
-     --> 1:1
-      |
-    1 | branches()
-      | ^------^
-      |
-      = branches() is deprecated; use bookmarks() instead
+      = username() is deprecated; use email().local() instead
     [EOF]
-    "##);
+    ");
 }
 
 #[test]

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -871,13 +871,6 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
         Ok(RevsetExpression::is_empty())
     });
     map.insert("files", |diagnostics, function, context| {
-        // TODO: Remove in jj 0.28+
-        if function.name != "files" {
-            diagnostics.add_warning(RevsetParseError::expression(
-                "file() is deprecated; use files() instead",
-                function.name_span,
-            ));
-        }
         let ctx = context.workspace.as_ref().ok_or_else(|| {
             RevsetParseError::with_span(
                 RevsetParseErrorKind::FsPathWithoutWorkspace,
@@ -898,8 +891,6 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
         let expr = FilesetExpression::union_all(file_expressions);
         Ok(RevsetExpression::filter(RevsetFilterPredicate::File(expr)))
     });
-    // TODO: Remove in jj 0.28+
-    map.insert("file", map["files"]);
     map.insert("diff_contains", |diagnostics, function, context| {
         let ([text_arg], [files_opt_arg]) = function.expect_arguments()?;
         let text = expect_string_pattern(diagnostics, text_arg)?;
@@ -920,19 +911,10 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
             RevsetFilterPredicate::DiffContains { text, files },
         ))
     });
-    map.insert("conflicts", |diagnostics, function, _context| {
-        // TODO: Remove in jj 0.28+
-        if function.name != "conflicts" {
-            diagnostics.add_warning(RevsetParseError::expression(
-                "conflict() is deprecated; use conflicts() instead",
-                function.name_span,
-            ));
-        }
+    map.insert("conflicts", |_diagnostics, function, _context| {
         function.expect_no_arguments()?;
         Ok(RevsetExpression::filter(RevsetFilterPredicate::HasConflict))
     });
-    // TODO: Remove in jj 0.28+
-    map.insert("conflict", map["conflicts"]);
     map.insert("present", |diagnostics, function, context| {
         let [arg] = function.expect_exact_arguments()?;
         let expression = lower_expression(diagnostics, arg, context)?;

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3219,16 +3219,16 @@ mod tests {
         assert!(parse_with_workspace("empty(foo)", &WorkspaceId::default()).is_err());
         assert!(parse_with_workspace("file()", &WorkspaceId::default()).is_err());
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(foo)", &WorkspaceId::default()).unwrap(),
+            parse_with_workspace("files(foo)", &WorkspaceId::default()).unwrap(),
             @r#"Filter(File(Pattern(PrefixPath("foo"))))"#);
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(all())", &WorkspaceId::default()).unwrap(),
+            parse_with_workspace("files(all())", &WorkspaceId::default()).unwrap(),
             @"Filter(File(All))");
         insta::assert_debug_snapshot!(
-            parse_with_workspace(r#"file(file:"foo")"#, &WorkspaceId::default()).unwrap(),
+            parse_with_workspace(r#"files(file:"foo")"#, &WorkspaceId::default()).unwrap(),
             @r#"Filter(File(Pattern(FilePath("foo"))))"#);
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(foo|bar&baz)", &WorkspaceId::default()).unwrap(), @r#"
+            parse_with_workspace("files(foo|bar&baz)", &WorkspaceId::default()).unwrap(), @r#"
         Filter(
             File(
                 UnionAll(
@@ -3244,7 +3244,7 @@ mod tests {
         )
         "#);
         insta::assert_debug_snapshot!(
-            parse_with_workspace("file(foo, bar, baz)", &WorkspaceId::default()).unwrap(), @r#"
+            parse_with_workspace("files(foo, bar, baz)", &WorkspaceId::default()).unwrap(), @r#"
         Filter(
             File(
                 UnionAll(
@@ -3394,7 +3394,7 @@ mod tests {
 
         // Alias can be substituted to string literal.
         insta::assert_debug_snapshot!(
-            parse_with_aliases_and_workspace("file(A)", [("A", "a")], &WorkspaceId::default())
+            parse_with_aliases_and_workspace("files(A)", [("A", "a")], &WorkspaceId::default())
                 .unwrap(),
             @r#"Filter(File(Pattern(PrefixPath("a"))))"#);
 
@@ -3872,7 +3872,7 @@ mod tests {
         "#);
         insta::assert_debug_snapshot!(
             optimize(parse_with_workspace(
-                "committer_name(foo) & file(bar) & baz",
+                "committer_name(foo) & files(bar) & baz",
                 &WorkspaceId::default()).unwrap(),
             ), @r#"
         Intersection(
@@ -3885,7 +3885,7 @@ mod tests {
         "#);
         insta::assert_debug_snapshot!(
             optimize(parse_with_workspace(
-                "committer_name(foo) & file(bar) & author_name(baz)",
+                "committer_name(foo) & files(bar) & author_name(baz)",
                 &WorkspaceId::default()).unwrap(),
             ), @r#"
         Intersection(
@@ -3896,7 +3896,11 @@ mod tests {
             Filter(AuthorName(Substring("baz"))),
         )
         "#);
-        insta::assert_debug_snapshot!(optimize(parse_with_workspace("foo & file(bar) & baz", &WorkspaceId::default()).unwrap()), @r#"
+        insta::assert_debug_snapshot!(
+            optimize(parse_with_workspace(
+                "foo & files(bar) & baz",
+                &WorkspaceId::default()).unwrap(),
+            ), @r#"
         Intersection(
             Intersection(
                 CommitRef(Symbol("foo")),

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -729,13 +729,6 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
         Ok(RevsetExpression::root())
     });
     map.insert("bookmarks", |diagnostics, function, _context| {
-        if function.name != "bookmarks" {
-            // TODO: Remove in jj 0.28+
-            diagnostics.add_warning(RevsetParseError::expression(
-                "branches() is deprecated; use bookmarks() instead",
-                function.name_span,
-            ));
-        }
         let ([], [opt_arg]) = function.expect_arguments()?;
         let pattern = if let Some(arg) = opt_arg {
             expect_string_pattern(diagnostics, arg)?
@@ -745,53 +738,20 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
         Ok(RevsetExpression::bookmarks(pattern))
     });
     map.insert("remote_bookmarks", |diagnostics, function, _context| {
-        if function.name != "remote_bookmarks" {
-            // TODO: Remove in jj 0.28+
-            diagnostics.add_warning(RevsetParseError::expression(
-                "remote_branches() is deprecated; use remote_bookmarks() instead",
-                function.name_span,
-            ));
-        }
         parse_remote_bookmarks_arguments(diagnostics, function, None)
     });
     map.insert(
         "tracked_remote_bookmarks",
         |diagnostics, function, _context| {
-            if function.name != "tracked_remote_bookmarks" {
-                // TODO: Remove in jj 0.28+
-                diagnostics.add_warning(RevsetParseError::expression(
-                    "tracked_remote_branches() is deprecated; use tracked_remote_bookmarks() \
-                     instead",
-                    function.name_span,
-                ));
-            }
             parse_remote_bookmarks_arguments(diagnostics, function, Some(RemoteRefState::Tracking))
         },
     );
     map.insert(
         "untracked_remote_bookmarks",
         |diagnostics, function, _context| {
-            if function.name != "untracked_remote_bookmarks" {
-                // TODO: Remove in jj 0.28+
-                diagnostics.add_warning(RevsetParseError::expression(
-                    "untracked_remote_branches() is deprecated; use untracked_remote_bookmarks() \
-                     instead",
-                    function.name_span,
-                ));
-            }
             parse_remote_bookmarks_arguments(diagnostics, function, Some(RemoteRefState::New))
         },
     );
-
-    // TODO: Remove in jj 0.28+
-    map.insert("branches", map["bookmarks"]);
-    map.insert("remote_branches", map["remote_bookmarks"]);
-    map.insert("tracked_remote_branches", map["tracked_remote_bookmarks"]);
-    map.insert(
-        "untracked_remote_branches",
-        map["untracked_remote_bookmarks"],
-    );
-
     map.insert("tags", |diagnostics, function, _context| {
         let ([], [opt_arg]) = function.expect_arguments()?;
         let pattern = if let Some(arg) = opt_arg {


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
