### PR TITLE
cli: debug copy-detection: fix help text

### DIFF
--- a/cli/src/commands/debug/copy_detection.rs
+++ b/cli/src/commands/debug/copy_detection.rs
@@ -24,10 +24,11 @@ use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Rebuild commit index
+/// Show information about file copies detected
 #[derive(clap::Args, Clone, Debug)]
 pub struct CopyDetectionArgs {
-    /// Show changes in this revision, compared to its parent(s)
+    /// Show file copies detected in changed files in this revision, compared to
+    /// its parent(s)
     #[arg(default_value = "@", value_name = "REVSET")]
     revision: RevisionArg,
 }


### PR DESCRIPTION
It looks like the help text was copied from another command and not updated.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
