### PR TITLE
lib rewrite: Add CommitWithSelection::invert() to invert the selection

### DIFF
--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1878,4 +1878,10 @@ fn test_commit_with_selection() {
     };
     assert!(!full_selection.is_empty_selection());
     assert!(full_selection.is_full_selection());
+
+    assert_eq!(empty_selection.clone().invert().unwrap(), full_selection);
+    assert_eq!(
+        empty_selection.clone().invert().unwrap().invert().unwrap(),
+        empty_selection
+    );
 }


### PR DESCRIPTION
This will be used in `jj split` in a follow up commit and when the new -A, -B, and -d options are added.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
