### PR TITLE
cargo-deny: Ignore paste crate deprecation

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0395", reason = "temporary, to unblock PRs" },
+    { id = "RUSTSEC-2024-0436", reason = "Used by ratatui with no direct alternative." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,11 @@ dev = [
 package = false
 
 [tool.codespell]
-check-filenames=true
-check-hidden=true
+check-filenames = true
+check-hidden = true
 # Codespell does not respect .gitignore. It may be necessary to add to
 # this list by running e.g. `uv run codespell --skip=./rendered-docs`
 # if you have less common ignored files or globally ignored files present.
 # Alternatively, try `uv run codespell $(jj file list)`.
-skip="./target,./.jj,*.lock,./.git,./.venv,./.direnv"
-ignore-words-list="crate,NotIn,Wirth,abd"
-
+skip = "./target,./.jj,*.lock,./.git,./.venv,./.direnv"
+ignore-words-list = "crate,NotIn,Wirth,abd,ratatui"


### PR DESCRIPTION
The paste crate hasn't had a maintainer since Oct. 2024. We don't use it directly, but it's used by ratatui, and there's no direct replacement for it AFAIK.

Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436

This is currently blocking PRs because ci fails:
```
error[unmaintained]: paste - no longer maintained
    ┌─ /github/workspace/Cargo.lock:262:1
    │
262 │ paste 1.0.15 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0436
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436
    ├ The creator of the crate `paste` has stated in the [`README.md`](https://github.com/dtolnay/paste/blob/master/README.md) 
      that this project is not longer maintained as well as archived the repository
    ├ Announcement: https://github.com/dtolnay/paste
    ├ Solution: No safe upgrade is available!
    ├ paste v1.0.15
      └── ratatui v0.29.0
          └── scm-record v0.5.0
              └── jj-cli v0.27.0
                  └── (dev) jj-cli v0.27.0 (*)

advisories FAILED
```