### PR TITLE
Don't show console on Windows

### DIFF
--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -105,6 +105,14 @@ impl<'a> GitSubprocessContext<'a> {
     /// Create the Git command
     fn create_command(&self) -> Command {
         let mut git_cmd = Command::new(self.git_executable_path);
+        // Hide console window on Windows (https://stackoverflow.com/a/60958956)
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            git_cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
         // TODO: here we are passing the full path to the git_dir, which can lead to UNC
         // bugs in Windows. The ideal way to do this is to pass the workspace
         // root to Command::current_dir and then pass a relative path to the git

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -156,6 +156,14 @@ impl GpgBackend {
 
     fn create_command(&self) -> Command {
         let mut command = Command::new(&self.program);
+        // Hide console window on Windows (https://stackoverflow.com/a/60958956)
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            command.creation_flags(CREATE_NO_WINDOW);
+        }
+
         command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -130,6 +130,13 @@ impl SshBackend {
 
     fn create_command(&self) -> Command {
         let mut command = Command::new(&self.program);
+        // Hide console window on Windows (https://stackoverflow.com/a/60958956)
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            command.creation_flags(CREATE_NO_WINDOW);
+        }
 
         command
             .stdin(Stdio::piped())


### PR DESCRIPTION
When used inside GUI application, git.subprocess=true option or enabled signing cause console window to appear temporarily.

std::process::Command needs special flags to prevent that. More details: https://stackoverflow.com/a/60958956

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
