### PR TITLE
cli: git push: rename git.sign-on-push to `git.sign-on-push.enabled` and add `git.sign-on-push.behavior`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `core.watchman.register_snapshot_trigger` has been renamed to `core.watchman.register-snapshot-trigger` for consistency with other configuration options.
 
+* The `git.sign-on-push` config option has been deprecated in favor of
+  `git.sign-on-push.enabled` and `git.sign-on-push.behavior` options.
+  `git.sign-on-push.behavior` allows customizing the signing behavior similar to
+  `signing.behavior`. Valid options are `drop` (drop all signatures), `keep`
+  (preserve existing signatures), `own` (sign own commits), or `force` (sign all
+  commits). The default value is set to `own` to match the previous behavior.
+
 ### New features
 
 * The 'how to resolve conflicts' hint that is shown when conflicts appear can

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -406,9 +406,21 @@
                     "default": "origin"
                 },
                 "sign-on-push": {
-                    "type": "boolean",
-                    "description": "Whether jj should sign commits before pushing",
-                    "default": "false"
+                    "type": "object",
+                    "description": "Settings for signing commits before pushing",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether jj should sign commits before pushing",
+                            "default": "false"
+                        },
+                        "behavior": {
+                            "type": "string",
+                            "enum": ["drop", "keep", "own", "force"],
+                            "description": "Which commits to sign before pushing. Values: drop (never sign), keep (preserve existing signatures), own (sign own commits), force (sign all commits)",
+                            "default": "keep"
+                        }
+                    }
                 },
                 "subprocess": {
                     "type": "boolean",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -16,7 +16,10 @@ context = 3
 private-commits = "none()"
 push-bookmark-prefix = "push-"
 push-new-bookmarks = false
-sign-on-push = false
+
+[git.sign-on-push]
+enabled = false
+behavior = "keep"
 
 [ui]
 always-allow-large-revsets = false

--- a/docs/config.md
+++ b/docs/config.md
@@ -1191,6 +1191,20 @@ as follows:
 backends.ssh.allowed-signers = "/path/to/allowed-signers"
 ```
 
+### Signing behavior
+
+The `signing.behavior` config option can be used to customize whether commits
+are signed when creating new commits or creating new commits from of existing
+commits. The valid options are:
+
+- `drop`: Does not sign new commits and drops all signatures when creating new
+  commits from an existing signed commit.
+- `keep` (default): Does not sign new commits, but preserve existing signatures
+  when creating new commits from a signed commit.
+- `own`: Signs all commits with author set to the current user email
+  (`user.email`).
+- `force`: Signs all commits.
+
 ### Sign commits only on `jj git push`
 
 Instead of signing all commits during creation when `signing.behavior` is

--- a/docs/config.md
+++ b/docs/config.md
@@ -1221,8 +1221,9 @@ behavior = "drop"
 backend = "ssh"
 key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj+J6N6SO+4P8dOZqfR1oiay2yxhhHnagH52avUqw5h"
 
-[git]
-sign-on-push = true
+[git.sign-on-push]
+enabled = true
+behavior = "own"
 ```
 
 ### Manually signing commits


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Previously, when `git.sign-on-push` is set to `true`, commits would be
signed upon pushing with Git with the sign behavior of
`SignBehavior::Own`. However, this could not be customized like
`signing.sign-behavior`.

This commit renames `git.sign-on-push` to `git.sign-on-push.enabled` and
adds `git.sign-on-push.behavior` to allow users to customize the sign
behavior when pushing commits.
# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
