### PR TITLE
config: update diff-editor and merge-editor schema

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -210,14 +210,34 @@
                     "description": "Editor to use for commands that involve editing text"
                 },
                 "diff-editor": {
-                    "type": "string",
                     "description": "Editor tool to use for editing diffs",
-                    "default": ":builtin"
+                    "default": ":builtin",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 },
                 "merge-editor": {
-                    "type": "string",
                     "description": "Tool to use for resolving three-way merges. Behavior for a given tool name can be configured in merge-tools.TOOL tables",
-                    "default": ":builtin"
+                    "default": ":builtin",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 },
                 "conflict-marker-style": {
                     "$ref": "#/properties/ui/definitions/conflict-marker-style"


### PR DESCRIPTION
Hello!

The docs show that the diff-editor, and merge-editor settings
can be a string or an array of strings. This updates the config
schema to reflect that.

Thanks!

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
