### PR TITLE
cli: bookmark move: allow short aliases for `--to`/`--from`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj op log -d` now has an alias for `jj op log --op-diff`.
 
+* `jj bookmark move --to/--from` can now be abbreviated to `jj bookmark move -t/-f`
+
 ### Fixed bugs
 
 ## [0.27.0] - 2025-03-05

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -43,11 +43,8 @@ use crate::ui::Ui;
 #[command(group(clap::ArgGroup::new("source").multiple(true).required(true)))]
 pub struct BookmarkMoveArgs {
     /// Move bookmarks from the given revisions
-    // We intentionally do not support the short `-f` for `--from` since it
-    // could be confused with a shorthand for `--force`, and people might not
-    // realize they need `-B`/`--allow-backwards` instead.
     #[arg(
-        long,
+        long, short,
         group = "source",
         value_name = "REVSETS",
         add = ArgValueCandidates::new(complete::all_revisions),
@@ -56,11 +53,10 @@ pub struct BookmarkMoveArgs {
 
     // TODO(#5374): Make required in jj 0.32+
     /// Move bookmarks to this revision
-    // We intentionally do not support the short `-t` for `--to` since we don't
-    // support `-f` for `--from`. Currently this defaults to the working copy, but in the near
+    // Currently this defaults to the working copy, but in the near
     // future it will be required to explicitly specify it.
     #[arg(
-        long,
+        long, short,
         value_name = "REVSET",
         add = ArgValueCandidates::new(complete::all_revisions),
     )]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -433,8 +433,8 @@ $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 
 ###### **Options:**
 
-* `--from <REVSETS>` — Move bookmarks from the given revisions
-* `--to <REVSET>` — Move bookmarks to this revision
+* `-f`, `--from <REVSETS>` — Move bookmarks from the given revisions
+* `-t`, `--to <REVSET>` — Move bookmarks to this revision
 * `-B`, `--allow-backwards` — Allow moving bookmarks backwards or sideways
 
 


### PR DESCRIPTION
Hello!

If `--to` is going to become a required argument, it should have a short alias as it will be used quite frequently.

Additionally, I would argue in favor of using `-f` for `--from`, given that is it used for other commands and we should be consistent (if users can use `-f` as an alias for `--from` on other commands then logically they would assume they can use it for this one). Not allowing it because users might mistake it to mean `--force` isn't that big of a concern in my book given that `--force` is not used as an option anywhere else (as far as I am aware) and the option requires an argument so it will fail even if a user does try to use it for such a purpose.

If this is acceptable then I can send a follow up PR to add the alias for `--from` (or edit the current commit).

Thanks!

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
