### PR TITLE
revset globs: `substr-i` as an alias for `substring-i:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj bookmark move --to/--from` can now be abbreviated to `jj bookmark move -t/-f`
 
+* In string patterns for revsets or bookmarks, `substr:` is now a shortcut for
+  `substring:`.
+
 ### Fixed bugs
 
 

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -864,7 +864,7 @@ fn revset_resolution_error_hint(err: &RevsetResolutionError) -> Option<String> {
 fn string_pattern_parse_error_hint(err: &StringPatternParseError) -> Option<String> {
     match err {
         StringPatternParseError::InvalidKind(_) => Some(
-            "Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these \
+            "Try prefixing with one of `exact:`, `glob:`, `regex:`, `substr:`, or one of these \
              with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching"
                 .into(),
         ),

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -850,7 +850,7 @@ fn test_bookmark_delete_glob() {
     error: invalid value 'whatever:bookmark' for '<NAMES>...': Invalid string pattern kind `whatever:`
 
     For more information, try '--help'.
-    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
+    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substr:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
     [EOF]
     [exit status: 2]
     ");

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1094,7 +1094,7 @@ fn test_log_contained_in() {
       |
       = Invalid string pattern
     3: Invalid string pattern kind `x:`
-    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
+    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substr:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -252,7 +252,7 @@ fn test_bad_function_call() {
       |
       = Invalid string pattern
     2: Invalid string pattern kind `bad:`
-    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
+    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substr:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
     [EOF]
     [exit status: 1]
     ");

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -410,7 +410,10 @@ revsets (expressions) as arguments.
 Functions that perform string matching support the following pattern syntax (the
 quotes are optional):
 
-* `"string"` or `substring:"string"`: Matches strings that contain `string`.
+<!-- TODO: Make it clear when `exact:` is the default instead of `sub:` -->
+
+* `"string"`, or `substr:"string"`, or `substring:"string"`: Matches strings
+  that contain `string`.
 * `exact:"string"`: Matches strings exactly equal to `string`.
 * `glob:"pattern"`: Matches strings with Unix-style shell [wildcard
   `pattern`](https://docs.rs/glob/latest/glob/struct.Pattern.html).

--- a/lib/src/str_util.rs
+++ b/lib/src/str_util.rs
@@ -125,8 +125,8 @@ impl StringPattern {
         match kind {
             "exact" => Ok(StringPattern::exact(src)),
             "exact-i" => Ok(StringPattern::exact_i(src)),
-            "substring" => Ok(StringPattern::substring(src)),
-            "substring-i" => Ok(StringPattern::substring_i(src)),
+            "substring" | "substr" => Ok(StringPattern::substring(src)),
+            "substring-i" | "substr-i" => Ok(StringPattern::substring_i(src)),
             "glob" => StringPattern::glob(src),
             "glob-i" => StringPattern::glob_i(src),
             "regex" => StringPattern::regex(src),
@@ -292,12 +292,20 @@ mod tests {
             Ok(StringPattern::Glob(p)) if p.as_str() == "foo*"
         );
         assert_matches!(
+            StringPattern::parse("substr:foo"),
+            Ok(StringPattern::Substring(s)) if s == "foo"
+        );
+        assert_matches!(
             StringPattern::parse("substring:foo"),
             Ok(StringPattern::Substring(s)) if s == "foo"
         );
         assert_matches!(
             StringPattern::from_str_kind("foo", "substring"),
             Ok(StringPattern::Substring(s)) if s == "foo"
+        );
+        assert_matches!(
+            StringPattern::parse("substr-i:foo"),
+            Ok(StringPattern::SubstringI(s)) if s == "foo"
         );
         assert_matches!(
             StringPattern::parse("substring-i:foo"),


### PR DESCRIPTION
My instinct is to try `iglob:` instead of the
correct `glob-i:`.

@yuja, is this correct in every case? I found it difficult to find where the `-i` postfix is parsed.

* [x] Add to CHANGELOG if we keep the second commit