### PR TITLE
tests: remove `libgit2` test performance hack

### DIFF
--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -134,14 +134,6 @@ impl TestEnvironment {
         cmd.env("JJ_TIMESTAMP", timestamp.to_rfc3339());
         cmd.env("JJ_OP_TIMESTAMP", timestamp.to_rfc3339());
 
-        // libgit2 always initializes OpenSSL, and it takes a few tens of milliseconds
-        // to load the system CA certificates in X509_load_cert_crl_file_ex(). As we
-        // don't use HTTPS in our tests, we can disable the cert loading to speed up the
-        // CLI tests. If we migrated to gitoxide, maybe we can remove this hack.
-        if cfg!(unix) {
-            cmd.env("SSL_CERT_FILE", "/dev/null");
-        }
-
         if cfg!(windows) {
             // Windows uses `TEMP` to create temporary directories, which we need for some
             // tests.


### PR DESCRIPTION
I think we should only initialize the library for the fetch/push tests now, so it should be okay to drop this.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
