### PR TITLE
git: make `git2` support optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,18 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        build: [linux-x86_64-gnu, linux-aarch64-gnu, macos-x86_64, macos-aarch64, windows-x86_64]
+        build: [linux-x86_64-gnu, 'linux-x86_64-gnu, no git2', linux-aarch64-gnu, macos-x86_64, macos-aarch64, windows-x86_64]
         include:
         - build: linux-x86_64-gnu
           os: ubuntu-24.04
           target: x86_64-unknown-linux-gnu
           cargo_flags: "--all-features"
+        - build: 'linux-x86_64-gnu, no git2'
+          os: ubuntu-24.04
+          target: x86_64-unknown-linux-gnu
+          cargo_flags: "--no-default-features --features git"
+          # Ensure we don’t link to `libgit2`.
+          LIBGIT2_NO_VENDOR: 1
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-gnu
@@ -82,6 +88,7 @@ jobs:
       env:
         RUST_BACKTRACE: 1
         CARGO_TERM_COLOR: always
+        LIBGIT2_NO_VENDOR: ${{ matrix.LIBGIT2_NO_VENDOR || '0' }}
 
   no-git:
     name: build (no git)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ winreg = "0.52"
 
 jj-lib = { path = "lib", version = "0.27.0", default-features = false }
 jj-lib-proc-macros = { path = "lib/proc-macros", version = "0.27.0" }
-testutils = { path = "lib/testutils" }
+testutils = { path = "lib/testutils", default-features = false }
 
 [workspace.lints.clippy]
 explicit_iter_loop = "warn"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -95,6 +95,9 @@ tracing-subscriber = { workspace = true }
 unicode-width = { workspace = true }
 whoami = { workspace = true }
 
+# TODO: Workaround for Cargo weirdness; remove when `git2` goes away.
+testutils = { workspace = true, optional = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
@@ -110,9 +113,10 @@ testutils = { workspace = true }
 jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 
 [features]
-default = ["watchman", "git"]
+default = ["watchman", "git", "git2"]
 bench = ["dep:criterion"]
-git = ["jj-lib/git", "dep:git2", "dep:gix"]
+git = ["jj-lib/git", "dep:gix"]
+git2 = ["git", "jj-lib/git2", "testutils?/git2", "dep:git2"]
 gix-max-performance = ["jj-lib/gix-max-performance"]
 packaging = ["gix-max-performance"]
 test-fakes = ["jj-lib/testing"]

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -535,6 +535,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
                     "Run `jj git remote rename` to give a different name.",
                 ),
                 GitFetchError::InvalidBranchPattern(_) => user_error(err),
+                #[cfg(feature = "git2")]
                 GitFetchError::InternalGitError(err) => map_git2_error(err),
                 GitFetchError::Subprocess(_) => user_error(err),
             }
@@ -544,6 +545,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
     impl From<GitFetchPrepareError> for CommandError {
         fn from(err: GitFetchPrepareError) -> Self {
             match err {
+                #[cfg(feature = "git2")]
                 GitFetchPrepareError::Git2(err) => map_git2_error(err),
                 GitFetchPrepareError::UnexpectedBackend(_) => user_error(err),
             }
@@ -568,6 +570,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
                      it to be, and push again.",
                 ),
                 GitPushError::RefUpdateRejected(_) => user_error(err),
+                #[cfg(feature = "git2")]
                 GitPushError::InternalGitError(err) => map_git2_error(err),
                 GitPushError::Subprocess(_) => user_error(err),
                 GitPushError::UnexpectedBackend(_) => user_error(err),
@@ -587,6 +590,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
         }
     }
 
+    #[cfg(feature = "git2")]
     fn map_git2_error(err: git2::Error) -> CommandError {
         if err.class() == git2::ErrorClass::Ssh {
             let hint = if err.code() == git2::ErrorCode::Certificate

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -625,6 +625,17 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
         ),
         // TODO: Delete in jj 0.34+
         ConfigMigrationRule::rename_value("diff.format", "ui.diff.format"),
+        // TODO: Delete with the `git.subprocess` setting.
+        #[cfg(not(feature = "git2"))]
+        ConfigMigrationRule::custom(
+            |layer| {
+                let Ok(Some(subprocess)) = layer.look_up_item("git.subprocess") else {
+                    return false;
+                };
+                subprocess.as_bool() == Some(false)
+            },
+            |_| Ok("jj was compiled without `git.subprocess = false` support".into()),
+        ),
     ]
 }
 

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -45,7 +45,7 @@ pub struct TestEnvironment {
 
 impl Default for TestEnvironment {
     fn default() -> Self {
-        testutils::hermetic_libgit2();
+        testutils::hermetic_git();
 
         let tmp_dir = testutils::new_temp_dir();
         let env_root = dunce::canonicalize(tmp_dir.path()).unwrap();

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -40,7 +40,7 @@ fn set_up_git_repo_with_file(git_repo: &gix::Repository, filename: &str) {
     git::set_symbolic_reference(git_repo, "HEAD", "refs/heads/main");
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -200,7 +200,7 @@ fn test_git_clone(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_bad_source(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -234,7 +234,7 @@ fn test_git_clone_bad_source(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_colocate(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -471,7 +471,7 @@ fn test_git_clone_colocate(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -601,7 +601,7 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
 // A branch with a strange name should get quoted in the config. Windows doesn't
 // like the strange name, so we don't run the test there.
 #[cfg(unix)]
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -649,7 +649,7 @@ fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_ignore_working_copy(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -700,7 +700,7 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_at_operation(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -722,7 +722,7 @@ fn test_git_clone_at_operation(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_remote_name(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -753,7 +753,7 @@ fn test_git_clone_with_remote_name(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -774,7 +774,7 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -798,7 +798,7 @@ fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_trunk_deleted(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -943,6 +943,7 @@ fn test_git_clone_conditional_config() {
     ");
 }
 
+#[cfg(feature = "git2")]
 #[test]
 fn test_git_clone_with_depth_git2() {
     let test_env = TestEnvironment::default();
@@ -1000,7 +1001,7 @@ fn test_git_clone_with_depth_subprocess() {
     ");
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1032,7 +1033,7 @@ fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_malformed(subprocess: bool) {
     let test_env = TestEnvironment::default();

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -96,7 +96,7 @@ fn clone_git_remote_into(
     fork_repo
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_default_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -116,7 +116,7 @@ fn test_git_fetch_with_default_config(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_default_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -138,7 +138,7 @@ fn test_git_fetch_default_remote(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -168,7 +168,7 @@ fn test_git_fetch_single_remote(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -192,7 +192,7 @@ fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -216,7 +216,7 @@ fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -239,7 +239,7 @@ fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_multiple_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -269,7 +269,7 @@ fn test_git_fetch_multiple_remotes(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -292,7 +292,7 @@ fn test_git_fetch_with_glob(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob_and_exact_match(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -322,7 +322,7 @@ fn test_git_fetch_with_glob_and_exact_match(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -347,7 +347,7 @@ fn test_git_fetch_with_glob_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob_with_no_matching_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -373,7 +373,7 @@ fn test_git_fetch_with_glob_with_no_matching_remotes(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_all_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -408,7 +408,7 @@ fn test_git_fetch_all_remotes(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -434,7 +434,7 @@ fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -463,7 +463,7 @@ fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -490,7 +490,7 @@ fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -574,7 +574,7 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_from_remote_with_slashes(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -606,7 +606,7 @@ fn test_git_fetch_from_remote_with_slashes(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -649,7 +649,7 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -691,7 +691,7 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -776,7 +776,7 @@ fn create_trunk2_and_rebase_bookmarks(test_env: &TestEnvironment, repo_path: &Pa
     )
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_all(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -968,7 +968,7 @@ fn test_git_fetch_all(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1251,7 +1251,7 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1409,7 +1409,7 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
 
 // See `test_undo_restore_commands.rs` for fetch-undo-push and fetch-undo-fetch
 // of the same bookmarks for various kinds of undo.
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_undo(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1512,7 +1512,7 @@ fn test_git_fetch_undo(subprocess: bool) {
 
 // Compare to `test_git_import_undo` in test_git_import_export
 // TODO: Explain why these behaviors are useful
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_undo_what(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1646,7 +1646,7 @@ fn test_fetch_undo_what(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_remove_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1715,7 +1715,7 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_rename_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1775,7 +1775,7 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_removed_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -1897,7 +1897,7 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -2004,7 +2004,7 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default();
@@ -2079,7 +2079,7 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     let test_env = TestEnvironment::default();

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2194,3 +2194,23 @@ fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     ");
     }
 }
+
+// TODO: Remove with the `git.subprocess` setting.
+#[cfg(not(feature = "git2"))]
+#[test]
+fn test_git_fetch_git2_warning() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("git.subprocess = false");
+    test_env.add_config("git.auto-local-bookmark = true");
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let repo_path = test_env.env_root().join("repo");
+    add_git_remote(&test_env, &repo_path, "origin");
+
+    let output = test_env.run_jj_in(&repo_path, ["git", "fetch"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
+    bookmark: origin@origin [new] tracked
+    [EOF]
+    "#);
+}

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -63,7 +63,7 @@ fn set_up() -> (TestEnvironment, PathBuf) {
     (test_env, workspace_root)
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_nothing(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -91,7 +91,7 @@ fn test_git_push_nothing(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_current_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -203,7 +203,7 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_parent_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -235,7 +235,7 @@ fn test_git_push_parent_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_matching_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -254,7 +254,7 @@ fn test_git_push_no_matching_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -278,7 +278,7 @@ fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
 /// Test that `jj git push` without arguments pushes a bookmark to the specified
 /// remote even if it's already up to date on another remote
 /// (`remote_bookmarks(remote=<remote>)..@` vs. `remote_bookmarks()..@`).
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -354,7 +354,7 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -399,7 +399,7 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -466,7 +466,7 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
 
 // This tests whether the push checks that the remote bookmarks are in expected
 // positions.
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -524,7 +524,7 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -624,7 +624,7 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -671,7 +671,7 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -749,7 +749,7 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_multiple(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -918,7 +918,7 @@ fn test_git_push_multiple(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_changes(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1066,7 +1066,7 @@ fn test_git_push_changes(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_revisions(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1181,7 +1181,7 @@ fn test_git_push_revisions(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_mixed(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1263,7 +1263,7 @@ fn test_git_push_mixed(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_existing_long_bookmark(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1297,7 +1297,7 @@ fn test_git_push_existing_long_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_unsnapshotted_change(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1317,7 +1317,7 @@ fn test_git_push_unsnapshotted_change(subprocess: bool) {
         .success();
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_conflict(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1357,7 +1357,7 @@ fn test_git_push_conflict(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_description(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1401,7 +1401,7 @@ fn test_git_push_no_description(subprocess: bool) {
         .success();
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_description_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1467,7 +1467,7 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_author(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1511,7 +1511,7 @@ fn test_git_push_missing_author(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1581,7 +1581,7 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_committer(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1655,7 +1655,7 @@ fn test_git_push_missing_committer(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1726,7 +1726,7 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deleted(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1769,7 +1769,7 @@ fn test_git_push_deleted(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1878,7 +1878,7 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deleted_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -1913,7 +1913,7 @@ fn test_git_push_deleted_untracked(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_tracked_vs_all(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -2015,7 +2015,7 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_moved_forward_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -2044,7 +2044,7 @@ fn test_git_push_moved_forward_untracked(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -2076,7 +2076,7 @@ fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_to_remote_named_git(subprocess: bool) {
     let (test_env, workspace_root) = set_up();
@@ -2105,7 +2105,7 @@ fn test_git_push_to_remote_named_git(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_to_remote_with_slashes(subprocess: bool) {
     let (test_env, workspace_root) = set_up();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -94,8 +94,9 @@ testutils = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["git"]
-git = ["dep:git2", "dep:gix"]
+default = ["git", "git2"]
+git = ["dep:gix"]
+git2 = ["git", "testutils/git2", "dep:git2"]
 gix-max-performance = [
     # Requires `cmake` as a build dependency.
     # Note that this feature is different from `gix/max-performance-safe`.

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2053,7 +2053,7 @@ impl<'a> GitFetchImpl<'a> {
                 GitSubprocessContext::from_git_backend(git_backend, &git_settings.executable_path);
             Ok(GitFetchImpl::Subprocess { git_repo, git_ctx })
         } else {
-            let git_repo = git_backend.open_git_repo()?;
+            let git_repo = git2::Repository::open(git_backend.git_repo_path())?;
             Ok(GitFetchImpl::Git2 { git_repo })
         }
     }
@@ -2351,7 +2351,7 @@ pub fn push_updates(
             callbacks,
         )
     } else {
-        let git_repo = git_backend.open_git_repo()?;
+        let git_repo = git2::Repository::open(git_backend.git_repo_path())?;
         let refspecs: Vec<String> = refspecs.iter().map(RefSpec::to_git_format).collect();
         git2_push_refs(
             repo,

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -18,6 +18,7 @@ use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+#[cfg(feature = "git2")]
 use std::collections::HashSet;
 use std::default::Default;
 use std::fmt;
@@ -41,6 +42,7 @@ use crate::file_util::PathError;
 use crate::git_backend::GitBackend;
 use crate::git_subprocess::GitSubprocessContext;
 use crate::git_subprocess::GitSubprocessError;
+#[cfg(feature = "git2")]
 use crate::index::Index;
 use crate::merged_tree::MergedTree;
 use crate::object_id::ObjectId;
@@ -48,6 +50,7 @@ use crate::op_store::RefTarget;
 use crate::op_store::RefTargetOptionExt;
 use crate::op_store::RemoteRef;
 use crate::op_store::RemoteRefState;
+#[cfg(feature = "git2")]
 use crate::refs;
 use crate::refs::BookmarkPushUpdate;
 use crate::refs::RemoteRefSymbol;
@@ -1411,6 +1414,7 @@ impl GitRemoteManagementError {
     }
 }
 
+#[cfg(feature = "git2")]
 fn is_remote_not_found_err(err: &git2::Error) -> bool {
     matches!(
         (err.class(), err.code()),
@@ -1875,6 +1879,7 @@ pub enum GitFetchError {
     #[error(transparent)]
     RemoteName(#[from] GitRemoteNameError),
     // TODO: I'm sure there are other errors possible, such as transport-level errors.
+    #[cfg(feature = "git2")]
     #[error("Unexpected git error when fetching")]
     InternalGitError(#[from] git2::Error),
     #[error(transparent)]
@@ -1885,12 +1890,14 @@ pub enum GitFetchError {
 // UnexpectedGitBackendError.
 #[derive(Debug, Error)]
 pub enum GitFetchPrepareError {
+    #[cfg(feature = "git2")]
     #[error(transparent)]
     Git2(#[from] git2::Error),
     #[error(transparent)]
     UnexpectedBackend(#[from] UnexpectedGitBackendError),
 }
 
+#[cfg(feature = "git2")]
 fn git2_fetch_options(
     mut callbacks: RemoteCallbacks<'_>,
     depth: Option<NonZeroU32>,
@@ -2035,9 +2042,8 @@ fn expand_fetch_refspecs(
 }
 
 enum GitFetchImpl<'a> {
-    Git2 {
-        git_repo: git2::Repository,
-    },
+    #[cfg(feature = "git2")]
+    Git2 { git_repo: git2::Repository },
     Subprocess {
         git_repo: Box<gix::Repository>,
         git_ctx: GitSubprocessContext<'a>,
@@ -2047,15 +2053,15 @@ enum GitFetchImpl<'a> {
 impl<'a> GitFetchImpl<'a> {
     fn new(store: &Store, git_settings: &'a GitSettings) -> Result<Self, GitFetchPrepareError> {
         let git_backend = get_git_backend(store)?;
-        if git_settings.subprocess {
-            let git_repo = Box::new(git_backend.git_repo());
-            let git_ctx =
-                GitSubprocessContext::from_git_backend(git_backend, &git_settings.executable_path);
-            Ok(GitFetchImpl::Subprocess { git_repo, git_ctx })
-        } else {
+        #[cfg(feature = "git2")]
+        if !git_settings.subprocess {
             let git_repo = git2::Repository::open(git_backend.git_repo_path())?;
-            Ok(GitFetchImpl::Git2 { git_repo })
+            return Ok(GitFetchImpl::Git2 { git_repo });
         }
+        let git_repo = Box::new(git_backend.git_repo());
+        let git_ctx =
+            GitSubprocessContext::from_git_backend(git_backend, &git_settings.executable_path);
+        Ok(GitFetchImpl::Subprocess { git_repo, git_ctx })
     }
 
     fn fetch(
@@ -2066,6 +2072,7 @@ impl<'a> GitFetchImpl<'a> {
         depth: Option<NonZeroU32>,
     ) -> Result<(), GitFetchError> {
         match self {
+            #[cfg(feature = "git2")]
             GitFetchImpl::Git2 { git_repo } => {
                 git2_fetch(git_repo, remote_name, branch_names, callbacks, depth)
             }
@@ -2086,6 +2093,7 @@ impl<'a> GitFetchImpl<'a> {
         callbacks: RemoteCallbacks<'_>,
     ) -> Result<Option<String>, GitFetchError> {
         match self {
+            #[cfg(feature = "git2")]
             GitFetchImpl::Git2 { git_repo } => {
                 git2_get_default_branch(git_repo, remote_name, callbacks)
             }
@@ -2096,6 +2104,7 @@ impl<'a> GitFetchImpl<'a> {
     }
 }
 
+#[cfg(feature = "git2")]
 fn git2_fetch(
     git_repo: &git2::Repository,
     remote_name: &str,
@@ -2138,6 +2147,7 @@ fn git2_fetch(
     Ok(())
 }
 
+#[cfg(feature = "git2")]
 fn git2_get_default_branch(
     git_repo: &git2::Repository,
     remote_name: &str,
@@ -2246,6 +2256,7 @@ pub enum GitPushError {
     RefUpdateRejected(Vec<String>),
     // TODO: I'm sure there are other errors possible, such as transport-level errors,
     // and errors caused by the remote rejecting the push.
+    #[cfg(feature = "git2")]
     #[error("Unexpected git error when pushing")]
     InternalGitError(#[from] git2::Error),
     #[error(transparent)]
@@ -2338,32 +2349,33 @@ pub fn push_updates(
     // requires adjusting some tests.
 
     let git_backend = get_git_backend(repo.store())?;
-    if git_settings.subprocess {
-        let git_repo = git_backend.git_repo();
-        let git_ctx =
-            GitSubprocessContext::from_git_backend(git_backend, &git_settings.executable_path);
-        subprocess_push_refs(
-            &git_repo,
-            &git_ctx,
-            remote_name,
-            &qualified_remote_refs_expected_locations,
-            &refspecs,
-            callbacks,
-        )
-    } else {
+    #[cfg(feature = "git2")]
+    if !git_settings.subprocess {
         let git_repo = git2::Repository::open(git_backend.git_repo_path())?;
         let refspecs: Vec<String> = refspecs.iter().map(RefSpec::to_git_format).collect();
-        git2_push_refs(
+        return git2_push_refs(
             repo,
             &git_repo,
             remote_name,
             &qualified_remote_refs_expected_locations,
             &refspecs,
             callbacks,
-        )
+        );
     }
+    let git_repo = git_backend.git_repo();
+    let git_ctx =
+        GitSubprocessContext::from_git_backend(git_backend, &git_settings.executable_path);
+    subprocess_push_refs(
+        &git_repo,
+        &git_ctx,
+        remote_name,
+        &qualified_remote_refs_expected_locations,
+        &refspecs,
+        callbacks,
+    )
 }
 
+#[cfg(feature = "git2")]
 fn git2_push_refs(
     repo: &dyn Repo,
     git_repo: &git2::Repository,
@@ -2524,6 +2536,7 @@ fn subprocess_push_refs(
     }
 }
 
+#[cfg(feature = "git2")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PushAllowReason {
     NormalMatch,
@@ -2531,6 +2544,7 @@ enum PushAllowReason {
     UnexpectedNoop,
 }
 
+#[cfg(feature = "git2")]
 fn allow_push(
     index: &dyn Index,
     actual_remote_location: Option<&CommitId>,
@@ -2593,6 +2607,7 @@ pub struct RemoteCallbacks<'a> {
     pub get_username_password: Option<&'a mut dyn FnMut(&str) -> Option<(String, String)>>,
 }
 
+#[cfg(feature = "git2")]
 impl<'a> RemoteCallbacks<'a> {
     fn into_git(mut self) -> git2::RemoteCallbacks<'a> {
         let mut callbacks = git2::RemoteCallbacks::new();

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -306,11 +306,6 @@ impl GitBackend {
         self.base_repo.to_thread_local()
     }
 
-    /// Creates new owned git repository instance.
-    pub fn open_git_repo(&self) -> Result<git2::Repository, git2::Error> {
-        git2::Repository::open(self.git_repo_path())
-    }
-
     /// Path to the `.git` directory or the repository itself if it's bare.
     pub fn git_repo_path(&self) -> &Path {
         self.base_repo.path()

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -119,7 +119,7 @@ mod tests {
     use tempfile::TempDir;
 
     /// Unlike `testutils::new_temp_dir()`, this function doesn't set up
-    /// hermetic libgit2 environment.
+    /// hermetic Git environment.
     pub fn new_temp_dir() -> TempDir {
         tempfile::Builder::new()
             .prefix("jj-test-")

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -61,6 +61,9 @@ struct UserSettingsData {
 pub struct GitSettings {
     pub auto_local_bookmark: bool,
     pub abandon_unreachable_commits: bool,
+    // TODO: Remove this from the configuration schema when dropping
+    // `git2` support.
+    #[cfg(feature = "git2")]
     pub subprocess: bool,
     pub executable_path: PathBuf,
 }
@@ -70,6 +73,7 @@ impl GitSettings {
         Ok(GitSettings {
             auto_local_bookmark: settings.get_bool("git.auto-local-bookmark")?,
             abandon_unreachable_commits: settings.get_bool("git.abandon-unreachable-commits")?,
+            #[cfg(feature = "git2")]
             subprocess: settings.get_bool("git.subprocess")?,
             executable_path: settings.get("git.executable-path")?,
         })
@@ -81,6 +85,7 @@ impl Default for GitSettings {
         GitSettings {
             auto_local_bookmark: false,
             abandon_unreachable_commits: true,
+            #[cfg(feature = "git2")]
             subprocess: true,
             executable_path: PathBuf::from("git"),
         }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -125,7 +125,10 @@ fn get_git_repo(repo: &Arc<ReadonlyRepo>) -> gix::Repository {
 }
 
 fn get_git_settings(subprocess: bool) -> GitSettings {
+    #[cfg(not(feature = "git2"))]
+    assert!(subprocess);
     GitSettings {
+        #[cfg(feature = "git2")]
         subprocess,
         ..Default::default()
     }
@@ -2744,7 +2747,7 @@ fn test_init() {
     assert!(!repo.view().heads().contains(&jj_id(initial_git_commit)));
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_empty_repo(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -2765,7 +2768,7 @@ fn test_fetch_empty_repo(subprocess: bool) {
     assert_eq!(tx.repo().view().bookmarks().count(), 0);
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -2814,7 +2817,7 @@ fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
     );
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_initial_commit_head_is_set(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -2852,7 +2855,7 @@ fn test_fetch_initial_commit_head_is_set(subprocess: bool) {
     assert!(stats.import_stats.abandoned_commits.is_empty());
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_success(subprocess: bool) {
     let mut test_data = GitRepoData::create();
@@ -2934,7 +2937,7 @@ fn test_fetch_success(subprocess: bool) {
     );
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_prune_deleted_ref(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -2981,7 +2984,7 @@ fn test_fetch_prune_deleted_ref(subprocess: bool) {
         .is_absent());
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_no_default_branch(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -3021,7 +3024,7 @@ fn test_fetch_no_default_branch(subprocess: bool) {
     assert_eq!(stats.default_branch, None);
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_empty_refspecs(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -3043,7 +3046,7 @@ fn test_fetch_empty_refspecs(subprocess: bool) {
         .is_absent());
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_no_such_remote(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -3185,7 +3188,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_success(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3248,7 +3251,7 @@ fn test_push_bookmarks_success(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_deletion(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3304,7 +3307,7 @@ fn test_push_bookmarks_deletion(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3376,7 +3379,7 @@ fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_not_fast_forward(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3413,7 +3416,7 @@ fn test_push_bookmarks_not_fast_forward(subprocess: bool) {
 // may want to add tests for when a bookmark unexpectedly moved backwards or
 // unexpectedly does not exist for bookmark deletion.
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_unexpectedly_moved_sideways_on_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3480,7 +3483,7 @@ fn test_push_updates_unexpectedly_moved_sideways_on_remote(subprocess: bool) {
     );
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_unexpectedly_moved_forward_on_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3552,7 +3555,7 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_unexpectedly_exists_on_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3605,7 +3608,7 @@ fn test_push_updates_unexpectedly_exists_on_remote(subprocess: bool) {
     }
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_success(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3641,7 +3644,7 @@ fn test_push_updates_success(subprocess: bool) {
     assert_eq!(new_target.target().id(), new_oid);
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_no_such_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3662,7 +3665,7 @@ fn test_push_updates_no_such_remote(subprocess: bool) {
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
 }
 
-#[test_case(false; "use git2 for remote calls")]
+#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_invalid_remote(subprocess: bool) {
     let settings = testutils::user_settings();

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -18,7 +18,7 @@ readme = { workspace = true }
 async-trait = { workspace = true }
 bstr = { workspace = true }
 futures = { workspace = true }
-git2 = { workspace = true }
+git2 = { workspace = true, optional = true }
 gix = { workspace = true, features = [
     "status",
     "tree-editor",
@@ -30,6 +30,10 @@ jj-lib = { workspace = true, features = ["testing"] }
 pollster = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
+
+[features]
+default = ["git2"]
+git2 = ["jj-lib/git2", "dep:git2"]
 
 [lints]
 workspace = true

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -21,7 +21,6 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Once;
 
 use itertools::Itertools;
 use jj_lib::backend;
@@ -72,21 +71,29 @@ use crate::test_backend::TestBackendFactory;
 pub mod git;
 pub mod test_backend;
 
-pub fn hermetic_libgit2() {
-    // libgit2 respects init.defaultBranch (and possibly other config
-    // variables) in the user's config files. Disable access to them to make
-    // our tests hermetic.
-    //
-    // set_search_path is unsafe because it cannot guarantee thread safety (as
-    // its documentation states). For the same reason, we wrap these invocations
-    // in `call_once`.
-    static CONFIGURE_GIT2: Once = Once::new();
-    CONFIGURE_GIT2.call_once(|| unsafe {
-        git2::opts::set_search_path(git2::ConfigLevel::System, "").unwrap();
-        git2::opts::set_search_path(git2::ConfigLevel::Global, "").unwrap();
-        git2::opts::set_search_path(git2::ConfigLevel::XDG, "").unwrap();
-        git2::opts::set_search_path(git2::ConfigLevel::ProgramData, "").unwrap();
-    });
+// TODO: Consider figuring out a way to make `GitBackend` and `git(1)` calls in
+// tests ignore external configuration and removing this function. This is
+// somewhat tricky because `gix` looks at system and user configuration, and
+// `GitBackend` also calls into `git(1)` for things like garbage collection.
+pub fn hermetic_git() {
+    #[cfg(feature = "git2")]
+    {
+        // libgit2 respects init.defaultBranch (and possibly other config
+        // variables) in the user's config files. Disable access to them to make
+        // our tests hermetic.
+        //
+        // set_search_path is unsafe because it cannot guarantee thread safety (as
+        // its documentation states). For the same reason, we wrap these invocations
+        // in `call_once`.
+        use std::sync::Once;
+        static CONFIGURE_GIT2: Once = Once::new();
+        CONFIGURE_GIT2.call_once(|| unsafe {
+            git2::opts::set_search_path(git2::ConfigLevel::System, "").unwrap();
+            git2::opts::set_search_path(git2::ConfigLevel::Global, "").unwrap();
+            git2::opts::set_search_path(git2::ConfigLevel::XDG, "").unwrap();
+            git2::opts::set_search_path(git2::ConfigLevel::ProgramData, "").unwrap();
+        });
+    }
 
     // Prevent GitBackend from loading user and system configurations. For
     // gitoxide API use in tests, Config::isolated() is probably better.
@@ -100,7 +107,7 @@ pub fn hermetic_libgit2() {
 }
 
 pub fn new_temp_dir() -> TempDir {
-    hermetic_libgit2();
+    hermetic_git();
     tempfile::Builder::new()
         .prefix("jj-test-")
         .tempdir()


### PR DESCRIPTION
This helps us prepare for removing the functionality down the line and makes things easier for people building or packaging their own Jujutsu.
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
