### PR TITLE
cli: git fetch: allow short alias for --all-remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj bookmark move --to/--from` can now be abbreviated to `jj bookmark move -t/-f`
 
+* `jj git fetch --all-remotes` can now be abbreviated to `jj git fetch -a`.
+
 ### Fixed bugs
 
 ## [0.27.0] - 2025-03-05

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -73,7 +73,7 @@ pub struct GitFetchArgs {
     )]
     remotes: Vec<StringPattern>,
     /// Fetch from all remotes
-    #[arg(long, conflicts_with = "remotes")]
+    #[arg(long, short, conflicts_with = "remotes")]
     all_remotes: bool,
 }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1178,7 +1178,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
    By default, the specified remote names matches exactly. Use a [string pattern], e.g. `--remote 'glob:*'`, to select remotes using patterns.
 
    [string pattern]: https://jj-vcs.github.io/jj/latest/revsets#string-patterns
-* `--all-remotes` — Fetch from all remotes
+* `-a`, `--all-remotes` — Fetch from all remotes
 
 
 


### PR DESCRIPTION
Allows using `-a` as a short alias for `--all-remotes` in the `git fetch` command.


Thanks!
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
