### PR TITLE
cli: annotate: do not panic on reaching initial commit.

### DIFF
--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -124,8 +124,13 @@ fn render_file_annotation(
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     let mut last_id = None;
+    let default_id = repo.store().root_commit_id();
     for (line_number, (commit_id, content)) in annotation.lines().enumerate() {
-        let commit_id = commit_id.expect("should reached to the empty ancestor");
+        /* At least in cases where the repository was jj-initialized shallowly,
+        then unshallow'd with git, some changes will not have a commit id
+        because jj does not import the unshallow'd commits. So we default
+        to the root commit id for now. */
+        let commit_id = commit_id.unwrap_or(default_id);
         let commit = repo.store().get_commit(commit_id)?;
         let first_line_in_hunk = last_id != Some(commit_id);
         let annotation_line = AnnotationLine {

--- a/lib/src/annotate.rs
+++ b/lib/src/annotate.rs
@@ -296,7 +296,8 @@ fn process_commit(
         };
         // If an omitted parent had the file, leave these lines unresolved.
         // TODO: These unresolved lines could be copied to the original_line_map
-        // as Err(commit_id) or something instead of None.
+        // as Err(commit_id) or something instead of None; or the farthest ancestor
+        // commit ID.
         if parent_source.line_map.is_empty() || parent_edge.edge_type == GraphEdgeType::Missing {
             commit_source_map.remove(parent_commit_id);
         }


### PR DESCRIPTION
As described in #5909, in the case where jj was initialized in a shallowly cloned repository which was then unshallow'd, jj does not import the fetched commits that were outside the shallow boundary.

However, it does import the ones after the boundary, which after unshallowing do not contain the changes made before the boundary.

Therefore, when running annotate in such a case, jj would panic because it does not find the commit from which a line originates. This simply sets the empty commit as carrying the blame for that line.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes

# Questions for the maintainers

- It was suggested in #5909 to add a marker to the output that would make it more intelligible to the user that the line originates from an unfound commit rather than from the initial empty commit. I have looked a bit at the template rendering code but did not see an easy way to achieve this: any pointers in that direction would be greatly appreciated.

- I'm not quite sure what the best way to test this is in this project (I'm still very new to Rust). Would it make sense to somehow mock the formatter and ensure the commits are provided correctly ?
