### PR TITLE
git: use translated remote symbols in import_refs()

### DIFF
--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -181,7 +181,7 @@ fn test_git_import_undo() {
     let output = test_env.run_jj_in(&repo_path, ["git", "import"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    bookmark: a [new] tracked
+    bookmark: a@git [new] tracked
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
@@ -202,7 +202,7 @@ fn test_git_import_undo() {
     let output = test_env.run_jj_in(&repo_path, ["git", "import"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    bookmark: a [new] tracked
+    bookmark: a@git [new] tracked
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
@@ -243,7 +243,7 @@ fn test_git_import_move_export_with_default_undo() {
     let output = test_env.run_jj_in(&repo_path, ["git", "import"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    bookmark: a [new] tracked
+    bookmark: a@git [new] tracked
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"
@@ -298,7 +298,7 @@ fn test_git_import_move_export_with_default_undo() {
     let output = test_env.run_jj_in(&repo_path, ["git", "import"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    bookmark: a [new] tracked
+    bookmark: a@git [new] tracked
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&test_env, &repo_path), @r"

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1463,9 +1463,9 @@ fn test_import_refs_missing_git_commit() {
     assert_matches!(
         result,
         Err(GitImportError::MissingRefAncestor {
-            ref_name,
+            symbol,
             err: BackendError::ObjectNotFound { .. }
-        }) if &ref_name == "main"
+        }) if symbol == remote_symbol("main", "git")
     );
 
     // Missing commit is ancestor of HEAD
@@ -3086,12 +3086,9 @@ fn test_fetch_multiple_branches() {
             .changed_remote_refs
             .keys()
             .collect_vec(),
-        vec![&RefName::RemoteBranch(
-            RemoteRefSymbol {
-                name: "main",
-                remote: "origin",
-            }
-            .to_owned()
+        vec![&(
+            GitRefKind::Bookmark,
+            remote_symbol("main", "origin").to_owned()
         )]
     );
 }


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
