### PR TITLE
cli: config: support multiple user configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Multiple user configs are now supported and are loaded in the following precedence order:
+  - `$HOME/.jjconfig.toml`
+  - `$XDG_CONFIG_HOME/jj/config.toml`
+  - `$XDG_CONFIG_HOME/jj/conf.d/*.toml`
+
+* The `JJ_CONFIG` environment variable can now contain multiple paths separated
+  by a colon (or semicolon on Windows).
+
 * The command `jj config list` now supports showing the origin of each variable
   via the `builtin_config_list_detailed` template.
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3772,7 +3772,7 @@ impl CliRunner {
                     "Did you update to a commit where the directory doesn't exist?",
                 )
             })?;
-        let mut config_env = ConfigEnv::from_environment()?;
+        let mut config_env = ConfigEnv::from_environment();
         let mut last_config_migration_descriptions = Vec::new();
         let mut migrate_config = |config: &mut StackedConfig| -> Result<(), CommandError> {
             last_config_migration_descriptions =

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -59,7 +59,6 @@ use jj_lib::workspace::WorkspaceInitError;
 use thiserror::Error;
 
 use crate::cli_util::short_operation_hash;
-use crate::config::ConfigEnvError;
 use crate::description_util::ParseBulkEditMessageError;
 use crate::description_util::TempTextEditError;
 use crate::description_util::TextEditError;
@@ -239,12 +238,6 @@ impl From<io::Error> for CommandError {
 impl From<jj_lib::file_util::PathError> for CommandError {
     fn from(err: jj_lib::file_util::PathError) -> Self {
         user_error(err)
-    }
-}
-
-impl From<ConfigEnvError> for CommandError {
-    fn from(err: ConfigEnvError) -> Self {
-        config_error(err)
     }
 }
 

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -29,7 +29,7 @@ use crate::template_builder::TemplateLanguage as _;
 use crate::templater::TemplatePropertyExt as _;
 use crate::ui::Ui;
 
-/// List variables set in config file, along with their values.
+/// List variables set in config files, along with their values.
 #[derive(clap::Args, Clone, Debug)]
 #[command(mut_group("config_level", |g| g.required(false)))]
 pub struct ConfigListArgs {

--- a/cli/src/commands/config/path.rs
+++ b/cli/src/commands/config/path.rs
@@ -22,11 +22,11 @@ use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Print the path to the config file
+/// Print the paths to the config files
 ///
 /// A config file at that path may or may not exist.
 ///
-/// See `jj config edit` if you'd like to immediately edit the file.
+/// See `jj config edit` if you'd like to immediately edit a file.
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigPathArgs {
     #[command(flatten)]
@@ -39,13 +39,14 @@ pub fn cmd_config_path(
     command: &CommandHelper,
     args: &ConfigPathArgs,
 ) -> Result<(), CommandError> {
-    let config_path = args.level.config_path(command.config_env())?;
-    writeln!(
-        ui.stdout(),
-        "{}",
-        config_path
-            .to_str()
-            .ok_or_else(|| user_error("The config path is not valid UTF-8"))?
-    )?;
+    for config_path in args.level.config_paths(command.config_env())? {
+        writeln!(
+            ui.stdout(),
+            "{}",
+            config_path
+                .to_str()
+                .ok_or_else(|| user_error("The config path is not valid UTF-8"))?
+        )?;
+    }
     Ok(())
 }

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -30,7 +30,7 @@ use crate::complete;
 use crate::config::parse_value_or_bare_string;
 use crate::ui::Ui;
 
-/// Update config file to set the given option to a given value.
+/// Update a config file to set the given option to a given value.
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigSetArgs {
     #[arg(required = true, add = ArgValueCandidates::new(complete::leaf_config_keys))]

--- a/cli/src/commands/config/unset.rs
+++ b/cli/src/commands/config/unset.rs
@@ -24,7 +24,7 @@ use crate::command_error::CommandError;
 use crate::complete;
 use crate::ui::Ui;
 
-/// Update config file to unset the given option.
+/// Update a config file to unset the given option.
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigUnsetArgs {
     #[arg(required = true, add = ArgValueCandidates::new(complete::leaf_config_keys))]

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -788,7 +788,7 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
         .and_then(dunce::canonicalize)
         .map_err(user_error)?;
     // No config migration for completion. Simply ignore deprecated variables.
-    let mut config_env = ConfigEnv::from_environment()?;
+    let mut config_env = ConfigEnv::from_environment();
     let maybe_cwd_workspace_loader = DefaultWorkspaceLoaderFactory.create(find_workspace_dir(&cwd));
     let _ = config_env.reload_user_config(&mut raw_config);
     if let Ok(loader) = &maybe_cwd_workspace_loader {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -557,10 +557,10 @@ See [`jj help -k config`] to know more about file locations, supported config op
 
 * `edit` — Start an editor on a jj config file
 * `get` — Get the value of a given config option.
-* `list` — List variables set in config file, along with their values
-* `path` — Print the path to the config file
-* `set` — Update config file to set the given option to a given value
-* `unset` — Update config file to unset the given option
+* `list` — List variables set in config files, along with their values
+* `path` — Print the paths to the config files
+* `set` — Update a config file to set the given option to a given value
+* `unset` — Update a config file to unset the given option
 
 
 
@@ -601,7 +601,7 @@ Martin von Zweigbergk
 
 ## `jj config list`
 
-List variables set in config file, along with their values
+List variables set in config files, along with their values
 
 **Usage:** `jj config list [OPTIONS] [NAME]`
 
@@ -638,11 +638,11 @@ List variables set in config file, along with their values
 
 ## `jj config path`
 
-Print the path to the config file
+Print the paths to the config files
 
 A config file at that path may or may not exist.
 
-See `jj config edit` if you'd like to immediately edit the file.
+See `jj config edit` if you'd like to immediately edit a file.
 
 **Usage:** `jj config path <--user|--repo>`
 
@@ -655,7 +655,7 @@ See `jj config edit` if you'd like to immediately edit the file.
 
 ## `jj config set`
 
-Update config file to set the given option to a given value
+Update a config file to set the given option to a given value
 
 **Usage:** `jj config set <--user|--repo> <NAME> <VALUE>`
 
@@ -677,7 +677,7 @@ Update config file to set the given option to a given value
 
 ## `jj config unset`
 
-Update config file to unset the given option
+Update a config file to unset the given option
 
 **Usage:** `jj config unset <--user|--repo> <NAME>`
 

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env::join_paths;
 use std::path::PathBuf;
 
 use indoc::indoc;
@@ -981,6 +982,22 @@ fn test_config_path() {
     Error: No repo config path found
     [EOF]
     [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_config_path_multiple() {
+    let mut test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let config_path = test_env.config_path().join("config.toml");
+    let work_config_path = test_env.config_path().join("conf.d");
+    let user_config_path = join_paths([config_path, work_config_path]).unwrap();
+    test_env.set_config_path(&user_config_path);
+    let work_dir = test_env.work_dir("repo");
+    insta::assert_snapshot!(work_dir.run_jj(["config", "path", "--user"]), @r"
+    $TEST_ENV/config/config.toml
+    $TEST_ENV/config/conf.d
+    [EOF]
     ");
 }
 


### PR DESCRIPTION
~~The `platform_config_path` now defaults to the `jj` directory as opposed to the `config.toml` file. This loads all configuration files in the directory by default, removing the need to set JJ_CONFIG for a multi-file approach.~~

Multiple user configs are now supported and are loaded in the following precedence order:
  - `$HOME/.jjconfig.toml`
  - `$XDG_CONFIG_HOME/jj/config.toml`
  - `$XDG_CONFIG_HOME/jj/conf.d/*.toml`

which removes the need to set `JJ_CONFIG` for a multi-file approach.
Later files override earlier files and the `JJ_CONFIG` environment
variable can be used to override the default paths.

The `JJ_CONFIG` environment variable can now contain multiple paths separated
by a colon (or semicolon on Windows).

Thanks!
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
