### PR TITLE
faq: in entry about default `jj log` revset, explain rationale

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -21,9 +21,12 @@ options:
 
 Is your commit visible with `jj log -r 'all()'`?
 
-If yes, you should be aware that `jj log` only shows the revisions matching
-`revsets.log` by default. You can change it as described in [config] to show
-more revisions.
+If yes, you should be aware that `jj log` only shows a subset of the commits in
+the repo by default. Most commits that exist on a remote are not shown. Local
+commits and their immediate parents (for context) are shown. The thinking is
+that you are more likely to interact with this set of commits. You can configure
+the set of revisions to show by default by overriding `revsets.log` as described
+in [config].
 
 If not, the revision may have been abandoned (e.g. because you
 used `jj abandon`, or because it's an obsolete version that's been rewritten


### PR DESCRIPTION
The FAQ entry explaining why `jj log` doesn't show all commits explained that the behavior is configurable but it didn't explain what the rationale for not showing all commits is. Users coming from Git are used to seeing all commits and probably read this FAQ entry to find an answer. We don't want them to just update their config without understanding why we have the default we have.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
