### PR TITLE
cli clone and init: remove unhelpful parts of clap error 

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3941,10 +3941,15 @@ impl CliRunner {
 fn map_clap_cli_error(err: clap::Error, ui: &Ui, config: &StackedConfig) -> CommandError {
     if let Some(ContextValue::String(cmd)) = err.get(ContextKind::InvalidSubcommand) {
         match cmd.as_str() {
-            // git commands that a brand-new user might type on their first experiment with
-            // `jj`
+            // git commands that a brand-new user might type during their first
+            // experiments with `jj`
             "clone" | "init" => {
                 let cmd = cmd.clone();
+                let mut err = err;
+                // Clap suggests an unhelpful subcommand, e.g. `config` for `clone`.
+                err.remove(ContextKind::SuggestedSubcommand);
+                err.remove(ContextKind::Suggested); // Remove an empty line
+                err.remove(ContextKind::Usage);
                 return CommandError::from(err)
                     .hinted(format!(
                         "You probably want `jj git {cmd}`. See also `jj help git`."

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -422,10 +422,6 @@ fn test_aliases_overriding_friendly_errors() {
     ------- stderr -------
     [1m[31merror:[0m unrecognized subcommand '[33minit[0m'
 
-      [32mtip:[0m a similar subcommand exists: '[32mgit[0m'
-
-    [1m[33mUsage:[0m [1m[32mjj[0m [32m[OPTIONS][0m [32m<COMMAND>[0m
-
     For more information, try '[1m[32m--help[0m'.
     [1m[38;5;6mHint: [0m[39mYou probably want `jj git init`. See also `jj help git`.[39m
     [1m[38;5;6mHint: [0m[39mYou can configure `aliases.init = ["git", "init"]` if you want `jj init` to work and always use the Git backend.[39m
@@ -438,10 +434,6 @@ fn test_aliases_overriding_friendly_errors() {
     ------- stderr -------
     error: unrecognized subcommand 'init'
 
-      tip: a similar subcommand exists: 'git'
-
-    Usage: jj [OPTIONS] <COMMAND>
-
     For more information, try '--help'.
     Hint: You probably want `jj git init`. See also `jj help git`.
     Hint: You can configure `aliases.init = ["git", "init"]` if you want `jj init` to work and always use the Git backend.
@@ -452,10 +444,6 @@ fn test_aliases_overriding_friendly_errors() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     error: unrecognized subcommand 'clone'
-
-      tip: a similar subcommand exists: 'config'
-
-    Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
     Hint: You probably want `jj git clone`. See also `jj help git`.
@@ -481,10 +469,6 @@ fn test_aliases_overriding_friendly_errors() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     error: unrecognized subcommand 'init'
-
-      tip: a similar subcommand exists: 'git'
-
-    Usage: jj [OPTIONS] <COMMAND>
 
     For more information, try '--help'.
     Hint: You probably want `jj git init`. See also `jj help git`.

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -416,6 +416,23 @@ fn test_alias_in_config_arg() {
 #[test]
 fn test_aliases_overriding_friendly_errors() {
     let test_env = TestEnvironment::default();
+    // Test with color
+    let output = test_env.run_jj_in(".", ["--color=always", "init", "repo"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    [1m[31merror:[0m unrecognized subcommand '[33minit[0m'
+
+      [32mtip:[0m a similar subcommand exists: '[32mgit[0m'
+
+    [1m[33mUsage:[0m [1m[32mjj[0m [32m[OPTIONS][0m [32m<COMMAND>[0m
+
+    For more information, try '[1m[32m--help[0m'.
+    [1m[38;5;6mHint: [0m[39mYou probably want `jj git init`. See also `jj help git`.[39m
+    [1m[38;5;6mHint: [0m[39mYou can configure `aliases.init = ["git", "init"]` if you want `jj init` to work and always use the Git backend.[39m
+    [EOF]
+    [exit status: 2]
+    "#);
+
     let output = test_env.run_jj_in(".", ["init", "repo"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------


### PR DESCRIPTION
As an aside, I didn't touch `revert` to avoid conflicts with https://github.com/jj-vcs/jj/pull/5932.

# Checklist

If applicable:
- ~~[ ] I have updated `CHANGELOG.md`~~
- ~~[ ] I have updated the documentation (README.md, docs/, demos/)~~
- ~~[ ] I have updated the config schema (cli/src/config-schema.json)~~
- [x] I have added tests to cover my changes
