### PR TITLE
revset globs: explain case-insensitive string prefixes

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -863,9 +863,11 @@ fn revset_resolution_error_hint(err: &RevsetResolutionError) -> Option<String> {
 
 fn string_pattern_parse_error_hint(err: &StringPatternParseError) -> Option<String> {
     match err {
-        StringPatternParseError::InvalidKind(_) => {
-            Some("Try prefixing with one of `exact:`, `glob:`, `regex:`, or `substring:`".into())
-        }
+        StringPatternParseError::InvalidKind(_) => Some(
+            "Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these \
+             with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching"
+                .into(),
+        ),
         StringPatternParseError::GlobPattern(_) | StringPatternParseError::Regex(_) => None,
     }
 }

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -911,7 +911,7 @@ fn test_bookmark_delete_glob() {
     error: invalid value 'whatever:bookmark' for '<NAMES>...': Invalid string pattern kind `whatever:`
 
     For more information, try '--help'.
-    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, or `substring:`
+    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
     [EOF]
     [exit status: 2]
     ");

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1094,7 +1094,7 @@ fn test_log_contained_in() {
       |
       = Invalid string pattern
     3: Invalid string pattern kind `x:`
-    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, or `substring:`
+    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -252,7 +252,7 @@ fn test_bad_function_call() {
       |
       = Invalid string pattern
     2: Invalid string pattern kind `bad:`
-    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, or `substring:`
+    Hint: Try prefixing with one of `exact:`, `glob:`, `regex:`, `substring:`, or one of these with `-i` suffix added (e.g. `glob-i:`) for case-insensitive matching
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
This is the first commit from https://github.com/jj-vcs/jj/pull/5944.