### PR TITLE
cli: config {edit,set,unset}: prompt when multiple files exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj config {edit,set,unset}` now prompt when multiple config files are found.
+
 * `jj diff -r` now allows multiple revisions (as long as there are no gaps in
   the revset), such as `jj diff -r 'mutable()'`.
 

--- a/cli/src/commands/config/edit.rs
+++ b/cli/src/commands/config/edit.rs
@@ -31,12 +31,12 @@ pub struct ConfigEditArgs {
 
 #[instrument(skip_all)]
 pub fn cmd_config_edit(
-    _ui: &mut Ui,
+    ui: &mut Ui,
     command: &CommandHelper,
     args: &ConfigEditArgs,
 ) -> Result<(), CommandError> {
     let editor = command.text_editor()?;
-    let file = args.level.edit_config_file(command)?;
+    let file = args.level.edit_config_file(ui, command)?;
     if !file.path().exists() {
         file.save()?;
     }

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -65,7 +65,7 @@ pub fn cmd_config_set(
     command: &CommandHelper,
     args: &ConfigSetArgs,
 ) -> Result<(), CommandError> {
-    let mut file = args.level.edit_config_file(command)?;
+    let mut file = args.level.edit_config_file(ui, command)?;
 
     // If the user is trying to change the author config, we should warn them that
     // it won't affect the working copy author

--- a/cli/src/commands/config/unset.rs
+++ b/cli/src/commands/config/unset.rs
@@ -35,11 +35,11 @@ pub struct ConfigUnsetArgs {
 
 #[instrument(skip_all)]
 pub fn cmd_config_unset(
-    _ui: &mut Ui,
+    ui: &mut Ui,
     command: &CommandHelper,
     args: &ConfigUnsetArgs,
 ) -> Result<(), CommandError> {
-    let mut file = args.level.edit_config_file(command)?;
+    let mut file = args.level.edit_config_file(ui, command)?;
     let old_value = file
         .delete_value(&args.name)
         .map_err(|err| user_error_with_message(format!("Failed to unset {}", args.name), err))?;

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -161,6 +161,12 @@ impl TestEnvironment {
         &self.config_path
     }
 
+    pub fn first_config_file_path(&self) -> PathBuf {
+        let config_file_number = 1;
+        self.config_path
+            .join(format!("config{config_file_number:04}.toml"))
+    }
+
     pub fn last_config_file_path(&self) -> PathBuf {
         let config_file_number = self.config_file_number.borrow();
         self.config_path

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -589,15 +589,30 @@ fn test_config_set_for_user_directory() {
 
     // Add one more config file to the directory
     test_env.add_config("");
-    let output = test_env.run_jj_in(".", ["config", "set", "--user", "test-key", "test-val"]);
+    let output = test_env.run_jj_in(
+        ".",
+        ["config", "set", "--user", "test-key", "test-other-val"],
+    );
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Cannot determine config file to edit:
-      $TEST_ENV/config/config0001.toml
-      $TEST_ENV/config/config0002.toml
+    1: $TEST_ENV/config/config0001.toml
+    2: $TEST_ENV/config/config0002.toml
+    Choose a config file (default 1): 1
     [EOF]
-    [exit status: 1]
     ");
+
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.first_config_file_path()).unwrap(),
+        @r#"
+    test-key = "test-other-val"
+
+    [template-aliases]
+    'format_time_range(time_range)' = 'time_range.start() ++ " - " ++ time_range.end()'
+    "#);
+
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.last_config_file_path()).unwrap(),
+        @"");
 }
 
 #[test]

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -528,7 +528,7 @@ fn new_implicit_table() -> ConfigItem {
 
 /// Wrapper for file-based [`ConfigLayer`], providing convenient methods for
 /// modification.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ConfigFile {
     layer: Arc<ConfigLayer>,
 }


### PR DESCRIPTION
Hello!

This allows the user to select a particular file when using multiple configs. In the event that a prompt cannot be displayed, the first file will be automatically selected.

This is part of my work on #5971 but was relatively independent so decided to send it.

Thanks!
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
