### PR TITLE
diff: fix inconsistent handling of "short" format arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj log -p --stat` now shows diff stats as well as the default color-words/git
+  diff output. [#5986](https://github.com/jj-vcs/jj/issues/5986)
 
 ## [0.27.0] - 2025-03-05
 

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -150,6 +150,53 @@ fn test_log_with_or_without_diff() {
     [EOF]
     ");
 
+    // `-p` for default diff output, `--stat` for diff-stat
+    let output = test_env.run_jj_in(&repo_path, ["log", "-T", "description", "-p", "--stat"]);
+    insta::assert_snapshot!(output, @r"
+    @  a new commit
+    │  file1 | 1 +
+    │  1 file changed, 1 insertion(+), 0 deletions(-)
+    │  Modified regular file file1:
+    │     1    1: foo
+    │          2: bar
+    ○  add a file
+    │  file1 | 1 +
+    │  1 file changed, 1 insertion(+), 0 deletions(-)
+    │  Added regular file file1:
+    │          1: foo
+    ◆
+       0 files changed, 0 insertions(+), 0 deletions(-)
+    [EOF]
+    ");
+
+    // `--stat` is short format, which should be printed first
+    let output = test_env.run_jj_in(&repo_path, ["log", "-T", "description", "--git", "--stat"]);
+    insta::assert_snapshot!(output, @r"
+    @  a new commit
+    │  file1 | 1 +
+    │  1 file changed, 1 insertion(+), 0 deletions(-)
+    │  diff --git a/file1 b/file1
+    │  index 257cc5642c..3bd1f0e297 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -1,1 +1,2 @@
+    │   foo
+    │  +bar
+    ○  add a file
+    │  file1 | 1 +
+    │  1 file changed, 1 insertion(+), 0 deletions(-)
+    │  diff --git a/file1 b/file1
+    │  new file mode 100644
+    │  index 0000000000..257cc5642c
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,1 @@
+    │  +foo
+    ◆
+       0 files changed, 0 insertions(+), 0 deletions(-)
+    [EOF]
+    ");
+
     // `-p` enables default "summary" output, so `-s` is noop
     let output = test_env.run_jj_in(
         &repo_path,


### PR DESCRIPTION
Fixes #5986

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
