### PR TITLE
git: use translated remote symbols in export_refs(), refactor import_refs()

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -587,9 +587,9 @@ pub fn print_failed_git_export(
     if !failed_refs.is_empty() {
         writeln!(ui.warning_default(), "Failed to export some bookmarks:")?;
         let mut formatter = ui.stderr_formatter();
-        for FailedRefExport { name, reason } in failed_refs {
+        for FailedRefExport { symbol, reason } in failed_refs {
             write!(formatter, "  ")?;
-            write!(formatter.labeled("bookmark"), "{name}")?;
+            write!(formatter.labeled("bookmark"), "{symbol}")?;
             for err in iter::successors(Some(reason as &dyn error::Error), |err| err.source()) {
                 write!(formatter, ": {err}")?;
             }

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -129,7 +129,7 @@ fn test_bookmark_at_root() {
     ------- stderr -------
     Nothing changed.
     Warning: Failed to export some bookmarks:
-      fred: Ref cannot point to the root commit in Git
+      fred@git: Ref cannot point to the root commit in Git
     [EOF]
     ");
 }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -462,7 +462,7 @@ fn test_git_colocated_bookmark_at_root() {
     ------- stderr -------
     Created 1 bookmarks pointing to zzzzzzzz 00000000 foo | (empty) (no description set)
     Warning: Failed to export some bookmarks:
-      foo: Ref cannot point to the root commit in Git
+      foo@git: Ref cannot point to the root commit in Git
     [EOF]
     ");
 
@@ -484,7 +484,7 @@ fn test_git_colocated_bookmark_at_root() {
     ------- stderr -------
     Moved 1 bookmarks to zzzzzzzz 00000000 foo* | (empty) (no description set)
     Warning: Failed to export some bookmarks:
-      foo: Ref cannot point to the root commit in Git
+      foo@git: Ref cannot point to the root commit in Git
     [EOF]
     ");
 }
@@ -506,7 +506,7 @@ fn test_git_colocated_conflicting_git_refs() {
         ------- stderr -------
         Created 1 bookmarks pointing to qpvuntsm 230dd059 main main/sub | (empty) (no description set)
         Warning: Failed to export some bookmarks:
-          main/sub: Failed to set: ...
+          main/sub@git: Failed to set: ...
         Hint: Git doesn't allow a branch name that looks like a parent directory of
         another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
         export or their "parent" bookmarks.
@@ -667,7 +667,7 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     [EOF]
     ------- stderr -------
     Warning: Failed to export some bookmarks:
-      feature: Modified ref had been deleted in Git
+      feature@git: Modified ref had been deleted in Git
     Done importing changes from the underlying Git repo.
     [EOF]
     ");

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -79,7 +79,7 @@ fn test_git_export_conflicting_git_refs() {
         insta::assert_snapshot!(output, @r#"
         ------- stderr -------
         Warning: Failed to export some bookmarks:
-          main/sub: Failed to set: ...
+          main/sub@git: Failed to set: ...
         Hint: Git doesn't allow a branch name that looks like a parent directory of
         another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
         export or their "parent" bookmarks.

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -3085,13 +3085,10 @@ fn test_fetch_multiple_branches() {
     assert_eq!(
         fetch_stats
             .import_stats
-            .changed_remote_refs
+            .changed_remote_bookmarks
             .keys()
             .collect_vec(),
-        vec![&(
-            GitRefKind::Bookmark,
-            remote_symbol("main", "origin").to_owned()
-        )]
+        [remote_symbol("main", "origin")]
     );
 }
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -3086,7 +3086,8 @@ fn test_fetch_multiple_branches() {
         fetch_stats
             .import_stats
             .changed_remote_bookmarks
-            .keys()
+            .iter()
+            .map(|(symbol, _)| symbol)
             .collect_vec(),
         [remote_symbol("main", "origin")]
     );


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
