### PR TITLE
cli: emit warning for deprecated diff.format, move default to config/misc.toml

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -624,6 +624,8 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
             "core.watchman.register_snapshot_trigger",
             "core.watchman.register-snapshot-trigger",
         ),
+        // TODO: Delete in jj 0.34+
+        ConfigMigrationRule::rename_value("diff.format", "ui.diff.format"),
     ]
 }
 

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -23,6 +23,8 @@ always-allow-large-revsets = false
 color = "auto"
 default-description = ""
 diff-instructions = true
+diff.format = "color-words"
+# diff.tool = <use-format>
 graph.style = "curved"
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 paginate = "auto"

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -239,14 +239,7 @@ fn default_diff_format(
         .unwrap_or_else(|| ExternalMergeTool::with_diff_args(&args));
         return Ok(DiffFormat::Tool(Box::new(tool)));
     }
-    let name = if let Some(name) = settings.get_string("ui.diff.format").optional()? {
-        name
-    } else if let Some(name) = settings.get_string("diff.format").optional()? {
-        name // old config name
-    } else {
-        "color-words".to_owned()
-    };
-    match name.as_ref() {
+    match settings.get_string("ui.diff.format")?.as_ref() {
         "summary" => Ok(DiffFormat::Summary),
         "stat" => {
             let mut options = DiffStatOptions::default();
@@ -265,7 +258,7 @@ fn default_diff_format(
             options.merge_args(args);
             Ok(DiffFormat::ColorWords(Box::new(options)))
         }
-        _ => Err(ConfigGetError::Type {
+        name => Err(ConfigGetError::Type {
             name: "ui.diff.format".to_owned(),
             error: format!("Invalid diff format: {name}").into(),
             source_path: None,


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
