### PR TITLE
git: tolerate unknown `git.fetch` remotes if others are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added `ui.streampager.show-ruler` setting to configure whether the ruler should be
   shown when the builtin pager starts up.
 
+* `jj git fetch` now warns instead of erroring for unknown `git.fetch` remotes
+  if other remotes are available.
+
 ### Fixed bugs
 
 * Fixed crash on change-delete conflict resolution.


### PR DESCRIPTION
If `git.fetch` contains remotes that are not available, we currently error even if other remotes are available. For common fork workflows with separate `upstream` and `origin` remotes (for example), this requires a user to either set both remotes in their user config and override single-remote repos or set only one in their user config and override all multi-remote repos to fetch from `upstream` (or both).

This change updates fetching to only *warn* about unknown remotes **if** other remotes are available. If none of the configured remotes are available, an error is still raised as before.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] ~I have updated the documentation (README.md, docs/, demos/)~
- [ ] ~I have updated the config schema (cli/src/config-schema.json)~
- [x] I have added tests to cover my changes
