### PR TITLE
git: properly detect remote refusal on push

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2441,15 +2441,14 @@ fn subprocess_push_refs(
         .map(|full_refspec| RefToPush::new(full_refspec, qualified_remote_refs_expected_locations))
         .collect();
 
-    let (failed_ref_matches, successful_pushes) =
-        git_ctx.spawn_push(remote_name, &refs_to_push, &mut callbacks)?;
+    let push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, &mut callbacks)?;
 
-    for remote_ref in successful_pushes {
+    for remote_ref in push_stats.pushed {
         remaining_remote_refs.remove(remote_ref.as_str());
     }
 
-    if !failed_ref_matches.is_empty() {
-        let mut refs_in_unexpected_locations = failed_ref_matches;
+    if !push_stats.rejected.is_empty() {
+        let mut refs_in_unexpected_locations = push_stats.rejected;
         refs_in_unexpected_locations.sort();
         Err(GitPushError::RefInUnexpectedLocation(
             refs_in_unexpected_locations,

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2404,9 +2404,7 @@ fn git2_push_refs(
         if remaining_remote_refs.is_empty() {
             Ok(())
         } else {
-            // TODO: this is probably dead code right now
-            // The only way this would happen is if a push fails from some
-            // other reason other than a lease failing (which our tests don't cover)
+            // remote rejected refs because of remote config (e.g., no push on main)
             Err(GitPushError::RefUpdateRejected(
                 remaining_remote_refs
                     .iter()
@@ -2431,11 +2429,6 @@ fn subprocess_push_refs(
         return Err(GitPushError::NoSuchRemote(remote_name.to_owned()));
     }
 
-    let mut remaining_remote_refs: HashSet<_> = qualified_remote_refs_expected_locations
-        .keys()
-        .copied()
-        .collect();
-
     let refs_to_push: Vec<RefToPush> = refspecs
         .iter()
         .map(|full_refspec| RefToPush::new(full_refspec, qualified_remote_refs_expected_locations))
@@ -2443,29 +2436,19 @@ fn subprocess_push_refs(
 
     let push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, &mut callbacks)?;
 
-    for remote_ref in push_stats.pushed {
-        remaining_remote_refs.remove(remote_ref.as_str());
-    }
-
     if !push_stats.rejected.is_empty() {
         let mut refs_in_unexpected_locations = push_stats.rejected;
         refs_in_unexpected_locations.sort();
         Err(GitPushError::RefInUnexpectedLocation(
             refs_in_unexpected_locations,
         ))
-    } else if remaining_remote_refs.is_empty() {
-        Ok(())
+    } else if !push_stats.remote_rejected.is_empty() {
+        let mut rejected_refs = push_stats.remote_rejected;
+        rejected_refs.sort();
+        // remote rejected refs because of remote config (e.g., no push on main)
+        Err(GitPushError::RefUpdateRejected(rejected_refs))
     } else {
-        // TODO: this is probably dead code right now
-        // The only way this would happen is if a push fails from some
-        // other reason other than a lease failing (which our tests don't cover)
-        Err(GitPushError::RefUpdateRejected(
-            remaining_remote_refs
-                .iter()
-                .sorted()
-                .map(|name| name.to_string())
-                .collect(),
-        ))
+        Ok(())
     }
 }
 


### PR DESCRIPTION
When we push a ref to a git remote, we use `--force-with-lease`
Our understanding was that this could fail iff the expected location of
the ref on the remote was not that of the local tracking ref

However, if the ref is from a protected branch (e.g., main) it will be
rejected by the remote for a different reason.

This commit solves this, by detecting this difference.

# Checklist

If applicable:
- [x] I have added tests to cover my changes
