### PR TITLE
cli: config list: show origin of config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* The command `jj config list` now supports showing the origin of each variable
+  via the `builtin_config_list_detailed` template.
+
 * `jj config {edit,set,unset}` now prompt when multiple config files are found.
 
 * `jj diff -r` now allows multiple revisions (as long as there are no gaps in

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -96,7 +96,8 @@ pub struct AnnotatedValue {
     pub value: ConfigValue,
     /// Source of the configuration value.
     pub source: ConfigSource,
-    // TODO: add source file path
+    /// Path to the source file, if available.
+    pub path: Option<PathBuf>,
     /// True if this value is overridden in higher precedence layers.
     pub is_overridden: bool,
 }
@@ -151,6 +152,7 @@ pub fn resolved_config_values(
                     name,
                     value,
                     source: layer.source,
+                    path: layer.path.clone(),
                     is_overridden,
                 });
             }
@@ -969,6 +971,7 @@ mod tests {
                     },
                 ),
                 source: EnvBase,
+                path: None,
                 is_overridden: false,
             },
             AnnotatedValue {
@@ -996,6 +999,7 @@ mod tests {
                     },
                 ),
                 source: EnvBase,
+                path: None,
                 is_overridden: true,
             },
             AnnotatedValue {
@@ -1023,6 +1027,7 @@ mod tests {
                     },
                 ),
                 source: Repo,
+                path: None,
                 is_overridden: false,
             },
         ]
@@ -1071,6 +1076,7 @@ mod tests {
                     },
                 ),
                 source: User,
+                path: None,
                 is_overridden: false,
             },
             AnnotatedValue {
@@ -1098,6 +1104,7 @@ mod tests {
                     },
                 ),
                 source: Repo,
+                path: None,
                 is_overridden: false,
             },
         ]

--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -72,9 +72,13 @@
 
 "config_list name" = "green"
 "config_list value" = "yellow"
+"config_list source" = "blue"
+"config_list path" = "magenta"
 "config_list overridden" = "bright black"
 "config_list overridden name" = "bright black"
 "config_list overridden value" = "bright black"
+"config_list overridden source" = "bright black"
+"config_list overridden path" = "bright black"
 
 "diff header" = "yellow"
 "diff empty" = "cyan"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -31,12 +31,7 @@ separate(" ",
 ) ++ ": " ++ content
 '''
 
-config_list = '''
-if(overridden,
-  label("overridden", indent("# ", name ++ " = " ++ value)),
-  name ++ " = " ++ value,
-) ++ "\n"
-'''
+config_list = 'builtin_config_list'
 
 draft_commit_description = '''
 concat(
@@ -72,6 +67,23 @@ separate(" ",
 '''
 
 [template-aliases]
+
+builtin_config_item = '''
+if(overridden,
+  label("overridden", indent("# ", name ++ " = " ++ value)),
+  name ++ " = " ++ value,
+)
+'''
+
+builtin_config_list = 'builtin_config_item ++ "\n"'
+
+builtin_config_list_detailed = '''
+if(overridden,
+  label("overridden", builtin_config_item ++ " # " ++ separate(" ", source, path)),
+  builtin_config_item ++ " # " ++ separate(" ", source, path),
+) ++ "\n"
+'''
+
 builtin_log_oneline = '''
 if(root,
   format_root_commit(self),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -622,6 +622,12 @@ List variables set in config file, along with their values
    * `name: String`: Config name.
    * `value: ConfigValue`: Value to be formatted in TOML syntax.
    * `overridden: Boolean`: True if the value is shadowed by other.
+   * `source: String`: Source of the value.
+   * `path: String`: Path to the config file.
+
+   Can be overridden by the `templates.config_list` setting. To
+   see a detailed config list, use the `builtin_config_list_detailed`
+   template.
 
    See [`jj help -k templates`] for more information.
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -718,6 +718,9 @@ fn test_template_alias() {
 
     let output = test_env.run_jj_in(dir, ["--", "jj", "log", "-T", ""]);
     insta::assert_snapshot!(output, @r"
+    builtin_config_item
+    builtin_config_list
+    builtin_config_list_detailed
     builtin_log_comfortable
     builtin_log_compact
     builtin_log_compact_full_description

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -365,6 +365,9 @@ fn test_evolog_with_no_template() {
 
     For more information, try '--help'.
     Hint: The following template aliases are defined:
+    - builtin_config_item
+    - builtin_config_list
+    - builtin_config_list_detailed
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -45,6 +45,9 @@ fn test_log_with_no_template() {
 
     For more information, try '--help'.
     Hint: The following template aliases are defined:
+    - builtin_config_item
+    - builtin_config_list
+    - builtin_config_list_detailed
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -170,6 +170,9 @@ fn test_op_log_with_no_template() {
 
     For more information, try '--help'.
     Hint: The following template aliases are defined:
+    - builtin_config_item
+    - builtin_config_list
+    - builtin_config_list_detailed
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -270,6 +270,9 @@ fn test_show_with_no_template() {
 
     For more information, try '--help'.
     Hint: The following template aliases are defined:
+    - builtin_config_item
+    - builtin_config_list
+    - builtin_config_list_detailed
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -147,7 +147,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword `builtin` doesn't exist
-    Hint: Did you mean `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`?
+    Hint: Did you mean `builtin_config_item`, `builtin_config_list`, `builtin_config_list_detailed`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`?
     [EOF]
     [exit status: 1]
     ");

--- a/docs/config.md
+++ b/docs/config.md
@@ -368,6 +368,29 @@ edit = true
 You can pass the `--no-edit` flag to `prev` and `next` if you find yourself
 needing the original behavior.
 
+## List
+
+### Default Template
+
+You can configure the template used when no `-T` is specified.
+
+- `templates.config_list` for `jj config list`
+
+```toml
+[templates]
+# Use builtin config list template
+config_list = "builtin_config_list"
+```
+
+If you want to see the config variable origin (type and path) when you do `jj config list`
+you can add this to your config:
+
+```toml
+[templates]
+config_list = "builtin_config_list_detailed"
+```
+
+
 ## Log
 
 ### Default revisions

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -17,6 +17,7 @@
 use std::borrow::Borrow;
 use std::convert::Infallible;
 use std::fmt;
+use std::fmt::Display;
 use std::fs;
 use std::io;
 use std::ops::Range;
@@ -291,6 +292,20 @@ pub enum ConfigSource {
     EnvOverrides,
     /// Command-line arguments (which has the highest precedence.)
     CommandArg,
+}
+
+impl Display for ConfigSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use ConfigSource::*;
+        let c = match self {
+            Default => "default",
+            User => "user",
+            Repo => "repo",
+            CommandArg => "cli",
+            EnvBase | EnvOverrides => "env",
+        };
+        write!(f, "{c}")
+    }
 }
 
 /// Set of configuration variables with source information.


### PR DESCRIPTION
Hello!

This adds the config origin to the end of the line for each config value in the list.
Options coming from files will show the file path.

![image](https://github.com/user-attachments/assets/a4711b82-cfc7-4da1-a3ae-fb50777bd977)

Thanks!

Closes #1047

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
