### PR TITLE
cli: change debug logging behaviour to whitelist `jj` crates 

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -260,10 +260,15 @@ impl TracingSubscription {
     pub fn enable_debug_logging(&self) -> Result<(), CommandError> {
         self.reload_log_filter
             .modify(|filter| {
+                // The default is INFO.
+                // jj-lib and jj-cli are whitelisted for DEBUG logging.
+                // This ensures that other crates' logging doesn't show up by default.
                 *filter = tracing_subscriber::EnvFilter::builder()
-                    .with_default_directive(tracing::metadata::LevelFilter::DEBUG.into())
+                    .with_default_directive(tracing::metadata::LevelFilter::INFO.into())
                     .with_env_var(Self::ENV_VAR_NAME)
-                    .from_env_lossy();
+                    .from_env_lossy()
+                    .add_directive("jj_lib=debug".parse().unwrap())
+                    .add_directive("jj_cli=debug".parse().unwrap());
             })
             .map_err(|err| internal_error_with_message("failed to enable debug logging", err))?;
         tracing::info!("debug logging enabled");

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -470,9 +470,9 @@ want to adjust the `site_url` to something like `https://jjfan.github.io/jj`.
 
 You can print internal jj logs using `JJ_LOG`. It acts like the `RUST_LOG`
 environment variable, frequent in Rust codebases, and accepts one or more
-[directives]. You can also use the `--debug` global option that sets
-`debug` log level for all targets by default. `JJ_LOG` is still respected when
-using `--debug`.
+[directives]. You can also run `JJ_LOG=debug jj` to get `debug` level logs
+enabled for all targets. You can also use the `--debug` global option, which
+turns on `debug` log level for `jj-lib` and `jj-cli` only.
 
 [directives]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 


### PR DESCRIPTION
The current behaviour means (transitively) dependent crates' debug logs end up
in our logs when `--debug` is active.

The biggest offender here is `globset`, imported from the `ignore
crate`. These logs are extremely noisy and mostly irrelevant from our usecase.

This commit changes this behaviour to whitelist `jj` related debug logs,
while allowing more debugging to come from env vars