### PR TITLE
cli: use RemoteRefSymbol to format trackable bookmarks

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -114,7 +114,6 @@ use jj_lib::settings::HumanByteSize;
 use jj_lib::settings::UserSettings;
 use jj_lib::str_util::StringPattern;
 use jj_lib::transaction::Transaction;
-use jj_lib::view::View;
 use jj_lib::working_copy;
 use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
@@ -2814,40 +2813,6 @@ pub fn print_unmatched_explicit_paths<'a>(
         ui.warning_default(),
         "No matching entries for paths: {ui_paths}"
     )?;
-    Ok(())
-}
-
-pub fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
-    let remote_bookmark_names = view
-        .bookmarks()
-        .filter(|(_, bookmark_target)| bookmark_target.local_target.is_present())
-        .flat_map(|(name, bookmark_target)| {
-            bookmark_target
-                .remote_refs
-                .into_iter()
-                .filter(|&(_, remote_ref)| !remote_ref.is_tracking())
-                .map(move |(remote, _)| format!("{name}@{remote}"))
-        })
-        .collect_vec();
-    if remote_bookmark_names.is_empty() {
-        return Ok(());
-    }
-
-    if let Some(mut formatter) = ui.status_formatter() {
-        writeln!(
-            formatter.labeled("hint").with_heading("Hint: "),
-            "The following remote bookmarks aren't associated with the existing local bookmarks:"
-        )?;
-        for full_name in &remote_bookmark_names {
-            write!(formatter, "  ")?;
-            writeln!(formatter.labeled("bookmark"), "{full_name}")?;
-        }
-        writeln!(
-            formatter.labeled("hint").with_heading("Hint: "),
-            "Run `jj bookmark track {names}` to keep local bookmarks updated on future pulls.",
-            names = remote_bookmark_names.join(" "),
-        )?;
-    }
     Ok(())
 }
 

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -259,7 +259,7 @@ pub fn maybe_set_repository_level_trunk_alias(
 }
 
 fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
-    let remote_bookmark_names = view
+    let remote_bookmark_symbols = view
         .bookmarks()
         .filter(|(_, bookmark_target)| bookmark_target.local_target.is_present())
         .flat_map(|(name, bookmark_target)| {
@@ -267,10 +267,10 @@ fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
                 .remote_refs
                 .into_iter()
                 .filter(|&(_, remote_ref)| !remote_ref.is_tracking())
-                .map(move |(remote, _)| format!("{name}@{remote}"))
+                .map(move |(remote, _)| RemoteRefSymbol { name, remote })
         })
         .collect_vec();
-    if remote_bookmark_names.is_empty() {
+    if remote_bookmark_symbols.is_empty() {
         return Ok(());
     }
 
@@ -279,14 +279,14 @@ fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
             formatter.labeled("hint").with_heading("Hint: "),
             "The following remote bookmarks aren't associated with the existing local bookmarks:"
         )?;
-        for full_name in &remote_bookmark_names {
+        for symbol in &remote_bookmark_symbols {
             write!(formatter, "  ")?;
-            writeln!(formatter.labeled("bookmark"), "{full_name}")?;
+            writeln!(formatter.labeled("bookmark"), "{symbol}")?;
         }
         writeln!(
             formatter.labeled("hint").with_heading("Hint: "),
-            "Run `jj bookmark track {names}` to keep local bookmarks updated on future pulls.",
-            names = remote_bookmark_names.join(" "),
+            "Run `jj bookmark track {syms}` to keep local bookmarks updated on future pulls.",
+            syms = remote_bookmark_symbols.iter().join(" "),
         )?;
     }
     Ok(())


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
