### PR TITLE
sign: gpg: automatically use user email as signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj sign` will automatically use the gpg key associated with the author's email
+  in the absence of a `signing.key` configuration.
+
 * Multiple user configs are now supported and are loaded in the following precedence order:
   - `$HOME/.jjconfig.toml`
   - `$XDG_CONFIG_HOME/jj/config.toml`

--- a/docs/config.md
+++ b/docs/config.md
@@ -1162,8 +1162,9 @@ Setting the backend to `"none"` disables signing.
 [signing]
 behavior = "own"
 backend = "gpg"
-key = "4ED556E9729E000F"
 ## You can set `key` to anything accepted by `gpg -u`
+## If not set then defaults to the key associated with `user.email`
+# key = "4ED556E9729E000F"
 # key = "signing@example.com"
 ```
 

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -90,7 +90,7 @@ macro_rules! gpg_guard {
 fn backend(env: &GpgEnvironment) -> GpgBackend {
     // don't really need faked time for current tests,
     // but probably will need it for end-to-end cli tests
-    GpgBackend::new("gpg".into(), false).with_extra_args(&[
+    GpgBackend::new("gpg".into(), false, "someone@example.com".to_owned()).with_extra_args(&[
         "--homedir".into(),
         env.homedir.path().as_os_str().into(),
         "--faked-system-time=1701042000!".into(),


### PR DESCRIPTION
If a signing key is not configured, the user's email will be used as the signing key. This aligns with `git`'s behavior and allows the users to not have to specify the key in their configs given that they have a key associated with their email.

Thanks!
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
