### PR TITLE
cli: annotate: add --domain

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -922,6 +922,7 @@ Annotates a revision line by line. Each line includes the source change that int
 ###### **Options:**
 
 * `-r`, `--revision <REVSET>` — an optional revision to start at
+* `--domain <REVSET>` — An optional domain to restrict the query to
 * `-T`, `--template <TEMPLATE>` — Render each line using the given template
 
    All 0-argument methods of the [`AnnotationLine` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.


### PR DESCRIPTION
There's been talk about adding this, most recently https://github.com/jj-vcs/jj/pull/5967#discussion_r1991345773.

The main question is what to show in the "diff not contained in domain" case. Some possibilities:

- Root commit
  - (+) Root commit is always empty, no confusion between "blamed because actually changed" and "blamed because oldest ancestor"
  - (-) Not immediately obvious
- Oldest commit in domain
  - (-) Confusion about blame reason as mentioned above
- Other special marker
  - (+) immediately obvious
  - (-) changes `AnnotationLine` type

Currently, the implementation chooses the root commit. I'm partial to either that or the "other special marker" solution --- I do _not_ like the idea of using the farthest ancestor, since it would be both surprising (when the commit does not actually touch the line) and have no way to tell inside the `file annotate` output.

WIP due to missing tests, documentation, etc.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
