### PR TITLE
github: fix `ci` workflow concurrency setting in the queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number
-      || github.event.merge_queue.head_ref
+      || github.event.merge_group.head_ref
     }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Whoops.

https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
