### PR TITLE
config: only load toml files in a directory

### DIFF
--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1006,6 +1006,20 @@ fn test_config_path_multiple() {
 }
 
 #[test]
+fn test_config_only_loads_toml_files() {
+    let mut test_env = TestEnvironment::default();
+    test_env.set_up_fake_editor();
+    std::fs::File::create(test_env.config_path().join("is-not.loaded")).unwrap();
+    insta::assert_snapshot!(test_env.run_jj_in(".", ["config", "edit", "--user"]), @r"
+    ------- stderr -------
+    1: $TEST_ENV/config/config0001.toml
+    2: $TEST_ENV/config/config0002.toml
+    Choose a config file (default 1): 1
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_config_edit_repo_outside_repo() {
     let test_env = TestEnvironment::default();
     let output = test_env.run_jj_in(".", ["config", "edit", "--repo"]);

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -366,8 +366,7 @@ impl ConfigLayer {
             .and_then(|dir_entries| {
                 dir_entries
                     .map(|entry| Ok(entry?.path()))
-                    // TODO: Accept only certain file extensions?
-                    .filter_ok(|path| path.is_file())
+                    .filter_ok(|path| path.is_file() && path.extension() == Some("toml".as_ref()))
                     .try_collect()
             })
             .context(path)


### PR DESCRIPTION
This helps avoid loading errors should the JJ_CONFIG environment variable be set to a directory that
contains other file types.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
