### PR TITLE
annotate: report root commit id if no origin found within range

### DIFF
--- a/lib/src/absorb.rs
+++ b/lib/src/absorb.rs
@@ -148,7 +148,7 @@ pub async fn split_hunks_to_trees(
         )?;
         let annotation_ranges = annotation
             .compact_line_ranges()
-            .filter_map(|(commit_id, range)| Some((commit_id?, range)))
+            .filter_map(|(commit_id, range)| Some((commit_id.ok()?, range)))
             .collect_vec();
         let diff = Diff::by_line([&left_text, &right_text]);
         let selected_ranges = split_file_hunks(&annotation_ranges, &diff);


### PR DESCRIPTION
Suppose we add "jj file annotate" option to specify the search domain or depth, the root commit within the range can be displayed as the boundary commit. "git blame" for example displays boundary commits with ^ prefix.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
