### PR TITLE
git: add deprecation warnings for `git.subprocess`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* `git.subprocess = false` has been deprecated, and the old `libgit2`
+  code path for fetches and pushes will be removed entirely in 0.30.
+  Please report any remaining issues you have with the Git
+  subprocessing path.
+
 ### New features
 
 ### Fixed bugs

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -36,6 +36,8 @@ use crate::command_error::user_error_with_message;
 use crate::command_error::CommandError;
 use crate::commands::git::maybe_add_gitignore;
 use crate::git_util::absolute_git_url;
+#[cfg(feature = "git2")]
+use crate::git_util::print_git2_deprecation_warning;
 use crate::git_util::print_git_import_stats;
 use crate::git_util::with_remote_git_callbacks;
 use crate::ui::Ui;
@@ -118,6 +120,8 @@ pub fn cmd_git_clone(
 
     let clone_result = (|| -> Result<_, CommandError> {
         let workspace_command = init_workspace(ui, command, &canonical_wc_path, args.colocate)?;
+        #[cfg(feature = "git2")]
+        print_git2_deprecation_warning(ui, workspace_command.settings())?;
         let mut workspace_command =
             configure_remote(ui, command, workspace_command, remote_name, &source)?;
         let default_branch = fetch_new_remote(ui, &mut workspace_command, remote_name, args.depth)?;

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -31,6 +31,8 @@ use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::commands::git::get_single_remote;
 use crate::complete;
+#[cfg(feature = "git2")]
+use crate::git_util::print_git2_deprecation_warning;
 use crate::git_util::print_git_import_stats;
 use crate::git_util::with_remote_git_callbacks;
 use crate::ui::Ui;
@@ -127,6 +129,9 @@ pub fn cmd_git_fetch(
         .filter(|r| matching_remotes.contains(r))
         .map(|r| r.as_ref())
         .collect_vec();
+
+    #[cfg(feature = "git2")]
+    print_git2_deprecation_warning(ui, workspace_command.settings())?;
 
     let mut tx = workspace_command.start_transaction();
     do_git_fetch(ui, &mut tx, &remotes, &args.branch)?;

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -62,6 +62,8 @@ use crate::command_error::CommandError;
 use crate::commands::git::get_single_remote;
 use crate::complete;
 use crate::formatter::Formatter;
+#[cfg(feature = "git2")]
+use crate::git_util::print_git2_deprecation_warning;
 use crate::git_util::with_remote_git_callbacks;
 use crate::revset_util::parse_bookmark_name;
 use crate::ui::Ui;
@@ -223,6 +225,9 @@ pub fn cmd_git_push(
         default_remote = get_default_push_remote(ui, &workspace_command)?;
         &default_remote
     };
+
+    #[cfg(feature = "git2")]
+    print_git2_deprecation_warning(ui, workspace_command.settings())?;
 
     let mut tx = workspace_command.start_transaction();
     let view = tx.repo().view();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -629,6 +629,16 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
             },
             |_| Ok("jj was compiled without `git.subprocess = false` support".into()),
         ),
+        // TODO: Delete with the `git.subprocess` setting.
+        ConfigMigrationRule::custom(
+            |layer| {
+                let Ok(Some(subprocess)) = layer.look_up_item("git.subprocess") else {
+                    return false;
+                };
+                subprocess.as_bool() == Some(true) && layer.source != ConfigSource::Default
+            },
+            |_| Ok("`git.subprocess = true` is now the default".into()),
+        ),
     ]
 }
 

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -30,6 +30,8 @@ use crossterm::terminal::Clear;
 use crossterm::terminal::ClearType;
 use indoc::writedoc;
 use itertools::Itertools as _;
+#[cfg(feature = "git2")]
+use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::fmt_util::binary_prefix;
 use jj_lib::git;
 use jj_lib::git::FailedRefExportReason;
@@ -41,6 +43,8 @@ use jj_lib::op_store::RemoteRef;
 use jj_lib::ref_name::RemoteRefSymbol;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
+#[cfg(feature = "git2")]
+use jj_lib::settings::UserSettings;
 use jj_lib::workspace::Workspace;
 use unicode_width::UnicodeWidthStr as _;
 
@@ -608,6 +612,26 @@ another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
 export or their "parent" bookmarks."#,
             )?;
         }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "git2")]
+pub fn print_git2_deprecation_warning(
+    ui: &Ui,
+    settings: &UserSettings,
+) -> Result<(), CommandError> {
+    if !settings.git_settings()?.subprocess
+        && !settings
+            .get("debug.suppress-git2-deprecation-warning")
+            .optional()?
+            .unwrap_or(false)
+    {
+        writeln!(
+            ui.warning_default(),
+            "`git.subprocess = false` will be removed in 0.30; please report any issues you have \
+             with the default.",
+        )?;
     }
     Ok(())
 }

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -202,7 +202,10 @@ impl TestEnvironment {
     pub fn with_git_subprocess(self, subprocess: bool) -> Self {
         #[cfg(feature = "git2")]
         if !subprocess {
-            self.add_config("git.subprocess = false");
+            self.add_config(formatdoc! {"
+                git.subprocess = false
+                debug.suppress-git2-deprecation-warning = true
+            "});
             return self;
         }
         assert!(subprocess);

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -1094,7 +1094,6 @@ fn get_bookmark_output(work_dir: &TestWorkDir) -> CommandOutput {
 }
 
 // TODO: Remove with the `git.subprocess` setting.
-#[cfg(not(feature = "git2"))]
 #[test]
 fn test_git_clone_git2_warning() {
     let test_env = TestEnvironment::default();
@@ -1107,15 +1106,29 @@ fn test_git_clone_git2_warning() {
     set_up_non_empty_git_repo(&git_repo);
 
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::assert_snapshot!(output, @r#"
-    ------- stderr -------
-    Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
-    Fetching into new repo in "$TEST_ENV/clone"
-    bookmark: main@origin [new] tracked
-    Setting the revset alias `trunk()` to `main@origin`
-    Working copy  (@) now at: sqpuoqvx 2ca1c979 (empty) (no description set)
-    Parent commit (@-)      : qomsplrm ebeb70d8 main | message
-    Added 1 files, modified 0 files, removed 0 files
-    [EOF]
-    "#);
+    if cfg!(feature = "git2") {
+        insta::assert_snapshot!(output, @r#"
+        ------- stderr -------
+        Warning: `git.subprocess = false` will be removed in 0.30; please report any issues you have with the default.
+        Fetching into new repo in "$TEST_ENV/clone"
+        bookmark: main@origin [new] tracked
+        Setting the revset alias `trunk()` to `main@origin`
+        Working copy  (@) now at: sqpuoqvx 2ca1c979 (empty) (no description set)
+        Parent commit (@-)      : qomsplrm ebeb70d8 main | message
+        Added 1 files, modified 0 files, removed 0 files
+        [EOF]
+        "#);
+    } else {
+        insta::assert_snapshot!(output, @r#"
+        ------- stderr -------
+        Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
+        Fetching into new repo in "$TEST_ENV/clone"
+        bookmark: main@origin [new] tracked
+        Setting the revset alias `trunk()` to `main@origin`
+        Working copy  (@) now at: sqpuoqvx 2ca1c979 (empty) (no description set)
+        Parent commit (@-)      : qomsplrm ebeb70d8 main | message
+        Added 1 files, modified 0 files, removed 0 files
+        [EOF]
+        "#);
+    }
 }

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2014,7 +2014,6 @@ fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
 }
 
 // TODO: Remove with the `git.subprocess` setting.
-#[cfg(not(feature = "git2"))]
 #[test]
 fn test_git_fetch_git2_warning() {
     let test_env = TestEnvironment::default();
@@ -2025,10 +2024,19 @@ fn test_git_fetch_git2_warning() {
     add_git_remote(&test_env, &work_dir, "origin");
 
     let output = work_dir.run_jj(["git", "fetch"]);
-    insta::assert_snapshot!(output, @r#"
-    ------- stderr -------
-    Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
-    bookmark: origin@origin [new] tracked
-    [EOF]
-    "#);
+    if cfg!(feature = "git2") {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Warning: `git.subprocess = false` will be removed in 0.30; please report any issues you have with the default.
+        bookmark: origin@origin [new] tracked
+        [EOF]
+        ");
+    } else {
+        insta::assert_snapshot!(output, @r#"
+        ------- stderr -------
+        Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
+        bookmark: origin@origin [new] tracked
+        [EOF]
+        "#);
+    }
 }

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -2572,7 +2572,6 @@ fn get_bookmark_output(work_dir: &TestWorkDir) -> CommandOutput {
 }
 
 // TODO: Remove with the `git.subprocess` setting.
-#[cfg(not(feature = "git2"))]
 #[test]
 fn test_git_push_git2_warning() {
     let test_env = TestEnvironment::default();
@@ -2583,11 +2582,21 @@ fn test_git_push_git2_warning() {
         .run_jj(["describe", "bookmark1", "-m", "modified bookmark1 commit"])
         .success();
     let output = work_dir.run_jj(["git", "push", "--all"]);
-    insta::assert_snapshot!(output, @r#"
-    ------- stderr -------
-    Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
-    Changes to push to origin:
-      Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8dc6560f32
-    [EOF]
-    "#);
+    if cfg!(feature = "git2") {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Warning: `git.subprocess = false` will be removed in 0.30; please report any issues you have with the default.
+        Changes to push to origin:
+          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8dc6560f32
+        [EOF]
+        ");
+    } else {
+        insta::assert_snapshot!(output, @r#"
+        ------- stderr -------
+        Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
+        Changes to push to origin:
+          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8dc6560f32
+        [EOF]
+        "#);
+    }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1426,8 +1426,9 @@ subprocessing, you can switch back to `libgit2` with:
 subprocess = false
 ```
 
-Note that `libgit2` support will likely be removed in the future, so you are
-encouraged to report any issues you experience with the default configuration.
+Note that `libgit2` support will be removed in 0.30, so you are encouraged to
+[report any issues](https://github.com/jj-vcs/jj/issues) you experience with
+the default configuration.
 
 ## Filesystem monitor
 

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -23,10 +23,7 @@ a comparison with Git, including how workflows are different, see the
     [only the last pushurl](https://github.com/jj-vcs/jj/issues/4889) is
     respected).
   * `core.excludesFile`
-* **Authentication: Yes.** With the default authentication scheme, which uses
-  `git` under the hood. With `git.subprocess = false`, only `ssh-agent`, a
-   password-less key (only `~/.ssh/id_rsa`, `~/.ssh/id_ed25519` or
-   `~/.ssh/id_ed25519_sk`), or a `credential.helper` are supported.
+* **Authentication: Yes.** `git` is used for remote operations under the hood.
 * **Branches: Yes.** You can read more about
   [how branches work in Jujutsu](bookmarks.md)
   and [how they interoperate with Git](#branches).


### PR DESCRIPTION
~~Only intended for merge when we decide to start the deprecation process, but~~ should be ready ~~for code review now.~~

~~The first commit could be split out into another PR if we want to merge it now.~~
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
