### PR TITLE
git: remove `git.subprocess` setting

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -56,7 +56,7 @@ jobs:
           target: ${{ matrix.target }}
       - name: Build release binary
         shell: bash
-        run: cargo build --target ${{ matrix.target }} --verbose --release --features vendored-openssl
+        run: cargo build --target ${{ matrix.target }} --verbose --release
 
       - name: Set up artifact directory
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,11 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        build: [linux-x86_64-gnu, 'linux-x86_64-gnu, no git2', linux-aarch64-gnu, macos-x86_64, macos-aarch64, windows-x86_64]
+        build: [linux-x86_64-gnu, linux-aarch64-gnu, macos-x86_64, macos-aarch64, windows-x86_64]
         include:
         - build: linux-x86_64-gnu
           os: ubuntu-24.04
           cargo_flags: "--all-features"
-        - build: 'linux-x86_64-gnu, no git2'
-          os: ubuntu-24.04
-          cargo_flags: "--no-default-features --features git"
-          # Ensure we don’t link to `libgit2`.
-          LIBGIT2_NO_VENDOR: 1
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           cargo_flags: "--all-features"
@@ -81,8 +76,6 @@ jobs:
         --all-targets
         --verbose
         ${{ matrix.cargo_flags }}
-      env:
-        LIBGIT2_NO_VENDOR: ${{ matrix.LIBGIT2_NO_VENDOR || '0' }}
     - name: Test
       run: >-
         cargo nextest run
@@ -95,7 +88,6 @@ jobs:
       env:
         RUST_BACKTRACE: 1
         CARGO_TERM_COLOR: always
-        LIBGIT2_NO_VENDOR: ${{ matrix.LIBGIT2_NO_VENDOR || '0' }}
 
   no-git:
     name: build (no git)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         target: ${{ matrix.target }}
     - name: Build release binary
       shell: bash
-      run: cargo build --target ${{ matrix.target }} --verbose --release --features vendored-openssl
+      run: cargo build --target ${{ matrix.target }} --verbose --release
     - name: Build archive
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Packaging changes
 
+* Due to the removal of the `libgit2` code path, packagers should
+  remove any dependencies on `libgit2`, `libssh2`, Zlib, OpenSSL, and
+  `pkg-config`, and ensure they are not setting the Cargo `git2` or
+  `vendored-openssl` features.
+
 ## [0.29.0] - 2025-05-07
 
 ### Release highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* The old `libgit2` code path for fetches and pushes has been removed,
+  and the `git.subprocess` setting along with it.
+
 ### Deprecations
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,8 +342,6 @@ version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1122,21 +1120,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "git2"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
-dependencies = [
- "bitflags 2.9.0",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
 
 [[package]]
 name = "gix"
@@ -2366,7 +2349,6 @@ dependencies = [
  "dunce",
  "etcetera",
  "futures 0.3.31",
- "git2",
  "gix",
  "glob",
  "indexmap",
@@ -2421,7 +2403,6 @@ dependencies = [
  "dunce",
  "either",
  "futures 0.3.31",
- "git2",
  "gix",
  "glob",
  "hashbrown 0.15.3",
@@ -2475,16 +2456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
-dependencies = [
- "getrandom 0.3.2",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,20 +2493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.1+1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,20 +2501,6 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2579,18 +2522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
 dependencies = [
  "zlib-rs",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2863,34 +2794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.0+3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.107"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,12 +2977,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -4373,12 +4270,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,6 @@ dunce = "1.0.5"
 etcetera = "0.10.0"
 either = "1.15.0"
 futures = "0.3.31"
-git2 = { version = "0.20.1", features = [
-    # Do *not* disable this feature even if you'd like dynamic linking. Instead,
-    # set the environment variable `LIBGIT2_NO_VENDOR=1` if dynamic linking must
-    # be used (this will override the Cargo feature), and allow static linking
-    # in other cases. Rationale: If neither the feature nor the environment
-    # variable are set, `git2` may still decide to vendor `libgit2` if it
-    # doesn't find a version of `libgit2` to link to dynamically. See also
-    # https://github.com/rust-lang/git2-rs/commit/3cef4119f
-    "vendored-libgit2"
-] }
 gix = { version = "0.71.0", default-features = false, features = [
     "attributes",
     "blob-diff",

--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ the header of the website when you scroll to the top of any page.
 
 Jujutsu is designed so that the underlying data and storage model is abstract.
 Today, only the Git backend is production-ready. The Git backend uses the
-[libgit2](https://libgit2.org/) C library and the
 [gitoxide](https://github.com/Byron/gitoxide) Rust library.
 
 [backends]: https://jj-vcs.github.io/jj/latest/glossary#backend

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,7 +65,6 @@ crossterm = { workspace = true }
 dunce = { workspace = true }
 etcetera = { workspace = true }
 futures = { workspace = true }
-git2 = { workspace = true, optional = true }
 gix = { workspace = true, optional = true }
 glob = { workspace = true }
 indexmap = { workspace = true }
@@ -114,12 +113,10 @@ testutils = { workspace = true }
 jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 
 [features]
-default = ["watchman", "git", "git2"]
+default = ["watchman", "git"]
 bench = ["dep:criterion"]
 git = ["jj-lib/git", "dep:gix"]
-git2 = ["git", "jj-lib/git2", "dep:git2"]
 test-fakes = ["jj-lib/testing"]
-vendored-openssl = ["git2/vendored-openssl", "jj-lib/vendored-openssl"]
 watchman = ["jj-lib/watchman"]
 
 [package.metadata.binstall]

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -508,7 +508,6 @@ impl From<TrailerParseError> for CommandError {
 mod git {
     use jj_lib::git::GitExportError;
     use jj_lib::git::GitFetchError;
-    use jj_lib::git::GitFetchPrepareError;
     use jj_lib::git::GitImportError;
     use jj_lib::git::GitPushError;
     use jj_lib::git::GitRemoteManagementError;
@@ -563,14 +562,6 @@ jj currently does not support partial clones. To use jj with this repository, tr
                 ),
                 GitFetchError::InvalidBranchPattern(_) => user_error(err),
                 GitFetchError::Subprocess(_) => user_error(err),
-            }
-        }
-    }
-
-    impl From<GitFetchPrepareError> for CommandError {
-        fn from(err: GitFetchPrepareError) -> Self {
-            match err {
-                GitFetchPrepareError::UnexpectedBackend(_) => user_error(err),
             }
         }
     }

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -222,8 +222,7 @@ fn fetch_new_remote(
     with_remote_git_callbacks(ui, |cb| {
         git_fetch.fetch(remote_name, &[StringPattern::everything()], cb, depth)
     })?;
-    let default_branch =
-        with_remote_git_callbacks(ui, |cb| git_fetch.get_default_branch(remote_name, cb))?;
+    let default_branch = git_fetch.get_default_branch(remote_name)?;
     let import_stats = git_fetch.import_refs()?;
     print_git_import_stats(ui, fetch_tx.repo(), &import_stats, true)?;
     fetch_tx.finish(ui, "fetch from git remote into empty repo")?;

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -36,8 +36,6 @@ use crate::command_error::user_error_with_message;
 use crate::command_error::CommandError;
 use crate::commands::git::maybe_add_gitignore;
 use crate::git_util::absolute_git_url;
-#[cfg(feature = "git2")]
-use crate::git_util::print_git2_deprecation_warning;
 use crate::git_util::print_git_import_stats;
 use crate::git_util::with_remote_git_callbacks;
 use crate::ui::Ui;
@@ -120,8 +118,6 @@ pub fn cmd_git_clone(
 
     let clone_result = (|| -> Result<_, CommandError> {
         let workspace_command = init_workspace(ui, command, &canonical_wc_path, args.colocate)?;
-        #[cfg(feature = "git2")]
-        print_git2_deprecation_warning(ui, workspace_command.settings())?;
         let mut workspace_command =
             configure_remote(ui, command, workspace_command, remote_name, &source)?;
         let default_branch = fetch_new_remote(ui, &mut workspace_command, remote_name, args.depth)?;

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -31,8 +31,6 @@ use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::commands::git::get_single_remote;
 use crate::complete;
-#[cfg(feature = "git2")]
-use crate::git_util::print_git2_deprecation_warning;
 use crate::git_util::print_git_import_stats;
 use crate::git_util::with_remote_git_callbacks;
 use crate::ui::Ui;
@@ -119,9 +117,6 @@ pub fn cmd_git_fetch(
         .map(|r| r.as_ref())
         .sorted()
         .collect_vec();
-
-    #[cfg(feature = "git2")]
-    print_git2_deprecation_warning(ui, workspace_command.settings())?;
 
     let mut tx = workspace_command.start_transaction();
     do_git_fetch(ui, &mut tx, &remotes, &args.branch)?;

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -62,8 +62,6 @@ use crate::command_error::CommandError;
 use crate::commands::git::get_single_remote;
 use crate::complete;
 use crate::formatter::Formatter;
-#[cfg(feature = "git2")]
-use crate::git_util::print_git2_deprecation_warning;
 use crate::git_util::with_remote_git_callbacks;
 use crate::revset_util::parse_bookmark_name;
 use crate::ui::Ui;
@@ -225,9 +223,6 @@ pub fn cmd_git_push(
         default_remote = get_default_push_remote(ui, &workspace_command)?;
         &default_remote
     };
-
-    #[cfg(feature = "git2")]
-    print_git2_deprecation_warning(ui, workspace_command.settings())?;
 
     let mut tx = workspace_command.start_transaction();
     let view = tx.repo().view();

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -474,11 +474,6 @@
                     "description": "Whether jj should sign commits before pushing",
                     "default": false
                 },
-                "subprocess": {
-                    "type": "boolean",
-                    "description": "Whether jj spawns a git subprocess for network operations (push/fetch/clone)",
-                    "default": true
-                },
                 "write-change-id-header": {
                     "type": "boolean",
                     "description": "Whether the change id should be stored in the Git commit object",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -714,27 +714,6 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
         ),
         // TODO: Delete in jj 0.34+
         ConfigMigrationRule::rename_value("diff.format", "ui.diff.format"),
-        // TODO: Delete with the `git.subprocess` setting.
-        #[cfg(not(feature = "git2"))]
-        ConfigMigrationRule::custom(
-            |layer| {
-                let Ok(Some(subprocess)) = layer.look_up_item("git.subprocess") else {
-                    return false;
-                };
-                subprocess.as_bool() == Some(false)
-            },
-            |_| Ok("jj was compiled without `git.subprocess = false` support".into()),
-        ),
-        // TODO: Delete with the `git.subprocess` setting.
-        ConfigMigrationRule::custom(
-            |layer| {
-                let Ok(Some(subprocess)) = layer.look_up_item("git.subprocess") else {
-                    return false;
-                };
-                subprocess.as_bool() == Some(true) && layer.source != ConfigSource::Default
-            },
-            |_| Ok("`git.subprocess = true` is now the default".into()),
-        ),
         // TODO: Delete in jj 0.35.0+
         ConfigMigrationRule::rename_update_value(
             "ui.default-description",

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -30,8 +30,6 @@ use crossterm::terminal::Clear;
 use crossterm::terminal::ClearType;
 use indoc::writedoc;
 use itertools::Itertools as _;
-#[cfg(feature = "git2")]
-use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::fmt_util::binary_prefix;
 use jj_lib::git;
 use jj_lib::git::FailedRefExportReason;
@@ -43,8 +41,6 @@ use jj_lib::op_store::RemoteRef;
 use jj_lib::ref_name::RemoteRefSymbol;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
-#[cfg(feature = "git2")]
-use jj_lib::settings::UserSettings;
 use jj_lib::workspace::Workspace;
 use unicode_width::UnicodeWidthStr as _;
 
@@ -612,26 +608,6 @@ another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
 export or their "parent" bookmarks."#,
             )?;
         }
-    }
-    Ok(())
-}
-
-#[cfg(feature = "git2")]
-pub fn print_git2_deprecation_warning(
-    ui: &Ui,
-    settings: &UserSettings,
-) -> Result<(), CommandError> {
-    if !settings.git_settings()?.subprocess
-        && !settings
-            .get("debug.suppress-git2-deprecation-warning")
-            .optional()?
-            .unwrap_or(false)
-    {
-        writeln!(
-            ui.warning_default(),
-            "`git.subprocess = false` will be removed in 0.30; please report any issues you have \
-             with the default.",
-        )?;
     }
     Ok(())
 }

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -198,12 +198,6 @@ impl TestEnvironment {
         self.env_vars.insert(key.into(), val.into());
     }
 
-    // TODO: Remove with the `git.subprocess` setting.
-    pub fn with_git_subprocess(self, subprocess: bool) -> Self {
-        assert!(subprocess);
-        self
-    }
-
     /// Sets up the fake editor to read an edit script from the returned path
     /// Also sets up the fake editor as a merge tool named "fake-editor"
     pub fn set_up_fake_editor(&mut self) -> PathBuf {

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -200,14 +200,6 @@ impl TestEnvironment {
 
     // TODO: Remove with the `git.subprocess` setting.
     pub fn with_git_subprocess(self, subprocess: bool) -> Self {
-        #[cfg(feature = "git2")]
-        if !subprocess {
-            self.add_config(formatdoc! {"
-                git.subprocess = false
-                debug.suppress-git2-deprecation-warning = true
-            "});
-            return self;
-        }
         assert!(subprocess);
         self
     }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -755,7 +755,7 @@ fn test_git_clone_conditional_config() {
 }
 
 #[test]
-fn test_git_clone_with_depth_subprocess() {
+fn test_git_clone_with_depth() {
     let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     test_env.add_config("git.auto-local-bookmark = true");
@@ -764,8 +764,6 @@ fn test_git_clone_with_depth_subprocess() {
     let git_repo = git::init(git_repo_path);
     set_up_non_empty_git_repo(&git_repo);
 
-    // git does support shallow clones on the local transport, so it will work
-    // (we cannot replicate git2's erroneous behaviour wrt git)
     let output = root_dir.run_jj(["git", "clone", "--depth", "1", "source", "clone"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -49,20 +49,17 @@ fn test_git_clone() {
 
     // Clone an empty repo
     let output = root_dir.run_jj(["git", "clone", "source", "empty"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/empty"
     Nothing changed.
     [EOF]
     "#);
-    }
 
     set_up_non_empty_git_repo(&git_repo);
 
     // Clone with relative source path
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -73,19 +70,16 @@ fn test_git_clone() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
     let clone_dir = test_env.work_dir("clone");
     assert!(clone_dir.root().join("file").exists());
 
     // Subsequent fetch should just work even if the source path was relative
     let output = clone_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
 
     // Failed clone should clean up the destination directory
     root_dir.create_dir("bad");
@@ -114,54 +108,45 @@ fn test_git_clone() {
 
     // Failed clone (if attempted) shouldn't remove the existing workspace
     let output = root_dir.run_jj(["git", "clone", "bad", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
     assert!(clone_dir.root().join(".jj").exists());
 
     // Try cloning into an existing workspace
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Try cloning into an existing file
     root_dir.write_file("file", "contents");
     let output = root_dir.run_jj(["git", "clone", "source", "file"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Try cloning into non-empty, non-workspace directory
     clone_dir.remove_dir_all(".jj");
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Clone into a nested path
     let output = root_dir.run_jj(["git", "clone", "source", "nested/path/to/repo"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/nested/path/to/repo"
@@ -172,7 +157,6 @@ fn test_git_clone() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
 }
 
 #[test]
@@ -181,18 +165,15 @@ fn test_git_clone_bad_source() {
     let root_dir = test_env.work_dir("");
 
     let output = root_dir.run_jj(["git", "clone", "", "dest"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: local path "" does not specify a path to a repository
     [EOF]
     [exit status: 2]
     "#);
-    }
 
     // Invalid port number
     let output = root_dir.run_jj(["git", "clone", "https://example.net:bad-port/bar", "dest"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: URL "https://example.net:bad-port/bar" can not be parsed as valid URL
@@ -200,7 +181,6 @@ fn test_git_clone_bad_source() {
     [EOF]
     [exit status: 2]
     "#);
-    }
 }
 
 #[test]
@@ -213,30 +193,25 @@ fn test_git_clone_colocate() {
 
     // Clone an empty repo
     let output = root_dir.run_jj(["git", "clone", "source", "empty", "--colocate"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/empty"
     Nothing changed.
     [EOF]
     "#);
-    }
 
     // git_target path should be relative to the store
     let empty_dir = test_env.work_dir("empty");
     let git_target_file_contents =
         String::from_utf8(empty_dir.read_file(".jj/repo/store/git_target").into()).unwrap();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(
         git_target_file_contents.replace(path::MAIN_SEPARATOR, "/"),
         @"../../../.git");
-    }
 
     set_up_non_empty_git_repo(&git_repo);
 
     // Clone with relative source path
     let output = root_dir.run_jj(["git", "clone", "source", "clone", "--colocate"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -247,7 +222,6 @@ fn test_git_clone_colocate() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
     let clone_dir = test_env.work_dir("clone");
     assert!(clone_dir.root().join("file").exists());
     assert!(clone_dir.root().join(".git").exists());
@@ -270,7 +244,6 @@ fn test_git_clone_colocate() {
     );
     // ".jj" directory should be ignored at Git side.
     let git_statuses = git::status(&jj_git_repo);
-    insta::allow_duplicates! {
     insta::assert_debug_snapshot!(git_statuses, @r#"
     [
         GitStatus {
@@ -293,27 +266,22 @@ fn test_git_clone_colocate() {
         },
     ]
     "#);
-    }
 
     // The old default bookmark "master" shouldn't exist.
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&clone_dir), @r"
     main: qomsplrm ebeb70d8 message
       @git: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
     [EOF]
     ");
-    }
 
     // Subsequent fetch should just work even if the source path was relative
     let output = clone_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
 
     // Failed clone should clean up the destination directory
     root_dir.create_dir("bad");
@@ -343,51 +311,43 @@ fn test_git_clone_colocate() {
 
     // Failed clone (if attempted) shouldn't remove the existing workspace
     let output = root_dir.run_jj(["git", "clone", "--colocate", "bad", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
     assert!(clone_dir.root().join(".git").exists());
     assert!(clone_dir.root().join(".jj").exists());
 
     // Try cloning into an existing workspace
     let output = root_dir.run_jj(["git", "clone", "source", "clone", "--colocate"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Try cloning into an existing file
     root_dir.write_file("file", "contents");
     let output = root_dir.run_jj(["git", "clone", "source", "file", "--colocate"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Try cloning into non-empty, non-workspace directory
     clone_dir.remove_dir_all(".jj");
     let output = root_dir.run_jj(["git", "clone", "source", "clone", "--colocate"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Destination path exists and is not an empty directory
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Clone into a nested path
     let output = root_dir.run_jj([
@@ -397,7 +357,6 @@ fn test_git_clone_colocate() {
         "nested/path/to/repo",
         "--colocate",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/nested/path/to/repo"
@@ -408,7 +367,6 @@ fn test_git_clone_colocate() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
 }
 
 #[test]
@@ -434,7 +392,6 @@ fn test_git_clone_remote_default_bookmark() {
     // All fetched bookmarks will be imported if auto-local-bookmark is on
     test_env.add_config("git.auto-local-bookmark = true");
     let output = root_dir.run_jj(["git", "clone", "source", "clone1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone1"
@@ -446,9 +403,7 @@ fn test_git_clone_remote_default_bookmark() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
     let clone_dir1 = test_env.work_dir("clone1");
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&clone_dir1), @r"
     feature1: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
@@ -456,21 +411,17 @@ fn test_git_clone_remote_default_bookmark() {
       @origin: qomsplrm ebeb70d8 message
     [EOF]
     ");
-    }
 
     // "trunk()" alias should be set to default bookmark "main"
     let output = clone_dir1.run_jj(["config", "list", "--repo", "revset-aliases.'trunk()'"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     revset-aliases.'trunk()' = "main@origin"
     [EOF]
     "#);
-    }
 
     // Only the default bookmark will be imported if auto-local-bookmark is off
     test_env.add_config("git.auto-local-bookmark = false");
     let output = root_dir.run_jj(["git", "clone", "source", "clone2"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone2"
@@ -482,21 +433,17 @@ fn test_git_clone_remote_default_bookmark() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
     let clone_dir2 = test_env.work_dir("clone2");
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&clone_dir2), @r"
     feature1@origin: qomsplrm ebeb70d8 message
     main: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
     [EOF]
     ");
-    }
 
     // Change the default bookmark in remote
     git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/feature1");
     let output = root_dir.run_jj(["git", "clone", "source", "clone3"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone3"
@@ -508,25 +455,20 @@ fn test_git_clone_remote_default_bookmark() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
     let clone_dir3 = test_env.work_dir("clone3");
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&clone_dir3), @r"
     feature1: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
     main@origin: qomsplrm ebeb70d8 message
     [EOF]
     ");
-    }
 
     // "trunk()" alias should be set to new default bookmark "feature1"
     let output = clone_dir3.run_jj(["config", "list", "--repo", "revset-aliases.'trunk()'"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     revset-aliases.'trunk()' = "feature1@origin"
     [EOF]
     "#);
-    }
 }
 
 // A branch with a strange name should get quoted in the config. Windows doesn't
@@ -551,7 +493,6 @@ fn test_git_clone_remote_default_bookmark_with_escape() {
     git::set_head_to_id(&git_repo, commit_id);
 
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -562,17 +503,14 @@ fn test_git_clone_remote_default_bookmark_with_escape() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
 
     // "trunk()" alias should be escaped and quoted
     let clone_dir = test_env.work_dir("clone");
     let output = clone_dir.run_jj(["config", "list", "--repo", "revset-aliases.'trunk()'"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     revset-aliases.'trunk()' = '"\""@origin'
     [EOF]
     "#);
-    }
 }
 
 #[test]
@@ -585,7 +523,6 @@ fn test_git_clone_ignore_working_copy() {
 
     // Should not update working-copy files
     let output = root_dir.run_jj(["git", "clone", "--ignore-working-copy", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -593,22 +530,18 @@ fn test_git_clone_ignore_working_copy() {
     Setting the revset alias `trunk()` to `main@origin`
     [EOF]
     "#);
-    }
     let clone_dir = test_env.work_dir("clone");
 
     let output = clone_dir.run_jj(["status", "--ignore-working-copy"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     The working copy has no changes.
     Working copy  (@) : sqpuoqvx 2ca1c979 (empty) (no description set)
     Parent commit (@-): qomsplrm ebeb70d8 main | message
     [EOF]
     ");
-    }
 
     // TODO: Correct, but might be better to check out the root commit?
     let output = clone_dir.run_jj(["status"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The working copy is stale (not updated since operation eac759b9ab75).
@@ -617,7 +550,6 @@ fn test_git_clone_ignore_working_copy() {
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -629,14 +561,12 @@ fn test_git_clone_at_operation() {
     set_up_non_empty_git_repo(&git_repo);
 
     let output = root_dir.run_jj(["git", "clone", "--at-op=@-", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: --at-op is not respected
     [EOF]
     [exit status: 2]
     ");
-    }
 }
 
 #[test]
@@ -650,7 +580,6 @@ fn test_git_clone_with_remote_name() {
 
     // Clone with relative source path and a non-default remote name
     let output = root_dir.run_jj(["git", "clone", "source", "clone", "--remote", "upstream"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -661,7 +590,6 @@ fn test_git_clone_with_remote_name() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
 }
 
 #[test]
@@ -672,14 +600,12 @@ fn test_git_clone_with_remote_named_git() {
     git::init(git_repo_path);
 
     let output = root_dir.run_jj(["git", "clone", "--remote=git", "source", "dest"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Git remote named 'git' is reserved for local Git repository
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -690,14 +616,12 @@ fn test_git_clone_with_remote_with_slashes() {
     git::init(git_repo_path);
 
     let output = root_dir.run_jj(["git", "clone", "--remote=slash/origin", "source", "dest"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Git remotes with slashes are incompatible with jj: slash/origin
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -710,7 +634,6 @@ fn test_git_clone_trunk_deleted() {
     let clone_dir = test_env.work_dir("clone");
 
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -721,10 +644,8 @@ fn test_git_clone_trunk_deleted() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
 
     let output = clone_dir.run_jj(["bookmark", "forget", "--include-remotes", "main"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Forgot 1 local bookmarks.
@@ -733,10 +654,8 @@ fn test_git_clone_trunk_deleted() {
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     [EOF]
     ");
-    }
 
     let output = clone_dir.run_jj(["log"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     @  sqpuoqvx test.user@example.com 2001-02-03 08:05:07 2ca1c979
     │  (empty) (no description set)
@@ -749,7 +668,6 @@ fn test_git_clone_trunk_deleted() {
     Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -886,7 +804,6 @@ fn test_git_clone_invalid_immutable_heads() {
     // The error shouldn't be counted as an immutable working-copy commit. It
     // should be reported.
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -897,7 +814,6 @@ fn test_git_clone_invalid_immutable_heads() {
     [EOF]
     [exit status: 1]
     "#);
-    }
 }
 
 #[test]
@@ -912,7 +828,6 @@ fn test_git_clone_malformed() {
 
     // TODO: Perhaps, this should be a user error, not an internal error.
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -923,11 +838,9 @@ fn test_git_clone_malformed() {
     [EOF]
     [exit status: 255]
     "#);
-    }
 
     // The cloned workspace isn't usable.
     let output = clone_dir.run_jj(["status"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The working copy is stale (not updated since operation 57e024eb3edf).
@@ -936,12 +849,10 @@ fn test_git_clone_malformed() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // The error can be somehow recovered.
     // TODO: add an update-stale flag to reset the working-copy?
     let output = clone_dir.run_jj(["workspace", "update-stale"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Internal error: Failed to check out commit 0a09cb41583450703459a2310d63da61456364ce
@@ -949,20 +860,15 @@ fn test_git_clone_malformed() {
     [EOF]
     [exit status: 255]
     ");
-    }
     let output = clone_dir.run_jj(["new", "root()", "--ignore-working-copy"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @"");
-    }
     let output = clone_dir.run_jj(["status"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     The working copy has no changes.
     Working copy  (@) : zsuskuln f652c321 (empty) (no description set)
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -986,7 +892,6 @@ fn test_git_clone_with_global_git_remote_config() {
     set_up_non_empty_git_repo(&git_repo);
 
     let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/clone"
@@ -997,7 +902,6 @@ fn test_git_clone_with_global_git_remote_config() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     "#);
-    }
 }
 
 #[test]

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -90,47 +90,25 @@ fn test_git_clone() {
     // Failed clone should clean up the destination directory
     root_dir.create_dir("bad");
     let output = root_dir.run_jj(["git", "clone", "bad", "failed"]);
-    // git2's internal error is slightly different
-    if true {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: Could not find repository at '$TEST_ENV/bad'
-        [EOF]
-        [exit status: 1]
-        "#);
-    } else {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
-        [EOF]
-        [exit status: 1]
-        "#);
-    }
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Fetching into new repo in "$TEST_ENV/failed"
+    Error: Could not find repository at '$TEST_ENV/bad'
+    [EOF]
+    [exit status: 1]
+    "#);
     assert!(!test_env.env_root().join("failed").exists());
 
     // Failed clone shouldn't remove the existing destination directory
     let failed_dir = root_dir.create_dir("failed");
     let output = root_dir.run_jj(["git", "clone", "bad", "failed"]);
-    // git2's internal error is slightly different
-    if true {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: Could not find repository at '$TEST_ENV/bad'
-        [EOF]
-        [exit status: 1]
-        "#);
-    } else {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
-        [EOF]
-        [exit status: 1]
-        "#);
-    }
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Fetching into new repo in "$TEST_ENV/failed"
+    Error: Could not find repository at '$TEST_ENV/bad'
+    [EOF]
+    [exit status: 1]
+    "#);
     assert!(failed_dir.root().exists());
     assert!(!failed_dir.root().join(".jj").exists());
 
@@ -340,47 +318,25 @@ fn test_git_clone_colocate() {
     // Failed clone should clean up the destination directory
     root_dir.create_dir("bad");
     let output = root_dir.run_jj(["git", "clone", "--colocate", "bad", "failed"]);
-    // git2's internal error is slightly different
-    if true {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: Could not find repository at '$TEST_ENV/bad'
-        [EOF]
-        [exit status: 1]
-        "#);
-    } else {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
-        [EOF]
-        [exit status: 1]
-        "#);
-    }
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Fetching into new repo in "$TEST_ENV/failed"
+    Error: Could not find repository at '$TEST_ENV/bad'
+    [EOF]
+    [exit status: 1]
+    "#);
     assert!(!test_env.env_root().join("failed").exists());
 
     // Failed clone shouldn't remove the existing destination directory
     let failed_dir = root_dir.create_dir("failed");
     let output = root_dir.run_jj(["git", "clone", "--colocate", "bad", "failed"]);
-    // git2's internal error is slightly different
-    if true {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: Could not find repository at '$TEST_ENV/bad'
-        [EOF]
-        [exit status: 1]
-        "#);
-    } else {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Fetching into new repo in "$TEST_ENV/failed"
-        Error: could not find repository at '$TEST_ENV/bad'; class=Repository (6)
-        [EOF]
-        [exit status: 1]
-        "#);
-    }
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Fetching into new repo in "$TEST_ENV/failed"
+    Error: Could not find repository at '$TEST_ENV/bad'
+    [EOF]
+    [exit status: 1]
+    "#);
     assert!(failed_dir.root().exists());
     assert!(!failed_dir.root().join(".git").exists());
     assert!(!failed_dir.root().join(".jj").exists());

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -41,7 +41,7 @@ fn set_up_git_repo_with_file(git_repo: &gix::Repository, filename: &str) {
 
 #[test]
 fn test_git_clone() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo_path = test_env.env_root().join("source");
@@ -199,7 +199,7 @@ fn test_git_clone() {
 
 #[test]
 fn test_git_clone_bad_source() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
 
     let output = root_dir.run_jj(["git", "clone", "", "dest"]);
@@ -227,7 +227,7 @@ fn test_git_clone_bad_source() {
 
 #[test]
 fn test_git_clone_colocate() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo_path = test_env.env_root().join("source");
@@ -457,7 +457,7 @@ fn test_git_clone_colocate() {
 
 #[test]
 fn test_git_clone_remote_default_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path.clone());
@@ -578,7 +578,7 @@ fn test_git_clone_remote_default_bookmark() {
 #[cfg(unix)]
 #[test]
 fn test_git_clone_remote_default_bookmark_with_escape() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -621,7 +621,7 @@ fn test_git_clone_remote_default_bookmark_with_escape() {
 
 #[test]
 fn test_git_clone_ignore_working_copy() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -666,7 +666,7 @@ fn test_git_clone_ignore_working_copy() {
 
 #[test]
 fn test_git_clone_at_operation() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -685,7 +685,7 @@ fn test_git_clone_at_operation() {
 
 #[test]
 fn test_git_clone_with_remote_name() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo_path = test_env.env_root().join("source");
@@ -710,7 +710,7 @@ fn test_git_clone_with_remote_name() {
 
 #[test]
 fn test_git_clone_with_remote_named_git() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     git::init(git_repo_path);
@@ -728,7 +728,7 @@ fn test_git_clone_with_remote_named_git() {
 
 #[test]
 fn test_git_clone_with_remote_with_slashes() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     git::init(git_repo_path);
@@ -746,7 +746,7 @@ fn test_git_clone_with_remote_with_slashes() {
 
 #[test]
 fn test_git_clone_trunk_deleted() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -917,7 +917,7 @@ fn test_git_clone_with_depth_subprocess() {
 
 #[test]
 fn test_git_clone_invalid_immutable_heads() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -946,7 +946,7 @@ fn test_git_clone_invalid_immutable_heads() {
 
 #[test]
 fn test_git_clone_malformed() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -1011,7 +1011,7 @@ fn test_git_clone_malformed() {
 
 #[test]
 fn test_git_clone_with_global_git_remote_config() {
-    let mut test_env = TestEnvironment::default().with_git_subprocess(true);
+    let mut test_env = TestEnvironment::default();
     test_env.work_dir("").write_file(
         "git-config",
         indoc! {r#"

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -40,7 +40,6 @@ fn set_up_git_repo_with_file(git_repo: &gix::Repository, filename: &str) {
     git::set_symbolic_reference(git_repo, "HEAD", "refs/heads/main");
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -199,7 +198,6 @@ fn test_git_clone(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_bad_source(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -228,7 +226,6 @@ fn test_git_clone_bad_source(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_colocate(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -459,7 +456,6 @@ fn test_git_clone_colocate(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_remote_default_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -581,7 +577,6 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
 // A branch with a strange name should get quoted in the config. Windows doesn't
 // like the strange name, so we don't run the test there.
 #[cfg(unix)]
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -625,7 +620,6 @@ fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_ignore_working_copy(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -671,7 +665,6 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_at_operation(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -691,7 +684,6 @@ fn test_git_clone_at_operation(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_remote_name(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -717,7 +709,6 @@ fn test_git_clone_with_remote_name(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -736,7 +727,6 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -755,7 +745,6 @@ fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_trunk_deleted(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -892,30 +881,6 @@ fn test_git_clone_conditional_config() {
     ");
 }
 
-#[cfg(feature = "git2")]
-#[test]
-fn test_git_clone_with_depth_git2() {
-    let test_env = TestEnvironment::default().with_git_subprocess(false);
-    let root_dir = test_env.work_dir("");
-    test_env.add_config("git.auto-local-bookmark = true");
-    let git_repo_path = test_env.env_root().join("source");
-    let git_repo = git::init(git_repo_path);
-    set_up_non_empty_git_repo(&git_repo);
-
-    // git does support shallow clones on the local transport, so it will work
-    // (we cannot replicate git2's erroneous behaviour wrt git)
-    // local transport does not support shallow clones so we just test that the
-    // depth arg is passed on here
-    let output = root_dir.run_jj(["git", "clone", "--depth", "1", "source", "clone"]);
-    insta::assert_snapshot!(output, @r#"
-    ------- stderr -------
-    Fetching into new repo in "$TEST_ENV/clone"
-    Error: shallow fetch is not supported by the local transport; class=Net (12)
-    [EOF]
-    [exit status: 1]
-    "#);
-}
-
 #[test]
 fn test_git_clone_with_depth_subprocess() {
     let test_env = TestEnvironment::default();
@@ -951,7 +916,6 @@ fn test_git_clone_with_depth_subprocess() {
     ");
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -981,7 +945,6 @@ fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_malformed(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1047,7 +1010,6 @@ fn test_git_clone_malformed(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_clone_with_global_git_remote_config(subprocess: bool) {
     let mut test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1128,44 +1090,4 @@ fn test_git_clone_no_git_executable_with_path() {
 #[must_use]
 fn get_bookmark_output(work_dir: &TestWorkDir) -> CommandOutput {
     work_dir.run_jj(["bookmark", "list", "--all-remotes"])
-}
-
-// TODO: Remove with the `git.subprocess` setting.
-#[test]
-fn test_git_clone_git2_warning() {
-    let test_env = TestEnvironment::default();
-    let root_dir = test_env.work_dir("");
-    test_env.add_config("git.subprocess = false");
-    test_env.add_config("git.auto-local-bookmark = true");
-    let git_repo_path = test_env.env_root().join("source");
-    let git_repo = git::init(git_repo_path);
-
-    set_up_non_empty_git_repo(&git_repo);
-
-    let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
-    if cfg!(feature = "git2") {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Warning: `git.subprocess = false` will be removed in 0.30; please report any issues you have with the default.
-        Fetching into new repo in "$TEST_ENV/clone"
-        bookmark: main@origin [new] tracked
-        Setting the revset alias `trunk()` to `main@origin`
-        Working copy  (@) now at: sqpuoqvx 2ca1c979 (empty) (no description set)
-        Parent commit (@-)      : qomsplrm ebeb70d8 main | message
-        Added 1 files, modified 0 files, removed 0 files
-        [EOF]
-        "#);
-    } else {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
-        Fetching into new repo in "$TEST_ENV/clone"
-        bookmark: main@origin [new] tracked
-        Setting the revset alias `trunk()` to `main@origin`
-        Working copy  (@) now at: sqpuoqvx 2ca1c979 (empty) (no description set)
-        Parent commit (@-)      : qomsplrm ebeb70d8 main | message
-        Added 1 files, modified 0 files, removed 0 files
-        [EOF]
-        "#);
-    }
 }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -16,7 +16,6 @@ use std::path;
 
 use indoc::formatdoc;
 use indoc::indoc;
-use test_case::test_case;
 use testutils::git;
 
 use crate::common::to_toml_value;
@@ -40,9 +39,9 @@ fn set_up_git_repo_with_file(git_repo: &gix::Repository, filename: &str) {
     git::set_symbolic_reference(git_repo, "HEAD", "refs/heads/main");
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo_path = test_env.env_root().join("source");
@@ -92,7 +91,7 @@ fn test_git_clone(subprocess: bool) {
     root_dir.create_dir("bad");
     let output = root_dir.run_jj(["git", "clone", "bad", "failed"]);
     // git2's internal error is slightly different
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r#"
         ------- stderr -------
         Fetching into new repo in "$TEST_ENV/failed"
@@ -115,7 +114,7 @@ fn test_git_clone(subprocess: bool) {
     let failed_dir = root_dir.create_dir("failed");
     let output = root_dir.run_jj(["git", "clone", "bad", "failed"]);
     // git2's internal error is slightly different
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r#"
         ------- stderr -------
         Fetching into new repo in "$TEST_ENV/failed"
@@ -198,9 +197,9 @@ fn test_git_clone(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_bad_source(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_bad_source() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
 
     let output = root_dir.run_jj(["git", "clone", "", "dest"]);
@@ -226,9 +225,9 @@ fn test_git_clone_bad_source(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_colocate(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_colocate() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo_path = test_env.env_root().join("source");
@@ -342,7 +341,7 @@ fn test_git_clone_colocate(subprocess: bool) {
     root_dir.create_dir("bad");
     let output = root_dir.run_jj(["git", "clone", "--colocate", "bad", "failed"]);
     // git2's internal error is slightly different
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r#"
         ------- stderr -------
         Fetching into new repo in "$TEST_ENV/failed"
@@ -365,7 +364,7 @@ fn test_git_clone_colocate(subprocess: bool) {
     let failed_dir = root_dir.create_dir("failed");
     let output = root_dir.run_jj(["git", "clone", "--colocate", "bad", "failed"]);
     // git2's internal error is slightly different
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r#"
         ------- stderr -------
         Fetching into new repo in "$TEST_ENV/failed"
@@ -456,9 +455,9 @@ fn test_git_clone_colocate(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_remote_default_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_remote_default_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path.clone());
@@ -577,9 +576,9 @@ fn test_git_clone_remote_default_bookmark(subprocess: bool) {
 // A branch with a strange name should get quoted in the config. Windows doesn't
 // like the strange name, so we don't run the test there.
 #[cfg(unix)]
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_remote_default_bookmark_with_escape() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -620,9 +619,9 @@ fn test_git_clone_remote_default_bookmark_with_escape(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_ignore_working_copy(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_ignore_working_copy() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -665,9 +664,9 @@ fn test_git_clone_ignore_working_copy(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_at_operation(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_at_operation() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -684,9 +683,9 @@ fn test_git_clone_at_operation(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_with_remote_name(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_with_remote_name() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     test_env.add_config("git.auto-local-bookmark = true");
     let git_repo_path = test_env.env_root().join("source");
@@ -709,9 +708,9 @@ fn test_git_clone_with_remote_name(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_with_remote_named_git(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_with_remote_named_git() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     git::init(git_repo_path);
@@ -727,9 +726,9 @@ fn test_git_clone_with_remote_named_git(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_with_remote_with_slashes() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     git::init(git_repo_path);
@@ -745,9 +744,9 @@ fn test_git_clone_with_remote_with_slashes(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_trunk_deleted(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_trunk_deleted() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -916,9 +915,9 @@ fn test_git_clone_with_depth_subprocess() {
     ");
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_invalid_immutable_heads() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -945,9 +944,9 @@ fn test_git_clone_invalid_immutable_heads(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_malformed(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_malformed() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     let root_dir = test_env.work_dir("");
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);
@@ -1010,9 +1009,9 @@ fn test_git_clone_malformed(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_clone_with_global_git_remote_config(subprocess: bool) {
-    let mut test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_clone_with_global_git_remote_config() {
+    let mut test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.work_dir("").write_file(
         "git-config",
         indoc! {r#"

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -104,12 +104,10 @@ fn test_git_fetch_with_default_config() {
     add_git_remote(&test_env, &work_dir, "origin");
 
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin@origin: qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -121,13 +119,11 @@ fn test_git_fetch_default_remote() {
     add_git_remote(&test_env, &work_dir, "origin");
 
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin: qmyrypzk ab8b299e message
       @origin: qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -139,21 +135,17 @@ fn test_git_fetch_single_remote() {
     add_git_remote(&test_env, &work_dir, "rem1");
 
     let output = work_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Hint: Fetching from the only existing remote: rem1
     bookmark: rem1@rem1 [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: ppspxspk 4acd0343 message
       @rem1: ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -165,13 +157,11 @@ fn test_git_fetch_single_remote_all_remotes_flag() {
     add_git_remote(&test_env, &work_dir, "rem1");
 
     work_dir.run_jj(["git", "fetch", "--all-remotes"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: ppspxspk 4acd0343 message
       @rem1: ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -185,13 +175,11 @@ fn test_git_fetch_single_remote_from_arg() {
     work_dir
         .run_jj(["git", "fetch", "--remote", "rem1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: ppspxspk 4acd0343 message
       @rem1: ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -204,13 +192,11 @@ fn test_git_fetch_single_remote_from_config() {
     test_env.add_config(r#"git.fetch = "rem1""#);
 
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: ppspxspk 4acd0343 message
       @rem1: ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -225,7 +211,6 @@ fn test_git_fetch_multiple_remotes() {
     work_dir
         .run_jj(["git", "fetch", "--remote", "rem1", "--remote", "rem2"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: ppspxspk 4acd0343 message
       @rem1: ppspxspk 4acd0343 message
@@ -233,7 +218,6 @@ fn test_git_fetch_multiple_remotes() {
       @rem2: pzqqpnpo 44c57802 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -245,14 +229,12 @@ fn test_git_fetch_with_glob() {
     add_git_remote(&test_env, &work_dir, "rem2");
 
     let output = work_dir.run_jj(["git", "fetch", "--remote", "glob:*"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: rem1@rem1 [new] untracked
     bookmark: rem2@rem2 [new] untracked
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -267,7 +249,6 @@ fn test_git_fetch_with_glob_and_exact_match() {
     add_git_remote(&test_env, &work_dir, "origin");
 
     let output = work_dir.run_jj(["git", "fetch", "--remote=glob:rem*", "--remote=origin"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: origin@origin [new] untracked
@@ -275,7 +256,6 @@ fn test_git_fetch_with_glob_and_exact_match() {
     bookmark: rem2@rem2     [new] untracked
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -289,14 +269,12 @@ fn test_git_fetch_with_glob_from_config() {
     add_git_remote(&test_env, &work_dir, "upstream");
 
     let output = work_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: rem1@rem1 [new] untracked
     bookmark: rem2@rem2 [new] untracked
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -307,7 +285,6 @@ fn test_git_fetch_with_glob_with_no_matching_remotes() {
     add_git_remote(&test_env, &work_dir, "upstream");
 
     let output = work_dir.run_jj(["git", "fetch", "--remote=glob:rem*"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No git remotes matching 'rem*'
@@ -315,11 +292,8 @@ fn test_git_fetch_with_glob_with_no_matching_remotes() {
     [EOF]
     [exit status: 1]
     ");
-    }
     // No remote should have been fetched as part of the failing transaction
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
-    }
 }
 
 #[test]
@@ -340,7 +314,6 @@ fn test_git_fetch_all_remotes() {
         .success();
 
     work_dir.run_jj(["git", "fetch", "--all-remotes"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: ppspxspk 4acd0343 message
       @rem1: ppspxspk 4acd0343 message
@@ -348,7 +321,6 @@ fn test_git_fetch_all_remotes() {
       @rem2: pzqqpnpo 44c57802 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -362,7 +334,6 @@ fn test_git_fetch_multiple_remotes_from_config() {
     test_env.add_config(r#"git.fetch = ["rem1", "rem2"]"#);
 
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: ppspxspk 4acd0343 message
       @rem1: ppspxspk 4acd0343 message
@@ -370,7 +341,6 @@ fn test_git_fetch_multiple_remotes_from_config() {
       @rem2: pzqqpnpo 44c57802 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -380,7 +350,6 @@ fn test_git_fetch_no_matching_remote() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["git", "fetch", "--remote", "rem1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No git remotes matching 'rem1'
@@ -388,10 +357,7 @@ fn test_git_fetch_no_matching_remote() {
     [EOF]
     [exit status: 1]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
-    }
 }
 
 #[test]
@@ -402,20 +368,16 @@ fn test_git_fetch_nonexistent_remote() {
     add_git_remote(&test_env, &work_dir, "rem1");
 
     let output = work_dir.run_jj(["git", "fetch", "--remote", "rem1", "--remote", "rem2"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No git remotes matching 'rem2'
     bookmark: rem1@rem1 [new] untracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1@rem1: ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -427,20 +389,16 @@ fn test_git_fetch_nonexistent_remote_from_config() {
     test_env.add_config(r#"git.fetch = ["rem1", "rem2"]"#);
 
     let output = work_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No git remotes matching 'rem2'
     bookmark: rem1@rem1 [new] untracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1@rem1: ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -458,7 +416,6 @@ fn test_git_fetch_from_remote_named_git() {
 
     // Try fetching from the remote named 'git'.
     let output = work_dir.run_jj(["git", "fetch", "--remote=git"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Git remote named 'git' is reserved for local Git repository
@@ -466,14 +423,12 @@ fn test_git_fetch_from_remote_named_git() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Fetch remote refs by using the git CLI.
     git::fetch(work_dir.root(), "git");
 
     // Implicit import shouldn't fail because of the remote ref.
     let output = work_dir.run_jj(["bookmark", "list", "--all-remotes"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Failed to import some Git refs:
@@ -482,12 +437,10 @@ fn test_git_fetch_from_remote_named_git() {
     Use `jj git remote rename` to give a different name.
     [EOF]
     ");
-    }
 
     // Explicit import also works. Warnings are printed twice because this is a
     // colocated repo. That should be fine since "jj git import" wouldn't be
     // used in colocated environment.
-    insta::allow_duplicates! {
     insta::assert_snapshot!(work_dir.run_jj(["git", "import"]), @r"
     ------- stderr -------
     Warning: Failed to import some Git refs:
@@ -501,14 +454,12 @@ fn test_git_fetch_from_remote_named_git() {
     Nothing changed.
     [EOF]
     ");
-    }
 
     // The remote can be renamed, and the ref can be imported.
     work_dir
         .run_jj(["git", "remote", "rename", "git", "bar"])
         .success();
     let output = work_dir.run_jj(["bookmark", "list", "--all-remotes"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     git: vkponlun 400c483d message
       @bar: vkponlun 400c483d message
@@ -518,7 +469,6 @@ fn test_git_fetch_from_remote_named_git() {
     Done importing changes from the underlying Git repo.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -536,7 +486,6 @@ fn test_git_fetch_from_remote_with_slashes() {
 
     // Try fetching from the remote named 'git'.
     let output = work_dir.run_jj(["git", "fetch", "--remote=slash/origin"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Git remotes with slashes are incompatible with jj: slash/origin
@@ -544,7 +493,6 @@ fn test_git_fetch_from_remote_with_slashes() {
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -555,13 +503,11 @@ fn test_git_fetch_prune_before_updating_tips() {
     let work_dir = test_env.work_dir("repo");
     let git_repo = add_git_remote(&test_env, &work_dir, "origin");
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin: qmyrypzk ab8b299e message
       @origin: qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 
     // Remove origin bookmark in git repo and create origin/subname
     let mut origin_reference = git_repo.find_reference("refs/heads/origin").unwrap();
@@ -577,13 +523,11 @@ fn test_git_fetch_prune_before_updating_tips() {
         .unwrap();
 
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin/subname: qmyrypzk ab8b299e message
       @origin: qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -599,18 +543,15 @@ fn test_git_fetch_conflicting_bookmarks() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "rem1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: kkmpptxz fcdbbd73 (empty) (no description set)
     [EOF]
     ");
-    }
 
     work_dir
         .run_jj(["git", "fetch", "--remote", "rem1", "--branch", "glob:*"])
         .success();
     // This should result in a CONFLICTED bookmark
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1 (conflicted):
       + kkmpptxz fcdbbd73 (empty) (no description set)
@@ -618,7 +559,6 @@ fn test_git_fetch_conflicting_bookmarks() {
       @rem1 (behind by 1 commits): ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -632,29 +572,24 @@ fn test_git_fetch_conflicting_bookmarks_colocated() {
         .run_jj(["git", "init", "--git-repo", "."])
         .success();
     add_git_remote(&test_env, &work_dir, "rem1");
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
-    }
 
     // Create a rem1 bookmark locally
     work_dir.run_jj(["new", "root()"]).success();
     work_dir
         .run_jj(["bookmark", "create", "-r@", "rem1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1: zsuskuln f652c321 (empty) (no description set)
       @git: zsuskuln f652c321 (empty) (no description set)
     [EOF]
     ");
-    }
 
     work_dir
         .run_jj(["git", "fetch", "--remote", "rem1", "--branch", "rem1"])
         .success();
     // This should result in a CONFLICTED bookmark
     // See https://github.com/jj-vcs/jj/pull/1146#discussion_r1112372340 for the bug this tests for.
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     rem1 (conflicted):
       + zsuskuln f652c321 (empty) (no description set)
@@ -663,7 +598,6 @@ fn test_git_fetch_conflicting_bookmarks_colocated() {
       @rem1 (behind by 1 commits): ppspxspk 4acd0343 message
     [EOF]
     ");
-    }
 }
 
 // Helper functions to test obtaining multiple bookmarks at once and changed
@@ -706,18 +640,15 @@ fn test_git_fetch_all() {
 
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let output = test_env.run_jj_in(".", ["git", "clone", "source", "target"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     [EOF]
     "#);
-    }
     let target_dir = test_env.work_dir("target");
 
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     @  8cc4df9dd488 "b" b
@@ -729,21 +660,15 @@ fn test_git_fetch_all() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Nothing in our repo before the fetch
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"");
-    }
     let output = target_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin     [new] tracked
@@ -752,8 +677,6 @@ fn test_git_fetch_all() {
     bookmark: trunk1@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @r"
     a1: spvnozwy dd42071f a1
       @origin: spvnozwy dd42071f a1
@@ -765,8 +688,6 @@ fn test_git_fetch_all() {
       @origin: qzywppkx 9929b494 trunk1
     [EOF]
     ");
-        }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -779,12 +700,10 @@ fn test_git_fetch_all() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     ○  7c277a6aa3c3 "b" b
@@ -797,14 +716,12 @@ fn test_git_fetch_all() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     target_dir
         .run_jj(["describe", "b", "-m=new_descr_for_b_to_create_conflict"])
         .success();
 
     // Our repo before and after fetch
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  5b3bc9c99bb3 "new_descr_for_b_to_create_conflict" b*
@@ -817,8 +734,6 @@ fn test_git_fetch_all() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @r"
     a1: spvnozwy dd42071f a1
       @origin: spvnozwy dd42071f a1
@@ -830,9 +745,7 @@ fn test_git_fetch_all() {
       @origin: qzywppkx 9929b494 trunk1
     [EOF]
     ");
-    }
     let output = target_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin     [updated] tracked
@@ -842,8 +755,6 @@ fn test_git_fetch_all() {
     Abandoned 2 commits that are no longer reachable.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @r"
     a1: vrnsrlyk a3f24106 a1
       @origin: vrnsrlyk a3f24106 a1
@@ -860,8 +771,6 @@ fn test_git_fetch_all() {
       @origin: lzqpwqnx e7525a46 trunk2
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  7c277a6aa3c3 "b" b?? b@origin
@@ -877,7 +786,6 @@ fn test_git_fetch_all() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 }
 
 #[test]
@@ -890,18 +798,15 @@ fn test_git_fetch_some_of_many_bookmarks() {
 
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let output = test_env.run_jj_in(".", ["git", "clone", "source", "target"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     [EOF]
     "#);
-    }
     let target_dir = test_env.work_dir("target");
 
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     @  8cc4df9dd488 "b" b
@@ -913,20 +818,16 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Test an error message
     let output = target_dir.run_jj(["git", "fetch", "--branch", "glob:^:a*"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Invalid branch pattern provided. When fetching, branch names and globs may not contain the characters `:`, `^`, `?`, `[`, `]`
     [EOF]
     [exit status: 1]
     ");
-    }
     let output = target_dir.run_jj(["git", "fetch", "--branch", "a*"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Branch names may not include `*`.
@@ -934,26 +835,20 @@ fn test_git_fetch_some_of_many_bookmarks() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Nothing in our repo before the fetch
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     // Fetch one bookmark...
     let output = target_dir.run_jj(["git", "fetch", "--branch", "b"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: b@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -962,26 +857,20 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     // ...check what the intermediate state looks like...
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @r"
     b: lnxrmsmo 8cc4df9d b
       @origin: lnxrmsmo 8cc4df9d b
     [EOF]
     ");
-    }
     // ...then fetch two others with a glob.
     let output = target_dir.run_jj(["git", "fetch", "--branch", "glob:a*"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin [new] tracked
     bookmark: a2@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  e2a95b19b745 "a2" a2
@@ -994,17 +883,13 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     // Fetching the same bookmark again
     let output = target_dir.run_jj(["git", "fetch", "--branch", "a1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  e2a95b19b745 "a2" a2
@@ -1017,12 +902,10 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // ==== Change both repos ====
     // First, change the target repo:
     let source_log = create_trunk2_and_rebase_bookmarks(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     ○  96c8ad25ad36 "b" b
@@ -1035,14 +918,12 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     // Change a bookmark in the source repo as well, so that it becomes conflicted.
     target_dir
         .run_jj(["describe", "b", "-m=new_descr_for_b_to_create_conflict"])
         .success();
 
     // Our repo before and after fetch of two bookmarks
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  e9445259b932 "new_descr_for_b_to_create_conflict" b*
@@ -1055,9 +936,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     let output = target_dir.run_jj(["git", "fetch", "--branch", "b", "--branch", "a1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin [updated] tracked
@@ -1065,8 +944,6 @@ fn test_git_fetch_some_of_many_bookmarks() {
     Abandoned 1 commits that are no longer reachable.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  96c8ad25ad36 "b" b?? b@origin
@@ -1082,10 +959,8 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // We left a2 where it was before, let's see how `jj bookmark list` sees this.
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @r"
     a1: qptloxlm 527d2e46 a1
       @origin: qptloxlm 527d2e46 a1
@@ -1098,19 +973,15 @@ fn test_git_fetch_some_of_many_bookmarks() {
       @origin (behind by 1 commits): rruvkzpm 96c8ad25 b
     [EOF]
     ");
-    }
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
     // anything.
     let output = target_dir.run_jj(["git", "fetch", "--branch", "b", "--branch", "glob:a*"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a2@origin [updated] tracked
     Abandoned 1 commits that are no longer reachable.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  9ccd9f75fc0c "a2" a2
@@ -1126,8 +997,6 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @r"
     a1: qptloxlm 527d2e46 a1
       @origin: qptloxlm 527d2e46 a1
@@ -1140,7 +1009,6 @@ fn test_git_fetch_some_of_many_bookmarks() {
       @origin (behind by 1 commits): rruvkzpm 96c8ad25 b
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1156,23 +1024,18 @@ fn test_git_fetch_bookmarks_some_missing() {
 
     // single missing bookmark, implicit remotes (@origin)
     let output = work_dir.run_jj(["git", "fetch", "--branch", "noexist"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No branch matching `noexist` found on any specified/configured remote
     Nothing changed.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
-    }
 
     // multiple missing bookmarks, implicit remotes (@origin)
     let output = work_dir.run_jj([
         "git", "fetch", "--branch", "noexist1", "--branch", "noexist2",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No branch matching `noexist1` found on any specified/configured remote
@@ -1180,27 +1043,20 @@ fn test_git_fetch_bookmarks_some_missing() {
     Nothing changed.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
-    }
 
     // single existing bookmark, implicit remotes (@origin)
     let output = work_dir.run_jj(["git", "fetch", "--branch", "origin"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: origin@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin: qmyrypzk ab8b299e message
       @origin: qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 
     // multiple existing bookmark, explicit remotes, each bookmark is only in one
     // remote.
@@ -1208,7 +1064,6 @@ fn test_git_fetch_bookmarks_some_missing() {
         "git", "fetch", "--branch", "rem1", "--branch", "rem2", "--branch", "rem3", "--remote",
         "rem1", "--remote", "rem2", "--remote", "rem3",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: rem1@rem1 [new] tracked
@@ -1216,8 +1071,6 @@ fn test_git_fetch_bookmarks_some_missing() {
     bookmark: rem3@rem3 [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin: qmyrypzk ab8b299e message
       @origin: qmyrypzk ab8b299e message
@@ -1228,22 +1081,18 @@ fn test_git_fetch_bookmarks_some_missing() {
     rem3: wrzwlmys 45a3faef message
       @rem3: wrzwlmys 45a3faef message
     [EOF]
-    ")
-    }
+    ");
 
     // multiple bookmarks, one exists, one doesn't
     let output = work_dir.run_jj([
         "git", "fetch", "--branch", "rem1", "--branch", "notexist", "--remote", "rem1",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No branch matching `notexist` found on any specified/configured remote
     Nothing changed.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin: qmyrypzk ab8b299e message
       @origin: qmyrypzk ab8b299e message
@@ -1255,7 +1104,6 @@ fn test_git_fetch_bookmarks_some_missing() {
       @rem3: wrzwlmys 45a3faef message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1296,18 +1144,15 @@ fn test_git_fetch_undo() {
 
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let output = test_env.run_jj_in(".", ["git", "clone", "source", "target"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     [EOF]
     "#);
-    }
     let target_dir = test_env.work_dir("target");
 
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     @  8cc4df9dd488 "b" b
@@ -1319,19 +1164,15 @@ fn test_git_fetch_undo() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Fetch 2 bookmarks
     let output = target_dir.run_jj(["git", "fetch", "--branch", "b", "--branch", "a1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin [new] tracked
     bookmark: b@origin  [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1342,33 +1183,25 @@ fn test_git_fetch_undo() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     let output = target_dir.run_jj(["undo"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Undid operation: 4bd67fb242bc (2001-02-03 08:05:18) fetch from git remote(s) origin
     [EOF]
     ");
-    }
     // The undo works as expected
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
     // Now try to fetch just one bookmark
     let output = target_dir.run_jj(["git", "fetch", "--branch", "b"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: b@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1377,7 +1210,6 @@ fn test_git_fetch_undo() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 }
 
 // Compare to `test_git_import_undo` in test_git_import_export
@@ -1391,18 +1223,15 @@ fn test_fetch_undo_what() {
 
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let output = test_env.run_jj_in(".", ["git", "clone", "source", "target"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     [EOF]
     "#);
-    }
     let work_dir = test_env.work_dir("target");
 
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     @  8cc4df9dd488 "b" b
@@ -1414,25 +1243,19 @@ fn test_fetch_undo_what() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Initial state we will try to return to after `op restore`. There are no
     // bookmarks.
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
-    }
     let base_operation_id = work_dir.current_operation_id();
 
     // Fetch a bookmark
     let output = work_dir.run_jj(["git", "fetch", "--branch", "b"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: b@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1441,46 +1264,37 @@ fn test_fetch_undo_what() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     b: lnxrmsmo 8cc4df9d b
       @origin: lnxrmsmo 8cc4df9d b
     [EOF]
     ");
-    }
 
     // We can undo the change in the repo without moving the remote-tracking
     // bookmark
     let output = work_dir.run_jj(["op", "restore", "--what", "repo", &base_operation_id]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     b (deleted)
       @origin: lnxrmsmo hidden 8cc4df9d b
     [EOF]
     ");
-    }
 
     // Now, let's demo restoring just the remote-tracking bookmark. First, let's
     // change our local repo state...
     work_dir
         .run_jj(["bookmark", "c", "-r@", "newbookmark"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     b (deleted)
       @origin: lnxrmsmo hidden 8cc4df9d b
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)
     [EOF]
     ");
-    }
     // Restoring just the remote-tracking state will not affect `newbookmark`, but
     // will eliminate `b@origin`.
     let output = work_dir.run_jj([
@@ -1490,19 +1304,15 @@ fn test_fetch_undo_what() {
         "remote-tracking",
         &base_operation_id,
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Restored to operation: eac759b9ab75 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     newbookmark: qpvuntsm 230dd059 (empty) (no description set)
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1516,15 +1326,12 @@ fn test_git_fetch_remove_fetch() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "origin"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin: qpvuntsm 230dd059 (empty) (no description set)
     [EOF]
     ");
-    }
 
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
@@ -1532,19 +1339,16 @@ fn test_git_fetch_remove_fetch() {
       @origin (behind by 1 commits): qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 
     work_dir
         .run_jj(["git", "remote", "remove", "origin"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
       + qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 
     work_dir
         .run_jj(["git", "remote", "add", "origin", "../origin"])
@@ -1552,14 +1356,11 @@ fn test_git_fetch_remove_fetch() {
 
     // Check that origin@origin is properly recreated
     let output = work_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: origin@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
@@ -1567,7 +1368,6 @@ fn test_git_fetch_remove_fetch() {
       @origin (behind by 1 commits): qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1581,15 +1381,12 @@ fn test_git_fetch_rename_fetch() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "origin"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin: qpvuntsm 230dd059 (empty) (no description set)
     [EOF]
     ");
-    }
 
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
@@ -1597,12 +1394,10 @@ fn test_git_fetch_rename_fetch() {
       @origin (behind by 1 commits): qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 
     work_dir
         .run_jj(["git", "remote", "rename", "origin", "upstream"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     origin (conflicted):
       + qpvuntsm 230dd059 (empty) (no description set)
@@ -1610,17 +1405,14 @@ fn test_git_fetch_rename_fetch() {
       @upstream (behind by 1 commits): qmyrypzk ab8b299e message
     [EOF]
     ");
-    }
 
     // Check that jj indicates that nothing has changed
     let output = work_dir.run_jj(["git", "fetch", "--remote", "upstream"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1632,18 +1424,15 @@ fn test_git_fetch_removed_bookmark() {
 
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let output = test_env.run_jj_in(".", ["git", "clone", "source", "target"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     [EOF]
     "#);
-    }
     let target_dir = test_env.work_dir("target");
 
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     @  8cc4df9dd488 "b" b
@@ -1655,11 +1444,9 @@ fn test_git_fetch_removed_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Fetch all bookmarks
     let output = target_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin     [new] tracked
@@ -1668,8 +1455,6 @@ fn test_git_fetch_removed_bookmark() {
     bookmark: trunk1@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1682,7 +1467,6 @@ fn test_git_fetch_removed_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Remove a2 bookmark in origin
     source_dir
@@ -1691,14 +1475,11 @@ fn test_git_fetch_removed_bookmark() {
 
     // Fetch bookmark a1 from origin and check that a2 is still there
     let output = target_dir.run_jj(["git", "fetch", "--branch", "a1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1711,19 +1492,15 @@ fn test_git_fetch_removed_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Fetch bookmarks a2 from origin, and check that it has been removed locally
     let output = target_dir.run_jj(["git", "fetch", "--branch", "a2"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a2@origin [deleted] untracked
     Abandoned 1 commits that are no longer reachable.
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1734,7 +1511,6 @@ fn test_git_fetch_removed_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 }
 
 #[test]
@@ -1746,18 +1522,15 @@ fn test_git_fetch_removed_parent_bookmark() {
 
     // Clone an empty repo. The target repo is a normal `jj` repo, *not* colocated
     let output = test_env.run_jj_in(".", ["git", "clone", "source", "target"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/target"
     Nothing changed.
     [EOF]
     "#);
-    }
     let target_dir = test_env.work_dir("target");
 
     let source_log = create_colocated_repo_and_bookmarks_from_trunk1(&source_dir);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(source_log, @r#"
        ===== Source git repo contents =====
     @  8cc4df9dd488 "b" b
@@ -1769,11 +1542,9 @@ fn test_git_fetch_removed_parent_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Fetch all bookmarks
     let output = target_dir.run_jj(["git", "fetch"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin     [new] tracked
@@ -1782,8 +1553,6 @@ fn test_git_fetch_removed_parent_bookmark() {
     bookmark: trunk1@origin [new] tracked
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1796,7 +1565,6 @@ fn test_git_fetch_removed_parent_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 
     // Remove all bookmarks in origin.
     source_dir
@@ -1809,7 +1577,6 @@ fn test_git_fetch_removed_parent_bookmark() {
     let output = target_dir.run_jj([
         "git", "fetch", "--branch", "master", "--branch", "trunk1", "--branch", "a1",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin     [deleted] untracked
@@ -1818,8 +1585,6 @@ fn test_git_fetch_removed_parent_bookmark() {
     Warning: No branch matching `master` found on any specified/configured remote
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  8cc4df9dd488 "b" b
@@ -1830,7 +1595,6 @@ fn test_git_fetch_removed_parent_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
 }
 
 #[test]
@@ -1861,13 +1625,11 @@ fn test_git_fetch_remote_only_bookmark() {
     work_dir
         .run_jj(["git", "fetch", "--remote=origin"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     feature1: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
     [EOF]
     ");
-    }
 
     git::write_commit(
         &git_repo,
@@ -1882,7 +1644,6 @@ fn test_git_fetch_remote_only_bookmark() {
     work_dir
         .run_jj(["git", "fetch", "--remote=origin"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  230dd059e1b0 ""
     │ ◆  ebeb70d8c5f9 "message" feature1 feature2@origin
@@ -1890,15 +1651,12 @@ fn test_git_fetch_remote_only_bookmark() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     feature1: qomsplrm ebeb70d8 message
       @origin: qomsplrm ebeb70d8 message
     feature2@origin: qomsplrm ebeb70d8 message
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1923,7 +1681,6 @@ fn test_git_fetch_preserve_commits_across_repos() {
     work_dir
         .run_jj(["git", "fetch", "--remote=fork", "--remote=upstream"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  230dd059e1b0 ""
     │ ○  bcd7cd779791 "message" upstream
@@ -1933,8 +1690,6 @@ fn test_git_fetch_preserve_commits_across_repos() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     feature: srwrtuky 16ec9ef2 message
       @fork: srwrtuky 16ec9ef2 message
@@ -1943,7 +1698,6 @@ fn test_git_fetch_preserve_commits_across_repos() {
       @upstream: zkvzklqn bcd7cd77 message
     [EOF]
     ");
-    }
 
     // merge fork/feature into the upstream/upstream
     git::add_remote(upstream_repo.git_dir(), "fork", fork_path.to_str().unwrap());
@@ -1984,7 +1738,6 @@ fn test_git_fetch_preserve_commits_across_repos() {
     work_dir
         .run_jj(["git", "fetch", "--remote=fork", "--remote=upstream"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  230dd059e1b0 ""
     │ ○    f3e9250bd003 "merge" upstream*
@@ -1996,13 +1749,10 @@ fn test_git_fetch_preserve_commits_across_repos() {
     ◆  000000000000 ""
     [EOF]
     "#);
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     upstream: trrkvuqr f3e9250b merge
       @fork (behind by 2 commits): zkvzklqn bcd7cd77 message
       @upstream: trrkvuqr f3e9250b merge
     [EOF]
     ");
-    }
 }

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -98,7 +98,7 @@ fn clone_git_remote_into(
 
 #[test]
 fn test_git_fetch_with_default_config() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "origin");
@@ -114,7 +114,7 @@ fn test_git_fetch_with_default_config() {
 
 #[test]
 fn test_git_fetch_default_remote() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -132,7 +132,7 @@ fn test_git_fetch_default_remote() {
 
 #[test]
 fn test_git_fetch_single_remote() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -158,7 +158,7 @@ fn test_git_fetch_single_remote() {
 
 #[test]
 fn test_git_fetch_single_remote_all_remotes_flag() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -176,7 +176,7 @@ fn test_git_fetch_single_remote_all_remotes_flag() {
 
 #[test]
 fn test_git_fetch_single_remote_from_arg() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -196,7 +196,7 @@ fn test_git_fetch_single_remote_from_arg() {
 
 #[test]
 fn test_git_fetch_single_remote_from_config() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -215,7 +215,7 @@ fn test_git_fetch_single_remote_from_config() {
 
 #[test]
 fn test_git_fetch_multiple_remotes() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -238,7 +238,7 @@ fn test_git_fetch_multiple_remotes() {
 
 #[test]
 fn test_git_fetch_with_glob() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -257,7 +257,7 @@ fn test_git_fetch_with_glob() {
 
 #[test]
 fn test_git_fetch_with_glob_and_exact_match() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -280,7 +280,7 @@ fn test_git_fetch_with_glob_and_exact_match() {
 
 #[test]
 fn test_git_fetch_with_glob_from_config() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config(r#"git.fetch = "glob:rem*""#);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -301,7 +301,7 @@ fn test_git_fetch_with_glob_from_config() {
 
 #[test]
 fn test_git_fetch_with_glob_with_no_matching_remotes() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "upstream");
@@ -324,7 +324,7 @@ fn test_git_fetch_with_glob_with_no_matching_remotes() {
 
 #[test]
 fn test_git_fetch_all_remotes() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -353,7 +353,7 @@ fn test_git_fetch_all_remotes() {
 
 #[test]
 fn test_git_fetch_multiple_remotes_from_config() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -375,7 +375,7 @@ fn test_git_fetch_multiple_remotes_from_config() {
 
 #[test]
 fn test_git_fetch_no_matching_remote() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
@@ -396,7 +396,7 @@ fn test_git_fetch_no_matching_remote() {
 
 #[test]
 fn test_git_fetch_nonexistent_remote() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -420,7 +420,7 @@ fn test_git_fetch_nonexistent_remote() {
 
 #[test]
 fn test_git_fetch_nonexistent_remote_from_config() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -445,7 +445,7 @@ fn test_git_fetch_nonexistent_remote_from_config() {
 
 #[test]
 fn test_git_fetch_from_remote_named_git() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     let work_dir = test_env.work_dir("repo");
     init_git_remote(&test_env, "git");
@@ -523,7 +523,7 @@ fn test_git_fetch_from_remote_named_git() {
 
 #[test]
 fn test_git_fetch_from_remote_with_slashes() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     let work_dir = test_env.work_dir("repo");
     init_git_remote(&test_env, "source");
@@ -549,7 +549,7 @@ fn test_git_fetch_from_remote_with_slashes() {
 
 #[test]
 fn test_git_fetch_prune_before_updating_tips() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -588,7 +588,7 @@ fn test_git_fetch_prune_before_updating_tips() {
 
 #[test]
 fn test_git_fetch_conflicting_bookmarks() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -623,7 +623,7 @@ fn test_git_fetch_conflicting_bookmarks() {
 
 #[test]
 fn test_git_fetch_conflicting_bookmarks_colocated() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     let work_dir = test_env.work_dir("repo");
     git::init(work_dir.root());
@@ -698,7 +698,7 @@ fn create_trunk2_and_rebase_bookmarks(work_dir: &TestWorkDir) -> String {
 
 #[test]
 fn test_git_fetch_all() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let source_dir = test_env.work_dir("source");
@@ -882,7 +882,7 @@ fn test_git_fetch_all() {
 
 #[test]
 fn test_git_fetch_some_of_many_bookmarks() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let source_dir = test_env.work_dir("source");
@@ -1145,7 +1145,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
 
 #[test]
 fn test_git_fetch_bookmarks_some_missing() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -1289,7 +1289,7 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
 // of the same bookmarks for various kinds of undo.
 #[test]
 fn test_git_fetch_undo() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1384,7 +1384,7 @@ fn test_git_fetch_undo() {
 // TODO: Explain why these behaviors are useful
 #[test]
 fn test_fetch_undo_what() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1507,7 +1507,7 @@ fn test_fetch_undo_what() {
 
 #[test]
 fn test_git_fetch_remove_fetch() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -1572,7 +1572,7 @@ fn test_git_fetch_remove_fetch() {
 
 #[test]
 fn test_git_fetch_rename_fetch() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -1625,7 +1625,7 @@ fn test_git_fetch_rename_fetch() {
 
 #[test]
 fn test_git_fetch_removed_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1739,7 +1739,7 @@ fn test_git_fetch_removed_bookmark() {
 
 #[test]
 fn test_git_fetch_removed_parent_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1835,7 +1835,7 @@ fn test_git_fetch_removed_parent_bookmark() {
 
 #[test]
 fn test_git_fetch_remote_only_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
@@ -1903,7 +1903,7 @@ fn test_git_fetch_remote_only_bookmark() {
 
 #[test]
 fn test_git_fetch_preserve_commits_across_repos() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -97,7 +97,6 @@ fn clone_git_remote_into(
     fork_repo
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_default_config(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -114,7 +113,6 @@ fn test_git_fetch_with_default_config(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_default_remote(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -133,7 +131,6 @@ fn test_git_fetch_default_remote(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -160,7 +157,6 @@ fn test_git_fetch_single_remote(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -179,7 +175,6 @@ fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -200,7 +195,6 @@ fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -220,7 +214,6 @@ fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_multiple_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -244,7 +237,6 @@ fn test_git_fetch_multiple_remotes(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -264,7 +256,6 @@ fn test_git_fetch_with_glob(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob_and_exact_match(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -288,7 +279,6 @@ fn test_git_fetch_with_glob_and_exact_match(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -310,7 +300,6 @@ fn test_git_fetch_with_glob_from_config(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_with_glob_with_no_matching_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -334,7 +323,6 @@ fn test_git_fetch_with_glob_with_no_matching_remotes(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_all_remotes(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -364,7 +352,6 @@ fn test_git_fetch_all_remotes(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -387,7 +374,6 @@ fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_no_matching_remote(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -409,7 +395,6 @@ fn test_git_fetch_no_matching_remote(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -434,7 +419,6 @@ fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -460,7 +444,6 @@ fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -539,7 +522,6 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_from_remote_with_slashes(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -566,7 +548,6 @@ fn test_git_fetch_from_remote_with_slashes(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -606,7 +587,6 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -642,7 +622,6 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -718,7 +697,6 @@ fn create_trunk2_and_rebase_bookmarks(work_dir: &TestWorkDir) -> String {
     )
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_all(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -903,7 +881,6 @@ fn test_git_fetch_all(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1167,7 +1144,6 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1312,7 +1288,6 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
 
 // See `test_undo_restore_commands.rs` for fetch-undo-push and fetch-undo-fetch
 // of the same bookmarks for various kinds of undo.
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_undo(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1408,7 +1383,6 @@ fn test_git_fetch_undo(subprocess: bool) {
 
 // Compare to `test_git_import_undo` in test_git_import_export
 // TODO: Explain why these behaviors are useful
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_undo_what(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1532,7 +1506,6 @@ fn test_fetch_undo_what(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_remove_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1598,7 +1571,6 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_rename_fetch(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1652,7 +1624,6 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_removed_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1767,7 +1738,6 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1864,7 +1834,6 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1933,7 +1902,6 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2037,33 +2005,5 @@ fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
       @upstream: trrkvuqr f3e9250b merge
     [EOF]
     ");
-    }
-}
-
-// TODO: Remove with the `git.subprocess` setting.
-#[test]
-fn test_git_fetch_git2_warning() {
-    let test_env = TestEnvironment::default();
-    test_env.add_config("git.subprocess = false");
-    test_env.add_config("git.auto-local-bookmark = true");
-    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let work_dir = test_env.work_dir("repo");
-    add_git_remote(&test_env, &work_dir, "origin");
-
-    let output = work_dir.run_jj(["git", "fetch"]);
-    if cfg!(feature = "git2") {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Warning: `git.subprocess = false` will be removed in 0.30; please report any issues you have with the default.
-        bookmark: origin@origin [new] tracked
-        [EOF]
-        ");
-    } else {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
-        bookmark: origin@origin [new] tracked
-        [EOF]
-        "#);
     }
 }

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use test_case::test_case;
 use testutils::git;
 
 use crate::common::create_commit;
@@ -97,9 +96,9 @@ fn clone_git_remote_into(
     fork_repo
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_with_default_config(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_with_default_config() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "origin");
@@ -113,9 +112,9 @@ fn test_git_fetch_with_default_config(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_default_remote(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_default_remote() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -131,9 +130,9 @@ fn test_git_fetch_default_remote(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_single_remote(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_single_remote() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -157,9 +156,9 @@ fn test_git_fetch_single_remote(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_single_remote_all_remotes_flag() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -175,9 +174,9 @@ fn test_git_fetch_single_remote_all_remotes_flag(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_single_remote_from_arg() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -195,9 +194,9 @@ fn test_git_fetch_single_remote_from_arg(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_single_remote_from_config(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_single_remote_from_config() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -214,9 +213,9 @@ fn test_git_fetch_single_remote_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_multiple_remotes(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_multiple_remotes() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -237,9 +236,9 @@ fn test_git_fetch_multiple_remotes(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_with_glob(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_with_glob() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -256,9 +255,9 @@ fn test_git_fetch_with_glob(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_with_glob_and_exact_match(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_with_glob_and_exact_match() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -279,9 +278,9 @@ fn test_git_fetch_with_glob_and_exact_match(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_with_glob_from_config(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_with_glob_from_config() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config(r#"git.fetch = "glob:rem*""#);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -300,9 +299,9 @@ fn test_git_fetch_with_glob_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_with_glob_with_no_matching_remotes(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_with_glob_with_no_matching_remotes() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "upstream");
@@ -323,9 +322,9 @@ fn test_git_fetch_with_glob_with_no_matching_remotes(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_all_remotes(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_all_remotes() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -352,9 +351,9 @@ fn test_git_fetch_all_remotes(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_multiple_remotes_from_config() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -374,9 +373,9 @@ fn test_git_fetch_multiple_remotes_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_no_matching_remote(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_no_matching_remote() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
@@ -395,9 +394,9 @@ fn test_git_fetch_no_matching_remote(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_nonexistent_remote(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_nonexistent_remote() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -419,9 +418,9 @@ fn test_git_fetch_nonexistent_remote(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_nonexistent_remote_from_config() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
     add_git_remote(&test_env, &work_dir, "rem1");
@@ -444,9 +443,9 @@ fn test_git_fetch_nonexistent_remote_from_config(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_from_remote_named_git(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_from_remote_named_git() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     let work_dir = test_env.work_dir("repo");
     init_git_remote(&test_env, "git");
@@ -522,9 +521,9 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_from_remote_with_slashes(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_from_remote_with_slashes() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     let work_dir = test_env.work_dir("repo");
     init_git_remote(&test_env, "source");
@@ -548,9 +547,9 @@ fn test_git_fetch_from_remote_with_slashes(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_prune_before_updating_tips() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -587,9 +586,9 @@ fn test_git_fetch_prune_before_updating_tips(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_conflicting_bookmarks() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -622,9 +621,9 @@ fn test_git_fetch_conflicting_bookmarks(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_conflicting_bookmarks_colocated(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_conflicting_bookmarks_colocated() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     let work_dir = test_env.work_dir("repo");
     git::init(work_dir.root());
@@ -697,9 +696,9 @@ fn create_trunk2_and_rebase_bookmarks(work_dir: &TestWorkDir) -> String {
     )
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_all(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_all() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let source_dir = test_env.work_dir("source");
@@ -881,9 +880,9 @@ fn test_git_fetch_all(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_some_of_many_bookmarks() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
     let source_dir = test_env.work_dir("source");
@@ -1144,9 +1143,9 @@ fn test_git_fetch_some_of_many_bookmarks(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_bookmarks_some_missing(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_bookmarks_some_missing() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -1288,9 +1287,9 @@ fn test_git_fetch_bookmarks_missing_with_subprocess_localized_message() {
 
 // See `test_undo_restore_commands.rs` for fetch-undo-push and fetch-undo-fetch
 // of the same bookmarks for various kinds of undo.
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_undo(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_undo() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1383,9 +1382,9 @@ fn test_git_fetch_undo(subprocess: bool) {
 
 // Compare to `test_git_import_undo` in test_git_import_export
 // TODO: Explain why these behaviors are useful
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_undo_what(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_fetch_undo_what() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1506,9 +1505,9 @@ fn test_fetch_undo_what(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_remove_fetch(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_remove_fetch() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -1571,9 +1570,9 @@ fn test_git_fetch_remove_fetch(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_rename_fetch(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_rename_fetch() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -1624,9 +1623,9 @@ fn test_git_fetch_rename_fetch(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_removed_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_removed_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1738,9 +1737,9 @@ fn test_git_fetch_removed_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_removed_parent_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     let source_dir = test_env.work_dir("source");
     git::init(source_dir.root());
@@ -1834,9 +1833,9 @@ fn test_git_fetch_removed_parent_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_remote_only_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
@@ -1902,9 +1901,9 @@ fn test_git_fetch_remote_only_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_fetch_preserve_commits_across_repos(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_fetch_preserve_commits_across_repos() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     test_env.add_config("git.auto-local-bookmark = true");
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -335,31 +335,17 @@ fn test_git_push_forward_unexpectedly_moved() {
 
     // Pushing should fail
     let output = work_dir.run_jj(["git", "push"]);
-    if true {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    } else {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    }
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 #[test]
@@ -405,31 +391,17 @@ fn test_git_push_sideways_unexpectedly_moved() {
     }
 
     let output = work_dir.run_jj(["git", "push"]);
-    if true {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    } else {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    }
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 // This tests whether the push checks that the remote bookmarks are in expected
@@ -475,31 +447,17 @@ fn test_git_push_deletion_unexpectedly_moved() {
     }
 
     let output = work_dir.run_jj(["git", "push", "--bookmark", "bookmark1"]);
-    if true {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Delete bookmark bookmark1 from d13ecdbda2a2
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    } else {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Delete bookmark bookmark1 from d13ecdbda2a2
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    }
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Delete bookmark bookmark1 from d13ecdbda2a2
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 #[test]
@@ -542,31 +500,17 @@ fn test_git_push_unexpectedly_deleted() {
 
     // Pushing a moved bookmark fails if deleted on remote
     let output = work_dir.run_jj(["git", "push"]);
-    if true {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    } else {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    }
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
 
     work_dir
         .run_jj(["bookmark", "delete", "bookmark1"])
@@ -581,32 +525,20 @@ fn test_git_push_unexpectedly_deleted() {
     ");
     }
 
-    if true {
-        // git does not allow to push a deleted bookmark if we expect it to exist even
-        // though it was already deleted
-        let output = work_dir.run_jj(["git", "push", "-bbookmark1"]);
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Delete bookmark bookmark1 from d13ecdbda2a2
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    } else {
-        // Pushing a *deleted* bookmark succeeds if deleted on remote, even if we expect
-        // bookmark1@origin to exist and point somewhere.
-        let output = work_dir.run_jj(["git", "push", "-bbookmark1"]);
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Delete bookmark bookmark1 from d13ecdbda2a2
-        [EOF]
-        ");
-    }
+    // git does not allow to push a deleted bookmark if we expect it to exist even
+    // though it was already deleted
+    let output = work_dir.run_jj(["git", "push", "-bbookmark1"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Delete bookmark bookmark1 from d13ecdbda2a2
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 #[test]
@@ -638,31 +570,17 @@ fn test_git_push_creation_unexpectedly_already_exists() {
     }
 
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
-    if true {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Add bookmark bookmark1 to cb17dcdc74d5
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    } else {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Add bookmark bookmark1 to cb17dcdc74d5
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    }
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Add bookmark bookmark1 to cb17dcdc74d5
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 #[test]
@@ -1372,75 +1290,46 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     // Make sure push still errors if we try to push a bookmark with the same name
     // to a different location.
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@-"]);
-    if true {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Add bookmark b1 to 57ec90f54125
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/b1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    } else {
-        // For libgit2, the error is the same but missing the "reason: stale info"
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Add bookmark b1 to 57ec90f54125
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/b1
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-    }
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Add bookmark b1 to 57ec90f54125
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/b1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
 
     // The bookmark is still forgotten
     let output = work_dir.run_jj(["bookmark", "list", "--all", "b1"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(output, @"");
     }
-    // This command behaves differently. In libgit2 flow, a conflict between a
-    // revision and its descendant is resolved in favor of the latter, like in `jj
-    // git fetch`. In subprocess flow, this logic is not implemented. As far as `jj
-    // git push --named` goes, the stricter behavior of the subprocess flow is
-    // probably slightly better.
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@+"]);
-    if true {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Add bookmark b1 to 08fcdf4055ae
-        Error: Failed to push some bookmarks
-        Hint: The following references unexpectedly moved on the remote:
-          refs/heads/b1 (reason: stale info)
-        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-        [EOF]
-        [exit status: 1]
-        ");
-        // In this case, pushing the bookmark to the same location where it already is
-        // succeeds. TODO: This seems pretty safe, but perhaps it should still show
-        // an error or some sort of warning?
-        let output = work_dir.run_jj(["git", "push", "--named", "b1=@"]);
-        insta::allow_duplicates! {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Add bookmark b1 to ec992a1a9381
-        [EOF]
-        ");
-        }
-    } else {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Changes to push to origin:
-          Add bookmark b1 to 08fcdf4055ae
-        [EOF]
-        ");
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Add bookmark b1 to 08fcdf4055ae
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/b1 (reason: stale info)
+    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    [EOF]
+    [exit status: 1]
+    ");
+    // In this case, pushing the bookmark to the same location where it already is
+    // succeeds. TODO: This seems pretty safe, but perhaps it should still show
+    // an error or some sort of warning?
+    let output = work_dir.run_jj(["git", "push", "--named", "b1=@"]);
+    insta::allow_duplicates! {
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Changes to push to origin:
+      Add bookmark b1 to ec992a1a9381
+    [EOF]
+    ");
     }
 }
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use test_case::test_case;
 use testutils::git;
 
 use crate::common::CommandOutput;
@@ -61,9 +60,9 @@ fn set_up(test_env: &TestEnvironment) {
         .success();
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_nothing(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_nothing() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
@@ -87,9 +86,9 @@ fn test_git_push_nothing(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_current_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_current_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -184,9 +183,9 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_parent_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_parent_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -209,9 +208,9 @@ fn test_git_push_parent_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_no_matching_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_no_matching_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["new"]).success();
@@ -226,9 +225,9 @@ fn test_git_push_no_matching_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_matching_bookmark_unchanged() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["new", "bookmark1"]).success();
@@ -246,9 +245,9 @@ fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
 /// Test that `jj git push` without arguments pushes a bookmark to the specified
 /// remote even if it's already up to date on another remote
 /// (`remote_bookmarks(remote=<remote>)..@` vs. `remote_bookmarks()..@`).
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_other_remote_has_bookmark() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -310,9 +309,9 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_forward_unexpectedly_moved() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -336,7 +335,7 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
 
     // Pushing should fail
     let output = work_dir.run_jj(["git", "push"]);
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
@@ -363,9 +362,9 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_sideways_unexpectedly_moved() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -406,7 +405,7 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     }
 
     let output = work_dir.run_jj(["git", "push"]);
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
@@ -435,9 +434,9 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
 
 // This tests whether the push checks that the remote bookmarks are in expected
 // positions.
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_deletion_unexpectedly_moved() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -476,7 +475,7 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     }
 
     let output = work_dir.run_jj(["git", "push", "--bookmark", "bookmark1"]);
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
@@ -503,9 +502,9 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_unexpectedly_deleted(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_unexpectedly_deleted() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -543,7 +542,7 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
 
     // Pushing a moved bookmark fails if deleted on remote
     let output = work_dir.run_jj(["git", "push"]);
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
@@ -582,7 +581,7 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     ");
     }
 
-    if subprocess {
+    if true {
         // git does not allow to push a deleted bookmark if we expect it to exist even
         // though it was already deleted
         let output = work_dir.run_jj(["git", "push", "-bbookmark1"]);
@@ -610,9 +609,9 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_creation_unexpectedly_already_exists() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -639,7 +638,7 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     }
 
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
@@ -666,9 +665,9 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_locally_created_and_rewritten() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     // Ensure that remote bookmarks aren't tracked automatically
@@ -735,9 +734,9 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_multiple(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_multiple() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -909,9 +908,9 @@ fn test_git_push_multiple(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_changes(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_changes() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1040,9 +1039,9 @@ fn test_git_push_changes(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_changes_with_name(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_changes_with_name() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1172,9 +1171,9 @@ fn test_git_push_changes_with_name(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_changes_with_name_deleted_tracked(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_changes_with_name_deleted_tracked() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     // Unset immutable_heads so that untracking branches does not move the working
     // copy
@@ -1285,9 +1284,9 @@ fn test_git_push_changes_with_name_deleted_tracked(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_changes_with_name_untracked_or_forgotten(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_changes_with_name_untracked_or_forgotten() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     // Unset immutable_heads so that untracking branches does not move the working
@@ -1373,7 +1372,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten(subprocess: bool) {
     // Make sure push still errors if we try to push a bookmark with the same name
     // to a different location.
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@-"]);
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
@@ -1411,7 +1410,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten(subprocess: bool) {
     // git push --named` goes, the stricter behavior of the subprocess flow is
     // probably slightly better.
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@+"]);
-    if subprocess {
+    if true {
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
@@ -1445,9 +1444,9 @@ fn test_git_push_changes_with_name_untracked_or_forgotten(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_revisions(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_revisions() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1534,9 +1533,9 @@ fn test_git_push_revisions(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_mixed(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_mixed() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1596,9 +1595,9 @@ fn test_git_push_mixed(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_unsnapshotted_change(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_unsnapshotted_change() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1608,9 +1607,9 @@ fn test_git_push_unsnapshotted_change(subprocess: bool) {
     work_dir.run_jj(["git", "push", "--change", "@"]).success();
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_conflict(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_conflict() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.write_file("file", "first");
@@ -1637,9 +1636,9 @@ fn test_git_push_conflict(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_no_description(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_no_description() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -1668,9 +1667,9 @@ fn test_git_push_no_description(subprocess: bool) {
         .success();
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_no_description_in_immutable(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_no_description_in_immutable() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -1719,9 +1718,9 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_missing_author(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_missing_author() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1755,9 +1754,9 @@ fn test_git_push_missing_author(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_missing_author_in_immutable(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_missing_author_in_immutable() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1812,9 +1811,9 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_missing_committer(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_missing_committer() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1867,9 +1866,9 @@ fn test_git_push_missing_committer(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_missing_committer_in_immutable() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1925,9 +1924,9 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_deleted(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_deleted() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -1966,9 +1965,9 @@ fn test_git_push_deleted(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_conflicting_bookmarks(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_conflicting_bookmarks() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config("git.auto-local-bookmark = true");
@@ -2064,9 +2063,9 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_deleted_untracked(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_deleted_untracked() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -2097,9 +2096,9 @@ fn test_git_push_deleted_untracked(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_tracked_vs_all(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_tracked_vs_all() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -2208,9 +2207,9 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_moved_forward_untracked(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_moved_forward_untracked() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -2235,9 +2234,9 @@ fn test_git_push_moved_forward_untracked(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_moved_sideways_untracked(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_moved_sideways_untracked() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -2262,9 +2261,9 @@ fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_to_remote_named_git(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_to_remote_named_git() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let git_repo_path = {
@@ -2289,9 +2288,9 @@ fn test_git_push_to_remote_named_git(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_git_push_to_remote_with_slashes(subprocess: bool) {
-    let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
+#[test]
+fn test_git_push_to_remote_with_slashes() {
+    let test_env = TestEnvironment::default().with_git_subprocess(true);
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let git_repo_path = {

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -66,7 +66,6 @@ fn test_git_push_nothing() {
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: xtvrqkyv d13ecdbd (empty) description 1
       @origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -74,16 +73,13 @@ fn test_git_push_nothing() {
       @origin: rlzusymt 8476341e (empty) description 2
     [EOF]
     ");
-    }
     // No bookmarks to push yet
     let output = work_dir.run_jj(["git", "push", "--all"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -106,7 +102,6 @@ fn test_git_push_current_bookmark() {
         .success();
     work_dir.run_jj(["describe", "-m", "foo"]).success();
     // Check the setup
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: xtvrqkyv 0f8dc656 (empty) modified bookmark1 commit
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
@@ -115,10 +110,8 @@ fn test_git_push_current_bookmark() {
     my-bookmark: yostqsxw bc7610b6 (empty) foo
     [EOF]
     ");
-    }
     // First dry-run. `bookmark1` should not get pushed.
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -127,9 +120,7 @@ fn test_git_push_current_bookmark() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -137,8 +128,6 @@ fn test_git_push_current_bookmark() {
       Add bookmark my-bookmark to bc7610b65a91
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: xtvrqkyv 0f8dc656 (empty) modified bookmark1 commit
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv hidden d13ecdbd (empty) description 1
@@ -148,7 +137,6 @@ fn test_git_push_current_bookmark() {
       @origin: yostqsxw bc7610b6 (empty) foo
     [EOF]
     ");
-    }
 
     // Try pushing backwards
     work_dir
@@ -163,24 +151,20 @@ fn test_git_push_current_bookmark() {
     // This behavior is a strangeness of our definition of the default push revset.
     // We could consider changing it.
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
     [EOF]
     ");
-    }
     // We can move a bookmark backwards
     let output = work_dir.run_jj(["git", "push", "-bbookmark2"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Move backward bookmark bookmark2 from bc7610b65a91 to 8476341eb395
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -198,14 +182,12 @@ fn test_git_push_parent_bookmark() {
         .success();
     work_dir.write_file("file", "file");
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to e612d524a5c6
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -215,14 +197,12 @@ fn test_git_push_no_matching_bookmark() {
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["new"]).success();
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -232,14 +212,12 @@ fn test_git_push_matching_bookmark_unchanged() {
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["new", "bookmark1"]).success();
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
     [EOF]
     ");
-    }
 }
 
 /// Test that `jj git push` without arguments pushes a bookmark to the specified
@@ -272,24 +250,20 @@ fn test_git_push_other_remote_has_bookmark() {
     work_dir.run_jj(["edit", "bookmark1"]).success();
     work_dir.run_jj(["describe", "-m=modified"]).success();
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to a657f1b61b94
     [EOF]
     ");
-    }
     // Since it's already pushed to origin, nothing will happen if push again
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
     Nothing changed.
     [EOF]
     ");
-    }
     // The bookmark was moved on the "other" remote as well (since it's actually the
     // same remote), but `jj` is not aware of that since it thinks this is a
     // different remote. So, the push should fail.
@@ -299,14 +273,12 @@ fn test_git_push_other_remote_has_bookmark() {
     //
     // TODO: Saner test?
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--remote=other"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to other:
       Add bookmark bookmark1 to a657f1b61b94
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -363,7 +335,6 @@ fn test_git_push_sideways_unexpectedly_moved() {
     origin_dir
         .run_jj(["bookmark", "set", "bookmark1", "-r@"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&origin_dir), @r"
     bookmark1: vruxwmqv 80284bec remote
       @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
@@ -371,7 +342,6 @@ fn test_git_push_sideways_unexpectedly_moved() {
       @git: zsuskuln 8476341e (empty) description 2
     [EOF]
     ");
-    }
     origin_dir.run_jj(["git", "export"]).success();
 
     // Move bookmark1 sideways to another commit locally
@@ -380,7 +350,6 @@ fn test_git_push_sideways_unexpectedly_moved() {
     work_dir
         .run_jj(["bookmark", "set", "bookmark1", "--allow-backwards", "-r@"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: kmkuslsw 0f8bf988 local
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
@@ -388,7 +357,6 @@ fn test_git_push_sideways_unexpectedly_moved() {
       @origin: rlzusymt 8476341e (empty) description 2
     [EOF]
     ");
-    }
 
     let output = work_dir.run_jj(["git", "push"]);
     insta::assert_snapshot!(output, @r"
@@ -421,7 +389,6 @@ fn test_git_push_deletion_unexpectedly_moved() {
     origin_dir
         .run_jj(["bookmark", "set", "bookmark1", "-r@"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&origin_dir), @r"
     bookmark1: vruxwmqv 80284bec remote
       @git (behind by 1 commits): qpvuntsm d13ecdbd (empty) description 1
@@ -429,14 +396,12 @@ fn test_git_push_deletion_unexpectedly_moved() {
       @git: zsuskuln 8476341e (empty) description 2
     [EOF]
     ");
-    }
     origin_dir.run_jj(["git", "export"]).success();
 
     // Delete bookmark1 locally
     work_dir
         .run_jj(["bookmark", "delete", "bookmark1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -444,7 +409,6 @@ fn test_git_push_deletion_unexpectedly_moved() {
       @origin: rlzusymt 8476341e (empty) description 2
     [EOF]
     ");
-    }
 
     let output = work_dir.run_jj(["git", "push", "--bookmark", "bookmark1"]);
     insta::assert_snapshot!(output, @r"
@@ -471,7 +435,6 @@ fn test_git_push_unexpectedly_deleted() {
     origin_dir
         .run_jj(["bookmark", "delete", "bookmark1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&origin_dir), @r"
     bookmark1 (deleted)
       @git: qpvuntsm d13ecdbd (empty) description 1
@@ -479,7 +442,6 @@ fn test_git_push_unexpectedly_deleted() {
       @git: zsuskuln 8476341e (empty) description 2
     [EOF]
     ");
-    }
     origin_dir.run_jj(["git", "export"]).success();
 
     // Move bookmark1 sideways to another commit locally
@@ -488,7 +450,6 @@ fn test_git_push_unexpectedly_deleted() {
     work_dir
         .run_jj(["bookmark", "set", "bookmark1", "--allow-backwards", "-r@"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: kpqxywon 1ebe27ba local
       @origin (ahead by 1 commits, behind by 1 commits): xtvrqkyv d13ecdbd (empty) description 1
@@ -496,7 +457,6 @@ fn test_git_push_unexpectedly_deleted() {
       @origin: rlzusymt 8476341e (empty) description 2
     [EOF]
     ");
-    }
 
     // Pushing a moved bookmark fails if deleted on remote
     let output = work_dir.run_jj(["git", "push"]);
@@ -515,7 +475,6 @@ fn test_git_push_unexpectedly_deleted() {
     work_dir
         .run_jj(["bookmark", "delete", "bookmark1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -523,7 +482,6 @@ fn test_git_push_unexpectedly_deleted() {
       @origin: rlzusymt 8476341e (empty) description 2
     [EOF]
     ");
-    }
 
     // git does not allow to push a deleted bookmark if we expect it to exist even
     // though it was already deleted
@@ -560,14 +518,12 @@ fn test_git_push_creation_unexpectedly_already_exists() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "bookmark1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: yostqsxw cb17dcdc new bookmark1
     bookmark2: rlzusymt 8476341e (empty) description 2
       @origin: rlzusymt 8476341e (empty) description 2
     [EOF]
     ");
-    }
 
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
     insta::assert_snapshot!(output, @r"
@@ -597,7 +553,6 @@ fn test_git_push_locally_created_and_rewritten() {
         .run_jj(["bookmark", "create", "-r@", "my"])
         .success();
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Refusing to create new remote bookmark my@origin
@@ -605,10 +560,8 @@ fn test_git_push_locally_created_and_rewritten() {
     Nothing changed.
     [EOF]
     ");
-    }
     // Either --allow-new or git.push-new-bookmarks=true should work
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -616,21 +569,17 @@ fn test_git_push_locally_created_and_rewritten() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--config=git.push-new-bookmarks=true"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark my to fcc999921ce9
     [EOF]
     ");
-    }
 
     // Rewrite it and push again, which would fail if the pushed bookmark weren't
     // set to "tracking"
     work_dir.run_jj(["describe", "-mlocal 2"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: xtvrqkyv d13ecdbd (empty) description 1
       @origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -640,16 +589,13 @@ fn test_git_push_locally_created_and_rewritten() {
       @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv hidden fcc99992 (empty) local 1
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark my from fcc999921ce9 to 423bb66069e7
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -668,7 +614,6 @@ fn test_git_push_multiple() {
         .success();
     work_dir.run_jj(["describe", "-m", "foo"]).success();
     // Check the setup
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1 (deleted)
       @origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -677,10 +622,8 @@ fn test_git_push_multiple() {
     my-bookmark: yqosqzyt c4a3c310 (empty) foo
     [EOF]
     ");
-    }
     // First dry-run
     let output = work_dir.run_jj(["git", "push", "--all", "--deleted", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -690,7 +633,6 @@ fn test_git_push_multiple() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     // Dry run requesting two specific bookmarks
     let output = work_dir.run_jj([
         "git",
@@ -700,7 +642,6 @@ fn test_git_push_multiple() {
         "-b=my-bookmark",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -709,7 +650,6 @@ fn test_git_push_multiple() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     // Dry run requesting two specific bookmarks twice
     let output = work_dir.run_jj([
         "git",
@@ -721,7 +661,6 @@ fn test_git_push_multiple() {
         "-b=glob:my-*",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -730,10 +669,8 @@ fn test_git_push_multiple() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     // Dry run with glob pattern
     let output = work_dir.run_jj(["git", "push", "-b=glob:bookmark?", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -742,31 +679,25 @@ fn test_git_push_multiple() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
 
     // Unmatched bookmark name is error
     let output = work_dir.run_jj(["git", "push", "-b=foo"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: No such bookmark: foo
     [EOF]
     [exit status: 1]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "-b=foo", "-b=glob:?bookmark"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: No matching bookmarks for patterns: foo, ?bookmark
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // --deleted is required to push deleted bookmarks even with --all
     let output = work_dir.run_jj(["git", "push", "--all", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Refusing to push deleted bookmark bookmark1
@@ -777,9 +708,7 @@ fn test_git_push_multiple() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--all", "--deleted", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -789,10 +718,8 @@ fn test_git_push_multiple() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
 
     let output = work_dir.run_jj(["git", "push", "--all", "--deleted"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -801,8 +728,6 @@ fn test_git_push_multiple() {
       Add bookmark my-bookmark to c4a3c3105d92
     [EOF]
     ");
-    }
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark2: yqosqzyt c4a3c310 (empty) foo
       @origin: yqosqzyt c4a3c310 (empty) foo
@@ -810,9 +735,7 @@ fn test_git_push_multiple() {
       @origin: yqosqzyt c4a3c310 (empty) foo
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["log", "-rall()"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:17 bookmark2 my-bookmark c4a3c310
     │  (empty) foo
@@ -823,7 +746,6 @@ fn test_git_push_multiple() {
     ◆  zzzzzzzz root() 00000000
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -837,7 +759,6 @@ fn test_git_push_changes() {
     work_dir.write_file("file", "modified");
 
     let output = work_dir.run_jj(["git", "push", "--change", "@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Creating bookmark push-yostqsxwqrlt for revision yostqsxwqrlt
@@ -845,11 +766,9 @@ fn test_git_push_changes() {
       Add bookmark push-yostqsxwqrlt to cf1a53a8800a
     [EOF]
     ");
-    }
     // test pushing two changes at once
     work_dir.write_file("file", "modified2");
     let output = work_dir.run_jj(["git", "push", "-c=(@|@-)"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Revset `(@|@-)` resolved to more than one revision
@@ -860,10 +779,8 @@ fn test_git_push_changes() {
     [EOF]
     [exit status: 1]
     ");
-    }
     // test pushing two changes at once, part 2
     let output = work_dir.run_jj(["git", "push", "-c=all:(@|@-)"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
@@ -872,30 +789,25 @@ fn test_git_push_changes() {
       Add bookmark push-yqosqzytrlsw to a050abf4ff07
     [EOF]
     ");
-    }
     // specifying the same change twice doesn't break things
     work_dir.write_file("file", "modified3");
     let output = work_dir.run_jj(["git", "push", "-c=all:(@|@)"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from 16c169664e9f to ef6313d50ac1
     [EOF]
     ");
-    }
 
     // specifying the same bookmark with --change/--bookmark doesn't break things
     work_dir.write_file("file", "modified4");
     let output = work_dir.run_jj(["git", "push", "-c=@", "-b=push-yostqsxwqrlt"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark push-yostqsxwqrlt from ef6313d50ac1 to c1e65d3a64ce
     [EOF]
     ");
-    }
 
     // try again with --change that could move the bookmark forward
     work_dir.write_file("file", "modified5");
@@ -909,7 +821,6 @@ fn test_git_push_changes() {
         ])
         .success();
     let output = work_dir.run_jj(["status"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     Working copy changes:
     M file
@@ -917,9 +828,7 @@ fn test_git_push_changes() {
     Parent commit (@-): yqosqzyt a050abf4 push-yostqsxwqrlt* push-yqosqzytrlsw | foo
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "-c=@", "-b=push-yostqsxwqrlt"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Bookmark already exists: push-yostqsxwqrlt
@@ -927,9 +836,7 @@ fn test_git_push_changes() {
     [EOF]
     [exit status: 1]
     ");
-    }
     let output = work_dir.run_jj(["status"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     Working copy changes:
     M file
@@ -937,7 +844,6 @@ fn test_git_push_changes() {
     Parent commit (@-): yqosqzyt a050abf4 push-yostqsxwqrlt* push-yqosqzytrlsw | foo
     [EOF]
     ");
-    }
 
     // Test changing `git.push-bookmark-prefix`. It causes us to push again.
     let output = work_dir.run_jj([
@@ -946,7 +852,6 @@ fn test_git_push_changes() {
         "--config=git.push-bookmark-prefix=test-",
         "--change=@",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Creating bookmark test-yostqsxwqrlt for revision yostqsxwqrlt
@@ -954,7 +859,6 @@ fn test_git_push_changes() {
       Add bookmark test-yostqsxwqrlt to 38cb417ce3a6
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -969,18 +873,15 @@ fn test_git_push_changes_with_name() {
 
     // Normal behavior.
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark b1 to 3e677c129c1d
     [EOF]
     ");
-    }
     // Spaces before the = sign are treated like part of the bookmark name and such
     // bookmarks cannot be pushed.
     let output = work_dir.run_jj(["git", "push", "--named", "b1 = @"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Could not parse 'b1 ' as a bookmark name
@@ -996,10 +897,8 @@ fn test_git_push_changes_with_name() {
     [EOF]
     [exit status: 2]
     ");
-    }
     // test pushing a change with an empty name
     let output = work_dir.run_jj(["git", "push", "--named", "=@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Argument '=@' must have the form NAME=REVISION, with both NAME and REVISION non-empty
@@ -1007,10 +906,8 @@ fn test_git_push_changes_with_name() {
     [EOF]
     [exit status: 2]
     ");
-    }
     // Unparsable name
     let output = work_dir.run_jj(["git", "push", "--named", ":!:=@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Could not parse ':!:' as a bookmark name
@@ -1026,10 +923,8 @@ fn test_git_push_changes_with_name() {
     [EOF]
     [exit status: 2]
     ");
-    }
     // test pushing a change with an empty revision
     let output = work_dir.run_jj(["git", "push", "--named", "b2="]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Argument 'b2=' must have the form NAME=REVISION, with both NAME and REVISION non-empty
@@ -1037,10 +932,8 @@ fn test_git_push_changes_with_name() {
     [EOF]
     [exit status: 2]
     ");
-    }
     // test pushing a change with no equals sign
     let output = work_dir.run_jj(["git", "push", "--named", "b2"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Argument 'b2' must include '=' and have the form NAME=REVISION
@@ -1048,11 +941,9 @@ fn test_git_push_changes_with_name() {
     [EOF]
     [exit status: 2]
     ");
-    }
 
     // test pushing the same change with the same name again
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Bookmark already exists: b1
@@ -1060,11 +951,9 @@ fn test_git_push_changes_with_name() {
     [EOF]
     [exit status: 1]
     ");
-    }
     // test pushing two changes at once
     work_dir.write_file("file", "modified2");
     let output = work_dir.run_jj(["git", "push", "--named=b2=all:(@|@-)"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Revset `all:(@|@-)` resolved to more than one revision
@@ -1074,19 +963,16 @@ fn test_git_push_changes_with_name() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // specifying the same bookmark with --named/--bookmark
     work_dir.write_file("file", "modified4");
     let output = work_dir.run_jj(["git", "push", "--named=b2=@", "-b=b2"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark b2 to 477da21559d5
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1118,21 +1004,18 @@ fn test_git_push_changes_with_name_deleted_tracked() {
     work_dir.write_file("file", "modified");
     // Normal push as part of the test setup
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark b1 to fd39fc9ddae4
     [EOF]
     ");
-    }
     work_dir.run_jj(["bookmark", "delete", "b1"]).success();
 
     // Test the setup
     let output = work_dir
         .run_jj(["bookmark", "list", "--all", "b1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     b1 (deleted)
       @origin: kpqxywon fd39fc9d pushed
@@ -1141,12 +1024,10 @@ fn test_git_push_changes_with_name_deleted_tracked() {
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
     [EOF]
     ");
-    }
 
     // Can't push `b1` with --named to the same or another remote if it's deleted
     // locally and still tracked on `origin`
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@", "--remote=another_remote"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Tracked remote bookmarks exist for deleted bookmark: b1
@@ -1154,9 +1035,7 @@ fn test_git_push_changes_with_name_deleted_tracked() {
     [EOF]
     [exit status: 1]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@", "--remote=origin"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Tracked remote bookmarks exist for deleted bookmark: b1
@@ -1164,7 +1043,6 @@ fn test_git_push_changes_with_name_deleted_tracked() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // OK to push to a different remote once the bookmark is no longer tracked on
     // `origin`
@@ -1174,32 +1052,26 @@ fn test_git_push_changes_with_name_deleted_tracked() {
     let output = work_dir
         .run_jj(["bookmark", "list", "--all", "b1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     b1@origin: kpqxywon fd39fc9d pushed
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@", "--remote=another_remote"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to another_remote:
       Add bookmark b1 to fd39fc9ddae4
     [EOF]
     ");
-    }
     let output = work_dir
         .run_jj(["bookmark", "list", "--all", "b1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     b1: kpqxywon fd39fc9d pushed
       @another_remote: kpqxywon fd39fc9d pushed
     b1@origin: kpqxywon fd39fc9d pushed
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1234,7 +1106,6 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
             r#"-T=separate(" ", commit_id.shortest(3), bookmarks, description)"#,
         ])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ○  08f child
     @  ec9 b1@origin pushed_to_remote
@@ -1242,19 +1113,15 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     ◆  000
     [EOF]
     ");
-    }
     let output = work_dir
         .run_jj(["bookmark", "list", "--all", "b1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     b1@origin: yostqsxw ec992a1a pushed_to_remote
     [EOF]
     ");
-    }
 
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Non-tracking remote bookmark b1@origin exists
@@ -1262,10 +1129,8 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@+"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Non-tracking remote bookmark b1@origin exists
@@ -1273,7 +1138,6 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // The bookmarked is still pushed to the remote, but let's entirely forget
     // it. In other words, let's forget the remote-tracking bookmarks.
@@ -1283,9 +1147,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     let output = work_dir
         .run_jj(["bookmark", "list", "--all", "b1"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @"");
-    }
 
     // Make sure push still errors if we try to push a bookmark with the same name
     // to a different location.
@@ -1304,9 +1166,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
 
     // The bookmark is still forgotten
     let output = work_dir.run_jj(["bookmark", "list", "--all", "b1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @"");
-    }
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@+"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
@@ -1323,14 +1183,12 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     // succeeds. TODO: This seems pretty safe, but perhaps it should still show
     // an error or some sort of warning?
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark b1 to ec992a1a9381
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1356,27 +1214,22 @@ fn test_git_push_revisions() {
 
     // Push an empty set
     let output = work_dir.run_jj(["git", "push", "--allow-new", "-r=none()"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No bookmarks point to the specified revisions: none()
     Nothing changed.
     [EOF]
     ");
-    }
     // Push a revision with no bookmarks
     let output = work_dir.run_jj(["git", "push", "--allow-new", "-r=@--"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No bookmarks point to the specified revisions: @--
     Nothing changed.
     [EOF]
     ");
-    }
     // Push a revision with a single bookmark
     let output = work_dir.run_jj(["git", "push", "--allow-new", "-r=@-", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -1384,10 +1237,8 @@ fn test_git_push_revisions() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     // Push multiple revisions of which some have bookmarks
     let output = work_dir.run_jj(["git", "push", "--allow-new", "-r=@--", "-r=@-", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No bookmarks point to the specified revisions: @--
@@ -1396,10 +1247,8 @@ fn test_git_push_revisions() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     // Push a revision with a multiple bookmarks
     let output = work_dir.run_jj(["git", "push", "--allow-new", "-r=@", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -1408,10 +1257,8 @@ fn test_git_push_revisions() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
     // Repeating a commit doesn't result in repeated messages about the bookmark
     let output = work_dir.run_jj(["git", "push", "--allow-new", "-r=@-", "-r=@-", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -1419,7 +1266,6 @@ fn test_git_push_revisions() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1451,7 +1297,6 @@ fn test_git_push_mixed() {
         "--bookmark=bookmark-1",
         "-r=@",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
@@ -1460,7 +1305,6 @@ fn test_git_push_mixed() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     let output = work_dir.run_jj([
         "git",
@@ -1470,7 +1314,6 @@ fn test_git_push_mixed() {
         "--bookmark=bookmark-1",
         "-r=@",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Creating bookmark push-yqosqzytrlsw for revision yqosqzytrlsw
@@ -1481,7 +1324,6 @@ fn test_git_push_mixed() {
       Add bookmark bookmark-2b to 84f499037f5c
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1514,7 +1356,6 @@ fn test_git_push_conflict() {
         .success();
     work_dir.run_jj(["describe", "-m", "third"]).success();
     let output = work_dir.run_jj(["git", "push", "--all"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit e2221a796300 since it has conflicts
@@ -1522,7 +1363,6 @@ fn test_git_push_conflict() {
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -1535,7 +1375,6 @@ fn test_git_push_no_description() {
         .success();
     work_dir.run_jj(["describe", "-m="]).success();
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--bookmark", "my-bookmark"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 5b36783cd11c since it has no description
@@ -1543,7 +1382,6 @@ fn test_git_push_no_description() {
     [EOF]
     [exit status: 1]
     ");
-    }
     work_dir
         .run_jj([
             "git",
@@ -1578,7 +1416,6 @@ fn test_git_push_no_description_in_immutable() {
         "--bookmark=my-bookmark",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 5b36783cd11c since it has no description
@@ -1586,7 +1423,6 @@ fn test_git_push_no_description_in_immutable() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "imm""#);
     let output = work_dir.run_jj([
@@ -1596,7 +1432,6 @@ fn test_git_push_no_description_in_immutable() {
         "--bookmark=my-bookmark",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -1604,7 +1439,6 @@ fn test_git_push_no_description_in_immutable() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1620,7 +1454,6 @@ fn test_git_push_missing_author() {
     run_without_var("JJ_USER", &["new", "root()", "-m=initial"]);
     run_without_var("JJ_USER", &["bookmark", "create", "-r@", "missing-name"]);
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--bookmark", "missing-name"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 944313939bbd since it has no author and/or committer set
@@ -1628,11 +1461,9 @@ fn test_git_push_missing_author() {
     [EOF]
     [exit status: 1]
     ");
-    }
     run_without_var("JJ_EMAIL", &["new", "root()", "-m=initial"]);
     run_without_var("JJ_EMAIL", &["bookmark", "create", "-r@", "missing-email"]);
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--bookmark=missing-email"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 59354714f789 since it has no author and/or committer set
@@ -1640,7 +1471,6 @@ fn test_git_push_missing_author() {
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -1671,7 +1501,6 @@ fn test_git_push_missing_author_in_immutable() {
         "--bookmark=my-bookmark",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 011f740bf8b5 since it has no author and/or committer set
@@ -1679,7 +1508,6 @@ fn test_git_push_missing_author_in_immutable() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "imm""#);
     let output = work_dir.run_jj([
@@ -1689,7 +1517,6 @@ fn test_git_push_missing_author_in_immutable() {
         "--bookmark=my-bookmark",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -1697,7 +1524,6 @@ fn test_git_push_missing_author_in_immutable() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1715,7 +1541,6 @@ fn test_git_push_missing_committer() {
         .success();
     run_without_var("JJ_USER", &["describe", "-m=no committer name"]);
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--bookmark=missing-name"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 4fd190283d1a since it has no author and/or committer set
@@ -1723,14 +1548,12 @@ fn test_git_push_missing_committer() {
     [EOF]
     [exit status: 1]
     ");
-    }
     work_dir.run_jj(["new", "root()"]).success();
     work_dir
         .run_jj(["bookmark", "create", "-r@", "missing-email"])
         .success();
     run_without_var("JJ_EMAIL", &["describe", "-m=no committer email"]);
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--bookmark=missing-email"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit eab97428a6ec since it has no author and/or committer set
@@ -1738,13 +1561,11 @@ fn test_git_push_missing_committer() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // Test message when there are multiple reasons (missing committer and
     // description)
     run_without_var("JJ_EMAIL", &["describe", "-m=", "missing-email"]);
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--bookmark=missing-email"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 1143ed607f54 since it has no description and it has no author and/or committer set
@@ -1752,7 +1573,6 @@ fn test_git_push_missing_committer() {
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -1784,7 +1604,6 @@ fn test_git_push_missing_committer_in_immutable() {
         "--bookmark=my-bookmark",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 7e61dc727a8f since it has no author and/or committer set
@@ -1792,7 +1611,6 @@ fn test_git_push_missing_committer_in_immutable() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "imm""#);
     let output = work_dir.run_jj([
@@ -1802,7 +1620,6 @@ fn test_git_push_missing_committer_in_immutable() {
         "--bookmark=my-bookmark",
         "--dry-run",
     ]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -1810,7 +1627,6 @@ fn test_git_push_missing_committer_in_immutable() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1823,16 +1639,13 @@ fn test_git_push_deleted() {
         .run_jj(["bookmark", "delete", "bookmark1"])
         .success();
     let output = work_dir.run_jj(["git", "push", "--deleted"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["log", "-rall()"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 5b36783c
     │  (empty) (no description set)
@@ -1843,15 +1656,12 @@ fn test_git_push_deleted() {
     ◆  zzzzzzzz root() 00000000
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--deleted"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1880,7 +1690,6 @@ fn test_git_push_conflicting_bookmarks() {
         .run_jj(["bookmark", "create", "-r@", "bookmark2"])
         .success();
     work_dir.run_jj(["git", "fetch"]).success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: xtvrqkyv d13ecdbd (empty) description 1
       @origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -1890,7 +1699,6 @@ fn test_git_push_conflicting_bookmarks() {
       @origin (behind by 1 commits): rlzusymt 8476341e (empty) description 2
     [EOF]
     ");
-    }
 
     let bump_bookmark1 = || {
         work_dir.run_jj(["new", "bookmark1", "-m=bump"]).success();
@@ -1901,7 +1709,6 @@ fn test_git_push_conflicting_bookmarks() {
 
     // Conflicting bookmark at @
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Bookmark bookmark2 is conflicted
@@ -1909,11 +1716,9 @@ fn test_git_push_conflicting_bookmarks() {
     Nothing changed.
     [EOF]
     ");
-    }
 
     // --bookmark should be blocked by conflicting bookmark
     let output = work_dir.run_jj(["git", "push", "--allow-new", "--bookmark", "bookmark2"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Bookmark bookmark2 is conflicted
@@ -1921,12 +1726,10 @@ fn test_git_push_conflicting_bookmarks() {
     [EOF]
     [exit status: 1]
     ");
-    }
 
     // --all shouldn't be blocked by conflicting bookmark
     bump_bookmark1();
     let output = work_dir.run_jj(["git", "push", "--all"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Bookmark bookmark2 is conflicted
@@ -1935,12 +1738,10 @@ fn test_git_push_conflicting_bookmarks() {
       Move forward bookmark bookmark1 from d13ecdbda2a2 to 8df52121b022
     [EOF]
     ");
-    }
 
     // --revisions shouldn't be blocked by conflicting bookmark
     bump_bookmark1();
     let output = work_dir.run_jj(["git", "push", "--allow-new", "-rall()"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Bookmark bookmark2 is conflicted
@@ -1949,7 +1750,6 @@ fn test_git_push_conflicting_bookmarks() {
       Move forward bookmark bookmark1 from 8df52121b022 to 345e1f64a64d
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -1967,22 +1767,18 @@ fn test_git_push_deleted_untracked() {
         .run_jj(["bookmark", "untrack", "bookmark1@origin"])
         .success();
     let output = work_dir.run_jj(["git", "push", "--deleted"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--bookmark=bookmark1"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: No such bookmark: bookmark1
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -2008,7 +1804,6 @@ fn test_git_push_tracked_vs_all() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "bookmark3"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: vruxwmqv db059e3f (empty) moved bookmark1
     bookmark1@origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -2017,13 +1812,11 @@ fn test_git_push_tracked_vs_all() {
     bookmark3: znkkpsqq 1aa4f1f2 (empty) moved bookmark2
     [EOF]
     ");
-    }
 
     // At this point, only bookmark2 is still tracked.
     // `jj git push --tracked --deleted` would try to push it and no other
     // bookmarks.
     let output = work_dir.run_jj(["git", "push", "--tracked", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Refusing to push deleted bookmark bookmark2
@@ -2031,9 +1824,7 @@ fn test_git_push_tracked_vs_all() {
     Nothing changed.
     [EOF]
     ");
-    }
     let output = work_dir.run_jj(["git", "push", "--tracked", "--deleted", "--dry-run"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -2041,13 +1832,11 @@ fn test_git_push_tracked_vs_all() {
     Dry-run requested, not pushing.
     [EOF]
     ");
-    }
 
     // Untrack the last remaining tracked bookmark.
     work_dir
         .run_jj(["bookmark", "untrack", "bookmark2@origin"])
         .success();
-    insta::allow_duplicates! {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: vruxwmqv db059e3f (empty) moved bookmark1
     bookmark1@origin: xtvrqkyv d13ecdbd (empty) description 1
@@ -2055,17 +1844,14 @@ fn test_git_push_tracked_vs_all() {
     bookmark3: znkkpsqq 1aa4f1f2 (empty) moved bookmark2
     [EOF]
     ");
-    }
 
     // Now, no bookmarks are tracked. --tracked does not push anything
     let output = work_dir.run_jj(["git", "push", "--tracked"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    }
 
     // All bookmarks are still untracked.
     // - --all tries to push bookmark1, but fails because a bookmark with the same
@@ -2084,7 +1870,6 @@ fn test_git_push_tracked_vs_all() {
     // - We could consider showing some hint on `jj bookmark untrack
     //   bookmark2@origin` instead of showing an error here.
     let output = work_dir.run_jj(["git", "push", "--all"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Non-tracking remote bookmark bookmark1@origin exists
@@ -2093,7 +1878,6 @@ fn test_git_push_tracked_vs_all() {
       Add bookmark bookmark3 to 1aa4f1f2ef7f
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -2112,7 +1896,6 @@ fn test_git_push_moved_forward_untracked() {
         .run_jj(["bookmark", "untrack", "bookmark1@origin"])
         .success();
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Non-tracking remote bookmark bookmark1@origin exists
@@ -2120,7 +1903,6 @@ fn test_git_push_moved_forward_untracked() {
     Nothing changed.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -2139,7 +1921,6 @@ fn test_git_push_moved_sideways_untracked() {
         .run_jj(["bookmark", "untrack", "bookmark1@origin"])
         .success();
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Non-tracking remote bookmark bookmark1@origin exists
@@ -2147,7 +1928,6 @@ fn test_git_push_moved_sideways_untracked() {
     Nothing changed.
     [EOF]
     ");
-    }
 }
 
 #[test]
@@ -2163,7 +1943,6 @@ fn test_git_push_to_remote_named_git() {
     git::rename_remote(&git_repo_path, "origin", "git");
 
     let output = work_dir.run_jj(["git", "push", "--all", "--remote=git"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to git:
@@ -2174,7 +1953,6 @@ fn test_git_push_to_remote_named_git() {
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]
@@ -2190,7 +1968,6 @@ fn test_git_push_to_remote_with_slashes() {
     git::rename_remote(&git_repo_path, "origin", "slash/origin");
 
     let output = work_dir.run_jj(["git", "push", "--all", "--remote=slash/origin"]);
-    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to slash/origin:
@@ -2201,7 +1978,6 @@ fn test_git_push_to_remote_with_slashes() {
     [EOF]
     [exit status: 1]
     ");
-    }
 }
 
 #[test]

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -61,7 +61,6 @@ fn set_up(test_env: &TestEnvironment) {
         .success();
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_nothing(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -88,7 +87,6 @@ fn test_git_push_nothing(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_current_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -186,7 +184,6 @@ fn test_git_push_current_bookmark(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_parent_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -212,7 +209,6 @@ fn test_git_push_parent_bookmark(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_matching_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -230,7 +226,6 @@ fn test_git_push_no_matching_bookmark(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -251,7 +246,6 @@ fn test_git_push_matching_bookmark_unchanged(subprocess: bool) {
 /// Test that `jj git push` without arguments pushes a bookmark to the specified
 /// remote even if it's already up to date on another remote
 /// (`remote_bookmarks(remote=<remote>)..@` vs. `remote_bookmarks()..@`).
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -316,7 +310,6 @@ fn test_git_push_other_remote_has_bookmark(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -370,7 +363,6 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -443,7 +435,6 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
 
 // This tests whether the push checks that the remote bookmarks are in expected
 // positions.
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -512,7 +503,6 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -620,7 +610,6 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -677,7 +666,6 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -747,7 +735,6 @@ fn test_git_push_locally_created_and_rewritten(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_multiple(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -922,7 +909,6 @@ fn test_git_push_multiple(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_changes(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1054,7 +1040,6 @@ fn test_git_push_changes(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_changes_with_name(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1187,7 +1172,6 @@ fn test_git_push_changes_with_name(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_changes_with_name_deleted_tracked(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1301,7 +1285,6 @@ fn test_git_push_changes_with_name_deleted_tracked(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_changes_with_name_untracked_or_forgotten(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1462,7 +1445,6 @@ fn test_git_push_changes_with_name_untracked_or_forgotten(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_revisions(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1552,7 +1534,6 @@ fn test_git_push_revisions(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_mixed(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1615,7 +1596,6 @@ fn test_git_push_mixed(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_unsnapshotted_change(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1628,7 +1608,6 @@ fn test_git_push_unsnapshotted_change(subprocess: bool) {
     work_dir.run_jj(["git", "push", "--change", "@"]).success();
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_conflict(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1658,7 +1637,6 @@ fn test_git_push_conflict(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_description(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1690,7 +1668,6 @@ fn test_git_push_no_description(subprocess: bool) {
         .success();
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_no_description_in_immutable(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1742,7 +1719,6 @@ fn test_git_push_no_description_in_immutable(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_author(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1779,7 +1755,6 @@ fn test_git_push_missing_author(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1837,7 +1812,6 @@ fn test_git_push_missing_author_in_immutable(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_committer(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1893,7 +1867,6 @@ fn test_git_push_missing_committer(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1952,7 +1925,6 @@ fn test_git_push_missing_committer_in_immutable(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deleted(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -1994,7 +1966,6 @@ fn test_git_push_deleted(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2093,7 +2064,6 @@ fn test_git_push_conflicting_bookmarks(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_deleted_untracked(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2127,7 +2097,6 @@ fn test_git_push_deleted_untracked(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_tracked_vs_all(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2239,7 +2208,6 @@ fn test_git_push_tracked_vs_all(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_moved_forward_untracked(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2267,7 +2235,6 @@ fn test_git_push_moved_forward_untracked(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2295,7 +2262,6 @@ fn test_git_push_moved_sideways_untracked(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_to_remote_named_git(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2323,7 +2289,6 @@ fn test_git_push_to_remote_named_git(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_git_push_to_remote_with_slashes(subprocess: bool) {
     let test_env = TestEnvironment::default().with_git_subprocess(subprocess);
@@ -2570,34 +2535,4 @@ fn test_git_push_rejected_by_remote() {
 fn get_bookmark_output(work_dir: &TestWorkDir) -> CommandOutput {
     // --quiet to suppress deleted bookmarks hint
     work_dir.run_jj(["bookmark", "list", "--all-remotes", "--quiet"])
-}
-
-// TODO: Remove with the `git.subprocess` setting.
-#[test]
-fn test_git_push_git2_warning() {
-    let test_env = TestEnvironment::default();
-    set_up(&test_env);
-    let work_dir = test_env.work_dir("local");
-    test_env.add_config("git.subprocess = false");
-    work_dir
-        .run_jj(["describe", "bookmark1", "-m", "modified bookmark1 commit"])
-        .success();
-    let output = work_dir.run_jj(["git", "push", "--all"]);
-    if cfg!(feature = "git2") {
-        insta::assert_snapshot!(output, @r"
-        ------- stderr -------
-        Warning: `git.subprocess = false` will be removed in 0.30; please report any issues you have with the default.
-        Changes to push to origin:
-          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8dc6560f32
-        [EOF]
-        ");
-    } else {
-        insta::assert_snapshot!(output, @r#"
-        ------- stderr -------
-        Warning: Deprecated config: jj was compiled without `git.subprocess = false` support
-        Changes to push to origin:
-          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8dc6560f32
-        [EOF]
-        "#);
-    }
 }

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -62,7 +62,7 @@ fn set_up(test_env: &TestEnvironment) {
 
 #[test]
 fn test_git_push_nothing() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     // Show the setup. `insta` has trouble if this is done inside `set_up()`
@@ -88,7 +88,7 @@ fn test_git_push_nothing() {
 
 #[test]
 fn test_git_push_current_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -185,7 +185,7 @@ fn test_git_push_current_bookmark() {
 
 #[test]
 fn test_git_push_parent_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -210,7 +210,7 @@ fn test_git_push_parent_bookmark() {
 
 #[test]
 fn test_git_push_no_matching_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["new"]).success();
@@ -227,7 +227,7 @@ fn test_git_push_no_matching_bookmark() {
 
 #[test]
 fn test_git_push_matching_bookmark_unchanged() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["new", "bookmark1"]).success();
@@ -247,7 +247,7 @@ fn test_git_push_matching_bookmark_unchanged() {
 /// (`remote_bookmarks(remote=<remote>)..@` vs. `remote_bookmarks()..@`).
 #[test]
 fn test_git_push_other_remote_has_bookmark() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
@@ -311,7 +311,7 @@ fn test_git_push_other_remote_has_bookmark() {
 
 #[test]
 fn test_git_push_forward_unexpectedly_moved() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -364,7 +364,7 @@ fn test_git_push_forward_unexpectedly_moved() {
 
 #[test]
 fn test_git_push_sideways_unexpectedly_moved() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -436,7 +436,7 @@ fn test_git_push_sideways_unexpectedly_moved() {
 // positions.
 #[test]
 fn test_git_push_deletion_unexpectedly_moved() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -504,7 +504,7 @@ fn test_git_push_deletion_unexpectedly_moved() {
 
 #[test]
 fn test_git_push_unexpectedly_deleted() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -611,7 +611,7 @@ fn test_git_push_unexpectedly_deleted() {
 
 #[test]
 fn test_git_push_creation_unexpectedly_already_exists() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -667,7 +667,7 @@ fn test_git_push_creation_unexpectedly_already_exists() {
 
 #[test]
 fn test_git_push_locally_created_and_rewritten() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     // Ensure that remote bookmarks aren't tracked automatically
@@ -736,7 +736,7 @@ fn test_git_push_locally_created_and_rewritten() {
 
 #[test]
 fn test_git_push_multiple() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -910,7 +910,7 @@ fn test_git_push_multiple() {
 
 #[test]
 fn test_git_push_changes() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1041,7 +1041,7 @@ fn test_git_push_changes() {
 
 #[test]
 fn test_git_push_changes_with_name() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1173,7 +1173,7 @@ fn test_git_push_changes_with_name() {
 
 #[test]
 fn test_git_push_changes_with_name_deleted_tracked() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     // Unset immutable_heads so that untracking branches does not move the working
     // copy
@@ -1286,7 +1286,7 @@ fn test_git_push_changes_with_name_deleted_tracked() {
 
 #[test]
 fn test_git_push_changes_with_name_untracked_or_forgotten() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     // Unset immutable_heads so that untracking branches does not move the working
@@ -1446,7 +1446,7 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
 
 #[test]
 fn test_git_push_revisions() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1535,7 +1535,7 @@ fn test_git_push_revisions() {
 
 #[test]
 fn test_git_push_mixed() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1597,7 +1597,7 @@ fn test_git_push_mixed() {
 
 #[test]
 fn test_git_push_unsnapshotted_change() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.run_jj(["describe", "-m", "foo"]).success();
@@ -1609,7 +1609,7 @@ fn test_git_push_unsnapshotted_change() {
 
 #[test]
 fn test_git_push_conflict() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir.write_file("file", "first");
@@ -1638,7 +1638,7 @@ fn test_git_push_conflict() {
 
 #[test]
 fn test_git_push_no_description() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -1669,7 +1669,7 @@ fn test_git_push_no_description() {
 
 #[test]
 fn test_git_push_no_description_in_immutable() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -1720,7 +1720,7 @@ fn test_git_push_no_description_in_immutable() {
 
 #[test]
 fn test_git_push_missing_author() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1756,7 +1756,7 @@ fn test_git_push_missing_author() {
 
 #[test]
 fn test_git_push_missing_author_in_immutable() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1813,7 +1813,7 @@ fn test_git_push_missing_author_in_immutable() {
 
 #[test]
 fn test_git_push_missing_committer() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1868,7 +1868,7 @@ fn test_git_push_missing_committer() {
 
 #[test]
 fn test_git_push_missing_committer_in_immutable() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let run_without_var = |var: &str, args: &[&str]| {
@@ -1926,7 +1926,7 @@ fn test_git_push_missing_committer_in_immutable() {
 
 #[test]
 fn test_git_push_deleted() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -1967,7 +1967,7 @@ fn test_git_push_deleted() {
 
 #[test]
 fn test_git_push_conflicting_bookmarks() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     test_env.add_config("git.auto-local-bookmark = true");
@@ -2065,7 +2065,7 @@ fn test_git_push_conflicting_bookmarks() {
 
 #[test]
 fn test_git_push_deleted_untracked() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -2098,7 +2098,7 @@ fn test_git_push_deleted_untracked() {
 
 #[test]
 fn test_git_push_tracked_vs_all() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     work_dir
@@ -2209,7 +2209,7 @@ fn test_git_push_tracked_vs_all() {
 
 #[test]
 fn test_git_push_moved_forward_untracked() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -2236,7 +2236,7 @@ fn test_git_push_moved_forward_untracked() {
 
 #[test]
 fn test_git_push_moved_sideways_untracked() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
 
@@ -2263,7 +2263,7 @@ fn test_git_push_moved_sideways_untracked() {
 
 #[test]
 fn test_git_push_to_remote_named_git() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let git_repo_path = {
@@ -2290,7 +2290,7 @@ fn test_git_push_to_remote_named_git() {
 
 #[test]
 fn test_git_push_to_remote_with_slashes() {
-    let test_env = TestEnvironment::default().with_git_subprocess(true);
+    let test_env = TestEnvironment::default();
     set_up(&test_env);
     let work_dir = test_env.work_dir("local");
     let git_repo_path = {

--- a/docs/config.md
+++ b/docs/config.md
@@ -1501,7 +1501,7 @@ would require pushing the private commit as well.
 
 ### Git subprocessing behaviour
 
-By default, Git remote interactions are handled by spawning a `git` subprocess.
+Git remote interactions are handled by spawning a `git` subprocess.
 If `git` is not on your OS path, or you want to specify a particular binary,
 you can:
 
@@ -1509,21 +1509,6 @@ you can:
 [git]
 executable-path = "/path/to/git"
 ```
-
-Previously, remote interactions were handled by
-[`libgit2`](https://github.com/libgit2/libgit2) by default, which sometimes
-caused [SSH problems](https://github.com/jj-vcs/jj/issues/4979) that could not
-be solved by `jj` directly. If you have any issues with the `git`
-subprocessing, you can switch back to `libgit2` with:
-
-```toml
-[git]
-subprocess = false
-```
-
-Note that `libgit2` support will be removed in 0.30, so you are encouraged to
-[report any issues](https://github.com/jj-vcs/jj/issues) you experience with
-the default configuration.
 
 ## Filesystem monitor
 

--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -30,12 +30,11 @@ be compiled from the same source code.
 
 #### From Source
 
-First make sure that you have a Rust version >= 1.84 and that the `libssl-dev`,
-`openssl`, `pkg-config`, and `build-essential` packages are installed by running
-something like this:
+First make sure that you have a Rust version >= 1.84 and that the
+`build-essential` package is installed by running something like this:
 
 ```shell
-sudo apt-get install libssl-dev openssl pkg-config build-essential
+sudo apt-get install build-essential
 ```
 
 Now run either:
@@ -115,7 +114,7 @@ zypper install jujutsu
 
 ### Mac
 
-#### From Source, Vendored OpenSSL
+#### From Source
 
 First make sure that you have a Rust version >= 1.84. You may also need to run:
 
@@ -128,34 +127,7 @@ Now run either:
 ```shell
 # To install the *prerelease* version from the main branch
 cargo install --git https://github.com/jj-vcs/jj.git \
-     --features vendored-openssl --locked --bin jj jj-cli
-```
-
-or:
-
-```shell
-# To install the latest release
-cargo install --features vendored-openssl --locked --bin jj jj-cli
-```
-
-#### From Source, Homebrew OpenSSL
-
-First make sure that you have a Rust version >= 1.84. You will also need
-[Homebrew] installed. You may then need to run some or all of
-these:
-
-```shell
-xcode-select --install
-brew install openssl
-brew install pkg-config
-export PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl@3/lib/pkgconfig"
-```
-
-Now run either:
-
-```shell
-# To install the *prerelease* version from the main branch
-cargo install --git https://github.com/jj-vcs/jj.git --locked --bin jj jj-cli
+     --locked --bin jj jj-cli
 ```
 
 or:
@@ -164,7 +136,6 @@ or:
 # To install the latest release
 cargo install --locked --bin jj jj-cli
 ```
-
 
 #### Homebrew
 
@@ -191,14 +162,14 @@ First make sure that you have a Rust version >= 1.84. Now run either:
 
 ```shell
 # To install the *prerelease* version from the main branch
-cargo install --git https://github.com/jj-vcs/jj.git --locked --bin jj jj-cli --features vendored-openssl
+cargo install --git https://github.com/jj-vcs/jj.git --locked --bin jj jj-cli
 ```
 
 or:
 
 ```shell
 # To install the latest release
-cargo install --locked --bin jj jj-cli --features vendored-openssl
+cargo install --locked --bin jj jj-cli
 ```
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,20 +61,13 @@
         in pkgs.makeRustPlatform { rustc = platform; cargo = platform; };
 
       nativeBuildInputs = with pkgs;
-        [
-          gzip
-          pkg-config
-        ]
+        [ ]
         ++ lib.optionals stdenv.isLinux [
           mold-wrapped
         ];
 
       buildInputs = with pkgs;
-        [
-          openssl
-          libgit2
-          libssh2
-        ]
+        [ ]
         ++ lib.optionals stdenv.isDarwin [
           darwin.apple_sdk.frameworks.Security
           darwin.apple_sdk.frameworks.SystemConfiguration
@@ -94,7 +87,6 @@
       ];
 
       env = {
-        LIBSSH2_SYS_USE_PKG_CONFIG = "1";
         RUST_BACKTRACE = 1;
         CARGO_INCREMENTAL = "0"; # https://github.com/rust-lang/rust/issues/139110
       };

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -42,7 +42,6 @@ digest = { workspace = true }
 dunce = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
-git2 = { workspace = true, optional = true }
 gix = { workspace = true, optional = true }
 glob = { workspace = true }
 hashbrown = { workspace = true }
@@ -94,10 +93,8 @@ testutils = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["git", "git2"]
+default = ["git"]
 git = ["dep:gix"]
-git2 = ["git", "dep:git2"]
-vendored-openssl = ["git2/vendored-openssl"]
 watchman = ["dep:tokio", "dep:watchman_client"]
 testing = ["git"]
 

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -12,7 +12,6 @@ register-snapshot-trigger = false
 [git]
 abandon-unreachable-commits = true
 auto-local-bookmark = false
-subprocess = true
 executable-path = "git"
 write-change-id-header = false
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2207,11 +2207,10 @@ impl<'a> GitFetch<'a> {
     }
 
     /// Queries remote for the default branch name.
-    #[tracing::instrument(skip(self, _callbacks))]
+    #[tracing::instrument(skip(self))]
     pub fn get_default_branch(
         &self,
         remote_name: &RemoteName,
-        _callbacks: RemoteCallbacks<'_>,
     ) -> Result<Option<RefNameBuf>, GitFetchError> {
         if self
             .git_repo

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2338,7 +2338,7 @@ pub fn push_updates(
     git_settings: &GitSettings,
     remote_name: &RemoteName,
     updates: &[GitRefUpdate],
-    callbacks: RemoteCallbacks<'_>,
+    mut callbacks: RemoteCallbacks<'_>,
 ) -> Result<GitPushStats, GitPushError> {
     let mut qualified_remote_refs_expected_locations = HashMap::new();
     let mut refspecs = vec![];
@@ -2359,31 +2359,12 @@ pub fn push_updates(
             refspecs.push(RefSpec::delete(&update.qualified_name));
         }
     }
-    // TODO(ilyagr): `push_refs`, or parts of it, should probably be inlined. This
-    // requires adjusting some tests.
 
     let git_backend = get_git_backend(repo.store())?;
     let git_repo = git_backend.git_repo();
     let git_ctx =
         GitSubprocessContext::from_git_backend(git_backend, &git_settings.executable_path);
-    subprocess_push_refs(
-        &git_repo,
-        &git_ctx,
-        remote_name,
-        &qualified_remote_refs_expected_locations,
-        &refspecs,
-        callbacks,
-    )
-}
 
-fn subprocess_push_refs(
-    git_repo: &gix::Repository,
-    git_ctx: &GitSubprocessContext,
-    remote_name: &RemoteName,
-    qualified_remote_refs_expected_locations: &HashMap<&GitRefName, Option<&CommitId>>,
-    refspecs: &[RefSpec],
-    mut callbacks: RemoteCallbacks<'_>,
-) -> Result<GitPushStats, GitPushError> {
     // check the remote exists
     if git_repo.try_find_remote(remote_name.as_str()).is_none() {
         return Err(GitPushError::NoSuchRemote(remote_name.to_owned()));
@@ -2391,7 +2372,7 @@ fn subprocess_push_refs(
 
     let refs_to_push: Vec<RefToPush> = refspecs
         .iter()
-        .map(|full_refspec| RefToPush::new(full_refspec, qualified_remote_refs_expected_locations))
+        .map(|full_refspec| RefToPush::new(full_refspec, &qualified_remote_refs_expected_locations))
         .collect();
 
     let mut push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, &mut callbacks)?;

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2084,14 +2084,6 @@ pub enum GitFetchError {
     Subprocess(#[from] GitSubprocessError),
 }
 
-// TODO: If Git2 implementation is removed, this can be replaced with
-// UnexpectedGitBackendError.
-#[derive(Debug, Error)]
-pub enum GitFetchPrepareError {
-    #[error(transparent)]
-    UnexpectedBackend(#[from] UnexpectedGitBackendError),
-}
-
 struct FetchedBranches {
     remote: RemoteNameBuf,
     branches: Vec<StringPattern>,
@@ -2109,7 +2101,7 @@ impl<'a> GitFetch<'a> {
     pub fn new(
         mut_repo: &'a mut MutableRepo,
         git_settings: &'a GitSettings,
-    ) -> Result<Self, GitFetchPrepareError> {
+    ) -> Result<Self, UnexpectedGitBackendError> {
         let fetch_impl = GitFetchImpl::new(mut_repo.store(), git_settings)?;
         Ok(GitFetch {
             mut_repo,
@@ -2220,7 +2212,10 @@ enum GitFetchImpl<'a> {
 }
 
 impl<'a> GitFetchImpl<'a> {
-    fn new(store: &Store, git_settings: &'a GitSettings) -> Result<Self, GitFetchPrepareError> {
+    fn new(
+        store: &Store,
+        git_settings: &'a GitSettings,
+    ) -> Result<Self, UnexpectedGitBackendError> {
         let git_backend = get_git_backend(store)?;
         let git_repo = Box::new(git_backend.git_repo());
         let git_ctx =

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2283,7 +2283,7 @@ impl<'a> GitFetchImpl<'a> {
     fn new(store: &Store, git_settings: &'a GitSettings) -> Result<Self, GitFetchPrepareError> {
         let git_backend = get_git_backend(store)?;
         #[cfg(feature = "git2")]
-        if !git_settings.subprocess {
+        if false {
             let git_repo = open_git2_repo(git_backend)?;
             return Ok(GitFetchImpl::Git2 { git_repo });
         }
@@ -2587,7 +2587,7 @@ pub fn push_updates(
 
     let git_backend = get_git_backend(repo.store())?;
     #[cfg(feature = "git2")]
-    if !git_settings.subprocess {
+    if false {
         let git_repo = open_git2_repo(git_backend)?;
         let refspecs: Vec<String> = refspecs.iter().map(RefSpec::to_git_format).collect();
         return git2_push_refs(

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -61,10 +61,6 @@ struct UserSettingsData {
 pub struct GitSettings {
     pub auto_local_bookmark: bool,
     pub abandon_unreachable_commits: bool,
-    // TODO: Remove this from the configuration schema when dropping
-    // `git2` support.
-    #[cfg(feature = "git2")]
-    pub subprocess: bool,
     pub executable_path: PathBuf,
     pub write_change_id_header: bool,
 }
@@ -74,8 +70,6 @@ impl GitSettings {
         Ok(GitSettings {
             auto_local_bookmark: settings.get_bool("git.auto-local-bookmark")?,
             abandon_unreachable_commits: settings.get_bool("git.abandon-unreachable-commits")?,
-            #[cfg(feature = "git2")]
-            subprocess: settings.get_bool("git.subprocess")?,
             executable_path: settings.get("git.executable-path")?,
             write_change_id_header: settings.get("git.write-change-id-header")?,
         })
@@ -87,8 +81,6 @@ impl Default for GitSettings {
         GitSettings {
             auto_local_bookmark: false,
             abandon_unreachable_commits: true,
-            #[cfg(feature = "git2")]
-            subprocess: true,
             executable_path: PathBuf::from("git"),
             write_change_id_header: false,
         }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -148,8 +148,7 @@ fn git_fetch(
         git::RemoteCallbacks::default(),
         None,
     )?;
-    let default_branch =
-        git_fetch.get_default_branch(remote_name, git::RemoteCallbacks::default())?;
+    let default_branch = git_fetch.get_default_branch(remote_name)?;
 
     let import_stats = git_fetch.import_refs().unwrap();
     let stats = GitFetchStats {

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -2836,10 +2836,10 @@ fn test_init() {
     assert!(!repo.view().heads().contains(&jj_id(initial_git_commit)));
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_empty_repo(subprocess: bool) {
+#[test]
+fn test_fetch_empty_repo() {
     let test_data = GitRepoData::create();
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     let mut tx = test_data.repo.start_transaction();
     let stats = git_fetch(
@@ -2856,12 +2856,12 @@ fn test_fetch_empty_repo(subprocess: bool) {
     assert_eq!(tx.repo().view().bookmarks().count(), 0);
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
+#[test]
+fn test_fetch_initial_commit_head_is_not_set() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(subprocess)
+        ..get_git_settings(true)
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -2904,12 +2904,12 @@ fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
     );
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_initial_commit_head_is_set(subprocess: bool) {
+#[test]
+fn test_fetch_initial_commit_head_is_set() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(subprocess)
+        ..get_git_settings(true)
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
     testutils::git::set_symbolic_reference(&test_data.origin_repo, "HEAD", "refs/heads/main");
@@ -2941,12 +2941,12 @@ fn test_fetch_initial_commit_head_is_set(subprocess: bool) {
     assert!(stats.import_stats.abandoned_commits.is_empty());
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_success(subprocess: bool) {
+#[test]
+fn test_fetch_success() {
     let mut test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(subprocess)
+        ..get_git_settings(true)
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -3022,12 +3022,12 @@ fn test_fetch_success(subprocess: bool) {
     );
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_prune_deleted_ref(subprocess: bool) {
+#[test]
+fn test_fetch_prune_deleted_ref() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(subprocess)
+        ..get_git_settings(true)
     };
     let commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -3068,12 +3068,12 @@ fn test_fetch_prune_deleted_ref(subprocess: bool) {
         .is_absent());
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_no_default_branch(subprocess: bool) {
+#[test]
+fn test_fetch_no_default_branch() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(subprocess)
+        ..get_git_settings(true)
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -3107,10 +3107,10 @@ fn test_fetch_no_default_branch(subprocess: bool) {
     assert_eq!(stats.default_branch, None);
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_empty_refspecs(subprocess: bool) {
+#[test]
+fn test_fetch_empty_refspecs() {
     let test_data = GitRepoData::create();
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
     empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     // Base refspecs shouldn't be respected
@@ -3128,10 +3128,10 @@ fn test_fetch_empty_refspecs(subprocess: bool) {
         .is_absent());
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_fetch_no_such_remote(subprocess: bool) {
+#[test]
+fn test_fetch_no_such_remote() {
     let test_data = GitRepoData::create();
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
     let mut tx = test_data.repo.start_transaction();
     let result = git_fetch(
         tx.repo_mut(),
@@ -3267,14 +3267,14 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_bookmarks_success(subprocess: bool) {
+#[test]
+fn test_push_bookmarks_success() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let clone_repo = get_git_repo(&setup.jj_repo);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     let targets = GitBranchPushTargets {
         branch_updates: vec![(
@@ -3335,14 +3335,14 @@ fn test_push_bookmarks_success(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_bookmarks_deletion(subprocess: bool) {
+#[test]
+fn test_push_bookmarks_deletion() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let clone_repo = get_git_repo(&setup.jj_repo);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     let source_repo = testutils::git::open(&setup.source_repo_dir);
     // Test the setup
@@ -3398,13 +3398,13 @@ fn test_push_bookmarks_deletion(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
+#[test]
+fn test_push_bookmarks_mixed_deletion_and_addition() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     let targets = GitBranchPushTargets {
         branch_updates: vec![
@@ -3477,13 +3477,13 @@ fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_bookmarks_not_fast_forward(subprocess: bool) {
+#[test]
+fn test_push_bookmarks_not_fast_forward() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     let targets = GitBranchPushTargets {
         branch_updates: vec![(
@@ -3519,12 +3519,12 @@ fn test_push_bookmarks_not_fast_forward(subprocess: bool) {
 // may want to add tests for when a bookmark unexpectedly moved backwards or
 // unexpectedly does not exist for bookmark deletion.
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_updates_unexpectedly_moved_sideways_on_remote(subprocess: bool) {
+#[test]
+fn test_push_updates_unexpectedly_moved_sideways_on_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     // The main bookmark is actually at `main_commit` on the remote. If we expect
     // it to be at `sideways_commit`, it unexpectedly moved sideways from our
@@ -3595,12 +3595,12 @@ fn test_push_updates_unexpectedly_moved_sideways_on_remote(subprocess: bool) {
     );
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_updates_unexpectedly_moved_forward_on_remote(subprocess: bool) {
+#[test]
+fn test_push_updates_unexpectedly_moved_forward_on_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     // The main bookmark is actually at `main_commit` on the remote. If we
     // expected it to be at `parent_of_commit`, it unexpectedly moved forward
@@ -3654,7 +3654,7 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote(subprocess: bool) {
         ["refs/heads/main"].map(GitRefNameBuf::from)
     );
 
-    if subprocess {
+    if true {
         // git is strict about honouring the expected location on --force-with-lease
         assert_eq!(
             push_status_rejected_references(
@@ -3676,12 +3676,12 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_updates_unexpectedly_exists_on_remote(subprocess: bool) {
+#[test]
+fn test_push_updates_unexpectedly_exists_on_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
 
     // The main bookmark is actually at `main_commit` on the remote. In this test,
     // we expect it to not exist on the remote at all.
@@ -3714,7 +3714,7 @@ fn test_push_updates_unexpectedly_exists_on_remote(subprocess: bool) {
         ["refs/heads/main"].map(GitRefNameBuf::from)
     );
 
-    if subprocess {
+    if true {
         // Git is strict with enforcing the expected location
         assert_eq!(
             push_status_rejected_references(
@@ -3736,12 +3736,12 @@ fn test_push_updates_unexpectedly_exists_on_remote(subprocess: bool) {
     }
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_updates_success(subprocess: bool) {
+#[test]
+fn test_push_updates_success() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
     let clone_repo = get_git_repo(&setup.jj_repo);
     let result = git::push_updates(
         setup.jj_repo.as_ref(),
@@ -3777,12 +3777,12 @@ fn test_push_updates_success(subprocess: bool) {
     assert_eq!(new_target.target().id(), new_oid);
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_updates_no_such_remote(subprocess: bool) {
+#[test]
+fn test_push_updates_no_such_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
     let result = git::push_updates(
         setup.jj_repo.as_ref(),
         &git_settings,
@@ -3797,12 +3797,12 @@ fn test_push_updates_no_such_remote(subprocess: bool) {
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
 }
 
-#[test_case(true; "spawn a git subprocess for remote calls")]
-fn test_push_updates_invalid_remote(subprocess: bool) {
+#[test]
+fn test_push_updates_invalid_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(subprocess);
+    let git_settings = get_git_settings(true);
     let result = git::push_updates(
         setup.jj_repo.as_ref(),
         &git_settings,

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -136,11 +136,8 @@ fn get_git_repo(repo: &Arc<ReadonlyRepo>) -> gix::Repository {
 }
 
 fn get_git_settings(subprocess: bool) -> GitSettings {
-    #[cfg(not(feature = "git2"))]
     assert!(subprocess);
     GitSettings {
-        #[cfg(feature = "git2")]
-        subprocess,
         ..Default::default()
     }
 }
@@ -2839,7 +2836,6 @@ fn test_init() {
     assert!(!repo.view().heads().contains(&jj_id(initial_git_commit)));
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_empty_repo(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -2860,7 +2856,6 @@ fn test_fetch_empty_repo(subprocess: bool) {
     assert_eq!(tx.repo().view().bookmarks().count(), 0);
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -2909,7 +2904,6 @@ fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
     );
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_initial_commit_head_is_set(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -2947,7 +2941,6 @@ fn test_fetch_initial_commit_head_is_set(subprocess: bool) {
     assert!(stats.import_stats.abandoned_commits.is_empty());
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_success(subprocess: bool) {
     let mut test_data = GitRepoData::create();
@@ -3029,7 +3022,6 @@ fn test_fetch_success(subprocess: bool) {
     );
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_prune_deleted_ref(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -3076,7 +3068,6 @@ fn test_fetch_prune_deleted_ref(subprocess: bool) {
         .is_absent());
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_no_default_branch(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -3116,7 +3107,6 @@ fn test_fetch_no_default_branch(subprocess: bool) {
     assert_eq!(stats.default_branch, None);
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_empty_refspecs(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -3138,7 +3128,6 @@ fn test_fetch_empty_refspecs(subprocess: bool) {
         .is_absent());
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_fetch_no_such_remote(subprocess: bool) {
     let test_data = GitRepoData::create();
@@ -3278,7 +3267,6 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_success(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3347,7 +3335,6 @@ fn test_push_bookmarks_success(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_deletion(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3411,7 +3398,6 @@ fn test_push_bookmarks_deletion(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3491,7 +3477,6 @@ fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
     assert!(!tx.repo().has_changes());
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_bookmarks_not_fast_forward(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3534,7 +3519,6 @@ fn test_push_bookmarks_not_fast_forward(subprocess: bool) {
 // may want to add tests for when a bookmark unexpectedly moved backwards or
 // unexpectedly does not exist for bookmark deletion.
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_unexpectedly_moved_sideways_on_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3611,7 +3595,6 @@ fn test_push_updates_unexpectedly_moved_sideways_on_remote(subprocess: bool) {
     );
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_unexpectedly_moved_forward_on_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3693,7 +3676,6 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_unexpectedly_exists_on_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3754,7 +3736,6 @@ fn test_push_updates_unexpectedly_exists_on_remote(subprocess: bool) {
     }
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_success(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3796,7 +3777,6 @@ fn test_push_updates_success(subprocess: bool) {
     assert_eq!(new_target.target().id(), new_oid);
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_no_such_remote(subprocess: bool) {
     let settings = testutils::user_settings();
@@ -3817,7 +3797,6 @@ fn test_push_updates_no_such_remote(subprocess: bool) {
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
 }
 
-#[cfg_attr(feature = "git2", test_case(false; "use git2 for remote calls"))]
 #[test_case(true; "spawn a git subprocess for remote calls")]
 fn test_push_updates_invalid_remote(subprocess: bool) {
     let settings = testutils::user_settings();

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -135,13 +135,6 @@ fn get_git_repo(repo: &Arc<ReadonlyRepo>) -> gix::Repository {
     get_git_backend(repo).git_repo()
 }
 
-fn get_git_settings(subprocess: bool) -> GitSettings {
-    assert!(subprocess);
-    GitSettings {
-        ..Default::default()
-    }
-}
-
 fn git_fetch(
     mut_repo: &mut MutableRepo,
     remote_name: &RemoteName,
@@ -2839,7 +2832,7 @@ fn test_init() {
 #[test]
 fn test_fetch_empty_repo() {
     let test_data = GitRepoData::create();
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     let mut tx = test_data.repo.start_transaction();
     let stats = git_fetch(
@@ -2861,7 +2854,7 @@ fn test_fetch_initial_commit_head_is_not_set() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(true)
+        ..GitSettings::default()
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -2909,7 +2902,7 @@ fn test_fetch_initial_commit_head_is_set() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(true)
+        ..GitSettings::default()
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
     testutils::git::set_symbolic_reference(&test_data.origin_repo, "HEAD", "refs/heads/main");
@@ -2946,7 +2939,7 @@ fn test_fetch_success() {
     let mut test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(true)
+        ..GitSettings::default()
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -3027,7 +3020,7 @@ fn test_fetch_prune_deleted_ref() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(true)
+        ..GitSettings::default()
     };
     let commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -3073,7 +3066,7 @@ fn test_fetch_no_default_branch() {
     let test_data = GitRepoData::create();
     let git_settings = GitSettings {
         auto_local_bookmark: true,
-        ..get_git_settings(true)
+        ..GitSettings::default()
     };
     let initial_git_commit = empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
@@ -3110,7 +3103,7 @@ fn test_fetch_no_default_branch() {
 #[test]
 fn test_fetch_empty_refspecs() {
     let test_data = GitRepoData::create();
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
     empty_git_commit(&test_data.origin_repo, "refs/heads/main", &[]);
 
     // Base refspecs shouldn't be respected
@@ -3131,7 +3124,7 @@ fn test_fetch_empty_refspecs() {
 #[test]
 fn test_fetch_no_such_remote() {
     let test_data = GitRepoData::create();
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
     let mut tx = test_data.repo.start_transaction();
     let result = git_fetch(
         tx.repo_mut(),
@@ -3274,7 +3267,7 @@ fn test_push_bookmarks_success() {
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let clone_repo = get_git_repo(&setup.jj_repo);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     let targets = GitBranchPushTargets {
         branch_updates: vec![(
@@ -3342,7 +3335,7 @@ fn test_push_bookmarks_deletion() {
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let clone_repo = get_git_repo(&setup.jj_repo);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     let source_repo = testutils::git::open(&setup.source_repo_dir);
     // Test the setup
@@ -3404,7 +3397,7 @@ fn test_push_bookmarks_mixed_deletion_and_addition() {
     let temp_dir = testutils::new_temp_dir();
     let mut setup = set_up_push_repos(&settings, &temp_dir);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     let targets = GitBranchPushTargets {
         branch_updates: vec![
@@ -3483,7 +3476,7 @@ fn test_push_bookmarks_not_fast_forward() {
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
     let mut tx = setup.jj_repo.start_transaction();
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     let targets = GitBranchPushTargets {
         branch_updates: vec![(
@@ -3524,7 +3517,7 @@ fn test_push_updates_unexpectedly_moved_sideways_on_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     // The main bookmark is actually at `main_commit` on the remote. If we expect
     // it to be at `sideways_commit`, it unexpectedly moved sideways from our
@@ -3600,7 +3593,7 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     // The main bookmark is actually at `main_commit` on the remote. If we
     // expected it to be at `parent_of_commit`, it unexpectedly moved forward
@@ -3681,7 +3674,7 @@ fn test_push_updates_unexpectedly_exists_on_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
 
     // The main bookmark is actually at `main_commit` on the remote. In this test,
     // we expect it to not exist on the remote at all.
@@ -3741,7 +3734,7 @@ fn test_push_updates_success() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
     let clone_repo = get_git_repo(&setup.jj_repo);
     let result = git::push_updates(
         setup.jj_repo.as_ref(),
@@ -3782,7 +3775,7 @@ fn test_push_updates_no_such_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
     let result = git::push_updates(
         setup.jj_repo.as_ref(),
         &git_settings,
@@ -3802,7 +3795,7 @@ fn test_push_updates_invalid_remote() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let setup = set_up_push_repos(&settings, &temp_dir);
-    let git_settings = get_git_settings(true);
+    let git_settings = GitSettings::default();
     let result = git::push_updates(
         setup.jj_repo.as_ref(),
         &git_settings,

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -3647,26 +3647,13 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote() {
         ["refs/heads/main"].map(GitRefNameBuf::from)
     );
 
-    if true {
-        // git is strict about honouring the expected location on --force-with-lease
-        assert_eq!(
-            push_status_rejected_references(
-                attempt_push_expecting_parent(Some(setup.child_of_main_commit.id().clone()))
-                    .unwrap()
-            ),
-            ["refs/heads/main"].map(GitRefNameBuf::from)
-        );
-    } else {
-        // Moving the bookmark *forwards* is OK, as an exception matching our bookmark
-        // conflict resolution rules
-        assert_eq!(
-            attempt_push_expecting_parent(Some(setup.child_of_main_commit.id().clone())).unwrap(),
-            GitPushStats {
-                pushed: vec!["refs/heads/main".into()],
-                ..Default::default()
-            }
-        );
-    }
+    // git is strict about honouring the expected location on --force-with-lease
+    assert_eq!(
+        push_status_rejected_references(
+            attempt_push_expecting_parent(Some(setup.child_of_main_commit.id().clone())).unwrap()
+        ),
+        ["refs/heads/main"].map(GitRefNameBuf::from)
+    );
 }
 
 #[test]
@@ -3707,26 +3694,13 @@ fn test_push_updates_unexpectedly_exists_on_remote() {
         ["refs/heads/main"].map(GitRefNameBuf::from)
     );
 
-    if true {
-        // Git is strict with enforcing the expected location
-        assert_eq!(
-            push_status_rejected_references(
-                attempt_push_expecting_absence(Some(setup.child_of_main_commit.id().clone()))
-                    .unwrap()
-            ),
-            ["refs/heads/main"].map(GitRefNameBuf::from)
-        );
-    } else {
-        // In git2: We *can* move the bookmark forward even if we didn't expect it to
-        // exist
-        assert_eq!(
-            attempt_push_expecting_absence(Some(setup.child_of_main_commit.id().clone())).unwrap(),
-            GitPushStats {
-                pushed: vec!["refs/heads/main".into()],
-                ..Default::default()
-            }
-        );
-    }
+    // Git is strict with enforcing the expected location
+    assert_eq!(
+        push_status_rejected_references(
+            attempt_push_expecting_absence(Some(setup.child_of_main_commit.id().clone())).unwrap()
+        ),
+        ["refs/heads/main"].map(GitRefNameBuf::from)
+    );
 }
 
 #[test]

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -85,7 +85,7 @@ pub fn hermetic_git() {
     // gitoxide API use in tests, Config::isolated() is probably better.
     env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
     env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
-    // gitoxide uses "main" as the default branch name, whereas git and libgit2
+    // gitoxide uses "main" as the default branch name, whereas git
     // uses "master".
     env::set_var("GIT_CONFIG_KEY_0", "init.defaultBranch");
     env::set_var("GIT_CONFIG_VALUE_0", "master");

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -81,17 +81,6 @@ pub mod test_backend;
 // somewhat tricky because `gix` looks at system and user configuration, and
 // `GitBackend` also calls into `git(1)` for things like garbage collection.
 pub fn hermetic_git() {
-    // TODO: Remove these with `git2` support.
-    {
-        env::set_var("JJ_DEBUG_HERMETIC_GIT2", "1");
-        if cfg!(target_os = "windows") {
-            env::set_var("PROGRAMDATA", "\\jj-test-nonexistent-xdg-config-home");
-            env::set_var("XDG_CONFIG_HOME", "\\jj-test-nonexistent-xdg-config-home");
-        } else {
-            env::set_var("XDG_CONFIG_HOME", "/jj-test-nonexistent-xdg-config-home");
-        }
-    }
-
     // Prevent GitBackend from loading user and system configurations. For
     // gitoxide API use in tests, Config::isolated() is probably better.
     env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");


### PR DESCRIPTION
The last mile of the journey, for after https://github.com/jj-vcs/jj/pull/6047 is merged and the deprecation period is over.

The first couple of commits are functional changes and the rest are just very gradually removing a lot of dead code and tidying up. I’ve tried to structure them so that it's easy to review commit‐by‐commit and the largest commits are entirely mechanical.

I probably won’t rebase this much until it’s time to actually merge, but the approach should be ready for review.
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
