### PR TITLE
git: add more targetted debug logging for subprocess code

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2207,6 +2207,7 @@ fn subprocess_fetch(
     while let Some(failing_refspec) =
         git_ctx.spawn_fetch(remote_name, &remaining_refspecs, &mut callbacks, depth)?
     {
+        tracing::debug!(failing_refspec, "failed to fetch ref");
         remaining_refspecs.retain(|r| r.source.as_ref() != Some(&failing_refspec));
 
         if let Some(branch_name) = failing_refspec.strip_prefix("refs/heads/") {
@@ -2507,6 +2508,7 @@ fn subprocess_push_refs(
         .collect();
 
     let push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, &mut callbacks)?;
+    tracing::debug!(?push_stats);
 
     if !push_stats.rejected.is_empty() {
         let mut refs_in_unexpected_locations = push_stats.rejected;


### PR DESCRIPTION
In recent bugs, it's been really hard to triage the behaviour from the existing debug logs.

In particular, there have been situations where the `git` command is not enough to triage, because the bug stems from a particular environment/config issue. Moreover, these bugs are either transient, and as such hard to replicate, or they only manifest when spawning `git` from `jj` (and as such re-running the `git` command does not yield useful information).

In those cases, seeing what the subprocessing code is seeing becomes very much useful. This commit adds some debug logging to help with this problem.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
