### PR TITLE
github: simple CI speed‐ups

### DIFF
--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -3,21 +3,4 @@ description: |
   This action configures the Windows builders to run tests.
 runs:
   using: "composite"
-  steps:
-    # The default version of gpg installed on the runners is a version baked in with git
-    # which only contains the components needed by git and doesn't work for our test cases.
-    #
-    # This installs the latest gpg4win version, which is a variation of GnuPG built for
-    # Windows.
-    #
-    # There is some issue with windows PATH max length which is what all the PATH wrangling
-    # below is for. Please see the below link for where this fix was derived from:
-    # https://github.com/orgs/community/discussions/24933
-    - name: Set up GnuPG [windows]
-      if: startsWith(matrix.os, 'windows')
-      shell: pwsh
-      run: |
-        $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin"
-        [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
-        choco install --yes gpg4win
-        echo "C:\Program Files (x86)\Gpg4win\..\GnuPG\bin" >> $env:GITHUB_PATH
+  steps: []

--- a/.github/actions/setup-windows/action.yml
+++ b/.github/actions/setup-windows/action.yml
@@ -21,13 +21,3 @@ runs:
         [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
         choco install --yes gpg4win
         echo "C:\Program Files (x86)\Gpg4win\..\GnuPG\bin" >> $env:GITHUB_PATH
-
-    # The default version of openssh on windows server is quite old (8.1) and doesn't have
-    # all the necessary signing/verification commands available (such as -Y find-principals)
-    - name: Set up ssh-agent [windows]
-      if: startsWith(matrix.os, 'windows')
-      shell: pwsh
-      run: |
-        Remove-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-        Remove-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
-        choco install openssh --pre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         tool: nextest,taplo-cli
     - name: Build
       run: cargo build --target ${{ matrix.target }} --workspace --all-targets --verbose ${{ matrix.cargo_flags }}
+      env:
+        LIBGIT2_NO_VENDOR: ${{ matrix.LIBGIT2_NO_VENDOR || '0' }}
     - name: Test
       run: cargo nextest run --target ${{ matrix.target }} --workspace --profile ci --all-targets --verbose ${{ matrix.cargo_flags }}
       env:


### PR DESCRIPTION
Fixes a one to two minute CI speed regression from https://github.com/jj-vcs/jj/pull/5956, and shaves another couple minutes off the Windows build. I’ll leave the GnuPG hack commit in here to demonstrate that it works in CI and remove it after this is approved. (https://github.com/jj-vcs/jj/pull/5854 is the longer‐term solution and we should land it.)

More ambitious wins to come, but these are really simple and should get the Windows build down from ~16 minutes to ~13. I’ve left the empty `setup-windows` action because I plan to put more stuff back in it.
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
