### PR TITLE
docs: fish shell enables completions by default

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -257,6 +257,10 @@ source <(COMPLETE=zsh jj)
 
 ### Fish
 
+!!! note
+
+    No configuration is required with fish >= 4.1 which loads dynamic completions by default.
+
 #### Standard
 
 ```shell


### PR DESCRIPTION
To avoid redundant computation, users who run `COMPLETE=fish jj | source`
in their ~/.config/fish/config.fish should eventually remove that, or move it
to ~/.config/fish/completions/jj.fish which overrides the default completions.

Ref: https://github.com/fish-shell/fish-shell/pull/11046
