### PR TITLE
repo: suppress warning about unused SimpleBackend on non-dev build

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -396,7 +396,6 @@ impl Default for StoreFactories {
         let mut factories = StoreFactories::empty();
 
         // Backends
-        #[cfg(feature = "testing")]
         factories.add_backend(
             SimpleBackend::name(),
             Box::new(|_settings, store_path| Ok(Box::new(SimpleBackend::load(store_path)))),


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
