### PR TITLE
Make debug output for StringPatttern::Glob and `jj git fetch --debug` less verbose

### DIFF
--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -77,7 +77,7 @@ pub struct GitFetchArgs {
     all_remotes: bool,
 }
 
-#[tracing::instrument(skip(ui, command))]
+#[tracing::instrument(skip_all)]
 pub fn cmd_git_fetch(
     ui: &mut Ui,
     command: &CommandHelper,


### PR DESCRIPTION
Previously, globs were printed extremely verbosely and all the important arguments were repeated twice for no reason.

The two commits are independent, I can split them into separate PRs if one is more controversial than the other.

Running `jj git fetch --remote upstream --branch main  --branch master --branch 'glob:gh-readonly-queue*' --branch 'glob:ig/*' --debug`

Previously:

```
2025-03-18T05:11:35.515812Z  INFO jj_cli::cli_util: debug logging enabled
2025-03-18T05:11:35.528165Z DEBUG run_command:cmd_git_fetch{args=GitFetchArgs { branch: [Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })], remotes: [Exact("upstream")], all_remotes: false }}:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })] depth=None}: jj_lib::git_subprocess: spawning a git subprocess cmd=LC_ALL="C" "git" "--git-dir" "/Users/ilyagr/dev/jj/.git" "fetch" "--prune" "--no-write-fetch-head" "--progress" "--" "upstream" "+refs/heads/main:refs/remotes/upstream/main" "+refs/heads/master:refs/remotes/upstream/master" "+refs/heads/gh-readonly-queue*:refs/remotes/upstream/gh-readonly-queue*" "+refs/heads/ig/*:refs/remotes/upstream/ig/*"
2025-03-18T05:11:36.865710Z DEBUG run_command:cmd_git_fetch{args=GitFetchArgs { branch: [Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })], remotes: [Exact("upstream")], all_remotes: false }}:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })] depth=None}: jj_lib::git: failed to fetch ref failing_refspec="refs/heads/master"
2025-03-18T05:11:36.865893Z DEBUG run_command:cmd_git_fetch{args=GitFetchArgs { branch: [Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })], remotes: [Exact("upstream")], all_remotes: false }}:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })] depth=None}: jj_lib::git_subprocess: spawning a git subprocess cmd=LC_ALL="C" "git" "--git-dir" "/Users/ilyagr/dev/jj/.git" "fetch" "--prune" "--no-write-fetch-head" "--progress" "--" "upstream" "+refs/heads/main:refs/remotes/upstream/main" "+refs/heads/gh-readonly-queue*:refs/remotes/upstream/gh-readonly-queue*" "+refs/heads/ig/*:refs/remotes/upstream/ig/*"
2025-03-18T05:11:38.151298Z DEBUG run_command:cmd_git_fetch{args=GitFetchArgs { branch: [Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })], remotes: [Exact("upstream")], all_remotes: false }}:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })] depth=None}: jj_lib::git_subprocess: pruning branches branches_to_prune=["upstream/master"]
2025-03-18T05:11:38.151379Z DEBUG run_command:cmd_git_fetch{args=GitFetchArgs { branch: [Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })], remotes: [Exact("upstream")], all_remotes: false }}:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })] depth=None}: jj_lib::git_subprocess: spawning a git subprocess cmd=LC_ALL="C" "git" "--git-dir" "/Users/ilyagr/dev/jj/.git" "branch" "--remotes" "--delete" "--" "upstream/master"
2025-03-18T05:11:38.156114Z DEBUG run_command:cmd_git_fetch{args=GitFetchArgs { branch: [Exact("main"), Exact("master"), Glob(Pattern { original: "gh-readonly-queue*", tokens: [Char('g'), Char('h'), Char('-'), Char('r'), Char('e'), Char('a'), Char('d'), Char('o'), Char('n'), Char('l'), Char('y'), Char('-'), Char('q'), Char('u'), Char('e'), Char('u'), Char('e'), AnySequence], is_recursive: false }), Glob(Pattern { original: "ig/*", tokens: [Char('i'), Char('g'), Char('/'), AnySequence], is_recursive: false })], remotes: [Exact("upstream")], all_remotes: false }}:import_refs: jj_lib::git: import_refs
Warning: No branch matching `master` found on any specified/configured remote
Warning: No branch matching `gh-readonly-queue*` found on any specified/configured remote
Nothing changed.
```

Now:

```
2025-03-18T05:07:30.553939Z  INFO jj_cli::cli_util: debug logging enabled
2025-03-18T05:07:30.632310Z DEBUG run_command:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(GlobPattern("gh-readonly-queue*")), Glob(GlobPattern("ig/*"))] depth=None}: jj_lib::git_subprocess: spawning a git subprocess cmd=LC_ALL="C" "git" "--git-dir" "/Users/ilyagr/dev/jj/.git" "fetch" "--prune" "--no-write-fetch-head" "--progress" "--" "upstream" "+refs/heads/main:refs/remotes/upstream/main" "+refs/heads/master:refs/remotes/upstream/master" "+refs/heads/gh-readonly-queue*:refs/remotes/upstream/gh-readonly-queue*" "+refs/heads/ig/*:refs/remotes/upstream/ig/*"
2025-03-18T05:07:31.986980Z DEBUG run_command:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(GlobPattern("gh-readonly-queue*")), Glob(GlobPattern("ig/*"))] depth=None}: jj_lib::git: failed to fetch ref failing_refspec="refs/heads/master"
2025-03-18T05:07:31.988300Z DEBUG run_command:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(GlobPattern("gh-readonly-queue*")), Glob(GlobPattern("ig/*"))] depth=None}: jj_lib::git_subprocess: spawning a git subprocess cmd=LC_ALL="C" "git" "--git-dir" "/Users/ilyagr/dev/jj/.git" "fetch" "--prune" "--no-write-fetch-head" "--progress" "--" "upstream" "+refs/heads/main:refs/remotes/upstream/main" "+refs/heads/gh-readonly-queue*:refs/remotes/upstream/gh-readonly-queue*" "+refs/heads/ig/*:refs/remotes/upstream/ig/*"
2025-03-18T05:07:33.321225Z DEBUG run_command:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(GlobPattern("gh-readonly-queue*")), Glob(GlobPattern("ig/*"))] depth=None}: jj_lib::git_subprocess: pruning branches branches_to_prune=["upstream/master"]
2025-03-18T05:07:33.321292Z DEBUG run_command:fetch{remote_name="upstream" branch_names=[Exact("main"), Exact("master"), Glob(GlobPattern("gh-readonly-queue*")), Glob(GlobPattern("ig/*"))] depth=None}: jj_lib::git_subprocess: spawning a git subprocess cmd=LC_ALL="C" "git" "--git-dir" "/Users/ilyagr/dev/jj/.git" "branch" "--remotes" "--delete" "--" "upstream/master"
2025-03-18T05:07:33.325834Z DEBUG run_command:import_refs: jj_lib::git: import_refs
Warning: No branch matching `master` found on any specified/configured remote
Warning: No branch matching `gh-readonly-queue*` found on any specified/configured remote
Nothing changed.
```

(Hint: open the markdown editor or try "Quote reply" to enable wrapping and see the difference more clearly)