### PR TITLE
git: forward rejection reason on push

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -554,16 +554,6 @@ jj currently does not support partial clones. To use jj with this repository, tr
                     err,
                     "Run `jj git remote rename` to give a different name.",
                 ),
-                GitPushError::RefInUnexpectedLocation(refs) => user_error_with_hint(
-                    format!(
-                        "Refusing to push a bookmark that unexpectedly moved on the remote. \
-                         Affected refs: {}",
-                        refs.join(", ")
-                    ),
-                    "Try fetching from the remote, then make the bookmark point to where you want \
-                     it to be, and push again.",
-                ),
-                GitPushError::RefUpdateRejected(_) => user_error(err),
                 #[cfg(feature = "git2")]
                 GitPushError::InternalGitError(err) => map_git2_error(err),
                 GitPushError::Subprocess(_) => user_error(err),

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -393,9 +393,12 @@ fn process_push_stats(push_stats: &GitPushStats) -> Result<(), CommandError> {
                     formatter,
                     "The following references unexpectedly moved on the remote:"
                 )?;
-                for reference in &push_stats.rejected {
+                for (reference, reason) in &push_stats.rejected {
                     write!(formatter, "  ")?;
                     write!(formatter.labeled("git_ref"), "{reference}")?;
+                    if let Some(r) = reason {
+                        write!(formatter, " (reason: {r})")?;
+                    }
                     writeln!(formatter)?;
                 }
                 Ok(())
@@ -408,9 +411,12 @@ fn process_push_stats(push_stats: &GitPushStats) -> Result<(), CommandError> {
         if !push_stats.remote_rejected.is_empty() {
             error.add_formatted_hint_with(|formatter| {
                 writeln!(formatter, "The remote rejected the following updates:")?;
-                for reference in &push_stats.remote_rejected {
+                for (reference, reason) in &push_stats.remote_rejected {
                     write!(formatter, "  ")?;
                     write!(formatter.labeled("git_ref"), "{reference}")?;
+                    if let Some(r) = reason {
+                        write!(formatter, " (reason: {r})")?;
+                    }
                     writeln!(formatter)?;
                 }
                 Ok(())

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -365,7 +365,9 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
     ------- stderr -------
     Changes to push to origin:
       Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
-    Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
     [EOF]
     [exit status: 1]
@@ -425,7 +427,9 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
-    Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
     [EOF]
     [exit status: 1]
@@ -485,7 +489,9 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     ------- stderr -------
     Changes to push to origin:
       Delete bookmark bookmark1 from d13ecdbda2a2
-    Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
     [EOF]
     [exit status: 1]
@@ -542,7 +548,9 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
-    Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
     [EOF]
     [exit status: 1]
@@ -570,7 +578,9 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
         ------- stderr -------
         Changes to push to origin:
           Delete bookmark bookmark1 from d13ecdbda2a2
-        Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1
         Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
         [EOF]
         [exit status: 1]
@@ -626,7 +636,9 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     ------- stderr -------
     Changes to push to origin:
       Add bookmark bookmark1 to cb17dcdc74d5
-    Error: Refusing to push a bookmark that unexpectedly moved on the remote. Affected refs: refs/heads/bookmark1
+    Error: Failed to push some bookmarks
+    Hint: The following references unexpectedly moved on the remote:
+      refs/heads/bookmark1
     Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
     [EOF]
     [exit status: 1]
@@ -2155,15 +2167,18 @@ fn test_git_push_rejected_by_remote() {
     let mut settings = insta::Settings::clone_current();
     settings.add_filter(r"\s*\n", "\n");
     settings.bind(|| {
-        insta::assert_snapshot!(output, @r#"
+        insta::assert_snapshot!(output, @r"
         ------- stderr -------
         Changes to push to origin:
           Move forward bookmark bookmark1 from d13ecdbda2a2 to dd5c09b30f9f
         remote: error: hook declined to update refs/heads/bookmark1
-        Error: Remote rejected the update of some refs (do you have permission to push to ["refs/heads/bookmark1"]?)
+        Error: Failed to push some bookmarks
+        Hint: The remote rejected the following updates:
+          refs/heads/bookmark1
+        Hint: Try checking if you have permission to push to all the bookmarks.
         [EOF]
         [exit status: 1]
-        "#);
+        ");
     });
 }
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -360,18 +360,30 @@ fn test_git_push_forward_unexpectedly_moved(subprocess: bool) {
 
     // Pushing should fail
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Changes to push to origin:
-      Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
-    Error: Failed to push some bookmarks
-    Hint: The following references unexpectedly moved on the remote:
-      refs/heads/bookmark1
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    [EOF]
-    [exit status: 1]
-    ");
+    if subprocess {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1 (reason: stale info)
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
+    } else {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Move forward bookmark bookmark1 from d13ecdbda2a2 to 6750425ff51c
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
     }
 }
 
@@ -422,18 +434,30 @@ fn test_git_push_sideways_unexpectedly_moved(subprocess: bool) {
     }
 
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Changes to push to origin:
-      Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
-    Error: Failed to push some bookmarks
-    Hint: The following references unexpectedly moved on the remote:
-      refs/heads/bookmark1
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    [EOF]
-    [exit status: 1]
-    ");
+    if subprocess {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1 (reason: stale info)
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
+    } else {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 0f8bf988588e
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
     }
 }
 
@@ -484,18 +508,30 @@ fn test_git_push_deletion_unexpectedly_moved(subprocess: bool) {
     }
 
     let output = work_dir.run_jj(["git", "push", "--bookmark", "bookmark1"]);
-    insta::allow_duplicates! {
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Changes to push to origin:
-      Delete bookmark bookmark1 from d13ecdbda2a2
-    Error: Failed to push some bookmarks
-    Hint: The following references unexpectedly moved on the remote:
-      refs/heads/bookmark1
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    [EOF]
-    [exit status: 1]
-    ");
+    if subprocess {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Delete bookmark bookmark1 from d13ecdbda2a2
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1 (reason: stale info)
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
+    } else {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Delete bookmark bookmark1 from d13ecdbda2a2
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
     }
 }
 
@@ -543,18 +579,30 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
 
     // Pushing a moved bookmark fails if deleted on remote
     let output = work_dir.run_jj(["git", "push"]);
-    insta::allow_duplicates! {
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Changes to push to origin:
-      Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
-    Error: Failed to push some bookmarks
-    Hint: The following references unexpectedly moved on the remote:
-      refs/heads/bookmark1
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    [EOF]
-    [exit status: 1]
-    ");
+    if subprocess {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1 (reason: stale info)
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
+    } else {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Move sideways bookmark bookmark1 from d13ecdbda2a2 to 1ebe27ba04bf
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
     }
 
     work_dir
@@ -580,7 +628,7 @@ fn test_git_push_unexpectedly_deleted(subprocess: bool) {
           Delete bookmark bookmark1 from d13ecdbda2a2
         Error: Failed to push some bookmarks
         Hint: The following references unexpectedly moved on the remote:
-          refs/heads/bookmark1
+          refs/heads/bookmark1 (reason: stale info)
         Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
         [EOF]
         [exit status: 1]
@@ -631,18 +679,30 @@ fn test_git_push_creation_unexpectedly_already_exists(subprocess: bool) {
     }
 
     let output = work_dir.run_jj(["git", "push", "--allow-new"]);
-    insta::allow_duplicates! {
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Changes to push to origin:
-      Add bookmark bookmark1 to cb17dcdc74d5
-    Error: Failed to push some bookmarks
-    Hint: The following references unexpectedly moved on the remote:
-      refs/heads/bookmark1
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
-    [EOF]
-    [exit status: 1]
-    ");
+    if subprocess {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Add bookmark bookmark1 to cb17dcdc74d5
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1 (reason: stale info)
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
+    } else {
+        insta::assert_snapshot!(output, @r"
+        ------- stderr -------
+        Changes to push to origin:
+          Add bookmark bookmark1 to cb17dcdc74d5
+        Error: Failed to push some bookmarks
+        Hint: The following references unexpectedly moved on the remote:
+          refs/heads/bookmark1
+        Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+        [EOF]
+        [exit status: 1]
+        ");
     }
 }
 
@@ -2174,7 +2234,7 @@ fn test_git_push_rejected_by_remote() {
         remote: error: hook declined to update refs/heads/bookmark1
         Error: Failed to push some bookmarks
         Hint: The remote rejected the following updates:
-          refs/heads/bookmark1
+          refs/heads/bookmark1 (reason: hook declined)
         Hint: Try checking if you have permission to push to all the bookmarks.
         [EOF]
         [exit status: 1]

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -100,6 +100,23 @@ pub enum GitRefKind {
     Tag,
 }
 
+/// Stats from a git push
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct GitPushStats {
+    /// reference accepted by the remote
+    pub pushed: Vec<String>,
+    /// rejected reference, due to lease failure, with an optional reason
+    pub rejected: Vec<String>,
+    /// reference rejected by the remote, with an optional reason
+    pub remote_rejected: Vec<String>,
+}
+
+impl GitPushStats {
+    pub fn all_ok(&self) -> bool {
+        self.rejected.is_empty() && self.remote_rejected.is_empty()
+    }
+}
+
 /// Newtype to look up `HashMap` entry by key of shorter lifetime.
 ///
 /// https://users.rust-lang.org/t/unexpected-lifetime-issue-with-hashmap-remove/113961/6
@@ -2287,10 +2304,6 @@ pub enum GitPushError {
     NoSuchRemote(String),
     #[error(transparent)]
     RemoteName(#[from] GitRemoteNameError),
-    #[error("Refs in unexpected location: {0:?}")]
-    RefInUnexpectedLocation(Vec<String>),
-    #[error("Remote rejected the update of some refs (do you have permission to push to {0:?}?)")]
-    RefUpdateRejected(Vec<String>),
     // TODO: I'm sure there are other errors possible, such as transport-level errors,
     // and errors caused by the remote rejecting the push.
     #[cfg(feature = "git2")]
@@ -2324,7 +2337,7 @@ pub fn push_branches(
     remote: &str,
     targets: &GitBranchPushTargets,
     callbacks: RemoteCallbacks<'_>,
-) -> Result<(), GitPushError> {
+) -> Result<GitPushStats, GitPushError> {
     validate_remote_name(remote)?;
 
     let ref_updates = targets
@@ -2336,23 +2349,27 @@ pub fn push_branches(
             new_target: update.new_target.clone(),
         })
         .collect_vec();
-    push_updates(mut_repo, git_settings, remote, &ref_updates, callbacks)?;
+
+    let push_stats = push_updates(mut_repo, git_settings, remote, &ref_updates, callbacks)?;
+    tracing::debug!(?push_stats);
 
     // TODO: add support for partially pushed refs? we could update the view
     // excluding rejected refs, but the transaction would be aborted anyway
     // if we returned an Err.
-    for (name, update) in &targets.branch_updates {
-        let remote_symbol = RemoteRefSymbol { name, remote };
-        let git_ref_name = format!("refs/remotes/{remote}/{name}");
-        let new_remote_ref = RemoteRef {
-            target: RefTarget::resolved(update.new_target.clone()),
-            state: RemoteRefState::Tracking,
-        };
-        mut_repo.set_git_ref_target(&git_ref_name, new_remote_ref.target.clone());
-        mut_repo.set_remote_bookmark(remote_symbol, new_remote_ref);
+    if push_stats.all_ok() {
+        for (name, update) in &targets.branch_updates {
+            let remote_symbol = RemoteRefSymbol { name, remote };
+            let git_ref_name = format!("refs/remotes/{remote}/{name}");
+            let new_remote_ref = RemoteRef {
+                target: RefTarget::resolved(update.new_target.clone()),
+                state: RemoteRefState::Tracking,
+            };
+            mut_repo.set_git_ref_target(&git_ref_name, new_remote_ref.target.clone());
+            mut_repo.set_remote_bookmark(remote_symbol, new_remote_ref);
+        }
     }
 
-    Ok(())
+    Ok(push_stats)
 }
 
 /// Pushes the specified Git refs without updating the repo view.
@@ -2362,7 +2379,7 @@ pub fn push_updates(
     remote_name: &str,
     updates: &[GitRefUpdate],
     callbacks: RemoteCallbacks<'_>,
-) -> Result<(), GitPushError> {
+) -> Result<GitPushStats, GitPushError> {
     let mut qualified_remote_refs_expected_locations = HashMap::new();
     let mut refspecs = vec![];
     for update in updates {
@@ -2420,7 +2437,7 @@ fn git2_push_refs(
     qualified_remote_refs_expected_locations: &HashMap<&str, Option<&CommitId>>,
     refspecs: &[String],
     callbacks: RemoteCallbacks<'_>,
-) -> Result<(), GitPushError> {
+) -> Result<GitPushStats, GitPushError> {
     let mut remote = git_repo.find_remote(remote_name).map_err(|err| {
         if is_remote_not_found_err(&err) {
             GitPushError::NoSuchRemote(remote_name.to_string())
@@ -2428,11 +2445,14 @@ fn git2_push_refs(
             GitPushError::InternalGitError(err)
         }
     })?;
+
     let mut remaining_remote_refs: HashSet<_> = qualified_remote_refs_expected_locations
         .keys()
         .copied()
         .collect();
     let mut failed_push_negotiations = vec![];
+    let mut pushed_refs = vec![];
+
     let push_result = {
         let mut push_options = git2::PushOptions::new();
         let mut proxy_options = git2::ProxyOptions::new();
@@ -2492,6 +2512,7 @@ fn git2_push_refs(
                     }
                 }
             }
+
             if failed_push_negotiations.is_empty() {
                 Ok(())
             } else {
@@ -2499,42 +2520,52 @@ fn git2_push_refs(
             }
         });
         callbacks.push_update_reference(|refname, status| {
-            // The status is Some if the ref update was rejected
+            // The status is Some if the ref update was rejected by the remote
             if status.is_none() {
                 remaining_remote_refs.remove(refname);
+                pushed_refs.push(refname.to_owned());
             }
             Ok(())
         });
         push_options.remote_callbacks(callbacks);
         remote.push(refspecs, Some(&mut push_options))
     };
-    if !failed_push_negotiations.is_empty() {
+
+    for failed_update in &failed_push_negotiations {
+        remaining_remote_refs.remove(failed_update.as_str());
+    }
+    let rejected: Vec<_> = failed_push_negotiations.into_iter().sorted().collect();
+    let remote_rejected: Vec<_> = remaining_remote_refs
+        .into_iter()
+        .sorted()
+        .map(str::to_owned)
+        .collect();
+    pushed_refs.sort();
+
+    let push_stats = if !rejected.is_empty() {
         // If the push negotiation returned an error, `remote.push` would not
         // have pushed anything and would have returned an error, as expected.
         // However, the error it returns is not necessarily the error we'd
         // expect. It also depends on the exact versions of `libgit2` and
         // `git2.rs`. So, we cannot rely on it containing any useful
         // information. See https://github.com/rust-lang/git2-rs/issues/1042.
+
         assert!(push_result.is_err());
-        failed_push_negotiations.sort();
-        Err(GitPushError::RefInUnexpectedLocation(
-            failed_push_negotiations,
-        ))
+        GitPushStats {
+            rejected,
+            remote_rejected,
+            ..Default::default()
+        }
     } else {
         push_result?;
-        if remaining_remote_refs.is_empty() {
-            Ok(())
-        } else {
-            // remote rejected refs because of remote config (e.g., no push on main)
-            Err(GitPushError::RefUpdateRejected(
-                remaining_remote_refs
-                    .iter()
-                    .sorted()
-                    .map(|name| name.to_string())
-                    .collect(),
-            ))
+        GitPushStats {
+            pushed: pushed_refs,
+            remote_rejected,
+            ..Default::default()
         }
-    }
+    };
+
+    Ok(push_stats)
 }
 
 fn subprocess_push_refs(
@@ -2544,7 +2575,7 @@ fn subprocess_push_refs(
     qualified_remote_refs_expected_locations: &HashMap<&str, Option<&CommitId>>,
     refspecs: &[RefSpec],
     mut callbacks: RemoteCallbacks<'_>,
-) -> Result<(), GitPushError> {
+) -> Result<GitPushStats, GitPushError> {
     // check the remote exists
     if git_repo.try_find_remote(remote_name).is_none() {
         return Err(GitPushError::NoSuchRemote(remote_name.to_owned()));
@@ -2555,23 +2586,11 @@ fn subprocess_push_refs(
         .map(|full_refspec| RefToPush::new(full_refspec, qualified_remote_refs_expected_locations))
         .collect();
 
-    let push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, &mut callbacks)?;
-    tracing::debug!(?push_stats);
-
-    if !push_stats.rejected.is_empty() {
-        let mut refs_in_unexpected_locations = push_stats.rejected;
-        refs_in_unexpected_locations.sort();
-        Err(GitPushError::RefInUnexpectedLocation(
-            refs_in_unexpected_locations,
-        ))
-    } else if !push_stats.remote_rejected.is_empty() {
-        let mut rejected_refs = push_stats.remote_rejected;
-        rejected_refs.sort();
-        // remote rejected refs because of remote config (e.g., no push on main)
-        Err(GitPushError::RefUpdateRejected(rejected_refs))
-    } else {
-        Ok(())
-    }
+    let mut push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, &mut callbacks)?;
+    push_stats.pushed.sort();
+    push_stats.rejected.sort();
+    push_stats.remote_rejected.sort();
+    Ok(push_stats)
 }
 
 #[cfg(feature = "git2")]

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -106,9 +106,9 @@ pub struct GitPushStats {
     /// reference accepted by the remote
     pub pushed: Vec<String>,
     /// rejected reference, due to lease failure, with an optional reason
-    pub rejected: Vec<String>,
+    pub rejected: Vec<(String, Option<String>)>,
     /// reference rejected by the remote, with an optional reason
-    pub remote_rejected: Vec<String>,
+    pub remote_rejected: Vec<(String, Option<String>)>,
 }
 
 impl GitPushStats {
@@ -2534,11 +2534,15 @@ fn git2_push_refs(
     for failed_update in &failed_push_negotiations {
         remaining_remote_refs.remove(failed_update.as_str());
     }
-    let rejected: Vec<_> = failed_push_negotiations.into_iter().sorted().collect();
+    let rejected: Vec<_> = failed_push_negotiations
+        .into_iter()
+        .sorted()
+        .map(|name| (name, None))
+        .collect();
     let remote_rejected: Vec<_> = remaining_remote_refs
         .into_iter()
         .sorted()
-        .map(str::to_owned)
+        .map(|name| (name.to_owned(), None))
         .collect();
     pushed_refs.sort();
 


### PR DESCRIPTION
We've been finding that a lot of bug reports on `jj git push` come from
sub-standard error reporting on the reasons the failure happens.

It can come from a number of places:
 - hook failure
 - remote branch protection
 - git config

This commit forwards the reason as explained by the ouptut of git push
to help users figure out what is happening.
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
