### PR TITLE
cli: truncate list of updated commits, remove `abandon --summary` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `git.push-branch-prefix` config has been removed in favor of
   `git.push-bookmark-prefix`.
 
+* `jj abandon` no longer supports `--summary` to suppress the list of abandoned
+  commits. The list won't show more than 10 commits to not clutter the console.
+
 * `jj unsquash` has been removed in favor of `jj squash` and
   `jj diffedit --restore-descendants`.
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2595,17 +2595,21 @@ fn update_stale_working_copy(
     Ok(stats)
 }
 
-/// Prints a list of commits by the given summary template. Use this to show
-/// created, rewritten, or abandoned commits.
+/// Prints a list of commits by the given summary template. The list may be
+/// elided. Use this to show created, rewritten, or abandoned commits.
 pub fn print_updated_commits<'a>(
     formatter: &mut dyn Formatter,
     template: &TemplateRenderer<Commit>,
     commits: impl IntoIterator<Item = &'a Commit>,
 ) -> io::Result<()> {
-    for commit in commits {
+    let mut commits = commits.into_iter().fuse();
+    for commit in commits.by_ref().take(10) {
         write!(formatter, "  ")?;
         template.format(commit, formatter)?;
         writeln!(formatter)?;
+    }
+    if commits.next().is_some() {
+        writeln!(formatter, "  ...")?;
     }
     Ok(())
 }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2595,6 +2595,21 @@ fn update_stale_working_copy(
     Ok(stats)
 }
 
+/// Prints a list of commits by the given summary template. Use this to show
+/// created, rewritten, or abandoned commits.
+pub fn print_updated_commits<'a>(
+    formatter: &mut dyn Formatter,
+    template: &TemplateRenderer<Commit>,
+    commits: impl IntoIterator<Item = &'a Commit>,
+) -> io::Result<()> {
+    for commit in commits {
+        write!(formatter, "  ")?;
+        template.format(commit, formatter)?;
+        writeln!(formatter)?;
+    }
+    Ok(())
+}
+
 #[instrument(skip_all)]
 pub fn print_conflicted_paths(
     conflicts: Vec<(RepoPathBuf, BackendResult<MergedTreeValue>)>,

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -25,6 +25,7 @@ use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::RewriteRefsOptions;
 use tracing::instrument;
 
+use crate::cli_util::print_updated_commits;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
@@ -118,13 +119,12 @@ pub(crate) fn cmd_abandon(
                 .write_commit_summary(formatter.as_mut(), &to_abandon[0])?;
             writeln!(ui.status())?;
         } else if !args.summary {
-            let template = tx.base_workspace_helper().commit_summary_template();
             writeln!(formatter, "Abandoned the following commits:")?;
-            for commit in &to_abandon {
-                write!(formatter, "  ")?;
-                template.format(commit, formatter.as_mut())?;
-                writeln!(formatter)?;
-            }
+            print_updated_commits(
+                formatter.as_mut(),
+                &tx.base_workspace_helper().commit_summary_template(),
+                &to_abandon,
+            )?;
         } else {
             writeln!(formatter, "Abandoned {} commits.", to_abandon.len())?;
         }

--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -119,7 +119,7 @@ pub(crate) fn cmd_abandon(
                 .write_commit_summary(formatter.as_mut(), &to_abandon[0])?;
             writeln!(ui.status())?;
         } else if !args.summary {
-            writeln!(formatter, "Abandoned the following commits:")?;
+            writeln!(formatter, "Abandoned {} commits:", to_abandon.len())?;
             print_updated_commits(
                 formatter.as_mut(),
                 &tx.base_workspace_helper().commit_summary_template(),

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -20,6 +20,7 @@ use jj_lib::matchers::EverythingMatcher;
 use pollster::FutureExt as _;
 use tracing::instrument;
 
+use crate::cli_util::print_updated_commits;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
@@ -98,12 +99,11 @@ pub(crate) fn cmd_absorb(
     if let Some(mut formatter) = ui.status_formatter() {
         if !stats.rewritten_destinations.is_empty() {
             writeln!(formatter, "Absorbed changes into these revisions:")?;
-            let template = tx.commit_summary_template();
-            for commit in stats.rewritten_destinations.iter().rev() {
-                write!(formatter, "  ")?;
-                template.format(commit, formatter.as_mut())?;
-                writeln!(formatter)?;
-            }
+            print_updated_commits(
+                formatter.as_mut(),
+                &tx.commit_summary_template(),
+                stats.rewritten_destinations.iter().rev(),
+            )?;
         }
         if stats.num_rebased > 0 {
             writeln!(

--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -98,7 +98,11 @@ pub(crate) fn cmd_absorb(
 
     if let Some(mut formatter) = ui.status_formatter() {
         if !stats.rewritten_destinations.is_empty() {
-            writeln!(formatter, "Absorbed changes into these revisions:")?;
+            writeln!(
+                formatter,
+                "Absorbed changes into {} revisions:",
+                stats.rewritten_destinations.len()
+            )?;
             print_updated_commits(
                 formatter.as_mut(),
                 &tx.commit_summary_template(),

--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -26,6 +26,7 @@ use jj_lib::rewrite::merge_commit_trees;
 use tracing::instrument;
 
 use crate::cli_util::compute_commit_location;
+use crate::cli_util::print_updated_commits;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
@@ -189,17 +190,16 @@ pub(crate) fn cmd_revert(
         })?;
 
     if let Some(mut formatter) = ui.status_formatter() {
-        let template = tx.commit_summary_template();
         writeln!(
             formatter,
             "Reverted {} commits as follows:",
             reverted_commits.len()
         )?;
-        for commit in &reverted_commits {
-            write!(formatter, "  ")?;
-            template.format(commit, formatter.as_mut())?;
-            writeln!(formatter)?;
-        }
+        print_updated_commits(
+            formatter.as_mut(),
+            &tx.commit_summary_template(),
+            &reverted_commits,
+        )?;
         if num_rebased > 0 {
             writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
         }

--- a/cli/src/commands/sign.rs
+++ b/cli/src/commands/sign.rs
@@ -20,6 +20,7 @@ use jj_lib::commit::CommitIteratorExt as _;
 use jj_lib::repo::Repo as _;
 use jj_lib::signing::SignBehavior;
 
+use crate::cli_util::print_updated_commits;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::user_error_with_hint;
@@ -113,13 +114,12 @@ pub fn cmd_sign(ui: &mut Ui, command: &CommandHelper, args: &SignArgs) -> Result
 
     if let Some(mut formatter) = ui.status_formatter() {
         if !signed_commits.is_empty() {
-            let template = tx.commit_summary_template();
             writeln!(formatter, "Signed {} commits:", signed_commits.len())?;
-            for commit in &signed_commits {
-                write!(formatter, "  ")?;
-                template.format(commit, formatter.as_mut())?;
-                writeln!(formatter)?;
-            }
+            print_updated_commits(
+                formatter.as_mut(),
+                &tx.commit_summary_template(),
+                &signed_commits,
+            )?;
         }
     }
 

--- a/cli/src/commands/unsign.rs
+++ b/cli/src/commands/unsign.rs
@@ -19,6 +19,7 @@ use jj_lib::commit::Commit;
 use jj_lib::commit::CommitIteratorExt as _;
 use jj_lib::signing::SignBehavior;
 
+use crate::cli_util::print_updated_commits;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
@@ -88,13 +89,12 @@ pub fn cmd_unsign(
 
     if let Some(mut formatter) = ui.status_formatter() {
         if !unsigned_commits.is_empty() {
-            let template = tx.commit_summary_template();
             writeln!(formatter, "Unsigned {} commits:", unsigned_commits.len())?;
-            for commit in &unsigned_commits {
-                write!(formatter, "  ")?;
-                template.format(commit, formatter.as_mut())?;
-                writeln!(formatter)?;
-            }
+            print_updated_commits(
+                formatter.as_mut(),
+                &tx.commit_summary_template(),
+                &unsigned_commits,
+            )?;
         }
     }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -224,7 +224,6 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 ###### **Options:**
 
-* `-s`, `--summary` — Do not print every abandoned commit on a separate line
 * `--retain-bookmarks` — Do not delete bookmarks pointing to the revisions to abandon
 
    Bookmarks will be moved to the parent revisions instead.

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -45,7 +45,8 @@ fn test_basics() {
     let output = work_dir.run_jj(["abandon", "--retain-bookmarks", "d"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit vruxwmqv b7c62f28 d | d
+    Abandoned 1 commits:
+      vruxwmqv b7c62f28 d | d
     Rebased 1 descendant commits onto parents of abandoned commits
     Working copy now at: znkkpsqq 11a2e10e e | e
     Parent commit      : rlvkpnrz 2443ea76 a | a
@@ -69,7 +70,8 @@ fn test_basics() {
     let output = work_dir.run_jj(["abandon", "--retain-bookmarks"]); // abandons `e`
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit znkkpsqq 5557ece3 e | e
+    Abandoned 1 commits:
+      znkkpsqq 5557ece3 e | e
     Working copy now at: nkmrtpmo d4f8ea73 (empty) (no description set)
     Parent commit      : rlvkpnrz 2443ea76 a e?? | a
     Parent commit      : vruxwmqv b7c62f28 d e?? | d
@@ -120,7 +122,8 @@ fn test_basics() {
     let output = work_dir.run_jj(["abandon", "-rb", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit zsuskuln 1394f625 b | b
+    Abandoned 1 commits:
+      zsuskuln 1394f625 b | b
     Deleted bookmarks: b
     [EOF]
     ");
@@ -237,7 +240,8 @@ fn test_bug_2600() {
     let output = work_dir.run_jj(["abandon", "base"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit zsuskuln 73c929fc base | base
+    Abandoned 1 commits:
+      zsuskuln 73c929fc base | base
     Deleted bookmarks: base
     Rebased 3 descendant commits onto parents of abandoned commits
     Working copy now at: znkkpsqq 86e31bec c | c
@@ -262,7 +266,8 @@ fn test_bug_2600() {
     let output = work_dir.run_jj(["abandon", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit royxmykx 98f3b9ba a | a
+    Abandoned 1 commits:
+      royxmykx 98f3b9ba a | a
     Deleted bookmarks: a
     Rebased 2 descendant commits onto parents of abandoned commits
     Working copy now at: znkkpsqq 683b9435 c | c
@@ -286,7 +291,8 @@ fn test_bug_2600() {
     let output = work_dir.run_jj(["abandon", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit vruxwmqv 8c0dced0 b | b
+    Abandoned 1 commits:
+      vruxwmqv 8c0dced0 b | b
     Deleted bookmarks: b
     Rebased 1 descendant commits onto parents of abandoned commits
     Working copy now at: znkkpsqq 33a94991 c | c
@@ -405,7 +411,8 @@ fn test_double_abandon() {
     let output = work_dir.run_jj(["abandon", &commit_id]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit rlvkpnrz 2443ea76 a | a
+    Abandoned 1 commits:
+      rlvkpnrz 2443ea76 a | a
     Deleted bookmarks: a
     Working copy now at: royxmykx f37b4afd (empty) (no description set)
     Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
@@ -415,7 +422,8 @@ fn test_double_abandon() {
     let output = work_dir.run_jj(["abandon", &commit_id]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit rlvkpnrz hidden 2443ea76 a
+    Abandoned 1 commits:
+      rlvkpnrz hidden 2443ea76 a
     Nothing changed.
     [EOF]
     ");
@@ -437,7 +445,8 @@ fn test_abandon_restore_descendants() {
     let output = work_dir.run_jj(["abandon", "-r@-", "--restore-descendants"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit rlvkpnrz 225adef1 (no description set)
+    Abandoned 1 commits:
+      rlvkpnrz 225adef1 (no description set)
     Rebased 1 descendant commits (while preserving their content) onto parents of abandoned commits
     Working copy now at: kkmpptxz a734deb0 (no description set)
     Parent commit      : qpvuntsm 485d52a9 (no description set)

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -93,7 +93,7 @@ fn test_basics() {
     let output = work_dir.run_jj(["abandon", "descendants(d)"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned the following commits:
+    Abandoned 2 commits:
       znkkpsqq 5557ece3 e | e
       vruxwmqv b7c62f28 d | d
     Deleted bookmarks: d, e
@@ -140,7 +140,7 @@ fn test_basics() {
     let output = work_dir.run_jj(["abandon", "d::", "e"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned the following commits:
+    Abandoned 2 commits:
       znkkpsqq 5557ece3 e | e
       vruxwmqv b7c62f28 d | d
     Deleted bookmarks: d, e
@@ -166,6 +166,38 @@ fn test_basics() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     No revisions to abandon.
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_abandon_many() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    for i in 0..10 {
+        work_dir.run_jj(["new", &format!("-mcommit{i}")]).success();
+    }
+
+    // The list of commits should be elided.
+    let output = work_dir.run_jj(["abandon", ".."]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Abandoned 11 commits:
+      kpqxywon 0b998aa3 (empty) commit9
+      znkkpsqq c37abefb (empty) commit8
+      yostqsxw 6256698f (empty) commit7
+      vruxwmqv 9350f605 (empty) commit6
+      yqosqzyt 196bd23d (empty) commit5
+      royxmykx bb676781 (empty) commit4
+      mzvwutvl 6f1e55a6 (empty) commit3
+      zsuskuln baf1311c (empty) commit2
+      kkmpptxz 5fc5f374 (empty) commit1
+      rlvkpnrz 9451b4ea (empty) commit0
+      ...
+    Working copy now at: kmkuslsw 822a2cf5 (empty) (no description set)
+    Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
     ");
 }
@@ -291,7 +323,7 @@ fn test_bug_2600() {
     let output = work_dir.run_jj(["abandon", "--retain-bookmarks", "a", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned the following commits:
+    Abandoned 2 commits:
       vruxwmqv 8c0dced0 b | b
       royxmykx 98f3b9ba a | a
     Rebased 1 descendant commits onto parents of abandoned commits

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -45,7 +45,7 @@ fn test_absorb_simple() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 2 revisions:
       zsuskuln 3027ca7a 2
       kkmpptxz d0f1e8dd 1
     Working copy now at: yqosqzyt 277bed24 (empty) (no description set)
@@ -58,7 +58,7 @@ fn test_absorb_simple() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       kkmpptxz d366d92c 1
     Rebased 1 descendant commits.
     Working copy now at: vruxwmqv 32eb72fe (empty) (no description set)
@@ -71,7 +71,7 @@ fn test_absorb_simple() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       zsuskuln 6e2c4777 2
     Working copy now at: yostqsxw 4a48490c (empty) (no description set)
     Parent commit      : zsuskuln 6e2c4777 2
@@ -175,7 +175,7 @@ fn test_absorb_replace_single_line_hunk() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       qpvuntsm 7e885236 (conflict) 1
     Rebased 1 descendant commits.
     Working copy now at: mzvwutvl e9c3b95b (empty) (no description set)
@@ -259,7 +259,7 @@ fn test_absorb_merge() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 2 revisions:
       zsuskuln 71d1ee56 2
       kkmpptxz 4d379399 1
     Rebased 1 descendant commits.
@@ -278,7 +278,7 @@ fn test_absorb_merge() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       mzvwutvl e93c0210 3
     Working copy now at: vruxwmqv 1b10dfa4 (empty) (no description set)
     Parent commit      : mzvwutvl e93c0210 3
@@ -359,7 +359,7 @@ fn test_absorb_discardable_merge_with_descendant() {
     let output = work_dir.run_jj(["absorb", "--from=@-"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 2 revisions:
       zsuskuln 02668cf6 2
       kkmpptxz fcabe394 1
     Rebased 1 descendant commits.
@@ -511,7 +511,7 @@ fn test_absorb_file_mode() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       qpvuntsm 991365da 1
     Rebased 1 descendant commits.
     Working copy now at: zsuskuln 77de368e (no description set)
@@ -557,7 +557,7 @@ fn test_absorb_from_into() {
     let output = work_dir.run_jj(["absorb", "--into=@-"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       kkmpptxz 91df4543 2
     Rebased 1 descendant commits.
     Working copy now at: zsuskuln d5424357 (no description set)
@@ -602,7 +602,7 @@ fn test_absorb_from_into() {
     let output = work_dir.run_jj(["absorb", "--from=@-"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       rlvkpnrz 3a5fd02e 1
     Rebased 2 descendant commits.
     Working copy now at: zsuskuln 53ce490b (no description set)
@@ -671,7 +671,7 @@ fn test_absorb_paths() {
     let output = work_dir.run_jj(["absorb", "file1"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       qpvuntsm ae044adb 1
     Rebased 1 descendant commits.
     Working copy now at: kkmpptxz c6f31836 (no description set)
@@ -732,7 +732,7 @@ fn test_absorb_immutable() {
     let output = work_dir.run_jj(["absorb"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Absorbed changes into these revisions:
+    Absorbed changes into 1 revisions:
       kkmpptxz d80e3c2a 2
     Rebased 1 descendant commits.
     Working copy now at: mzvwutvl 3021153d (no description set)

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1701,7 +1701,8 @@ fn test_op_diff_patch() {
     let output = test_env.run_jj_in(&repo_path, ["abandon"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit mzvwutvl 9f4fb57f (empty) (no description set)
+    Abandoned 1 commits:
+      mzvwutvl 9f4fb57f (empty) (no description set)
     Working copy now at: yqosqzyt 33f321c4 (empty) (no description set)
     Parent commit      : qpvuntsm 2ac85fd1 (no description set)
     [EOF]
@@ -2454,7 +2455,8 @@ fn test_op_show_patch() {
     let output = test_env.run_jj_in(&repo_path, ["abandon"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Abandoned commit mzvwutvl 9f4fb57f (empty) (no description set)
+    Abandoned 1 commits:
+      mzvwutvl 9f4fb57f (empty) (no description set)
     Working copy now at: yqosqzyt 33f321c4 (empty) (no description set)
     Parent commit      : qpvuntsm 2ac85fd1 (no description set)
     [EOF]


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
