### PR TITLE
conflicts: document the "same-change rule"

### DIFF
--- a/docs/technical/conflicts.md
+++ b/docs/technical/conflicts.md
@@ -62,4 +62,19 @@ non-conflict state `C`. We then revert that change. Reverting a change means
 applying its reverse diff `-(E-C)`, so the result is `E+(C-E) =
 (C+(B-A))+(C-(C+(B-A)))`, which we can simplify to just `C` (i.e. no conflict).
 
+## Same-change rule
+
+When all sides of a conflict make the same change,
+[we automatically consider it resolved to that value][resolve]. We call this
+"the same-change rule". This behavior matches what Git and Mercurial do.
+Darcs, on the other hand, considers it a  conflict. The automatic conflict
+resolution we do is lossy in terms of conflict algebra; it means that rebasing
+a commit onto a commit that has the same changes (or a subset thereof) and then
+rebasing it back will lose changes (for a real-life example see [bug #6369]).
+We do it because it is more user-friendly in the vast majority of cases. We
+may at some point experiment with a config option to disable the same-change
+rule.
+
+[bug #6369]: https://github.com/jj-vcs/jj/issues/6369
 [merge-rs]: https://github.com/jj-vcs/jj/blob/main/lib/src/merge.rs
+[resolve]: https://github.com/jj-vcs/jj/blob/53272510bf879086d83bb5eea1406f75ba31f138/lib/src/merge.rs#L85-L99


### PR DESCRIPTION
I think its time to finally give our Conflict Algebra rule a name and a Glossary term. This is will make our documentation alot easier, and gives it a name for new design docs.

All credit goes to @martinvonz for coming up with the term in #4988.



# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
