### PR TITLE
github: use native builder for x86 macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,17 +33,8 @@ jobs:
           os: ubuntu-24.04-arm
           cargo_flags: "--all-features"
         - build: macos-x86_64
-          os: macos-14
-          targets: x86_64-apple-darwin
-          # We pass `--target` here rather than unconditionally for all
-          # platforms because otherwise Rust flag settings are ignored
-          # for build scripts and the like, preventing us from getting
-          # the full benefit from faster linkers.
-          #
-          # See:
-          # * <https://doc.rust-lang.org/1.84.1/cargo/reference/config.html#buildrustflags>
-          # * <https://github.com/rust-lang/cargo/issues/4423>
-          cargo_flags: "--target x86_64-apple-darwin --features vendored-openssl"
+          os: macos-13
+          cargo_flags: ""
         - build: macos-aarch64
           os: macos-14
           cargo_flags: ""
@@ -75,7 +66,6 @@ jobs:
       uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
       with:
         toolchain: 1.84
-        target: ${{ matrix.targets }}
     - uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
       with:
         tool: nextest,taplo-cli


### PR DESCRIPTION
This shaves over 3½ minutes off the tests, taking this from the slowest job to faster than Windows again. The macOS 13 builders presumably won’t be around forever, and the newer free builders are all Apple Silicon, but this is an easy substantial improvement for now.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
