### PR TITLE
cli: remove dumb suffix from sideband writer

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -178,7 +178,8 @@ impl GitSidebandProgressMessageWriter {
 
         GitSidebandProgressMessageWriter {
             display_prefix: "remote: ".as_bytes(),
-            suffix: if is_terminal { "\x1B[K" } else { "        " }.as_bytes(),
+            // \x1B[K is a terminal code to clear the terminal
+            suffix: if is_terminal { "\x1B[K" } else { "" }.as_bytes(),
             scratch: Vec::new(),
         }
     }

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -2346,7 +2346,7 @@ fn test_git_push_rejected_by_remote() {
     ------- stderr -------
     Changes to push to origin:
       Move forward bookmark bookmark1 from d13ecdbda2a2 to dd5c09b30f9f
-    remote: error: hook declined to update refs/heads/bookmark1        
+    remote: error: hook declined to update refs/heads/bookmark1
     Error: Remote rejected the update of some refs (do you have permission to push to ["refs/heads/bookmark1"]?)
     [EOF]
     [exit status: 1]


### PR DESCRIPTION
The `GitSidebandProgressMessageWriter` was ported from `git`'s implementation:
https://github.com/git/git/blob/43072b4ca132437f21975ac6acc6b72dc22fd398/sideband.c#L138

This implementation includes a `DUMB_SUFFIX` of whitespace, to be used in alternative to a terminal escape code.

However, there's no good reason for this suffix, as far as we can see. This was also messing up with some snapshots.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
