### PR TITLE
docs: fix spelling of «NixOS»

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -65,9 +65,9 @@ Or install from the [AUR repository](https://aur.archlinux.org/packages/jujutsu-
 yay -S jujutsu-git
 ```
 
-#### Nix OS
+#### NixOS
 
-If you're on Nix OS you can install a **released** version of `jj` using the
+If you're on NixOS you can install a **released** version of `jj` using the
 [nixpkgs `jujutsu` package](https://search.nixos.org/packages?channel=unstable&show=jujutsu).
 
 To install a **prerelease** version, you can use the flake for this repository.


### PR DESCRIPTION
The name «NixOS» doesn't have a space in it.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
  - (I don't know whether this change is notable enough to warrant an entry there.)
- [x] I have updated the documentation (README.md, docs/, demos/)
  - (This is a docs-only change, so it does update `docs/`. As it doesn't change the behavior of `jj`, not anything substantial about its development, no change to `README.md` or `demos/` is needed.)
- [ ] I have updated the config schema (cli/src/config-schema.json)
  - (Probably not needed for this change.)
- [ ] I have added tests to cover my changes
  - (Probably not warranted for this change.)