### PR TITLE
Back out "github: only run `dependabot` workflow on `dependabot/**` branches"

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,8 +2,6 @@ name: Enable auto-merge for Dependabot PRs
 
 on:
   pull_request:
-    branches:
-      - 'dependabot/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION


This might be the cause of dependabot PRs not having automerge. Let's just revert it and see what happens when the next PRs roll in.

This backs out commit 47cd10669de28ecc36f0d7dbbb9964945124b730.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
