### PR TITLE
templates: create `builtin_draft_commit_description` template

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -33,15 +33,7 @@ separate(" ",
 
 config_list = 'builtin_config_list'
 
-draft_commit_description = '''
-concat(
-  description,
-  surround(
-    "\nJJ: This commit contains the following changes:\n", "",
-    indent("JJ:     ", diff.summary()),
-  ),
-)
-'''
+draft_commit_description = 'builtin_draft_commit_description'
 
 file_list = '''
 path.display() ++ "\n"
@@ -91,6 +83,16 @@ label(if(overridden, "overridden"),
 builtin_config_list_detailed = '''
 label(if(overridden, "overridden"),
   format_config_item(self) ++ " # " ++ separate(" ", source, path) ++ "\n")
+'''
+
+builtin_draft_commit_description = '''
+concat(
+  description,
+  surround(
+    "\nJJ: This commit contains the following changes:\n", "",
+    indent("JJ:     ", diff.summary()),
+  ),
+)
 '''
 
 builtin_log_oneline = '''

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -720,6 +720,7 @@ fn test_template_alias() {
     insta::assert_snapshot!(output, @r"
     builtin_config_list
     builtin_config_list_detailed
+    builtin_draft_commit_description
     builtin_log_comfortable
     builtin_log_compact
     builtin_log_compact_full_description

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -345,6 +345,7 @@ fn test_evolog_with_no_template() {
     Hint: The following template aliases are defined:
     - builtin_config_list
     - builtin_config_list_detailed
+    - builtin_draft_commit_description
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -47,6 +47,7 @@ fn test_log_with_no_template() {
     Hint: The following template aliases are defined:
     - builtin_config_list
     - builtin_config_list_detailed
+    - builtin_draft_commit_description
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -172,6 +172,7 @@ fn test_op_log_with_no_template() {
     Hint: The following template aliases are defined:
     - builtin_config_list
     - builtin_config_list_detailed
+    - builtin_draft_commit_description
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -272,6 +272,7 @@ fn test_show_with_no_template() {
     Hint: The following template aliases are defined:
     - builtin_config_list
     - builtin_config_list_detailed
+    - builtin_draft_commit_description
     - builtin_log_comfortable
     - builtin_log_compact
     - builtin_log_compact_full_description

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -147,7 +147,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword `builtin` doesn't exist
-    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`?
+    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`?
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
This moves the default template to `builtin_draft_commit_description` and points `draft_commit_description` to it. This makes it easier to override the template while still being able to refer to the default.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
