### PR TITLE
cli split: Rename "siblings" test to "parallel"

### DIFF
--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -352,7 +352,7 @@ fn test_split_with_merge_child() {
 #[test]
 // Split a commit with no descendants into siblings. Also tests that the default
 // description is set correctly on the first commit.
-fn test_split_siblings_no_descendants() {
+fn test_split_parallel_no_descendants() {
     let mut test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     test_env.add_config(r#"ui.default-description = "\n\nTESTED=TODO""#);
@@ -411,7 +411,7 @@ fn test_split_siblings_no_descendants() {
 }
 
 #[test]
-fn test_split_siblings_with_descendants() {
+fn test_split_parallel_with_descendants() {
     // Configure the environment and make the initial commits.
     let mut test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
@@ -513,7 +513,7 @@ fn test_split_siblings_with_descendants() {
 // This test makes sure that the children of the commit being split retain any
 // other parents which weren't involved in the split.
 #[test]
-fn test_split_siblings_with_merge_child() {
+fn test_split_parallel_with_merge_child() {
     let mut test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let workspace_path = test_env.env_root().join("repo");


### PR DESCRIPTION
The name of the flag was changed from --siblings to --parallel a while back, but the tests weren't renamed.

#cleanup

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
