### PR TITLE
config: relax bare string rule to accept middle apostrophes, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The built-in diff editor now correctly retains the executable bit on newly
   added files when splitting. [#3846](https://github.com/jj-vcs/jj/issues/3846)
 
+* `jj config set`/`--config` value parsing rule is relaxed in a way that
+  unquoted apostrophes are allowed.
+  [#5748](https://github.com/jj-vcs/jj/issues/5748)
+
 ## [0.27.0] - 2025-03-05
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3267,8 +3267,8 @@ pub struct EarlyArgs {
     /// Additional configuration options (can be repeated)
     ///
     /// The name should be specified as TOML dotted keys. The value should be
-    /// specified as a TOML expression. If string value doesn't contain any TOML
-    /// constructs (such as array notation), quotes can be omitted.
+    /// specified as a TOML expression. If string value isn't enclosed by any
+    /// TOML constructs (such as array notation), quotes can be omitted.
     #[arg(long, value_name = "NAME=VALUE", global = true, add = ArgValueCompleter::new(complete::leaf_config_key_value))]
     pub config: Vec<String>,
     /// Additional configuration options (can be repeated) (DEPRECATED)

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -38,12 +38,12 @@ pub struct ConfigSetArgs {
     /// New value to set
     ///
     /// The value should be specified as a TOML expression. If string value
-    /// doesn't contain any TOML constructs (such as apostrophes or array
+    /// isn't enclosed by any TOML constructs (such as apostrophes or array
     /// notation), quotes can be omitted. Note that the value may also need
     /// shell quoting. TOML multi-line strings can be useful if the value
     /// contains apostrophes. For example, to set `foo.bar` to the string
-    /// "don't" use `jj config set --user foo.bar "'''don't'''"`. This
-    /// is valid in both Bash and Fish.
+    /// "{don't}" use `jj config set --user foo.bar "'''{don't}'''"`. This is
+    /// valid in both Bash and Fish.
     ///
     /// Alternative, e.g. to avoid dealing with shell quoting, use `jj config
     /// edit` to edit the TOML file directly.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -203,7 +203,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
 * `--no-pager` — Disable the pager
 * `--config <NAME=VALUE>` — Additional configuration options (can be repeated)
 
-   The name should be specified as TOML dotted keys. The value should be specified as a TOML expression. If string value doesn't contain any TOML constructs (such as array notation), quotes can be omitted.
+   The name should be specified as TOML dotted keys. The value should be specified as a TOML expression. If string value isn't enclosed by any TOML constructs (such as array notation), quotes can be omitted.
 * `--config-file <PATH>` — Additional configuration files (can be repeated)
 
 
@@ -644,7 +644,7 @@ Update a config file to set the given option to a given value
 * `<NAME>`
 * `<VALUE>` — New value to set
 
-   The value should be specified as a TOML expression. If string value doesn't contain any TOML constructs (such as apostrophes or array notation), quotes can be omitted. Note that the value may also need shell quoting. TOML multi-line strings can be useful if the value contains apostrophes. For example, to set `foo.bar` to the string "don't" use `jj config set --user foo.bar "'''don't'''"`. This is valid in both Bash and Fish.
+   The value should be specified as a TOML expression. If string value isn't enclosed by any TOML constructs (such as apostrophes or array notation), quotes can be omitted. Note that the value may also need shell quoting. TOML multi-line strings can be useful if the value contains apostrophes. For example, to set `foo.bar` to the string "{don't}" use `jj config set --user foo.bar "'''{don't}'''"`. This is valid in both Bash and Fish.
 
    Alternative, e.g. to avoid dealing with shell quoting, use `jj config edit` to edit the TOML file directly.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1573,8 +1573,8 @@ config files or environment variables. For example,
 jj --config ui.color=always --config ui.diff-editor=meld split
 ```
 
-Config value should be specified as a TOML expression. If string value doesn't
-contain any TOML constructs (such as array notation), quotes can be omitted.
+Config value should be specified as a TOML expression. If string value isn't
+enclosed by any TOML constructs (such as array notation), quotes can be omitted.
 Here is an example with more advanced TOML constructs:
 
 ```shell


### PR DESCRIPTION
# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
