### PR TITLE
cli split: Explain how the diff script works in test_split_interactive_with_paths

### DIFF
--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -692,6 +692,11 @@ fn test_split_interactive_with_paths() {
     let edit_script = test_env.set_up_fake_editor();
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     let diff_editor = test_env.set_up_fake_diff_editor();
+    // On the before side, file2 is empty. On the after side, it contains "bar".
+    // The "reset file2" copies the empty version from the before side to the
+    // after side, effectively "unselecting" the changes and leaving only the
+    // changes made to file1. file3 doesn't appear on either side since it isn't
+    // in the filesets passed to `jj split`.
     let diff_script = [
         "files-before file2",
         "files-after JJ-INSTRUCTIONS file1 file2",
@@ -700,7 +705,8 @@ fn test_split_interactive_with_paths() {
     .join("\0");
     std::fs::write(diff_editor, diff_script).unwrap();
 
-    // Select file1 and file2 by args, then select file1 interactively
+    // Select file1 and file2 by args, then select file1 interactively via the diff
+    // script.
     let output = test_env.run_jj_in(&workspace_path, ["split", "-i", "file1", "file2"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------


### PR DESCRIPTION
It wasn't immediately obvious to me what was happening here, but once I understood it it seemed pretty simple. Perhaps it's worth a comment to explain it to the next reader.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
