### PR TITLE
conflicts: pack MaterializedTreeValue::File fields, use read_all() helper

### DIFF
--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -130,8 +130,8 @@ fn write_tree_entries<P: AsRef<RepoPath>>(
                     "Path '{ui_path}' exists but access is denied: {err}"
                 )?;
             }
-            MaterializedTreeValue::File { mut reader, .. } => {
-                io::copy(&mut reader, &mut ui.stdout_formatter().as_mut())?;
+            MaterializedTreeValue::File(mut file) => {
+                io::copy(&mut file.reader, &mut ui.stdout_formatter().as_mut())?;
             }
             MaterializedTreeValue::FileConflict { contents, .. } => {
                 materialize_merge_result(

--- a/lib/src/absorb.rs
+++ b/lib/src/absorb.rs
@@ -336,15 +336,7 @@ fn to_file_value(value: MaterializedTreeValue) -> Result<Option<MaterializedFile
     match value {
         MaterializedTreeValue::Absent => Ok(None), // New or deleted file
         MaterializedTreeValue::AccessDenied(err) => Err(format!("Access is denied: {err}")),
-        MaterializedTreeValue::File {
-            id,
-            executable,
-            reader,
-        } => Ok(Some(MaterializedFileValue {
-            id,
-            executable,
-            reader,
-        })),
+        MaterializedTreeValue::File(file) => Ok(Some(file)),
         MaterializedTreeValue::Symlink { .. } => Err("Is a symlink".into()),
         MaterializedTreeValue::FileConflict { .. }
         | MaterializedTreeValue::OtherConflict { .. } => Err("Is a conflict".into()),

--- a/lib/src/annotate.rs
+++ b/lib/src/annotate.rs
@@ -362,17 +362,7 @@ fn get_file_contents(
     let file_value = tree.path_value(path)?;
     let effective_file_value = materialize_tree_value(store, path, file_value).block_on()?;
     match effective_file_value {
-        MaterializedTreeValue::File { mut reader, id, .. } => {
-            let mut file_contents = Vec::new();
-            reader
-                .read_to_end(&mut file_contents)
-                .map_err(|e| BackendError::ReadFile {
-                    path: path.to_owned(),
-                    id,
-                    source: Box::new(e),
-                })?;
-            Ok(file_contents.into())
-        }
+        MaterializedTreeValue::File(mut file) => Ok(file.read_all(path)?.into()),
         MaterializedTreeValue::FileConflict { contents, .. } => Ok(
             materialize_merge_result_to_bytes(&contents, ConflictMarkerStyle::default()),
         ),

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -134,11 +134,7 @@ pub async fn extract_as_single_hunk(
 pub enum MaterializedTreeValue {
     Absent,
     AccessDenied(Box<dyn std::error::Error + Send + Sync>),
-    File {
-        id: FileId,
-        executable: bool,
-        reader: Box<dyn Read>,
-    },
+    File(MaterializedFileValue),
     Symlink {
         id: SymlinkId,
         target: String,
@@ -214,11 +210,11 @@ async fn materialize_tree_value_no_access_denied(
         Ok(None) => Ok(MaterializedTreeValue::Absent),
         Ok(Some(TreeValue::File { id, executable })) => {
             let reader = store.read_file_async(path, &id).await?;
-            Ok(MaterializedTreeValue::File {
+            Ok(MaterializedTreeValue::File(MaterializedFileValue {
                 id,
                 executable,
                 reader,
-            })
+            }))
         }
         Ok(Some(TreeValue::Symlink(id))) => {
             let target = store.read_symlink_async(path, &id).await?;

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -36,7 +36,6 @@ use super::rev_walk::PeekableRevWalk;
 use super::rev_walk::RevWalk;
 use super::rev_walk::RevWalkBuilder;
 use super::revset_graph_iterator::RevsetGraphWalk;
-use crate::backend::BackendError;
 use crate::backend::BackendResult;
 use crate::backend::ChangeId;
 use crate::backend::CommitId;
@@ -1355,17 +1354,7 @@ fn to_file_content(path: &RepoPath, value: MaterializedTreeValue) -> BackendResu
     match value {
         MaterializedTreeValue::Absent => Ok(vec![]),
         MaterializedTreeValue::AccessDenied(_) => Ok(vec![]),
-        MaterializedTreeValue::File { id, mut reader, .. } => {
-            let mut content = vec![];
-            reader
-                .read_to_end(&mut content)
-                .map_err(|err| BackendError::ReadFile {
-                    path: path.to_owned(),
-                    id: id.clone(),
-                    source: err.into(),
-                })?;
-            Ok(content)
-        }
+        MaterializedTreeValue::File(mut file) => file.read_all(path),
         MaterializedTreeValue::Symlink { id: _, target } => Ok(target.into_bytes()),
         MaterializedTreeValue::GitSubmodule(_) => Ok(vec![]),
         MaterializedTreeValue::FileConflict { contents, .. } => {

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1830,11 +1830,9 @@ impl TreeState {
                     deleted_files.insert(path);
                     continue;
                 }
-                MaterializedTreeValue::File {
-                    executable,
-                    mut reader,
-                    ..
-                } => self.write_file(&disk_path, &mut reader, executable)?,
+                MaterializedTreeValue::File(mut file) => {
+                    self.write_file(&disk_path, &mut file.reader, file.executable)?
+                }
                 MaterializedTreeValue::Symlink { id: _, target } => {
                     if self.symlink_support {
                         self.write_symlink(&disk_path, target)?


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
