### PR TITLE
cli: do not print commit summary for previously-conflicted commits

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2223,24 +2223,21 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
             .retain(|change_id, _commits| !removed_conflicts_by_change_id.contains_key(change_id));
 
         // TODO: Also report new divergence and maybe resolved divergence
-        let template = self.commit_summary_template();
         if !resolved_conflicts_by_change_id.is_empty() {
+            // TODO: Report resolved and abandoned numbers separately. However,
+            // that involves resolving the change_id among the visible commits in the new
+            // repo, which isn't currently supported by Google's revset engine.
+            let num_resolved: usize = resolved_conflicts_by_change_id
+                .values()
+                .map(|commits| commits.len())
+                .sum();
             writeln!(
                 fmt,
-                "Existing conflicts were resolved or abandoned from these commits:"
+                "Existing conflicts were resolved or abandoned from {num_resolved} commits."
             )?;
-            for (_, old_commits) in &resolved_conflicts_by_change_id {
-                // TODO: Report which ones were resolved and which ones were abandoned. However,
-                // that involves resolving the change_id among the visible commits in the new
-                // repo, which isn't currently supported by Google's revset engine.
-                for commit in old_commits {
-                    write!(fmt, "  ")?;
-                    template.format(commit, fmt.as_mut())?;
-                    writeln!(fmt)?;
-                }
-            }
         }
         if !new_conflicts_by_change_id.is_empty() {
+            let template = self.commit_summary_template();
             writeln!(fmt, "New conflicts appeared in these commits:")?;
             for (_, new_commits) in &new_conflicts_by_change_id {
                 for commit in new_commits {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2237,15 +2237,16 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
             )?;
         }
         if !new_conflicts_by_change_id.is_empty() {
-            let template = self.commit_summary_template();
-            writeln!(fmt, "New conflicts appeared in these commits:")?;
-            for (_, new_commits) in &new_conflicts_by_change_id {
-                for commit in new_commits {
-                    write!(fmt, "  ")?;
-                    template.format(commit, fmt.as_mut())?;
-                    writeln!(fmt)?;
-                }
-            }
+            let num_conflicted: usize = new_conflicts_by_change_id
+                .values()
+                .map(|commits| commits.len())
+                .sum();
+            writeln!(fmt, "New conflicts appeared in {num_conflicted} commits:")?;
+            print_updated_commits(
+                fmt.as_mut(),
+                &self.commit_summary_template(),
+                new_conflicts_by_change_id.values().flatten().copied(),
+            )?;
         }
 
         // Hint that the user might want to `jj new` to the first conflict commit to

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -180,7 +180,7 @@ fn test_absorb_replace_single_line_hunk() {
     Rebased 1 descendant commits.
     Working copy now at: mzvwutvl e9c3b95b (empty) (no description set)
     Parent commit      : kkmpptxz 7c36845c 2
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       qpvuntsm 7e885236 (conflict) 1
     Hint: To resolve the conflicts, start by updating to it:
       jj new qpvuntsm
@@ -428,7 +428,7 @@ fn test_absorb_conflict() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file1    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       kkmpptxz 74405a07 (conflict) (no description set)
     Hint: To resolve the conflicts, start by updating to it:
       jj new kkmpptxz

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -345,8 +345,7 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    Existing conflicts were resolved or abandoned from these commits:
-      mzvwutvl hidden a813239f (conflict) (no description set)
+    Existing conflicts were resolved or abandoned from 1 commits.
     [EOF]
     ");
     // Conflicts should render using "snapshot" format in diff editor

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -202,7 +202,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion and an executable
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       kmkuslsw 139dee15 file_deletion | (conflict) file_deletion
     Hint: To resolve the conflicts, start by updating to it:
       jj new kmkuslsw

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -36,7 +36,7 @@ fn test_report_conflicts() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
-    New conflicts appeared in these commits:
+    New conflicts appeared in 2 commits:
       kkmpptxz 2271a49e (conflict) C
       rlvkpnrz b7d83633 (conflict) B
     Hint: To resolve the conflicts, start by updating to the first one:
@@ -69,7 +69,7 @@ fn test_report_conflicts() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 2 commits:
       kkmpptxz 331a2fce (conflict) C
       rlvkpnrz b42f84eb (conflict) B
     Hint: To resolve the conflicts, start by updating to one of the first ones:
@@ -134,7 +134,7 @@ fn test_report_conflicts_with_divergent_commits() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
-    New conflicts appeared in these commits:
+    New conflicts appeared in 3 commits:
       zsuskuln?? 1db43f23 (conflict) C3
       zsuskuln?? 4ca807ad (conflict) C2
       kkmpptxz b42f84eb (conflict) B
@@ -167,7 +167,7 @@ fn test_report_conflicts_with_divergent_commits() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       zsuskuln?? 3c36afc9 (conflict) C2
     Hint: To resolve the conflicts, start by updating to it:
       jj new zsuskuln
@@ -181,7 +181,7 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits onto destination
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       zsuskuln?? e3ff827e (conflict) C3
     Hint: To resolve the conflicts, start by updating to it:
       jj new zsuskuln
@@ -247,7 +247,7 @@ fn test_report_conflicts_with_resolving_conflicts_hint_disabled() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
-    New conflicts appeared in these commits:
+    New conflicts appeared in 2 commits:
       kkmpptxz 2271a49e (conflict) C
       rlvkpnrz b7d83633 (conflict) B
     [EOF]

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -54,9 +54,7 @@ fn test_report_conflicts() {
     Working copy now at: zsuskuln d70c003d (empty) (no description set)
     Parent commit      : kkmpptxz 43e94449 C
     Added 0 files, modified 1 files, removed 0 files
-    Existing conflicts were resolved or abandoned from these commits:
-      kkmpptxz hidden 2271a49e (conflict) C
-      rlvkpnrz hidden b7d83633 (conflict) B
+    Existing conflicts were resolved or abandoned from 2 commits.
     [EOF]
     ");
 
@@ -100,8 +98,7 @@ fn test_report_conflicts() {
     ------- stderr -------
     Working copy now at: yostqsxw f5a0cf8c (empty) (no description set)
     Parent commit      : rlvkpnrz 87370844 B
-    Existing conflicts were resolved or abandoned from these commits:
-      rlvkpnrz hidden b42f84eb (conflict) B
+    Existing conflicts were resolved or abandoned from 1 commits.
     [EOF]
     ");
 }
@@ -156,10 +153,7 @@ fn test_report_conflicts_with_divergent_commits() {
     Working copy now at: zsuskuln?? f2d7a228 C2
     Parent commit      : kkmpptxz db069a22 B
     Added 0 files, modified 1 files, removed 0 files
-    Existing conflicts were resolved or abandoned from these commits:
-      zsuskuln hidden 1db43f23 (conflict) C3
-      zsuskuln hidden 4ca807ad (conflict) C2
-      kkmpptxz hidden b42f84eb (conflict) B
+    Existing conflicts were resolved or abandoned from 3 commits.
     [EOF]
     ");
 
@@ -207,8 +201,7 @@ fn test_report_conflicts_with_divergent_commits() {
     Working copy now at: zsuskuln?? 1f9680bd C2
     Parent commit      : kkmpptxz db069a22 B
     Added 0 files, modified 1 files, removed 0 files
-    Existing conflicts were resolved or abandoned from these commits:
-      zsuskuln hidden 3c36afc9 (conflict) C2
+    Existing conflicts were resolved or abandoned from 1 commits.
     [EOF]
     ");
 
@@ -219,8 +212,7 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits onto destination
-    Existing conflicts were resolved or abandoned from these commits:
-      zsuskuln hidden e3ff827e (conflict) C3
+    Existing conflicts were resolved or abandoned from 1 commits.
     [EOF]
     ");
 }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -245,7 +245,7 @@ fn test_resolution() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv 608a2310 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -391,7 +391,7 @@ fn test_resolution() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv 8e03fefa conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -472,7 +472,7 @@ fn test_resolution() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv a786ac2f conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -875,7 +875,7 @@ fn test_simplify_conflict_sides() {
     Warning: There are unresolved conflicts at these paths:
     fileA    2-sided conflict
     fileB    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       nkmrtpmo 69cc0c2d conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new nkmrtpmo
@@ -1152,7 +1152,7 @@ fn test_resolve_conflicts_with_executable() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict including an executable
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       znkkpsqq eb159d56 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new znkkpsqq
@@ -1196,7 +1196,7 @@ fn test_resolve_conflicts_with_executable() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file1    2-sided conflict including an executable
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       znkkpsqq 4dccbb3c conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new znkkpsqq
@@ -1305,7 +1305,7 @@ fn test_resolve_long_conflict_markers() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv 2b985546 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -1378,7 +1378,7 @@ fn test_resolve_long_conflict_markers() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv fac9406d conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -1457,7 +1457,7 @@ fn test_resolve_long_conflict_markers() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv 1b29631a conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -1593,7 +1593,7 @@ fn test_multiple_conflicts() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv 309e981c conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -1765,7 +1765,7 @@ fn test_multiple_conflicts_with_error() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv d2f3f858 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv
@@ -1817,7 +1817,7 @@ fn test_multiple_conflicts_with_error() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       vruxwmqv 0a54e8ed conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by updating to it:
       jj new vruxwmqv

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -73,7 +73,7 @@ fn test_restore() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict including 1 deletion
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       kkmpptxz 5b361547 (conflict) (no description set)
     Hint: To resolve the conflicts, start by updating to it:
       jj new kkmpptxz

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -817,7 +817,7 @@ fn test_squash_from_multiple() {
     Rebased 2 descendant commits
     Working copy now at: kpqxywon 7ea39167 f | (no description set)
     Parent commit      : yostqsxw acfbf2a0 e | (no description set)
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       yqosqzyt 4df3b215 d | (conflict) (no description set)
     Hint: To resolve the conflicts, start by updating to it:
       jj new yqosqzyt
@@ -963,7 +963,7 @@ fn test_squash_from_multiple_partial() {
     Rebased 2 descendant commits
     Working copy now at: kpqxywon a8530305 f | (no description set)
     Parent commit      : yostqsxw 0a3637fc e | (no description set)
-    New conflicts appeared in these commits:
+    New conflicts appeared in 1 commits:
       yqosqzyt 05a3ab3d d | (conflict) (no description set)
     Hint: To resolve the conflicts, start by updating to it:
       jj new yqosqzyt


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
