### PR TITLE
git: replace remaining caller of old parse_git_ref()

### DIFF
--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -23,7 +23,7 @@ use itertools::Itertools as _;
 use jj_lib::file_util;
 use jj_lib::git;
 use jj_lib::git::parse_git_ref;
-use jj_lib::git::RefName;
+use jj_lib::git::GitRefKind;
 use jj_lib::refs::RemoteRefSymbol;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
@@ -241,13 +241,13 @@ pub fn maybe_set_repository_level_trunk_alias(
         .map_err(internal_error)?
     {
         if let Some(reference_name) = reference.target().try_name() {
-            if let Some(RefName::RemoteBranch(symbol)) = str::from_utf8(reference_name.as_bstr())
+            if let Some((GitRefKind::Bookmark, symbol)) = str::from_utf8(reference_name.as_bstr())
                 .ok()
                 .and_then(parse_git_ref)
             {
                 // TODO: Can we assume the symbolic target points to the same remote?
                 let symbol = RemoteRefSymbol {
-                    name: &symbol.name,
+                    name: symbol.name,
                     remote: "origin",
                 };
                 write_repository_level_trunk_alias(ui, workspace_command.repo_path(), symbol)?;

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2255,11 +2255,13 @@ fn git2_get_default_branch(
     tracing::debug!("remote.default_branch");
     if let Ok(default_ref_buf) = connection.default_branch() {
         if let Some(default_ref) = default_ref_buf.as_str() {
-            // LocalBranch here is the local branch on the remote, so it's really the remote
-            // branch
-            if let Some(RefName::LocalBranch(branch_name)) = parse_git_ref(default_ref) {
+            // Here the ref should point to local branch on the remote
+            if let Some(branch_name) = default_ref
+                .strip_prefix("refs/heads/")
+                .filter(|&name| name != "HEAD")
+            {
                 tracing::debug!(default_branch = branch_name);
-                default_branch = Some(branch_name);
+                default_branch = Some(branch_name.to_owned());
             }
         }
     }


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
