### PR TITLE
index: don't preserve commits not referred to by operations/views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* `jj op abandon` now discards previous versions of a change (or predecessors)
+  if they become unreachable from the operation history. The evolution history
+  is truncated accordingly.
+
+  Once `jj op abandon` and `jj util gc` are run in a repository, old versions of
+  `jj` might get "commit not found" error on `jj evolog`.
+
 ### Deprecations
 
 ### New features

--- a/cli/src/commands/operation/abandon.rs
+++ b/cli/src/commands/operation/abandon.rs
@@ -37,8 +37,10 @@ use crate::ui::Ui;
 /// To discard recent operations, use `jj op restore <operation ID>` followed
 /// by `jj op abandon <operation ID>..@-`.
 ///
-/// The abandoned operations, commits, and other unreachable objects can later
-/// be garbage collected by using `jj util gc` command.
+/// Previous versions of a change (or predecessors) are also discarded if they
+/// become unreachable from the operation history. The abandoned operations,
+/// commits, and other unreachable objects can later be garbage collected by
+/// using `jj util gc` command.
 #[derive(clap::Args, Clone, Debug)]
 pub struct OperationAbandonArgs {
     /// The operation or operation range to abandon

--- a/cli/src/commands/util/gc.rs
+++ b/cli/src/commands/util/gc.rs
@@ -27,9 +27,6 @@ use crate::ui::Ui;
 ///
 /// To garbage-collect old operations and the commits/objects referenced by
 /// them, run `jj op abandon ..<some old operation>` before `jj util gc`.
-///
-/// Previous versions of a change that are reachable via the evolution log are
-/// not garbage-collected.
 #[derive(clap::Args, Clone, Debug)]
 pub struct UtilGcArgs {
     /// Time threshold

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1709,7 +1709,7 @@ To discard old operation history, use `jj op abandon ..<operation ID>`. It will 
 
 To discard recent operations, use `jj op restore <operation ID>` followed by `jj op abandon <operation ID>..@-`.
 
-The abandoned operations, commits, and other unreachable objects can later be garbage collected by using `jj util gc` command.
+Previous versions of a change (or predecessors) are also discarded if they become unreachable from the operation history. The abandoned operations, commits, and other unreachable objects can later be garbage collected by using `jj util gc` command.
 
 **Usage:** `jj operation abandon <OPERATION>`
 
@@ -2762,8 +2762,6 @@ echo "args: $@"
 Run backend-dependent garbage collection.
 
 To garbage-collect old operations and the commits/objects referenced by them, run `jj op abandon ..<some old operation>` before `jj util gc`.
-
-Previous versions of a change that are reachable via the evolution log are not garbage-collected.
 
 **Usage:** `jj util gc [OPTIONS]`
 

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -109,10 +109,9 @@ pub trait Index: Send + Sync {
 
     /// Heads among all indexed commits at the associated operation.
     ///
-    /// Suppose the index contains all the historical heads and their
-    /// ancestors/predecessors reachable from the associated operation, this
-    /// function returns the heads that should be preserved on garbage
-    /// collection.
+    /// Suppose the index contains all the historical heads and their ancestors
+    /// reachable from the associated operation, this function returns the heads
+    /// that should be preserved on garbage collection.
     ///
     /// The iteration order is unspecified.
     fn all_heads_for_gc(

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -359,9 +359,9 @@ impl View {
     /// Iterates all commit ids referenced by this view.
     ///
     /// This can include hidden commits referenced by remote bookmarks, previous
-    /// positions of conflicted bookmarks, etc. The ancestors and predecessors
-    /// of the returned commits should be considered reachable from the
-    /// view. Use this to build commit index from scratch.
+    /// positions of conflicted bookmarks, etc. The ancestors of the returned
+    /// commits should be considered reachable from the view. Use this to build
+    /// commit index from scratch.
     ///
     /// The iteration order is unspecified, and may include duplicated entries.
     pub fn all_referenced_commit_ids(&self) -> impl Iterator<Item = &CommitId> {


### PR DESCRIPTION
~I originally considered it would be a bad idea to ignore predecessors that don't exist in the store because doing that could shadow potential data corruption issues. However, we have index built from the op log, which knows all reachable commits. So we can ask index whether the predecessor id is supposed to exist. If a predecessor exists in the index but not in the Git object store, the repository is corrupted.~

~https://github.com/jj-vcs/jj/pull/4953#issuecomment-2495735683~

~In this implementation, we assume that predecessor commits are reachable from at least one of the historical views. Some commands (e.g. squash into descendants) may create transitive commits within an operation. In that case, the predecessor chain is initially preserved, but will be lost after reindexing. We might have to fix these commands to not record transitive predecessors.~

Note that this change should be considered forward-incompatible change. We can't easily revert this patch because the stored commits will have unreachable predecessors once we run "jj op abandon && jj util gc".

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
