### PR TITLE
git_backend: don't allow single tree in `jj:trees` header

### DIFF
--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -92,7 +92,7 @@ const CHANGE_ID_LENGTH: usize = 16;
 const NO_GC_REF_NAMESPACE: &str = "refs/jj/keep/";
 const CONFLICT_SUFFIX: &str = ".jjconflict";
 
-const JJ_TREES_COMMIT_HEADER: &[u8] = b"jj:trees";
+pub const JJ_TREES_COMMIT_HEADER: &[u8] = b"jj:trees";
 
 #[derive(Debug, Error)]
 pub enum GitBackendInitError {

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -496,7 +496,10 @@ fn root_tree_from_header(git_commit: &CommitRef) -> Result<Option<MergedTreeId>,
                 }
                 tree_ids.push(tree_id);
             }
-            if tree_ids.len() % 2 == 0 {
+            // It is invalid to use `jj:trees` with a non-conflicted tree. If this were
+            // allowed, it would be possible to construct a commit which appears to have
+            // different contents depending on whether it is viewed using `jj` or `git`.
+            if tree_ids.len() == 1 || tree_ids.len() % 2 == 0 {
                 return Err(());
             }
             return Ok(Some(MergedTreeId::Merge(Merge::from_vec(tree_ids))));


### PR DESCRIPTION
It is important for this case to be an error, because otherwise it would be possible to construct a non-conflicted commit which appears to have a different tree when viewed using `jj` than when viewed using Git. This could potentially be used to hide malicious code in commits in such a way that on GitHub, the code would appear normal, but it would become malicious when cloned using `jj`.

Prior to f7b14beacc678a9b351ae65224df43a96aa26392, if a commit had a `jj:trees` header with only a single tree, it would result in a panic of "root tree should have been initialized to a legacy id". This commit restores the error behavior by adding an explicit check for this case.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
