### PR TITLE
formatter: add support for reversing colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   now show up in `git diff` (as if you had run `git add --intent-to-add` on
   them).
 
+* Reversing colors is now supported. For example, to highlight words by
+  reversing colors rather than underlining, you can set
+  `colors."diff token"={ underline = false, reverse = true }` in your config.
+
 ### Fixed bugs
 
 * `jj log -p --stat` now shows diff stats as well as the default color-words/git

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -342,6 +342,9 @@
                             },
                             "underline": {
                                 "type": "boolean"
+                            },
+                            "reverse": {
+                                "type": "boolean"
                             }
                         }
                     }

--- a/docs/config.md
+++ b/docs/config.md
@@ -129,12 +129,14 @@ change_id = "#ff1525"
 ```
 
 If you use a string value for a color, as in the examples above, it will be used
-for the foreground color. You can also set the background color, or make the
-text bold, italic, or underlined. For that, you need to use a table:
+for the foreground color. You can also set the background color, reverse colors
+(swap foreground and background), or make the text bold, italic, or underlined.
+For that, you need to use a table:
 
 ```toml
 [colors]
-commit_id = { fg = "green", bg = "#ff1525", bold = true, italic = true, underline = true }
+commit_id = { fg = "green", bg = "#ff1525", bold = true, underline = true }
+change_id = { reverse = true, italic = true }
 ```
 
 The key names are called "labels". The above used `commit_id` as label. You can
@@ -205,6 +207,8 @@ can override the default style with the following keys:
 # Highlight hunks with background
 "diff removed token" = { bg = "#221111", underline = false }
 "diff added token" = { bg = "#002200", underline = false }
+# Alternatively, swap colors
+"diff token" = { reverse = true, underline = false }
 ```
 
 ### Diff format


### PR DESCRIPTION
The main goal here is to support formatting comparable to git's [diff-highlight](https://github.com/git/git/tree/master/contrib/diff-highlight). Using RGB colors is admittedly even better, but sadly not all terminals support them, notably macOS's Terminal.app.

I'd like to thank @gechr, as this is heavily based on his work on #5396.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
