### PR TITLE
cli: git: add `git root` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   adds the `--destination`, `--insert-after`, and `--insert-before` options to
   customize the location of reverted commits.
 
+* A new command `jj git root` is added, which prints the location of the Git
+  directory of a repository using the Git backend.
+
 ### Fixed bugs
 
 * `jj log -p --stat` now shows diff stats as well as the default color-words/git

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -19,6 +19,7 @@ mod import;
 mod init;
 mod push;
 mod remote;
+mod root;
 
 use std::path::Path;
 
@@ -44,6 +45,8 @@ use self::push::cmd_git_push;
 use self::push::GitPushArgs;
 use self::remote::cmd_git_remote;
 use self::remote::RemoteCommand;
+use self::root::cmd_git_root;
+use self::root::GitRootArgs;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::WorkspaceCommandHelper;
 use crate::command_error::user_error_with_message;
@@ -69,6 +72,7 @@ pub enum GitCommand {
     Push(GitPushArgs),
     #[command(subcommand)]
     Remote(RemoteCommand),
+    Root(GitRootArgs),
 }
 
 pub fn cmd_git(
@@ -84,6 +88,7 @@ pub fn cmd_git(
         GitCommand::Init(args) => cmd_git_init(ui, command, args),
         GitCommand::Push(args) => cmd_git_push(ui, command, args),
         GitCommand::Remote(args) => cmd_git_remote(ui, command, args),
+        GitCommand::Root(args) => cmd_git_root(ui, command, args),
     }
 }
 

--- a/cli/src/commands/git/root.rs
+++ b/cli/src/commands/git/root.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write as _;
+
+use jj_lib::repo::Repo as _;
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::user_error;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Show the underlying Git directory of a repository using the Git backend
+#[derive(clap::Args, Clone, Debug)]
+pub struct GitRootArgs {}
+
+#[instrument(skip_all)]
+pub fn cmd_git_root(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    _args: &GitRootArgs,
+) -> Result<(), CommandError> {
+    let workspace_command = command.workspace_helper(ui)?;
+    let store = workspace_command.repo().store();
+    let git_backend = jj_lib::git::get_git_backend(store)?;
+    let root = git_backend
+        .git_repo_path()
+        .to_str()
+        .ok_or_else(|| user_error("The workspace root is not valid UTF-8"))?;
+    writeln!(ui.stdout(), "{root}")?;
+    Ok(())
+}

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -58,6 +58,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj git remote remove`↴](#jj-git-remote-remove)
 * [`jj git remote rename`↴](#jj-git-remote-rename)
 * [`jj git remote set-url`↴](#jj-git-remote-set-url)
+* [`jj git root`↴](#jj-git-root)
 * [`jj help`↴](#jj-help)
 * [`jj interdiff`↴](#jj-interdiff)
 * [`jj log`↴](#jj-log)
@@ -1108,6 +1109,7 @@ See this [comparison], including a [table of commands].
 * `init` — Create a new Git backed repo
 * `push` — Push to a Git remote
 * `remote` — Manage Git remotes
+* `root` — Show the underlying Git directory of a repository using the Git backend
 
 
 
@@ -1339,6 +1341,14 @@ Set the URL of a Git remote
 * `<URL>` — The desired URL or path for `remote`
 
    Local path will be resolved to absolute form.
+
+
+
+## `jj git root`
+
+Show the underlying Git directory of a repository using the Git backend
+
+**Usage:** `jj git root`
 
 
 

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -45,6 +45,7 @@ mod test_git_init;
 mod test_git_private_commits;
 mod test_git_push;
 mod test_git_remotes;
+mod test_git_root;
 mod test_gitignores;
 mod test_global_opts;
 mod test_help_command;

--- a/cli/tests/test_git_root.rs
+++ b/cli/tests/test_git_root.rs
@@ -1,0 +1,102 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use testutils::git;
+
+use crate::common::TestEnvironment;
+
+#[test]
+fn test_git_root_git_backend_noncolocated() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["git", "root"]);
+    insta::assert_snapshot!(output, @r#"
+    $TEST_ENV/repo/.jj/repo/store/git
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_root_git_backend_colocated() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["git", "root"]);
+    insta::assert_snapshot!(output, @r#"
+    $TEST_ENV/repo/.git
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_root_git_backend_external_git_dir() {
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("").create_dir("repo");
+    let git_repo_work_dir = test_env.work_dir("git-repo");
+    let git_repo = git::init(git_repo_work_dir.root());
+
+    // Create an initial commit in Git
+    let tree_id = git::add_commit(
+        &git_repo,
+        "refs/heads/master",
+        "file",
+        b"contents",
+        "initial",
+        &[],
+    )
+    .tree_id;
+    git::checkout_tree_index(&git_repo, tree_id);
+    assert_eq!(git_repo_work_dir.read_file("file"), b"contents");
+    insta::assert_snapshot!(
+        git_repo.head_id().unwrap().to_string(),
+        @"97358f54806c7cd005ed5ade68a779595efbae7e"
+    );
+
+    work_dir
+        .run_jj([
+            "git",
+            "init",
+            "--git-repo",
+            git_repo_work_dir.root().to_str().unwrap(),
+        ])
+        .success();
+
+    let output = work_dir.run_jj(["git", "root"]);
+    insta::assert_snapshot!(output, @r#"
+    $TEST_ENV/git-repo/.git
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_root_simple_backend() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["debug", "init-simple", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["git", "root"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: The repo is not backed by a Git repo
+    [EOF]
+    [exit status: 1]
+    "#);
+}


### PR DESCRIPTION
This was discussed briefly in [1], and makes it easier to execute scripts which require a reference to the Git directory.

[1]: https://github.com/jj-vcs/jj/discussions/5767#discussioncomment-12480764

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
