### PR TITLE
RFC: improve SIGPIPE handling

### DIFF
--- a/cli/src/cleanup_guard.rs
+++ b/cli/src/cleanup_guard.rs
@@ -57,6 +57,7 @@ mod platform {
 
     use libc::c_int;
     use libc::SIGINT;
+    use libc::SIGPIPE;
     use libc::SIGTERM;
 
     use super::*;
@@ -89,6 +90,7 @@ mod platform {
         SIGNAL_SEND = send.into_raw_fd();
         libc::signal(SIGINT, handler as libc::sighandler_t);
         libc::signal(SIGTERM, handler as libc::sighandler_t);
+        libc::signal(SIGPIPE, handler as libc::sighandler_t);
         Ok(())
     }
 

--- a/cli/src/cleanup_guard.rs
+++ b/cli/src/cleanup_guard.rs
@@ -57,7 +57,6 @@ mod platform {
 
     use libc::c_int;
     use libc::SIGINT;
-    use libc::SIGPIPE;
     use libc::SIGTERM;
 
     use super::*;
@@ -90,7 +89,6 @@ mod platform {
         SIGNAL_SEND = send.into_raw_fd();
         libc::signal(SIGINT, handler as libc::sighandler_t);
         libc::signal(SIGTERM, handler as libc::sighandler_t);
-        libc::signal(SIGPIPE, handler as libc::sighandler_t);
         Ok(())
     }
 


### PR DESCRIPTION
This matches what git does, where it returns exit code 141 (128 + 13) when exiting the pager after running e.g. `git log`.

---

My desire to change this is so that I can continue to have exit statuses printed in my prompt, but ignored for these "not-really-an-error" exit statuses. I use fish, which already ignores  a 141 exit status in its default prompt like `git log` produces (as a result of this function ignoring it: https://github.com/fish-shell/fish-shell/blob/360cfdb7ae7af9a73cc3f357a78bd35b5b12e829/share/functions/__fish_print_pipestatus.fish#L22-L24), but I feel like blanket ignoring exit status 3 the same way would mask other CLI's actually-is-an-error exit statuses.

I marked this as an "RFC" because in https://github.com/jj-vcs/jj/issues/6107#issuecomment-2749797250, @yuja had some reservations (despite it not being "a strong feeling" either way, I still want to point this out) about changing this. That in addition to the fact it's been exit status 3 since 2022 means that this could break people's workflows if they depend on this exit status. I'm hoping that the benefits outweigh the detriments in your eyes, because this would make me really happy (not seeing an exit status of 3 in my prompt every time I use a `jj` command that spawns a pager).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
