### PR TITLE
vimdiff merge tool: use jj's diff conflict style and auto-navigate to conflicts

### DIFF
--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -52,7 +52,8 @@ program = "vim"
 # `-d` enables diff mode. `-f` makes vim run in foreground even if it starts a GUI.
 # The other options make sure that only the output file can be modified.
 merge-args = ["-f", "-d", "$output", "-M", "$left", "$base", "$right",
-              "-c", "wincmd J", "-c", "set modifiable", "-c", "set write"]
+              "-c", "wincmd J", "-c", "set modifiable", "-c", "set write",
+              "-c", "/<<<<<</+2"]
 merge-tool-edits-conflict-markers = true
 # Using vimdiff as a diff editor is not recommended. For instructions on configuring
 # the DirDiff Vim plugin for a better experience, see

--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -54,7 +54,6 @@ program = "vim"
 merge-args = ["-f", "-d", "$output", "-M", "$left", "$base", "$right",
               "-c", "wincmd J", "-c", "set modifiable", "-c", "set write"]
 merge-tool-edits-conflict-markers = true
-conflict-marker-style = "snapshot"
 # Using vimdiff as a diff editor is not recommended. For instructions on configuring
 # the DirDiff Vim plugin for a better experience, see
 # https://gist.github.com/ilyagr/5d6339fb7dac5e7ab06fe1561ec62d45


### PR DESCRIPTION
Cc @scott2000

Now, vimdiff automatically navigates to the first conflict, and looks like this:

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/d49dbedc-3e8d-4e3e-97ba-7498e6448a4b" />

The main pane now shows jj's diff view, since you can see the snapshot in the top panes

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md` (probably not needed?)
- ~~[ ] I have updated the documentation (README.md, docs/, demos/)~~
- ~~[ ] I have updated the config schema (cli/src/config-schema.json)~~
- ~~[ ] I have added tests to cover my changes~~
