### PR TITLE
description_template: Write intro verbatim when present

### DIFF
--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -146,18 +146,17 @@ pub(crate) fn cmd_split(
 
     // Create the first commit, which includes the changes selected by the user.
     let first_commit = {
+        let mut intro = "".to_string();
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder.set_tree_id(target.selected_tree.id());
         if commit_builder.description().is_empty() {
             commit_builder.set_description(tx.settings().get_string("ui.default-description")?);
+            intro += "\n";
         }
+        intro += "JJ: Enter a description for the first commit.";
+
         let temp_commit = commit_builder.write_hidden()?;
-        let template = description_template(
-            ui,
-            &tx,
-            "Enter a description for the first commit.",
-            &temp_commit,
-        )?;
+        let template = description_template(ui, &tx, &intro, &temp_commit)?;
         let description = edit_description(&text_editor, &template)?;
         commit_builder.set_description(description);
         commit_builder.write(tx.repo_mut())?
@@ -193,12 +192,8 @@ pub(crate) fn cmd_split(
             "".to_string()
         } else {
             let temp_commit = commit_builder.write_hidden()?;
-            let template = description_template(
-                ui,
-                &tx,
-                "Enter a description for the second commit.",
-                &temp_commit,
-            )?;
+            let intro = "JJ: Enter a description for the second commit.";
+            let template = description_template(ui, &tx, intro, &temp_commit)?;
             edit_description(&text_editor, &template)?
         };
         commit_builder.set_description(description);

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -183,7 +183,7 @@ pub(crate) fn cmd_squash(
                 if let Some(description) = try_combine_messages(abandoned_commits, &destination) {
                     description
                 } else {
-                    let intro = "Enter a description for the combined commit.";
+                    let intro = "JJ: Enter a description for the combined commit.";
                     let combined = combine_messages_for_editing(abandoned_commits, &destination);
                     // It's weird that commit.description() contains "JJ: " lines, but works.
                     commit_builder.set_description(combined);

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -347,7 +347,7 @@ pub fn description_template(
 
     let mut output = Vec::new();
     if !intro.is_empty() {
-        writeln!(output, "JJ: {intro}").unwrap();
+        writeln!(output, "{intro}").unwrap();
     }
     template
         .format(commit, &mut PlainTextFormatter::new(&mut output))


### PR DESCRIPTION
This way we can make it so split looks more like describe and has an empty line for the first line. Most other caller sets intro as the empty string, so does not need updating.

I'm adding the empty first line to `split` since its use is very similar to `describe`, namely the user is looking at a "blank" screen and expected to write a commit message.

Squash on the other hand is presenting information that the user is going to want to read first so it makes sense to avoid the empty line as the first line.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
