### PR TITLE
git_backend: derive the change ID from the git `change-id` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Release highlights
 
+* Experimental support for transferring the change ID to/from Git remotes behind configuration
+  setting `git.write-change-id-header`. If this is enabled, the change ID will be stored in the Git
+  commit itself (in a commit header called `change-id`), which means it will be transferred by
+  regular `git push` etc. This is an evolving feature that currently defaults to "false". This
+  default will likely change in the future as we gain confidence with forge support and user
+  expectations.
+
 ### Breaking changes
 
 ### Deprecations

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -470,6 +470,11 @@
                     "description": "Whether jj spawns a git subprocess for network operations (push/fetch/clone)",
                     "default": true
                 },
+                "write-change-id-header": {
+                    "type": "boolean",
+                    "description": "Whether the change id should be stored in the Git commit object",
+                    "default": false
+                },
                 "executable-path": {
                     "type": "string",
                     "description": "Path to the git executable",

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -217,3 +217,10 @@ directories in your working copy. If you then run e.g. `jj status`, the
 resulting snapshot will contain those directories, making it look like they
 replaced all the other paths in your repo. You will probably want to run
 `jj abandon` to get back to the state with the unresolved conflicts.
+
+Change IDs are stored in git commit headers as reverse hex encodings. These is
+a non-standard header and is not preserved by all `git` tooling. For example,
+the header is preserved by a `git commit --amend`, but is not preserved through
+a rebase operation. GitHub and other major forges seem to preserve them for the
+most part. This functionality is currently behind a `git.write-change-id-header`
+flag.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -54,9 +54,6 @@ A change ID is a unique identifier for a [change](#change). They are typically
 them as a sequence of 12 letters in the k-z range, at the beginning of a line.
 These are actually hexadecimal numbers that use "digits" z-k instead of 0-9a-f.
 
-For the Git backend, Change IDs are currently maintained only locally and not
-exchanged via push/fetch operations.
-
 ## Commit
 
 A snapshot of the files in the repository at a given point in time (technically

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -14,6 +14,7 @@ abandon-unreachable-commits = true
 auto-local-bookmark = false
 subprocess = true
 executable-path = "git"
+write-change-id-header = false
 
 [operation]
 hostname = ""

--- a/lib/src/hex_util.rs
+++ b/lib/src/hex_util.rs
@@ -29,10 +29,11 @@ fn to_forward_hex_digit(b: u8) -> Option<u8> {
     }
 }
 
-pub fn to_forward_hex(reverse_hex: &str) -> Option<String> {
+pub fn to_forward_hex(reverse_hex: impl AsRef<[u8]>) -> Option<String> {
     reverse_hex
-        .bytes()
-        .map(|b| to_forward_hex_digit(b).map(char::from))
+        .as_ref()
+        .iter()
+        .map(|b| to_forward_hex_digit(*b).map(char::from))
         .collect()
 }
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -66,6 +66,7 @@ pub struct GitSettings {
     #[cfg(feature = "git2")]
     pub subprocess: bool,
     pub executable_path: PathBuf,
+    pub change_id: bool,
 }
 
 impl GitSettings {
@@ -76,6 +77,7 @@ impl GitSettings {
             #[cfg(feature = "git2")]
             subprocess: settings.get_bool("git.subprocess")?,
             executable_path: settings.get("git.executable-path")?,
+            change_id: settings.get("git.write-change-id-header")?,
         })
     }
 }
@@ -88,6 +90,7 @@ impl Default for GitSettings {
             #[cfg(feature = "git2")]
             subprocess: true,
             executable_path: PathBuf::from("git"),
+            change_id: false,
         }
     }
 }


### PR DESCRIPTION
When read/writing commits from the git-backend, populate the git commit header with a backwards hash of the `change-id`. This should enable preserving change identity across various git remotes assuming a cooperative git server that doesn't strip the git header.

This feature is behind a `git.change-id` configuration flag at least to start.


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
