### PR TITLE
github: add a CODEOWNERS file with only the maintainers in

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The maintainers own all files.
+# See GOVERNANCE.md for the list of current maintainers.
+* @jj-vcs/maintainers


### PR DESCRIPTION
As discussed several times before, we want to restrict permission to approve PRs to the maintainers only. This patch adds a GitHub CODEOWNERS file for that purpose. Once this has been merged, I'm going to update the rulesets to make PRs requires approval from a maintainer.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
