### PR TITLE
templates: create new git_format_patch_email_headers template

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -402,3 +402,21 @@ coalesce(
   "o",
 )
 '''
+
+# The first line is a fixed magic date string used by
+# programs like file(1) to identify that this is output from
+# 'git format-patch'.
+# See https://git-scm.com/docs/git-format-patch#_description
+git_format_patch_email_headers = '''
+  concat(
+    "From " ++ commit_id ++ " Mon Sep 17 00:00:00 2001\n",
+    "From: " ++ author ++ "\n",
+    "Date: " ++ author.timestamp().format("%a, %-e %b %Y %T %z") ++ "\n",
+    "Subject: [PATCH] " ++ description.first_line() ++ "\n",
+    "\n",
+    description.remove_prefix(description.first_line()).trim_start(),
+    "---\n",
+    indent(" ", diff.stat()),
+    "\n"
+  )
+'''

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -766,6 +766,7 @@ fn test_template_alias() {
     commit_summary_separator
     description_placeholder
     email_placeholder
+    git_format_patch_email_headers
     name_placeholder
     [EOF]
     ");

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -361,6 +361,7 @@ fn test_evolog_with_no_template() {
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
+    - git_format_patch_email_headers
     - name_placeholder
     [EOF]
     [exit status: 2]

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -63,6 +63,7 @@ fn test_log_with_no_template() {
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
+    - git_format_patch_email_headers
     - name_placeholder
     [EOF]
     [exit status: 2]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -182,6 +182,7 @@ fn test_op_log_with_no_template() {
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
+    - git_format_patch_email_headers
     - name_placeholder
     [EOF]
     [exit status: 2]

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -288,6 +288,7 @@ fn test_show_with_no_template() {
     - commit_summary_separator
     - description_placeholder
     - email_placeholder
+    - git_format_patch_email_headers
     - name_placeholder
     [EOF]
     [exit status: 2]

--- a/demos/demo_git_compat.sh
+++ b/demos/demo_git_compat.sh
@@ -29,6 +29,9 @@ run_command "jj diff -r b1"
 blank
 run_command "jj diff -r b3"
 
+comment "We can generate a 'git format-patch' compatible diff"
+run_command "jj show --git --template git_format_patch_email_headers"
+
 comment "The repo is backed by the actual Git repo:"
 run_command "git --git-dir=.jj/repo/store/git log --graph --all --decorate --oneline"
 


### PR DESCRIPTION
With this template, a `git format-patch` compatible email message can be generated using something like:

`jj show --git --template git_format_patch_email_headers <rev>`

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
