### PR TITLE
cli/tests: Prevent git.subprocess from reading outside git config

### DIFF
--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -120,6 +120,9 @@ impl TestEnvironment {
         // executables like `git` from the PATH.
         cmd.env("PATH", std::env::var_os("PATH").unwrap_or_default());
         cmd.env("HOME", self.home_dir.to_str().unwrap());
+        // Prevent git.subprocess from reading outside git config
+        cmd.env("GIT_CONFIG_SYSTEM", "/dev/null");
+        cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
         cmd.env("JJ_CONFIG", self.config_path.to_str().unwrap());
         cmd.env("JJ_USER", "Test User");
         cmd.env("JJ_EMAIL", "test.user@example.com");

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -439,9 +439,10 @@ fn test_git_remote_with_branch_config() {
         .open(work_dir.root().join(".jj/repo/store/git/config"))
         .unwrap();
     // `git clone` adds branch configuration like this.
-    writeln!(config_file, "[branch \"test\"]").unwrap();
-    writeln!(config_file, "\tremote = foo").unwrap();
-    writeln!(config_file, "\tmerge = refs/heads/test").unwrap();
+    let eol = if cfg!(windows) { "\r\n" } else { "\n" };
+    write!(config_file, "[branch \"test\"]{eol}").unwrap();
+    write!(config_file, "\tremote = foo{eol}").unwrap();
+    write!(config_file, "\tmerge = refs/heads/test{eol}").unwrap();
     drop(config_file);
 
     let output = work_dir.run_jj(["git", "remote", "rename", "foo", "bar"]);


### PR DESCRIPTION
A subset of cli tests could fail if the system `/etc/gitconfig` had configuration interfering with the tests. The cause seems to be running of `jj` commands that would in turn use a `git` subprocess.

Fix this by setting `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_GLOBAL`, like in `hermetic_git`.

Fixes #6159

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- ~I have updated `CHANGELOG.md`~
- ~I have updated the documentation (README.md, docs/, demos/)~
- ~I have updated the config schema (cli/src/config-schema.json)~
- ~I have added tests to cover my changes~
