### PR TITLE
view: rename RemoteRefState::Tracking to Tracked

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2899,7 +2899,7 @@ pub fn has_tracked_remote_bookmarks(view: &View, bookmark: &RefName) -> bool {
         &StringPattern::everything(),
     )
     .filter(|&(symbol, _)| !jj_lib::git::is_special_git_remote(symbol.remote))
-    .any(|(_, remote_ref)| remote_ref.is_tracking())
+    .any(|(_, remote_ref)| remote_ref.is_tracked())
 }
 
 pub fn load_template_aliases(

--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -59,7 +59,7 @@ pub fn cmd_bookmark_track(
     let repo = workspace_command.repo().clone();
     let mut symbols = Vec::new();
     for (symbol, remote_ref) in find_remote_bookmarks(repo.view(), &args.names)? {
-        if remote_ref.is_tracking() {
+        if remote_ref.is_tracked() {
             writeln!(
                 ui.warning_default(),
                 "Remote bookmark already tracked: {symbol}"

--- a/cli/src/commands/bookmark/untrack.rs
+++ b/cli/src/commands/bookmark/untrack.rs
@@ -64,7 +64,7 @@ pub fn cmd_bookmark_untrack(
                 ui.warning_default(),
                 "Git-tracking bookmark cannot be untracked: {symbol}"
             )?;
-        } else if !remote_ref.is_tracking() {
+        } else if !remote_ref.is_tracked() {
             writeln!(
                 ui.warning_default(),
                 "Remote bookmark not tracked yet: {symbol}"

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -262,7 +262,7 @@ fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
             bookmark_target
                 .remote_refs
                 .into_iter()
-                .filter(|&(_, remote_ref)| !remote_ref.is_tracking())
+                .filter(|&(_, remote_ref)| !remote_ref.is_tracked())
                 .map(move |(remote, _)| name.to_remote_symbol(remote))
         })
         .collect_vec();

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -227,7 +227,7 @@ pub fn cmd_git_push(
         );
     } else if args.tracked {
         for (name, targets) in view.local_remote_bookmarks(remote) {
-            if !targets.remote_ref.is_tracking() {
+            if !targets.remote_ref.is_tracked() {
                 continue;
             }
             let allow_new = false; // doesn't matter
@@ -796,9 +796,9 @@ fn find_bookmarks_to_push<'a>(
         let mut matches = view
             .local_remote_bookmarks_matching(pattern, remote)
             .filter(|(_, targets)| {
-                // If the remote exists but is not tracking, the absent local shouldn't
+                // If the remote exists but is not tracked, the absent local shouldn't
                 // be considered a deleted bookmark.
-                targets.local_target.is_present() || targets.remote_ref.is_tracking()
+                targets.local_target.is_present() || targets.remote_ref.is_tracked()
             })
             .peekable();
         if matches.peek().is_none() {

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -389,7 +389,7 @@ pub fn show_op_diff(
         })?;
         let get_remote_ref_prefix = |remote_ref: &RemoteRef| match remote_ref.state {
             RemoteRefState::New => "untracked",
-            RemoteRefState::Tracking => "tracked",
+            RemoteRefState::Tracked => "tracked",
         };
         for (symbol, (from_ref, to_ref)) in changed_remote_bookmarks {
             with_content_format.write(formatter, |formatter| {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1173,7 +1173,7 @@ impl CommitRef {
     ) -> Rc<Self> {
         let synced = remote_refs
             .into_iter()
-            .all(|remote_ref| !remote_ref.is_tracking() || remote_ref.target == target);
+            .all(|remote_ref| !remote_ref.is_tracked() || remote_ref.target == target);
         Rc::new(CommitRef {
             name: name.into(),
             remote: None,
@@ -1196,8 +1196,8 @@ impl CommitRef {
         remote_ref: RemoteRef,
         local_target: &RefTarget,
     ) -> Rc<Self> {
-        let synced = remote_ref.is_tracking() && remote_ref.target == *local_target;
-        let tracking_ref = remote_ref.is_tracking().then(|| {
+        let synced = remote_ref.is_tracked() && remote_ref.target == *local_target;
+        let tracking_ref = remote_ref.is_tracked().then(|| {
             let count = if synced {
                 OnceCell::from((0, Some(0))) // fast path for synced remotes
             } else {

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -514,7 +514,7 @@ impl RefStatus {
     ) -> Self {
         let tracking_status = match ref_kind {
             GitRefKind::Bookmark => {
-                if repo.view().get_remote_bookmark(symbol).is_tracking() {
+                if repo.view().get_remote_bookmark(symbol).is_tracked() {
                     TrackingStatus::Tracked
                 } else {
                     TrackingStatus::Untracked

--- a/docs/design/tracking-branches.md
+++ b/docs/design/tracking-branches.md
@@ -126,9 +126,9 @@ branch. `jj branch` sub commands will be added to change the tracking state.
 ```rust
 fn default_state_for_newly_imported_branch(config, remote) {
     if remote == "git" {
-        State::Tracking
+        State::Tracked
     } else if config["git.auto-local-bookmark"] {
-        State::Tracking
+        State::Tracked
     } else {
         State::New
     }
@@ -141,7 +141,7 @@ A branch target to be merged is calculated based on the `state`.
 fn target_in_merge_context(known_target, state) {
     match state {
         State::New => RefTarget::absent(),
-        State::Tracking => known_target,
+        State::Tracked => known_target,
     }
 }
 ```

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -488,7 +488,7 @@ pub fn import_some_refs(
     }
     for (symbol, (old_remote_ref, new_target)) in &changed_remote_bookmarks {
         let symbol = symbol.as_ref();
-        let base_target = old_remote_ref.tracking_target();
+        let base_target = old_remote_ref.tracked_target();
         let new_remote_ref = RemoteRef {
             target: new_target.clone(),
             state: if old_remote_ref.is_present() {
@@ -497,7 +497,7 @@ pub fn import_some_refs(
                 default_remote_ref_state_for(GitRefKind::Bookmark, symbol, git_settings)
             },
         };
-        if new_remote_ref.is_tracking() {
+        if new_remote_ref.is_tracked() {
             mut_repo.merge_local_bookmark(symbol.name, base_target, &new_remote_ref.target);
         }
         // Remote-tracking branch is the last known state of the branch in the remote.
@@ -506,7 +506,7 @@ pub fn import_some_refs(
     }
     for (symbol, (old_remote_ref, new_target)) in &changed_remote_tags {
         let symbol = symbol.as_ref();
-        let base_target = old_remote_ref.tracking_target();
+        let base_target = old_remote_ref.tracked_target();
         let new_remote_ref = RemoteRef {
             target: new_target.clone(),
             state: if old_remote_ref.is_present() {
@@ -515,7 +515,7 @@ pub fn import_some_refs(
                 default_remote_ref_state_for(GitRefKind::Tag, symbol, git_settings)
             },
         };
-        if new_remote_ref.is_tracking() {
+        if new_remote_ref.is_tracked() {
             mut_repo.merge_tag(symbol.name, base_target, &new_remote_ref.target);
         }
         // TODO: If we add Git-tracking tag, it will be updated here.
@@ -604,7 +604,7 @@ fn diff_refs_to_import(
         .iter()
         .map(|(name, target)| {
             let symbol = name.to_remote_symbol(REMOTE_NAME_FOR_LOCAL_GIT_REPO);
-            let state = RemoteRefState::Tracking;
+            let state = RemoteRefState::Tracked;
             (symbol, (target, state))
         })
         .filter(|&(symbol, _)| git_ref_filter(GitRefKind::Tag, symbol))
@@ -737,12 +737,12 @@ fn default_remote_ref_state_for(
     match kind {
         GitRefKind::Bookmark => {
             if symbol.remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO || git_settings.auto_local_bookmark {
-                RemoteRefState::Tracking
+                RemoteRefState::Tracked
             } else {
                 RemoteRefState::New
             }
         }
-        GitRefKind::Tag => RemoteRefState::Tracking,
+        GitRefKind::Tag => RemoteRefState::Tracked,
     }
 }
 
@@ -769,7 +769,7 @@ fn pinned_commit_ids(view: &View) -> Vec<CommitId> {
 /// branches are considered independent refs.
 fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
     view.all_remote_bookmarks()
-        .filter(|(_, remote_ref)| !remote_ref.is_tracking())
+        .filter(|(_, remote_ref)| !remote_ref.is_tracked())
         .map(|(_, remote_ref)| &remote_ref.target)
         .flat_map(|target| target.added_ids())
         .cloned()
@@ -1021,7 +1021,7 @@ fn copy_exportable_local_bookmarks_to_remote_view(
     for (name, new_target) in new_local_bookmarks {
         let new_remote_ref = RemoteRef {
             target: new_target,
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         };
         mut_repo.set_remote_bookmark(name.to_remote_symbol(remote), new_remote_ref);
     }
@@ -2515,7 +2515,7 @@ pub fn push_branches(
             .into();
             let new_remote_ref = RemoteRef {
                 target: RefTarget::resolved(update.new_target.clone()),
-                state: RemoteRefState::Tracking,
+                state: RemoteRefState::Tracked,
             };
             mut_repo.set_git_ref_target(&git_ref_name, new_remote_ref.target.clone());
             mut_repo.set_remote_bookmark(name.to_remote_symbol(remote), new_remote_ref);

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -193,16 +193,16 @@ impl RemoteRef {
     }
 
     /// Returns true if the ref is supposed to be merged in to the local ref.
-    pub fn is_tracking(&self) -> bool {
-        self.state == RemoteRefState::Tracking
+    pub fn is_tracked(&self) -> bool {
+        self.state == RemoteRefState::Tracked
     }
 
     /// Target that should have been merged in to the local ref.
     ///
     /// Use this as the base or known target when merging new remote ref in to
     /// local or pushing local ref to remote.
-    pub fn tracking_target(&self) -> &RefTarget {
-        if self.is_tracking() {
+    pub fn tracked_target(&self) -> &RefTarget {
+        if self.is_tracked() {
             &self.target
         } else {
             RefTarget::absent_ref()
@@ -217,7 +217,7 @@ pub enum RemoteRefState {
     New,
     /// Remote ref has been merged in to the local ref. Incoming ref will be
     /// merged, too.
-    Tracking,
+    Tracked,
 }
 
 /// Helper to strip redundant `Option<T>` from `RefTarget` lookup result.
@@ -507,7 +507,7 @@ mod tests {
     fn test_merge_join_bookmark_views() {
         let remote_ref = |target: &RefTarget| RemoteRef {
             target: target.clone(),
-            state: RemoteRefState::Tracking, // doesn't matter
+            state: RemoteRefState::Tracked, // doesn't matter
         };
         let local_bookmark1_target = RefTarget::normal(CommitId::from_hex("111111"));
         let local_bookmark2_target = RefTarget::normal(CommitId::from_hex("222222"));

--- a/lib/src/protos/op_store.proto
+++ b/lib/src/protos/op_store.proto
@@ -40,7 +40,7 @@ message RefTarget {
 
 enum RemoteRefState {
   New = 0;
-  Tracking = 1;
+  Tracked = 1;
 }
 
 message RemoteBookmark {

--- a/lib/src/protos/op_store.rs
+++ b/lib/src/protos/op_store.rs
@@ -167,7 +167,7 @@ pub struct OperationMetadata {
 #[repr(i32)]
 pub enum RemoteRefState {
     New = 0,
-    Tracking = 1,
+    Tracked = 1,
 }
 impl RemoteRefState {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -177,14 +177,14 @@ impl RemoteRefState {
     pub fn as_str_name(&self) -> &'static str {
         match self {
             RemoteRefState::New => "New",
-            RemoteRefState::Tracking => "Tracking",
+            RemoteRefState::Tracked => "Tracked",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "New" => Some(Self::New),
-            "Tracking" => Some(Self::Tracking),
+            "Tracked" => Some(Self::Tracked),
             _ => None,
         }
     }

--- a/lib/src/refs.rs
+++ b/lib/src/refs.rs
@@ -209,14 +209,14 @@ pub enum BookmarkPushAction {
 /// this bookmark.
 pub fn classify_bookmark_push_action(targets: LocalAndRemoteRef) -> BookmarkPushAction {
     let local_target = targets.local_target;
-    let remote_target = targets.remote_ref.tracking_target();
+    let remote_target = targets.remote_ref.tracked_target();
     if local_target == remote_target {
         BookmarkPushAction::AlreadyMatches
     } else if local_target.has_conflict() {
         BookmarkPushAction::LocalConflicted
     } else if remote_target.has_conflict() {
         BookmarkPushAction::RemoteConflicted
-    } else if targets.remote_ref.is_present() && !targets.remote_ref.is_tracking() {
+    } else if targets.remote_ref.is_present() && !targets.remote_ref.is_tracked() {
         BookmarkPushAction::RemoteUntracked
     } else {
         BookmarkPushAction::Update(BookmarkPushUpdate {
@@ -238,10 +238,10 @@ mod tests {
         }
     }
 
-    fn tracking_remote_ref(target: RefTarget) -> RemoteRef {
+    fn tracked_remote_ref(target: RefTarget) -> RemoteRef {
         RemoteRef {
             target,
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         }
     }
 
@@ -250,7 +250,7 @@ mod tests {
         let commit_id1 = CommitId::from_hex("11");
         let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id1.clone()),
-            remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1)),
+            remote_ref: &tracked_remote_ref(RefTarget::normal(commit_id1)),
         };
         assert_eq!(
             classify_bookmark_push_action(targets),
@@ -279,7 +279,7 @@ mod tests {
         let commit_id1 = CommitId::from_hex("11");
         let targets = LocalAndRemoteRef {
             local_target: RefTarget::absent_ref(),
-            remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1.clone())),
+            remote_ref: &tracked_remote_ref(RefTarget::normal(commit_id1.clone())),
         };
         assert_eq!(
             classify_bookmark_push_action(targets),
@@ -296,7 +296,7 @@ mod tests {
         let commit_id2 = CommitId::from_hex("22");
         let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id2.clone()),
-            remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1.clone())),
+            remote_ref: &tracked_remote_ref(RefTarget::normal(commit_id1.clone())),
         };
         assert_eq!(
             classify_bookmark_push_action(targets),
@@ -342,7 +342,7 @@ mod tests {
         let commit_id2 = CommitId::from_hex("22");
         let targets = LocalAndRemoteRef {
             local_target: &RefTarget::from_legacy_form([], [commit_id1.clone(), commit_id2]),
-            remote_ref: &tracking_remote_ref(RefTarget::normal(commit_id1)),
+            remote_ref: &tracked_remote_ref(RefTarget::normal(commit_id1)),
         };
         assert_eq!(
             classify_bookmark_push_action(targets),
@@ -356,7 +356,7 @@ mod tests {
         let commit_id2 = CommitId::from_hex("22");
         let targets = LocalAndRemoteRef {
             local_target: &RefTarget::normal(commit_id1.clone()),
-            remote_ref: &tracking_remote_ref(RefTarget::from_legacy_form(
+            remote_ref: &tracked_remote_ref(RefTarget::from_legacy_form(
                 [],
                 [commit_id1, commit_id2],
             )),

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1578,9 +1578,9 @@ impl MutableRepo {
     /// tracking it.
     pub fn track_remote_bookmark(&mut self, symbol: RemoteRefSymbol<'_>) {
         let mut remote_ref = self.get_remote_bookmark(symbol);
-        let base_target = remote_ref.tracking_target();
+        let base_target = remote_ref.tracked_target();
         self.merge_local_bookmark(symbol.name, base_target, &remote_ref.target);
-        remote_ref.state = RemoteRefState::Tracking;
+        remote_ref.state = RemoteRefState::Tracked;
         self.set_remote_bookmark(symbol, remote_ref);
     }
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -743,7 +743,7 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
     map.insert(
         "tracked_remote_bookmarks",
         |diagnostics, function, _context| {
-            parse_remote_bookmarks_arguments(diagnostics, function, Some(RemoteRefState::Tracking))
+            parse_remote_bookmarks_arguments(diagnostics, function, Some(RemoteRefState::Tracked))
         },
     );
     map.insert(
@@ -1832,7 +1832,7 @@ fn all_formatted_bookmark_symbols(
             .into_iter()
             .filter(move |&(_, remote_ref)| {
                 include_synced_remotes
-                    || !remote_ref.is_tracking()
+                    || !remote_ref.is_tracked()
                     || remote_ref.target != *local_target
             })
             .map(move |(remote, _)| format_remote_symbol(name.as_str(), remote.as_str()));
@@ -2983,7 +2983,7 @@ mod tests {
             RemoteBookmarks {
                 bookmark_pattern: Substring(""),
                 remote_pattern: Substring(""),
-                remote_ref_state: Some(Tracking),
+                remote_ref_state: Some(Tracked),
             },
         )
         "#);
@@ -3317,7 +3317,7 @@ mod tests {
             RemoteBookmarks {
                 bookmark_pattern: Substring("foo"),
                 remote_pattern: Substring("bar"),
-                remote_ref_state: Some(Tracking),
+                remote_ref_state: Some(Tracked),
             },
         )
         "#);

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -608,7 +608,7 @@ fn bookmark_views_from_proto_legacy(
                 // setting could be toggled after the bookmark got merged.
                 let is_git_tracking = crate::git::is_special_git_remote(&remote_name);
                 let default_state = if is_git_tracking || local_target.is_present() {
-                    RemoteRefState::Tracking
+                    RemoteRefState::Tracked
                 } else {
                     RemoteRefState::New
                 };
@@ -712,7 +712,7 @@ fn ref_target_from_proto(maybe_proto: Option<crate::protos::op_store::RefTarget>
 fn remote_ref_state_to_proto(state: RemoteRefState) -> Option<i32> {
     let proto_state = match state {
         RemoteRefState::New => crate::protos::op_store::RemoteRefState::New,
-        RemoteRefState::Tracking => crate::protos::op_store::RemoteRefState::Tracking,
+        RemoteRefState::Tracked => crate::protos::op_store::RemoteRefState::Tracked,
     };
     Some(proto_state as i32)
 }
@@ -721,7 +721,7 @@ fn remote_ref_state_from_proto(proto_value: Option<i32>) -> Option<RemoteRefStat
     let proto_state = proto_value?.try_into().ok()?;
     let state = match proto_state {
         crate::protos::op_store::RemoteRefState::New => RemoteRefState::New,
-        crate::protos::op_store::RemoteRefState::Tracking => RemoteRefState::Tracking,
+        crate::protos::op_store::RemoteRefState::Tracked => RemoteRefState::Tracked,
     };
     Some(state)
 }
@@ -742,9 +742,9 @@ mod tests {
             target: target.clone(),
             state: RemoteRefState::New,
         };
-        let tracking_remote_ref = |target: &RefTarget| RemoteRef {
+        let tracked_remote_ref = |target: &RefTarget| RemoteRef {
             target: target.clone(),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         };
         let head_id1 = CommitId::from_hex("aaa111");
         let head_id2 = CommitId::from_hex("aaa222");
@@ -770,7 +770,7 @@ mod tests {
             remote_views: btreemap! {
                 "origin".into() => RemoteView {
                     bookmarks: btreemap! {
-                        "main".into() => tracking_remote_ref(&bookmark_main_origin_target),
+                        "main".into() => tracked_remote_ref(&bookmark_main_origin_target),
                         "deleted".into() => new_remote_ref(&bookmark_deleted_origin_target),
                     },
                 },
@@ -870,9 +870,9 @@ mod tests {
             target: target.clone(),
             state: RemoteRefState::New,
         };
-        let tracking_remote_ref = |target: &RefTarget| RemoteRef {
+        let tracked_remote_ref = |target: &RefTarget| RemoteRef {
             target: target.clone(),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         };
         let local_bookmark1_target = RefTarget::normal(CommitId::from_hex("111111"));
         let local_bookmark3_target = RefTarget::normal(CommitId::from_hex("222222"));
@@ -887,19 +887,19 @@ mod tests {
         let remote_views = btreemap! {
             "git".into() => RemoteView {
                 bookmarks: btreemap! {
-                    "bookmark1".into() => tracking_remote_ref(&git_bookmark1_target),
+                    "bookmark1".into() => tracked_remote_ref(&git_bookmark1_target),
                 },
             },
             "remote1".into() => RemoteView {
                 bookmarks: btreemap! {
-                    "bookmark1".into() => tracking_remote_ref(&remote1_bookmark1_target),
+                    "bookmark1".into() => tracked_remote_ref(&remote1_bookmark1_target),
                 },
             },
             "remote2".into() => RemoteView {
                 bookmarks: btreemap! {
                     // "bookmark2" is non-tracking. "bookmark4" is tracking, but locally deleted.
                     "bookmark2".into() => new_remote_ref(&remote2_bookmark2_target),
-                    "bookmark4".into() => tracking_remote_ref(&remote2_bookmark4_target),
+                    "bookmark4".into() => tracked_remote_ref(&remote2_bookmark4_target),
                 },
             },
         };

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -227,14 +227,14 @@ fn test_import_refs() {
         view.get_remote_bookmark(remote_symbol("main", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit2)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         view.get_remote_bookmark(remote_symbol("main", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit1)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
@@ -245,7 +245,7 @@ fn test_import_refs() {
         view.get_remote_bookmark(remote_symbol("feature1", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit3)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(view
@@ -259,7 +259,7 @@ fn test_import_refs() {
         view.get_remote_bookmark(remote_symbol("feature2", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit4)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(view
@@ -276,7 +276,7 @@ fn test_import_refs() {
         view.get_remote_bookmark(remote_symbol("feature3", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit6)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 
@@ -397,14 +397,14 @@ fn test_import_refs_reimport() {
         view.get_remote_bookmark(remote_symbol("main", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit2)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         view.get_remote_bookmark(remote_symbol("main", "origin")),
         &RemoteRef {
             target: commit1_target.clone(),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
@@ -415,7 +415,7 @@ fn test_import_refs_reimport() {
         view.get_remote_bookmark(remote_symbol("feature2", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit5)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(view
@@ -637,7 +637,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
         view.get_remote_bookmark(remote_symbol("feature-remote-only", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_only)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
@@ -648,14 +648,14 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
         view.get_remote_bookmark(remote_symbol("feature-remote-and-local", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_and_local)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         view.get_remote_bookmark(remote_symbol("feature-remote-and-local", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_and_local)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(view.get_local_bookmark("main".as_ref()).is_present()); // bookmark #3 of 3
@@ -688,7 +688,7 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
         view.get_remote_bookmark(remote_symbol("feature-remote-and-local", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_and_local)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(view
@@ -760,7 +760,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
         view.get_remote_bookmark(remote_symbol("feature-remote-only", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_only)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
@@ -771,14 +771,14 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
         view.get_remote_bookmark(remote_symbol("feature-remote-and-local", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_and_local)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         view.get_remote_bookmark(remote_symbol("feature-remote-and-local", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_and_local)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(view.get_local_bookmark("main".as_ref()).is_present()); // bookmark #3 of 3
@@ -818,7 +818,7 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
         view.get_remote_bookmark(remote_symbol("feature-remote-only", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(new_commit_remote_only)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
@@ -829,14 +829,14 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
         view.get_remote_bookmark(remote_symbol("feature-remote-and-local", "git")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_remote_and_local)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         view.get_remote_bookmark(remote_symbol("feature-remote-and-local", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(new_commit_remote_and_local)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(view.get_local_bookmark("main".as_ref()).is_present()); // bookmark #3 of 3
@@ -1180,7 +1180,7 @@ fn test_import_refs_reimport_conflicted_remote_bookmark() {
             .get_remote_bookmark(remote_symbol("main", "origin")),
         &RemoteRef {
             target: RefTarget::from_legacy_form([], [jj_id(commit1), jj_id(commit2)]),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 
@@ -1197,7 +1197,7 @@ fn test_import_refs_reimport_conflicted_remote_bookmark() {
             .get_remote_bookmark(remote_symbol("main", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit2)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 }
@@ -1269,19 +1269,19 @@ fn test_import_some_refs() {
     assert_eq!(view.bookmarks().count(), 4);
     let commit_feat1_remote_ref = RemoteRef {
         target: RefTarget::normal(jj_id(commit_feat1)),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     let commit_feat2_remote_ref = RemoteRef {
         target: RefTarget::normal(jj_id(commit_feat2)),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     let commit_feat3_remote_ref = RemoteRef {
         target: RefTarget::normal(jj_id(commit_feat3)),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     let commit_feat4_remote_ref = RemoteRef {
         target: RefTarget::normal(jj_id(commit_feat4)),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     assert_eq!(
         view.get_local_bookmark("feature1".as_ref()),
@@ -1892,7 +1892,7 @@ fn test_import_export_non_tracking_bookmark() {
             .get_remote_bookmark(remote_symbol("feat", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_feat_t1)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 
@@ -1924,7 +1924,7 @@ fn test_import_export_non_tracking_bookmark() {
             .get_remote_bookmark(remote_symbol("feat", "origin")),
         &RemoteRef {
             target: RefTarget::normal(jj_id(commit_feat_t2)),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 }
@@ -1979,14 +1979,14 @@ fn test_export_conflicts() {
         mut_repo.get_remote_bookmark(remote_symbol("feature", "git")),
         RemoteRef {
             target: RefTarget::normal(commit_a.id().clone()),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert_eq!(
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
         RemoteRef {
             target: RefTarget::normal(commit_b.id().clone()),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 }
@@ -2081,7 +2081,7 @@ fn test_export_partial_failure() {
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
         RemoteRef {
             target: target.clone(),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     assert!(mut_repo
@@ -2135,7 +2135,7 @@ fn test_export_partial_failure() {
         mut_repo.get_remote_bookmark(remote_symbol("main/sub", "git")),
         RemoteRef {
             target: target.clone(),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 }
@@ -2328,7 +2328,7 @@ fn test_export_undo_reexport() {
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
         RemoteRef {
             target: target_a.clone(),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 
@@ -2351,7 +2351,7 @@ fn test_export_undo_reexport() {
         mut_repo.get_remote_bookmark(remote_symbol("main", "git")),
         RemoteRef {
             target: target_a.clone(),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 }
@@ -2900,7 +2900,7 @@ fn test_fetch_initial_commit_head_is_not_set(subprocess: bool) {
     let initial_commit_target = RefTarget::normal(jj_id(initial_git_commit));
     let initial_commit_remote_ref = RemoteRef {
         target: initial_commit_target.clone(),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     assert_eq!(
         *view.git_refs(),
@@ -3013,7 +3013,7 @@ fn test_fetch_success(subprocess: bool) {
     let new_commit_target = RefTarget::normal(jj_id(new_git_commit));
     let new_commit_remote_ref = RemoteRef {
         target: new_commit_target.clone(),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     assert_eq!(
         *view.git_refs(),
@@ -3276,7 +3276,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
             target: RefTarget::normal(main_commit.id().clone()),
             // Caller expects the main bookmark is tracked. The corresponding local bookmark will
             // be created (or left as deleted) by caller.
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
     let jj_repo = tx.commit("test").unwrap();
@@ -3348,7 +3348,7 @@ fn test_push_bookmarks_success(subprocess: bool) {
         *view.get_remote_bookmark(remote_symbol("main", "origin")),
         RemoteRef {
             target: RefTarget::normal(setup.child_of_main_commit.id().clone()),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 
@@ -3492,7 +3492,7 @@ fn test_push_bookmarks_mixed_deletion_and_addition(subprocess: bool) {
         *view.get_remote_bookmark(remote_symbol("topic", "origin")),
         RemoteRef {
             target: RefTarget::normal(setup.child_of_main_commit.id().clone()),
-            state: RemoteRefState::Tracking,
+            state: RemoteRefState::Tracked,
         },
     );
 

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -468,7 +468,7 @@ fn test_has_changed() {
     let repo = &test_repo.repo;
     let normal_remote_ref = |id: &CommitId| RemoteRef {
         target: RefTarget::normal(id.clone()),
-        state: RemoteRefState::Tracking, // doesn't matter
+        state: RemoteRefState::Tracked, // doesn't matter
     };
 
     let mut tx = repo.start_transaction();
@@ -613,7 +613,7 @@ fn test_rename_remote() {
     let commit = write_random_commit(mut_repo);
     let remote_ref = RemoteRef {
         target: RefTarget::normal(commit.id().clone()),
-        state: RemoteRefState::Tracking, // doesn't matter
+        state: RemoteRefState::Tracked, // doesn't matter
     };
     mut_repo.set_remote_bookmark(remote_symbol("main", "origin"), remote_ref.clone());
     mut_repo.rename_remote("origin".as_ref(), "upstream".as_ref());

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -524,12 +524,12 @@ fn test_resolve_symbol_bookmarks() {
         target,
         state: RemoteRefState::New,
     };
-    let tracking_remote_ref = |target| RemoteRef {
+    let tracked_remote_ref = |target| RemoteRef {
         target,
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
-    let normal_tracking_remote_ref =
-        |id: &CommitId| tracking_remote_ref(RefTarget::normal(id.clone()));
+    let normal_tracked_remote_ref =
+        |id: &CommitId| tracked_remote_ref(RefTarget::normal(id.clone()));
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -543,7 +543,7 @@ fn test_resolve_symbol_bookmarks() {
     mut_repo.set_local_bookmark_target("local".as_ref(), RefTarget::normal(commit1.id().clone()));
     mut_repo.set_remote_bookmark(
         remote_symbol("remote", "origin"),
-        normal_tracking_remote_ref(commit2.id()),
+        normal_tracked_remote_ref(commit2.id()),
     );
     mut_repo.set_local_bookmark_target(
         "local-remote".as_ref(),
@@ -551,7 +551,7 @@ fn test_resolve_symbol_bookmarks() {
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("local-remote", "origin"),
-        normal_tracking_remote_ref(commit4.id()),
+        normal_tracked_remote_ref(commit4.id()),
     );
     mut_repo.set_local_bookmark_target(
         "local-remote@origin".as_ref(), // not a remote bookmark
@@ -559,7 +559,7 @@ fn test_resolve_symbol_bookmarks() {
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("local-remote", "mirror"),
-        tracking_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref())),
+        tracked_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref())),
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("local-remote", "untracked"),
@@ -567,7 +567,7 @@ fn test_resolve_symbol_bookmarks() {
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("local-remote", git::REMOTE_NAME_FOR_LOCAL_GIT_REPO),
-        tracking_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref())),
+        tracked_remote_ref(mut_repo.get_local_bookmark("local-remote".as_ref())),
     );
 
     mut_repo.set_local_bookmark_target(
@@ -579,7 +579,7 @@ fn test_resolve_symbol_bookmarks() {
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("remote-conflicted", "origin"),
-        tracking_remote_ref(RefTarget::from_legacy_form(
+        tracked_remote_ref(RefTarget::from_legacy_form(
             [commit3.id().clone()],
             [commit5.id().clone(), commit4.id().clone()],
         )),
@@ -2126,12 +2126,12 @@ fn test_evaluate_expression_bookmarks() {
 fn test_evaluate_expression_remote_bookmarks() {
     let test_repo = TestRepo::init();
     let repo = &test_repo.repo;
-    let tracking_remote_ref = |target| RemoteRef {
+    let tracked_remote_ref = |target| RemoteRef {
         target,
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
-    let normal_tracking_remote_ref =
-        |id: &CommitId| tracking_remote_ref(RefTarget::normal(id.clone()));
+    let normal_tracked_remote_ref =
+        |id: &CommitId| tracked_remote_ref(RefTarget::normal(id.clone()));
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -2155,12 +2155,12 @@ fn test_evaluate_expression_remote_bookmarks() {
     // Bookmark 2 is tracked on remote private
     mut_repo.set_remote_bookmark(
         remote_symbol("bookmark2", "private"),
-        normal_tracking_remote_ref(commit2.id()),
+        normal_tracked_remote_ref(commit2.id()),
     );
     // Git-tracking bookmarks aren't included
     mut_repo.set_remote_bookmark(
         remote_symbol("bookmark", git::REMOTE_NAME_FOR_LOCAL_GIT_REPO),
-        normal_tracking_remote_ref(commit_git_remote.id()),
+        normal_tracked_remote_ref(commit_git_remote.id()),
     );
     // Can get a few bookmarks
     assert_eq!(
@@ -2259,7 +2259,7 @@ fn test_evaluate_expression_remote_bookmarks() {
     // the revset
     mut_repo.set_remote_bookmark(
         remote_symbol("bookmark3", "origin"),
-        normal_tracking_remote_ref(commit2.id()),
+        normal_tracked_remote_ref(commit2.id()),
     );
     assert_eq!(
         resolve_commit_ids(mut_repo, "remote_bookmarks()"),
@@ -2274,14 +2274,14 @@ fn test_evaluate_expression_remote_bookmarks() {
     // Can get bookmarks when there are conflicted refs
     mut_repo.set_remote_bookmark(
         remote_symbol("bookmark1", "origin"),
-        tracking_remote_ref(RefTarget::from_legacy_form(
+        tracked_remote_ref(RefTarget::from_legacy_form(
             [commit1.id().clone()],
             [commit2.id().clone(), commit3.id().clone()],
         )),
     );
     mut_repo.set_remote_bookmark(
         remote_symbol("bookmark2", "private"),
-        tracking_remote_ref(RefTarget::from_legacy_form(
+        tracked_remote_ref(RefTarget::from_legacy_form(
             [commit2.id().clone()],
             [commit3.id().clone(), commit4.id().clone()],
         )),

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1023,7 +1023,7 @@ fn test_rebase_descendants_basic_bookmark_update_with_non_local_bookmark() {
     let commit_b = graph_builder.commit_with_parents(&[&commit_a]);
     let commit_b_remote_ref = RemoteRef {
         target: RefTarget::normal(commit_b.id().clone()),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     tx.repo_mut()
         .set_local_bookmark_target("main".as_ref(), RefTarget::normal(commit_b.id().clone()));
@@ -1077,7 +1077,7 @@ fn test_rebase_descendants_update_bookmark_after_abandon(delete_abandoned_bookma
     let commit_c = graph_builder.commit_with_parents(&[&commit_b]);
     let commit_b_remote_ref = RemoteRef {
         target: RefTarget::normal(commit_b.id().clone()),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     tx.repo_mut()
         .set_local_bookmark_target("main".as_ref(), RefTarget::normal(commit_b.id().clone()));

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -229,7 +229,7 @@ fn test_merge_views_bookmarks() {
     };
     let main_bookmark_alternate_tx0_remote_ref = RemoteRef {
         target: RefTarget::normal(main_bookmark_alternate_tx0.id().clone()),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     mut_repo.set_local_bookmark_target(
         "main".as_ref(),
@@ -267,7 +267,7 @@ fn test_merge_views_bookmarks() {
     let main_bookmark_origin_tx2 = write_random_commit(tx2.repo_mut());
     let main_bookmark_origin_tx2_remote_ref = RemoteRef {
         target: RefTarget::normal(main_bookmark_origin_tx2.id().clone()),
-        state: RemoteRefState::Tracking,
+        state: RemoteRefState::Tracked,
     };
     tx2.repo_mut().set_local_bookmark_target(
         "main".as_ref(),


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
