### PR TITLE
cli config edit: Rollback to previous config when invalid TOML is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Commit objects in templates now have `trailers() -> List<Trailer>`, the Trailer
   objects have `key() -> String` and `value() -> String`.
 
+* `jj config edit` will now roll back to previous version if a syntax error has been introduced in the new config.
+
+
 ### Fixed bugs
 
 * Fixed crash on change-delete conflict resolution.


### PR DESCRIPTION
This should fix #3905.

If applicable:

- [x] I have updated CHANGELOG.md.
- [x] I have added tests to cover my changes

My implementation is quite simple: if an error is added to the config, jj will prompt the user if he wants to keep editing the config. If the user don't want to, then the bad config is overwritten with the previous working one (Without the need of any temporary file). Otherwise, the user can fix the error
