### PR TITLE
diff: Add diff-do-chdir setting for external tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `jj log -r first-bookmark..sec` and then pressing Tab could complete the
   expression to `first-bookmark..second-bookmark`.
 
+* External diff tools are now run in the temporary directory containing
+  the before (`left`) and after (`right`) directories, making diffs appear
+  more pleasing for tools that display file paths prominently. Users can
+  opt out of this by setting `merge-tools.<tool>.diff-do-chdir = false`,
+  but this will likely be removed in a future release. Please report any
+  issues you run into.
+
 ### Fixed bugs
 
 * Fixed crash on change-delete conflict resolution.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -509,6 +509,11 @@
                         "description": "Array of exit codes that do not indicate tool failure, i.e. [0, 1] for unix diff.",
                         "default": [0]
                     },
+                    "diff-do-chdir": {
+                      "type": "boolean",
+                      "description": "Invoke the tool in the temporary diff directory. This setting will be removed soon",
+                      "default": true
+                    },
                     "diff-invocation-mode": {
                       "description": "Invoke the tool with directories or individual files",
                       "enum": [

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1360,18 +1360,18 @@ pub fn show_file_by_file_diff(
             }
             let left_path = create_file(left_path, &left_wc_dir, left_value)?;
             let right_path = create_file(right_path, &right_wc_dir, right_value)?;
+            let patterns = &maplit::hashmap! {
+                "left" => left_path
+                    .strip_prefix(temp_dir.path()).expect("path should be relative to temp_dir")
+                    .to_str().expect("temp_dir should be valid utf-8"),
+                "right" => right_path
+                    .strip_prefix(temp_dir.path()).expect("path should be relative to temp_dir")
+                    .to_str().expect("temp_dir should be valid utf-8"),
+            };
 
             let mut writer = formatter.raw()?;
-            invoke_external_diff(
-                ui,
-                writer.as_mut(),
-                tool,
-                &maplit::hashmap! {
-                    "left" => left_path.to_str().expect("temp_dir should be valid utf-8"),
-                    "right" => right_path.to_str().expect("temp_dir should be valid utf-8"),
-                },
-            )
-            .map_err(DiffRenderError::DiffGenerate)?;
+            invoke_external_diff(ui, writer.as_mut(), tool, temp_dir.path(), patterns)
+                .map_err(DiffRenderError::DiffGenerate)?;
         }
         Ok::<(), DiffRenderError>(())
     }

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -61,9 +61,21 @@ impl DiffWorkingCopies {
             .map(|state| state.working_copy_path())
     }
 
-    pub fn to_command_variables(&self) -> HashMap<&'static str, &str> {
-        let left_wc_dir = self.left_working_copy_path();
-        let right_wc_dir = self.right_working_copy_path();
+    pub fn temp_dir(&self) -> &Path {
+        self._temp_dir.path()
+    }
+
+    pub fn to_command_variables(&self, relative: bool) -> HashMap<&'static str, &str> {
+        let mut left_wc_dir = self.left_working_copy_path();
+        let mut right_wc_dir = self.right_working_copy_path();
+        if relative {
+            left_wc_dir = left_wc_dir
+                .strip_prefix(self.temp_dir())
+                .expect("path should be relative to temp_dir");
+            right_wc_dir = right_wc_dir
+                .strip_prefix(self.temp_dir())
+                .expect("path should be relative to temp_dir");
+        }
         let mut result = maplit::hashmap! {
             "left" => left_wc_dir.to_str().expect("temp_dir should be valid utf-8"),
             "right" => right_wc_dir.to_str().expect("temp_dir should be valid utf-8"),

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -516,6 +516,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",
@@ -546,6 +547,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "--edit",
                     "args",
@@ -592,6 +594,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",
@@ -618,6 +621,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "-l",
                     "$left",
@@ -646,6 +650,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "--diff",
                     "$left",
@@ -678,6 +683,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "--edit",
                     "args",
@@ -711,6 +717,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",
@@ -736,6 +743,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",
@@ -792,6 +800,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",
@@ -848,6 +857,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",
@@ -881,6 +891,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",
@@ -917,6 +928,7 @@ mod tests {
                     0,
                 ],
                 diff_invocation_mode: Dir,
+                diff_do_chdir: true,
                 edit_args: [
                     "$left",
                     "$right",

--- a/cli/testing/fake-diff-editor.rs
+++ b/cli/testing/fake-diff-editor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::exit;
@@ -91,6 +92,9 @@ fn main() {
             }
             ["print", message] => {
                 println!("{message}");
+            }
+            ["print-current-dir"] => {
+                println!("{}", env::current_dir().unwrap().display());
             }
             ["print-files-before"] => {
                 for base_name in files_recursively(&args.before).iter().sorted() {


### PR DESCRIPTION
The temporary folder name can add significant noise to the produced diff when using an external diff tool if the tool displays paths prominently. Add a setting, `diff-do-chdir`, that chdirs to the temporary directory before running the tool.

Closes #5801

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Disclaimer: I'm not a real Rust programmer, just cosplaying as one to get my pet change into jj. I'm also not sure about the `diff-do-chdir` name. Comments welcome!

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
