### PR TITLE
diff: add option to render color-words diffs without materializing conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Color-words diff has gained [an option to compare conflict pairs without
+  materializing](docs/config.md#color-words-diff-options).
+
 * `jj show` patches can now be suppressed with `--no-patch`.
 
 ### Fixed bugs

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -359,6 +359,15 @@
                     "type": "object",
                     "description": "Options for color-words diffs",
                     "properties": {
+                        "conflict": {
+                            "type": "string",
+                            "description": "How conflicts are processed and displayed",
+                            "enum": [
+                                "materialize",
+                                "pair"
+                            ],
+                            "default": "materialize"
+                        },
                         "max-inline-alternation": {
                             "type": "integer",
                             "description": "Maximum number of removed/added word alternation to inline",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -6,6 +6,7 @@ b = ["bookmark"]
 ci = ["commit"]
 
 [diff.color-words]
+conflict = "materialize"
 max-inline-alternation = 3
 context = 3
 

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -603,13 +603,14 @@ fn show_color_words_diff_hunks(
             DiffHunkKind::Matching => contexts.push(hunk_contents),
             DiffHunkKind::Different => {
                 let num_after = if emitted { options.context } else { 0 };
+                let num_before = options.context;
                 line_number = show_color_words_context_lines(
                     formatter,
                     &contexts,
                     line_number,
                     options,
                     num_after,
-                    options.context,
+                    num_before,
                 )?;
                 contexts.clear();
                 emitted = true;
@@ -619,16 +620,16 @@ fn show_color_words_diff_hunks(
         }
     }
 
-    if emitted {
-        show_color_words_context_lines(
-            formatter,
-            &contexts,
-            line_number,
-            options,
-            options.context,
-            0,
-        )?;
-    }
+    let num_after = if emitted { options.context } else { 0 };
+    let num_before = 0;
+    show_color_words_context_lines(
+        formatter,
+        &contexts,
+        line_number,
+        options,
+        num_after,
+        num_before,
+    )?;
     Ok(())
 }
 
@@ -1077,7 +1078,7 @@ pub fn show_color_words_diff(
                 }
                 if left_content.is_binary || right_content.is_binary {
                     writeln!(formatter.labeled("binary"), "    (binary)")?;
-                } else {
+                } else if left_content.contents != right_content.contents {
                     show_color_words_diff_hunks(
                         formatter,
                         [&left_content.contents, &right_content.contents].map(BStr::new),

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -2238,6 +2238,13 @@ fn test_diff_conflict_sides_differ() {
     insta::assert_snapshot!(output, @"");
     let output = work_dir.run_jj(["diff", "--color=always", "-rleft1+right1"]);
     insta::assert_snapshot!(output, @"");
+    let output = work_dir.run_jj([
+        "diff",
+        "--color=always",
+        "--config=diff.color-words.conflict=pair",
+        "-rleft1+right1",
+    ]);
+    insta::assert_snapshot!(output, @"");
 
     let diff_git_materialized = |from: &str, to: &str| {
         work_dir.run_jj([
@@ -2253,6 +2260,16 @@ fn test_diff_conflict_sides_differ() {
             "diff",
             "--color=always",
             "--context=1",
+            &format!("--from={from}"),
+            &format!("--to={to}"),
+        ])
+    };
+    let diff_color_words_conflict_pair = |from: &str, to: &str| {
+        work_dir.run_jj([
+            "diff",
+            "--color=always",
+            "--context=1",
+            "--config=diff.color-words.conflict=pair",
             &format!("--from={from}"),
             &format!("--to={to}"),
         ])
@@ -2296,6 +2313,24 @@ fn test_diff_conflict_sides_differ() {
     [38;5;1m   5[39m [38;5;2m  13[39m: line 5
     [EOF]
     ");
+    insta::assert_snapshot!(diff_color_words_conflict_pair("base", "left1+right1"), @r"
+    [38;5;3mCreated conflict in file:[39m
+    [38;5;1m   1[39m [38;5;2m   1[39m: line 1
+    [38;5;1m   2[39m [38;5;2m   2[39m: line 2
+    [38;5;6m<<<<<<< Created conflict[39m
+    [38;5;6m+++++++ left side #1 to right side #1[39m
+    [38;5;1m   3[39m [38;5;2m   3[39m: [4m[38;5;1mline[38;5;2mleft[24m[39m [4m[38;5;2m3.1[24m[39m
+         [38;5;2m   4[39m: [4m[38;5;2mleft 3.2[24m[39m
+    [38;5;1m   3[39m [38;5;2m   5[39m: [4m[38;5;2mleft 3.[24m[39m3
+    [38;5;6m------- left side #1 to right base #1[39m
+    [38;5;2m   3[39m [38;5;1m   3[39m: line 3
+    [38;5;6m+++++++ left side #1 to right side #2[39m
+    [38;5;1m   3[39m [38;5;2m   3[39m: [4m[38;5;1mline[38;5;2mright[24m[39m 3[4m[38;5;2m.1[24m[39m
+    [38;5;6m>>>>>>> Conflict ends[39m
+    [38;5;1m   4[39m [38;5;2m   6[39m: line 4
+    [38;5;1m   5[39m [38;5;2m   7[39m: line 5
+    [EOF]
+    ");
 
     // Diff from conflict to resolved
     insta::assert_snapshot!(diff_git_materialized("left1+right1", "base"), @r"
@@ -2335,6 +2370,24 @@ fn test_diff_conflict_sides_differ() {
     [38;5;1m  13[39m [38;5;2m   5[39m: line 5
     [EOF]
     ");
+    insta::assert_snapshot!(diff_color_words_conflict_pair("left1+right1", "base"), @r"
+    [38;5;3mResolved conflict in file:[39m
+    [38;5;1m   1[39m [38;5;2m   1[39m: line 1
+    [38;5;1m   2[39m [38;5;2m   2[39m: line 2
+    [38;5;6m<<<<<<< Resolved conflict[39m
+    [38;5;6m+++++++ left side #1 to right side #1[39m
+    [38;5;1m   3[39m [38;5;2m   3[39m: [4m[38;5;1mleft[38;5;2mline[24m[39m [4m[38;5;1m3.1[24m[39m
+    [38;5;1m   4[39m     : [4m[38;5;1mleft 3.2[24m[39m
+    [38;5;1m   5[39m [38;5;2m   3[39m: [4m[38;5;1mleft 3.[24m[39m3
+    [38;5;6m------- left base #1 to right side #1[39m
+    [38;5;2m   3[39m [38;5;1m   3[39m: line 3
+    [38;5;6m+++++++ left side #2 to right side #1[39m
+    [38;5;1m   3[39m [38;5;2m   3[39m: [4m[38;5;1mright[38;5;2mline[24m[39m 3[4m[38;5;1m.1[24m[39m
+    [38;5;6m>>>>>>> Conflict ends[39m
+    [38;5;1m   6[39m [38;5;2m   4[39m: line 4
+    [38;5;1m   7[39m [38;5;2m   5[39m: line 5
+    [EOF]
+    ");
 
     // Diff between conflicts
     insta::assert_snapshot!(diff_git_materialized("left1+right1", "left2+right2"), @r"
@@ -2365,6 +2418,24 @@ fn test_diff_conflict_sides_differ() {
         ...
     [38;5;1m  12[39m [38;5;2m  13[39m: line 4
     [38;5;1m  13[39m     : [4m[38;5;1mline 5[24m[39m
+    [EOF]
+    ");
+    insta::assert_snapshot!(diff_color_words_conflict_pair("left1+right1", "left2+right2"), @r"
+    [38;5;3mModified conflict in file:[39m
+    [38;5;1m   1[39m [38;5;2m   1[39m: [4m[38;5;1mline[38;5;2mleft[24m[39m [4m[38;5;2m1.[24m[39m1
+    [38;5;1m   2[39m [38;5;2m   2[39m: line 2
+    [38;5;6m<<<<<<< Modified conflict[39m
+    [38;5;6m+++++++ left side #1 to right side #1[39m
+        ...
+    [38;5;1m   5[39m [38;5;2m   5[39m: left 3.3
+         [38;5;2m   6[39m: [4m[38;5;2mleft 3.4[24m[39m
+    [38;5;6m------- left base #1 to right base #1[39m
+    [38;5;2m   3[39m [38;5;1m   3[39m: line 3
+    [38;5;6m+++++++ left side #2 to right side #2[39m
+    [38;5;1m   3[39m [38;5;2m   3[39m: right 3.1
+    [38;5;6m>>>>>>> Conflict ends[39m
+    [38;5;1m   6[39m [38;5;2m   7[39m: line 4
+    [38;5;1m   7[39m     : [4m[38;5;1mline 5[24m[39m
     [EOF]
     ");
 }
@@ -2476,6 +2547,16 @@ fn test_diff_conflict_bases_differ() {
             &format!("--to={to}"),
         ])
     };
+    let diff_color_words_conflict_pair = |from: &str, to: &str| {
+        work_dir.run_jj([
+            "diff",
+            "--color=always",
+            "--context=1",
+            "--config=diff.color-words.conflict=pair",
+            &format!("--from={from}"),
+            &format!("--to={to}"),
+        ])
+    };
 
     // Diff between conflicts
     insta::assert_snapshot!(diff_git_materialized("left1+right1", "left2+right2"), @r"
@@ -2503,6 +2584,22 @@ fn test_diff_conflict_bases_differ() {
     [38;5;1m   9[39m [38;5;2m   9[39m: [4m[38;5;2m-line 3.2[24m[39m
     [38;5;1m  10[39m [38;5;2m  10[39m: +right 3.1
         ...
+    [EOF]
+    ");
+    insta::assert_snapshot!(diff_color_words_conflict_pair("left1+right1", "left2+right2"), @r"
+    [38;5;3mModified conflict in file:[39m
+    [38;5;1m   1[39m     : [4m[38;5;1mline 1[24m[39m
+    [38;5;1m   2[39m [38;5;2m   1[39m: line 2
+    [38;5;6m<<<<<<< Modified conflict[39m
+    [38;5;6m+++++++ left side #1 to right side #1[39m
+        ...
+    [38;5;6m------- left base #1 to right base #1[39m
+    [38;5;2m   3[39m [38;5;1m   2[39m: line 3[4m[38;5;1m.1[24m[39m
+    [38;5;2m   3[39m [38;5;1m   3[39m: [4m[38;5;1mline 3.2[24m[39m
+    [38;5;6m+++++++ left side #2 to right side #2[39m
+    [38;5;1m   3[39m [38;5;2m   2[39m: right 3.1
+    [38;5;6m>>>>>>> Conflict ends[39m
+    [38;5;1m   6[39m [38;5;2m   5[39m: line 4
     [EOF]
     ");
 }
@@ -2612,6 +2709,16 @@ fn test_diff_conflict_three_sides() {
             &format!("--to={to}"),
         ])
     };
+    let diff_color_words_conflict_pair = |from: &str, to: &str| {
+        work_dir.run_jj([
+            "diff",
+            "--color=always",
+            "--context=1",
+            "--config=diff.color-words.conflict=pair",
+            &format!("--from={from}"),
+            &format!("--to={to}"),
+        ])
+    };
 
     // Diff between conflicts
     insta::assert_snapshot!(diff_git_materialized("side1+side2", "side1+side2+side3"), @r"
@@ -2644,6 +2751,29 @@ fn test_diff_conflict_three_sides() {
          [38;5;2m  15[39m: [4m[38;5;2m+line 3 c.2[24m[39m
     [38;5;1m  13[39m [38;5;2m  16[39m: >>>>>>> Conflict 1 of 1 ends
     [38;5;1m  14[39m [38;5;2m  17[39m: line 5
+    [EOF]
+    ");
+    insta::assert_snapshot!(diff_color_words_conflict_pair("side1+side2", "side1+side2+side3"), @r"
+    [38;5;3mModified conflict in file:[39m
+    [38;5;1m   1[39m [38;5;2m   1[39m: line 1
+    [38;5;6m<<<<<<< Modified conflict[39m
+    [38;5;6m+++++++ left side #1 to right side #1[39m
+        ...
+    [38;5;6m------- left base #1 to right base #1[39m
+        ...
+    [38;5;6m+++++++ left side #2 to right side #2[39m
+        ...
+    [38;5;6m------- left side #1 to right base #2[39m
+    [38;5;2m   2[39m [38;5;1m   2[39m: line 2 [4m[38;5;2ma.1[24m[39m
+    [38;5;2m   3[39m     : [4m[38;5;2mline 3 a.2[24m[39m
+    [38;5;2m   4[39m [38;5;1m   2[39m: [4m[38;5;2mline 4 [24m[39mbase
+    [38;5;6m+++++++ left side #1 to right side #3[39m
+    [38;5;1m   2[39m [38;5;2m   2[39m: line 2 [4m[38;5;1ma.1[24m[39m
+    [38;5;1m   3[39m     : [4m[38;5;1mline 3 a.2[24m[39m
+    [38;5;1m   4[39m [38;5;2m   2[39m: [4m[38;5;1mline 4 [24m[39mbase
+         [38;5;2m   3[39m: [4m[38;5;2mline 3 c.2[24m[39m
+    [38;5;6m>>>>>>> Conflict ends[39m
+    [38;5;1m   5[39m [38;5;2m   5[39m: line 5
     [EOF]
     ");
 }

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -163,4 +163,24 @@ fn test_interdiff_conflicting() {
     +def
     [EOF]
     ");
+
+    let output = work_dir.run_jj([
+        "interdiff",
+        "--config=diff.color-words.conflict=pair",
+        "--color=always",
+        "--from=left",
+        "--to=right",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    [38;5;3mResolved conflict in file:[39m
+    [38;5;6m<<<<<<< Resolved conflict[39m
+    [38;5;6m+++++++ left side #1 to right side #1[39m
+    [38;5;1m   1[39m [38;5;2m   1[39m: [4m[38;5;1mabc[38;5;2mdef[24m[39m
+    [38;5;6m------- left base #1 to right side #1[39m
+    [38;5;2m   1[39m [38;5;1m   1[39m: [4m[38;5;2mfoo[38;5;1mdef[24m[39m
+    [38;5;6m+++++++ left side #2 to right side #1[39m
+    [38;5;1m   1[39m [38;5;2m   1[39m: [4m[38;5;1mbar[38;5;2mdef[24m[39m
+    [38;5;6m>>>>>>> Conflict ends[39m
+    [EOF]
+    ");
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -239,6 +239,14 @@ the default number of lines of context shown.
   The default is `3`.
 
   **This parameter is experimental.** The definition is subject to change.
+
+* `conflict`: How conflicts are processed and displayed.
+
+   * `"materialize"`: compare materialized contents (default)
+   * `"pair"`: compare individual pairs
+
+   **This parameter is experimental.**
+
 * `context`: Number of lines of context to show in the diff. The default is `3`.
 
 ```toml


### PR DESCRIPTION
Closes #4062

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes

cc @ilyagr 