### PR TITLE
cli: pad empty description intro/instruction lines with "JJ:"

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -87,7 +87,7 @@ label(if(overridden, "overridden"),
 
 builtin_draft_commit_description = '''
 concat(
-  description,
+  coalesce(description, "\n"),
   surround(
     "\nJJ: This commit contains the following changes:\n", "",
     indent("JJ:     ", diff.summary()),

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -72,7 +72,7 @@ fn test_commit_with_editor() {
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 }
@@ -129,7 +129,7 @@ fn test_commit_interactive() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
@@ -149,7 +149,7 @@ fn test_commit_interactive() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
@@ -205,7 +205,7 @@ fn test_commit_interactive_with_paths() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
@@ -253,7 +253,7 @@ fn test_commit_with_default_description() {
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 }
@@ -300,7 +300,7 @@ fn test_commit_with_description_template() {
 
     JJ: file1 | 1 +
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
@@ -320,7 +320,7 @@ fn test_commit_with_description_template() {
 
     JJ: file2 | 1 +
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
@@ -333,7 +333,7 @@ fn test_commit_with_description_template() {
 
     JJ: file3 | 1 +
     JJ: 1 file changed, 1 insertion(+), 0 deletions(-)
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 }

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -318,6 +318,7 @@ fn test_describe_multiple_commits() {
 
     JJ: describe 8d650510daad -------
 
+
     JJ: describe 41659b846096 -------
     description from CLI
 

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -315,14 +315,14 @@ fn test_describe_multiple_commits() {
     JJ: Warning:
     JJ: - The text you enter will be lost on a syntax error.
     JJ: - The syntax of the separator lines may change in the future.
-
+    JJ:
     JJ: describe 8d650510daad -------
 
 
     JJ: describe 41659b846096 -------
     description from CLI
 
-    JJ: Lines starting with "JJ: " (like this one) will be removed.
+    JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
     // Set the description of multiple commits in the editor
@@ -629,7 +629,7 @@ fn test_describe_default_description() {
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 }
@@ -712,7 +712,7 @@ fn test_describe_author() {
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:12)
 
     JJ: 0 files changed, 0 insertions(+), 0 deletions(-)
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
@@ -792,22 +792,22 @@ fn test_describe_author() {
     JJ: Warning:
     JJ: - The text you enter will be lost on a syntax error.
     JJ: - The syntax of the separator lines may change in the future.
-
+    JJ:
     JJ: describe eae86afaa20c -------
 
     JJ: Author: Ove Ridder <ove.ridder@example.com> (2001-02-03 08:05:18)
     JJ: Committer: Ove Ridder <ove.ridder@example.com> (2001-02-03 08:05:18)
 
     JJ: 0 files changed, 0 insertions(+), 0 deletions(-)
-
+    JJ:
     JJ: describe ba485659f76a -------
 
     JJ: Author: Ove Ridder <ove.ridder@example.com> (2001-02-03 08:05:18)
     JJ: Committer: Ove Ridder <ove.ridder@example.com> (2001-02-03 08:05:18)
 
     JJ: 0 files changed, 0 insertions(+), 0 deletions(-)
-
-    JJ: Lines starting with "JJ: " (like this one) will be removed.
+    JJ:
+    JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 }
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -80,7 +80,7 @@ fn test_split_by_paths() {
 
     JJ: This commit contains the following changes:
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     assert!(!test_env.env_root().join("editor1").exists());
@@ -217,7 +217,7 @@ fn test_split_with_non_empty_description() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(
@@ -227,7 +227,7 @@ fn test_split_with_non_empty_description() {
 
     JJ: This commit contains the following changes:
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(get_log_output(&test_env, &workspace_path), @r"
@@ -277,7 +277,7 @@ fn test_split_with_default_description() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     assert!(!test_env.env_root().join("editor2").exists());
@@ -356,25 +356,25 @@ fn test_split_with_descendants() {
     // The commit we're splitting has a description, so the user will be
     // prompted to enter a description for each of the commits.
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
     Add file1 & file2
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
     insta::assert_snapshot!(
-        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r###"
+        std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r#"
     JJ: Enter a description for the second commit.
     Add file1 & file2
 
     JJ: This commit contains the following changes:
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
-    "###);
+    "#);
 
     // Check the evolog for the first commit. It shows four entries:
     // - The initial empty commit.
@@ -526,7 +526,7 @@ fn test_split_parallel_no_descendants() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     assert!(!test_env.env_root().join("editor2").exists());
@@ -644,7 +644,7 @@ fn test_split_parallel_with_descendants() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(
@@ -654,7 +654,7 @@ fn test_split_parallel_with_descendants() {
 
     JJ: This commit contains the following changes:
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 }
@@ -809,7 +809,7 @@ fn test_split_interactive() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 
@@ -874,7 +874,7 @@ fn test_split_interactive_with_paths() {
 
     JJ: This commit contains the following changes:
     JJ:     A file1
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -77,6 +77,7 @@ fn test_split_by_paths() {
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
+
     JJ: This commit contains the following changes:
     JJ:     A file2
 
@@ -805,6 +806,7 @@ fn test_split_interactive() {
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
 
+
     JJ: This commit contains the following changes:
     JJ:     A file1
 
@@ -868,6 +870,7 @@ fn test_split_interactive_with_paths() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     JJ: Enter a description for the first commit.
+
 
     JJ: This commit contains the following changes:
     JJ:     A file1

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -1264,7 +1264,7 @@ fn test_squash_description() {
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:     A file2
-
+    JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -178,7 +178,7 @@ The editor content of a commit description can be populated by the
 [templates]
 draft_commit_description = '''
 concat(
-  description,
+  coalesce(description, "\n"),
   surround(
     "\nJJ: This commit contains the following changes:\n", "",
     indent("JJ:     ", diff.stat(72)),


### PR DESCRIPTION
Closes #5484

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
