### PR TITLE
cargo: remove "optional" dependency of testutils from cli/Cargo.toml

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -95,9 +95,6 @@ tracing-subscriber = { workspace = true }
 unicode-width = { workspace = true }
 whoami = { workspace = true }
 
-# TODO: Workaround for Cargo weirdness; remove when `git2` goes away.
-testutils = { workspace = true, optional = true }
-
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
@@ -115,7 +112,7 @@ jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 default = ["watchman", "git", "git2"]
 bench = ["dep:criterion"]
 git = ["jj-lib/git", "dep:gix"]
-git2 = ["git", "jj-lib/git2", "testutils?/git2", "dep:git2"]
+git2 = ["git", "jj-lib/git2", "testutils/git2", "dep:git2"]
 gix-max-performance = ["jj-lib/gix-max-performance"]
 packaging = ["gix-max-performance"]
 test-fakes = ["jj-lib/testing"]


### PR DESCRIPTION
This is basically what we do for lib/Cargo.toml. The feature "git2" enables "testutils/git2", but I hope it wouldn't affect the non-dev dependencies.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
