### PR TITLE
fix: make `FileFixer::fix_files()` take `&mut self`

### DIFF
--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -143,7 +143,7 @@ pub(crate) fn cmd_fix(
         .to_matcher();
 
     let mut tx = workspace_command.start_transaction();
-    let parallel_fixer = ParallelFileFixer::new(|store, file_to_fix| {
+    let mut parallel_fixer = ParallelFileFixer::new(|store, file_to_fix| {
         fix_one_file(&workspace_root, &tools_config, store, file_to_fix)
     });
     let summary = fix_files(
@@ -151,7 +151,7 @@ pub(crate) fn cmd_fix(
         &matcher,
         args.include_unchanged_files,
         tx.repo_mut(),
-        &parallel_fixer,
+        &mut parallel_fixer,
     )?;
     writeln!(
         ui.status(),

--- a/lib/src/fix.rs
+++ b/lib/src/fix.rs
@@ -90,7 +90,7 @@ pub trait FileFixer {
     /// TODO: Better error handling so we can tell the user what went wrong with
     /// each failed input.
     fn fix_files<'a>(
-        &self,
+        &mut self,
         store: &Store,
         files_to_fix: &'a HashSet<FileToFix>,
     ) -> Result<HashMap<&'a FileToFix, FileId>, FixError>;
@@ -135,7 +135,7 @@ where
 {
     /// Applies `fix_fn()` to the inputs and stores the resulting file content.
     fn fix_files<'a>(
-        &self,
+        &mut self,
         store: &Store,
         files_to_fix: &'a HashSet<FileToFix>,
     ) -> Result<HashMap<&'a FileToFix, FileId>, FixError> {
@@ -178,7 +178,7 @@ pub fn fix_files(
     matcher: &dyn Matcher,
     include_unchanged_files: bool,
     repo_mut: &mut MutableRepo,
-    file_fixer: &impl FileFixer,
+    file_fixer: &mut impl FileFixer,
 ) -> Result<FixSummary, FixError> {
     let mut summary = FixSummary::default();
 

--- a/lib/tests/test_fix.rs
+++ b/lib/tests/test_fix.rs
@@ -50,7 +50,7 @@ impl TestFileFixer {
 // leaves files unchanged.
 impl FileFixer for TestFileFixer {
     fn fix_files<'a>(
-        &self,
+        &mut self,
         store: &Store,
         files_to_fix: &'a HashSet<FileToFix>,
     ) -> Result<HashMap<&'a FileToFix, FileId>, FixError> {
@@ -131,7 +131,7 @@ fn test_fix_one_file() {
     );
 
     let root_commits = vec![commit_a.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
     let include_unchanged_files = false;
 
     let summary = fix_files(
@@ -139,7 +139,7 @@ fn test_fix_one_file() {
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     )
     .unwrap();
 
@@ -171,7 +171,7 @@ fn test_fixer_does_not_change_content() {
     );
 
     let root_commits = vec![commit_a.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
     let include_unchanged_files = false;
 
     let summary = fix_files(
@@ -179,7 +179,7 @@ fn test_fixer_does_not_change_content() {
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     )
     .unwrap();
 
@@ -202,7 +202,7 @@ fn test_empty_commit() {
     );
 
     let root_commits = vec![commit_a.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
     let include_unchanged_files = false;
 
     let summary = fix_files(
@@ -210,7 +210,7 @@ fn test_empty_commit() {
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     )
     .unwrap();
 
@@ -234,7 +234,7 @@ fn test_fixer_fails() {
     );
 
     let root_commits = vec![commit_a.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
     let include_unchanged_files = false;
 
     let result = fix_files(
@@ -242,7 +242,7 @@ fn test_fixer_fails() {
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     );
 
     let error = result.err().unwrap();
@@ -267,7 +267,7 @@ fn test_unchanged_file_is_not_fixed() {
     let commit_b = create_commit(&mut tx, vec![commit_a.clone()], tree2.id());
 
     let root_commits = vec![commit_b.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
     let include_unchanged_files = false;
 
     let summary = fix_files(
@@ -275,7 +275,7 @@ fn test_unchanged_file_is_not_fixed() {
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     )
     .unwrap();
 
@@ -302,14 +302,14 @@ fn test_unchanged_file_is_fixed() {
     let commit_b = create_commit(&mut tx, vec![commit_a.clone()], tree2.id());
 
     let root_commits = vec![commit_b.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
 
     let summary = fix_files(
         root_commits,
         &EverythingMatcher,
         true,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     )
     .unwrap();
 
@@ -346,14 +346,14 @@ fn test_already_fixed_descendant() {
     let commit_b = create_commit(&mut tx, vec![commit_a.clone()], tree2.id());
 
     let root_commits = vec![commit_a.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
 
     let summary = fix_files(
         root_commits,
         &EverythingMatcher,
         true,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     )
     .unwrap();
 
@@ -391,14 +391,14 @@ fn test_parallel_fixer_basic() {
 
     let root_commits = vec![commit_a.clone()];
     let include_unchanged_files = false;
-    let parallel_fixer = ParallelFileFixer::new(fix_file);
+    let mut parallel_fixer = ParallelFileFixer::new(fix_file);
 
     let summary = fix_files(
         root_commits,
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &parallel_fixer,
+        &mut parallel_fixer,
     )
     .unwrap();
 
@@ -436,14 +436,14 @@ fn test_parallel_fixer_fixes_files() {
 
     let root_commits = vec![commit_a.clone()];
     let include_unchanged_files = false;
-    let parallel_fixer = ParallelFileFixer::new(fix_file);
+    let mut parallel_fixer = ParallelFileFixer::new(fix_file);
 
     let summary = fix_files(
         root_commits,
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &parallel_fixer,
+        &mut parallel_fixer,
     )
     .unwrap();
 
@@ -488,14 +488,14 @@ fn test_parallel_fixer_does_not_change_content() {
 
     let root_commits = vec![commit_a.clone()];
     let include_unchanged_files = false;
-    let parallel_fixer = ParallelFileFixer::new(fix_file);
+    let mut parallel_fixer = ParallelFileFixer::new(fix_file);
 
     let summary = fix_files(
         root_commits,
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &parallel_fixer,
+        &mut parallel_fixer,
     )
     .unwrap();
 
@@ -531,14 +531,14 @@ fn test_parallel_fixer_no_changes_upon_partial_failure() {
 
     let root_commits = vec![commit_a.clone()];
     let include_unchanged_files = false;
-    let parallel_fixer = ParallelFileFixer::new(fix_file);
+    let mut parallel_fixer = ParallelFileFixer::new(fix_file);
 
     let result = fix_files(
         root_commits,
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &parallel_fixer,
+        &mut parallel_fixer,
     );
     let error = result.err().unwrap();
     assert_eq!(error.to_string(), "Forced failure: boo7");
@@ -576,7 +576,7 @@ fn test_fix_multiple_revisions() {
     let _commit_d = create_commit(&mut tx, vec![commit_a.clone()], tree4.id());
 
     let root_commits = vec![commit_a.clone()];
-    let file_fixer = TestFileFixer::new();
+    let mut file_fixer = TestFileFixer::new();
     let include_unchanged_files = false;
 
     let summary = fix_files(
@@ -584,7 +584,7 @@ fn test_fix_multiple_revisions() {
         &EverythingMatcher,
         include_unchanged_files,
         tx.repo_mut(),
-        &file_fixer,
+        &mut file_fixer,
     )
     .unwrap();
 


### PR DESCRIPTION
It can be useful for fixers to record some information about the inputs they processed. For example, the `FileFixer` we use in our server at Google get more detailed error information back from its formatter tools. We may want to record these errors in our `FileFixer`'s state so we can then return that to the client.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
