### PR TITLE
merge_tools: fix `:ours` and `:theirs` merge tools

### DIFF
--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -570,7 +570,7 @@ fn make_merge_sections(
 fn make_merge_file(
     merge_tool_file: &MergeToolFile,
 ) -> Result<scm_record::File<'static>, BuiltinToolError> {
-    let merge_result = files::merge(&merge_tool_file.content);
+    let merge_result = files::merge(&merge_tool_file.simplified_file_content);
     let sections = make_merge_sections(merge_result)?;
     Ok(scm_record::File {
         old_path: None,

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -184,7 +184,7 @@ fn run_mergetool_external_single_file(
         repo_path,
         conflict,
         file_merge,
-        content,
+        simplified_file_content,
     } = merge_tool_file;
 
     let conflict_marker_style = editor
@@ -198,24 +198,24 @@ fn run_mergetool_external_single_file(
     // MIN_CONFLICT_MARKER_LEN since the merge tool can't know about our rules for
     // conflict marker length.
     let conflict_marker_len = if editor.merge_tool_edits_conflict_markers || uses_marker_length {
-        choose_materialized_conflict_marker_len(content)
+        choose_materialized_conflict_marker_len(simplified_file_content)
     } else {
         MIN_CONFLICT_MARKER_LEN
     };
     let initial_output_content = if editor.merge_tool_edits_conflict_markers {
         materialize_merge_result_to_bytes_with_marker_len(
-            content,
+            simplified_file_content,
             conflict_marker_style,
             conflict_marker_len,
         )
     } else {
         BString::default()
     };
-    assert_eq!(content.num_sides(), 2);
+    assert_eq!(simplified_file_content.num_sides(), 2);
     let files: HashMap<&str, &[u8]> = maplit::hashmap! {
-        "base" => content.get_remove(0).unwrap().as_slice(),
-        "left" => content.get_add(0).unwrap().as_slice(),
-        "right" => content.get_add(1).unwrap().as_slice(),
+        "base" => simplified_file_content.get_remove(0).unwrap().as_slice(),
+        "left" => simplified_file_content.get_add(0).unwrap().as_slice(),
+        "right" => simplified_file_content.get_add(1).unwrap().as_slice(),
         "output" => initial_output_content.as_slice(),
     };
 

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -185,6 +185,7 @@ fn run_mergetool_external_single_file(
         conflict,
         file_merge,
         simplified_file_content,
+        ..
     } = merge_tool_file;
 
     let conflict_marker_style = editor

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -316,7 +316,7 @@ struct MergeToolFile {
     repo_path: RepoPathBuf,
     conflict: MergedTreeValue,
     file_merge: Merge<Option<FileId>>,
-    content: Merge<BString>,
+    simplified_file_content: Merge<BString>,
 }
 
 impl MergeToolFile {
@@ -341,13 +341,13 @@ impl MergeToolFile {
                 sides: simplified_file_merge.num_sides(),
             });
         };
-        let content =
+        let simplified_file_content =
             extract_as_single_hunk(&simplified_file_merge, tree.store(), repo_path).block_on()?;
         Ok(MergeToolFile {
             repo_path: repo_path.to_owned(),
             conflict,
             file_merge,
-            content,
+            simplified_file_content,
         })
     }
 }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -1735,7 +1735,7 @@ fn test_resolve_with_contents_of_side() {
     let output = work_dir.run_jj(["resolve", "--tool", ":ours"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq 1a1b2ffb conflict | conflict
+    Working copy  (@) now at: znkkpsqq c83edc52 conflict | conflict
     Parent commit (@-)      : zsuskuln 83b81681 a | a
     Parent commit (@-)      : royxmykx 4f6eff49 b | b
     Parent commit (@-)      : vruxwmqv 1e360aff c | c
@@ -1743,8 +1743,7 @@ fn test_resolve_with_contents_of_side() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @"a");
-    // BUG: this shouldn't be "base"; it should be "left"
-    insta::assert_snapshot!(work_dir.read_file("other"), @"base");
+    insta::assert_snapshot!(work_dir.read_file("other"), @"left");
     insta::assert_snapshot!(work_dir.run_jj(["resolve", "--list"]), @r#"
     ------- stderr -------
     Error: No conflicts found at this revision
@@ -1758,17 +1757,15 @@ fn test_resolve_with_contents_of_side() {
     let output = work_dir.run_jj(["resolve", "--tool", ":theirs"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq 9470925b conflict | conflict
+    Working copy  (@) now at: znkkpsqq baf3a71d conflict | conflict
     Parent commit (@-)      : zsuskuln 83b81681 a | a
     Parent commit (@-)      : royxmykx 4f6eff49 b | b
     Parent commit (@-)      : vruxwmqv 1e360aff c | c
     Added 0 files, modified 2 files, removed 0 files
     [EOF]
     ");
-    // BUG: this shouldn't be "base"; it should be "b"
-    insta::assert_snapshot!(work_dir.read_file("file"), @"base");
-    // BUG: this shouldn't be "left"; it should be "right"
-    insta::assert_snapshot!(work_dir.read_file("other"), @"left");
+    insta::assert_snapshot!(work_dir.read_file("file"), @"b");
+    insta::assert_snapshot!(work_dir.read_file("other"), @"right");
     insta::assert_snapshot!(work_dir.run_jj(["resolve", "--list"]), @r#"
     ------- stderr -------
     Error: No conflicts found at this revision


### PR DESCRIPTION
These merge tools didn't work properly on conflicted trees with more than two sides since they didn't simplify the conflict before resolving.

https://discord.com/channels/968932220549103686/1357321005642678333

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
