### PR TITLE
cargo: don’t enable `testutils/git2` feature in `jj-cli`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -95,9 +95,6 @@ tracing-subscriber = { workspace = true }
 unicode-width = { workspace = true }
 whoami = { workspace = true }
 
-# TODO: Workaround for Cargo weirdness; remove when `git2` goes away.
-testutils = { workspace = true, optional = true }
-
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
@@ -115,7 +112,7 @@ jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 default = ["watchman", "git", "git2"]
 bench = ["dep:criterion"]
 git = ["jj-lib/git", "dep:gix"]
-git2 = ["git", "jj-lib/git2", "testutils?/git2", "dep:git2"]
+git2 = ["git", "jj-lib/git2", "dep:git2"]
 gix-max-performance = ["jj-lib/gix-max-performance"]
 packaging = ["gix-max-performance"]
 test-fakes = ["jj-lib/testing"]


### PR DESCRIPTION
Since we depend on `jj-lib/git2`, which sets `testutils/git2`, this should be redundant. Why it makes `cargo install` happy, I don’t know, but it does.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
