### PR TITLE
tests: don’t use `git2` in `testutils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3924,7 +3924,6 @@ dependencies = [
  "async-trait",
  "bstr",
  "futures 0.3.31",
- "git2",
  "gix",
  "hex",
  "itertools 0.13.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -95,9 +95,6 @@ tracing-subscriber = { workspace = true }
 unicode-width = { workspace = true }
 whoami = { workspace = true }
 
-# TODO: Workaround for Cargo weirdness; remove when `git2` goes away.
-testutils = { workspace = true, optional = true }
-
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
@@ -115,7 +112,7 @@ jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 default = ["watchman", "git", "git2"]
 bench = ["dep:criterion"]
 git = ["jj-lib/git", "dep:gix"]
-git2 = ["git", "jj-lib/git2", "testutils?/git2", "dep:git2"]
+git2 = ["git", "jj-lib/git2", "dep:git2"]
 gix-max-performance = ["jj-lib/gix-max-performance"]
 packaging = ["gix-max-performance"]
 test-fakes = ["jj-lib/testing"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -96,7 +96,7 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 default = ["git", "git2"]
 git = ["dep:gix"]
-git2 = ["git", "testutils/git2", "dep:git2"]
+git2 = ["git", "dep:git2"]
 gix-max-performance = [
     # Requires `cmake` as a build dependency.
     # Note that this feature is different from `gix/max-performance-safe`.

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -18,7 +18,6 @@ readme = { workspace = true }
 async-trait = { workspace = true }
 bstr = { workspace = true }
 futures = { workspace = true }
-git2 = { workspace = true, optional = true }
 gix = { workspace = true, features = [
     "status",
     "tree-editor",
@@ -30,10 +29,6 @@ jj-lib = { workspace = true, features = ["testing"] }
 pollster = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
-
-[features]
-default = ["git2"]
-git2 = ["jj-lib/git2", "dep:git2"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
Potential fix for the release issue. ~~If we don’t like the behaviour change here, we could set `JJ_DEBUG_HERMETIC_GIT` or something in `testutils::hermetic_git()` and condition on it.~~

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
