### PR TITLE
cli: Add config setting for bookmark list sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj show` patches can now be suppressed with `--no-patch`.
 
+* Added `ui.bookmark-list-sort-keys` setting to configure default sort keys for the
+  `jj bookmark list` command.
+
 ### Fixed bugs
 
 ## [0.28.2] - 2025-04-07

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -256,6 +256,29 @@
                             "default": false
                         }
                     }
+                },
+                "bookmark-list-sort-keys": {
+                    "type": "array",
+                    "description": "Specifies the sort keys for the bookmarks list. See the `jj bookmark list --help` for the `--sort` option",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "name",
+                            "name-",
+                            "author-name",
+                            "author-name-",
+                            "author-email",
+                            "author-email-",
+                            "author-date",
+                            "author-date-",
+                            "committer-name",
+                            "committer-name-",
+                            "committer-email",
+                            "committer-email-",
+                            "committer-date",
+                            "committer-date-"
+                        ]
+                    }
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -35,6 +35,7 @@ log-synthetic-elided-nodes = true
 conflict-marker-style = "diff"
 # signature verification is slow, disable by default
 show-cryptographic-signatures = false
+bookmark-list-sort-keys = ["name"]
 
 [ui.movement]
 edit = false

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -391,6 +391,8 @@ See [`jj help -k bookmarks`] for more information.
 
    Suffix the key with `-` to sort in descending order of the value (e.g. `--sort name-`). Note that when using multiple keys, the first key is the most significant.
 
+   This defaults to the `ui.bookmark-list-sort-keys` setting.
+
   Possible values: `name`, `name-`, `author-name`, `author-name-`, `author-email`, `author-email-`, `author-date`, `author-date-`, `committer-name`, `committer-name-`, `committer-email`, `committer-email-`, `committer-date`, `committer-date-`
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -197,6 +197,26 @@ fill in things like BUG=, TESTED= etc.
 default-description = "\n\nTESTED=TODO"
 ```
 
+### Bookmark listing order
+
+By default, `jj bookmark list` displays bookmarks sorted alphabetically by name.
+You can customize this sorting behavior by specifying sort keys in your config
+file:
+
+```toml
+[ui]
+bookmark-list-sort-keys = ["name"]
+```
+
+The configuration works identically to using the `--sort` option for
+`jj bookmark list`. The following sort keys are supported: `name`, `author-name`,
+`author-email`, `author-date`, `committer-name`, `committer-email`,
+`committer-date`. Suffix the key with `-` to sort in descending order. Multiple
+keys can be supplied here, the first key is the most significant.
+
+When the `--sort` option is used with `jj bookmark list`, the configuration
+is ignored.
+
 ### Diff colors and styles
 
 In color-words and git diffs, word-level hunks are rendered with underline. You


### PR DESCRIPTION
This is a conclusion of #5849.
Config setting to list bookmarks in specified order.

Closes #3831

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
