### PR TITLE
github: ward off future dependency bloat via dragon 

### DIFF
--- a/.github/scripts/dragon-bureaucrat
+++ b/.github/scripts/dragon-bureaucrat
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This script invokes the forbidden power of an ancient evil in order to defend
+# the one thing we hold most dear: bureaucratic norms
+
+# Many thanks to Phabricator (and Evan) for the vintage ASCII art (Apache 2.0)
+# <https://github.com/phacility/phabricator/blob/5720a38cfe95b00ca4be5016dd0d2f3195f4fa04/scripts/repository/commit_hook.php#L203>
+
+rejection_reason=${1:-"No reason provided. The Dragons have spoken."}
+
+cat >&2 <<'EOF'
++---------------------------------------------------------------+
+|      * * * PUSH REJECTED BY EVIL DRAGON BUREAUCRATS * * *     |
++---------------------------------------------------------------+
+             \
+              \                    ^    /^
+               \                  / \  // \
+                \   |\___/|      /   \//  .\
+                 \  /V  V  \__  /    //  | \ \           *----*
+                   /     /  \/_/    //   |  \  \          \   |
+                   @___@`    \/_   //    |   \   \         \/\ \
+                  0/0/|       \/_ //     |    \    \         \  \
+              0/0/0/0/|        \///      |     \     \       |  |
+           0/0/0/0/0/_|_ /   (  //       |      \     _\     |  /
+        0/0/0/0/0/0/`/,_ _ _/  ) ; -.    |    _ _\.-~       /   /
+                    ,-}        _      *-.|.-~-.           .~    ~
+  *     \__/         `/\      /                 ~-. _ .-~      /
+   \____(Oo)            *.   }            {                   /
+   (    (..)           .----~-.\        \-`                 .~
+   //___\\\\  \ DENIED!  ///.----..<        \             _ -~
+  //     \\\\                ///-._ _ _ _ _ _ _{^ - - - - ~
+
+EOF
+cat >&2 <<EOF
+       $rejection_reason
+
+EOF
+
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,29 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor
+  
+  # Count the number of dependencies in Cargo.lock and bail at a certain limit.
+  # This is extremely approximate because the Cargo.lock file contains
+  # dependencies for all features and platforms, but it helps us keep an eye on
+  # things.
+  check-cargo-lock-bloat:
+    name: check (Cargo.lock bloat)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+      - name: Check total dependency count in Cargo.lock
+        run: |
+          total_deps=$(grep -c '^\[\[package\]\]' Cargo.lock)
+          if [ "$total_deps" -gt "${TOTAL_DEP_LIMIT}" ]; then
+            ./.github/scripts/dragon-bureaucrat \
+              "Cargo.lock has too many dependencies ($total_deps > ${TOTAL_DEP_LIMIT}). The Dragon banishes thee!"
+          else
+            echo "Cargo.lock is within the allowed limit."
+          fi
+        env:
+          TOTAL_DEP_LIMIT: 500
 
   # Block the merge if required checks fail, but only in the merge
   # queue. See also `required-checks-hack.yml`.


### PR DESCRIPTION
After some discussion on Discord yesterday, Emily floated this idea to have a check that fails if `Cargo.lock` has too many dependencies, where "too many" means "more than a random number I made up and sounds good."

This implements that, as a non-required check, and to do so it invokes the power of an extremely evil and annoying Dragon. We could also ask this Dragon to do other things too I suppose (pending future contract negotiations).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
