### PR TITLE
github: show counts and allow offline counting for dependency-counting check

### DIFF
--- a/.github/scripts/count-cargo-lock-packages
+++ b/.github/scripts/count-cargo-lock-packages
@@ -1,0 +1,5 @@
+#!/bin/sh
+# This is extremely approximate because the Cargo.lock file contains
+# dependencies for all features and platforms, but it helps us keep an eye on
+# things.
+grep -c '^\[\[package\]\]' Cargo.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,13 +294,10 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor
-  
-  # Count the number of dependencies in Cargo.lock and bail at a certain limit.
-  # This is extremely approximate because the Cargo.lock file contains
-  # dependencies for all features and platforms, but it helps us keep an eye on
-  # things.
+
+  # Count the (very approximate) number of dependencies in Cargo.lock and bail at a certain limit.
   check-cargo-lock-bloat:
-    name: check (Cargo.lock bloat)
+    name: check (Cargo.lock dependency count)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -308,14 +305,16 @@ jobs:
           persist-credentials: false
       - name: Check total dependency count in Cargo.lock
         run: |
-          total_deps=$(grep -c '^\[\[package\]\]' Cargo.lock)
+          total_deps=$(./.github/scripts/count-cargo-lock-packages)
           if [ "$total_deps" -gt "${TOTAL_DEP_LIMIT}" ]; then
             ./.github/scripts/dragon-bureaucrat \
               "Cargo.lock has too many dependencies ($total_deps > ${TOTAL_DEP_LIMIT}). The Dragon banishes thee!"
           else
-            echo "Cargo.lock is within the allowed limit."
+            echo "Counted $total_deps Cargo.lock dependencies." \
+                 "This is within the allowed limit of ${TOTAL_DEP_LIMIT}."
           fi
         env:
+          # This limit *can* be raised, we just want to be aware if we exceed it
           TOTAL_DEP_LIMIT: 500
 
   # Block the merge if required checks fail, but only in the merge


### PR DESCRIPTION
Follow-up to b1bb5e1

This creates a `.github/scripts/count-cargo-lock-packages` script to count packages with our methodology that one can run outside CI.

Cc @thoughtpolice 

-----

I initially thought of making the whole check a script, but I the dragon would be annoying if you were repeatedly invoking the script locally.