### PR TITLE
formatter: indent multiline strings with heading

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2796,11 +2796,11 @@ pub fn print_snapshot_stats(
             ui.hint_default(),
             r"
             This is to prevent large files from being added by accident. You can fix this by:
-              - Adding the file to `.gitignore`
-              - Run `jj config set --repo snapshot.max-new-file-size {size}`
-                This will increase the maximum file size allowed for new files, in this repository only.
-              - Run `jj --config snapshot.max-new-file-size={size} st`
-                This will increase the maximum file size allowed for new files, for this command only.
+            - Adding the file to `.gitignore`
+            - Run `jj config set --repo snapshot.max-new-file-size {size}`
+              This will increase the maximum file size allowed for new files, in this repository only.
+            - Run `jj --config snapshot.max-new-file-size={size} st`
+              This will increase the maximum file size allowed for new files, for this command only.
             "
         )?;
     }

--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -109,11 +109,11 @@ pub fn print_track_snapshot_stats(
             ui.hint_default(),
             r"
             This is to prevent large files from being added by accident. You can fix this by:
-              - Adding the file to `.gitignore`
-              - Run `jj config set --repo snapshot.max-new-file-size {size}`
-                This will increase the maximum file size allowed for new files, in this repository only.
-              - Run `jj --config snapshot.max-new-file-size={size} file track {large_files_list}`
-                This will increase the maximum file size allowed for new files, for this command only.
+            - Adding the file to `.gitignore`
+            - Run `jj config set --repo snapshot.max-new-file-size {size}`
+              This will increase the maximum file size allowed for new files, in this repository only.
+            - Run `jj --config snapshot.max-new-file-size={size} file track {large_files_list}`
+              This will increase the maximum file size allowed for new files, for this command only.
             "
         )?;
     }

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -132,7 +132,17 @@ where
             if let Some(heading) = self.heading.take() {
                 write!(formatter.labeled("heading"), "{heading}")?;
             }
-            formatter.write_fmt(args)
+            let msg = args.to_string();
+            if msg.matches('\n').nth(1).is_some() {
+                // message is multi-line, print it in an indented block
+                writeln!(formatter)?;
+                for line in msg.lines() {
+                    writeln!(formatter, "  {line}")?;
+                }
+                Ok(())
+            } else {
+                formatter.write_fmt(args)
+            }
         })
     }
 }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1440,9 +1440,10 @@ fn test_config_author_change_warning() {
     let output = work_dir.run_jj(["config", "set", "--repo", "user.email", "'Foo'"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: This setting will only impact future commits.
-    The author of the working copy will stay "Test User <test.user@example.com>".
-    To change the working copy author, use "jj describe --reset-author --no-edit"
+    Warning: 
+      This setting will only impact future commits.
+      The author of the working copy will stay "Test User <test.user@example.com>".
+      To change the working copy author, use "jj describe --reset-author --no-edit"
     [EOF]
     "#);
 

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -555,9 +555,10 @@ fn test_git_colocated_conflicting_git_refs() {
         Created 1 bookmarks pointing to qpvuntsm 230dd059 main main/sub | (empty) (no description set)
         Warning: Failed to export some bookmarks:
           main/sub@git: Failed to set: ...
-        Hint: Git doesn't allow a branch name that looks like a parent directory of
-        another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
-        export or their "parent" bookmarks.
+        Hint: 
+          Git doesn't allow a branch name that looks like a parent directory of
+          another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
+          export or their "parent" bookmarks.
         [EOF]
         "#);
     });

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -469,8 +469,9 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     ------- stderr -------
     Warning: Failed to import some Git refs:
       refs/remotes/git/git
-    Hint: Git remote named 'git' is reserved for local Git repository.
-    Use `jj git remote rename` to give a different name.
+    Hint: 
+      Git remote named 'git' is reserved for local Git repository.
+      Use `jj git remote rename` to give a different name.
     [EOF]
     ");
     }
@@ -483,12 +484,14 @@ fn test_git_fetch_from_remote_named_git(subprocess: bool) {
     ------- stderr -------
     Warning: Failed to import some Git refs:
       refs/remotes/git/git
-    Hint: Git remote named 'git' is reserved for local Git repository.
-    Use `jj git remote rename` to give a different name.
+    Hint: 
+      Git remote named 'git' is reserved for local Git repository.
+      Use `jj git remote rename` to give a different name.
     Warning: Failed to import some Git refs:
       refs/remotes/git/git
-    Hint: Git remote named 'git' is reserved for local Git repository.
-    Use `jj git remote rename` to give a different name.
+    Hint: 
+      Git remote named 'git' is reserved for local Git repository.
+      Use `jj git remote rename` to give a different name.
     Nothing changed.
     [EOF]
     ");

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -80,9 +80,10 @@ fn test_git_export_conflicting_git_refs() {
         ------- stderr -------
         Warning: Failed to export some bookmarks:
           main/sub@git: Failed to set: ...
-        Hint: Git doesn't allow a branch name that looks like a parent directory of
-        another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
-        export or their "parent" bookmarks.
+        Hint: 
+          Git doesn't allow a branch name that looks like a parent directory of
+          another (e.g. `foo` and `foo/bar`). Try to rename the bookmarks that failed to
+          export or their "parent" bookmarks.
         [EOF]
         "#);
     });

--- a/cli/tests/test_gitignores.rs
+++ b/cli/tests/test_gitignores.rs
@@ -137,8 +137,9 @@ fn test_gitignores_ignored_file_in_target_commit() {
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 1 files, modified 0 files, removed 0 files
     Warning: 1 of those updates were skipped because there were conflicting changes in the working copy.
-    Hint: Inspect the changes compared to the intended target with `jj diff --from 5ada929e5d2e`.
-    Discard the conflicting changes with `jj restore --from 5ada929e5d2e`.
+    Hint: 
+      Inspect the changes compared to the intended target with `jj diff --from 5ada929e5d2e`.
+      Discard the conflicting changes with `jj restore --from 5ada929e5d2e`.
     [EOF]
     ");
     let output = work_dir.run_jj(["diff", "--git", "--from", &target_commit_id]);

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -35,9 +35,10 @@ fn test_restore() {
     let output = work_dir.run_jj(["restore", "-r=@-"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: `jj restore` does not have a `--revision`/`-r` option. If you'd like to modify
-    the *current* revision, use `--from`. If you'd like to modify a *different* revision,
-    use `--into` or `--changes-in`.
+    Error: 
+      `jj restore` does not have a `--revision`/`-r` option. If you'd like to modify
+      the *current* revision, use `--from`. If you'd like to modify a *different* revision,
+      use `--into` or `--changes-in`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -591,18 +591,20 @@ fn test_bad_alias_decl() {
     ◆  zzzzzzzz root() 00000000
     [EOF]
     ------- stderr -------
-    Warning: Failed to load `revset-aliases."bad"`:  --> 1:1
-      |
-    1 | "bad"
-      | ^---
-      |
-      = expected <strict_identifier> or <function_name>
-    Warning: Failed to load `revset-aliases.badfn(a, a)`:  --> 1:7
-      |
-    1 | badfn(a, a)
-      |       ^--^
-      |
-      = Redefinition of function parameter
+    Warning: 
+      Failed to load `revset-aliases."bad"`:  --> 1:1
+        |
+      1 | "bad"
+        | ^---
+        |
+        = expected <strict_identifier> or <function_name>
+    Warning: 
+      Failed to load `revset-aliases.badfn(a, a)`:  --> 1:7
+        |
+      1 | badfn(a, a)
+        |       ^--^
+        |
+        = Redefinition of function parameter
     [EOF]
     "#);
 }

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -472,12 +472,13 @@ fn test_templater_bad_alias_decl() {
     insta::assert_snapshot!(output, @r"
     000000000000[EOF]
     ------- stderr -------
-    Warning: Failed to load `template-aliases.badfn(a, a)`:  --> 1:7
-      |
-    1 | badfn(a, a)
-      |       ^--^
-      |
-      = Redefinition of function parameter
+    Warning: 
+      Failed to load `template-aliases.badfn(a, a)`:  --> 1:7
+        |
+      1 | badfn(a, a)
+        |       ^--^
+        |
+        = Redefinition of function parameter
     [EOF]
     ");
 }

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -35,7 +35,8 @@ fn test_snapshot_large_file() {
     ------- stderr -------
     Warning: Refused to snapshot some files:
       large: 13.0B (13 bytes); the maximum size allowed is 10.0B (10 bytes)
-    Hint: This is to prevent large files from being added by accident. You can fix this by:
+    Hint: 
+      This is to prevent large files from being added by accident. You can fix this by:
       - Adding the file to `.gitignore`
       - Run `jj config set --repo snapshot.max-new-file-size 13`
         This will increase the maximum file size allowed for new files, in this repository only.
@@ -55,7 +56,8 @@ fn test_snapshot_large_file() {
     ------- stderr -------
     Warning: Refused to snapshot some files:
       large: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
-    Hint: This is to prevent large files from being added by accident. You can fix this by:
+    Hint: 
+      This is to prevent large files from being added by accident. You can fix this by:
       - Adding the file to `.gitignore`
       - Run `jj config set --repo snapshot.max-new-file-size 11264`
         This will increase the maximum file size allowed for new files, in this repository only.
@@ -78,7 +80,8 @@ fn test_snapshot_large_file() {
     Warning: Refused to snapshot some files:
       large: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
       large2: 11.0KiB (11264 bytes); the maximum size allowed is 10.0KiB (10240 bytes)
-    Hint: This is to prevent large files from being added by accident. You can fix this by:
+    Hint: 
+      This is to prevent large files from being added by accident. You can fix this by:
       - Adding the file to `.gitignore`
       - Run `jj config set --repo snapshot.max-new-file-size 11264`
         This will increase the maximum file size allowed for new files, in this repository only.
@@ -134,7 +137,8 @@ fn test_snapshot_large_file_restore() {
     ------- stderr -------
     Warning: Refused to snapshot some files:
       file: 13.0B (13 bytes); the maximum size allowed is 10.0B (10 bytes)
-    Hint: This is to prevent large files from being added by accident. You can fix this by:
+    Hint: 
+      This is to prevent large files from being added by accident. You can fix this by:
       - Adding the file to `.gitignore`
       - Run `jj config set --repo snapshot.max-new-file-size 13`
         This will increase the maximum file size allowed for new files, in this repository only.
@@ -145,8 +149,9 @@ fn test_snapshot_large_file_restore() {
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 1 files, modified 0 files, removed 0 files
     Warning: 1 of those updates were skipped because there were conflicting changes in the working copy.
-    Hint: Inspect the changes compared to the intended target with `jj diff --from e3eb7e819de5`.
-    Discard the conflicting changes with `jj restore --from e3eb7e819de5`.
+    Hint: 
+      Inspect the changes compared to the intended target with `jj diff --from e3eb7e819de5`.
+      Discard the conflicting changes with `jj restore --from e3eb7e819de5`.
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @"a lot of text");


### PR DESCRIPTION
I think this is an improvement on its own.

But there are a lot of very long single-line strings that should probably be split up. I'm guessing this is the case because multiline strings weren't handled nicely so far, so a long single line was considered the lesser of two evils.

After this change, I'll probably go over some of the other strings and split them on multiple lines.

# Checklist

If applicable:
- [ ] ~I have updated `CHANGELOG.md`~
- [ ] ~I have updated the documentation (README.md, docs/, demos/)~
- [ ] ~I have updated the config schema (cli/src/config-schema.json)~
- [ ] ~I have added tests to cover my changes~
