### PR TITLE
cli: describe: reuse author field set to temporary builders

### DIFF
--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -632,6 +632,16 @@ fn test_describe_default_description() {
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
+
+    // Default description shouldn't be used if --no-edit
+    work_dir.run_jj(["new", "root()"]).success();
+    let output = work_dir.run_jj(["describe", "--no-edit", "--reset-author"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Working copy  (@) now at: kkmpptxz f652c321 (empty) (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ");
 }
 
 #[test]


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
