### PR TITLE
cli: resolve: do not use .with_new_file_ids() to construct resolved file value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Fixed crash on change-delete conflict resolution.
+  [#6250](https://github.com/jj-vcs/jj/issues/6250)
+
 ### Packaging changes
 
 * Jujutsu now uses

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -439,7 +439,17 @@ impl From<ConflictResolveError> for CommandError {
         match err {
             ConflictResolveError::Backend(err) => err.into(),
             ConflictResolveError::Io(err) => err.into(),
-            _ => user_error_with_message("Failed to resolve conflicts", err),
+            _ => {
+                let hint = match &err {
+                    ConflictResolveError::ExecutableConflict { .. } => {
+                        Some("Use `jj file chmod` to update the executable bit.".to_owned())
+                    }
+                    _ => None,
+                };
+                let mut cmd_err = user_error_with_message("Failed to resolve conflicts", err);
+                cmd_err.extend_hints(hint);
+                cmd_err
+            }
         }
     }
 }

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -29,6 +29,7 @@ use jj_lib::backend::ChangeId;
 use jj_lib::backend::CommitId;
 use jj_lib::backend::TreeValue;
 use jj_lib::commit::Commit;
+use jj_lib::conflicts;
 use jj_lib::conflicts::ConflictMarkerStyle;
 use jj_lib::copies::CopiesTreeDiffEntry;
 use jj_lib::copies::CopiesTreeDiffEntryPath;
@@ -2096,7 +2097,7 @@ fn describe_file_type(value: &MergedTreeValue) -> &'static str {
 
 fn is_executable_file(value: &MergedTreeValue) -> Option<bool> {
     let executable = value.to_executable_merge()?;
-    executable.resolve_trivial().copied()
+    conflicts::resolve_file_executable(&executable)
 }
 
 /// [`DiffStats`] with rendering parameters.

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1435,7 +1435,10 @@ fn git_diff_part(
             };
         }
         MaterializedTreeValue::FileConflict(file) => {
-            mode = if file.executable { "100755" } else { "100644" };
+            mode = match file.executable {
+                Some(true) => "100755",
+                Some(false) | None => "100644",
+            };
             hash = DUMMY_HASH.to_owned();
             content = FileContent {
                 is_binary: false, // TODO: are we sure this is never binary?

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -102,6 +102,8 @@ pub enum ConflictResolveError {
     NotNormalFiles { path: RepoPathBuf, summary: String },
     #[error("The conflict at {path:?} has {sides} sides. At most 2 sides are supported.")]
     ConflictTooComplicated { path: RepoPathBuf, sides: usize },
+    #[error("{path:?} has conflicts in executable bit\n{summary}", summary = summary.trim_end())]
+    ExecutableConflict { path: RepoPathBuf, summary: String },
     #[error(
         "The output file is either unchanged or empty after the editor quit (run with --debug to \
          see the exact invocation)."
@@ -341,6 +343,12 @@ impl MergeToolFile {
                 sides: file.ids.num_sides(),
             });
         };
+        if file.executable.is_none() {
+            return Err(ConflictResolveError::ExecutableConflict {
+                path: repo_path.to_owned(),
+                summary: conflict.describe(),
+            });
+        }
         Ok(MergeToolFile {
             repo_path: repo_path.to_owned(),
             conflict,

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1521,7 +1521,7 @@ impl FileSnapshotter<'_> {
                     let executable = {
                         let () = executable; // use the variable
                         if let Some(merge) = current_tree_values.to_executable_merge() {
-                            merge.resolve_trivial().copied().unwrap_or_default()
+                            conflicts::resolve_file_executable(&merge).unwrap_or(false)
                         } else {
                             false
                         }
@@ -1863,7 +1863,7 @@ impl TreeState {
                     self.write_conflict(
                         &disk_path,
                         data,
-                        file.executable,
+                        file.executable.unwrap_or(false),
                         Some(materialized_conflict_data),
                     )?
                 }

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -566,10 +566,10 @@ where
 
     /// If this merge contains only files or absent entries, returns a merge of
     /// the files' executable bits.
-    pub fn to_executable_merge(&self) -> Option<Merge<bool>> {
+    pub fn to_executable_merge(&self) -> Option<Merge<Option<bool>>> {
         self.try_map(|term| match borrow_tree_value(term.as_ref()) {
-            None => Ok(false),
-            Some(TreeValue::File { id: _, executable }) => Ok(*executable),
+            None => Ok(None),
+            Some(TreeValue::File { id: _, executable }) => Ok(Some(*executable)),
             _ => Err(()),
         })
         .ok()

--- a/lib/src/tree.rs
+++ b/lib/src/tree.rs
@@ -278,15 +278,15 @@ pub async fn try_resolve_file_conflict(
     // merge it. We check early so we don't waste time reading file contents if
     // we can't merge them anyway. At the same time we determine whether the
     // resulting file should be executable.
-    let Some(file_id_conflict) = conflict.maybe_map(|term| match term {
-        Some(TreeValue::File { id, executable: _ }) => Some(id),
-        _ => None,
+    let Ok(file_id_conflict) = conflict.try_map(|term| match term {
+        Some(TreeValue::File { id, executable: _ }) => Ok(id),
+        _ => Err(()),
     }) else {
         return Ok(None);
     };
-    let Some(executable_conflict) = conflict.maybe_map(|term| match term {
-        Some(TreeValue::File { id: _, executable }) => Some(executable),
-        _ => None,
+    let Ok(executable_conflict) = conflict.try_map(|term| match term {
+        Some(TreeValue::File { id: _, executable }) => Ok(executable),
+        _ => Err(()),
     }) else {
         return Ok(None);
     };


### PR DESCRIPTION

Fixes #6250

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
