### PR TITLE
Remove deprecated backout command from documentation table

### DIFF
--- a/docs/git-command-table.yml
+++ b/docs/git-command-table.yml
@@ -376,7 +376,7 @@
   Git command: >
     `git revert <revision>`
   Jujutsu command: >
-    `jj backout -r <revision>`
+    `jj revert -r <revision> -B @`
   Notes: ''
 
 - Use case: Show what revision and author last modified each line of a file


### PR DESCRIPTION
I just ran into this trying to figure out the equivalent to `git revert`. Turns out that backout is deprecated and revert does not have the same defaults.