### PR TITLE
repo: propagate error from tx.write(), attach file path to op_store errors

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -664,7 +664,7 @@ impl CommandHelper {
                         }
                     }
                     Ok(tx
-                        .write("reconcile divergent operations")
+                        .write("reconcile divergent operations")?
                         .leave_unpublished()
                         .operation()
                         .clone())

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -51,6 +51,7 @@ use jj_lib::revset::RevsetParseError;
 use jj_lib::revset::RevsetParseErrorKind;
 use jj_lib::revset::RevsetResolutionError;
 use jj_lib::str_util::StringPatternParseError;
+use jj_lib::transaction::TransactionCommitError;
 use jj_lib::view::RenameWorkspaceError;
 use jj_lib::working_copy::RecoverWorkspaceError;
 use jj_lib::working_copy::ResetError;
@@ -354,6 +355,7 @@ impl From<WorkspaceInitError> for CommandError {
                 internal_error_with_message("Failed to access the repository", err)
             }
             WorkspaceInitError::SignInit(err) => user_error(err),
+            WorkspaceInitError::TransactionCommit(err) => err.into(),
         }
     }
 }
@@ -405,6 +407,12 @@ impl From<RepoLoaderError> for CommandError {
 impl From<ResetError> for CommandError {
     fn from(err: ResetError) -> Self {
         internal_error_with_message("Failed to reset the working copy", err)
+    }
+}
+
+impl From<TransactionCommitError> for CommandError {
+    fn from(err: TransactionCommitError) -> Self {
+        internal_error(err)
     }
 }
 
@@ -629,9 +637,9 @@ impl From<RecoverWorkspaceError> for CommandError {
     fn from(err: RecoverWorkspaceError) -> Self {
         match err {
             RecoverWorkspaceError::Backend(err) => err.into(),
-            RecoverWorkspaceError::OpHeadsStore(err) => err.into(),
             RecoverWorkspaceError::Reset(err) => err.into(),
             RecoverWorkspaceError::RewriteRootCommit(err) => err.into(),
+            RecoverWorkspaceError::TransactionCommit(err) => err.into(),
             err @ RecoverWorkspaceError::WorkspaceMissingWorkingCopy(_) => user_error(err),
         }
     }

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -100,6 +100,7 @@ use crate::simple_op_store::SimpleOpStore;
 use crate::store::Store;
 use crate::submodule_store::SubmoduleStore;
 use crate::transaction::Transaction;
+use crate::transaction::TransactionCommitError;
 use crate::view::RenameWorkspaceError;
 use crate::view::View;
 
@@ -626,6 +627,8 @@ pub enum RepoLoaderError {
     OpHeadsStoreError(#[from] OpHeadsStoreError),
     #[error(transparent)]
     OpStore(#[from] OpStoreError),
+    #[error(transparent)]
+    TransactionCommit(#[from] TransactionCommitError),
 }
 
 /// Helps create `ReadonlyRepoo` instances of a repo at the head operation or at
@@ -790,7 +793,7 @@ impl RepoLoader {
                 || format!("merge {num_operations} operations"),
                 |tx_description| tx_description.to_string(),
             );
-            let merged_repo = tx.write(tx_description).leave_unpublished();
+            let merged_repo = tx.write(tx_description)?.leave_unpublished();
             merged_repo.operation().clone()
         } else {
             base_op

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1807,7 +1807,8 @@ fn reload_repo_at_operation(
         RepoLoaderError::IndexRead(_)
         | RepoLoaderError::OpHeadResolution(_)
         | RepoLoaderError::OpHeadsStoreError(_)
-        | RepoLoaderError::OpStore(_) => RevsetResolutionError::Other(err.into()),
+        | RepoLoaderError::OpStore(_)
+        | RepoLoaderError::TransactionCommit(_) => RevsetResolutionError::Other(err.into()),
     })
 }
 

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -35,7 +35,6 @@ use crate::gitignore::GitIgnoreError;
 use crate::gitignore::GitIgnoreFile;
 use crate::matchers::EverythingMatcher;
 use crate::matchers::Matcher;
-use crate::op_heads_store::OpHeadsStoreError;
 use crate::op_store::OpStoreError;
 use crate::op_store::OperationId;
 use crate::operation::Operation;
@@ -48,6 +47,7 @@ use crate::repo_path::InvalidRepoPathError;
 use crate::repo_path::RepoPath;
 use crate::repo_path::RepoPathBuf;
 use crate::store::Store;
+use crate::transaction::TransactionCommitError;
 
 /// The trait all working-copy implementations must implement.
 pub trait WorkingCopy: Send {
@@ -417,15 +417,15 @@ pub enum RecoverWorkspaceError {
     /// Backend error.
     #[error(transparent)]
     Backend(#[from] BackendError),
-    /// Error during transaction.
-    #[error(transparent)]
-    OpHeadsStore(#[from] OpHeadsStoreError),
     /// Error during checkout.
     #[error(transparent)]
     Reset(#[from] ResetError),
     /// Checkout attempted to modify the root commit.
     #[error(transparent)]
     RewriteRootCommit(#[from] RewriteRootCommit),
+    /// Error during transaction.
+    #[error(transparent)]
+    TransactionCommit(#[from] TransactionCommitError),
     /// Working copy commit is missing.
     #[error(r#""{}" doesn't have a working-copy commit"#, .0.as_symbol())]
     WorkspaceMissingWorkingCopy(WorkspaceNameBuf),

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -54,6 +54,7 @@ use crate::signing::SignInitError;
 use crate::signing::Signer;
 use crate::simple_backend::SimpleBackend;
 use crate::store::Store;
+use crate::transaction::TransactionCommitError;
 use crate::working_copy::CheckoutError;
 use crate::working_copy::CheckoutOptions;
 use crate::working_copy::CheckoutStats;
@@ -75,11 +76,13 @@ pub enum WorkspaceInitError {
     #[error(transparent)]
     Path(#[from] PathError),
     #[error(transparent)]
-    OpHeadsStore(#[from] OpHeadsStoreError),
+    OpHeadsStore(OpHeadsStoreError),
     #[error(transparent)]
     Backend(#[from] BackendInitError),
     #[error(transparent)]
     SignInit(#[from] SignInitError),
+    #[error(transparent)]
+    TransactionCommit(#[from] TransactionCommitError),
 }
 
 #[derive(Error, Debug)]

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -54,7 +54,7 @@ fn test_unpublished_operation() {
 
     let mut tx1 = repo.start_transaction();
     write_random_commit(tx1.repo_mut());
-    let unpublished_op = tx1.write("transaction 1");
+    let unpublished_op = tx1.write("transaction 1").unwrap();
     let op_id1 = unpublished_op.operation().id().clone();
     assert_ne!(op_id1, op_id0);
     assert_eq!(list_dir(&op_heads_dir), vec![op_id0.hex()]);


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
