### PR TITLE
config: Use XDG-standard config location on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fixed bash and zsh shell completion when completing aliases of multiple arguments.
   [#5377](https://github.com/jj-vcs/jj/issues/5377)
 
+* On macOS, jj now defaults to looking for its config in `$XDG_CONFIG_HOME`
+  (`~/.config` by default) rather than the more GUI-native
+  `~/Library/Application Support`.
+
 ### Packaging changes
 
 * Jujutsu now uses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [`templates.draft_commit_description`](docs/config.md#default-description),
   and/or [`templates.commit_trailers`](docs/config.md#commit-trailers).
 
+* On macOS, config.toml files in `~/Library/Application Support/jj` are
+  deprecated; one should instead use `$XDG_CONFIG_HOME/jj`
+  (defaults to `~/.config/jj`)
+
 ### New features
 
 * Color-words diff has gained [an option to compare conflict pairs without

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,8 +2363,8 @@ dependencies = [
  "criterion",
  "crossterm",
  "datatest-stable",
- "dirs",
  "dunce",
+ "etcetera",
  "futures 0.3.31",
  "git2",
  "gix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ criterion = "0.5.1"
 crossterm = { version = "0.28", default-features = false, features = ["windows"] }
 datatest-stable = "0.3.2"
 digest = "0.10.7"
-dirs = "6.0.0"
 dunce = "1.0.5"
+etcetera = "0.10.0"
 either = "1.15.0"
 futures = "0.3.31"
 git2 = { version = "0.20.1", features = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,8 +62,8 @@ clap_complete_nushell = { workspace = true }
 clap_mangen = { workspace = true }
 criterion = { workspace = true, optional = true }
 crossterm = { workspace = true }
-dirs = { workspace = true }
 dunce = { workspace = true }
+etcetera = { workspace = true }
 futures = { workspace = true }
 git2 = { workspace = true, optional = true }
 gix = { workspace = true, optional = true }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3873,7 +3873,7 @@ impl<'a> CliRunner<'a> {
                     "Did you update to a commit where the directory doesn't exist?",
                 )
             })?;
-        let mut config_env = ConfigEnv::from_environment();
+        let mut config_env = ConfigEnv::from_environment(ui);
         let mut last_config_migration_descriptions = Vec::new();
         let mut migrate_config = |config: &mut StackedConfig| -> Result<(), CommandError> {
             last_config_migration_descriptions =

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -838,7 +838,7 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
         .and_then(dunce::canonicalize)
         .map_err(user_error)?;
     // No config migration for completion. Simply ignore deprecated variables.
-    let mut config_env = ConfigEnv::from_environment();
+    let mut config_env = ConfigEnv::from_environment(&ui);
     let maybe_cwd_workspace_loader = DefaultWorkspaceLoaderFactory.create(find_workspace_dir(&cwd));
     let _ = config_env.reload_user_config(&mut raw_config);
     if let Ok(loader) = &maybe_cwd_workspace_loader {

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -153,8 +153,8 @@ fn pinentry_get_pw(url: &str) -> Option<String> {
 #[tracing::instrument]
 fn get_ssh_keys(_username: &str) -> Vec<PathBuf> {
     let mut paths = vec![];
-    if let Some(home_dir) = dirs::home_dir() {
-        let ssh_dir = Path::new(&home_dir).join(".ssh");
+    if let Ok(home_dir) = etcetera::home_dir() {
+        let ssh_dir = home_dir.join(".ssh");
         for filename in ["id_ed25519_sk", "id_ed25519", "id_rsa"] {
             let key_path = ssh_dir.join(filename);
             if key_path.is_file() {

--- a/docs/config.md
+++ b/docs/config.md
@@ -1599,11 +1599,15 @@ The files in the `conf.d` directory are loaded in lexicographic order. This allo
 configs to be split across multiple files and combines well
 with [Conditional Variables](#conditional-variables).
 
-| Platform | Location of `<PLATFORM_SPECIFIC>` dir | Example config file location                              |
-| :------- | :------------------------------------ | :-------------------------------------------------------- |
-| Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/jj/config.toml`                      |
-| macOS    | `$HOME/Library/Application Support`   | `/Users/Alice/Library/Application Support/jj/config.toml` |
-| Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Roaming\jj\config.toml`           |
+| Platform        | Location of `<PLATFORM_SPECIFIC>` dir | Example config file location                              |
+| :-------------- | :------------------------------------ | :-------------------------------------------------------- |
+| Linux and macOS | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/jj/config.toml`                      |
+| Windows         | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Roaming\jj\config.toml`           |
+
+On macOS, jj used to put the user config in `~/Library/Application Support`,
+and jj will still look there for backwards compatibility purposes; this is
+considered a deprecated location, and you should use the new default
+`XDG_CONFIG_HOME`.
 
 The location of the `jj` user config files/directories can also be overridden with the
 `JJ_CONFIG` environment variable. If it is not empty, it will be used instead


### PR DESCRIPTION
Changing where the default config location is on macOS, switching to [etcetera][] from [dirs][].

Some points for discussion:

- I am treating the classic behaviour as a bug, not a feature; I do _not_ believe that it is correct in any way to place configuration in `~/Library/Application Support`, ever, and certainly not for CLI applications
- ~~Currently, if you run `jj config edit --user`, and you already have a config in `~/Library/Application Support`, you'll get a picker for both; this seems less than ideal? Perhaps advice would be good? Or we could ignore the normal file if the legacy file exists?~~
  - ~~This has been changed as of latest patch set – it may be desireable to pull that patch out into its own PR. Let me know.~~
  - ~~This bugfix has been pulled into its own PR: #6315~~
  - This was not a bug. I screwed up my own computer's configuration.

This PR takes a lot of inspiration from @ckoehler's #3466, but has been rewritten since the current codebase is a hell of a lot more amenable to these changes.

Fixes #3434 

[etcetera]: https://crates.io/crates/etcetera
[dirs]: https://crates.io/crates/dirs

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [x] ~~I have updated the config schema (cli/src/config-schema.json)~~
- [x] I have added tests to cover my changes
- [x] I have played around with my changes
