### PR TITLE
rebase: skip duplicate divergent commits by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The deprecated `jj branch` subcommands have been removed. Use the `jj bookmark`
   subcommands instead.
 
+* `jj rebase` now automatically abandons divergent commits if another commit
+  with the same change ID is already present in the destination with identical
+  changes. To keep these divergent commits, use the `--keep-divergent` flag.
+
 ### Deprecations
 
 * The `ui.diff.format` and `ui.diff.tool` config options have been merged as

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2223,6 +2223,9 @@ J           J
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `--skip-emptied` — If true, when rebasing would produce an empty commit, the commit is abandoned. It will not be abandoned if it was already empty before the rebase. Will never skip merge commits with multiple non-empty parents
+* `--keep-divergent` — Keep divergent commits while rebasing
+
+   Without this flag, divergent commits are abandoned while rebasing if another commit with the same change ID is already present in the destination with identical changes.
 
 
 


### PR DESCRIPTION
This is a partial fix for #5381 and #2979. It doesn't handle the general case (it only detects duplicate changes between divergent commits with the same change ID), but I think it should handle many useful cases, especially for users with the `change-id` header enabled. I'm looking for feedback about whether this is a good general approach and about the implementation.

This serves a similar purpose to Git's patch ID mechanism, however it is slightly different in that it only compares commits which have the same change ID as each other (divergent changes), and it does a full comparison of the commits to see if they would have identical trees if rebased onto the same parents. Since most changes aren't divergent, I believe this should have a negligible performance cost in most cases.

I think skipping these commits by default makes sense for `jj rebase`, since usually this will be a helpful behavior for the user. With this behavior, a safe first step when encountering divergent changes would be to rebase one branch on top of the other, since that will abandon any divergent changes that have identical contents to existing commits, leaving behind any non-trivial divergent changes for the user to resolve manually.

# Checklist

If applicable:
- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [X] I have added tests to cover my changes
