### PR TITLE
cli: duplicate: add setting for templating the new commit descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   template, to the commit description. Use cases include DCO Sign Off and
   Gerrit Change Id.
 
+* Added `duplicate_description` template, which allows [customizing the descriptions
+  of the commits `jj duplicate` creates](docs/config.md#duplicate-commit-description).
+
 ### Fixed bugs
 
 * Fixed crash on change-delete conflict resolution.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -35,6 +35,8 @@ config_list = 'builtin_config_list'
 
 draft_commit_description = 'builtin_draft_commit_description'
 
+duplicate_description = 'description'
+
 commit_trailers = ''
 
 file_list = '''

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -802,6 +802,8 @@ When none of the `--destination`, `--insert-after`, or `--insert-before` argumen
 
 When any of the `--destination`, `--insert-after`, or `--insert-before` arguments are provided, the roots of the specified commits will be duplicated onto the destination indicated by the arguments. Other specified commits will be duplicated onto these newly duplicated commits. If the `--insert-after` or `--insert-before` arguments are provided, the new children indicated by the arguments will be rebased onto the heads of the specified commits.
 
+By default, the duplicated commits retain the descriptions of the originals. This can be customized with the `templates.duplicate_description` setting.
+
 **Usage:** `jj duplicate [OPTIONS] [REVSETS]...`
 
 ###### **Arguments:**

--- a/docs/config.md
+++ b/docs/config.md
@@ -197,6 +197,24 @@ fill in things like BUG=, TESTED= etc.
 default-description = "\n\nTESTED=TODO"
 ```
 
+### Duplicate commit description
+
+By default, `jj duplicate` copies the descriptions from the original commits.
+You can customize this behavior by specifying the `duplicate_description`
+template, which is given a `Commit` type of the original commit.
+
+```toml
+[templates]
+duplicate_description = '''
+concat(
+  description,
+  "\n(cherry picked from commit ",
+  commit_id,
+  ")"
+)
+'''
+```
+
 ### Bookmark listing order
 
 By default, `jj bookmark list` displays bookmarks sorted alphabetically by name.

--- a/lib/tests/test_rewrite_duplicate.rs
+++ b/lib/tests/test_rewrite_duplicate.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 use jj_lib::repo::Repo as _;
@@ -76,6 +78,7 @@ fn test_duplicate_linear_contents() {
         duplicate_commits(
             tx.repo_mut(),
             &target_commits.iter().copied().cloned().collect_vec(),
+            &HashMap::new(),
             &parent_commit_ids.iter().copied().cloned().collect_vec(),
             &children_commit_ids.iter().copied().cloned().collect_vec(),
         )


### PR DESCRIPTION
This allows the customization of the duplicated commit descriptions.

An ideal use case for this is emulating `git cherry-pick -x`, as illustrated in the tests.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
