### PR TITLE
revset: add `signed()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added `ui.bookmark-list-sort-keys` setting to configure default sort keys for the
   `jj bookmark list` command.
 
+* New `signed` revset function to filter for cryptographically signed commits.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -304,6 +304,8 @@ revsets (expressions) as arguments.
 * `committer_date(pattern)`: Commits with committer dates matching the specified
   [date pattern](#date-patterns).
 
+* `signed()`: Commits that are cryptographically signed.
+
 * `empty()`: Commits modifying no files. This also includes `merges()` without
   user modifications and `root()`.
 

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1248,6 +1248,11 @@ fn build_predicate_fn(
             let commit = store.get_commit(&entry.commit_id())?;
             Ok(commit.has_conflict()?)
         }),
+        RevsetFilterPredicate::Signed => box_pure_predicate_fn(move |index, pos| {
+            let entry = index.entry_by_pos(pos);
+            let commit = store.get_commit(&entry.commit_id())?;
+            Ok(commit.is_signed())
+        }),
         RevsetFilterPredicate::Extension(ext) => {
             let ext = ext.clone();
             box_pure_predicate_fn(move |index, pos| {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -181,6 +181,8 @@ pub enum RevsetFilterPredicate {
     },
     /// Commits with conflicts
     HasConflict,
+    /// Commits that are cryptographically signed.
+    Signed,
     /// Custom predicates provided by extensions
     Extension(Rc<dyn RevsetFilterExtension>),
 }
@@ -830,6 +832,11 @@ static BUILTIN_FUNCTION_MAP: Lazy<HashMap<&'static str, RevsetFunction>> = Lazy:
         Ok(RevsetExpression::filter(RevsetFilterPredicate::AuthorDate(
             pattern,
         )))
+    });
+    map.insert("signed", |_diagnostics, function, _context| {
+        function.expect_no_arguments()?;
+        let predicate = RevsetFilterPredicate::Signed;
+        Ok(RevsetExpression::filter(predicate))
     });
     map.insert("mine", |_diagnostics, function, context| {
         function.expect_no_arguments()?;
@@ -3245,6 +3252,7 @@ mod tests {
             ),
         )
         "#);
+        insta::assert_debug_snapshot!(parse("signed()").unwrap(), @"Filter(Signed)");
     }
 
     #[test]


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Related to #5786

This PR adds a new `signed()` revset function that filters for signed commits.

cc @yuja 


# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] ~~I have updated the config schema (cli/src/config-schema.json)~~
- [x] I have added tests to cover my changes
