### PR TITLE
cli abandon: convert deleted bookmark warning to hint

### DIFF
--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -174,9 +174,9 @@ pub(crate) fn cmd_abandon(
             .any(|name| has_tracked_remote_bookmarks(view, name))
         {
             writeln!(
-                ui.warning_default(),
-                "Remote bookmarks tracked by deleted bookmarks will be deleted on the next `jj \
-                 git push`."
+                ui.hint_default(),
+                "Deleted bookmarks can be pushed by name or all at once with `jj git push \
+                 --deleted`."
             )?;
         }
     }

--- a/cli/tests/test_abandon_command.rs
+++ b/cli/tests/test_abandon_command.rs
@@ -508,7 +508,7 @@ fn test_abandon_tracking_bookmarks() {
     Abandoned 1 commits:
       vvkvtnvv 230dd059 foo | (empty) (no description set)
     Deleted bookmarks: foo
-    Warning: Remote bookmarks tracked by deleted bookmarks will be deleted on the next `jj git push`.
+    Hint: Deleted bookmarks can be pushed by name or all at once with `jj git push --deleted`.
     [EOF]
     ");
     let output = local_dir.run_jj(["abandon", "bar"]);


### PR DESCRIPTION
Bookmarks are no longer deleted on the next `jj git push` command, so this updates the language and downgrades the warning to a hint.

Thanks!

Related: https://github.com/jj-vcs/jj/pull/6189

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
