### PR TITLE
cli: fix version test when @ has multiple parents

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -61,6 +61,7 @@ fn get_git_hash() -> Option<String> {
             "log",
             "--no-graph",
             "-r=@-",
+            "-n=1",
             "-T=commit_id",
         ])
         .output()


### PR DESCRIPTION
The `jj log` command ran by the build script returns the commit IDs concatenated together, while the test expects only one ID in the version string.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
