### PR TITLE
nix: disable incremental builds within the dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
       env = {
         LIBSSH2_SYS_USE_PKG_CONFIG = "1";
         RUST_BACKTRACE = 1;
+        CARGO_INCREMENTAL = "0"; # https://github.com/rust-lang/rust/issues/139110
       };
     in {
       formatter = pkgs.alejandra;
@@ -124,7 +125,6 @@
             // {
               RUSTFLAGS = pkgs.lib.optionalString pkgs.stdenv.isLinux "-C link-arg=-fuse-ld=mold";
               NIX_JJ_GIT_HASH = self.rev or "";
-              CARGO_INCREMENTAL = "0";
             };
 
           postInstall = ''


### PR DESCRIPTION
Latest rustc nightlies seem to have broken incremental compilation [0].

I apparently have the worst luck in this department, as I've gotten multiple ICEs within the last few hours alone. So, I'm putting future me out of her misery.

[0]: https://github.com/rust-lang/rust/issues/139110

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
