### PR TITLE
config: only add new when no other config exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* When there are existing config.toml files, don't suggest creating a new file
+  in the config file picker.
+
 ### Packaging changes
 
 * Jujutsu now uses


### PR DESCRIPTION
In current jj, when you have something like:

```
~/
  .jjconfig.toml
  .config/
```

even though `.jjconfig.toml` exists, and `~/.config/jj/config.toml` does not, `jj config edit --user` will ask you if you would like to either edit `.jjconfig.toml`, or create `~/.config/jj/config.toml` newly.

After this patch, `jj config edit --user` in this situation will just edit the config.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] ~~I have updated the documentation (README.md, docs/, demos/)~~
- [ ] ~~I have updated the config schema (cli/src/config-schema.json)~~
- [x] I have added tests to cover my changes
