### PR TITLE
cleanup: use new array methods instead of .collect_tuple()/.next_tuple()

### DIFF
--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -471,7 +471,7 @@ fn parse_term_node(pair: Pair<Rule>) -> TemplateParseResult<ExpressionNode> {
             ExpressionNode::new(ExpressionKind::String(text), span)
         }
         Rule::raw_string_literal => {
-            let (content,) = expr.into_inner().collect_tuple().unwrap();
+            let [content] = expr.into_inner().collect_array().unwrap();
             assert_eq!(content.as_rule(), Rule::raw_string_content);
             let text = content.as_str().to_owned();
             ExpressionNode::new(ExpressionKind::String(text), span)

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -796,7 +796,7 @@ fn test_op_abandon_multiple_heads() {
     let output = work_dir
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
-    let (head_op_id, prev_op_id) = output.stdout.raw().lines().next_tuple().unwrap();
+    let [head_op_id, prev_op_id] = output.stdout.raw().lines().next_array().unwrap();
     insta::assert_snapshot!(head_op_id, @"b0711a8ac91f");
     insta::assert_snapshot!(prev_op_id, @"116edde65ded");
 
@@ -893,7 +893,7 @@ fn test_op_recover_from_bad_gc() {
     let output = work_dir
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
-    let (head_op_id, _, _, bad_op_id) = output.stdout.raw().lines().next_tuple().unwrap();
+    let [head_op_id, _, _, bad_op_id] = output.stdout.raw().lines().next_array().unwrap();
     insta::assert_snapshot!(head_op_id, @"f999e12a5d8b");
     insta::assert_snapshot!(bad_op_id, @"e7377e6a642b");
 
@@ -1696,8 +1696,8 @@ fn test_op_diff_sibling() {
     let output = work_dir
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
-    let (head_op_id, p1_op_id, _, _, _, _, p2_op_id) =
-        output.stdout.raw().lines().next_tuple().unwrap();
+    let [head_op_id, p1_op_id, _, _, _, _, p2_op_id] =
+        output.stdout.raw().lines().next_array().unwrap();
     insta::assert_snapshot!(head_op_id, @"779ecb7ea7f0");
     insta::assert_snapshot!(p1_op_id, @"d700dc16fded");
     insta::assert_snapshot!(p2_op_id, @"13b143e1f4f9");

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -475,7 +475,7 @@ impl<R: RuleType> FunctionCallParser<R> {
         parse_name: impl Fn(Pair<'i, R>) -> Result<&'i str, E>,
         parse_value: impl Fn(Pair<'i, R>) -> Result<ExpressionNode<'i, T>, E>,
     ) -> Result<FunctionCallNode<'i, T>, E> {
-        let (name_pair, args_pair) = pair.into_inner().collect_tuple().unwrap();
+        let [name_pair, args_pair] = pair.into_inner().collect_array().unwrap();
         assert_eq!(name_pair.as_rule(), self.function_name_rule);
         assert_eq!(args_pair.as_rule(), self.function_arguments_rule);
         let name_span = name_pair.as_span();
@@ -496,7 +496,7 @@ impl<R: RuleType> FunctionCallParser<R> {
                 }
                 args.push(parse_value(pair)?);
             } else if pair.as_rule() == self.keyword_argument_rule {
-                let (name_pair, value_pair) = pair.into_inner().collect_tuple().unwrap();
+                let [name_pair, value_pair] = pair.into_inner().collect_array().unwrap();
                 assert_eq!(name_pair.as_rule(), self.argument_name_rule);
                 assert_eq!(value_pair.as_rule(), self.argument_value_rule);
                 let name_span = name_pair.as_span();

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -217,7 +217,7 @@ fn union_nodes<'i>(lhs: ExpressionNode<'i>, rhs: ExpressionNode<'i>) -> Expressi
 
 fn parse_function_call_node(pair: Pair<Rule>) -> FilesetParseResult<FunctionCallNode> {
     assert_eq!(pair.as_rule(), Rule::function);
-    let (name_pair, args_pair) = pair.into_inner().collect_tuple().unwrap();
+    let [name_pair, args_pair] = pair.into_inner().collect_array().unwrap();
     assert_eq!(name_pair.as_rule(), Rule::function_name);
     assert_eq!(args_pair.as_rule(), Rule::function_arguments);
     let name_span = name_pair.as_span();
@@ -241,7 +241,7 @@ fn parse_as_string_literal(pair: Pair<Rule>) -> String {
         Rule::identifier => pair.as_str().to_owned(),
         Rule::string_literal => STRING_LITERAL_PARSER.parse(pair.into_inner()),
         Rule::raw_string_literal => {
-            let (content,) = pair.into_inner().collect_tuple().unwrap();
+            let [content] = pair.into_inner().collect_array().unwrap();
             assert_eq!(content.as_rule(), Rule::raw_string_content);
             content.as_str().to_owned()
         }
@@ -260,7 +260,7 @@ fn parse_primary_node(pair: Pair<Rule>) -> FilesetParseResult<ExpressionNode> {
             ExpressionKind::FunctionCall(function)
         }
         Rule::string_pattern => {
-            let (lhs, op, rhs) = first.into_inner().collect_tuple().unwrap();
+            let [lhs, op, rhs] = first.into_inner().collect_array().unwrap();
             assert_eq!(lhs.as_rule(), Rule::strict_identifier);
             assert_eq!(op.as_rule(), Rule::pattern_kind_op);
             let kind = lhs.as_str();
@@ -332,7 +332,7 @@ pub fn parse_program_or_bare_string(text: &str) -> FilesetParseResult<Expression
     let expr = match first.as_rule() {
         Rule::expression => return parse_expression_node(first),
         Rule::bare_string_pattern => {
-            let (lhs, op, rhs) = first.into_inner().collect_tuple().unwrap();
+            let [lhs, op, rhs] = first.into_inner().collect_array().unwrap();
             assert_eq!(lhs.as_rule(), Rule::strict_identifier);
             assert_eq!(op.as_rule(), Rule::pattern_kind_op);
             assert_eq!(rhs.as_rule(), Rule::bare_string);

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -459,7 +459,7 @@ fn parse_ref_pushes(stdout: &[u8]) -> Result<GitPushStats, GitSubprocessError> {
         .enumerate()
     {
         tracing::debug!("response #{idx}: {}", line.to_str_lossy());
-        let (flag, reference, summary) = line.split_str("\t").collect_tuple().ok_or_else(|| {
+        let [flag, reference, summary] = line.split_str("\t").collect_array().ok_or_else(|| {
             GitSubprocessError::External(format!(
                 "Line #{idx} of git-push has unknown format: {}",
                 line.to_str_lossy()

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -89,7 +89,7 @@ where
         // TODO: Consider removing this special case, making the algorithm more strict,
         // and maybe add a more lenient version that is used when the user explicitly
         // asks for conflict resolution.
-        let ((value1, count1), (value2, count2)) = counts.into_iter().next_tuple().unwrap();
+        let [(value1, count1), (value2, count2)] = counts.into_iter().next_array().unwrap();
         assert_eq!(count1 + count2, 1);
         if count1 > 0 {
             Some(value1)

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -471,7 +471,7 @@ pub fn parse_program(revset_str: &str) -> Result<ExpressionNode, RevsetParseErro
     match first.as_rule() {
         Rule::expression => parse_expression_node(first.into_inner()),
         Rule::program_modifier => {
-            let (lhs, op) = first.into_inner().collect_tuple().unwrap();
+            let [lhs, op] = first.into_inner().collect_array().unwrap();
             let rhs = pairs.next().unwrap();
             assert_eq!(lhs.as_rule(), Rule::strict_identifier);
             assert_eq!(op.as_rule(), Rule::pattern_kind_op);
@@ -632,7 +632,7 @@ fn parse_primary_node(pair: Pair<Rule>) -> Result<ExpressionNode, RevsetParseErr
             ExpressionKind::FunctionCall(function)
         }
         Rule::string_pattern => {
-            let (lhs, op, rhs) = first.into_inner().collect_tuple().unwrap();
+            let [lhs, op, rhs] = first.into_inner().collect_array().unwrap();
             assert_eq!(lhs.as_rule(), Rule::strict_identifier);
             assert_eq!(op.as_rule(), Rule::pattern_kind_op);
             let kind = lhs.as_str();
@@ -674,7 +674,7 @@ fn parse_as_string_literal(pair: Pair<Rule>) -> String {
         Rule::identifier => pair.as_str().to_owned(),
         Rule::string_literal => STRING_LITERAL_PARSER.parse(pair.into_inner()),
         Rule::raw_string_literal => {
-            let (content,) = pair.into_inner().collect_tuple().unwrap();
+            let [content] = pair.into_inner().collect_array().unwrap();
             assert_eq!(content.as_rule(), Rule::raw_string_content);
             content.as_str().to_owned()
         }
@@ -722,7 +722,7 @@ impl AliasDeclarationParser for RevsetAliasParser {
         match first.as_rule() {
             Rule::strict_identifier => Ok(AliasDeclaration::Symbol(first.as_str().to_owned())),
             Rule::function_alias_declaration => {
-                let (name_pair, params_pair) = first.into_inner().collect_tuple().unwrap();
+                let [name_pair, params_pair] = first.into_inner().collect_array().unwrap();
                 assert_eq!(name_pair.as_rule(), Rule::function_name);
                 assert_eq!(params_pair.as_rule(), Rule::formal_parameters);
                 let name = name_pair.as_str().to_owned();

--- a/lib/tests/test_rewrite_duplicate.rs
+++ b/lib/tests/test_rewrite_duplicate.rs
@@ -170,7 +170,7 @@ fn test_duplicate_linear_contents() {
         stats.duplicated_commits[commit_b.id()].tree_id(),
         &tree_1_2.id()
     );
-    let (head_id,) = tx.repo().view().heads().iter().collect_tuple().unwrap();
+    let [head_id] = tx.repo().view().heads().iter().collect_array().unwrap();
     assert_ne!(head_id, commit_e.id());
     assert_eq!(
         tx.repo().store().get_commit(head_id).unwrap().tree_id(),


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
