### PR TITLE
revset: don't crash if revset engine returns non-BackendError

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -564,10 +564,10 @@ fn abandon_unreachable_commits(
         .intersection(&RevsetExpression::visible_heads().ancestors());
     let abandoned_commit_ids: Vec<_> = abandoned_expression
         .evaluate(mut_repo)
-        .map_err(|err| err.expect_backend_error())?
+        .map_err(|err| err.into_backend_error())?
         .iter()
         .try_collect()
-        .map_err(|err| err.expect_backend_error())?;
+        .map_err(|err| err.into_backend_error())?;
     for id in &abandoned_commit_ids {
         let commit = mut_repo.store().get_commit(id)?;
         mut_repo.record_abandoned_commit(&commit);

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1186,13 +1186,12 @@ impl MutableRepo {
                 self.parent_mapping.keys().cloned().collect(),
             ))
             .evaluate(self)
-            .map_err(|err| err.expect_backend_error())?;
+            .map_err(|err| err.into_backend_error())?;
         let to_visit = to_visit_revset
             .iter()
             .commits(self.store())
             .try_collect()
-            // TODO: Return evaluation error to caller
-            .map_err(|err| err.expect_backend_error())?;
+            .map_err(|err| err.into_backend_error())?;
         Ok(to_visit)
     }
 
@@ -1801,10 +1800,10 @@ impl MutableRepo {
     ) -> BackendResult<()> {
         let mut removed_changes: HashMap<ChangeId, Vec<CommitId>> = HashMap::new();
         for item in revset::walk_revs(self, old_heads, new_heads)
-            .map_err(|err| err.expect_backend_error())?
+            .map_err(|err| err.into_backend_error())?
             .commit_change_ids()
         {
-            let (commit_id, change_id) = item.map_err(|err| err.expect_backend_error())?;
+            let (commit_id, change_id) = item.map_err(|err| err.into_backend_error())?;
             removed_changes
                 .entry(change_id)
                 .or_default()
@@ -1817,10 +1816,10 @@ impl MutableRepo {
         let mut rewritten_changes = HashSet::new();
         let mut rewritten_commits: HashMap<CommitId, Vec<CommitId>> = HashMap::new();
         for item in revset::walk_revs(self, new_heads, old_heads)
-            .map_err(|err| err.expect_backend_error())?
+            .map_err(|err| err.into_backend_error())?
             .commit_change_ids()
         {
-            let (commit_id, change_id) = item.map_err(|err| err.expect_backend_error())?;
+            let (commit_id, change_id) = item.map_err(|err| err.into_backend_error())?;
             if let Some(old_commits) = removed_changes.get(&change_id) {
                 for old_commit in old_commits {
                     rewritten_commits

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -103,10 +103,12 @@ pub enum RevsetEvaluationError {
 }
 
 impl RevsetEvaluationError {
-    pub fn expect_backend_error(self) -> BackendError {
+    // TODO: Create a higher-level error instead of putting non-BackendErrors in a
+    // BackendError
+    pub fn into_backend_error(self) -> BackendError {
         match self {
             Self::StoreError(err) => err,
-            Self::Other(err) => panic!("Unexpected revset error: {err}"),
+            Self::Other(err) => BackendError::Other(err),
         }
     }
 }

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -444,12 +444,11 @@ pub fn move_commits(
                 RevsetExpression::commits(target_commits.iter().ids().cloned().collect_vec())
                     .connected()
                     .evaluate(mut_repo)
-                    .map_err(|err| err.expect_backend_error())?
+                    .map_err(|err| err.into_backend_error())?
                     .iter()
                     .commits(mut_repo.store())
                     .try_collect()
-                    // TODO: Return evaluation error to caller
-                    .map_err(|err| err.expect_backend_error())?;
+                    .map_err(|err| err.into_backend_error())?;
             connected_target_commits_internal_parents =
                 compute_internal_parents_within(&target_commit_ids, &connected_target_commits);
 
@@ -469,12 +468,11 @@ pub fn move_commits(
             target_commits = RevsetExpression::commits(roots.iter().ids().cloned().collect_vec())
                 .descendants()
                 .evaluate(mut_repo)
-                .map_err(|err| err.expect_backend_error())?
+                .map_err(|err| err.into_backend_error())?
                 .iter()
                 .commits(mut_repo.store())
                 .try_collect()
-                // TODO: Return evaluation error to caller
-                .map_err(|err| err.expect_backend_error())?;
+                .map_err(|err| err.into_backend_error())?;
             target_commit_ids = target_commits.iter().ids().cloned().collect();
 
             connected_target_commits = target_commits.iter().cloned().collect_vec();
@@ -529,12 +527,11 @@ pub fn move_commits(
                         .children(),
                 )
                 .evaluate(mut_repo)
-                .map_err(|err| err.expect_backend_error())?
+                .map_err(|err| err.into_backend_error())?
                 .iter()
                 .commits(mut_repo.store())
                 .try_collect()
-                // TODO: Return evaluation error to caller
-                .map_err(|err| err.expect_backend_error())?;
+                .map_err(|err| err.into_backend_error())?;
 
         // For all commits in the target set, compute its transitive descendant commits
         // which are outside of the target set by up to 1 generation.
@@ -792,12 +789,11 @@ pub fn duplicate_commits(
         RevsetExpression::commits(target_commit_ids.iter().cloned().collect_vec())
             .connected()
             .evaluate(mut_repo)
-            .map_err(|err| err.expect_backend_error())?
+            .map_err(|err| err.into_backend_error())?
             .iter()
             .commits(mut_repo.store())
             .try_collect()
-            // TODO: Return evaluation error to caller
-            .map_err(|err| err.expect_backend_error())?;
+            .map_err(|err| err.into_backend_error())?;
 
     // Commits in the target set should only have other commits in the set as
     // parents, except the roots of the set, which persist their original


### PR DESCRIPTION

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
