### PR TITLE
nix: fix tests in darwin sandbox

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,12 @@
             "^target/"
           ];
 
+          # Taplo requires SystemConfiguration access, as it unconditionally creates a
+          # reqwest client.
+          sandboxProfile = ''
+            (allow mach-lookup (global-name "com.apple.SystemConfiguration.configd"))
+          '';
+
           cargoLock.lockFile = ./Cargo.lock;
           nativeBuildInputs = nativeBuildInputs ++ [pkgs.installShellFiles];
           inherit buildInputs nativeCheckInputs;


### PR DESCRIPTION
I imagine it may be a good idea to poke the Taplo folks about this, but this is a good stopgap in the meantime for the two people who use Jujutsu via Nix on macOS with the sandbox enabled. 😉

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
