### PR TITLE
merge-tools: fix builtin merge editor to not ignore executable bit

### DIFF
--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -567,7 +567,13 @@ fn make_merge_sections(
 fn make_merge_file(
     merge_tool_file: &MergeToolFile,
 ) -> Result<scm_record::File<'static>, BuiltinToolError> {
-    let merge_result = files::merge_hunks(&merge_tool_file.file.contents);
+    let file = &merge_tool_file.file;
+    let file_mode = if file.executable.expect("should have been resolved") {
+        mode::EXECUTABLE
+    } else {
+        mode::NORMAL
+    };
+    let merge_result = files::merge_hunks(&file.contents);
     let sections = make_merge_sections(merge_result)?;
     Ok(scm_record::File {
         old_path: None,
@@ -577,7 +583,7 @@ fn make_merge_file(
                 .repo_path
                 .to_fs_path_unchecked(Path::new("")),
         ),
-        file_mode: mode::NORMAL,
+        file_mode,
         sections,
     })
 }


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
