### PR TITLE
merge: remove redundant .clone() from .simplify()

### DIFF
--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -249,7 +249,7 @@ pub async fn try_materialize_file_conflict_value(
     else {
         return Ok(None);
     };
-    let ids = unsimplified_ids.clone().simplify();
+    let ids = unsimplified_ids.simplify();
     let contents = extract_as_single_hunk(&ids, store, path).await?;
     let executable = resolve_file_executable(&executable_bits);
     Ok(Some(MaterializedFileConflictValue {
@@ -950,7 +950,7 @@ pub async fn update_from_content(
     conflict_marker_style: ConflictMarkerStyle,
     conflict_marker_len: usize,
 ) -> BackendResult<Merge<Option<FileId>>> {
-    let simplified_file_ids = file_ids.clone().simplify();
+    let simplified_file_ids = file_ids.simplify();
 
     // First check if the new content is unchanged compared to the old content. If
     // it is, we don't need parse the content or write any new objects to the

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -276,17 +276,18 @@ impl<T> Merge<T> {
 
     /// Simplify the merge by joining diffs like A->B and B->C into A->C.
     /// Also drops trivial diffs like A->A.
-    pub fn simplify(mut self) -> Self
+    #[must_use]
+    pub fn simplify(&self) -> Self
     where
         T: PartialEq + Clone,
     {
         let mapping = self.get_simplified_mapping();
         // Reorder values based on their new indices in the simplified merge.
-        self.values = mapping
+        let values = mapping
             .iter()
             .map(|index| self.values[*index].clone())
             .collect();
-        self
+        Merge { values }
     }
 
     /// Updates the merge based on the given simplified merge.
@@ -1006,13 +1007,13 @@ mod tests {
             let merge = Merge::from_vec(terms.to_vec());
             // `simplify()` is idempotent
             assert_eq!(
-                merge.clone().simplify().simplify(),
-                merge.clone().simplify(),
+                merge.simplify().simplify(),
+                merge.simplify(),
                 "simplify() not idempotent for {merge:?}"
             );
             // `resolve_trivial()` is unaffected by `simplify()`
             assert_eq!(
-                merge.clone().simplify().resolve_trivial(),
+                merge.simplify().resolve_trivial(),
                 merge.resolve_trivial(),
                 "simplify() changed result of resolve_trivial() for {merge:?}"
             );

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -1764,7 +1764,7 @@ fn test_update_conflict_from_content_simplified_conflict() {
             Some(right_file_id.clone()),
         ],
     );
-    let simplified_conflict = conflict.clone().simplify();
+    let simplified_conflict = conflict.simplify();
 
     // If the content is unchanged compared to the materialized value, we get the
     // old conflict id back.


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
