### PR TITLE
docs: enable MkDocs' GitHub features

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,15 +5,18 @@ site_dir: 'rendered-docs'
 site_url: 'https://jj-vcs.github.io/jj/'
 repo_url: https://github.com/jj-vcs/jj
 repo_name: jj-vcs/jj
+edit_uri: edit/main/docs/
 theme:
   name: 'material'
   language: 'en'
   favicon: images/favicon-96x96.png
   features:
     # - navigation.top
+    - content.action.edit
 
   icon:
     repo: fontawesome/brands/github
+    edit: material/pencil
 
   # Respect the user's default settings and add a toggle for manually choosing
   # automatic/light/dark palette.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,12 +3,17 @@ site_dir: 'rendered-docs'
 # Not having this (or viewing the site locally, or from any place other than the
 # site_url) leads to version switching failing to preserve the current path.
 site_url: 'https://jj-vcs.github.io/jj/'
+repo_url: https://github.com/jj-vcs/jj
+repo_name: jj-vcs/jj
 theme:
   name: 'material'
   language: 'en'
   favicon: images/favicon-96x96.png
   features:
     # - navigation.top
+
+  icon:
+    repo: fontawesome/brands/github
 
   # Respect the user's default settings and add a toggle for manually choosing
   # automatic/light/dark palette.


### PR DESCRIPTION
First commit adds this to the header:

![image](https://github.com/user-attachments/assets/690aae79-9fce-41ac-a5e6-2b6b5e7863d6)

Second commit adds this to all the pages:

![image](https://github.com/user-attachments/assets/92e5ce20-5fe2-47a6-bec4-3a89a15a1996)

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
