### PR TITLE
cli: git push: show hint when there are bookmarks pending deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added `duplicate_description` template, which allows [customizing the descriptions
   of the commits `jj duplicate` creates](docs/config.md#duplicate-commit-description).
 
+* `jj git push` now shows a hint to use `--deleted` if there are bookmarks
+  pending deletion.
+
 ### Fixed bugs
 
 * Fixed crash on change-delete conflict resolution.

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -1961,6 +1961,14 @@ fn test_git_push_deleted(subprocess: bool) {
     work_dir
         .run_jj(["bookmark", "delete", "bookmark1"])
         .success();
+    let output = work_dir.run_jj(["git", "push"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
+    Hint: You can push 1 deleted bookmark(s) with `--deleted`
+    Nothing changed.
+    [EOF]
+    ");
     let output = work_dir.run_jj(["git", "push", "--deleted"]);
     insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"


### PR DESCRIPTION
This comes from a personal experience where the following sequence of events happened:

1. `jj git push -c @-`
2. Oops, that was the wrong one, so I'll `jj bookmark delete` and `jj git push`
3. Hm... why didn't that do anything? Oh, right, `--deleted`

As described in the diff, this hint only fires when `jj git push` is used with no arguments, as any user that passes `--all`, `--tracked`, or `--revisions` (targeting a deleted bookmark) will already get an error instructing them to use `--deleted`.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
