### PR TITLE
repo: mark view dirty after setting local bookmark target

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1605,6 +1605,7 @@ impl MutableRepo {
             view.add_head(id);
         }
         view.set_local_bookmark_target(name, target);
+        self.view.mark_dirty();
     }
 
     pub fn merge_local_bookmark(


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
