### PR TITLE
docs: mention openSUSE installation method in docs

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -105,6 +105,14 @@ Once you have synced the GURU repository, you can install `dev-vcs/jj` via Porta
 emerge -av dev-vcs/jj
 ```
 
+#### openSUSE Tumbleweed
+
+`jujutsu` can be installed from the official [openSUSE-Tumbleweed-Oss](http://download.opensuse.org/tumbleweed/repo/oss/) repository:
+
+```shell
+zypper install jujutsu
+```
+
 ### Mac
 
 #### From Source, Vendored OpenSSL


### PR DESCRIPTION
I stumbled across https://github.com/jj-vcs/jj/issues/6241 
Since there seems to be an officially maintained package providing `jujutsu` for openSUSE Tumbleweed, I added the according documentation