### PR TITLE
config-schema: add test asserting schema defaults match default config

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -590,7 +590,7 @@
                 "immutable_heads()": {
                     "type": "string",
                     "description": "Revisions to consider immutable. Ancestors of these are also considered immutable. The root commit is always considered immutable.",
-                    "default": "present(trunk()) | tags() | untracked_remote_branches()"
+                    "default": "present(trunk()) | tags() | untracked_remote_bookmarks()"
                 }
             },
             "additionalProperties": {

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -776,7 +776,7 @@
                 "legacy-bookmark-behavior": {
                     "type": "boolean",
                     "description": "If true, bookmarks will move to the second commit instead of the first.",
-                    "default": false
+                    "default": true
                 }
             }
         },

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -468,7 +468,7 @@
                 "write-change-id-header": {
                     "type": "boolean",
                     "description": "Whether the change id should be stored in the Git commit object",
-                    "default": false
+                    "default": true
                 },
                 "executable-path": {
                     "type": "string",

--- a/cli/tests/common/config_schema_defaults.rs
+++ b/cli/tests/common/config_schema_defaults.rs
@@ -1,0 +1,86 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::process::Command;
+use std::process::Stdio;
+
+use bstr::ByteSlice as _;
+use testutils::is_external_tool_installed;
+
+/// Produce a synthetic TOML document containing a default config according to
+/// the schema.
+///
+/// Uses the `jq` program to extract "default" nodes from the schema's JSON
+/// document and construct a corresponding TOML file. This TOML document
+/// consists of a single table with fully-qualified dotted keys.
+///
+/// # Limitations
+/// Defaults in `"additionalProperties"` are ignored, as are those in
+/// `"definitions"` nodes (which might be referenced by `"$ref"`).
+///
+/// Defaults which are JSON object-valued are supported and are specified as
+/// multiple lines, descending into the object fields. Arrays of scalars or
+/// other arrays are also supported (as they have the same representation in
+/// JSON and TOML), but arrays of objects are not.
+///
+/// When `jq` is not available on the system, returns `None`. This allows the
+/// caller to decide how to handle this.
+///
+/// # Panics
+/// Panics for all other error conditions related to
+/// - process spawning,
+/// - errors from running the jq program,
+/// - non-UTF-8 encoding,
+/// - parsing of the TOML output from `jq`.
+pub fn default_toml_from_schema() -> Option<toml_edit::DocumentMut> {
+    const JQ_PROGRAM: &str = r#"
+        paths as $p
+        | select($p | any(. == "default") and all(type == "string" and . != "additionalProperties" and . != "definitions"))
+        | getpath($p)
+        | select(type != "object")
+        | tojson as $v
+        | $p
+        | map(select(. != "properties" and . != "default")
+        | if test("^[A-Za-z0-9_-]+$") then . else "'\(.)'" end)
+        | join(".") as $k
+        | "\($k)=\($v)"
+    "#;
+
+    if !is_external_tool_installed("jq") {
+        return None;
+    }
+
+    let output = Command::new("jq")
+        .args(["-r", JQ_PROGRAM, "src/config-schema.json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap()
+        .wait_with_output()
+        .unwrap();
+
+    if output.status.success() {
+        Some(
+            toml_edit::ImDocument::parse(String::from_utf8(output.stdout).unwrap())
+                .unwrap()
+                .into_mut(),
+        )
+    } else {
+        panic!(
+            "failed to extract default TOML from schema using `jq`: exit code {}:\n{}",
+            output.status,
+            output.stderr.to_str_lossy(),
+        );
+    }
+}

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 mod command_output;
+mod config_schema_defaults;
 mod test_environment;
 
 pub use self::command_output::CommandOutput;
+pub use self::config_schema_defaults::default_toml_from_schema;
 pub use self::test_environment::TestEnvironment;
 pub use self::test_environment::TestWorkDir;
 

--- a/cli/tests/datatest_config_schema.rs
+++ b/cli/tests/datatest_config_schema.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::path::Path;
 use std::process::Command;
 use std::process::Output;

--- a/cli/tests/datatest_runner.rs
+++ b/cli/tests/datatest_runner.rs
@@ -1,18 +1,18 @@
-mod test_config_schema;
+mod datatest_config_schema;
 
 datatest_stable::harness! {
     {
-        test = test_config_schema::taplo_check_config_valid,
+        test = datatest_config_schema::taplo_check_config_valid,
         root = "src/config",
         pattern = r".*\.toml",
     },
     {
-        test = test_config_schema::taplo_check_config_valid,
+        test = datatest_config_schema::taplo_check_config_valid,
         root = "tests/sample-configs/valid",
         pattern = r".*\.toml",
     },
     {
-        test = test_config_schema::taplo_check_config_invalid,
+        test = datatest_config_schema::taplo_check_config_invalid,
         root = "tests/sample-configs/invalid",
         pattern = r".*\.toml",
     }

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -21,6 +21,7 @@ mod test_commit_template;
 mod test_completion;
 mod test_concurrent_operations;
 mod test_config_command;
+mod test_config_schema;
 mod test_copy_detection;
 mod test_debug_command;
 mod test_debug_init_simple_command;

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -16,8 +16,10 @@ use std::env::join_paths;
 use std::path::PathBuf;
 
 use indoc::indoc;
+use itertools::Itertools as _;
 use regex::Regex;
 
+use crate::common::default_toml_from_schema;
 use crate::common::fake_editor_path;
 use crate::common::force_interactive;
 use crate::common::to_toml_value;
@@ -1239,6 +1241,82 @@ fn test_config_get() {
     bar
     [EOF]
     ");
+}
+
+#[test]
+fn test_config_get_yields_values_consistent_with_schema_defaults() {
+    let test_env = TestEnvironment::default();
+    let get_true_default = move |key: &str| {
+        let output = test_env.run_jj_in(".", ["config", "get", key]).success();
+        let output_doc =
+            toml_edit::ImDocument::parse(format!("test={}", output.stdout.normalized()))
+                .unwrap_or_else(|_| {
+                    // Unfortunately for this test, `config get` is "lossy" and does not print
+                    // quoted strings. This means that e.g. `false` and `"false"` are not
+                    // distinguishable. If value couldn't be parsed, it's probably a string, so
+                    // let's parse its Debug string instead.
+                    toml_edit::ImDocument::parse(format!(
+                        "test={:?}",
+                        output.stdout.normalized().trim()
+                    ))
+                    .unwrap()
+                });
+        output_doc.get("test").unwrap().as_value().unwrap().clone()
+    };
+
+    let Some(schema_defaults) = default_toml_from_schema() else {
+        testutils::ensure_running_outside_ci("`jq` must be in the PATH");
+        eprintln!("Skipping test because jq is not installed on the system");
+        return;
+    };
+
+    for (key, schema_default) in schema_defaults.as_table().get_values() {
+        let key = key.iter().join(".");
+        match key.as_str() {
+            // These keys technically don't have a default value, but they exhibit a default
+            // behavior consistent with the value claimed by the schema. When these defaults are
+            // used, a hint is printed to stdout.
+            "ui.default-command" => insta::assert_snapshot!(schema_default, @r#""log""#),
+            "ui.diff-editor" => insta::assert_snapshot!(schema_default, @r#"":builtin""#),
+            "ui.merge-editor" => insta::assert_snapshot!(schema_default, @r#"":builtin""#),
+            "git.fetch" => insta::assert_snapshot!(schema_default, @r#""origin""#),
+            "git.push" => insta::assert_snapshot!(schema_default, @r#""origin""#),
+
+            // When no `short-prefixes` revset is explicitly configured, the revset for `log` is
+            // used instead, even if that has a value different from the default. The schema
+            // represents this behavior with a symbolic default value.
+            "revsets.short-prefixes" => {
+                insta::assert_snapshot!(schema_default, @r#""<revsets.log>""#);
+            }
+
+            // The default for `ui.pager` is a table; `ui.pager.command` is an array and `jj config
+            // get` currently cannot print that. The schema default omits the env variable
+            // `LESSCHARSET` and gives the default as a plain string.
+            "ui.pager" => insta::assert_snapshot!(schema_default, @r#""less -FRX""#),
+
+            // The `immutable_heads()` revset actually defaults to `builtin_immutable_heads()` but
+            // this would be a poor starting point for a custom revset, so the schema "inlines"
+            // `builtin_immutable_heads()`.
+            "revset-aliases.'immutable_heads()'" => {
+                let builtin_default =
+                    get_true_default("revset-aliases.'builtin_immutable_heads()'");
+                assert!(
+                    builtin_default.to_string() == schema_default.to_string(),
+                    "{key}: the schema claims a default ({schema_default}) which is different \
+                     from what builtin_immutable_heads() resolves to ({builtin_default})"
+                );
+            }
+
+            _ => {
+                let true_default = get_true_default(&key);
+                assert!(
+                    true_default.to_string() == schema_default.to_string(),
+                    "{key}: true default value ({true_default}) is not consistent with default \
+                     claimed by schema ({schema_default})"
+                );
+            }
+        }
+    }
 }
 
 #[test]

--- a/cli/tests/test_config_schema.rs
+++ b/cli/tests/test_config_schema.rs
@@ -1,0 +1,69 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write as _;
+use std::process::Command;
+use std::process::Output;
+use std::process::Stdio;
+
+use testutils::ensure_running_outside_ci;
+use testutils::is_external_tool_installed;
+
+use crate::common::default_toml_from_schema;
+
+#[test]
+fn test_config_schema_default_values_are_consistent_with_schema() {
+    if !is_external_tool_installed("taplo") {
+        ensure_running_outside_ci("`taplo` must be in the PATH");
+        eprintln!("Skipping test because taplo is not installed on the system");
+        return;
+    }
+
+    let Some(schema_defaults) = default_toml_from_schema() else {
+        ensure_running_outside_ci("`jq` must be in the PATH");
+        eprintln!("Skipping test because jq is not installed on the system");
+        return;
+    };
+
+    // Taplo requires an absolute URL to the schema :/
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut taplo_child = Command::new("taplo")
+        .args([
+            "check",
+            "--schema",
+            &format!("file://{}/src/config-schema.json", root.display()),
+            "-", // read from stdin
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    {
+        let mut stdin = taplo_child.stdin.take().unwrap();
+        write!(stdin, "{schema_defaults}").unwrap();
+        // pipe is closed here by dropping it
+    }
+
+    let Output { status, stderr, .. } = taplo_child.wait_with_output().unwrap();
+    if !status.success() {
+        eprintln!(
+            "taplo exited with status {status}:\n{}",
+            String::from_utf8_lossy(&stderr)
+        );
+        eprintln!("while validating synthetic defaults TOML:\n{schema_defaults}");
+        panic!("Schema defaults are not valid according to schema");
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
         git
 
         # for schema tests
+        jq
         taplo
       ];
 


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
