### PR TITLE
Add a dry_run mode to LockedWorkingCopy snapshot method.

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1409,6 +1409,7 @@ to the current parents may contain changes from multiple commits.
             start_tracking_matcher,
             max_new_file_size,
             conflict_marker_style,
+            dry_run: false,
         })
     }
 

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -299,6 +299,7 @@ diff editing in mind and be a little inaccurate.
             start_tracking_matcher: &EverythingMatcher,
             max_new_file_size: u64::MAX,
             conflict_marker_style,
+            dry_run: false,
         })?;
         Ok(output_tree_state.current_tree_id().clone())
     }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -222,6 +222,9 @@ pub struct SnapshotOptions<'a> {
     pub max_new_file_size: u64,
     /// Expected conflict marker style for checking for changed files.
     pub conflict_marker_style: ConflictMarkerStyle,
+    /// If true, skip any updates to the working copy metadata files when
+    /// snapshotting.
+    pub dry_run: bool,
 }
 
 impl SnapshotOptions<'_> {
@@ -234,6 +237,7 @@ impl SnapshotOptions<'_> {
             start_tracking_matcher: &EverythingMatcher,
             max_new_file_size: u64::MAX,
             conflict_marker_style: ConflictMarkerStyle::default(),
+            dry_run: false,
         }
     }
 }
@@ -246,6 +250,8 @@ pub type SnapshotProgress<'a> = dyn Fn(&RepoPath) + 'a + Sync;
 pub struct SnapshotStats {
     /// List of new (previously untracked) files which are still untracked.
     pub untracked_paths: BTreeMap<RepoPathBuf, UntrackedReason>,
+    /// The tree id generated in dry_run mode. Set iff dry_run is enabled.
+    pub dry_run_tree_id: Option<MergedTreeId>,
 }
 
 /// Reason why the new path isn't tracked.

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -839,6 +839,33 @@ fn test_snapshot_file_directory_transition() {
 }
 
 #[test]
+fn test_snapshot_dry_run() {
+    let mut test_workspace = TestWorkspace::init();
+    let workspace_root = test_workspace.workspace.workspace_root().to_owned();
+    let file_path = workspace_root.join("file");
+    std::fs::write(&file_path, "contents".as_bytes()).unwrap();
+    let repo = &test_workspace.repo;
+    let mut locked_ws = test_workspace
+        .workspace
+        .start_working_copy_mutation()
+        .unwrap();
+    let (new_tree_id, stats) = locked_ws
+        .locked_wc()
+        .snapshot(&SnapshotOptions {
+            dry_run: true,
+            ..SnapshotOptions::empty_for_test()
+        })
+        .unwrap();
+    assert_eq!(new_tree_id, repo.store().empty_merged_tree_id());
+    assert_ne!(
+        stats
+            .dry_run_tree_id
+            .expect("dry_run_tree_id must be set in dry_run mode"),
+        repo.store().empty_merged_tree_id()
+    );
+}
+
+#[test]
 fn test_materialize_snapshot_conflicted_files() {
     let mut test_workspace = TestWorkspace::init();
     let repo = &test_workspace.repo.clone();


### PR DESCRIPTION
At Google, we are building a tool that needs to know the state of a jj repo constantly. Always snapshotting and updating .jj/working_copy/checkout increases the likelihood of write races and should be avoided. 

I came across https://github.com/jj-vcs/jj/issues/2562 that encountered the same problem. From the post, the suggested solution is to add a --dry-run/--no-commit-transaction flag. This commit does a part of that by adding a `dry_run` mode to the WorkingCopy snapshot method. I don't intend to address the whole FR.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
