### PR TITLE
config: migrate ui.default-description to template alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Please report any remaining issues you have with the Git
   subprocessing path.
 
-* `ui.default-description` has been deprecated, and will be removed
-  in a future release. Please migrate to `template-aliases.default_commit_description`,
+* `ui.default-description` has been deprecated, and will be migrated to
+  `template-aliases.default_commit_description`. Please also consider using
   [`templates.draft_commit_description`](docs/config.md#default-description),
   and/or [`templates.commit_trailers`](docs/config.md#commit-trailers).
 

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -143,11 +143,6 @@ new working-copy commit.
         }
         description
     } else {
-        if commit_builder.description().is_empty() {
-            // TODO: Remove in jj 0.35.0+
-            let description = tx.settings().get_string("ui.default-description")?;
-            commit_builder.set_description(description);
-        }
         let description = add_trailers(ui, &tx, &commit_builder)?;
         commit_builder.set_description(description);
         let temp_commit = commit_builder.write_hidden()?;

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -142,8 +142,6 @@ pub(crate) fn cmd_describe(
         )
     };
 
-    // TODO: Remove in jj 0.35.0+
-    let default_description_to_edit = tx.settings().get_string("ui.default-description")?;
     let shared_description = if args.stdin {
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer)?;
@@ -165,8 +163,6 @@ pub(crate) fn cmd_describe(
             let mut commit_builder = tx.repo_mut().rewrite_commit(commit).detach();
             if let Some(description) = &shared_description {
                 commit_builder.set_description(description);
-            } else if use_editor && commit_builder.description().is_empty() {
-                commit_builder.set_description(&default_description_to_edit);
             }
             if args.reset_author {
                 let new_author = commit_builder.committer().clone();

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -149,10 +149,6 @@ pub(crate) fn cmd_split(
     let first_commit = {
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder.set_tree_id(target.selected_tree.id());
-        if commit_builder.description().is_empty() {
-            // TODO: Remove in jj 0.35.0+
-            commit_builder.set_description(tx.settings().get_string("ui.default-description")?);
-        }
         let new_description = add_trailers(ui, &tx, &commit_builder)?;
         commit_builder.set_description(new_description);
         let temp_commit = commit_builder.write_hidden()?;

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -83,11 +83,6 @@
                         }
                     ]
                 },
-                "default-description": {
-                    "type": "string",
-                    "description": "Default description to use when describing changes with an empty description (deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead)",
-                    "default": ""
-                },
                 "color": {
                     "description": "Whether to colorize command output",
                     "enum": [

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -22,7 +22,6 @@ sign-on-push = false
 [ui]
 always-allow-large-revsets = false
 color = "auto"
-default-description = ""
 diff-instructions = true
 diff.format = "color-words"
 # diff.tool = <use-format>

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -240,15 +240,15 @@ fn test_commit_with_default_description() {
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     work_dir.run_jj(["commit"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  c65242099289
     ○  573b6df51aea TESTED=TODO
     ◆  000000000000
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     TESTED=TODO

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -616,13 +616,13 @@ fn test_describe_default_description() {
     work_dir.write_file("file2", "bar\n");
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
     let output = work_dir.run_jj(["describe"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     Working copy  (@) now at: qpvuntsm 573b6df5 TESTED=TODO
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
-    ");
+    "#);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
     TESTED=TODO
@@ -637,13 +637,13 @@ fn test_describe_default_description() {
     // Default description shouldn't be used if --no-edit
     work_dir.run_jj(["new", "root()"]).success();
     let output = work_dir.run_jj(["describe", "--no-edit", "--reset-author"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     Working copy  (@) now at: kkmpptxz f652c321 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
-    ");
+    "#);
 }
 
 #[test]

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -199,15 +199,15 @@ fn test_split_with_non_empty_description() {
     )
     .unwrap();
     let output = work_dir.run_jj(["split", "file1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     First part: qpvuntsm 231a3c00 part 1
     Second part: kkmpptxz e96291aa part 2
     Working copy  (@) now at: kkmpptxz e96291aa part 2
     Parent commit (@-)      : qpvuntsm 231a3c00 part 1
     [EOF]
-    ");
+    "#);
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
@@ -229,15 +229,15 @@ fn test_split_with_non_empty_description() {
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  kkmpptxzrspx false part 2
     ○  qpvuntsmwlqt false part 1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
 }
 
 #[test]
@@ -257,15 +257,15 @@ fn test_split_with_default_description() {
     )
     .unwrap();
     let output = work_dir.run_jj(["split", "file1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     First part: qpvuntsm 02ee5d60 TESTED=TODO
     Second part: rlvkpnrz 33cd046b (no description set)
     Working copy  (@) now at: rlvkpnrz 33cd046b (no description set)
     Parent commit (@-)      : qpvuntsm 02ee5d60 TESTED=TODO
     [EOF]
-    ");
+    "#);
 
     // Since the commit being split has no description, the user will only be
     // prompted to add a description to the first commit, which will use the
@@ -284,15 +284,15 @@ fn test_split_with_default_description() {
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     assert!(!test_env.env_root().join("editor2").exists());
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  rlvkpnrzqnoo false
     ○  qpvuntsmwlqt false TESTED=TODO
     ◆  zzzzzzzzzzzz true
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
 }
 
 #[test]
@@ -479,14 +479,14 @@ fn test_split_parallel_no_descendants() {
     work_dir.write_file("file1", "foo\n");
     work_dir.write_file("file2", "bar\n");
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  qpvuntsmwlqt false
     ◆  zzzzzzzzzzzz true
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
 
     std::fs::write(
         edit_script,
@@ -494,26 +494,26 @@ fn test_split_parallel_no_descendants() {
     )
     .unwrap();
     let output = work_dir.run_jj(["split", "--parallel", "file1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     First part: qpvuntsm 48018df6 TESTED=TODO
     Second part: kkmpptxz 7eddbf93 (no description set)
     Working copy  (@) now at: kkmpptxz 7eddbf93 (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
-    ");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    "#);
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  kkmpptxzrspx false
     │ ○  qpvuntsmwlqt false TESTED=TODO
     ├─╯
     ◆  zzzzzzzzzzzz true
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
 
     // Since the commit being split has no description, the user will only be
     // prompted to add a description to the first commit, which will use the
@@ -538,7 +538,7 @@ fn test_split_parallel_no_descendants() {
     // - The rewritten commit from the snapshot after the files were added.
     // - The rewritten commit after the split.
     let evolog_1 = work_dir.run_jj(["evolog", "-r", "qpvun"]);
-    insta::assert_snapshot!(evolog_1, @r"
+    insta::assert_snapshot!(evolog_1, @r#"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 48018df6
     │  TESTED=TODO
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 44af2155
@@ -547,14 +547,14 @@ fn test_split_parallel_no_descendants() {
        (empty) (no description set)
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
 
     // The evolog for the second commit is the same, except that the change id
     // changes after the split.
     let evolog_2 = work_dir.run_jj(["evolog", "-r", "kkmpp"]);
-    insta::assert_snapshot!(evolog_2, @r"
+    insta::assert_snapshot!(evolog_2, @r#"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 7eddbf93
     │  (no description set)
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 44af2155
@@ -563,9 +563,9 @@ fn test_split_parallel_no_descendants() {
        (empty) (no description set)
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
 }
 
 #[test]
@@ -1041,15 +1041,15 @@ fn test_split_with_non_empty_description_and_trailers() {
         commit_trailers = '''"Signed-off-by: " ++ committer.email()'''"#,
     );
     let output = work_dir.run_jj(["split", "file1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     First part: qpvuntsm 231a3c00 part 1
     Second part: kkmpptxz e96291aa part 2
     Working copy  (@) now at: kkmpptxz e96291aa part 2
     Parent commit (@-)      : qpvuntsm 231a3c00 part 1
     [EOF]
-    ");
+    "#);
 
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r#"
@@ -1075,15 +1075,15 @@ fn test_split_with_non_empty_description_and_trailers() {
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  kkmpptxzrspx false part 2
     ○  qpvuntsmwlqt false part 1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ------- stderr -------
-    Warning: Deprecated config: `ui.default-description` is deprecated; use `templates.draft_commit_description` and/or `templates.commit_trailers` instead.
+    Warning: Deprecated config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
     [EOF]
-    ");
+    "#);
 }
 
 enum BookmarkBehavior {

--- a/docs/config.md
+++ b/docs/config.md
@@ -178,7 +178,7 @@ The editor content of a commit description can be populated by the
 [templates]
 draft_commit_description = '''
 concat(
-  coalesce(description, default_commit_description),
+  coalesce(description, default_commit_description, "\n"),
   surround(
     "\nJJ: This commit contains the following changes:\n", "",
     indent("JJ:     ", diff.stat(72)),


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
