### PR TITLE
annotate: reorganize functions as restartable process

### DIFF
--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -14,8 +14,8 @@
 
 use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
-use jj_lib::annotate::get_annotation_for_file;
 use jj_lib::annotate::FileAnnotation;
+use jj_lib::annotate::FileAnnotator;
 use jj_lib::repo::Repo;
 use jj_lib::revset::RevsetExpression;
 use tracing::instrument;
@@ -108,8 +108,9 @@ pub(crate) fn cmd_file_annotate(
     // Note that this is probably different from "--skip REVS", which won't
     // exclude the revisions, but will ignore diffs in those revisions as if
     // ancestor revisions had new content.
-    let domain = RevsetExpression::all();
-    let annotation = get_annotation_for_file(repo.as_ref(), &starting_commit, &domain, &file_path)?;
+    let mut annotator = FileAnnotator::from_commit(&starting_commit, &file_path)?;
+    annotator.compute(repo.as_ref(), &RevsetExpression::all())?;
+    let annotation = annotator.to_annotation();
 
     render_file_annotation(repo.as_ref(), ui, &template, &annotation)?;
     Ok(())


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
