### PR TITLE
split: add the --message option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj split` has gained a `--message` option to set the description of the
+  commit with the selected changes.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2457,6 +2457,9 @@ Splitting an empty commit is not supported because the same effect can be achiev
 * `-r`, `--revision <REVSET>` — The revision to split
 
   Default value: `@`
+* `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
+
+   The description is used for the commit with the selected changes. The source commit description is kept unchanged.
 * `-p`, `--parallel` — Split the revision into two parallel revisions instead of a parent and child
 
 


### PR DESCRIPTION
to set the message on the first commit, where the selected changes are going. The commit with the remaining changes keeps the original description.
With this option it becomes possible to use split in a fully non-interactive way, in combination with the filset feature. It also makes jj split more consistent with other commands like squash, commit or new.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
