### PR TITLE
git_backend: do not include renamed trees in copy records

### DIFF
--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -550,7 +550,7 @@ fn test_diff_renamed_file_and_dir() {
     let output = work_dir.run_jj(["diff", "--summary"]);
     insta::assert_snapshot!(output.normalize_backslash(), @r"
     R {y => x}/file
-    C {x => y}
+    R {x => y}
     [EOF]
     ");
 
@@ -560,8 +560,8 @@ fn test_diff_renamed_file_and_dir() {
     rename from y/file
     rename to x/file
     diff --git a/x b/y
-    copy from x
-    copy to y
+    rename from x
+    rename to y
     [EOF]
     ");
 }

--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -166,7 +166,8 @@ impl<'a> CopiesTreeDiffStream<'a> {
         let (_, target_value) = values?;
         let source_value = self.source_tree.path_value(source)?;
         // If the source path is deleted in the target tree, it's a rename.
-        let copy_op = if self.target_tree.path_value(source)?.is_absent() {
+        let source_value_at_target = self.target_tree.path_value(source)?;
+        let copy_op = if source_value_at_target.is_absent() || source_value_at_target.is_tree() {
             CopyOperation::Rename
         } else {
             CopyOperation::Copy


### PR DESCRIPTION
Fixes #6390

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
