### PR TITLE
docs: document code to avoid duplicating gerrit change-id

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -537,13 +537,23 @@ commits associated with it.
 
 ### How do I integrate Jujutsu with Gerrit?
 
-At the moment you'll need a script, which adds the required fields for Gerrit
-like the `Change-Id` footer. Then `jj` can invoke it via an `$EDITOR` override
-in an aliased command. Here's an [example][gerrit-integration] from a
-contributor (look for the `jj signoff` alias).
+Add this to your configuration to automatically add Change-Id trailers to commit messages:
+```toml
+[templates]
+commit_trailers = '''
+if(
+  !trailers.contains_key("Change-Id"),
+  format_gerrit_change_id_trailer(self)
+)
+'''
+```
+Note: If you don't check for the presence of the "Change-Id" trailer, you might
+occasionally get duplicate trailers.
+This happens when Jujutsu's change-id isn't in sync with the "Change-Id" trailer.
+Eg. after `jj split`, the "Change-Id" trailer generated for the new change would
+be different from the original one, it wouldn't be deduplicated.
 
-After you have attached the `Change-Id:` footer to the commit series, you'll
-have to manually invoke `git push` of `HEAD` on the underlying git repository
+You'll have to manually invoke `git push` of `HEAD` on the underlying git repository
 into the remote Gerrit bookmark `refs/for/$BRANCH`, where `$BRANCH` is the base
 bookmark you want your changes to go to (e.g., `git push origin
 HEAD:refs/for/main`). Using a [co-located][co-located] repo


### PR DESCRIPTION
Adapted from:
- https://gist.github.com/thoughtpolice/8f2fd36ae17cd11b8e7bd93a70e31ad6#file-jjconfig-toml-L247
- https://github.com/avamsi/dotfiles/blob/28a0e40439de56fe179a1b0e705727c85e075464/.jjconfig.toml#L150

I'm not sure if I should add tests. I can add them if needed.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
