### PR TITLE
completion: fix bash and zsh shell completion when completing aliases of multiple arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The builtin diff editor now tries to preserve unresolved conflicts.
   [#4963](https://github.com/jj-vcs/jj/issues/4963)
 
+* Fixed bash and zsh shell completion when completing aliases of multiple arguments.
+  [#5377](https://github.com/jj-vcs/jj/issues/5377)
+
 ### Packaging changes
 
 * Jujutsu now uses

--- a/cli/tests/common/command_output.rs
+++ b/cli/tests/common/command_output.rs
@@ -57,6 +57,16 @@ impl CommandOutput {
         }
     }
 
+    /// Removes all but the first `n` lines from normalized stdout text.
+    #[must_use]
+    pub fn take_stdout_n_lines(self, n: usize) -> Self {
+        CommandOutput {
+            stdout: self.stdout.take_n_lines(n),
+            stderr: self.stderr,
+            status: self.status,
+        }
+    }
+
     #[must_use]
     pub fn normalize_stdout_with(self, f: impl FnOnce(String) -> String) -> Self {
         CommandOutput {
@@ -139,6 +149,12 @@ impl CommandOutputString {
             s.truncate(strip_last_line(&s).len());
             s
         })
+    }
+
+    /// Removes all but the first `n` lines from the normalized text.
+    #[must_use]
+    pub fn take_n_lines(self, n: usize) -> Self {
+        self.normalize_with(|s| s.split_inclusive("\n").take(n).collect())
     }
 
     #[must_use]

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -37,7 +37,7 @@ fn test_non_utf8_arg() {
     let output = test_env.run_jj_in(".", [&invalid_utf]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Non-utf8 argument
+    Error: Non-UTF-8 argument
     [EOF]
     [exit status: 2]
     ");


### PR DESCRIPTION
Fixes #5377.

The fix ended up as exactly like @yuja mentioned in the issue and what the `TODO` comment in the code was already proposing. Still, it took a fair bit of fiddling around with the different shells to understand where they are differing in behavior exactly. 

I've gotten a wee bit carried away refactoring the existing tests to cover multiple shells (where sensible) without duplicating too much of the test code. Even so, insta needs a `match` over the different shell flavors to snapshot their output individually. For a while, I've entertained the idea of adding a `.normalize_shell_completions(shell)` function on the test output to basically strip away the comment (because bash doesn't have that) such that it would produce the same (normalized) output for each shell and we could do away with the `match`es. Obviously, that would lose the comment snapshots, so I decided against it for now. Let me know if that's something you want me to revisit.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
