### PR TITLE
docs cli reference: update and pin clap-markdown, include aliases in reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "clap-markdown"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebc67e6266e14f8b31541c2f204724fa2ac7ad5c17d6f5908fbb92a60f42cff"
+checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
 dependencies = [
  "clap",
 ]
@@ -843,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2254,7 +2254,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2317,7 +2317,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3479,7 +3479,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3492,7 +3492,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3860,7 +3860,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4632,7 +4632,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ clap = { version = "4.5.37", features = [
 ] }
 clap_complete = { version = "4.5.47", features = ["unstable-dynamic"] }
 clap_complete_nushell = "4.5.5"
-clap-markdown = "0.1.4"
+# Update clap-markdown manually since test_generate_md_cli_help snapshot
+# will need regenerating.
+clap-markdown = "=0.1.5"
 clap_mangen = "0.2.25"
 chrono = { version = "0.4.40", default-features = false, features = [
     "std",

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -180,7 +180,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
    By default, Jujutsu prevents rewriting commits in the configured set of immutable commits. This option disables that check and lets you rewrite any commit but the root commit.
 
    This option only affects the check. It does not affect the `immutable_heads()` revset or the `immutable` template keyword.
-* `--at-operation <AT_OPERATION>` — Operation to load the repo at
+* `--at-operation <AT_OPERATION>` [alias: `at-op`] — Operation to load the repo at
 
    Operation to load the repo at. By default, Jujutsu loads the repo at the most recent operation, or at the merge of the divergent operations if any.
 
@@ -253,7 +253,7 @@ The modification made by `jj absorb` can be reviewed by `jj op show -p`.
 * `-f`, `--from <REVSET>` — Source revision to absorb from
 
   Default value: `@`
-* `-t`, `--into <REVSETS>` — Destination revisions to absorb into
+* `-t`, `--into <REVSETS>` [alias: `to`] — Destination revisions to absorb into
 
    Only ancestors of the source revision will be considered.
 
@@ -291,13 +291,15 @@ Create a new bookmark
 
 **Usage:** `jj bookmark create [OPTIONS] <NAMES>...`
 
+**Command Alias:** `c`
+
 ###### **Arguments:**
 
 * `<NAMES>` — The bookmarks to create
 
 ###### **Options:**
 
-* `-r`, `--revision <REVSET>` — The bookmark's target revision
+* `-r`, `--revision <REVSET>` [alias: `to`] — The bookmark's target revision
 
 
 
@@ -310,6 +312,8 @@ Revisions referred to by the deleted bookmarks are not abandoned. To delete revi
 If you don't want the deletion of the local bookmark to propagate to any tracked remote bookmarks, use `jj bookmark forget` instead.
 
 **Usage:** `jj bookmark delete <NAMES>...`
+
+**Command Alias:** `d`
 
 ###### **Arguments:**
 
@@ -328,6 +332,8 @@ Forget a bookmark without marking it as a deletion to be pushed
 If a local bookmark is forgotten, any corresponding remote bookmarks will become untracked to ensure that the forgotten bookmark will not impact remotes on future pushes.
 
 **Usage:** `jj bookmark forget [OPTIONS] <NAMES>...`
+
+**Command Alias:** `f`
 
 ###### **Arguments:**
 
@@ -356,6 +362,8 @@ See [`jj help -k bookmarks`] for more information.
 [`jj help -k bookmarks`]: https://jj-vcs.github.io/jj/latest/bookmarks
 
 **Usage:** `jj bookmark list [OPTIONS] [NAMES]...`
+
+**Command Alias:** `l`
 
 ###### **Arguments:**
 
@@ -412,6 +420,8 @@ $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 
 **Usage:** `jj bookmark move [OPTIONS] <--from <REVSETS>|NAMES>`
 
+**Command Alias:** `m`
+
 ###### **Arguments:**
 
 * `<NAMES>` — Move bookmarks matching the given name patterns
@@ -436,6 +446,8 @@ The new bookmark name points at the same commit as the old bookmark name.
 
 **Usage:** `jj bookmark rename <OLD> <NEW>`
 
+**Command Alias:** `r`
+
 ###### **Arguments:**
 
 * `<OLD>` — The old name of the bookmark
@@ -449,13 +461,15 @@ Create or update a bookmark to point to a certain commit
 
 **Usage:** `jj bookmark set [OPTIONS] <NAMES>...`
 
+**Command Alias:** `s`
+
 ###### **Arguments:**
 
 * `<NAMES>` — The bookmarks to update
 
 ###### **Options:**
 
-* `-r`, `--revision <REVSET>` — The bookmark's target revision
+* `-r`, `--revision <REVSET>` [alias: `to`] — The bookmark's target revision
 * `-B`, `--allow-backwards` — Allow moving the bookmark backwards or sideways
 
 
@@ -467,6 +481,8 @@ Start tracking given remote bookmarks
 A tracking remote bookmark will be imported as a local bookmark of the same name. Changes to it will propagate to the existing local bookmark on future pulls.
 
 **Usage:** `jj bookmark track <BOOKMARK@REMOTE>...`
+
+**Command Alias:** `t`
 
 ###### **Arguments:**
 
@@ -561,6 +577,8 @@ Creates the file if it doesn't already exist regardless of what the editor does.
 
 **Usage:** `jj config edit <--user|--repo>`
 
+**Command Alias:** `e`
+
 ###### **Options:**
 
 * `--user` — Target the user-level config
@@ -582,6 +600,8 @@ Martin von Zweigbergk
 
 **Usage:** `jj config get <NAME>`
 
+**Command Alias:** `g`
+
 ###### **Arguments:**
 
 * `<NAME>`
@@ -593,6 +613,8 @@ Martin von Zweigbergk
 List variables set in config files, along with their values
 
 **Usage:** `jj config list [OPTIONS] [NAME]`
+
+**Command Alias:** `l`
 
 ###### **Arguments:**
 
@@ -635,6 +657,8 @@ See `jj config edit` if you'd like to immediately edit a file.
 
 **Usage:** `jj config path <--user|--repo>`
 
+**Command Alias:** `p`
+
 ###### **Options:**
 
 * `--user` — Target the user-level config
@@ -647,6 +671,8 @@ See `jj config edit` if you'd like to immediately edit a file.
 Update a config file to set the given option to a given value
 
 **Usage:** `jj config set <--user|--repo> <NAME> <VALUE>`
+
+**Command Alias:** `s`
 
 ###### **Arguments:**
 
@@ -670,6 +696,8 @@ Update a config file to unset the given option
 
 **Usage:** `jj config unset <--user|--repo> <NAME>`
 
+**Command Alias:** `u`
+
 ###### **Arguments:**
 
 * `<NAME>`
@@ -688,6 +716,8 @@ Update the change description or other metadata
 Starts an editor to let you edit the description of changes. The editor will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
 
 **Usage:** `jj describe [OPTIONS] [REVSETS]...`
+
+**Command Alias:** `desc`
 
 ###### **Arguments:**
 
@@ -813,8 +843,8 @@ By default, the duplicated commits retain the descriptions of the originals. Thi
 ###### **Options:**
 
 * `-d`, `--destination <REVSETS>` — The revision(s) to duplicate onto (can be repeated to create a merge commit)
-* `-A`, `--insert-after <REVSETS>` — The revision(s) to insert after (can be repeated to create a merge commit)
-* `-B`, `--insert-before <REVSETS>` — The revision(s) to insert before (can be repeated to create a merge commit)
+* `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
+* `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 
 
 
@@ -841,6 +871,8 @@ Show how a change has evolved over time
 Lists the previous commits which a change has pointed to. The current commit of a change evolves when the change is updated, rebased, etc.
 
 **Usage:** `jj evolog [OPTIONS]`
+
+**Command Alias:** `evolution-log`
 
 ###### **Options:**
 
@@ -1514,7 +1546,7 @@ Note that you can create a merge commit by specifying multiple revisions as argu
 
 * `-m`, `--message <MESSAGE>` — The change description to use
 * `--no-edit` — Do not edit the newly created change
-* `-A`, `--insert-after <REVSETS>` — Insert the new change after the given commit(s)
+* `-A`, `--insert-after <REVSETS>` [alias: `after`] — Insert the new change after the given commit(s)
 
    Example: `jj new --after A` creates a new change between `A` and its
    children:
@@ -1540,7 +1572,7 @@ Note that you can create a merge commit by specifying multiple revisions as argu
        |  |         / \
        A  X        A   X
    ```
-* `-B`, `--insert-before <REVSETS>` — Insert the new change before the given commit(s)
+* `-B`, `--insert-before <REVSETS>` [alias: `before`] — Insert the new change before the given commit(s)
 
    Example: `jj new --before C` creates a new change between `C` and its
    parents:
@@ -1633,6 +1665,8 @@ See the [operation log documentation] for more information.
 
 **Usage:** `jj operation <COMMAND>`
 
+**Command Alias:** `op`
+
 ###### **Subcommands:**
 
 * `abandon` — Abandon operation history
@@ -1670,7 +1704,7 @@ Compare changes to the repository between two operations
 
 ###### **Options:**
 
-* `--operation <OPERATION>` — Show repository changes in this operation, compared to its parent
+* `--operation <OPERATION>` [alias: `op`] — Show repository changes in this operation, compared to its parent
 * `-f`, `--from <FROM>` — Show repository changes from this operation
 * `-t`, `--to <TO>` — Show repository changes to this operation
 * `--no-graph` — Don't show the graph, show a flat list of modified changes
@@ -2164,8 +2198,8 @@ J           J
 
    If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
 * `-d`, `--destination <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
-* `-A`, `--insert-after <REVSETS>` — The revision(s) to insert after (can be repeated to create a merge commit)
-* `-B`, `--insert-before <REVSETS>` — The revision(s) to insert before (can be repeated to create a merge commit)
+* `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
+* `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `--skip-emptied` — If true, when rebasing would produce an empty commit, the commit is abandoned. It will not be abandoned if it was already empty before the rebase. Will never skip merge commits with multiple non-empty parents
 
 
@@ -2217,7 +2251,7 @@ See `jj diffedit` if you'd like to restore portions of files rather than entire 
 ###### **Options:**
 
 * `-f`, `--from <REVSET>` — Revision to restore from (source)
-* `-t`, `--into <REVSET>` — Revision to restore into (destination)
+* `-t`, `--into <REVSET>` [alias: `to`] — Revision to restore into (destination)
 * `-c`, `--changes-in <REVSET>` — Undo the changes in a revision as compared to the merge of its parents.
 
    This undoes the changes that can be seen with `jj diff -r REVSET`. If `REVSET` only has a single parent, this option is equivalent to `jj restore --into REVSET --from REVSET-`.
@@ -2243,8 +2277,8 @@ The description of the new revisions can be customized with the `templates.rever
 
 * `-r`, `--revisions <REVSETS>` — The revision(s) to apply the reverse of
 * `-d`, `--destination <REVSETS>` — The revision(s) to apply the reverse changes on top of
-* `-A`, `--insert-after <REVSETS>` — The revision(s) to insert the reverse changes after (can be repeated to create a merge commit)
-* `-B`, `--insert-before <REVSETS>` — The revision(s) to insert the reverse changes before (can be repeated to create a merge commit)
+* `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert the reverse changes after (can be repeated to create a merge commit)
+* `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert the reverse changes before (can be repeated to create a merge commit)
 
 
 
@@ -2451,7 +2485,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 * `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @)
 * `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
-* `-t`, `--into <REVSET>` — Revision to squash into (default: @)
+* `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
 * `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
 * `-i`, `--interactive` — Interactively choose which parts to squash
@@ -2471,6 +2505,8 @@ This includes:
 [Conflicted bookmarks]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
 
 **Usage:** `jj status [FILESETS]...`
+
+**Command Alias:** `st`
 
 ###### **Arguments:**
 
@@ -2495,6 +2531,8 @@ Manage tags
 List tags
 
 **Usage:** `jj tag list [OPTIONS] [NAMES]...`
+
+**Command Alias:** `l`
 
 ###### **Arguments:**
 


### PR DESCRIPTION
clap-markdown doesn't follow semver, so I pinned the version exactly.

If we don't like the changes, we could pin the older versions instead. The main goal is so to prevent this from messing up dependabot PRs.