### PR TITLE
templater: move `wrap_*()` functions to property types

### DIFF
--- a/cli/examples/custom-commit-templater/main.rs
+++ b/cli/examples/custom-commit-templater/main.rs
@@ -18,9 +18,9 @@ use std::rc::Rc;
 use itertools::Itertools as _;
 use jj_cli::cli_util::CliRunner;
 use jj_cli::commit_templater::CommitTemplateBuildFnTable;
-use jj_cli::commit_templater::CommitTemplateLanguage;
 use jj_cli::commit_templater::CommitTemplateLanguageExtension;
-use jj_cli::template_builder::TemplateLanguage as _;
+use jj_cli::commit_templater::CommitTemplatePropertyKind;
+use jj_cli::template_builder::CoreTemplatePropertyVar as _;
 use jj_cli::template_parser;
 use jj_cli::template_parser::TemplateParseError;
 use jj_cli::templater::TemplatePropertyExt as _;
@@ -121,7 +121,7 @@ impl SymbolResolverExtension for TheDigitest {
 
 impl CommitTemplateLanguageExtension for HexCounter {
     fn build_fn_table<'repo>(&self) -> CommitTemplateBuildFnTable<'repo> {
-        type L<'repo> = CommitTemplateLanguage<'repo>;
+        type P<'repo> = CommitTemplatePropertyKind<'repo>;
         let mut table = CommitTemplateBuildFnTable::empty();
         table.commit_methods.insert(
             "has_most_digits",
@@ -133,7 +133,7 @@ impl CommitTemplateLanguageExtension for HexCounter {
                     .count(language.repo());
                 let out_property =
                     property.map(move |commit| num_digits_in_id(commit.id()) == most_digits);
-                Ok(L::wrap_boolean(out_property.into_dyn()))
+                Ok(P::wrap_boolean(out_property.into_dyn()))
             },
         );
         table.commit_methods.insert(
@@ -141,7 +141,7 @@ impl CommitTemplateLanguageExtension for HexCounter {
             |_language, _diagnostics, _build_context, property, call| {
                 call.expect_no_arguments()?;
                 let out_property = property.map(|commit| num_digits_in_id(commit.id()));
-                Ok(L::wrap_integer(out_property.into_dyn()))
+                Ok(P::wrap_integer(out_property.into_dyn()))
             },
         );
         table.commit_methods.insert(
@@ -161,7 +161,7 @@ impl CommitTemplateLanguageExtension for HexCounter {
                     })?;
 
                 let out_property = property.map(move |commit| num_char_in_id(commit, char_arg));
-                Ok(L::wrap_integer(out_property.into_dyn()))
+                Ok(P::wrap_integer(out_property.into_dyn()))
             },
         );
 

--- a/cli/examples/custom-operation-templater/main.rs
+++ b/cli/examples/custom-operation-templater/main.rs
@@ -14,9 +14,9 @@
 
 use jj_cli::cli_util::CliRunner;
 use jj_cli::operation_templater::OperationTemplateBuildFnTable;
-use jj_cli::operation_templater::OperationTemplateLanguage;
 use jj_cli::operation_templater::OperationTemplateLanguageExtension;
-use jj_cli::template_builder::TemplateLanguage as _;
+use jj_cli::operation_templater::OperationTemplatePropertyKind;
+use jj_cli::template_builder::CoreTemplatePropertyVar as _;
 use jj_cli::template_parser;
 use jj_cli::template_parser::TemplateParseError;
 use jj_cli::templater::TemplatePropertyExt as _;
@@ -49,14 +49,14 @@ fn num_char_in_id(operation: Operation, ch_match: char) -> i64 {
 
 impl OperationTemplateLanguageExtension for HexCounter {
     fn build_fn_table(&self) -> OperationTemplateBuildFnTable {
-        type L = OperationTemplateLanguage;
+        type P = OperationTemplatePropertyKind;
         let mut table = OperationTemplateBuildFnTable::empty();
         table.operation_methods.insert(
             "num_digits_in_id",
             |_language, _diagnostics, _build_context, property, call| {
                 call.expect_no_arguments()?;
                 let out_property = property.map(|operation| num_digits_in_id(operation.id()));
-                Ok(L::wrap_integer(out_property.into_dyn()))
+                Ok(P::wrap_integer(out_property.into_dyn()))
             },
         );
         table.operation_methods.insert(
@@ -77,7 +77,7 @@ impl OperationTemplateLanguageExtension for HexCounter {
 
                 let out_property =
                     property.map(move |operation| num_char_in_id(operation, char_arg));
-                Ok(L::wrap_integer(out_property.into_dyn()))
+                Ok(P::wrap_integer(out_property.into_dyn()))
             },
         );
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -152,6 +152,7 @@ use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitTemplateLanguage;
 use crate::commit_templater::CommitTemplateLanguageExtension;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::config::config_from_environment;
 use crate::config::parse_config_args;
@@ -171,6 +172,7 @@ use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
 use crate::operation_templater::OperationTemplateLanguage;
 use crate::operation_templater::OperationTemplateLanguageExtension;
+use crate::operation_templater::OperationTemplatePropertyKind;
 use crate::revset_util;
 use crate::revset_util::RevsetExpressionEvaluator;
 use crate::template_builder;
@@ -1738,7 +1740,7 @@ to the current parents may contain changes from multiple commits.
             ui,
             &language,
             template_text,
-            CommitTemplateLanguage::wrap_commit,
+            CommitTemplatePropertyKind::wrap_commit,
         )
     }
 
@@ -1753,7 +1755,7 @@ to the current parents may contain changes from multiple commits.
             ui,
             &language,
             template_text,
-            OperationTemplateLanguage::wrap_operation,
+            OperationTemplatePropertyKind::wrap_operation,
         )
     }
 
@@ -1778,7 +1780,7 @@ to the current parents may contain changes from multiple commits.
         self.reparse_valid_template(
             &language,
             &self.commit_summary_template_text,
-            CommitTemplateLanguage::wrap_commit,
+            CommitTemplatePropertyKind::wrap_commit,
         )
     }
 
@@ -1788,7 +1790,7 @@ to the current parents may contain changes from multiple commits.
         self.reparse_valid_template(
             &language,
             &self.op_summary_template_text,
-            OperationTemplateLanguage::wrap_operation,
+            OperationTemplatePropertyKind::wrap_operation,
         )
         .labeled("operation")
     }
@@ -1798,7 +1800,7 @@ to the current parents may contain changes from multiple commits.
         self.reparse_valid_template(
             &language,
             SHORT_CHANGE_ID_TEMPLATE_TEXT,
-            CommitTemplateLanguage::wrap_commit,
+            CommitTemplatePropertyKind::wrap_commit,
         )
     }
 
@@ -2460,7 +2462,7 @@ impl WorkspaceCommandTransaction<'_> {
         self.helper.reparse_valid_template(
             &language,
             &self.helper.commit_summary_template_text,
-            CommitTemplateLanguage::wrap_commit,
+            CommitTemplatePropertyKind::wrap_commit,
         )
     }
 
@@ -2486,7 +2488,7 @@ impl WorkspaceCommandTransaction<'_> {
             ui,
             &language,
             template_text,
-            CommitTemplateLanguage::wrap_commit,
+            CommitTemplatePropertyKind::wrap_commit,
         )
     }
 

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -33,7 +33,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitRef;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::ui::Ui;
 
@@ -184,7 +184,7 @@ pub fn cmd_bookmark_list(
                 ui,
                 &language,
                 &text,
-                CommitTemplateLanguage::wrap_commit_ref,
+                CommitTemplatePropertyKind::wrap_commit_ref,
             )?
             .labeled("bookmark_list")
     };

--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -22,7 +22,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RemoteBookmarkNamePattern;
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitRef;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::ui::Ui;
 
@@ -97,7 +97,7 @@ pub fn cmd_bookmark_track(
                     ui,
                     &language,
                     &text,
-                    CommitTemplateLanguage::wrap_commit_ref,
+                    CommitTemplatePropertyKind::wrap_commit_ref,
                 )?
                 .labeled("bookmark_list")
         };

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -29,7 +29,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
 use crate::graphlog::get_graphlog;
@@ -114,7 +114,7 @@ pub(crate) fn cmd_evolog(
                 ui,
                 &language,
                 &template_string,
-                CommitTemplateLanguage::wrap_commit,
+                CommitTemplatePropertyKind::wrap_commit,
             )?
             .labeled("log");
         node_template = workspace_command
@@ -122,7 +122,7 @@ pub(crate) fn cmd_evolog(
                 ui,
                 &language,
                 &get_node_template(graph_style, workspace_command.settings())?,
-                CommitTemplateLanguage::wrap_commit_opt,
+                CommitTemplatePropertyKind::wrap_commit_opt,
             )?
             .labeled("node");
     }

--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -25,7 +25,7 @@ use crate::cli_util::RevisionArg;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::commit_templater::AnnotationLine;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::templater::TemplateRenderer;
 use crate::ui::Ui;
@@ -101,7 +101,7 @@ pub(crate) fn cmd_file_annotate(
         ui,
         &language,
         &template_text,
-        CommitTemplateLanguage::wrap_annotation_line,
+        CommitTemplatePropertyKind::wrap_annotation_line,
     )?;
 
     // TODO: Should we add an option to limit the domain to e.g. recent commits?

--- a/cli/src/commands/file/list.rs
+++ b/cli/src/commands/file/list.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::commit_templater::TreeEntry;
 use crate::complete;
 use crate::ui::Ui;
@@ -77,7 +77,7 @@ pub(crate) fn cmd_file_list(
                 ui,
                 &language,
                 &text,
-                CommitTemplateLanguage::wrap_tree_entry,
+                CommitTemplatePropertyKind::wrap_tree_entry,
             )?
             .labeled("file_list")
     };

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -35,7 +35,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
 use crate::graphlog::get_graphlog;
@@ -176,7 +176,7 @@ pub(crate) fn cmd_log(
                 ui,
                 &language,
                 &template_string,
-                CommitTemplateLanguage::wrap_commit,
+                CommitTemplatePropertyKind::wrap_commit,
             )?
             .labeled("log");
         node_template = workspace_command
@@ -184,7 +184,7 @@ pub(crate) fn cmd_log(
                 ui,
                 &language,
                 &get_node_template(graph_style, settings)?,
-                CommitTemplateLanguage::wrap_commit_opt,
+                CommitTemplatePropertyKind::wrap_commit_opt,
             )?
             .labeled("node");
     }

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -40,7 +40,7 @@ use jj_lib::revset::RevsetIteratorExt as _;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::command_error::CommandError;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::diff_util::diff_formats_for_log;
 use crate::diff_util::DiffFormatArgs;
@@ -132,7 +132,12 @@ pub fn cmd_op_diff(
     let commit_summary_template = {
         let language = workspace_env.commit_template_language(merged_repo, &id_prefix_context);
         let text = settings.get_string("templates.commit_summary")?;
-        workspace_env.parse_template(ui, &language, &text, CommitTemplateLanguage::wrap_commit)?
+        workspace_env.parse_template(
+            ui,
+            &language,
+            &text,
+            CommitTemplatePropertyKind::wrap_commit,
+        )?
     };
 
     let op_summary_template = workspace_command.operation_summary_template();

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -32,7 +32,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::cli_util::WorkspaceCommandEnvironment;
 use crate::command_error::CommandError;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::diff_util::diff_formats_for_log;
 use crate::diff_util::DiffFormatArgs;
@@ -41,6 +41,7 @@ use crate::formatter::Formatter;
 use crate::graphlog::get_graphlog;
 use crate::graphlog::GraphStyle;
 use crate::operation_templater::OperationTemplateLanguage;
+use crate::operation_templater::OperationTemplatePropertyKind;
 use crate::ui::Ui;
 
 /// Show the operation log
@@ -139,7 +140,7 @@ fn do_op_log(
                 ui,
                 &language,
                 &text,
-                OperationTemplateLanguage::wrap_operation,
+                OperationTemplatePropertyKind::wrap_operation,
             )?
             .labeled("operation")
             .labeled("op_log");
@@ -148,7 +149,7 @@ fn do_op_log(
                 ui,
                 &language,
                 &get_node_template(graph_style, settings)?,
-                OperationTemplateLanguage::wrap_operation,
+                OperationTemplatePropertyKind::wrap_operation,
             )?
             .labeled("node");
     }
@@ -173,7 +174,7 @@ fn do_op_log(
                     ui,
                     &language,
                     &template_text,
-                    CommitTemplateLanguage::wrap_commit,
+                    CommitTemplatePropertyKind::wrap_commit,
                 )?
             };
             let path_converter = workspace_env.path_converter();

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -19,7 +19,7 @@ use super::diff::show_op_diff;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
 use crate::command_error::CommandError;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::diff_util::diff_formats_for_log;
 use crate::diff_util::DiffFormatArgs;
@@ -66,7 +66,12 @@ pub fn cmd_op_show(
     let commit_summary_template = {
         let language = workspace_env.commit_template_language(repo.as_ref(), &id_prefix_context);
         let text = settings.get_string("templates.commit_summary")?;
-        workspace_env.parse_template(ui, &language, &text, CommitTemplateLanguage::wrap_commit)?
+        workspace_env.parse_template(
+            ui,
+            &language,
+            &text,
+            CommitTemplatePropertyKind::wrap_commit,
+        )?
     };
 
     let graph_style = GraphStyle::from_settings(settings)?;

--- a/cli/src/commands/tag.rs
+++ b/cli/src/commands/tag.rs
@@ -18,7 +18,7 @@ use jj_lib::str_util::StringPattern;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::commit_templater::CommitRef;
-use crate::commit_templater::CommitTemplateLanguage;
+use crate::commit_templater::CommitTemplatePropertyKind;
 use crate::complete;
 use crate::ui::Ui;
 
@@ -86,7 +86,7 @@ fn cmd_tag_list(
                 ui,
                 &language,
                 &text,
-                CommitTemplateLanguage::wrap_commit_ref,
+                CommitTemplatePropertyKind::wrap_commit_ref,
             )?
             .labeled("tag_list")
     };

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -359,118 +359,119 @@ impl<'repo> CommitTemplateLanguage<'repo> {
         self.cache_extensions.get::<T>()
     }
 
+    // TODO: delete
     pub fn wrap_commit(
         property: BoxedTemplateProperty<'repo, Commit>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::Commit(property)
+        CommitTemplatePropertyKind::wrap_commit(property)
     }
 
     pub fn wrap_commit_opt(
         property: BoxedTemplateProperty<'repo, Option<Commit>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::CommitOpt(property)
+        CommitTemplatePropertyKind::wrap_commit_opt(property)
     }
 
     pub fn wrap_commit_list(
         property: BoxedTemplateProperty<'repo, Vec<Commit>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::CommitList(property)
+        CommitTemplatePropertyKind::wrap_commit_list(property)
     }
 
     pub fn wrap_commit_ref(
         property: BoxedTemplateProperty<'repo, Rc<CommitRef>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::CommitRef(property)
+        CommitTemplatePropertyKind::wrap_commit_ref(property)
     }
 
     pub fn wrap_commit_ref_opt(
         property: BoxedTemplateProperty<'repo, Option<Rc<CommitRef>>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::CommitRefOpt(property)
+        CommitTemplatePropertyKind::wrap_commit_ref_opt(property)
     }
 
     pub fn wrap_commit_ref_list(
         property: BoxedTemplateProperty<'repo, Vec<Rc<CommitRef>>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::CommitRefList(property)
+        CommitTemplatePropertyKind::wrap_commit_ref_list(property)
     }
 
     pub fn wrap_repo_path(
         property: BoxedTemplateProperty<'repo, RepoPathBuf>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::RepoPath(property)
+        CommitTemplatePropertyKind::wrap_repo_path(property)
     }
 
     pub fn wrap_repo_path_opt(
         property: BoxedTemplateProperty<'repo, Option<RepoPathBuf>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::RepoPathOpt(property)
+        CommitTemplatePropertyKind::wrap_repo_path_opt(property)
     }
 
     pub fn wrap_commit_or_change_id(
         property: BoxedTemplateProperty<'repo, CommitOrChangeId>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::CommitOrChangeId(property)
+        CommitTemplatePropertyKind::wrap_commit_or_change_id(property)
     }
 
     pub fn wrap_shortest_id_prefix(
         property: BoxedTemplateProperty<'repo, ShortestIdPrefix>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::ShortestIdPrefix(property)
+        CommitTemplatePropertyKind::wrap_shortest_id_prefix(property)
     }
 
     pub fn wrap_tree_diff(
         property: BoxedTemplateProperty<'repo, TreeDiff>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::TreeDiff(property)
+        CommitTemplatePropertyKind::wrap_tree_diff(property)
     }
 
     pub fn wrap_tree_diff_entry(
         property: BoxedTemplateProperty<'repo, TreeDiffEntry>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::TreeDiffEntry(property)
+        CommitTemplatePropertyKind::wrap_tree_diff_entry(property)
     }
 
     pub fn wrap_tree_diff_entry_list(
         property: BoxedTemplateProperty<'repo, Vec<TreeDiffEntry>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::TreeDiffEntryList(property)
+        CommitTemplatePropertyKind::wrap_tree_diff_entry_list(property)
     }
 
     pub fn wrap_tree_entry(
         property: BoxedTemplateProperty<'repo, TreeEntry>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::TreeEntry(property)
+        CommitTemplatePropertyKind::wrap_tree_entry(property)
     }
 
     pub fn wrap_diff_stats(
         property: BoxedTemplateProperty<'repo, DiffStatsFormatted<'repo>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::DiffStats(property)
+        CommitTemplatePropertyKind::wrap_diff_stats(property)
     }
 
     fn wrap_cryptographic_signature_opt(
         property: BoxedTemplateProperty<'repo, Option<CryptographicSignature>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::CryptographicSignatureOpt(property)
+        CommitTemplatePropertyKind::wrap_cryptographic_signature_opt(property)
     }
 
     pub fn wrap_annotation_line(
         property: BoxedTemplateProperty<'repo, AnnotationLine>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::AnnotationLine(property)
+        CommitTemplatePropertyKind::wrap_annotation_line(property)
     }
 
     pub fn wrap_trailer(
         property: BoxedTemplateProperty<'repo, Trailer>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::Trailer(property)
+        CommitTemplatePropertyKind::wrap_trailer(property)
     }
 
     pub fn wrap_trailer_list(
         property: BoxedTemplateProperty<'repo, Vec<Trailer>>,
     ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::TrailerList(property)
+        CommitTemplatePropertyKind::wrap_trailer_list(property)
     }
 }
 
@@ -495,6 +496,32 @@ pub enum CommitTemplatePropertyKind<'repo> {
     AnnotationLine(BoxedTemplateProperty<'repo, AnnotationLine>),
     Trailer(BoxedTemplateProperty<'repo, Trailer>),
     TrailerList(BoxedTemplateProperty<'repo, Vec<Trailer>>),
+}
+
+impl<'repo> CommitTemplatePropertyKind<'repo> {
+    template_builder::impl_wrap_property_fns!('repo, CommitTemplatePropertyKind, {
+        pub wrap_commit(Commit) => Commit,
+        pub wrap_commit_opt(Option<Commit>) => CommitOpt,
+        pub wrap_commit_list(Vec<Commit>) => CommitList,
+        pub wrap_commit_ref(Rc<CommitRef>) => CommitRef,
+        pub wrap_commit_ref_opt(Option<Rc<CommitRef>>) => CommitRefOpt,
+        pub wrap_commit_ref_list(Vec<Rc<CommitRef>>) => CommitRefList,
+        pub wrap_repo_path(RepoPathBuf) => RepoPath,
+        pub wrap_repo_path_opt(Option<RepoPathBuf>) => RepoPathOpt,
+        pub wrap_commit_or_change_id(CommitOrChangeId) => CommitOrChangeId,
+        pub wrap_shortest_id_prefix(ShortestIdPrefix) => ShortestIdPrefix,
+        pub wrap_tree_diff(TreeDiff) => TreeDiff,
+        pub wrap_tree_diff_entry(TreeDiffEntry) => TreeDiffEntry,
+        pub wrap_tree_diff_entry_list(Vec<TreeDiffEntry>) => TreeDiffEntryList,
+        pub wrap_tree_entry(TreeEntry) => TreeEntry,
+        pub wrap_diff_stats(DiffStatsFormatted<'repo>) => DiffStats,
+        pub wrap_cryptographic_signature_opt(
+            Option<CryptographicSignature>
+        ) => CryptographicSignatureOpt,
+        pub wrap_annotation_line(AnnotationLine) => AnnotationLine,
+        pub wrap_trailer(Trailer) => Trailer,
+        pub wrap_trailer_list(Vec<Trailer>) => TrailerList,
+    });
 }
 
 impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo> {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -80,7 +80,6 @@ use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
 use crate::template_builder::CoreTemplatePropertyKind;
 use crate::template_builder::CoreTemplatePropertyVar;
-use crate::template_builder::IntoTemplateProperty;
 use crate::template_builder::TemplateBuildMethodFnMap;
 use crate::template_builder::TemplateLanguage;
 use crate::template_parser;
@@ -411,9 +410,7 @@ impl<'repo> CommitTemplatePropertyKind<'repo> {
 
 impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo> {
     template_builder::impl_core_wrap_property_fns!('repo, CommitTemplatePropertyKind::Core);
-}
 
-impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {
     fn type_name(&self) -> &'static str {
         match self {
             CommitTemplatePropertyKind::Core(property) => property.type_name(),

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -212,8 +212,8 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                     build_ctx,
                     property,
                     function,
-                    Self::wrap_commit,
-                    Self::wrap_commit_list,
+                    Self::Property::wrap_commit,
+                    Self::Property::wrap_commit_list,
                 )
             }
             CommitTemplatePropertyKind::CommitRef(property) => {
@@ -236,8 +236,8 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                     build_ctx,
                     property,
                     function,
-                    Self::wrap_commit_ref,
-                    Self::wrap_commit_ref_list,
+                    Self::Property::wrap_commit_ref,
+                    Self::Property::wrap_commit_ref_list,
                 )
             }
             CommitTemplatePropertyKind::RepoPath(property) => {
@@ -280,8 +280,8 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                     build_ctx,
                     property,
                     function,
-                    Self::wrap_tree_diff_entry,
-                    Self::wrap_tree_diff_entry_list,
+                    Self::Property::wrap_tree_diff_entry,
+                    Self::Property::wrap_tree_diff_entry_list,
                 )
             }
             CommitTemplatePropertyKind::TreeEntry(property) => {
@@ -323,7 +323,7 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                         expect_plain_text_expression(self, diagnostics, build_ctx, key_node)?;
                     let out_property = (property, key_property)
                         .map(|(trailers, key)| trailers.iter().any(|t| t.key == key));
-                    Ok(Self::wrap_boolean(out_property.into_dyn()))
+                    Ok(Self::Property::wrap_boolean(out_property.into_dyn()))
                 } else {
                     template_builder::build_formattable_list_method(
                         self,
@@ -331,8 +331,8 @@ impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
                         build_ctx,
                         property,
                         function,
-                        Self::wrap_trailer,
-                        Self::wrap_trailer_list,
+                        Self::Property::wrap_trailer,
+                        Self::Property::wrap_trailer_list,
                     )
                 }
             }
@@ -357,121 +357,6 @@ impl<'repo> CommitTemplateLanguage<'repo> {
 
     pub fn cache_extension<T: Any>(&self) -> Option<&T> {
         self.cache_extensions.get::<T>()
-    }
-
-    // TODO: delete
-    pub fn wrap_commit(
-        property: BoxedTemplateProperty<'repo, Commit>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_commit(property)
-    }
-
-    pub fn wrap_commit_opt(
-        property: BoxedTemplateProperty<'repo, Option<Commit>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_commit_opt(property)
-    }
-
-    pub fn wrap_commit_list(
-        property: BoxedTemplateProperty<'repo, Vec<Commit>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_commit_list(property)
-    }
-
-    pub fn wrap_commit_ref(
-        property: BoxedTemplateProperty<'repo, Rc<CommitRef>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_commit_ref(property)
-    }
-
-    pub fn wrap_commit_ref_opt(
-        property: BoxedTemplateProperty<'repo, Option<Rc<CommitRef>>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_commit_ref_opt(property)
-    }
-
-    pub fn wrap_commit_ref_list(
-        property: BoxedTemplateProperty<'repo, Vec<Rc<CommitRef>>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_commit_ref_list(property)
-    }
-
-    pub fn wrap_repo_path(
-        property: BoxedTemplateProperty<'repo, RepoPathBuf>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_repo_path(property)
-    }
-
-    pub fn wrap_repo_path_opt(
-        property: BoxedTemplateProperty<'repo, Option<RepoPathBuf>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_repo_path_opt(property)
-    }
-
-    pub fn wrap_commit_or_change_id(
-        property: BoxedTemplateProperty<'repo, CommitOrChangeId>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_commit_or_change_id(property)
-    }
-
-    pub fn wrap_shortest_id_prefix(
-        property: BoxedTemplateProperty<'repo, ShortestIdPrefix>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_shortest_id_prefix(property)
-    }
-
-    pub fn wrap_tree_diff(
-        property: BoxedTemplateProperty<'repo, TreeDiff>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_tree_diff(property)
-    }
-
-    pub fn wrap_tree_diff_entry(
-        property: BoxedTemplateProperty<'repo, TreeDiffEntry>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_tree_diff_entry(property)
-    }
-
-    pub fn wrap_tree_diff_entry_list(
-        property: BoxedTemplateProperty<'repo, Vec<TreeDiffEntry>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_tree_diff_entry_list(property)
-    }
-
-    pub fn wrap_tree_entry(
-        property: BoxedTemplateProperty<'repo, TreeEntry>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_tree_entry(property)
-    }
-
-    pub fn wrap_diff_stats(
-        property: BoxedTemplateProperty<'repo, DiffStatsFormatted<'repo>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_diff_stats(property)
-    }
-
-    fn wrap_cryptographic_signature_opt(
-        property: BoxedTemplateProperty<'repo, Option<CryptographicSignature>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_cryptographic_signature_opt(property)
-    }
-
-    pub fn wrap_annotation_line(
-        property: BoxedTemplateProperty<'repo, AnnotationLine>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_annotation_line(property)
-    }
-
-    pub fn wrap_trailer(
-        property: BoxedTemplateProperty<'repo, Trailer>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_trailer(property)
-    }
-
-    pub fn wrap_trailer_list(
-        property: BoxedTemplateProperty<'repo, Vec<Trailer>>,
-    ) -> CommitTemplatePropertyKind<'repo> {
-        CommitTemplatePropertyKind::wrap_trailer_list(property)
     }
 }
 
@@ -846,7 +731,7 @@ impl<'repo> CommitKeywordCache<'repo> {
 }
 
 fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Commit> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<Commit>::new();
@@ -856,7 +741,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let out_property =
                 self_property.map(|commit| text_util::complete_newline(commit.description()));
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -865,7 +750,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let out_property = self_property
                 .map(|commit| trailer::parse_description_trailers(commit.description()));
-            Ok(L::wrap_trailer_list(out_property.into_dyn()))
+            Ok(P::wrap_trailer_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -874,7 +759,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let out_property =
                 self_property.map(|commit| CommitOrChangeId::Change(commit.change_id().to_owned()));
-            Ok(L::wrap_commit_or_change_id(out_property.into_dyn()))
+            Ok(P::wrap_commit_or_change_id(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -883,7 +768,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let out_property =
                 self_property.map(|commit| CommitOrChangeId::Commit(commit.id().to_owned()));
-            Ok(L::wrap_commit_or_change_id(out_property.into_dyn()))
+            Ok(P::wrap_commit_or_change_id(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -892,7 +777,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let out_property =
                 self_property.and_then(|commit| Ok(commit.parents().try_collect()?));
-            Ok(L::wrap_commit_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -900,7 +785,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|commit| commit.author().clone());
-            Ok(L::wrap_signature(out_property.into_dyn()))
+            Ok(P::wrap_signature(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -908,7 +793,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|commit| commit.committer().clone());
-            Ok(L::wrap_signature(out_property.into_dyn()))
+            Ok(P::wrap_signature(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -917,7 +802,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let user_email = language.revset_parse_context.user_email.to_owned();
             let out_property = self_property.map(move |commit| commit.author().email == user_email);
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -925,7 +810,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(CryptographicSignature::new);
-            Ok(L::wrap_cryptographic_signature_opt(out_property.into_dyn()))
+            Ok(P::wrap_cryptographic_signature_opt(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -934,7 +819,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let repo = language.repo;
             let out_property = self_property.map(|commit| extract_working_copies(repo, &commit));
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -945,7 +830,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             let name = language.workspace_name.clone();
             let out_property = self_property
                 .map(move |commit| Some(commit.id()) == repo.view().get_wc_commit_id(&name));
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -964,7 +849,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                     .cloned()
                     .collect()
             });
-            Ok(L::wrap_commit_ref_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_ref_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -983,7 +868,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                     .cloned()
                     .collect()
             });
-            Ok(L::wrap_commit_ref_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_ref_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1002,7 +887,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                     .cloned()
                     .collect()
             });
-            Ok(L::wrap_commit_ref_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_ref_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1011,7 +896,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let index = language.keyword_cache.tags_index(language.repo).clone();
             let out_property = self_property.map(move |commit| index.get(commit.id()).to_vec());
-            Ok(L::wrap_commit_ref_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_ref_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1020,7 +905,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let index = language.keyword_cache.git_refs_index(language.repo).clone();
             let out_property = self_property.map(move |commit| index.get(commit.id()).to_vec());
-            Ok(L::wrap_commit_ref_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_ref_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1032,7 +917,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                 let target = repo.view().git_head();
                 target.added_ids().contains(commit.id())
             });
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1045,7 +930,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                 let maybe_entries = repo.resolve_change_id(commit.change_id());
                 maybe_entries.map_or(0, |entries| entries.len()) > 1
             });
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1054,7 +939,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let repo = language.repo;
             let out_property = self_property.map(|commit| commit.is_hidden(repo));
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1066,7 +951,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                 .is_immutable_fn(language, function.name_span)?
                 .clone();
             let out_property = self_property.and_then(move |commit| Ok(is_immutable(commit.id())?));
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1080,7 +965,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                 })?;
 
             let out_property = self_property.and_then(move |commit| Ok(is_contained(commit.id())?));
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1088,7 +973,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.and_then(|commit| Ok(commit.has_conflict()?));
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1097,7 +982,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             function.expect_no_arguments()?;
             let repo = language.repo;
             let out_property = self_property.and_then(|commit| Ok(commit.is_empty(repo)?));
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1115,7 +1000,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             let matcher: Rc<dyn Matcher> = files.to_matcher().into();
             let out_property = self_property
                 .and_then(move |commit| Ok(TreeDiff::from_commit(repo, &commit, matcher.clone())?));
-            Ok(L::wrap_tree_diff(out_property.into_dyn()))
+            Ok(P::wrap_tree_diff(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1125,7 +1010,7 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
             let repo = language.repo;
             let out_property =
                 self_property.map(|commit| commit.id() == repo.store().root_commit_id());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map
@@ -1415,7 +1300,7 @@ impl Template for Vec<Rc<CommitRef>> {
 }
 
 fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Rc<CommitRef>> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<Rc<CommitRef>>::new();
@@ -1424,7 +1309,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|commit_ref| commit_ref.name.clone());
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1433,7 +1318,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             function.expect_no_arguments()?;
             let out_property =
                 self_property.map(|commit_ref| commit_ref.remote.clone().unwrap_or_default());
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1441,7 +1326,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|commit_ref| commit_ref.is_present());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1449,7 +1334,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|commit_ref| commit_ref.has_conflict());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1461,7 +1346,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
                 let maybe_id = commit_ref.target.as_normal();
                 Ok(maybe_id.map(|id| repo.store().get_commit(id)).transpose()?)
             });
-            Ok(L::wrap_commit_opt(out_property.into_dyn()))
+            Ok(P::wrap_commit_opt(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1473,7 +1358,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
                 let ids = commit_ref.target.removed_ids();
                 Ok(ids.map(|id| repo.store().get_commit(id)).try_collect()?)
             });
-            Ok(L::wrap_commit_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1485,7 +1370,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
                 let ids = commit_ref.target.added_ids();
                 Ok(ids.map(|id| repo.store().get_commit(id)).try_collect()?)
             });
-            Ok(L::wrap_commit_list(out_property.into_dyn()))
+            Ok(P::wrap_commit_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1493,7 +1378,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|commit_ref| commit_ref.is_tracked());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1501,7 +1386,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|commit_ref| commit_ref.is_tracking_present());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1511,7 +1396,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             let repo = language.repo;
             let out_property =
                 self_property.and_then(|commit_ref| commit_ref.tracking_ahead_count(repo));
-            Ok(L::wrap_size_hint(out_property.into_dyn()))
+            Ok(P::wrap_size_hint(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1521,7 +1406,7 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             let repo = language.repo;
             let out_property =
                 self_property.and_then(|commit_ref| commit_ref.tracking_behind_count(repo));
-            Ok(L::wrap_size_hint(out_property.into_dyn()))
+            Ok(P::wrap_size_hint(out_property.into_dyn()))
         },
     );
     map
@@ -1586,7 +1471,7 @@ impl Template for RepoPathBuf {
 }
 
 fn builtin_repo_path_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, RepoPathBuf> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<RepoPathBuf>::new();
@@ -1596,7 +1481,7 @@ fn builtin_repo_path_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, R
             function.expect_no_arguments()?;
             let path_converter = language.path_converter;
             let out_property = self_property.map(|path| path_converter.format_file_path(&path));
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1604,7 +1489,7 @@ fn builtin_repo_path_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, R
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|path| Some(path.parent()?.to_owned()));
-            Ok(L::wrap_repo_path_opt(out_property.into_dyn()))
+            Ok(P::wrap_repo_path_opt(out_property.into_dyn()))
         },
     );
     map
@@ -1657,7 +1542,7 @@ impl Template for CommitOrChangeId {
 
 fn builtin_commit_or_change_id_methods<'repo>(
 ) -> CommitTemplateBuildMethodFnMap<'repo, CommitOrChangeId> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<CommitOrChangeId>::new();
@@ -1674,7 +1559,7 @@ fn builtin_commit_or_change_id_methods<'repo>(
                     CommitOrChangeId::Change(id) => id.hex(),
                 }
             });
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1693,7 +1578,7 @@ fn builtin_commit_or_change_id_methods<'repo>(
                 .transpose()?;
             let out_property =
                 (self_property, len_property).map(|(id, len)| id.short(len.unwrap_or(12)));
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1728,7 +1613,7 @@ fn builtin_commit_or_change_id_methods<'repo>(
             };
             let out_property = (self_property, len_property)
                 .map(move |(id, len)| id.shortest(repo, &index, len.unwrap_or(0)));
-            Ok(L::wrap_shortest_id_prefix(out_property.into_dyn()))
+            Ok(P::wrap_shortest_id_prefix(out_property.into_dyn()))
         },
     );
     map
@@ -1764,7 +1649,7 @@ impl ShortestIdPrefix {
 
 fn builtin_shortest_id_prefix_methods<'repo>(
 ) -> CommitTemplateBuildMethodFnMap<'repo, ShortestIdPrefix> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<ShortestIdPrefix>::new();
@@ -1773,7 +1658,7 @@ fn builtin_shortest_id_prefix_methods<'repo>(
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|id| id.prefix);
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1781,7 +1666,7 @@ fn builtin_shortest_id_prefix_methods<'repo>(
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|id| id.rest);
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1789,7 +1674,7 @@ fn builtin_shortest_id_prefix_methods<'repo>(
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|id| id.to_upper());
-            Ok(L::wrap_shortest_id_prefix(out_property.into_dyn()))
+            Ok(P::wrap_shortest_id_prefix(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1797,7 +1682,7 @@ fn builtin_shortest_id_prefix_methods<'repo>(
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|id| id.to_lower());
-            Ok(L::wrap_shortest_id_prefix(out_property.into_dyn()))
+            Ok(P::wrap_shortest_id_prefix(out_property.into_dyn()))
         },
     );
     map
@@ -1873,7 +1758,7 @@ where
 }
 
 fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, TreeDiff> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<TreeDiff>::new();
@@ -1884,7 +1769,7 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
             // TODO: cache and reuse diff entries within the current evaluation?
             let out_property =
                 self_property.and_then(|diff| Ok(diff.collect_entries().block_on()?));
-            Ok(L::wrap_tree_diff_entry_list(out_property.into_dyn()))
+            Ok(P::wrap_tree_diff_entry_list(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -1926,7 +1811,7 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
                     })
                 })
                 .into_template();
-            Ok(L::wrap_template(template))
+            Ok(P::wrap_template(template))
         },
     );
     map.insert(
@@ -1966,7 +1851,7 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
                     })
                 })
                 .into_template();
-            Ok(L::wrap_template(template))
+            Ok(P::wrap_template(template))
         },
     );
     map.insert(
@@ -2000,7 +1885,7 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
                     width: width.unwrap_or(80),
                 })
             });
-            Ok(L::wrap_diff_stats(out_property.into_dyn()))
+            Ok(P::wrap_diff_stats(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2015,7 +1900,7 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
                     })
                 })
                 .into_template();
-            Ok(L::wrap_template(template))
+            Ok(P::wrap_template(template))
         },
     );
     // TODO: add support for external tools
@@ -2066,7 +1951,7 @@ impl TreeDiffEntry {
 
 fn builtin_tree_diff_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, TreeDiffEntry>
 {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<TreeDiffEntry>::new();
@@ -2075,7 +1960,7 @@ fn builtin_tree_diff_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|entry| entry.path.target);
-            Ok(L::wrap_repo_path(out_property.into_dyn()))
+            Ok(P::wrap_repo_path(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2083,7 +1968,7 @@ fn builtin_tree_diff_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|entry| entry.status_label().to_owned());
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     // TODO: add status_code() or status_char()?
@@ -2092,7 +1977,7 @@ fn builtin_tree_diff_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(TreeDiffEntry::into_source_entry);
-            Ok(L::wrap_tree_entry(out_property.into_dyn()))
+            Ok(P::wrap_tree_entry(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2100,7 +1985,7 @@ fn builtin_tree_diff_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(TreeDiffEntry::into_target_entry);
-            Ok(L::wrap_tree_entry(out_property.into_dyn()))
+            Ok(P::wrap_tree_entry(out_property.into_dyn()))
         },
     );
     map
@@ -2114,7 +1999,7 @@ pub struct TreeEntry {
 }
 
 fn builtin_tree_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, TreeEntry> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<TreeEntry>::new();
@@ -2123,7 +2008,7 @@ fn builtin_tree_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|entry| entry.path);
-            Ok(L::wrap_repo_path(out_property.into_dyn()))
+            Ok(P::wrap_repo_path(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2131,7 +2016,7 @@ fn builtin_tree_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|entry| !entry.value.is_resolved());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2140,7 +2025,7 @@ fn builtin_tree_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             function.expect_no_arguments()?;
             let out_property =
                 self_property.map(|entry| describe_file_type(&entry.value).to_owned());
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2149,7 +2034,7 @@ fn builtin_tree_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             function.expect_no_arguments()?;
             let out_property =
                 self_property.map(|entry| is_executable_file(&entry.value).unwrap_or_default());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map
@@ -2191,7 +2076,7 @@ impl Template for DiffStatsFormatted<'_> {
 }
 
 fn builtin_diff_stats_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, DiffStats> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<DiffStats>::new();
@@ -2202,7 +2087,7 @@ fn builtin_diff_stats_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             function.expect_no_arguments()?;
             let out_property =
                 self_property.and_then(|stats| Ok(stats.count_total_added().try_into()?));
-            Ok(L::wrap_integer(out_property.into_dyn()))
+            Ok(P::wrap_integer(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2211,7 +2096,7 @@ fn builtin_diff_stats_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             function.expect_no_arguments()?;
             let out_property =
                 self_property.and_then(|stats| Ok(stats.count_total_removed().try_into()?));
-            Ok(L::wrap_integer(out_property.into_dyn()))
+            Ok(P::wrap_integer(out_property.into_dyn()))
         },
     );
     map
@@ -2253,7 +2138,7 @@ impl CryptographicSignature {
 
 fn builtin_cryptographic_signature_methods<'repo>(
 ) -> CommitTemplateBuildMethodFnMap<'repo, CryptographicSignature> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = CommitTemplateBuildMethodFnMap::<CryptographicSignature>::new();
@@ -2266,7 +2151,7 @@ fn builtin_cryptographic_signature_methods<'repo>(
                 Err(SignError::InvalidSignatureFormat) => Ok("invalid".to_string()),
                 Err(err) => Err(err.into()),
             });
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2274,7 +2159,7 @@ fn builtin_cryptographic_signature_methods<'repo>(
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.and_then(|sig| Ok(sig.key()?));
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2282,7 +2167,7 @@ fn builtin_cryptographic_signature_methods<'repo>(
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.and_then(|sig| Ok(sig.display()?));
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map
@@ -2298,14 +2183,14 @@ pub struct AnnotationLine {
 
 fn builtin_annotation_line_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, AnnotationLine>
 {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     let mut map = CommitTemplateBuildMethodFnMap::<AnnotationLine>::new();
     map.insert(
         "commit",
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|line| line.commit);
-            Ok(L::wrap_commit(out_property.into_dyn()))
+            Ok(P::wrap_commit(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2314,7 +2199,7 @@ fn builtin_annotation_line_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
             function.expect_no_arguments()?;
             let out_property = self_property.map(|line| line.content);
             // TODO: Add Bytes or BString template type?
-            Ok(L::wrap_template(out_property.into_template()))
+            Ok(P::wrap_template(out_property.into_template()))
         },
     );
     map.insert(
@@ -2322,7 +2207,7 @@ fn builtin_annotation_line_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.and_then(|line| Ok(line.line_number.try_into()?));
-            Ok(L::wrap_integer(out_property.into_dyn()))
+            Ok(P::wrap_integer(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2330,7 +2215,7 @@ fn builtin_annotation_line_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|line| line.first_line_in_hunk);
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map
@@ -2349,14 +2234,14 @@ impl Template for Vec<Trailer> {
 }
 
 fn builtin_trailer_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Trailer> {
-    type L<'repo> = CommitTemplateLanguage<'repo>;
+    type P<'repo> = CommitTemplatePropertyKind<'repo>;
     let mut map = CommitTemplateBuildMethodFnMap::<Trailer>::new();
     map.insert(
         "key",
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|trailer| trailer.key);
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -2364,7 +2249,7 @@ fn builtin_trailer_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Tra
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|trailer| trailer.value);
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -79,6 +79,7 @@ use crate::template_builder::merge_fn_map;
 use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
 use crate::template_builder::CoreTemplatePropertyKind;
+use crate::template_builder::CoreTemplatePropertyVar;
 use crate::template_builder::IntoTemplateProperty;
 use crate::template_builder::TemplateBuildMethodFnMap;
 use crate::template_builder::TemplateLanguage;
@@ -163,8 +164,6 @@ impl<'repo> CommitTemplateLanguage<'repo> {
 
 impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
     type Property = CommitTemplatePropertyKind<'repo>;
-
-    template_builder::impl_core_wrap_property_fns!('repo, CommitTemplatePropertyKind::Core);
 
     fn settings(&self) -> &UserSettings {
         self.repo.base_repo().settings()
@@ -496,6 +495,10 @@ pub enum CommitTemplatePropertyKind<'repo> {
     AnnotationLine(BoxedTemplateProperty<'repo, AnnotationLine>),
     Trailer(BoxedTemplateProperty<'repo, Trailer>),
     TrailerList(BoxedTemplateProperty<'repo, Vec<Trailer>>),
+}
+
+impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo> {
+    template_builder::impl_core_wrap_property_fns!('repo, CommitTemplatePropertyKind::Core);
 }
 
 impl<'repo> IntoTemplateProperty<'repo> for CommitTemplatePropertyKind<'repo> {

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -129,13 +129,6 @@ impl<'a, C> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
     }
 }
 
-impl<'a, C> GenericTemplateLanguage<'a, C> {
-    // TODO: delete
-    pub fn wrap_self(property: BoxedTemplateProperty<'a, C>) -> GenericTemplatePropertyKind<'a, C> {
-        GenericTemplatePropertyKind::wrap_self(property)
-    }
-}
-
 pub enum GenericTemplatePropertyKind<'a, C> {
     Core(CoreTemplatePropertyKind<'a>),
     Self_(BoxedTemplateProperty<'a, C>),

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -21,6 +21,7 @@ use crate::template_builder;
 use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
 use crate::template_builder::CoreTemplatePropertyKind;
+use crate::template_builder::CoreTemplatePropertyVar;
 use crate::template_builder::IntoTemplateProperty;
 use crate::template_builder::TemplateLanguage;
 use crate::template_parser;
@@ -90,8 +91,6 @@ impl<'a, C> GenericTemplateLanguage<'a, C> {
 impl<'a, C> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
     type Property = GenericTemplatePropertyKind<'a, C>;
 
-    template_builder::impl_core_wrap_property_fns!('a, GenericTemplatePropertyKind::Core);
-
     fn settings(&self) -> &UserSettings {
         &self.settings
     }
@@ -139,6 +138,10 @@ impl<'a, C> GenericTemplateLanguage<'a, C> {
 pub enum GenericTemplatePropertyKind<'a, C> {
     Core(CoreTemplatePropertyKind<'a>),
     Self_(BoxedTemplateProperty<'a, C>),
+}
+
+impl<'a, C> CoreTemplatePropertyVar<'a> for GenericTemplatePropertyKind<'a, C> {
+    template_builder::impl_core_wrap_property_fns!('a, GenericTemplatePropertyKind::Core);
 }
 
 impl<'a, C> IntoTemplateProperty<'a> for GenericTemplatePropertyKind<'a, C> {

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -130,14 +130,21 @@ impl<'a, C> TemplateLanguage<'a> for GenericTemplateLanguage<'a, C> {
 }
 
 impl<'a, C> GenericTemplateLanguage<'a, C> {
+    // TODO: delete
     pub fn wrap_self(property: BoxedTemplateProperty<'a, C>) -> GenericTemplatePropertyKind<'a, C> {
-        GenericTemplatePropertyKind::Self_(property)
+        GenericTemplatePropertyKind::wrap_self(property)
     }
 }
 
 pub enum GenericTemplatePropertyKind<'a, C> {
     Core(CoreTemplatePropertyKind<'a>),
     Self_(BoxedTemplateProperty<'a, C>),
+}
+
+impl<'a, C> GenericTemplatePropertyKind<'a, C> {
+    template_builder::impl_wrap_property_fns!('a, GenericTemplatePropertyKind, {
+        pub wrap_self(C) => Self_,
+    });
 }
 
 impl<'a, C> CoreTemplatePropertyVar<'a> for GenericTemplatePropertyKind<'a, C> {

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -22,7 +22,6 @@ use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
 use crate::template_builder::CoreTemplatePropertyKind;
 use crate::template_builder::CoreTemplatePropertyVar;
-use crate::template_builder::IntoTemplateProperty;
 use crate::template_builder::TemplateLanguage;
 use crate::template_parser;
 use crate::template_parser::FunctionCallNode;
@@ -142,9 +141,7 @@ impl<'a, C> GenericTemplatePropertyKind<'a, C> {
 
 impl<'a, C> CoreTemplatePropertyVar<'a> for GenericTemplatePropertyKind<'a, C> {
     template_builder::impl_core_wrap_property_fns!('a, GenericTemplatePropertyKind::Core);
-}
 
-impl<'a, C> IntoTemplateProperty<'a> for GenericTemplatePropertyKind<'a, C> {
     fn type_name(&self) -> &'static str {
         match self {
             GenericTemplatePropertyKind::Core(property) => property.type_name(),

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -31,7 +31,6 @@ use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
 use crate::template_builder::CoreTemplatePropertyKind;
 use crate::template_builder::CoreTemplatePropertyVar;
-use crate::template_builder::IntoTemplateProperty;
 use crate::template_builder::TemplateBuildMethodFnMap;
 use crate::template_builder::TemplateLanguage;
 use crate::template_parser;
@@ -151,9 +150,7 @@ impl OperationTemplatePropertyKind {
 
 impl CoreTemplatePropertyVar<'static> for OperationTemplatePropertyKind {
     template_builder::impl_core_wrap_property_fns!('static, OperationTemplatePropertyKind::Core);
-}
 
-impl IntoTemplateProperty<'static> for OperationTemplatePropertyKind {
     fn type_name(&self) -> &'static str {
         match self {
             OperationTemplatePropertyKind::Core(property) => property.type_name(),

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -134,19 +134,6 @@ impl OperationTemplateLanguage {
     pub fn cache_extension<T: Any>(&self) -> Option<&T> {
         self.cache_extensions.get::<T>()
     }
-
-    // TODO: delete
-    pub fn wrap_operation(
-        property: BoxedTemplateProperty<'static, Operation>,
-    ) -> OperationTemplatePropertyKind {
-        OperationTemplatePropertyKind::wrap_operation(property)
-    }
-
-    pub fn wrap_operation_id(
-        property: BoxedTemplateProperty<'static, OperationId>,
-    ) -> OperationTemplatePropertyKind {
-        OperationTemplatePropertyKind::wrap_operation_id(property)
-    }
 }
 
 pub enum OperationTemplatePropertyKind {
@@ -276,7 +263,7 @@ impl OperationTemplateBuildFnTable {
 }
 
 fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
-    type L = OperationTemplateLanguage;
+    type P = OperationTemplatePropertyKind;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = OperationTemplateBuildMethodFnMap::<Operation>::new();
@@ -286,7 +273,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
             function.expect_no_arguments()?;
             let current_op_id = language.current_op_id.clone();
             let out_property = self_property.map(move |op| Some(op.id()) == current_op_id.as_ref());
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -294,7 +281,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|op| op.metadata().description.clone());
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -302,7 +289,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|op| op.id().clone());
-            Ok(L::wrap_operation_id(out_property.into_dyn()))
+            Ok(P::wrap_operation_id(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -317,7 +304,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
                     .map(|(key, value)| format!("{key}: {value}"))
                     .join("\n")
             });
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -325,7 +312,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|op| op.metadata().is_snapshot);
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -336,7 +323,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
                 start: op.metadata().start_time,
                 end: op.metadata().end_time,
             });
-            Ok(L::wrap_timestamp_range(out_property.into_dyn()))
+            Ok(P::wrap_timestamp_range(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -347,7 +334,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
                 // TODO: introduce dedicated type and provide accessors?
                 format!("{}@{}", op.metadata().username, op.metadata().hostname)
             });
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map.insert(
@@ -356,7 +343,7 @@ fn builtin_operation_methods() -> OperationTemplateBuildMethodFnMap<Operation> {
             function.expect_no_arguments()?;
             let root_op_id = language.repo_loader.op_store().root_operation_id().clone();
             let out_property = self_property.map(move |op| op.id() == &root_op_id);
-            Ok(L::wrap_boolean(out_property.into_dyn()))
+            Ok(P::wrap_boolean(out_property.into_dyn()))
         },
     );
     map
@@ -369,7 +356,7 @@ impl Template for OperationId {
 }
 
 fn builtin_operation_id_methods() -> OperationTemplateBuildMethodFnMap<OperationId> {
-    type L = OperationTemplateLanguage;
+    type P = OperationTemplatePropertyKind;
     // Not using maplit::hashmap!{} or custom declarative macro here because
     // code completion inside macro is quite restricted.
     let mut map = OperationTemplateBuildMethodFnMap::<OperationId>::new();
@@ -392,7 +379,7 @@ fn builtin_operation_id_methods() -> OperationTemplateBuildMethodFnMap<Operation
                 hex.truncate(len.unwrap_or(12));
                 hex
             });
-            Ok(L::wrap_string(out_property.into_dyn()))
+            Ok(P::wrap_string(out_property.into_dyn()))
         },
     );
     map

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -30,6 +30,7 @@ use crate::template_builder::merge_fn_map;
 use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
 use crate::template_builder::CoreTemplatePropertyKind;
+use crate::template_builder::CoreTemplatePropertyVar;
 use crate::template_builder::IntoTemplateProperty;
 use crate::template_builder::TemplateBuildMethodFnMap;
 use crate::template_builder::TemplateLanguage;
@@ -87,8 +88,6 @@ impl OperationTemplateLanguage {
 
 impl TemplateLanguage<'static> for OperationTemplateLanguage {
     type Property = OperationTemplatePropertyKind;
-
-    template_builder::impl_core_wrap_property_fns!('static, OperationTemplatePropertyKind::Core);
 
     fn settings(&self) -> &UserSettings {
         self.repo_loader.settings()
@@ -153,6 +152,10 @@ pub enum OperationTemplatePropertyKind {
     Core(CoreTemplatePropertyKind<'static>),
     Operation(BoxedTemplateProperty<'static, Operation>),
     OperationId(BoxedTemplateProperty<'static, OperationId>),
+}
+
+impl CoreTemplatePropertyVar<'static> for OperationTemplatePropertyKind {
+    template_builder::impl_core_wrap_property_fns!('static, OperationTemplatePropertyKind::Core);
 }
 
 impl IntoTemplateProperty<'static> for OperationTemplatePropertyKind {

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -135,16 +135,17 @@ impl OperationTemplateLanguage {
         self.cache_extensions.get::<T>()
     }
 
+    // TODO: delete
     pub fn wrap_operation(
         property: BoxedTemplateProperty<'static, Operation>,
     ) -> OperationTemplatePropertyKind {
-        OperationTemplatePropertyKind::Operation(property)
+        OperationTemplatePropertyKind::wrap_operation(property)
     }
 
     pub fn wrap_operation_id(
         property: BoxedTemplateProperty<'static, OperationId>,
     ) -> OperationTemplatePropertyKind {
-        OperationTemplatePropertyKind::OperationId(property)
+        OperationTemplatePropertyKind::wrap_operation_id(property)
     }
 }
 
@@ -152,6 +153,13 @@ pub enum OperationTemplatePropertyKind {
     Core(CoreTemplatePropertyKind<'static>),
     Operation(BoxedTemplateProperty<'static, Operation>),
     OperationId(BoxedTemplateProperty<'static, OperationId>),
+}
+
+impl OperationTemplatePropertyKind {
+    template_builder::impl_wrap_property_fns!('static, OperationTemplatePropertyKind, {
+        pub wrap_operation(Operation) => Operation,
+        pub wrap_operation_id(OperationId) => OperationId,
+    });
 }
 
 impl CoreTemplatePropertyVar<'static> for OperationTemplatePropertyKind {

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -175,9 +175,15 @@ macro_rules! impl_core_wrap_property_fns {
 }
 
 macro_rules! impl_wrap_property_fns {
-    ($a:lifetime, $kind:path, $outer:path, { $( $func:ident($ty:ty) => $var:ident, )+ }) => {
+    ($a:lifetime, $kind:path, { $($body:tt)* }) => {
+        $crate::template_builder::impl_wrap_property_fns!(
+            $a, $kind, std::convert::identity, { $($body)* });
+    };
+    ($a:lifetime, $kind:path, $outer:path, {
+        $( $vis:vis $func:ident($ty:ty) => $var:ident, )+
+    }) => {
         $(
-            fn $func(
+            $vis fn $func(
                 property: $crate::templater::BoxedTemplateProperty<$a, $ty>,
             ) -> Self {
                 use $kind as Kind; // https://github.com/rust-lang/rust/issues/48067

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1419,7 +1419,7 @@ where
 
 /// Builds lambda expression to be evaluated with the provided arguments.
 /// `arg_fns` is usually an array of wrapped [`PropertyPlaceholder`]s.
-fn build_lambda_expression<'a, 'i, P: IntoTemplateProperty<'a>, T>(
+fn build_lambda_expression<'i, P, T>(
     build_ctx: &BuildContext<'i, P>,
     lambda: &LambdaNode<'i>,
     arg_fns: &[&'i dyn Fn() -> P],

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -68,22 +68,50 @@ use crate::time_util;
 
 /// Callbacks to build language-specific evaluation objects from AST nodes.
 pub trait TemplateLanguage<'a> {
-    type Property: IntoTemplateProperty<'a>;
+    type Property: CoreTemplatePropertyVar<'a> + IntoTemplateProperty<'a>;
 
-    fn wrap_string(property: BoxedTemplateProperty<'a, String>) -> Self::Property;
-    fn wrap_string_list(property: BoxedTemplateProperty<'a, Vec<String>>) -> Self::Property;
-    fn wrap_boolean(property: BoxedTemplateProperty<'a, bool>) -> Self::Property;
-    fn wrap_integer(property: BoxedTemplateProperty<'a, i64>) -> Self::Property;
-    fn wrap_integer_opt(property: BoxedTemplateProperty<'a, Option<i64>>) -> Self::Property;
-    fn wrap_config_value(property: BoxedTemplateProperty<'a, ConfigValue>) -> Self::Property;
-    fn wrap_signature(property: BoxedTemplateProperty<'a, Signature>) -> Self::Property;
-    fn wrap_email(property: BoxedTemplateProperty<'a, Email>) -> Self::Property;
-    fn wrap_size_hint(property: BoxedTemplateProperty<'a, SizeHint>) -> Self::Property;
-    fn wrap_timestamp(property: BoxedTemplateProperty<'a, Timestamp>) -> Self::Property;
-    fn wrap_timestamp_range(property: BoxedTemplateProperty<'a, TimestampRange>) -> Self::Property;
+    // TODO: delete
+    fn wrap_string(property: BoxedTemplateProperty<'a, String>) -> Self::Property {
+        Self::Property::wrap_string(property)
+    }
+    fn wrap_string_list(property: BoxedTemplateProperty<'a, Vec<String>>) -> Self::Property {
+        Self::Property::wrap_string_list(property)
+    }
+    fn wrap_boolean(property: BoxedTemplateProperty<'a, bool>) -> Self::Property {
+        Self::Property::wrap_boolean(property)
+    }
+    fn wrap_integer(property: BoxedTemplateProperty<'a, i64>) -> Self::Property {
+        Self::Property::wrap_integer(property)
+    }
+    fn wrap_integer_opt(property: BoxedTemplateProperty<'a, Option<i64>>) -> Self::Property {
+        Self::Property::wrap_integer_opt(property)
+    }
+    fn wrap_config_value(property: BoxedTemplateProperty<'a, ConfigValue>) -> Self::Property {
+        Self::Property::wrap_config_value(property)
+    }
+    fn wrap_signature(property: BoxedTemplateProperty<'a, Signature>) -> Self::Property {
+        Self::Property::wrap_signature(property)
+    }
+    fn wrap_email(property: BoxedTemplateProperty<'a, Email>) -> Self::Property {
+        Self::Property::wrap_email(property)
+    }
+    fn wrap_size_hint(property: BoxedTemplateProperty<'a, SizeHint>) -> Self::Property {
+        Self::Property::wrap_size_hint(property)
+    }
+    fn wrap_timestamp(property: BoxedTemplateProperty<'a, Timestamp>) -> Self::Property {
+        Self::Property::wrap_timestamp(property)
+    }
+    fn wrap_timestamp_range(property: BoxedTemplateProperty<'a, TimestampRange>) -> Self::Property {
+        Self::Property::wrap_timestamp_range(property)
+    }
 
-    fn wrap_template(template: Box<dyn Template + 'a>) -> Self::Property;
-    fn wrap_list_template(template: Box<dyn ListTemplate + 'a>) -> Self::Property;
+    // TODO: delete
+    fn wrap_template(template: Box<dyn Template + 'a>) -> Self::Property {
+        Self::Property::wrap_template(template)
+    }
+    fn wrap_list_template(template: Box<dyn ListTemplate + 'a>) -> Self::Property {
+        Self::Property::wrap_list_template(template)
+    }
 
     fn settings(&self) -> &UserSettings;
 
@@ -107,7 +135,7 @@ pub trait TemplateLanguage<'a> {
     ) -> TemplateParseResult<Self::Property>;
 }
 
-/// Implements `TemplateLanguage::wrap_<type>()` functions.
+/// Implements `CoreTemplatePropertyVar::wrap_<type>()` functions.
 ///
 /// - `impl_core_wrap_property_fns('a)` for `CoreTemplatePropertyKind`,
 /// - `impl_core_wrap_property_fns('a, MyKind::Core)` for `MyKind::Core(..)`.
@@ -133,13 +161,13 @@ macro_rules! impl_core_wrap_property_fns {
         );
         fn wrap_template(
             template: Box<dyn $crate::templater::Template + $a>,
-        ) -> Self::Property {
+        ) -> Self {
             use $crate::template_builder::CoreTemplatePropertyKind as Kind;
             $outer(Kind::Template(template))
         }
         fn wrap_list_template(
             template: Box<dyn $crate::templater::ListTemplate + $a>,
-        ) -> Self::Property {
+        ) -> Self {
             use $crate::template_builder::CoreTemplatePropertyKind as Kind;
             $outer(Kind::ListTemplate(template))
         }
@@ -151,7 +179,7 @@ macro_rules! impl_wrap_property_fns {
         $(
             fn $func(
                 property: $crate::templater::BoxedTemplateProperty<$a, $ty>,
-            ) -> Self::Property {
+            ) -> Self {
                 use $kind as Kind; // https://github.com/rust-lang/rust/issues/48067
                 $outer(Kind::$var(property))
             }
@@ -162,7 +190,26 @@ macro_rules! impl_wrap_property_fns {
 pub(crate) use impl_core_wrap_property_fns;
 pub(crate) use impl_wrap_property_fns;
 
+/// Wrapper for the core template property types.
+pub trait CoreTemplatePropertyVar<'a> {
+    fn wrap_string(property: BoxedTemplateProperty<'a, String>) -> Self;
+    fn wrap_string_list(property: BoxedTemplateProperty<'a, Vec<String>>) -> Self;
+    fn wrap_boolean(property: BoxedTemplateProperty<'a, bool>) -> Self;
+    fn wrap_integer(property: BoxedTemplateProperty<'a, i64>) -> Self;
+    fn wrap_integer_opt(property: BoxedTemplateProperty<'a, Option<i64>>) -> Self;
+    fn wrap_config_value(property: BoxedTemplateProperty<'a, ConfigValue>) -> Self;
+    fn wrap_signature(property: BoxedTemplateProperty<'a, Signature>) -> Self;
+    fn wrap_email(property: BoxedTemplateProperty<'a, Email>) -> Self;
+    fn wrap_size_hint(property: BoxedTemplateProperty<'a, SizeHint>) -> Self;
+    fn wrap_timestamp(property: BoxedTemplateProperty<'a, Timestamp>) -> Self;
+    fn wrap_timestamp_range(property: BoxedTemplateProperty<'a, TimestampRange>) -> Self;
+
+    fn wrap_template(template: Box<dyn Template + 'a>) -> Self;
+    fn wrap_list_template(template: Box<dyn ListTemplate + 'a>) -> Self;
+}
+
 /// Provides access to basic template property types.
+// TODO: merge with CoreTemplatePropertyVar<'a>?
 pub trait IntoTemplateProperty<'a> {
     /// Type name of the property output.
     fn type_name(&self) -> &'static str;

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -68,7 +68,7 @@ use crate::time_util;
 
 /// Callbacks to build language-specific evaluation objects from AST nodes.
 pub trait TemplateLanguage<'a> {
-    type Property: CoreTemplatePropertyVar<'a> + IntoTemplateProperty<'a>;
+    type Property: CoreTemplatePropertyVar<'a>;
 
     fn settings(&self) -> &UserSettings;
 
@@ -169,11 +169,7 @@ pub trait CoreTemplatePropertyVar<'a> {
 
     fn wrap_template(template: Box<dyn Template + 'a>) -> Self;
     fn wrap_list_template(template: Box<dyn ListTemplate + 'a>) -> Self;
-}
 
-/// Provides access to basic template property types.
-// TODO: merge with CoreTemplatePropertyVar<'a>?
-pub trait IntoTemplateProperty<'a> {
     /// Type name of the property output.
     fn type_name(&self) -> &'static str;
 
@@ -217,7 +213,9 @@ pub enum CoreTemplatePropertyKind<'a> {
     ListTemplate(Box<dyn ListTemplate + 'a>),
 }
 
-impl<'a> IntoTemplateProperty<'a> for CoreTemplatePropertyKind<'a> {
+impl<'a> CoreTemplatePropertyVar<'a> for CoreTemplatePropertyKind<'a> {
+    impl_core_wrap_property_fns!('a);
+
     fn type_name(&self) -> &'static str {
         match self {
             CoreTemplatePropertyKind::String(_) => "String",
@@ -591,7 +589,7 @@ impl<P> Expression<P> {
     }
 }
 
-impl<'a, P: IntoTemplateProperty<'a>> Expression<P> {
+impl<'a, P: CoreTemplatePropertyVar<'a>> Expression<P> {
     pub fn type_name(&self) -> &'static str {
         self.property.type_name()
     }


### PR DESCRIPTION

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
