### PR TITLE
builtin merge-tool: fix edge cases found by property-based testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj` will no longer warn about deprecated paths on macOS if the configured
   XDG directory is the deprecated one (~/Library/Application Support).
 
+* The builtin diff editor now correctly handles splitting changes where a file is
+  replaced by a directory of the same name.
+  [#5189](https://github.com/jj-vcs/jj/issues/5189)
+
 ### Packaging changes
 
 * Due to the removal of the `libgit2` code path, packagers should

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -863,17 +863,11 @@ mod tests {
 
         let added_executable_file_path = repo_path("executable_file");
         let left_tree = testutils::create_tree(&test_repo.repo, &[]);
-        let right_tree = {
-            // let store = test_repo.repo.store();
-            let mut tree_builder = store.tree_builder(store.empty_tree_id().clone());
-            testutils::write_executable_file(
-                &mut tree_builder,
-                added_executable_file_path,
-                "executable",
-            );
-            let id = tree_builder.write_tree().unwrap();
-            MergedTree::resolved(store.get_tree(RepoPathBuf::root(), &id).unwrap())
-        };
+        let right_tree = testutils::create_tree_with(&test_repo.repo, |builder| {
+            builder
+                .file(added_executable_file_path, "executable")
+                .executable(true);
+        });
 
         let (changed_files, files) = make_diff(store, &left_tree, &right_tree);
         insta::assert_debug_snapshot!(changed_files, @r#"

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -341,6 +341,18 @@ async fn make_diff_files(
                 sections.extend(make_diff_sections(&old_contents, &new_contents)?);
             }
 
+            (
+                FileContents::Binary {
+                    hash: Some(left_hash),
+                    ..
+                },
+                FileContents::Binary {
+                    hash: Some(right_hash),
+                    ..
+                },
+            ) if left_hash == right_hash => {
+                // Binary file contents have not changed.
+            }
             (left, right @ FileContents::Binary { .. })
             | (left @ FileContents::Binary { .. }, right) => {
                 sections.push(scm_record::Section::Binary {

--- a/lib/src/repo_path.rs
+++ b/lib/src/repo_path.rs
@@ -427,6 +427,10 @@ impl RepoPath {
         RepoPathComponentsIter { value: &self.value }
     }
 
+    pub fn ancestors(&self) -> impl Iterator<Item = &RepoPath> {
+        std::iter::successors(Some(self), |path| path.parent())
+    }
+
     pub fn join(&self, entry: &RepoPathComponent) -> RepoPathBuf {
         let value = if self.value.is_empty() {
             entry.as_internal_str().to_owned()
@@ -887,6 +891,22 @@ mod tests {
         assert_eq!(
             repo_path("dir/subdir").components().rev().collect_vec(),
             vec![repo_path_component("subdir"), repo_path_component("dir")]
+        );
+    }
+
+    #[test]
+    fn test_ancestors() {
+        assert_eq!(
+            RepoPath::root().ancestors().collect_vec(),
+            vec![RepoPath::root()]
+        );
+        assert_eq!(
+            repo_path("dir").ancestors().collect_vec(),
+            vec![repo_path("dir"), RepoPath::root()]
+        );
+        assert_eq!(
+            repo_path("dir/subdir").ancestors().collect_vec(),
+            vec![repo_path("dir/subdir"), repo_path("dir"), RepoPath::root()]
         );
     }
 

--- a/lib/tests/test_fix.rs
+++ b/lib/tests/test_fix.rs
@@ -14,9 +14,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::sync::Arc;
 
-use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 use jj_lib::backend::FileId;
 use jj_lib::backend::MergedTreeId;
@@ -26,13 +24,12 @@ use jj_lib::fix::FileToFix;
 use jj_lib::fix::FixError;
 use jj_lib::fix::ParallelFileFixer;
 use jj_lib::matchers::EverythingMatcher;
-use jj_lib::merged_tree::MergedTree;
-use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
 use jj_lib::store::Store;
 use jj_lib::transaction::Transaction;
 use pollster::FutureExt as _;
 use testutils::create_tree;
+use testutils::create_tree_with;
 use testutils::read_file;
 use testutils::repo_path;
 use testutils::TestRepo;
@@ -91,17 +88,6 @@ fn fix_file(store: &Store, file_to_fix: &FileToFix) -> Result<Option<FileId>, Fi
     } else {
         Ok(None)
     }
-}
-
-fn create_tree_helper(
-    repo: &Arc<ReadonlyRepo>,
-    path_and_content: &[(String, String)],
-) -> MergedTree {
-    let content_map = path_and_content
-        .iter()
-        .map(|p| (repo_path(&p.0), p.1.as_str()))
-        .collect_vec();
-    create_tree(repo, &content_map)
 }
 
 fn create_commit(tx: &mut Transaction, parents: Vec<CommitId>, tree_id: MergedTreeId) -> CommitId {
@@ -418,13 +404,11 @@ fn test_parallel_fixer_fixes_files() {
     let repo = &test_repo.repo;
 
     let mut tx = repo.start_transaction();
-    let mut path_contents1 = vec![];
-    for i in 0..100 {
-        let path = format!("file{i}");
-        let content = format!("fixme:content{i}");
-        path_contents1.push((path, content));
-    }
-    let tree1 = create_tree_helper(repo, &path_contents1);
+    let tree1 = create_tree_with(repo, |builder| {
+        for i in 0..100 {
+            builder.file(repo_path(&format!("file{i}")), format!("fixme:content{i}"));
+        }
+    });
     let commit_a = create_commit(
         &mut tx,
         vec![repo.store().root_commit_id().clone()],
@@ -444,13 +428,11 @@ fn test_parallel_fixer_fixes_files() {
     )
     .unwrap();
 
-    let mut expected_path_contents = vec![];
-    for i in 0..100 {
-        let path = format!("file{i}");
-        let content = format!("CONTENT{i}");
-        expected_path_contents.push((path, content));
-    }
-    let expected_tree_a = create_tree_helper(repo, &expected_path_contents);
+    let expected_tree_a = create_tree_with(repo, |builder| {
+        for i in 0..100 {
+            builder.file(repo_path(&format!("file{i}")), format!("CONTENT{i}"));
+        }
+    });
 
     assert_eq!(summary.rewrites.len(), 1);
     assert!(summary.rewrites.contains_key(&commit_a));
@@ -470,13 +452,11 @@ fn test_parallel_fixer_does_not_change_content() {
     let repo = &test_repo.repo;
 
     let mut tx = repo.start_transaction();
-    let mut path_contents1 = vec![];
-    for i in 0..100 {
-        let path = format!("file{i}");
-        let content = format!("content{i}");
-        path_contents1.push((path, content));
-    }
-    let tree1 = create_tree_helper(repo, &path_contents1);
+    let tree1 = create_tree_with(repo, |builder| {
+        for i in 0..100 {
+            builder.file(repo_path(&format!("file{i}")), format!("content{i}"));
+        }
+    });
     let commit_a = create_commit(
         &mut tx,
         vec![repo.store().root_commit_id().clone()],
@@ -507,19 +487,19 @@ fn test_parallel_fixer_no_changes_upon_partial_failure() {
     let repo = &test_repo.repo;
 
     let mut tx = repo.start_transaction();
-    let mut path_contents1 = vec![];
-    for i in 0..100 {
-        let path = format!("file{i}");
-        let content = if i == 7 {
-            format!("error:boo{i}")
-        } else if i % 3 == 0 {
-            format!("fixme:content{i}")
-        } else {
-            format!("foobar:{i}")
-        };
-        path_contents1.push((path, content));
-    }
-    let tree1 = create_tree_helper(repo, &path_contents1);
+    let tree1 = create_tree_with(repo, |builder| {
+        for i in 0..100 {
+            let contents = if i == 7 {
+                format!("error:boo{i}")
+            } else if i % 3 == 0 {
+                format!("fixme:content{i}")
+            } else {
+                format!("foobar:{i}")
+            };
+
+            builder.file(repo_path(&format!("file{i}")), &contents);
+        }
+    });
     let commit_a = create_commit(
         &mut tx,
         vec![repo.store().root_commit_id().clone()],

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -55,6 +55,7 @@ use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::commit_with_tree;
 use testutils::create_tree;
+use testutils::create_tree_with;
 use testutils::repo_path;
 use testutils::repo_path_buf;
 use testutils::repo_path_component;
@@ -565,7 +566,13 @@ fn test_tree_builder_file_directory_transition() {
 
     // Add file at parent_path
     let mut tree_builder = store.tree_builder(store.empty_tree_id().clone());
-    testutils::write_normal_file(&mut tree_builder, parent_path, "");
+    tree_builder.set(
+        parent_path.to_owned(),
+        TreeValue::File {
+            id: testutils::write_file(store, parent_path, ""),
+            executable: false,
+        },
+    );
     let tree_id = tree_builder.write_tree().unwrap();
     check_out_tree(&tree_id);
     assert!(parent_path.to_fs_path_unchecked(&workspace_root).is_file());
@@ -574,7 +581,13 @@ fn test_tree_builder_file_directory_transition() {
     // Turn parent_path into directory, add file at child_path
     let mut tree_builder = store.tree_builder(tree_id);
     tree_builder.remove(parent_path.to_owned());
-    testutils::write_normal_file(&mut tree_builder, child_path, "");
+    tree_builder.set(
+        child_path.to_owned(),
+        TreeValue::File {
+            id: testutils::write_file(store, child_path, ""),
+            executable: false,
+        },
+    );
     let tree_id = tree_builder.write_tree().unwrap();
     check_out_tree(&tree_id);
     assert!(parent_path.to_fs_path_unchecked(&workspace_root).is_dir());
@@ -583,7 +596,13 @@ fn test_tree_builder_file_directory_transition() {
     // Turn parent_path back to file
     let mut tree_builder = store.tree_builder(tree_id);
     tree_builder.remove(child_path.to_owned());
-    testutils::write_normal_file(&mut tree_builder, parent_path, "");
+    tree_builder.set(
+        parent_path.to_owned(),
+        TreeValue::File {
+            id: testutils::write_file(store, parent_path, ""),
+            executable: false,
+        },
+    );
     let tree_id = tree_builder.write_tree().unwrap();
     check_out_tree(&tree_id);
     assert!(parent_path.to_fs_path_unchecked(&workspace_root).is_file());
@@ -1198,32 +1217,6 @@ fn test_gitignores_ignored_directory_already_tracked() {
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
     let repo = test_workspace.repo.clone();
 
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    enum Kind {
-        Normal,
-        Executable,
-        Symlink,
-    }
-    let create_tree_with_kind = |path_contents: &[(&RepoPath, Kind, &str)]| {
-        let store = repo.store();
-        let mut tree_builder = store.tree_builder(store.empty_tree_id().clone());
-        for (path, kind, contents) in path_contents {
-            match kind {
-                Kind::Normal => {
-                    testutils::write_normal_file(&mut tree_builder, path, contents);
-                }
-                Kind::Executable => {
-                    testutils::write_executable_file(&mut tree_builder, path, contents);
-                }
-                Kind::Symlink => {
-                    testutils::write_symlink(&mut tree_builder, path, contents);
-                }
-            }
-        }
-        let id = tree_builder.write_tree().unwrap();
-        MergedTree::resolved(store.get_tree(RepoPathBuf::root(), &id).unwrap())
-    };
-
     let gitignore_path = repo_path(".gitignore");
     let unchanged_normal_path = repo_path("ignored/unchanged_normal");
     let modified_normal_path = repo_path("ignored/modified_normal");
@@ -1234,18 +1227,24 @@ fn test_gitignores_ignored_directory_already_tracked() {
     let unchanged_symlink_path = repo_path("ignored/unchanged_symlink");
     let modified_symlink_path = repo_path("ignored/modified_symlink");
     let deleted_symlink_path = repo_path("ignored/deleted_symlink");
-    let tree = create_tree_with_kind(&[
-        (gitignore_path, Kind::Normal, "/ignored/\n"),
-        (unchanged_normal_path, Kind::Normal, "contents"),
-        (modified_normal_path, Kind::Normal, "contents"),
-        (deleted_normal_path, Kind::Normal, "contents"),
-        (unchanged_executable_path, Kind::Executable, "contents"),
-        (modified_executable_path, Kind::Executable, "contents"),
-        (deleted_executable_path, Kind::Executable, "contents"),
-        (unchanged_symlink_path, Kind::Symlink, "contents"),
-        (modified_symlink_path, Kind::Symlink, "contents"),
-        (deleted_symlink_path, Kind::Symlink, "contents"),
-    ]);
+    let tree = create_tree_with(&repo, |builder| {
+        builder.file(gitignore_path, "/ignored/\n");
+        builder.file(unchanged_normal_path, "contents");
+        builder.file(modified_normal_path, "contents");
+        builder.file(deleted_normal_path, "contents");
+        builder
+            .file(unchanged_executable_path, "contents")
+            .executable(true);
+        builder
+            .file(modified_executable_path, "contents")
+            .executable(true);
+        builder
+            .file(deleted_executable_path, "contents")
+            .executable(true);
+        builder.symlink(unchanged_symlink_path, "contents");
+        builder.symlink(modified_symlink_path, "contents");
+        builder.symlink(deleted_symlink_path, "contents");
+    });
     let commit = commit_with_tree(repo.store(), tree.id());
 
     // Check out the tree with the files in `ignored/`
@@ -1282,15 +1281,19 @@ fn test_gitignores_ignored_directory_already_tracked() {
     }
     std::fs::remove_file(deleted_symlink_path.to_fs_path_unchecked(&workspace_root)).unwrap();
     let new_tree = test_workspace.snapshot().unwrap();
-    let expected_tree = create_tree_with_kind(&[
-        (gitignore_path, Kind::Normal, "/ignored/\n"),
-        (unchanged_normal_path, Kind::Normal, "contents"),
-        (modified_normal_path, Kind::Normal, "modified"),
-        (unchanged_executable_path, Kind::Executable, "contents"),
-        (modified_executable_path, Kind::Executable, "modified"),
-        (unchanged_symlink_path, Kind::Symlink, "contents"),
-        (modified_symlink_path, Kind::Symlink, "modified"),
-    ]);
+    let expected_tree = create_tree_with(&repo, |builder| {
+        builder.file(gitignore_path, "/ignored/\n");
+        builder.file(unchanged_normal_path, "contents");
+        builder.file(modified_normal_path, "modified");
+        builder
+            .file(unchanged_executable_path, "contents")
+            .executable(true);
+        builder
+            .file(modified_executable_path, "modified")
+            .executable(true);
+        builder.symlink(unchanged_symlink_path, "contents");
+        builder.symlink(modified_symlink_path, "modified");
+    });
     assert_eq!(tree_entries(&new_tree), tree_entries(&expected_tree));
 }
 
@@ -1981,13 +1984,11 @@ fn test_check_out_reserved_file_path_vfat(vfat_path_str: &str, file_path_strs: &
 
     let vfat_disk_path = workspace_root.join(vfat_path_str);
     let file_paths = file_path_strs.iter().map(|&s| repo_path(s)).collect_vec();
-    let tree1 = create_tree(
-        repo,
-        &file_paths
-            .iter()
-            .map(|&path| (path, "contents"))
-            .collect_vec(),
-    );
+    let tree1 = create_tree_with(repo, |builder| {
+        for path in file_paths {
+            builder.file(path, "contents");
+        }
+    });
     let tree2 = create_tree(repo, &[]);
     let commit1 = commit_with_tree(repo.store(), tree1.id());
     let commit2 = commit_with_tree(repo.store(), tree2.id());

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -44,6 +44,7 @@ use testutils::assert_abandoned_with_parent;
 use testutils::assert_rebased_onto;
 use testutils::create_random_commit;
 use testutils::create_tree;
+use testutils::create_tree_with;
 use testutils::rebase_descendants_with_options_return_map;
 use testutils::repo_path;
 use testutils::write_random_commit;
@@ -1661,8 +1662,11 @@ fn test_empty_commit_option(empty_behavior: EmptyBehaviour) {
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let create_fixed_tree = |paths: &[&str]| {
-        let content_map = paths.iter().map(|&p| (repo_path(p), p)).collect_vec();
-        create_tree(repo, &content_map)
+        create_tree_with(repo, |builder| {
+            for path in paths {
+                builder.file(repo_path(path), path);
+            }
+        })
     };
 
     // The commit_with_parents function generates non-empty merge commits, so it


### PR DESCRIPTION
Fixes #5189. As discussed in the issue, I went ahead with property-based testing and followed the state machine approach mentioned by @arxanas. Thanks for the pointers you gave in https://github.com/jj-vcs/jj/issues/5189#issuecomment-2836104306; they were quite helpful to get my head wrapped around it.

You mentioned that it would be nice to create working copy states for other tests. AFAIU the split been the `ReferenceStateMachine` and `StateMachineTest` traits in `proptest-state-machine` is intended to facilitate this kind of reuse of the reference state machine while keeping the test's state separate, so I've created a dedicated `proptest` module in `testutils` containing the data structure implementing `ReferenceStateMachine` the and associated strategies. The `StateMachineTest` implementation in `merge_tools::builtin` then applies the same transitions to its domain by manipulating the "right" `MergedTree`; another implementation could pick a different architectual flight level.

Regarding the state machine modeling:

- The transitions `CreateFile`/`DeleteFile` are implemented in a way that they don't require the path to be vacant/extant. `CreateFile` will overwrite existing files or even directories (as in the case of the issue) and `DeleteFile` is a no-op if the file does not exist. Of course, the strategies will generate the transitions such that `CreateFile` references a random file in an existing directory and `DeleteFile` references an existing file, but collisions might happen and shrinking can make existing files disappear (or even new ones appear, if a prior `DeleteFile` transition has been shrunk away). It is possible to impose preconditions for transitions and I did so at first but I've found that this really impedes the exploration of the state space and leads into dead ends when shrinking, presumably because the initial state can no longer be shrunk independently from the transitions and vice versa. This is a little hard to explain without going too deep; feel free to hit me up on Discord.
  
- I've not found a great way to test for other properties than what is done in the existing manual tests: selecting none of the changes produces the left tree, selecting them all produces the right tree. As mentioned in the discussion of the issue, it might make sense to apply only some changes, produce an intermediate tree, then apply the remaining changes to go all the way to the right tree. Usually, this sort of thing should be a perfect fit for proptesting but I've struggled to reconcile this with the state machine approach.
  
- The present incarnation is pretty limited to the issue at hand. There are several ways to expand on that (some of which you already mentioned). One thing that I _did_ include is file mode (well, at least the executable flag) and this promptly found another issue that is also fixed in this PR (in the last commit). (File mode was not covered by the manual tests so far because `testutils::create_tree` didn't account for it.)
  

The fix for the original issue is in the penultimate `tree_builder: ignore tombstone overrides on nested trees`. I've also added a regular regression test for this particular scenario. (Proptest docs recommend adding regular tests for known regressions as changes in the strategies effectively invalidate the checked-in seeds).

I'm not super happy with the fixes for either of the bugs. In both cases, it is the best thing I could do given the information that scm-record produces. I've highlighted the pain points in the ~commit messages~ change descriptions; perhaps you can judge for yourself whether to take any of that upstream.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to cover my changes
