### PR TITLE
docs: update git compatibility docs for commit signing

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -68,9 +68,9 @@ a comparison with Git, including how workflows are different, see the
   copies backed by a single repo. See the `jj workspace` family of commands.
 * **Sparse checkouts: No.** However, there's native support for sparse
   checkouts. See the `jj sparse` command.
-* **Signed commits: Partial.**
-  So far only [by configuration](https://github.com/jj-vcs/jj/blob/main/docs/config.md#commit-signing),
-  later perhaps [a command](https://github.com/jj-vcs/jj/pull/3142).
+* **Signed commits: Yes.**
+  You can sign commits automatically [by configuration](https://github.com/jj-vcs/jj/blob/main/docs/config.md#commit-signing),
+  or use the `jj sign` command.
 * **Git LFS: No.** ([#80](https://github.com/jj-vcs/jj/issues/80))
 
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

I noticed that the docs for signed commits in https://jj-vcs.github.io/jj/v0.28.0/git-compatibility/#supported-features are outdated. The `jj sign` command is now supported.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
