### PR TITLE
changelog: remove redundant entry about macOS config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,10 +90,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fixed bash and zsh shell completion when completing aliases of multiple arguments.
   [#5377](https://github.com/jj-vcs/jj/issues/5377)
 
-* On macOS, jj now defaults to looking for its config in `$XDG_CONFIG_HOME`
-  (`~/.config` by default) rather than the more GUI-native
-  `~/Library/Application Support`.
-
 ### Packaging changes
 
 * Jujutsu now uses


### PR DESCRIPTION
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
