### PR TITLE
split: implement -A/-B/-d flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj split` has gained a `--message` option to set the description of the
   commit with the selected changes.
 
+* `jj split` has gained the ability to place the revision with the selected changes
+  anywhere in the revision tree with the `--insert-before`, `--insert-after` and
+  `--destination` command line flags.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -562,6 +562,7 @@ fn print_move_commits_stats(ui: &Ui, stats: &MoveCommitsStats) -> std::io::Resul
         num_rebased_descendants,
         num_skipped_rebases,
         num_abandoned,
+        rebased_commits: _,
     } = stats;
     if num_skipped_rebases > 0 {
         writeln!(

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -11,16 +11,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::collections::HashMap;
 use std::io::Write as _;
 
 use clap_complete::ArgValueCompleter;
+use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
 use jj_lib::matchers::Matcher;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
+use jj_lib::rewrite::move_commits;
 use jj_lib::rewrite::CommitWithSelection;
+use jj_lib::rewrite::EmptyBehaviour;
+use jj_lib::rewrite::MoveCommitsLocation;
+use jj_lib::rewrite::MoveCommitsTarget;
+use jj_lib::rewrite::RebaseOptions;
+use jj_lib::rewrite::RebasedCommit;
+use jj_lib::rewrite::RewriteRefsOptions;
 use tracing::instrument;
 
+use crate::cli_util::compute_commit_location;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::DiffSelector;
 use crate::cli_util::RevisionArg;
@@ -70,6 +80,40 @@ pub(crate) struct SplitArgs {
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
     revision: RevisionArg,
+    /// The revision(s) to rebase onto (can be repeated to create a merge
+    /// commit)
+    #[arg(
+        long,
+        short,
+        conflicts_with = "parallel",
+        value_name = "REVSETS",
+        add = ArgValueCompleter::new(complete::revset_expression_all),
+    )]
+    destination: Option<Vec<RevisionArg>>,
+    /// The revision(s) to insert after (can be repeated to create a merge
+    /// commit)
+    #[arg(
+        long,
+        short = 'A',
+        visible_alias = "after",
+        conflicts_with = "destination",
+        conflicts_with = "parallel",
+        value_name = "REVSETS",
+        add = ArgValueCompleter::new(complete::revset_expression_all),
+    )]
+    insert_after: Option<Vec<RevisionArg>>,
+    /// The revision(s) to insert before (can be repeated to create a merge
+    /// commit)
+    #[arg(
+        long,
+        short = 'B',
+        visible_alias = "before",
+        conflicts_with = "destination",
+        conflicts_with = "parallel",
+        value_name = "REVSETS",
+        add = ArgValueCompleter::new(complete::revset_expression_mutable),
+    )]
+    insert_before: Option<Vec<RevisionArg>>,
     /// The change description to use (don't open editor)
     ///
     /// The description is used for the commit with the selected changes. The
@@ -116,11 +160,29 @@ impl SplitArgs {
             self.tool.as_deref(),
             self.interactive || self.paths.is_empty(),
         )?;
+        let use_move_flags = self.destination.is_some()
+            || self.insert_after.is_some()
+            || self.insert_before.is_some();
+        let (new_parent_ids, new_child_ids) = if use_move_flags {
+            compute_commit_location(
+                ui,
+                workspace_command,
+                self.destination.as_deref(),
+                self.insert_after.as_deref(),
+                self.insert_before.as_deref(),
+                "split-out commit",
+            )?
+        } else {
+            Default::default()
+        };
         Ok(ResolvedSplitArgs {
             target_commit,
             matcher,
             diff_selector,
             parallel: self.parallel,
+            use_move_flags,
+            new_parent_ids,
+            new_child_ids,
         })
     }
 }
@@ -130,6 +192,9 @@ struct ResolvedSplitArgs {
     matcher: Box<dyn Matcher>,
     diff_selector: DiffSelector,
     parallel: bool,
+    use_move_flags: bool,
+    new_parent_ids: Vec<CommitId>,
+    new_child_ids: Vec<CommitId>,
 }
 
 #[instrument(skip_all)]
@@ -144,6 +209,9 @@ pub(crate) fn cmd_split(
         matcher,
         diff_selector,
         parallel,
+        use_move_flags,
+        new_parent_ids,
+        new_child_ids,
     } = args.resolve(ui, &workspace_command)?;
     let text_editor = workspace_command.text_editor()?;
     let mut tx = workspace_command.start_transaction();
@@ -155,6 +223,12 @@ pub(crate) fn cmd_split(
     let first_commit = {
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder.set_tree_id(target.selected_tree.id());
+        if use_move_flags {
+            commit_builder
+                // Generate a new change id so that the commit being split doesn't
+                // become divergent.
+                .generate_new_change_id();
+        }
         let description = if !args.message_paragraphs.is_empty() {
             let description = join_message_paragraphs(&args.message_paragraphs);
             if !description.is_empty() {
@@ -183,7 +257,7 @@ pub(crate) fn cmd_split(
     // select.
     let second_commit = {
         let target_tree = target.commit.tree()?;
-        let new_tree = if args.parallel {
+        let new_tree = if parallel {
             // Merge the original commit tree with its parent using the tree
             // containing the user selected changes as the base for the merge.
             // This results in a tree with the changes the user didn't select.
@@ -199,10 +273,13 @@ pub(crate) fn cmd_split(
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder
             .set_parents(parents)
-            .set_tree_id(new_tree.id())
-            // Generate a new change id so that the commit being split doesn't
-            // become divergent.
-            .generate_new_change_id();
+            .set_tree_id(new_tree.id());
+        if !use_move_flags {
+            commit_builder
+                // Generate a new change id so that the commit being split doesn't
+                // become divergent.
+                .generate_new_change_id();
+        }
         let description = if target.commit.description().is_empty() {
             // If there was no description before, don't ask for one for the
             // second commit.
@@ -226,6 +303,106 @@ pub(crate) fn cmd_split(
         commit_builder.write(tx.repo_mut())?
     };
 
+    let (first_commit, second_commit, num_rebased) = if use_move_flags {
+        move_first_commit(
+            &mut tx,
+            &target,
+            first_commit,
+            second_commit,
+            new_parent_ids,
+            new_child_ids,
+        )?
+    } else {
+        rewrite_descendants(&mut tx, &target, first_commit, second_commit, parallel)?
+    };
+    if let Some(mut formatter) = ui.status_formatter() {
+        if num_rebased > 0 {
+            writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
+        }
+        write!(formatter, "First part: ")?;
+        tx.write_commit_summary(formatter.as_mut(), &first_commit)?;
+        write!(formatter, "\nSecond part: ")?;
+        tx.write_commit_summary(formatter.as_mut(), &second_commit)?;
+        writeln!(formatter)?;
+    }
+    tx.finish(ui, format!("split commit {}", target.commit.id().hex()))?;
+    Ok(())
+}
+
+fn move_first_commit(
+    tx: &mut WorkspaceCommandTransaction,
+    target: &CommitWithSelection,
+    mut first_commit: Commit,
+    mut second_commit: Commit,
+    new_parent_ids: Vec<CommitId>,
+    new_child_ids: Vec<CommitId>,
+) -> Result<(Commit, Commit, usize), CommandError> {
+    let mut rewritten_commits: HashMap<CommitId, CommitId> = HashMap::new();
+    rewritten_commits.insert(target.commit.id().clone(), second_commit.id().clone());
+    tx.repo_mut()
+        .transform_descendants(vec![target.commit.id().clone()], |rewriter| {
+            let old_commit_id = rewriter.old_commit().id().clone();
+            let new_commit = rewriter.rebase()?.write()?;
+            rewritten_commits.insert(old_commit_id, new_commit.id().clone());
+            Ok(())
+        })?;
+
+    let new_parent_ids: Vec<_> = new_parent_ids
+        .iter()
+        .map(|commit_id| rewritten_commits.get(commit_id).unwrap_or(commit_id))
+        .cloned()
+        .collect();
+    let new_child_ids: Vec<_> = new_child_ids
+        .iter()
+        .map(|commit_id| rewritten_commits.get(commit_id).unwrap_or(commit_id))
+        .cloned()
+        .collect();
+    let stats = move_commits(
+        tx.repo_mut(),
+        &MoveCommitsLocation {
+            new_parent_ids,
+            new_child_ids,
+            target: MoveCommitsTarget::Commits(vec![first_commit.id().clone()]),
+        },
+        &RebaseOptions {
+            empty: EmptyBehaviour::Keep,
+            rewrite_refs: RewriteRefsOptions {
+                delete_abandoned_bookmarks: false,
+            },
+            simplify_ancestor_merge: false,
+        },
+    )?;
+
+    // 1 for the transformation of the original commit to the second commit
+    // that was inserted in rewritten_commits
+    let mut num_new_rebased = 1;
+    if let Some(RebasedCommit::Rewritten(commit)) = stats.rebased_commits.get(first_commit.id()) {
+        first_commit = commit.clone();
+        num_new_rebased += 1;
+    }
+    if let Some(RebasedCommit::Rewritten(commit)) = stats.rebased_commits.get(second_commit.id()) {
+        second_commit = commit.clone();
+    }
+
+    let num_rebased = rewritten_commits.len() + stats.rebased_commits.len()
+        // don't count the commit generated by the split in the rebased commits
+        - num_new_rebased
+        // only count once a commit that may have been rewritten twice in the process
+        - rewritten_commits
+            .iter()
+            .filter(|(_, rewritten)| stats.rebased_commits.contains_key(rewritten))
+            .count();
+
+    Ok((first_commit, second_commit, num_rebased))
+}
+
+fn rewrite_descendants(
+    tx: &mut WorkspaceCommandTransaction,
+    target: &CommitWithSelection,
+    first_commit: Commit,
+    second_commit: Commit,
+    parallel: bool,
+) -> Result<(Commit, Commit, usize), CommandError> {
     let legacy_bookmark_behavior = tx.settings().get_bool("split.legacy-bookmark-behavior")?;
     if legacy_bookmark_behavior {
         // Mark the commit being split as rewritten to the second commit. This
@@ -258,18 +435,7 @@ pub(crate) fn cmd_split(
         }
     }
 
-    if let Some(mut formatter) = ui.status_formatter() {
-        if num_rebased > 0 {
-            writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
-        }
-        write!(formatter, "First part: ")?;
-        tx.write_commit_summary(formatter.as_mut(), &first_commit)?;
-        write!(formatter, "\nSecond part: ")?;
-        tx.write_commit_summary(formatter.as_mut(), &second_commit)?;
-        writeln!(formatter)?;
-    }
-    tx.finish(ui, format!("split commit {}", target.commit.id().hex()))?;
-    Ok(())
+    Ok((first_commit, second_commit, num_rebased))
 }
 
 /// Prompts the user to select the content they want in the first commit and

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2465,6 +2465,9 @@ Splitting an empty commit is not supported because the same effect can be achiev
 * `-r`, `--revision <REVSET>` — The revision to split
 
   Default value: `@`
+* `-d`, `--destination <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
+* `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
+* `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
 
    The description is used for the commit with the selected changes. The source commit description is kept unchanged.

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -482,6 +482,20 @@ fn test_rewrite_immutable_commands() {
     [EOF]
     [exit status: 1]
     "#);
+    // split -B
+    let output = work_dir.run_jj(["split", "-B=main", "-m", "will fail", "file"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Commit 4397373a0991 is immutable
+    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    "#);
     // squash -r
     let output = work_dir.run_jj(["squash", "-r=description(b)"]);
     insta::assert_snapshot!(output, @r#"

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -27,6 +27,12 @@ fn get_log_output(work_dir: &TestWorkDir) -> CommandOutput {
 }
 
 #[must_use]
+fn get_log_with_summary(work_dir: &TestWorkDir) -> CommandOutput {
+    let template = r#"separate(" ", change_id.short(), local_bookmarks, description)"#;
+    work_dir.run_jj(["log", "-T", template, "--summary"])
+}
+
+#[must_use]
 fn get_workspace_log_output(work_dir: &TestWorkDir) -> CommandOutput {
     let template = r#"separate(" ", change_id.short(), working_copies, description)"#;
     work_dir.run_jj(["log", "-T", template, "-r", "all()"])
@@ -1138,6 +1144,264 @@ fn test_split_with_message() {
     │
     │  CC: test.user@example.com
     ◆  zzzzzzzzzzzz true
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_split_move_first_commit() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1", "foo\n");
+    work_dir.write_file("file2", "bar\n");
+    work_dir.run_jj(["commit", "-m", "file2"]).success();
+    work_dir.write_file("file3", "bar\n");
+    work_dir.run_jj(["commit", "-m", "file3"]).success();
+    work_dir.write_file("file4", "bar\n");
+    work_dir.run_jj(["commit", "-m", "file4"]).success();
+    work_dir.run_jj(["new", "root()"]).success();
+    work_dir.write_file("file5", "bar\n");
+    work_dir.run_jj(["commit", "-m", "file5"]).success();
+
+    insta::assert_snapshot!(get_log_with_summary(&work_dir), @r"
+    @  royxmykxtrkr
+    ○  mzvwutvlkqwt file5
+    │  A file5
+    │ ○  kkmpptxzrspx file4
+    │ │  A file4
+    │ ○  rlvkpnrzqnoo file3
+    │ │  A file3
+    │ ○  qpvuntsmwlqt file2
+    ├─╯  A file1
+    │    A file2
+    ◆  zzzzzzzzzzzz
+    [EOF]
+    ");
+
+    // insert the commit before the source commit
+    let output = work_dir.run_jj([
+        "split",
+        "-m",
+        "file1",
+        "-r",
+        "qpvuntsmwlqt",
+        "--insert-before",
+        "qpvuntsmwlqt",
+        "file1",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 2 descendant commits
+    First part: vruxwmqv bf94c29a file1
+    Second part: qpvuntsm 66b1d4f1 file2
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(get_log_with_summary(&work_dir), @r"
+    @  royxmykxtrkr
+    ○  mzvwutvlkqwt file5
+    │  A file5
+    │ ○  kkmpptxzrspx file4
+    │ │  A file4
+    │ ○  rlvkpnrzqnoo file3
+    │ │  A file3
+    │ ○  qpvuntsmwlqt file2
+    │ │  A file2
+    │ ○  vruxwmqvtpmx file1
+    ├─╯  A file1
+    ◆  zzzzzzzzzzzz
+    [EOF]
+    ");
+
+    // insert the commit after the source commit
+    work_dir.run_jj(["undo"]).success();
+    let output = work_dir.run_jj([
+        "split",
+        "-m",
+        "file1",
+        "-r",
+        "qpvuntsmwlqt",
+        "--insert-after",
+        "qpvuntsmwlqt",
+        "file1",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 2 descendant commits
+    First part: kpqxywon 08294e90 file1
+    Second part: qpvuntsm 76ebcbb8 file2
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(get_log_with_summary(&work_dir), @r"
+    @  royxmykxtrkr
+    ○  mzvwutvlkqwt file5
+    │  A file5
+    │ ○  kkmpptxzrspx file4
+    │ │  A file4
+    │ ○  rlvkpnrzqnoo file3
+    │ │  A file3
+    │ ○  kpqxywonksrl file1
+    │ │  A file1
+    │ ○  qpvuntsmwlqt file2
+    ├─╯  A file2
+    ◆  zzzzzzzzzzzz
+    [EOF]
+    ");
+
+    // create a new branch anywhere in the tree
+    work_dir.run_jj(["undo"]).success();
+    let output = work_dir.run_jj([
+        "split",
+        "-m",
+        "file1",
+        "-r",
+        "qpvuntsmwlqt",
+        "--destination",
+        "rlvkpnrzqnoo",
+        "file1",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 2 descendant commits
+    First part: lylxulpl b42b2604 file1
+    Second part: qpvuntsm 0f76cbf0 file2
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(get_log_with_summary(&work_dir), @r"
+    @  royxmykxtrkr
+    ○  mzvwutvlkqwt file5
+    │  A file5
+    │ ○  kkmpptxzrspx file4
+    │ │  A file4
+    │ │ ○  lylxulplsnyw file1
+    │ ├─╯  A file1
+    │ ○  rlvkpnrzqnoo file3
+    │ │  A file3
+    │ ○  qpvuntsmwlqt file2
+    ├─╯  A file2
+    ◆  zzzzzzzzzzzz
+    [EOF]
+    ");
+
+    // create a bubble in the tree
+    work_dir.run_jj(["undo"]).success();
+    let output = work_dir.run_jj([
+        "split",
+        "-m",
+        "file1",
+        "-r",
+        "qpvuntsmwlqt",
+        "--insert-after",
+        "qpvuntsmwlqt",
+        "--insert-before",
+        "kkmpptxzrspx",
+        "file1",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 2 descendant commits
+    First part: uyznsvlq d0338445 file1
+    Second part: qpvuntsm 16d41320 file2
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(get_log_with_summary(&work_dir), @r"
+    @  royxmykxtrkr
+    ○  mzvwutvlkqwt file5
+    │  A file5
+    │ ○    kkmpptxzrspx file4
+    │ ├─╮  A file4
+    │ │ ○  uyznsvlquzzm file1
+    │ │ │  A file1
+    │ ○ │  rlvkpnrzqnoo file3
+    │ ├─╯  A file3
+    │ ○  qpvuntsmwlqt file2
+    ├─╯  A file2
+    ◆  zzzzzzzzzzzz
+    [EOF]
+    ");
+
+    // create a commit in another branch
+    work_dir.run_jj(["undo"]).success();
+    let output = work_dir.run_jj([
+        "split",
+        "-m",
+        "file1",
+        "-r",
+        "qpvuntsmwlqt",
+        "--before",
+        "@",
+        "file1",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 3 descendant commits
+    First part: nmzmmopx 72225233 file1
+    Second part: qpvuntsm 98b70782 file2
+    Working copy  (@) now at: royxmykx c3dd10b0 (empty) (no description set)
+    Parent commit (@-)      : nmzmmopx 72225233 file1
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(get_log_with_summary(&work_dir), @r"
+    @  royxmykxtrkr
+    ○  nmzmmopxokps file1
+    │  A file1
+    ○  mzvwutvlkqwt file5
+    │  A file5
+    │ ○  kkmpptxzrspx file4
+    │ │  A file4
+    │ ○  rlvkpnrzqnoo file3
+    │ │  A file3
+    │ ○  qpvuntsmwlqt file2
+    ├─╯  A file2
+    ◆  zzzzzzzzzzzz
+    [EOF]
+    ");
+
+    // merge two branches with the new commit
+    work_dir.run_jj(["undo"]).success();
+    let output = work_dir.run_jj([
+        "split",
+        "-m",
+        "file1",
+        "-r",
+        "qpvuntsmwlqt",
+        "--after",
+        "mzvwutvlkqwt",
+        "--after",
+        "kkmpptxzrspx",
+        "file1",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 3 descendant commits
+    First part: nlrtlrxv 1b6975b0 file1
+    Second part: qpvuntsm 905586dd file2
+    Working copy  (@) now at: royxmykx 85be9860 (empty) (no description set)
+    Parent commit (@-)      : nlrtlrxv 1b6975b0 file1
+    Added 4 files, modified 0 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(get_log_with_summary(&work_dir), @r"
+    @  royxmykxtrkr
+    ○    nlrtlrxvuusk file1
+    ├─╮  A file1
+    │ ○  kkmpptxzrspx file4
+    │ │  A file4
+    │ ○  rlvkpnrzqnoo file3
+    │ │  A file3
+    │ ○  qpvuntsmwlqt file2
+    │ │  A file2
+    ○ │  mzvwutvlkqwt file5
+    ├─╯  A file5
+    ◆  zzzzzzzzzzzz
     [EOF]
     ");
 }


### PR DESCRIPTION
See the comments in the commit descriptions.

The last two commits implement `jj --parallel -r x` as `jj split -r x -A x- -B x+` as discussed in #3419, but I'm not sure to see the point, except to document `--parallel` as equivalent to `-A x- -B x+` (or `-d x-` if x has no descendant). I'm including them here to continue the discussion.

Still some tests to implement, but some early feedback would be appreciated!

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
