### PR TITLE
split: the revision with the remaining changes keeps the change id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj gerrit upload` now supports the `-o` (`--option`) flag, which works like
   `git push -o` (`--push-option`).
 
+* `jj split` now consistently assigns the source revision's change ID to the
+  revision containing the non-selected changes—and ensures any associated
+  bookmark references that same change ID—regardless of the options used.
+  You can opt out of this change by setting `split.legacy-bookmark-behavior = true`,
+  but this will likely be removed in a future release.
+
 ### Fixed bugs
 
 * `jj` now creates a new working-copy revision during snapshotting if the

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -45,9 +45,10 @@ use crate::ui::Ui;
 /// * `jj commit` doesn't have a `-r` option. It always acts on the working-copy
 ///   commit (@).
 ///
-/// * `jj split` (without `-o`/`-A`/`-B`) will move bookmarks forward from the
-///   old change to the child change. `jj commit` doesn't move bookmarks
-///   forward.
+/// * `jj commit` creates the new commit as a child of the working-copy, and
+///   sets the new commit as the working-copy. `jj split` creates the new commit
+///   as a parent of the source commit and leaves the working copy on the child
+///   commit.
 ///
 /// * `jj split` allows you to move the selected changes to a different
 ///   destination with `-o`/`-A`/`-B`.

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -292,11 +292,14 @@ pub(crate) async fn cmd_split(
     // Prompt the user to select the changes they want for the first commit.
     let target = select_diff(ui, &tx, &target_commit, &matcher, &diff_selector).await?;
 
+    let source_id_to_first_commit =
+        !use_move_flags && tx.settings().get_bool("split.legacy-bookmark-behavior")?;
+
     // Create the first commit, which includes the changes selected by the user.
     let first_commit = {
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder.set_tree(target.selected_tree.clone());
-        if use_move_flags {
+        if !source_id_to_first_commit {
             commit_builder.clear_rewrite_source();
             // Generate a new change id so that the commit being split doesn't
             // become divergent.
@@ -365,7 +368,7 @@ pub(crate) async fn cmd_split(
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder.set_parents(parents).set_tree(new_tree);
         let mut show_editor = args.editor;
-        if !use_move_flags {
+        if source_id_to_first_commit {
             commit_builder.clear_rewrite_source();
             // Generate a new change id so that the commit being split doesn't
             // become divergent.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -1031,8 +1031,8 @@
             "properties": {
                 "legacy-bookmark-behavior": {
                     "type": "boolean",
-                    "description": "If true, bookmarks will move to the second commit instead of the first.",
-                    "default": true
+                    "description": "If true, bookmarks will move to the first commit instead of the second.",
+                    "default": false
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -64,4 +64,4 @@ auto-update-stale = false
 # The behavior when this flag is set to false is experimental and may be changed
 # in the future.
 [split]
-legacy-bookmark-behavior = true
+legacy-bookmark-behavior = false

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -715,7 +715,7 @@ When using `--interactive` or path arguments, the selected changes stay in the c
 
 * `jj commit` doesn't have a `-r` option. It always acts on the working-copy commit (@).
 
-* `jj split` (without `-o`/`-A`/`-B`) will move bookmarks forward from the old change to the child change. `jj commit` doesn't move bookmarks forward.
+* `jj commit` creates the new commit as a child of the working-copy, and sets the new commit as the working-copy. `jj split` creates the new commit as a parent of the source commit and leaves the working copy on the child commit.
 
 * `jj split` allows you to move the selected changes to a different destination with `-o`/`-A`/`-B`.
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -83,10 +83,10 @@ fn test_split_by_paths() -> TestResult {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm 6dbc7747 (no description set)
-    Remaining changes: zsuskuln 42cbbc02 (no description set)
-    Working copy  (@) now at: zsuskuln 42cbbc02 (no description set)
-    Parent commit (@-)      : qpvuntsm 6dbc7747 (no description set)
+    Selected changes : zsuskuln 8a73f71d (no description set)
+    Remaining changes: qpvuntsm c4d8ebac (no description set)
+    Working copy  (@) now at: qpvuntsm c4d8ebac (no description set)
+    Parent commit (@-)      : zsuskuln 8a73f71d (no description set)
     [EOF]
     ");
     // Trailers should be added to the editor template
@@ -97,7 +97,7 @@ fn test_split_by_paths() -> TestResult {
 
     Trailer: value
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: zsuskuln
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
@@ -106,8 +106,8 @@ fn test_split_by_paths() -> TestResult {
     assert!(!test_env.env_root().join("editor1").exists());
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  zsuskulnrvyr false
-    ○  qpvuntsmwlqt false
+    @  qpvuntsmwlqt false
+    ○  zsuskulnrvyr false
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -142,17 +142,17 @@ fn test_split_by_paths() -> TestResult {
     ------- stderr -------
     Warning: All changes have been selected, so the original revision will become empty
     Rebased 1 descendant commits
-    Selected changes : qpvuntsm 9fd1c9e1 (no description set)
-    Remaining changes: znkkpsqq 41e0da21 (empty) (no description set)
-    Working copy  (@) now at: zsuskuln a06e40b8 (no description set)
-    Parent commit (@-)      : znkkpsqq 41e0da21 (empty) (no description set)
+    Selected changes : znkkpsqq d6e65134 (no description set)
+    Remaining changes: zsuskuln aa27eaa3 (empty) (no description set)
+    Working copy  (@) now at: qpvuntsm e94cab21 (no description set)
+    Parent commit (@-)      : zsuskuln aa27eaa3 (empty) (no description set)
     [EOF]
     ");
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  zsuskulnrvyr false
-    ○  znkkpsqqskkl true
-    ○  qpvuntsmwlqt false
+    @  qpvuntsmwlqt false
+    ○  zsuskulnrvyr true
+    ○  znkkpsqqskkl false
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -174,17 +174,17 @@ fn test_split_by_paths() -> TestResult {
     Warning: No matching entries for paths: nonexistent
     Warning: No changes have been selected, so the new revision will be empty
     Rebased 1 descendant commits
-    Selected changes : qpvuntsm 49416632 (empty) (no description set)
-    Remaining changes: lylxulpl 718afbf5 (no description set)
-    Working copy  (@) now at: zsuskuln 0ed53ee6 (no description set)
-    Parent commit (@-)      : lylxulpl 718afbf5 (no description set)
+    Selected changes : lylxulpl 3d639d71 (empty) (no description set)
+    Remaining changes: znkkpsqq 706a0e77 (no description set)
+    Working copy  (@) now at: qpvuntsm 502cf440 (no description set)
+    Parent commit (@-)      : znkkpsqq 706a0e77 (no description set)
     [EOF]
     ");
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  zsuskulnrvyr false
-    ○  lylxulplsnyw false
-    ○  qpvuntsmwlqt true
+    @  qpvuntsmwlqt false
+    ○  znkkpsqqskkl false
+    ○  lylxulplsnyw true
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -202,10 +202,10 @@ fn test_split_by_paths() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: All changes have been selected, so the original revision will become empty
-    Selected changes : uyznsvlq 971ccc0b (no description set)
-    Remaining changes: xznxytkn a267cd96 (empty) (no description set)
-    Working copy  (@) now at: smwtzssm 6715dc2c (empty) (no description set)
-    Parent commit (@-)      : uyznsvlq 971ccc0b (no description set)
+    Selected changes : xznxytkn e69850ba (no description set)
+    Remaining changes: uyznsvlq df0b606a (empty) (no description set)
+    Working copy  (@) now at: smwtzssm 6c647048 (empty) (no description set)
+    Parent commit (@-)      : xznxytkn e69850ba (no description set)
     [EOF]
     ");
     Ok(())
@@ -236,10 +236,10 @@ fn test_split_with_non_empty_description() -> TestResult {
     let output = work_dir.run_jj(["split", "file1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm c7f7b14b part 1
-    Remaining changes: kkmpptxz ac33a5a9 part 2
-    Working copy  (@) now at: kkmpptxz ac33a5a9 part 2
-    Parent commit (@-)      : qpvuntsm c7f7b14b part 1
+    Selected changes : kkmpptxz 530f78ed part 1
+    Remaining changes: qpvuntsm 88189e08 part 2
+    Working copy  (@) now at: qpvuntsm 88189e08 part 2
+    Parent commit (@-)      : kkmpptxz 530f78ed part 1
     [EOF]
     ");
 
@@ -248,7 +248,7 @@ fn test_split_with_non_empty_description() -> TestResult {
     JJ: Enter a description for the selected changes.
     test
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: kkmpptxz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -259,15 +259,15 @@ fn test_split_with_non_empty_description() -> TestResult {
     JJ: Enter a description for the remaining changes.
     test
 
-    JJ: Change ID: kkmpptxz
+    JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kkmpptxzrspx false part 2
-    ○  qpvuntsmwlqt false part 1
+    @  qpvuntsmwlqt false part 2
+    ○  kkmpptxzrspx false part 1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -292,10 +292,10 @@ fn test_split_with_default_description() -> TestResult {
     let output = work_dir.run_jj(["split", "file1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm ff633dcc TESTED=TODO
-    Remaining changes: rlvkpnrz b1d20b7e (no description set)
-    Working copy  (@) now at: rlvkpnrz b1d20b7e (no description set)
-    Parent commit (@-)      : qpvuntsm ff633dcc TESTED=TODO
+    Selected changes : rlvkpnrz 16dc7e13 TESTED=TODO
+    Remaining changes: qpvuntsm f40d53f2 (no description set)
+    Working copy  (@) now at: qpvuntsm f40d53f2 (no description set)
+    Parent commit (@-)      : rlvkpnrz 16dc7e13 TESTED=TODO
     [EOF]
     ");
 
@@ -310,7 +310,7 @@ fn test_split_with_default_description() -> TestResult {
 
     TESTED=TODO
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: rlvkpnrz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -318,8 +318,8 @@ fn test_split_with_default_description() -> TestResult {
     "#);
     assert!(!test_env.env_root().join("editor2").exists());
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  rlvkpnrzqnoo false
-    ○  qpvuntsmwlqt false TESTED=TODO
+    @  qpvuntsmwlqt false
+    ○  rlvkpnrzqnoo false TESTED=TODO
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -370,17 +370,17 @@ fn test_split_with_descendants() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Selected changes : qpvuntsm 74306e35 Add file1
-    Remaining changes: royxmykx 0a37745e Add file2
-    Working copy  (@) now at: kkmpptxz 7ee84812 Add file4
-    Parent commit (@-)      : rlvkpnrz d335bd94 Add file3
+    Selected changes : royxmykx e13e94b9 Add file1
+    Remaining changes: qpvuntsm cf8ebbab Add file2
+    Working copy  (@) now at: kkmpptxz 73a16519 Add file4
+    Parent commit (@-)      : rlvkpnrz ec4d3a14 Add file3
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @  kkmpptxzrspx false Add file4
     ○  rlvkpnrzqnoo false Add file3
-    ○  royxmykxtrkr false Add file2
-    ○  qpvuntsmwlqt false Add file1
+    ○  qpvuntsmwlqt false Add file2
+    ○  royxmykxtrkr false Add file1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -392,7 +392,7 @@ fn test_split_with_descendants() -> TestResult {
     JJ: Enter a description for the selected changes.
     Add file1 & file2
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: royxmykx
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -403,7 +403,7 @@ fn test_split_with_descendants() -> TestResult {
     JJ: Enter a description for the remaining changes.
     Add file1 & file2
 
-    JJ: Change ID: royxmykx
+    JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
@@ -414,12 +414,12 @@ fn test_split_with_descendants() -> TestResult {
     // - The initial empty commit.
     // - The rewritten commit from the snapshot after the files were added.
     // - The rewritten commit once the description is added during `jj commit`.
-    // - The rewritten commit after the split.
-    let evolog_1 = work_dir.run_jj(["evolog", "-r", "qpvun"]);
+    // - The rewritten commit after the split with a new change ID.
+    let evolog_1 = work_dir.run_jj(["evolog", "-r", "royxm"]);
     insta::assert_snapshot!(evolog_1, @"
-    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:12 74306e35
+    ○  royxmykx test.user@example.com 2001-02-03 08:05:12 e13e94b9
     │  Add file1
-    │  -- operation ec53c39a72a8 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation a46f740694f0 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
     │  -- operation 8185a834cefe commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
@@ -433,12 +433,12 @@ fn test_split_with_descendants() -> TestResult {
     ");
 
     // The evolog for the second commit is the same, except that the change id
-    // changes after the split.
-    let evolog_2 = work_dir.run_jj(["evolog", "-r", "royxm"]);
+    // doesn't change after the split.
+    let evolog_2 = work_dir.run_jj(["evolog", "-r", "qpvun"]);
     insta::assert_snapshot!(evolog_2, @"
-    ○  royxmykx test.user@example.com 2001-02-03 08:05:12 0a37745e
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:12 cf8ebbab
     │  Add file2
-    │  -- operation ec53c39a72a8 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation a46f740694f0 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
     │  -- operation 8185a834cefe commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
@@ -487,18 +487,18 @@ fn test_split_with_merge_child() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Selected changes : kkmpptxz cc199567 Add file1
-    Remaining changes: royxmykx e488409f Add file2
-    Working copy  (@) now at: zsuskuln ace61421 (empty) 2
+    Selected changes : royxmykx ad21dad2 Add file1
+    Remaining changes: kkmpptxz 0922bd25 Add file2
+    Working copy  (@) now at: zsuskuln f59cd990 (empty) 2
     Parent commit (@-)      : qpvuntsm 884fe9b9 (empty) 1
-    Parent commit (@-)      : royxmykx e488409f Add file2
+    Parent commit (@-)      : kkmpptxz 0922bd25 Add file2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @    zsuskulnrvyr true 2
     ├─╮
-    │ ○  royxmykxtrkr false Add file2
-    │ ○  kkmpptxzrspx false Add file1
+    │ ○  kkmpptxzrspx false Add file2
+    │ ○  royxmykxtrkr false Add file1
     ○ │  qpvuntsmwlqt true 1
     ├─╯
     ◆  zzzzzzzzzzzz true
@@ -533,16 +533,16 @@ fn test_split_parallel_no_descendants() -> TestResult {
     let output = work_dir.run_jj(["split", "--parallel", "file1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm 7bcd474c TESTED=TODO
-    Remaining changes: kkmpptxz 431886f6 (no description set)
-    Working copy  (@) now at: kkmpptxz 431886f6 (no description set)
+    Selected changes : kkmpptxz bd9b3db1 TESTED=TODO
+    Remaining changes: qpvuntsm 5597b805 (no description set)
+    Working copy  (@) now at: qpvuntsm 5597b805 (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kkmpptxzrspx false
-    │ ○  qpvuntsmwlqt false TESTED=TODO
+    @  qpvuntsmwlqt false
+    │ ○  kkmpptxzrspx false TESTED=TODO
     ├─╯
     ◆  zzzzzzzzzzzz true
     [EOF]
@@ -559,7 +559,7 @@ fn test_split_parallel_no_descendants() -> TestResult {
 
     TESTED=TODO
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: kkmpptxz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -573,9 +573,9 @@ fn test_split_parallel_no_descendants() -> TestResult {
     // - The rewritten commit after the split.
     let evolog_1 = work_dir.run_jj(["evolog", "-r", "qpvun"]);
     insta::assert_snapshot!(evolog_1, @"
-    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 7bcd474c
-    │  TESTED=TODO
-    │  -- operation 90307a87dc57 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 5597b805
+    │  (no description set)
+    │  -- operation 41b094965e18 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
     │  -- operation f07456070284 snapshot working copy
@@ -589,9 +589,41 @@ fn test_split_parallel_no_descendants() -> TestResult {
     // changes after the split.
     let evolog_2 = work_dir.run_jj(["evolog", "-r", "kkmpp"]);
     insta::assert_snapshot!(evolog_2, @"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 431886f6
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:09 bd9b3db1
+    │  TESTED=TODO
+    │  -- operation 41b094965e18 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation 90307a87dc57 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation f07456070284 snapshot working copy
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
+       (empty) (no description set)
+       -- operation 90267f31f904 add workspace 'default'
+    [EOF]
+    ");
+
+    // The evolog for the second commit is the same, except that the change id
+    // changes after the split.
+    let evolog_2 = work_dir.run_jj(["evolog", "-r", "kkmpp"]);
+    insta::assert_snapshot!(evolog_2, @"
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:09 bd9b3db1
+    │  TESTED=TODO
+    │  -- operation 41b094965e18 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
+    │  (no description set)
+    │  -- operation f07456070284 snapshot working copy
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
+       (empty) (no description set)
+       -- operation 90267f31f904 add workspace 'default'
+    [EOF]
+    ");
+
+    // The evolog for the second commit is the same, except that the change id
+    // changes after the split.
+    let evolog_2 = work_dir.run_jj(["evolog", "-r", "kkmpp"]);
+    insta::assert_snapshot!(evolog_2, @"
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:09 bd9b3db1
+    │  TESTED=TODO
+    │  -- operation 41b094965e18 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
     │  -- operation f07456070284 snapshot working copy
@@ -651,9 +683,9 @@ fn test_split_parallel_with_descendants() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 2 descendant commits
-    Selected changes : qpvuntsm 18c85f56 Add file1
-    Remaining changes: vruxwmqv cbdfd9cf Add file2
-    Working copy  (@) now at: vruxwmqv cbdfd9cf Add file2
+    Selected changes : vruxwmqv 3f0980cb Add file1
+    Remaining changes: qpvuntsm dff79d19 Add file2
+    Working copy  (@) now at: qpvuntsm dff79d19 Add file2
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
@@ -662,8 +694,8 @@ fn test_split_parallel_with_descendants() -> TestResult {
     ○  kkmpptxzrspx false Add file4
     ○    rlvkpnrzqnoo false Add file3
     ├─╮
-    │ @  vruxwmqvtpmx false Add file2
-    ○ │  qpvuntsmwlqt false Add file1
+    │ @  qpvuntsmwlqt false Add file2
+    ○ │  vruxwmqvtpmx false Add file1
     ├─╯
     ◆  zzzzzzzzzzzz true
     [EOF]
@@ -676,7 +708,7 @@ fn test_split_parallel_with_descendants() -> TestResult {
     JJ: Enter a description for the selected changes.
     Add file1 & file2
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: vruxwmqv
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -687,7 +719,7 @@ fn test_split_parallel_with_descendants() -> TestResult {
     JJ: Enter a description for the remaining changes.
     Add file1 & file2
 
-    JJ: Change ID: vruxwmqv
+    JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
@@ -730,19 +762,19 @@ fn test_split_parallel_with_merge_child() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Selected changes : kkmpptxz cc199567 Add file1
-    Remaining changes: royxmykx 82a5c527 Add file2
-    Working copy  (@) now at: zsuskuln b7cdcdec (empty) 2
+    Selected changes : royxmykx ad21dad2 Add file1
+    Remaining changes: kkmpptxz 23a2daac Add file2
+    Working copy  (@) now at: zsuskuln f1fcb7a6 (empty) 2
     Parent commit (@-)      : qpvuntsm 884fe9b9 (empty) 1
-    Parent commit (@-)      : kkmpptxz cc199567 Add file1
-    Parent commit (@-)      : royxmykx 82a5c527 Add file2
+    Parent commit (@-)      : royxmykx ad21dad2 Add file1
+    Parent commit (@-)      : kkmpptxz 23a2daac Add file2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     @      zsuskulnrvyr true 2
     ├─┬─╮
-    │ │ ○  royxmykxtrkr false Add file2
-    │ ○ │  kkmpptxzrspx false Add file1
+    │ │ ○  kkmpptxzrspx false Add file2
+    │ ○ │  royxmykxtrkr false Add file1
     │ ├─╯
     ○ │  qpvuntsmwlqt true 1
     ├─╯
@@ -782,18 +814,18 @@ fn test_split_parallel_with_conflict() -> TestResult {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Rebased 1 descendant commits
-    Selected changes : rlvkpnrz abe15fea (no description set)
-    Remaining changes: royxmykx 4bbc5826 (conflict) (no description set)
-    Working copy  (@) now at: royxmykx 4bbc5826 (conflict) (no description set)
+    Selected changes : royxmykx ddb7c909 (no description set)
+    Remaining changes: rlvkpnrz 3dfda33c (conflict) (no description set)
+    Working copy  (@) now at: rlvkpnrz 3dfda33c (conflict) (no description set)
     Parent commit (@-)      : qpvuntsm ee8e9376 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      royxmykx 4bbc5826 (conflict) (no description set)
+      rlvkpnrz 3dfda33c (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new royxmykx
+      jj new rlvkpnrz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -802,8 +834,8 @@ fn test_split_parallel_with_conflict() -> TestResult {
     insta::assert_snapshot!(get_log_output(&work_dir), @"
     ○    kkmpptxzrspx false
     ├─╮
-    │ @  royxmykxtrkr false
-    ○ │  rlvkpnrzqnoo false
+    │ @  rlvkpnrzqnoo false
+    ○ │  royxmykxtrkr false
     ├─╯
     ○  qpvuntsmwlqt false
     ◆  zzzzzzzzzzzz true
@@ -857,23 +889,23 @@ fn test_split_empty() -> TestResult {
     Hint: Using default editor ':builtin'; run `jj config set --user ui.diff-editor :builtin` to disable this message.
     Warning: Empty diff - won't run diff editor.
     Warning: All changes have been selected, so the original revision will become empty
-    Selected changes : qpvuntsm a8bcd860 (empty) abc
-    Remaining changes: kkmpptxz 304fb14c (empty) abc
-    Working copy  (@) now at: kkmpptxz 304fb14c (empty) abc
-    Parent commit (@-)      : qpvuntsm a8bcd860 (empty) abc
+    Selected changes : kkmpptxz e9628e7f (empty) abc
+    Remaining changes: qpvuntsm 6fe455ca (empty) abc
+    Working copy  (@) now at: qpvuntsm 6fe455ca (empty) abc
+    Parent commit (@-)      : kkmpptxz e9628e7f (empty) abc
     [EOF]
     ");
 
     // With path argument (user meant to pass revision)
     let output = work_dir.run_jj(["split", "@"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: No matching entries for paths: @
     Warning: All changes have been selected, so the original revision will become empty
-    Selected changes : kkmpptxz cd55fd14 (empty) abc
-    Remaining changes: zsuskuln 49a292cc (empty) abc
-    Working copy  (@) now at: zsuskuln 49a292cc (empty) abc
-    Parent commit (@-)      : kkmpptxz cd55fd14 (empty) abc
+    Selected changes : zsuskuln f8b45f6f (empty) abc
+    Remaining changes: qpvuntsm 62dbf613 (empty) abc
+    Working copy  (@) now at: qpvuntsm 62dbf613 (empty) abc
+    Parent commit (@-)      : zsuskuln f8b45f6f (empty) abc
     [EOF]
     ");
     Ok(())
@@ -919,10 +951,10 @@ fn test_split_interactive() -> TestResult {
     let output = work_dir.run_jj(["split"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm c664a51b (no description set)
-    Remaining changes: rlvkpnrz 7e5d65b1 (no description set)
-    Working copy  (@) now at: rlvkpnrz 7e5d65b1 (no description set)
-    Parent commit (@-)      : qpvuntsm c664a51b (no description set)
+    Selected changes : rlvkpnrz 1ff7a783 (no description set)
+    Remaining changes: qpvuntsm 429f292f (no description set)
+    Working copy  (@) now at: qpvuntsm 429f292f (no description set)
+    Parent commit (@-)      : rlvkpnrz 1ff7a783 (no description set)
     [EOF]
     ");
 
@@ -942,7 +974,7 @@ fn test_split_interactive() -> TestResult {
     JJ: Enter a description for the selected changes.
 
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: rlvkpnrz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -951,10 +983,10 @@ fn test_split_interactive() -> TestResult {
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 7e5d65b1
+    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 429f292f
     │  (no description set)
     │  A file2
-    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c664a51b
+    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 1ff7a783
     │  (no description set)
     │  A file1
     ◆  zzzzzzzz root() 00000000
@@ -997,10 +1029,10 @@ fn test_split_interactive_with_paths() -> TestResult {
     let output = work_dir.run_jj(["split", "-i", "file1", "file2"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : rlvkpnrz cdc9960a (no description set)
-    Remaining changes: kkmpptxz 7255f070 (no description set)
-    Working copy  (@) now at: kkmpptxz 7255f070 (no description set)
-    Parent commit (@-)      : rlvkpnrz cdc9960a (no description set)
+    Selected changes : kkmpptxz 0a5bea34 (no description set)
+    Remaining changes: rlvkpnrz 7326e6fd (no description set)
+    Working copy  (@) now at: rlvkpnrz 7326e6fd (no description set)
+    Parent commit (@-)      : kkmpptxz 0a5bea34 (no description set)
     [EOF]
     ");
 
@@ -1009,7 +1041,7 @@ fn test_split_interactive_with_paths() -> TestResult {
     JJ: Enter a description for the selected changes.
 
 
-    JJ: Change ID: rlvkpnrz
+    JJ: Change ID: kkmpptxz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -1018,11 +1050,11 @@ fn test_split_interactive_with_paths() -> TestResult {
 
     let output = work_dir.run_jj(["log", "--summary"]);
     insta::assert_snapshot!(output, @"
-    @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 7255f070
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 7326e6fd
     │  (no description set)
     │  M file2
     │  M file3
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 cdc9960a
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:09 0a5bea34
     │  (no description set)
     │  A file1
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 ff687a2f
@@ -1077,8 +1109,8 @@ fn test_split_with_multiple_workspaces_same_working_copy() -> TestResult {
     main_dir.run_jj(["split", "file2"]).success();
     // The working copy for both workspaces will be the second split commit.
     insta::assert_snapshot!(get_workspace_log_output(&main_dir), @"
-    @  royxmykxtrkr default@ second@ second-commit
-    ○  qpvuntsmwlqt first-commit
+    @  qpvuntsmwlqt default@ second@ second-commit
+    ○  royxmykxtrkr first-commit
     ◆  zzzzzzzzzzzz
     [EOF]
     ");
@@ -1091,8 +1123,8 @@ fn test_split_with_multiple_workspaces_same_working_copy() -> TestResult {
     )?;
     main_dir.run_jj(["split", "file2", "--parallel"]).success();
     insta::assert_snapshot!(get_workspace_log_output(&main_dir), @"
-    @  yostqsxwqrlt default@ second@ second-commit
-    │ ○  qpvuntsmwlqt first-commit
+    @  qpvuntsmwlqt default@ second@ second-commit
+    │ ○  yostqsxwqrlt first-commit
     ├─╯
     ◆  zzzzzzzzzzzz
     [EOF]
@@ -1136,8 +1168,8 @@ fn test_split_with_multiple_workspaces_different_working_copy() -> TestResult {
     main_dir.run_jj(["split", "file2"]).success();
     // Only the working copy commit for the default workspace changes.
     insta::assert_snapshot!(get_workspace_log_output(&main_dir), @"
-    @  mzvwutvlkqwt default@ second-commit
-    ○  qpvuntsmwlqt first-commit
+    @  qpvuntsmwlqt default@ second-commit
+    ○  mzvwutvlkqwt first-commit
     │ ○  pmmvwywvzvvn second@
     ├─╯
     ◆  zzzzzzzzzzzz
@@ -1152,8 +1184,8 @@ fn test_split_with_multiple_workspaces_different_working_copy() -> TestResult {
     )?;
     main_dir.run_jj(["split", "file2", "--parallel"]).success();
     insta::assert_snapshot!(get_workspace_log_output(&main_dir), @"
-    @  vruxwmqvtpmx default@ second-commit
-    │ ○  qpvuntsmwlqt first-commit
+    @  qpvuntsmwlqt default@ second-commit
+    │ ○  vruxwmqvtpmx first-commit
     ├─╯
     │ ○  pmmvwywvzvvn second@
     ├─╯
@@ -1193,10 +1225,10 @@ fn test_split_with_non_empty_description_and_trailers() -> TestResult {
     let output = work_dir.run_jj(["split", "file1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm c7f7b14b part 1
-    Remaining changes: kkmpptxz ac33a5a9 part 2
-    Working copy  (@) now at: kkmpptxz ac33a5a9 part 2
-    Parent commit (@-)      : qpvuntsm c7f7b14b part 1
+    Selected changes : kkmpptxz 530f78ed part 1
+    Remaining changes: qpvuntsm 88189e08 part 2
+    Working copy  (@) now at: qpvuntsm 88189e08 part 2
+    Parent commit (@-)      : kkmpptxz 530f78ed part 1
     [EOF]
     ");
 
@@ -1207,7 +1239,7 @@ fn test_split_with_non_empty_description_and_trailers() -> TestResult {
 
     Signed-off-by: test.user@example.com
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: kkmpptxz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -1220,15 +1252,15 @@ fn test_split_with_non_empty_description_and_trailers() -> TestResult {
 
     Signed-off-by: test.user@example.com
 
-    JJ: Change ID: kkmpptxz
+    JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kkmpptxzrspx false part 2
-    ○  qpvuntsmwlqt false part 1
+    @  qpvuntsmwlqt false part 2
+    ○  kkmpptxzrspx false part 1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -1249,16 +1281,16 @@ fn test_split_with_message() -> TestResult {
     let output = work_dir.run_jj(["split", "-m", "fix in file1", "file1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm f2a70519 fix in file1
-    Remaining changes: kkmpptxz cac11766 my feature
-    Working copy  (@) now at: kkmpptxz cac11766 my feature
-    Parent commit (@-)      : qpvuntsm f2a70519 fix in file1
+    Selected changes : kkmpptxz b246503a fix in file1
+    Remaining changes: qpvuntsm e05b5012 my feature
+    Working copy  (@) now at: qpvuntsm e05b5012 my feature
+    Parent commit (@-)      : kkmpptxz b246503a fix in file1
     [EOF]
     ");
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kkmpptxzrspx false my feature
-    ○  qpvuntsmwlqt false fix in file1
+    @  qpvuntsmwlqt false my feature
+    ○  kkmpptxzrspx false fix in file1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -1275,16 +1307,16 @@ fn test_split_with_message() -> TestResult {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Selected changes : qpvuntsm d01cf12d fix in file1
-    Remaining changes: royxmykx b1556ed9 my feature
-    Working copy  (@) now at: royxmykx b1556ed9 my feature
-    Parent commit (@-)      : qpvuntsm d01cf12d fix in file1
+    Selected changes : royxmykx 87fbb488 fix in file1
+    Remaining changes: qpvuntsm fb598346 my feature
+    Working copy  (@) now at: qpvuntsm fb598346 my feature
+    Parent commit (@-)      : royxmykx 87fbb488 fix in file1
     [EOF]
     ");
 
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  royxmykxtrkr false my feature
-    ○  qpvuntsmwlqt false fix in file1
+    @  qpvuntsmwlqt false my feature
+    ○  royxmykxtrkr false fix in file1
     │
     │  CC: test.user@example.com
     ◆  zzzzzzzzzzzz true
@@ -1602,27 +1634,27 @@ fn test_split_with_bookmarks(bookmark_behavior: BookmarkBehavior) -> TestResult 
     )?;
     let output = main_dir.run_jj(["split", "file2"]);
     match bookmark_behavior {
-        BookmarkBehavior::LeaveBookmarkWithTarget => {
+        BookmarkBehavior::Default | BookmarkBehavior::LeaveBookmarkWithTarget => {
             insta::allow_duplicates! {
             insta::assert_snapshot!(output, @"
             ------- stderr -------
-            Selected changes : qpvuntsm a481fe8a *le-signet* | first-commit
-            Remaining changes: mzvwutvl 5f597a6e second-commit
-            Working copy  (@) now at: mzvwutvl 5f597a6e second-commit
-            Parent commit (@-)      : qpvuntsm a481fe8a *le-signet* | first-commit
+            Selected changes : mzvwutvl ac5cf500 first-commit
+            Remaining changes: qpvuntsm a13c536a *le-signet* | second-commit
+            Working copy  (@) now at: qpvuntsm a13c536a *le-signet* | second-commit
+            Parent commit (@-)      : mzvwutvl ac5cf500 first-commit
             [EOF]
             ");
             }
             insta::allow_duplicates! {
             insta::assert_snapshot!(get_log_output(&main_dir), @"
-            @  mzvwutvlkqwt false second-commit
-            ○  qpvuntsmwlqt false *le-signet* first-commit
+            @  qpvuntsmwlqt false *le-signet* second-commit
+            ○  mzvwutvlkqwt false first-commit
             ◆  zzzzzzzzzzzz true
             [EOF]
             ");
             }
         }
-        BookmarkBehavior::Default | BookmarkBehavior::MoveBookmarkToChild => {
+        BookmarkBehavior::MoveBookmarkToChild => {
             insta::allow_duplicates! {
             insta::assert_snapshot!(output, @"
             ------- stderr -------
@@ -1652,18 +1684,18 @@ fn test_split_with_bookmarks(bookmark_behavior: BookmarkBehavior) -> TestResult 
     )?;
     main_dir.run_jj(["split", "file2", "--parallel"]).success();
     match bookmark_behavior {
-        BookmarkBehavior::LeaveBookmarkWithTarget => {
+        BookmarkBehavior::Default | BookmarkBehavior::LeaveBookmarkWithTarget => {
             insta::allow_duplicates! {
             insta::assert_snapshot!(get_log_output(&main_dir), @"
-            @  vruxwmqvtpmx false second-commit
-            │ ○  qpvuntsmwlqt false *le-signet* first-commit
+            @  qpvuntsmwlqt false *le-signet* second-commit
+            │ ○  vruxwmqvtpmx false first-commit
             ├─╯
             ◆  zzzzzzzzzzzz true
             [EOF]
             ");
             }
         }
-        BookmarkBehavior::Default | BookmarkBehavior::MoveBookmarkToChild => {
+        BookmarkBehavior::MoveBookmarkToChild => {
             insta::allow_duplicates! {
             insta::assert_snapshot!(get_log_output(&main_dir), @"
             @  vruxwmqvtpmx false *le-signet* second-commit
@@ -1718,7 +1750,7 @@ fn test_split_with_editor_and_message_args() -> TestResult {
     JJ: Enter a description for the selected changes.
     message from command line
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: kkmpptxz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -1731,15 +1763,15 @@ fn test_split_with_editor_and_message_args() -> TestResult {
     JJ: Enter a description for the remaining changes.
     original description
 
-    JJ: Change ID: kkmpptxz
+    JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kkmpptxzrspx false edited message 2
-    ○  qpvuntsmwlqt false edited message 1
+    @  qpvuntsmwlqt false edited message 2
+    ○  kkmpptxzrspx false edited message 1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -1793,7 +1825,7 @@ fn test_split_with_editor_and_empty_message() -> TestResult {
 
     Trailer: value
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: kkmpptxz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -1807,15 +1839,15 @@ fn test_split_with_editor_and_empty_message() -> TestResult {
 
     Trailer: value
 
-    JJ: Change ID: kkmpptxz
+    JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kkmpptxzrspx false second commit
-    ○  qpvuntsmwlqt false first commit
+    @  qpvuntsmwlqt false second commit
+    ○  kkmpptxzrspx false first commit
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");
@@ -1855,7 +1887,7 @@ fn test_split_with_editor_without_message() -> TestResult {
     JJ: Enter a description for the selected changes.
     original description
 
-    JJ: Change ID: qpvuntsm
+    JJ: Change ID: kkmpptxz
     JJ: This commit contains the following changes:
     JJ:     A file1
     JJ:
@@ -1867,15 +1899,15 @@ fn test_split_with_editor_without_message() -> TestResult {
     JJ: Enter a description for the remaining changes.
     original description
 
-    JJ: Change ID: kkmpptxz
+    JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file2
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @"
-    @  kkmpptxzrspx false from editor2
-    ○  qpvuntsmwlqt false from editor1
+    @  qpvuntsmwlqt false from editor2
+    ○  kkmpptxzrspx false from editor1
     ◆  zzzzzzzzzzzz true
     [EOF]
     ");


### PR DESCRIPTION
based on: #6458

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [x] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
