### PR TITLE
Workaround `git` bug effecting `jj git clone --colocate` on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Work around a git issue that could cause subprocess operations to hang if the
+  `core.fsmonitor` gitconfig is set in the global or system gitconfigs.
+  [#6440](https://github.com/jj-vcs/jj/issues/6440)
+
 ### Packaging changes
 
 * Due to the removal of the `libgit2` code path, packagers should

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -111,6 +111,17 @@ impl<'a> GitSubprocessContext<'a> {
         // root to Command::current_dir and then pass a relative path to the git
         // dir
         git_cmd
+            // The gitconfig-controlled automated spawning of the macOS `fsmonitor--daemon`
+            // can cause strange behavior with certain subprocess operations.
+            // For example: https://github.com/jj-vcs/jj/issues/6440.
+            //
+            // Nothing we're doing in `jj` interacts with this daemon, so we force the
+            // config to be false for subprocess operations in order to avoid these
+            // interactions.
+            //
+            // In a colocated repo, the daemon will still get started the first time a `git`
+            // command is run manually if the gitconfigs are set up that way.
+            .args(["-c", "core.fsmonitor=false"])
             .arg("--git-dir")
             .arg(&self.git_dir)
             // Disable translation and other locale-dependent behavior so we can


### PR DESCRIPTION
This workaround addressed #6440.

The issue itself that this addresses is likely an upstream issue in `git` itself, as I can reproduce it using raw `git` commands (this is demonstrated on the bug ticket).

The cliff's notes for the issue are as follows:

If the macOS-specific `fsmonitor` is enabled in the Global or System `.gitconfig`, The `fetch` operation that `jj` uses during `jj git clone --colocate` will hang forever if it is invoked *outside* of the actual working copy.

~~The workaround here, then, is pretty brain-dead: Change the working directory before calling `fetch` via the subprocess.~~

~~To avoid forcing everything to suddenly change directories all over the place, I added a `with_working_dir` helper that can be used to wrap a closure with the relevant directory changes.~~

~~This helper is then used during the `fetch` operation that occurs during `jj git clone --colocate`.~~

~~I've attached a video showing the failure mode with the release version of JJ, and the behavior of the same operation under this patch:~~

~~https://github.com/user-attachments/assets/bc715496-0bdf-4e50-a195-a9d8631ecadb~~

I've updated this PR to use the approach proposed by @yuja, which makes a lot of sense.

The new approach is to explicitly set `core.fsmonitor-false` via git's `-c` flag if `target_os = "macos"` for any subprocess operation.

# Checklist

If applicable:
- [x] I have updated `CHANGELOG.md`
- (N/A) I have updated the documentation (README.md, docs/, demos/)
- (N/A) I have updated the config schema (cli/src/config-schema.json)
- (N/A) I have added tests to cover my changes
