### PR TITLE
nix: set `LD_LIBRARY_PATH` to get `uv` working

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -212,10 +212,19 @@
           pkgs.lib.concatStringsSep " "
           (pkgs.lib.concatMap (x: ["-C" "link-arg=${x}"]) rustLinkerFlags);
 
+        libraryPath = with pkgs;
+          lib.makeLibraryPath [
+            # add other library packages here if needed
+            stdenv.cc.cc
+          ];
+
         # The `RUSTFLAGS` environment variable is set in `shellHook` instead of `env`
         # to allow the `xcrun` command above to be interpreted by the shell.
-        shellHook = ''
+        #
+        # Also set LD_LIBRARY_PATH for `uv`: https://stackoverflow.com/questions/79563650/importerror-error-importing-numpy-you-should-not-try-to-import-numpy-from-its
+        shellHook =  ''
           export RUSTFLAGS="-Zthreads=0 ${rustLinkFlagsString}"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${libraryPath}"
         '';
       in
         pkgs.mkShell {


### PR DESCRIPTION
Apparently this is needed, otherwise we get problems loading `libstdc++.so.6` or whatever, but it's disguised as a `numpy` error.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
