### PR TITLE
nix: use uv2nix for managing the documentation's dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,60 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744599653,
+        "narHash": "sha256-nysSwVVjG4hKoOjhjvE6U5lIKA8sEr1d1QzEfZsannU=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "7dba6dbc73120e15b558754c26024f6c93015dd7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746540146,
+        "narHash": "sha256-QxdHGNpbicIrw5t6U3x+ZxeY/7IEJ6lYbvsjXmcxFIM=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e09c10c24ebb955125fda449939bfba664c467fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "rust-overlay": "rust-overlay",
+        "uv2nix": "uv2nix"
       }
     },
     "rust-overlay": {
@@ -73,6 +122,29 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746649034,
+        "narHash": "sha256-gmv+ZiY3pQnwgI0Gm3Z1tNSux1CnOJ0De+xeDOol1+0=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "fe540e91c26f378c62bf6da365a97e848434d0cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,17 @@
     # For installing non-standard rustc versions
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
+    # For building the docs
+    pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
+    pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
+    uv2nix.url = "github:pyproject-nix/uv2nix";
+    uv2nix.inputs.pyproject-nix.follows = "pyproject-nix";
+    uv2nix.inputs.nixpkgs.follows = "nixpkgs";
+    pyproject-build-systems.url = "github:pyproject-nix/build-system-pkgs";
+    pyproject-build-systems.inputs.pyproject-nix.follows = "pyproject-nix";
+    pyproject-build-systems.inputs.uv2nix.follows = "uv2nix";
+    pyproject-build-systems.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {
@@ -17,6 +28,9 @@
     nixpkgs,
     flake-utils,
     rust-overlay,
+    pyproject-nix,
+    uv2nix,
+    pyproject-build-systems,
   }:
     {
       overlays.default = final: prev: {
@@ -161,6 +175,15 @@
       });
 
       devShells.default = let
+        uvWorkspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = pkgs.lib.fileset.toSource { root = ./.; fileset = pkgs.lib.fileset.unions [ ./pyproject.toml ./uv.lock ]; }; };
+        pythonSet = (pkgs.callPackage pyproject-nix.build.packages { python = pkgs.python3; }).overrideScope (
+          pkgs.lib.composeManyExtensions [
+            (uvWorkspace.mkPyprojectOverlay { sourcePreference = "wheel"; })
+            pyproject-build-systems.overlays.default
+          ]
+        );
+        venv = pythonSet.mkVirtualEnv "jj-venv" uvWorkspace.deps.all;
+
         packages = with pkgs; [
           rustShellToolchain
 
@@ -178,9 +201,19 @@
 
           # For building the documentation website
           uv
-          # nixos does not work with uv-installed python
-          python3
+          venv
         ];
+
+        env' = env // {
+          # Don't create venv using uv.
+          UV_NO_SYNC = 1;
+
+          # Force uv to use Python interpreter from venv.
+          UV_PYTHON = "${venv}/bin/python";
+
+          # Prevent uv from downloading managed Pythons
+          UV_PYTHON_DOWNLOADS = "never";
+        };
 
         # on macOS and Linux, use faster parallel linkers that are much more
         # efficient than the defaults. these noticeably improve link time even for
@@ -208,12 +241,16 @@
         # to allow the `xcrun` command above to be interpreted by the shell.
         shellHook = ''
           export RUSTFLAGS="-Zthreads=0 ${rustLinkFlagsString}"
+
+          # Undo dependency propagation by Nixpkgs.
+          unset PYTHONPATH
         '';
       in
         pkgs.mkShell {
           name = "jujutsu";
           packages = packages ++ nativeBuildInputs ++ buildInputs ++ nativeCheckInputs;
-          inherit env shellHook;
+          env = env';
+          inherit shellHook;
         };
     }));
 }


### PR DESCRIPTION
Since 8e15a2634aaf6e68cf88868902b8f2900ac41156, we now depend on NumPy to build the docs, which is a departure from our previous happy path of not needing C extensions/platform-specific wheels, which unfortunately break on NixOS.

uv2nix luckily does the hard work for us and makes everything (including patching wheels and falling back to source compilation) pretty easy to do. This is arguably preferrable to solutions like [0], as now we don't have to deal with breakages like [1], and will be able to extend our Python dependency footprint in the future without much fuss.

[0]: https://github.com/jj-vcs/jj/pull/6472
[1]: https://github.com/jj-vcs/jj/pull/6472#issuecomment-2859626719

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
