### PR TITLE
cleanup: fixup to 920debc, delete now-irrelevant comment

### DIFF
--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -175,8 +175,6 @@ mod tests {
         let id_1 = CommitId::from_hex("111111");
         let change_id1 = new_change_id();
         let id_2 = CommitId::from_hex("222222");
-        // TODO: Remove the exception after https://github.com/rust-lang/rust-clippy/issues/10577
-        // is fixed or file a new bug.
         let change_id2 = change_id1.clone();
         mutable_segment.add_commit_data(id_0.clone(), change_id0, &[]);
         mutable_segment.add_commit_data(id_1.clone(), change_id1.clone(), &[id_0.clone()]);


### PR DESCRIPTION
Fixup to 920debc that removed the line this comment was about.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
