### PR TITLE
Aec3 wc settings

### DIFF
--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -45,6 +45,7 @@ use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::working_copy::SnapshotStats;
 use jj_lib::working_copy::WorkingCopy;
 use jj_lib::working_copy::WorkingCopyFactory;
+use jj_lib::working_copy::WorkingCopySettings;
 use jj_lib::working_copy::WorkingCopyStateError;
 use jj_lib::workspace::WorkingCopyFactories;
 use jj_lib::workspace::Workspace;
@@ -170,8 +171,11 @@ impl WorkingCopy for ConflictsWorkingCopy {
         self.inner.sparse_patterns()
     }
 
-    fn start_mutation(&self) -> Result<Box<dyn LockedWorkingCopy>, WorkingCopyStateError> {
-        let inner = self.inner.start_mutation()?;
+    fn start_mutation(
+        &self,
+        wc_settings: WorkingCopySettings,
+    ) -> Result<Box<dyn LockedWorkingCopy>, WorkingCopyStateError> {
+        let inner = self.inner.start_mutation(wc_settings)?;
         Ok(Box::new(LockedConflictsWorkingCopy {
             wc_path: self.working_copy_path.clone(),
             inner,

--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -36,7 +36,6 @@ use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
 use jj_lib::store::Store;
 use jj_lib::working_copy::CheckoutError;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
 use jj_lib::working_copy::ResetError;
@@ -254,18 +253,14 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
         self.inner.snapshot(&options)
     }
 
-    fn check_out(
-        &mut self,
-        commit: &Commit,
-        options: &CheckoutOptions,
-    ) -> Result<CheckoutStats, CheckoutError> {
+    fn check_out(&mut self, commit: &Commit) -> Result<CheckoutStats, CheckoutError> {
         let conflicts = commit
             .tree()?
             .conflicts()
             .map(|(path, _value)| format!("{}\n", path.as_internal_file_string()))
             .join("");
         std::fs::write(self.wc_path.join(".conflicts"), conflicts).unwrap();
-        self.inner.check_out(commit, options)
+        self.inner.check_out(commit)
     }
 
     fn rename_workspace(&mut self, new_name: WorkspaceNameBuf) {
@@ -287,9 +282,8 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
     fn set_sparse_patterns(
         &mut self,
         new_sparse_patterns: Vec<RepoPathBuf>,
-        options: &CheckoutOptions,
     ) -> Result<CheckoutStats, CheckoutError> {
-        self.inner.set_sparse_patterns(new_sparse_patterns, options)
+        self.inner.set_sparse_patterns(new_sparse_patterns)
     }
 
     fn finish(

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1382,27 +1382,6 @@ to the current parents may contain changes from multiple commits.
         Ok(expression.to_matcher())
     }
 
-    pub fn snapshot_options_with_start_tracking_matcher<'a>(
-        &self,
-        start_tracking_matcher: &'a dyn Matcher,
-    ) -> Result<SnapshotOptions<'a>, CommandError> {
-        let base_ignores = self.base_ignores()?;
-        let fsmonitor_settings = self.settings().fsmonitor_settings()?;
-        let HumanByteSize(mut max_new_file_size) = self
-            .settings()
-            .get_value_with("snapshot.max-new-file-size", TryInto::try_into)?;
-        if max_new_file_size == 0 {
-            max_new_file_size = u64::MAX;
-        }
-        Ok(SnapshotOptions {
-            base_ignores,
-            fsmonitor_settings,
-            progress: None,
-            start_tracking_matcher,
-            max_new_file_size,
-        })
-    }
-
     pub(crate) fn path_converter(&self) -> &RepoPathUiConverter {
         self.env.path_converter()
     }
@@ -1876,9 +1855,7 @@ to the current parents may contain changes from multiple commits.
         let auto_tracking_matcher = self
             .auto_tracking_matcher(ui)
             .map_err(snapshot_command_error)?;
-        let options = self
-            .snapshot_options_with_start_tracking_matcher(&auto_tracking_matcher)
-            .map_err(snapshot_command_error)?;
+        let base_ignores = self.base_ignores().map_err(snapshot_command_error)?;
 
         // Compare working-copy tree and operation with repo's, and reload as needed.
         let mut locked_ws = self
@@ -1939,9 +1916,12 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
             };
         self.user_repo = ReadonlyUserRepo::new(repo);
         let (new_tree_id, stats) = {
-            let mut options = options;
             let progress = crate::progress::snapshot_progress(ui);
-            options.progress = progress.as_ref().map(|x| x as _);
+            let options = SnapshotOptions {
+                base_ignores,
+                progress: progress.as_ref().map(|x| x as _),
+                start_tracking_matcher: &auto_tracking_matcher,
+            };
             locked_ws
                 .locked_wc()
                 .snapshot(&options)

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -120,7 +120,6 @@ use jj_lib::str_util::StringPattern;
 use jj_lib::transaction::Transaction;
 use jj_lib::view::View;
 use jj_lib::working_copy;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::working_copy::SnapshotStats;
@@ -549,7 +548,6 @@ impl CommandHelper {
                 let stale_wc_commit = repo.store().get_commit(wc_commit_id)?;
 
                 let mut workspace_command = self.workspace_helper_no_snapshot(ui)?;
-                let checkout_options = workspace_command.checkout_options();
 
                 let repo = workspace_command.repo().clone();
                 let (mut locked_ws, desired_wc_commit) =
@@ -572,7 +570,6 @@ impl CommandHelper {
                             repo.op_id().clone(),
                             &stale_wc_commit,
                             &desired_wc_commit,
-                            &checkout_options,
                         )?;
                         workspace_command.print_updated_working_copy_stats(
                             ui,
@@ -1254,12 +1251,6 @@ impl WorkspaceCommandHelper {
         &self.env
     }
 
-    pub fn checkout_options(&self) -> CheckoutOptions {
-        CheckoutOptions {
-            conflict_marker_style: self.env.conflict_marker_style(),
-        }
-    }
-
     pub fn unchecked_start_working_copy_mutation(
         &mut self,
     ) -> Result<(LockedWorkspace, Commit), CommandError> {
@@ -1403,14 +1394,12 @@ to the current parents may contain changes from multiple commits.
         if max_new_file_size == 0 {
             max_new_file_size = u64::MAX;
         }
-        let conflict_marker_style = self.env.conflict_marker_style();
         Ok(SnapshotOptions {
             base_ignores,
             fsmonitor_settings,
             progress: None,
             start_tracking_matcher,
             max_new_file_size,
-            conflict_marker_style,
         })
     }
 
@@ -2018,13 +2007,11 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
         new_commit: &Commit,
     ) -> Result<(), CommandError> {
         assert!(self.may_update_working_copy);
-        let checkout_options = self.checkout_options();
         let stats = update_working_copy(
             &self.user_repo.repo,
             &mut self.workspace,
             maybe_old_commit,
             new_commit,
-            &checkout_options,
         )?;
         self.print_updated_working_copy_stats(ui, maybe_old_commit, new_commit, &stats)
     }
@@ -2600,22 +2587,18 @@ fn update_stale_working_copy(
     op_id: OperationId,
     stale_commit: &Commit,
     new_commit: &Commit,
-    options: &CheckoutOptions,
 ) -> Result<CheckoutStats, CommandError> {
     // The same check as start_working_copy_mutation(), but with the stale
     // working-copy commit.
     if stale_commit.tree_id() != locked_ws.locked_wc().old_tree_id() {
         return Err(user_error("Concurrent working copy operation. Try again."));
     }
-    let stats = locked_ws
-        .locked_wc()
-        .check_out(new_commit, options)
-        .map_err(|err| {
-            internal_error_with_message(
-                format!("Failed to check out commit {}", new_commit.id().hex()),
-                err,
-            )
-        })?;
+    let stats = locked_ws.locked_wc().check_out(new_commit).map_err(|err| {
+        internal_error_with_message(
+            format!("Failed to check out commit {}", new_commit.id().hex()),
+            err,
+        )
+    })?;
     locked_ws.finish(op_id)?;
 
     Ok(stats)
@@ -2871,18 +2854,12 @@ pub fn update_working_copy(
     workspace: &mut Workspace,
     old_commit: Option<&Commit>,
     new_commit: &Commit,
-    options: &CheckoutOptions,
 ) -> Result<CheckoutStats, CommandError> {
     let old_tree_id = old_commit.map(|commit| commit.tree_id().clone());
     // TODO: CheckoutError::ConcurrentCheckout should probably just result in a
     // warning for most commands (but be an error for the checkout command)
     let stats = workspace
-        .check_out(
-            repo.op_id().clone(),
-            old_tree_id.as_ref(),
-            new_commit,
-            options,
-        )
+        .check_out(repo.op_id().clone(), old_tree_id.as_ref(), new_commit)
         .map_err(|err| {
             internal_error_with_message(
                 format!("Failed to check out commit {}", new_commit.id().hex()),

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -58,6 +58,7 @@ use jj_lib::working_copy::RecoverWorkspaceError;
 use jj_lib::working_copy::ResetError;
 use jj_lib::working_copy::SnapshotError;
 use jj_lib::working_copy::WorkingCopyStateError;
+use jj_lib::workspace::StartWorkingCopyMutError;
 use jj_lib::workspace::WorkspaceInitError;
 use thiserror::Error;
 
@@ -357,6 +358,17 @@ impl From<WorkspaceInitError> for CommandError {
             }
             WorkspaceInitError::SignInit(err) => user_error(err),
             WorkspaceInitError::TransactionCommit(err) => err.into(),
+        }
+    }
+}
+
+impl From<StartWorkingCopyMutError> for CommandError {
+    fn from(err: StartWorkingCopyMutError) -> Self {
+        match err {
+            StartWorkingCopyMutError::WcState(err) => {
+                internal_error_with_message("Failed to access the repository", err)
+            }
+            StartWorkingCopyMutError::ConfigGet(err) => config_error(err),
         }
     }
 }

--- a/cli/src/commands/debug/local_working_copy.rs
+++ b/cli/src/commands/debug/local_working_copy.rs
@@ -37,7 +37,7 @@ pub fn cmd_debug_local_working_copy(
     let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;
     writeln!(ui.stdout(), "Current operation: {:?}", wc.operation_id())?;
     writeln!(ui.stdout(), "Current tree: {:?}", wc.tree_id()?)?;
-    for (file, state) in wc.file_states()? {
+    for (file, state) in wc.file_states()?.iter() {
         writeln!(
             ui.stdout(),
             "{:?} {:13?} {:10?} {:?} {:?}",

--- a/cli/src/commands/debug/watchman.rs
+++ b/cli/src/commands/debug/watchman.rs
@@ -57,7 +57,7 @@ pub fn cmd_debug_watchman(
     match subcommand {
         DebugWatchmanCommand::Status => {
             // TODO(ilyagr): It would be nice to add colors here
-            let config = match workspace_command.settings().fsmonitor_settings()? {
+            let config = match FsmonitorSettings::from_settings(workspace_command.settings())? {
                 FsmonitorSettings::Watchman(config) => {
                     writeln!(ui.stdout(), "Watchman is enabled via `core.fsmonitor`.")?;
                     writeln!(

--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -18,6 +18,7 @@ use std::io::Write as _;
 use indoc::writedoc;
 use itertools::Itertools as _;
 use jj_lib::repo_path::RepoPathUiConverter;
+use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::working_copy::SnapshotStats;
 use jj_lib::working_copy::UntrackedReason;
 use tracing::instrument;
@@ -53,7 +54,11 @@ pub(crate) fn cmd_file_track(
     let matcher = workspace_command
         .parse_file_patterns(ui, &args.paths)?
         .to_matcher();
-    let options = workspace_command.snapshot_options_with_start_tracking_matcher(&matcher)?;
+    let options = SnapshotOptions {
+        base_ignores: workspace_command.base_ignores()?,
+        progress: None,
+        start_tracking_matcher: &matcher,
+    };
 
     let mut tx = workspace_command.start_transaction().into_inner();
     let (mut locked_ws, _wc_commit) = workspace_command.start_working_copy_mutation()?;

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -19,6 +19,7 @@ use itertools::Itertools as _;
 use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTreeBuilder;
 use jj_lib::repo::Repo as _;
+use jj_lib::working_copy::SnapshotOptions;
 use tracing::instrument;
 
 use crate::cli_util::print_snapshot_stats;
@@ -56,8 +57,11 @@ pub(crate) fn cmd_file_untrack(
         .parse_file_patterns(ui, &args.paths)?
         .to_matcher();
     let auto_tracking_matcher = workspace_command.auto_tracking_matcher(ui)?;
-    let options =
-        workspace_command.snapshot_options_with_start_tracking_matcher(&auto_tracking_matcher)?;
+    let options = SnapshotOptions {
+        base_ignores: workspace_command.base_ignores()?,
+        progress: None,
+        start_tracking_matcher: &auto_tracking_matcher,
+    };
 
     let mut tx = workspace_command.start_transaction().into_inner();
     let (mut locked_ws, wc_commit) = workspace_command.start_working_copy_mutation()?;

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -245,7 +245,7 @@ pub fn show_op_diff(
                 if !buffer.ends_with(b"\n") {
                     buffer.push(b'\n');
                 }
-                if let Some(diff_renderer) = &diff_renderer {
+                if let Some(diff_renderer) = diff_renderer {
                     let mut formatter = ui.new_formatter(&mut buffer);
                     show_change_diff(
                         ui,
@@ -275,7 +275,7 @@ pub fn show_op_diff(
                         modified_change,
                     )
                 })?;
-                if let Some(diff_renderer) = &diff_renderer {
+                if let Some(diff_renderer) = diff_renderer {
                     let width = with_content_format.width();
                     show_change_diff(ui, formatter, diff_renderer, modified_change, width)?;
                 }

--- a/cli/src/commands/sparse/mod.rs
+++ b/cli/src/commands/sparse/mod.rs
@@ -65,12 +65,11 @@ fn update_sparse_patterns_with(
     workspace_command: &mut WorkspaceCommandHelper,
     f: impl FnOnce(&mut Ui, &[RepoPathBuf]) -> Result<Vec<RepoPathBuf>, CommandError>,
 ) -> Result<(), CommandError> {
-    let checkout_options = workspace_command.checkout_options();
     let (mut locked_ws, wc_commit) = workspace_command.start_working_copy_mutation()?;
     let new_patterns = f(ui, locked_ws.locked_wc().sparse_patterns()?)?;
     let stats = locked_ws
         .locked_wc()
-        .set_sparse_patterns(new_patterns, &checkout_options)
+        .set_sparse_patterns(new_patterns)
         .map_err(|err| internal_error_with_message("Failed to update working copy paths", err))?;
     let operation_id = locked_ws.locked_wc().old_operation_id().clone();
     locked_ws.finish(operation_id)?;

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -147,11 +147,10 @@ pub fn cmd_workspace_add(
     };
 
     if let Some(sparse_patterns) = sparsity {
-        let checkout_options = new_workspace_command.checkout_options();
         let (mut locked_ws, _wc_commit) = new_workspace_command.start_working_copy_mutation()?;
         locked_ws
             .locked_wc()
-            .set_sparse_patterns(sparse_patterns, &checkout_options)
+            .set_sparse_patterns(sparse_patterns)
             .map_err(|err| internal_error_with_message("Failed to set sparse patterns", err))?;
         let operation_id = locked_ws.locked_wc().old_operation_id().clone();
         locked_ws.finish(operation_id)?;

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::fs;
 use std::io;
 use std::io::Write as _;
@@ -349,11 +350,13 @@ pub fn combine_messages_for_editing(
             .into_string()
             .map_err(|_| user_error("Trailers should be valid utf-8"))?;
         let new_trailers = parse_trailers(&trailer_lines)?;
-        let trailers: String = new_trailers
+        let trailers = new_trailers
             .iter()
             .filter(|trailer| !old_trailers.contains(trailer))
-            .map(|trailer| format!("{}: {}\n", trailer.key, trailer.value))
-            .collect();
+            .fold(String::new(), |mut output, trailer| {
+                writeln!(output, "{}: {}", trailer.key, trailer.value).unwrap();
+                output
+            });
         if !trailers.is_empty() {
             combined.push_str("\nJJ: Trailers not found in the squashed commits:\n");
             combined.push_str(&trailers);

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -278,10 +278,8 @@ diff editing in mind and be a little inaccurate.
         );
         wc.snapshot(&SnapshotOptions {
             base_ignores,
-            fsmonitor_settings: FsmonitorSettings::None,
             progress: None,
             start_tracking_matcher: &EverythingMatcher,
-            max_new_file_size: u64::MAX,
         })?;
         Ok(output.state.current_tree_id().clone())
     }
@@ -299,6 +297,9 @@ fn wc_mut<'a>(
         working_copy_path,
         config: WcMutConfig {
             conflict_marker_style,
+            // Merge tools shouldn't care about these settings.
+            fsmonitor_settings: FsmonitorSettings::None,
+            max_new_file_size: u64::MAX,
         },
     }
 }

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -17,7 +17,6 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::Matcher;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree::TreeDiffEntry;
-use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::store::Store;
 use jj_lib::working_copy::CheckoutError;
 use jj_lib::working_copy::CheckoutOptions;
@@ -39,61 +38,36 @@ pub enum DiffCheckoutError {
     TreeState(#[from] TreeStateError),
 }
 
+// A working copy's parent directory plus saved tree state.
+struct WcTree {
+    wc_path: PathBuf,
+    state: TreeState,
+}
+
 pub(crate) struct DiffWorkingCopies {
     _temp_dir: TempDir, // Temp dir will be deleted when this is dropped
-    left_tree_state: TreeState,
-    right_tree_state: TreeState,
-    output_tree_state: Option<TreeState>,
+    left: WcTree,
+    right: WcTree,
+    output: Option<WcTree>,
 }
 
 impl DiffWorkingCopies {
-    pub fn left_working_copy_path(&self) -> &Path {
-        self.left_tree_state.working_copy_path()
-    }
-
-    pub fn right_working_copy_path(&self) -> &Path {
-        self.right_tree_state.working_copy_path()
-    }
-
-    pub fn output_working_copy_path(&self) -> Option<&Path> {
-        self.output_tree_state
-            .as_ref()
-            .map(|state| state.working_copy_path())
-    }
-
     pub fn to_command_variables(&self) -> HashMap<&'static str, &str> {
-        let left_wc_dir = self.left_working_copy_path();
-        let right_wc_dir = self.right_working_copy_path();
         let mut result = maplit::hashmap! {
-            "left" => left_wc_dir.to_str().expect("temp_dir should be valid utf-8"),
-            "right" => right_wc_dir.to_str().expect("temp_dir should be valid utf-8"),
+            "left" => self.left.wc_path.to_str().expect("temp_dir should be valid utf-8"),
+            "right" => self.right.wc_path.to_str().expect("temp_dir should be valid utf-8"),
         };
-        if let Some(output_wc_dir) = self.output_working_copy_path() {
+        if let Some(wc_tree) = &self.output {
             result.insert(
                 "output",
-                output_wc_dir
+                wc_tree
+                    .wc_path
                     .to_str()
                     .expect("temp_dir should be valid utf-8"),
             );
         }
         result
     }
-}
-
-fn check_out(
-    store: Arc<Store>,
-    wc_dir: PathBuf,
-    state_dir: PathBuf,
-    tree: &MergedTree,
-    sparse_patterns: Vec<RepoPathBuf>,
-    options: &CheckoutOptions,
-) -> Result<TreeState, DiffCheckoutError> {
-    std::fs::create_dir(&wc_dir).map_err(DiffCheckoutError::SetUpDir)?;
-    std::fs::create_dir(&state_dir).map_err(DiffCheckoutError::SetUpDir)?;
-    let mut tree_state = TreeState::init(store, wc_dir, state_dir)?;
-    tree_state.set_sparse_patterns(sparse_patterns, options)?;
-    tree_state.check_out(tree, options)?;
-    Ok(tree_state)
 }
 
 pub(crate) fn new_utf8_temp_dir(prefix: &str) -> io::Result<TempDir> {
@@ -124,20 +98,24 @@ pub(crate) fn set_readonly_recursively(path: &Path) -> Result<(), std::io::Error
     }
 }
 
+/// How to prepare tree states from the working copy for a diff viewer/editor.
+///
+/// TwoWay: prepare a left and right tree; left is readonly.
+/// ThreeWay: prepare left, right, and output trees; left + right are readonly.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum DiffSide {
-    // Left,
-    Right,
+pub(crate) enum DiffType {
+    TwoWay,
+    ThreeWay,
 }
 
-/// Check out the two trees in temporary directories. Only include changed files
-/// in the sparse checkout patterns.
+/// Check out the two trees in temporary directories and make appropriate sides
+/// readonly. Only include changed files in the sparse checkout patterns.
 pub(crate) fn check_out_trees(
     store: &Arc<Store>,
     left_tree: &MergedTree,
     right_tree: &MergedTree,
     matcher: &dyn Matcher,
-    output_is: Option<DiffSide>,
+    diff_type: DiffType,
     options: &CheckoutOptions,
 ) -> Result<DiffWorkingCopies, DiffCheckoutError> {
     let changed_files: Vec<_> = left_tree
@@ -147,48 +125,40 @@ pub(crate) fn check_out_trees(
         .block_on();
 
     let temp_dir = new_utf8_temp_dir("jj-diff-").map_err(DiffCheckoutError::SetUpDir)?;
-    let left_wc_dir = temp_dir.path().join("left");
-    let left_state_dir = temp_dir.path().join("left_state");
-    let right_wc_dir = temp_dir.path().join("right");
-    let right_state_dir = temp_dir.path().join("right_state");
-    let left_tree_state = check_out(
-        store.clone(),
-        left_wc_dir,
-        left_state_dir,
-        left_tree,
-        changed_files.clone(),
-        options,
-    )?;
-    let right_tree_state = check_out(
-        store.clone(),
-        right_wc_dir,
-        right_state_dir,
-        right_tree,
-        changed_files.clone(),
-        options,
-    )?;
-    let output_tree_state = output_is
-        .map(|output_side| {
-            let output_wc_dir = temp_dir.path().join("output");
-            let output_state_dir = temp_dir.path().join("output_state");
-            check_out(
-                store.clone(),
-                output_wc_dir,
-                output_state_dir,
-                match output_side {
-                    // DiffSide::Left => left_tree,
-                    DiffSide::Right => right_tree,
-                },
-                changed_files,
-                options,
-            )
-        })
-        .transpose()?;
+    let temp_path = temp_dir.path();
+
+    // Checkout a tree into our temp directory with the given name prefix.
+    let check_out = |name: &str, tree, files, read_only| -> Result<WcTree, DiffCheckoutError> {
+        let wc_path = temp_path.join(name);
+        let state_dir = temp_path.join(format!("{name}_state"));
+        std::fs::create_dir(&wc_path).map_err(DiffCheckoutError::SetUpDir)?;
+        std::fs::create_dir(&state_dir).map_err(DiffCheckoutError::SetUpDir)?;
+        let mut state = TreeState::init(store.clone(), wc_path.clone(), state_dir)?;
+        state.set_sparse_patterns(files, options)?;
+        state.check_out(tree, options)?;
+        if read_only {
+            set_readonly_recursively(&wc_path).map_err(DiffCheckoutError::SetUpDir)?;
+        }
+        Ok(WcTree { state, wc_path })
+    };
+
+    let left = check_out("left", left_tree, changed_files.clone(), true)?;
+    let output = match diff_type {
+        DiffType::TwoWay => None,
+        DiffType::ThreeWay => Some(check_out(
+            "output",
+            right_tree,
+            changed_files.clone(),
+            false,
+        )?),
+    };
+    let right_readonly = output.is_some();
+    let right = check_out("right", right_tree, changed_files, right_readonly)?;
     Ok(DiffWorkingCopies {
         _temp_dir: temp_dir,
-        left_tree_state,
-        right_tree_state,
-        output_tree_state,
+        left,
+        right,
+        output,
     })
 }
 
@@ -205,40 +175,45 @@ impl DiffEditWorkingCopies {
         left_tree: &MergedTree,
         right_tree: &MergedTree,
         matcher: &dyn Matcher,
-        output_is: Option<DiffSide>,
+        diff_type: DiffType,
         instructions: Option<&str>,
         options: &CheckoutOptions,
     ) -> Result<Self, DiffEditError> {
-        let diff_wc = check_out_trees(store, left_tree, right_tree, matcher, output_is, options)?;
-        let got_output_field = output_is.is_some();
+        let working_copies =
+            check_out_trees(store, left_tree, right_tree, matcher, diff_type, options)?;
+        let instructions_path_to_cleanup = instructions
+            .map(|instructions| Self::write_edit_instructions(&working_copies, instructions))
+            .transpose()?;
+        Ok(Self {
+            working_copies,
+            instructions_path_to_cleanup,
+        })
+    }
 
-        set_readonly_recursively(diff_wc.left_working_copy_path())
-            .map_err(ExternalToolError::SetUpDir)?;
-        if got_output_field {
-            set_readonly_recursively(diff_wc.right_working_copy_path())
-                .map_err(ExternalToolError::SetUpDir)?;
-        }
-        let output_wc_path = diff_wc
-            .output_working_copy_path()
-            .unwrap_or_else(|| diff_wc.right_working_copy_path());
+    fn write_edit_instructions(
+        working_copies: &DiffWorkingCopies,
+        instructions: &str,
+    ) -> Result<PathBuf, DiffEditError> {
+        let (right_wc_path, output_wc_path) = match &working_copies.output {
+            Some(output) => (Some(&working_copies.right.wc_path), &output.wc_path),
+            None => (None, &working_copies.right.wc_path),
+        };
         let output_instructions_path = output_wc_path.join("JJ-INSTRUCTIONS");
         // In the unlikely event that the file already exists, then the user will simply
         // not get any instructions.
-        let add_instructions = if !output_instructions_path.exists() {
-            instructions
-        } else {
-            None
-        };
-        if let Some(instructions) = add_instructions {
-            let mut output_instructions_file =
-                File::create(&output_instructions_path).map_err(ExternalToolError::SetUpDir)?;
-            if diff_wc.right_working_copy_path() != output_wc_path {
-                let mut right_instructions_file =
-                    File::create(diff_wc.right_working_copy_path().join("JJ-INSTRUCTIONS"))
-                        .map_err(ExternalToolError::SetUpDir)?;
-                right_instructions_file
-                    .write_all(
-                        b"\
+        if output_instructions_path.exists() {
+            return Ok(output_instructions_path);
+        }
+        let mut output_instructions_file =
+            File::create(&output_instructions_path).map_err(ExternalToolError::SetUpDir)?;
+
+        // Write out our experimental three-way merge instructions first.
+        if let Some(right_wc_path) = right_wc_path {
+            let mut right_instructions_file = File::create(right_wc_path.join("JJ-INSTRUCTIONS"))
+                .map_err(ExternalToolError::SetUpDir)?;
+            right_instructions_file
+                .write_all(
+                    b"\
 The content of this pane should NOT be edited. Any edits will be
 lost.
 
@@ -247,16 +222,16 @@ the following instructions may have been written with a 2-pane
 diff editing in mind and be a little inaccurate.
 
 ",
-                    )
-                    .map_err(ExternalToolError::SetUpDir)?;
-                right_instructions_file
-                    .write_all(instructions.as_bytes())
-                    .map_err(ExternalToolError::SetUpDir)?;
-                // Note that some diff tools might not show this message and delete the contents
-                // of the output dir instead. Meld does show this message.
-                output_instructions_file
-                    .write_all(
-                        b"\
+                )
+                .map_err(ExternalToolError::SetUpDir)?;
+            right_instructions_file
+                .write_all(instructions.as_bytes())
+                .map_err(ExternalToolError::SetUpDir)?;
+            // Note that some diff tools might not show this message and delete the contents
+            // of the output dir instead. Meld does show this message.
+            output_instructions_file
+                .write_all(
+                    b"\
 Please make your edits in this pane.
 
 You are using the experimental 3-pane diff editor config. Some of
@@ -264,18 +239,14 @@ the following instructions may have been written with a 2-pane
 diff editing in mind and be a little inaccurate.
 
 ",
-                    )
-                    .map_err(ExternalToolError::SetUpDir)?;
-            }
-            output_instructions_file
-                .write_all(instructions.as_bytes())
+                )
                 .map_err(ExternalToolError::SetUpDir)?;
-        };
-
-        Ok(Self {
-            working_copies: diff_wc,
-            instructions_path_to_cleanup: add_instructions.map(|_| output_instructions_path),
-        })
+        }
+        // Now write the passed-in instructions.
+        output_instructions_file
+            .write_all(instructions.as_bytes())
+            .map_err(ExternalToolError::SetUpDir)?;
+        Ok(output_instructions_path)
     }
 
     pub fn snapshot_results(
@@ -289,9 +260,7 @@ diff editing in mind and be a little inaccurate.
 
         let diff_wc = self.working_copies;
         // Snapshot changes in the temporary output directory.
-        let mut output_tree_state = diff_wc
-            .output_tree_state
-            .unwrap_or(diff_wc.right_tree_state);
+        let mut output_tree_state = diff_wc.output.unwrap_or(diff_wc.right).state;
         output_tree_state.snapshot(&SnapshotOptions {
             base_ignores,
             fsmonitor_settings: FsmonitorSettings::None,

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -416,7 +416,7 @@ pub fn edit_diff_external(
         }));
     }
 
-    diffedit_wc.snapshot_results(base_ignores, options.conflict_marker_style)
+    diffedit_wc.snapshot_results(store, base_ignores, options.conflict_marker_style)
 }
 
 /// Generates textual diff by the specified `tool` and writes into `writer`.

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -30,7 +30,7 @@ use super::diff_working_copies::check_out_trees;
 use super::diff_working_copies::new_utf8_temp_dir;
 use super::diff_working_copies::set_readonly_recursively;
 use super::diff_working_copies::DiffEditWorkingCopies;
-use super::diff_working_copies::DiffSide;
+use super::diff_working_copies::DiffType;
 use super::ConflictResolveError;
 use super::DiffEditError;
 use super::DiffGenerateError;
@@ -384,13 +384,18 @@ pub fn edit_diff_external(
     };
 
     let got_output_field = find_all_variables(&editor.edit_args).contains(&"output");
+    let diff_type = if got_output_field {
+        DiffType::ThreeWay
+    } else {
+        DiffType::TwoWay
+    };
     let store = left_tree.store();
     let diffedit_wc = DiffEditWorkingCopies::check_out(
         store,
         left_tree,
         right_tree,
         matcher,
-        got_output_field.then_some(DiffSide::Right),
+        diff_type,
         instructions,
         &options,
     )?;
@@ -431,11 +436,14 @@ pub fn generate_diff(
         conflict_marker_style,
     };
     let store = left_tree.store();
-    let diff_wc = check_out_trees(store, left_tree, right_tree, matcher, None, &options)?;
-    set_readonly_recursively(diff_wc.left_working_copy_path())
-        .map_err(ExternalToolError::SetUpDir)?;
-    set_readonly_recursively(diff_wc.right_working_copy_path())
-        .map_err(ExternalToolError::SetUpDir)?;
+    let diff_wc = check_out_trees(
+        store,
+        left_tree,
+        right_tree,
+        matcher,
+        DiffType::TwoWay,
+        &options,
+    )?;
     invoke_external_diff(ui, writer, tool, &diff_wc.to_command_variables())
 }
 

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -22,7 +22,6 @@ use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree::MergedTreeBuilder;
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::store::Store;
-use jj_lib::working_copy::CheckoutOptions;
 use pollster::FutureExt as _;
 use thiserror::Error;
 
@@ -379,9 +378,6 @@ pub fn edit_diff_external(
     let conflict_marker_style = editor
         .conflict_marker_style
         .unwrap_or(default_conflict_marker_style);
-    let options = CheckoutOptions {
-        conflict_marker_style,
-    };
 
     let got_output_field = find_all_variables(&editor.edit_args).contains(&"output");
     let diff_type = if got_output_field {
@@ -397,7 +393,7 @@ pub fn edit_diff_external(
         matcher,
         diff_type,
         instructions,
-        &options,
+        conflict_marker_style,
     )?;
 
     let patterns = diffedit_wc.working_copies.to_command_variables();
@@ -416,7 +412,7 @@ pub fn edit_diff_external(
         }));
     }
 
-    diffedit_wc.snapshot_results(store, base_ignores, options.conflict_marker_style)
+    diffedit_wc.snapshot_results(store, base_ignores, conflict_marker_style)
 }
 
 /// Generates textual diff by the specified `tool` and writes into `writer`.
@@ -432,9 +428,6 @@ pub fn generate_diff(
     let conflict_marker_style = tool
         .conflict_marker_style
         .unwrap_or(default_conflict_marker_style);
-    let options = CheckoutOptions {
-        conflict_marker_style,
-    };
     let store = left_tree.store();
     let diff_wc = check_out_trees(
         store,
@@ -442,7 +435,7 @@ pub fn generate_diff(
         right_tree,
         matcher,
         DiffType::TwoWay,
-        &options,
+        conflict_marker_style,
     )?;
     invoke_external_diff(ui, writer, tool, &diff_wc.to_command_variables())
 }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -64,7 +64,7 @@ pub enum ConfigLoadError {
     Parse {
         /// Source error.
         #[source]
-        error: toml_edit::TomlError,
+        error: Box<toml_edit::TomlError>, // Box avoids a Windows lint for large Result type.
         /// Source file path.
         source_path: Option<PathBuf>,
     },
@@ -337,7 +337,7 @@ impl ConfigLayer {
     /// Parses TOML document `text` into new layer.
     pub fn parse(source: ConfigSource, text: &str) -> Result<Self, ConfigLoadError> {
         let data = ImDocument::parse(text).map_err(|error| ConfigLoadError::Parse {
-            error,
+            error: error.into(),
             source_path: None,
         })?;
         Ok(Self::with_data(source, data.into_mut()))
@@ -349,7 +349,7 @@ impl ConfigLayer {
             .context(&path)
             .map_err(ConfigLoadError::Read)?;
         let data = ImDocument::parse(text).map_err(|error| ConfigLoadError::Parse {
-            error,
+            error: error.into(),
             source_path: Some(path.clone()),
         })?;
         Ok(ConfigLayer {

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -36,6 +36,9 @@ program = "gpgsm"
 # allowed-signers = <unknown>
 program = "ssh-keygen"
 
+[snapshot]
+max-new-file-size = "1MiB"
+
 [ui]
 conflict-marker-style = "diff"
 

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -36,6 +36,9 @@ program = "gpgsm"
 # allowed-signers = <unknown>
 program = "ssh-keygen"
 
+[ui]
+conflict-marker-style = "diff"
+
 [user]
 email = ""
 name = ""

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -101,7 +101,7 @@ impl<'a> GitSubprocessContext<'a> {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             git_cmd.creation_flags(CREATE_NO_WINDOW);
         }

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -163,7 +163,7 @@ impl GpgBackend {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             command.creation_flags(CREATE_NO_WINDOW);
         }
@@ -251,7 +251,7 @@ impl GpgsmBackend {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             command.creation_flags(CREATE_NO_WINDOW);
         }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -112,6 +112,7 @@ use crate::working_copy::SnapshotStats;
 use crate::working_copy::UntrackedReason;
 use crate::working_copy::WorkingCopy;
 use crate::working_copy::WorkingCopyFactory;
+use crate::working_copy::WorkingCopySettings;
 use crate::working_copy::WorkingCopyStateError;
 
 /// On-disk state of file executable bit.
@@ -2027,7 +2028,10 @@ impl WorkingCopy for LocalWorkingCopy {
         Ok(self.tree_state()?.sparse_patterns())
     }
 
-    fn start_mutation(&self) -> Result<Box<dyn LockedWorkingCopy>, WorkingCopyStateError> {
+    fn start_mutation(
+        &self,
+        _wc_settings: WorkingCopySettings,
+    ) -> Result<Box<dyn LockedWorkingCopy>, WorkingCopyStateError> {
         let lock_path = self.state_path.join("working_copy.lock");
         let lock = FileLock::lock(lock_path).map_err(|err| WorkingCopyStateError {
             message: "Failed to lock working copy".to_owned(),

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -716,9 +716,7 @@ struct FsmonitorMatcher {
 }
 
 pub struct TreeState {
-    store: Arc<Store>,
-    working_copy_path: PathBuf,
-    state_path: PathBuf,
+    state_file: PathBuf,
     tree_id: MergedTreeId,
     file_states: FileStatesMap,
     // Currently only path prefixes
@@ -750,10 +748,6 @@ pub enum TreeStateError {
 }
 
 impl TreeState {
-    pub fn working_copy_path(&self) -> &Path {
-        &self.working_copy_path
-    }
-
     pub fn current_tree_id(&self) -> &MergedTreeId {
         &self.tree_id
     }
@@ -770,22 +764,18 @@ impl TreeState {
         Box::new(PrefixMatcher::new(&self.sparse_patterns))
     }
 
-    pub fn init(
-        store: Arc<Store>,
-        working_copy_path: PathBuf,
-        state_path: PathBuf,
-    ) -> Result<TreeState, TreeStateError> {
-        let mut wc = TreeState::empty(store, working_copy_path, state_path);
+    /// Initialize an empty tree state and save it to the filesystem.
+    pub fn init(store: &Arc<Store>, state_path: &Path) -> Result<TreeState, TreeStateError> {
+        let mut wc = TreeState::empty(store, state_path);
         wc.save()?;
         Ok(wc)
     }
 
-    fn empty(store: Arc<Store>, working_copy_path: PathBuf, state_path: PathBuf) -> TreeState {
+    /// Create a new empty tree state for this working copy path.
+    fn empty(store: &Arc<Store>, state_path: &Path) -> TreeState {
         let tree_id = store.empty_merged_tree_id();
         TreeState {
-            store,
-            working_copy_path,
-            state_path,
+            state_file: state_path.join("tree_state"),
             tree_id,
             file_states: FileStatesMap::new(),
             sparse_patterns: vec![RepoPathBuf::root()],
@@ -795,49 +785,46 @@ impl TreeState {
         }
     }
 
-    pub fn load(
-        store: Arc<Store>,
-        working_copy_path: PathBuf,
-        state_path: PathBuf,
-    ) -> Result<TreeState, TreeStateError> {
-        let tree_state_path = state_path.join("tree_state");
-        let file = match File::open(&tree_state_path) {
+    /// Load an existing tree state if present or initialize an empty one.
+    pub fn load(store: &Arc<Store>, state_path: PathBuf) -> Result<TreeState, TreeStateError> {
+        let mut wc = TreeState::empty(store, &state_path);
+        let file = match File::open(&wc.state_file) {
             Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
-                return TreeState::init(store, working_copy_path, state_path);
+                return TreeState::init(store, &state_path);
             }
             Err(err) => {
                 return Err(TreeStateError::ReadTreeState {
-                    path: tree_state_path,
+                    path: wc.state_file,
                     source: err,
                 });
             }
             Ok(file) => file,
         };
 
-        let mut wc = TreeState::empty(store, working_copy_path, state_path);
-        wc.read(&tree_state_path, file)?;
+        wc.read(file)?;
         Ok(wc)
     }
 
     fn update_own_mtime(&mut self) {
-        if let Ok(metadata) = self.state_path.join("tree_state").symlink_metadata() {
+        if let Ok(metadata) = self.state_file.symlink_metadata() {
             self.own_mtime = mtime_from_metadata(&metadata);
         } else {
             self.own_mtime = MillisSinceEpoch(0);
         }
     }
 
-    fn read(&mut self, tree_state_path: &Path, mut file: File) -> Result<(), TreeStateError> {
+    /// Load the tree's data by reading from the filesystem.
+    fn read(&mut self, mut file: File) -> Result<(), TreeStateError> {
         self.update_own_mtime();
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)
             .map_err(|err| TreeStateError::ReadTreeState {
-                path: tree_state_path.to_owned(),
+                path: self.state_file.clone(),
                 source: err,
             })?;
         let proto = crate::protos::working_copy::TreeState::decode(&*buf).map_err(|err| {
             TreeStateError::DecodeTreeState {
-                path: tree_state_path.to_owned(),
+                path: self.state_file.clone(),
                 source: err,
             }
         })?;
@@ -858,6 +845,7 @@ impl TreeState {
         Ok(())
     }
 
+    /// Save the tree's data to the filesystem.
     #[expect(clippy::assigning_clones)]
     fn save(&mut self) -> Result<(), TreeStateError> {
         let mut proto: crate::protos::working_copy::TreeState = Default::default();
@@ -882,12 +870,13 @@ impl TreeState {
         proto.sparse_patterns = Some(sparse_patterns);
         proto.watchman_clock = self.watchman_clock.clone();
 
-        let mut temp_file = NamedTempFile::new_in(&self.state_path).unwrap();
+        let state_path = self.state_file.parent().unwrap();
+        let mut temp_file = NamedTempFile::new_in(state_path).unwrap();
         temp_file
             .as_file_mut()
             .write_all(&proto.encode_to_vec())
             .map_err(|err| TreeStateError::WriteTreeState {
-                path: self.state_path.clone(),
+                path: state_path.to_owned(),
                 source: err,
             })?;
         // update own write time while we before we rename it, so we know
@@ -895,20 +884,13 @@ impl TreeState {
         self.update_own_mtime();
         // TODO: Retry if persisting fails (it will on Windows if the file happened to
         // be open for read).
-        let target_path = self.state_path.join("tree_state");
-        temp_file
-            .persist(&target_path)
-            .map_err(|tempfile::PersistError { error, file: _ }| {
-                TreeStateError::PersistTreeState {
-                    path: target_path.clone(),
-                    source: error,
-                }
-            })?;
+        temp_file.persist(&self.state_file).map_err(
+            |tempfile::PersistError { error, file: _ }| TreeStateError::PersistTreeState {
+                path: self.state_file.clone(),
+                source: error,
+            },
+        )?;
         Ok(())
-    }
-
-    fn current_tree(&self) -> BackendResult<MergedTree> {
-        self.store.get_root_tree(&self.tree_id)
     }
 
     fn reset_watchman(&mut self) {
@@ -920,9 +902,10 @@ impl TreeState {
     #[instrument(skip(self))]
     pub async fn query_watchman(
         &self,
+        working_copy_path: &Path,
         config: &WatchmanConfig,
     ) -> Result<(watchman::Clock, Option<Vec<PathBuf>>), TreeStateError> {
-        let fsmonitor = watchman::Fsmonitor::init(&self.working_copy_path, config)
+        let fsmonitor = watchman::Fsmonitor::init(working_copy_path, config)
             .await
             .map_err(|err| TreeStateError::Fsmonitor(Box::new(err)))?;
         let previous_clock = self.watchman_clock.clone().map(watchman::Clock::from);
@@ -938,9 +921,10 @@ impl TreeState {
     #[instrument(skip(self))]
     pub async fn is_watchman_trigger_registered(
         &self,
+        working_copy_path: &Path,
         config: &WatchmanConfig,
     ) -> Result<bool, TreeStateError> {
-        let fsmonitor = watchman::Fsmonitor::init(&self.working_copy_path, config)
+        let fsmonitor = watchman::Fsmonitor::init(working_copy_path, config)
             .await
             .map_err(|err| TreeStateError::Fsmonitor(Box::new(err)))?;
         fsmonitor
@@ -950,8 +934,22 @@ impl TreeState {
     }
 }
 
+/// A tree state plus configuration needed to mutate it by reading or writing
+/// to the working copy or repository store.
+pub struct WcTreeMutator<'a> {
+    pub state: &'a mut TreeState,
+    pub store: &'a Arc<Store>,
+    pub working_copy_path: &'a Path,
+}
+
+impl WcTreeMutator<'_> {
+    fn current_tree(&self) -> BackendResult<MergedTree> {
+        self.store.get_root_tree(&self.state.tree_id)
+    }
+}
+
 /// Functions to snapshot local-disk files to the store.
-impl TreeState {
+impl WcTreeMutator<'_> {
     /// Look for changes to the working copy. If there are any changes, create
     /// a new tree from it.
     #[instrument(skip_all)]
@@ -968,7 +966,7 @@ impl TreeState {
             conflict_marker_style,
         } = options;
 
-        let sparse_matcher = self.sparse_matcher();
+        let sparse_matcher = self.state.sparse_matcher();
 
         let fsmonitor_clock_needs_save = *fsmonitor_settings != FsmonitorSettings::None;
         let mut is_dirty = fsmonitor_clock_needs_save;
@@ -984,7 +982,7 @@ impl TreeState {
         let matcher = IntersectionMatcher::new(sparse_matcher.as_ref(), fsmonitor_matcher);
         if matcher.visit(RepoPath::root()).is_nothing() {
             // No need to load the current tree, set up channels, etc.
-            self.watchman_clock = watchman_clock;
+            self.state.watchman_clock = watchman_clock;
             return Ok((is_dirty, SnapshotStats::default()));
         }
 
@@ -994,9 +992,14 @@ impl TreeState {
         let (deleted_files_tx, deleted_files_rx) = channel();
 
         trace_span!("traverse filesystem").in_scope(|| -> Result<(), SnapshotError> {
+            let directory_to_visit = DirectoryToVisit {
+                dir: RepoPathBuf::root(),
+                disk_dir: self.working_copy_path.to_owned(),
+                git_ignore: base_ignores.clone(),
+                file_states: self.state.file_states.all(),
+            };
             let snapshotter = FileSnapshotter {
-                tree_state: self,
-                current_tree: &self.current_tree()?,
+                wc: self,
                 matcher: &matcher,
                 start_tracking_matcher,
                 // Move tx sides so they'll be dropped at the end of the scope.
@@ -1008,12 +1011,6 @@ impl TreeState {
                 progress,
                 max_new_file_size,
                 conflict_marker_style,
-            };
-            let directory_to_visit = DirectoryToVisit {
-                dir: RepoPathBuf::root(),
-                disk_dir: self.working_copy_path.clone(),
-                git_ignore: base_ignores.clone(),
-                file_states: self.file_states.all(),
             };
             // Here we use scope as a queue of per-directory jobs.
             rayon::scope(|scope| {
@@ -1027,7 +1024,7 @@ impl TreeState {
         let stats = SnapshotStats {
             untracked_paths: untracked_paths_rx.into_iter().collect(),
         };
-        let mut tree_builder = MergedTreeBuilder::new(self.tree_id.clone());
+        let mut tree_builder = MergedTreeBuilder::new(self.state.tree_id.clone());
         trace_span!("process tree entries").in_scope(|| {
             for (path, tree_values) in &tree_entries_rx {
                 tree_builder.set_or_remove(path, tree_values);
@@ -1047,13 +1044,14 @@ impl TreeState {
                 .sorted_unstable_by(|(path1, _), (path2, _)| path1.cmp(path2))
                 .collect_vec();
             is_dirty |= !changed_file_states.is_empty();
-            self.file_states
+            self.state
+                .file_states
                 .merge_in(changed_file_states, &deleted_files);
         });
         trace_span!("write tree").in_scope(|| {
-            let new_tree_id = tree_builder.write_tree(&self.store).unwrap();
-            is_dirty |= new_tree_id != self.tree_id;
-            self.tree_id = new_tree_id;
+            let new_tree_id = tree_builder.write_tree(self.store).unwrap();
+            is_dirty |= new_tree_id != self.state.tree_id;
+            self.state.tree_id = new_tree_id;
         });
         if cfg!(debug_assertions) {
             let tree = self.current_tree().unwrap();
@@ -1061,7 +1059,7 @@ impl TreeState {
                 .entries_matching(sparse_matcher.as_ref())
                 .filter_map(|(path, result)| result.is_ok().then_some(path))
                 .collect();
-            let file_states = self.file_states.all();
+            let file_states = self.state.file_states.all();
             let state_paths: HashSet<_> = file_states.paths().map(|path| path.to_owned()).collect();
             assert_eq!(state_paths, tree_paths);
         }
@@ -1069,7 +1067,7 @@ impl TreeState {
         // rescan the working directory changes to report or track them later.
         // TODO: store untracked paths and update watchman_clock?
         if stats.untracked_paths.is_empty() || watchman_clock.is_none() {
-            self.watchman_clock = watchman_clock;
+            self.state.watchman_clock = watchman_clock;
         } else {
             tracing::info!("not updating watchman clock because there are untracked files");
         }
@@ -1085,7 +1083,10 @@ impl TreeState {
             FsmonitorSettings::None => (None, None),
             FsmonitorSettings::Test { changed_files } => (None, Some(changed_files.clone())),
             #[cfg(feature = "watchman")]
-            FsmonitorSettings::Watchman(config) => match self.query_watchman(config) {
+            FsmonitorSettings::Watchman(config) => match self
+                .state
+                .query_watchman(self.working_copy_path, config)
+            {
                 Ok((watchman_clock, changed_files)) => (Some(watchman_clock.into()), changed_files),
                 Err(err) => {
                     tracing::warn!(?err, "Failed to query filesystem monitor");
@@ -1143,8 +1144,7 @@ struct PresentDirEntries {
 
 /// Helper to scan local-disk directories and files in parallel.
 struct FileSnapshotter<'a> {
-    tree_state: &'a TreeState,
-    current_tree: &'a MergedTree,
+    wc: &'a WcTreeMutator<'a>,
     matcher: &'a dyn Matcher,
     start_tracking_matcher: &'a dyn Matcher,
     tree_entries_tx: Sender<(RepoPathBuf, MergedTreeValue)>,
@@ -1331,7 +1331,7 @@ impl FileSnapshotter<'_> {
             if !self.matcher.matches(tracked_path) {
                 continue;
             }
-            let disk_path = tracked_path.to_fs_path(&self.tree_state.working_copy_path)?;
+            let disk_path = tracked_path.to_fs_path(self.wc.working_copy_path)?;
             let metadata = match disk_path.symlink_metadata() {
                 Ok(metadata) => Some(metadata),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => None,
@@ -1434,14 +1434,14 @@ impl FileSnapshotter<'_> {
                 // If the file's mtime was set at the same time as this state file's own mtime,
                 // then we don't know if the file was modified before or after this state file.
                 new_file_state.is_clean(current_file_state)
-                    && current_file_state.mtime < self.tree_state.own_mtime
+                    && current_file_state.mtime < self.wc.state.own_mtime
             }
         };
         if clean {
             Ok(None)
         } else {
-            let current_tree_values = self.current_tree.path_value(repo_path)?;
-            let new_file_type = if !self.tree_state.symlink_support {
+            let current_tree_values = self.wc.current_tree()?.path_value(repo_path)?;
+            let new_file_type = if !self.wc.state.symlink_support {
                 let mut new_file_type = new_file_state.file_type.clone();
                 if matches!(new_file_type, FileType::Normal { .. })
                     && matches!(current_tree_values.as_normal(), Some(TreeValue::Symlink(_)))
@@ -1478,10 +1478,6 @@ impl FileSnapshotter<'_> {
         }
     }
 
-    fn store(&self) -> &Store {
-        &self.tree_state.store
-    }
-
     async fn write_path_to_store(
         &self,
         repo_path: &RepoPath,
@@ -1511,7 +1507,7 @@ impl FileSnapshotter<'_> {
             })?;
             let new_file_ids = conflicts::update_from_content(
                 &old_file_ids,
-                self.store(),
+                self.wc.store,
                 repo_path,
                 &content,
                 self.conflict_marker_style,
@@ -1557,7 +1553,7 @@ impl FileSnapshotter<'_> {
             message: format!("Failed to open file {}", disk_path.display()),
             err: err.into(),
         })?;
-        Ok(self.store().write_file(path, &mut file).await?)
+        Ok(self.wc.store.write_file(path, &mut file).await?)
     }
 
     async fn write_symlink_to_store(
@@ -1565,7 +1561,7 @@ impl FileSnapshotter<'_> {
         path: &RepoPath,
         disk_path: &Path,
     ) -> Result<SymlinkId, SnapshotError> {
-        if self.tree_state.symlink_support {
+        if self.wc.state.symlink_support {
             let target = disk_path.read_link().map_err(|err| SnapshotError::Other {
                 message: format!("Failed to read symlink {}", disk_path.display()),
                 err: err.into(),
@@ -1576,7 +1572,7 @@ impl FileSnapshotter<'_> {
                     .ok_or_else(|| SnapshotError::InvalidUtf8SymlinkTarget {
                         path: disk_path.to_path_buf(),
                     })?;
-            Ok(self.store().write_symlink(path, str_target).await?)
+            Ok(self.wc.store.write_symlink(path, str_target).await?)
         } else {
             let target = fs::read(disk_path).map_err(|err| SnapshotError::Other {
                 message: format!("Failed to read file {}", disk_path.display()),
@@ -1586,13 +1582,13 @@ impl FileSnapshotter<'_> {
                 String::from_utf8(target).map_err(|_| SnapshotError::InvalidUtf8SymlinkTarget {
                     path: disk_path.to_path_buf(),
                 })?;
-            Ok(self.store().write_symlink(path, &string_target).await?)
+            Ok(self.wc.store.write_symlink(path, &string_target).await?)
         }
     }
 }
 
 /// Functions to update local-disk files from the store.
-impl TreeState {
+impl WcTreeMutator<'_> {
     fn write_file(
         &self,
         disk_path: &Path,
@@ -1697,11 +1693,11 @@ impl TreeState {
             .update(
                 &old_tree,
                 new_tree,
-                self.sparse_matcher().as_ref(),
+                self.state.sparse_matcher().as_ref(),
                 options.conflict_marker_style,
             )
             .block_on()?;
-        self.tree_id = new_tree.id();
+        self.state.tree_id = new_tree.id();
         Ok(stats)
     }
 
@@ -1716,7 +1712,7 @@ impl TreeState {
             },
             other => CheckoutError::InternalBackendError(other),
         })?;
-        let old_matcher = PrefixMatcher::new(&self.sparse_patterns);
+        let old_matcher = PrefixMatcher::new(&self.state.sparse_patterns);
         let new_matcher = PrefixMatcher::new(&sparse_patterns);
         let added_matcher = DifferenceMatcher::new(&new_matcher, &old_matcher);
         let removed_matcher = DifferenceMatcher::new(&old_matcher, &new_matcher);
@@ -1737,7 +1733,7 @@ impl TreeState {
                 options.conflict_marker_style,
             )
             .block_on()?;
-        self.sparse_patterns = sparse_patterns;
+        self.state.sparse_patterns = sparse_patterns;
         assert_eq!(added_stats.updated_files, 0);
         assert_eq!(added_stats.removed_files, 0);
         assert_eq!(removed_stats.updated_files, 0);
@@ -1773,7 +1769,7 @@ impl TreeState {
             .map(|TreeDiffEntry { path, values }| async {
                 match values {
                     Ok((before, after)) => {
-                        let result = materialize_tree_value(&self.store, &path, after).await;
+                        let result = materialize_tree_value(self.store, &path, after).await;
                         (path, result.map(|value| (before, value)))
                     }
                     Err(err) => (path, Err(err)),
@@ -1808,7 +1804,7 @@ impl TreeState {
 
             // Create parent directories no matter if after.is_present(). This
             // ensures that the path never traverses symlinks.
-            let Some(disk_path) = create_parent_dirs(&self.working_copy_path, &path)? else {
+            let Some(disk_path) = create_parent_dirs(self.working_copy_path, &path)? else {
                 changed_file_states.push((path, FileState::placeholder()));
                 stats.skipped_files += 1;
                 continue;
@@ -1839,7 +1835,7 @@ impl TreeState {
                     self.write_file(&disk_path, &mut file.reader, file.executable)?
                 }
                 MaterializedTreeValue::Symlink { id: _, target } => {
-                    if self.symlink_support {
+                    if self.state.symlink_support {
                         self.write_symlink(&disk_path, target)?
                     } else {
                         self.write_file(&disk_path, &mut target.as_bytes(), false)?
@@ -1881,7 +1877,8 @@ impl TreeState {
             };
             changed_file_states.push((path, file_state));
         }
-        self.file_states
+        self.state
+            .file_states
             .merge_in(changed_file_states, &deleted_files);
         Ok(stats)
     }
@@ -1894,7 +1891,7 @@ impl TreeState {
             other => ResetError::InternalBackendError(other),
         })?;
 
-        let matcher = self.sparse_matcher();
+        let matcher = self.state.sparse_matcher();
         let mut changed_file_states = Vec::new();
         let mut deleted_files = HashSet::new();
         let mut diff_stream = old_tree.diff_stream(new_tree, matcher.as_ref());
@@ -1936,15 +1933,16 @@ impl TreeState {
                 changed_file_states.push((path, file_state));
             }
         }
-        self.file_states
+        self.state
+            .file_states
             .merge_in(changed_file_states, &deleted_files);
-        self.tree_id = new_tree.id();
+        self.state.tree_id = new_tree.id();
         Ok(())
     }
 
     pub async fn recover(&mut self, new_tree: &MergedTree) -> Result<(), ResetError> {
-        self.file_states.clear();
-        self.tree_id = self.store.empty_merged_tree_id();
+        self.state.file_states.clear();
+        self.state.tree_id = self.store.empty_merged_tree_id();
         self.reset(new_tree).await
     }
 }
@@ -2085,12 +2083,10 @@ impl LocalWorkingCopy {
             .unwrap();
         file.write_all(&proto.encode_to_vec()).unwrap();
         let tree_state =
-            TreeState::init(store.clone(), working_copy_path.clone(), state_path.clone()).map_err(
-                |err| WorkingCopyStateError {
-                    message: "Failed to initialize working copy state".to_string(),
-                    err: err.into(),
-                },
-            )?;
+            TreeState::init(&store, &state_path).map_err(|err| WorkingCopyStateError {
+                message: "Failed to initialize working copy state".to_string(),
+                err: err.into(),
+            })?;
         Ok(LocalWorkingCopy {
             store,
             working_copy_path,
@@ -2128,13 +2124,7 @@ impl LocalWorkingCopy {
     #[instrument(skip_all)]
     fn tree_state(&self) -> Result<&TreeState, WorkingCopyStateError> {
         self.tree_state
-            .get_or_try_init(|| {
-                TreeState::load(
-                    self.store.clone(),
-                    self.working_copy_path.clone(),
-                    self.state_path.clone(),
-                )
-            })
+            .get_or_try_init(|| TreeState::load(&self.store, self.state_path.clone()))
             .map_err(|err| WorkingCopyStateError {
                 message: "Failed to read working copy state".to_string(),
                 err: err.into(),
@@ -2151,7 +2141,7 @@ impl LocalWorkingCopy {
         config: &WatchmanConfig,
     ) -> Result<(watchman::Clock, Option<Vec<PathBuf>>), WorkingCopyStateError> {
         self.tree_state()?
-            .query_watchman(config)
+            .query_watchman(&self.working_copy_path, config)
             .map_err(|err| WorkingCopyStateError {
                 message: "Failed to query watchman".to_string(),
                 err: err.into(),
@@ -2164,7 +2154,7 @@ impl LocalWorkingCopy {
         config: &WatchmanConfig,
     ) -> Result<bool, WorkingCopyStateError> {
         self.tree_state()?
-            .is_watchman_trigger_registered(config)
+            .is_watchman_trigger_registered(&self.working_copy_path, config)
             .map_err(|err| WorkingCopyStateError {
                 message: "Failed to query watchman".to_string(),
                 err: err.into(),
@@ -2218,11 +2208,15 @@ pub struct LockedLocalWorkingCopy {
 }
 
 impl LockedLocalWorkingCopy {
-    fn tree_state_mut(&mut self) -> Result<&mut TreeState, (String, Box<dyn Error + Send + Sync>)> {
+    fn wc_mut(&mut self) -> Result<WcTreeMutator<'_>, (String, Box<dyn Error + Send + Sync>)> {
         self.wc
             .tree_state() // Ensure loaded.
             .map_err(|WorkingCopyStateError { message, err }| (message, err))?;
-        Ok(self.wc.tree_state.get_mut().unwrap())
+        Ok(WcTreeMutator {
+            state: self.wc.tree_state.get_mut().unwrap(),
+            store: &self.wc.store,
+            working_copy_path: &self.wc.working_copy_path,
+        })
     }
 }
 
@@ -2247,11 +2241,11 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         &mut self,
         options: &SnapshotOptions,
     ) -> Result<(MergedTreeId, SnapshotStats), SnapshotError> {
-        let mut tree_state = self
-            .tree_state_mut()
+        let mut wc = self
+            .wc_mut()
             .map_err(|(message, err)| SnapshotError::Other { message, err })?;
-        let (is_dirty, stats) = tree_state.snapshot(options)?;
-        let tree_id = tree_state.tree_id.clone();
+        let (is_dirty, stats) = wc.snapshot(options)?;
+        let tree_id = wc.state.tree_id.clone();
         self.tree_state_dirty |= is_dirty;
         Ok((tree_id, stats))
     }
@@ -2264,11 +2258,11 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         // TODO: Write a "pending_checkout" file with the new TreeId so we can
         // continue an interrupted update if we find such a file.
         let new_tree = commit.tree()?;
-        let mut tree_state = self
-            .tree_state_mut()
+        let mut wc = self
+            .wc_mut()
             .map_err(|(message, err)| CheckoutError::Other { message, err })?;
-        if tree_state.tree_id != *commit.tree_id() {
-            let stats = tree_state.check_out(&new_tree, options)?;
+        if wc.state.tree_id != *commit.tree_id() {
+            let stats = wc.check_out(&new_tree, options)?;
             self.tree_state_dirty = true;
             Ok(stats)
         } else {
@@ -2282,7 +2276,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
 
     fn reset(&mut self, commit: &Commit) -> Result<(), ResetError> {
         let new_tree = commit.tree()?;
-        self.tree_state_mut()
+        self.wc_mut()
             .map_err(|(message, err)| ResetError::Other { message, err })?
             .reset(&new_tree)
             .block_on()?;
@@ -2292,7 +2286,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
 
     fn recover(&mut self, commit: &Commit) -> Result<(), ResetError> {
         let new_tree = commit.tree()?;
-        self.tree_state_mut()
+        self.wc_mut()
             .map_err(|(message, err)| ResetError::Other { message, err })?
             .recover(&new_tree)
             .block_on()?;
@@ -2312,7 +2306,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         // TODO: Write a "pending_checkout" file with new sparse patterns so we can
         // continue an interrupted update if we find such a file.
         let stats = self
-            .tree_state_mut()
+            .wc_mut()
             .map_err(|(message, err)| CheckoutError::Other { message, err })?
             .set_sparse_patterns(new_sparse_patterns, options)?;
         self.tree_state_dirty = true;
@@ -2326,8 +2320,9 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
     ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError> {
         assert!(self.tree_state_dirty || &self.old_tree_id == self.wc.tree_id()?);
         if self.tree_state_dirty {
-            self.tree_state_mut()
+            self.wc_mut()
                 .map_err(|(message, err)| WorkingCopyStateError { message, err })?
+                .state
                 .save()
                 .map_err(|err| WorkingCopyStateError {
                     message: "Failed to write working copy state".to_string(),
@@ -2353,8 +2348,9 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
 
 impl LockedLocalWorkingCopy {
     pub fn reset_watchman(&mut self) -> Result<(), SnapshotError> {
-        self.tree_state_mut()
+        self.wc_mut()
             .map_err(|(message, err)| SnapshotError::Other { message, err })?
+            .state
             .reset_watchman();
         self.tree_state_dirty = true;
         Ok(())

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -616,7 +616,7 @@ fn remove_old_file(disk_path: &Path) -> Result<bool, CheckoutError> {
     match fs::remove_file(disk_path) {
         Ok(()) => Ok(true),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
-        // TODO: Use io::ErrorKind::IsADirectory if it gets stabilized
+        Err(err) if err.kind() == io::ErrorKind::IsADirectory => Ok(false),
         Err(_) if disk_path.symlink_metadata().is_ok_and(|m| m.is_dir()) => Ok(false),
         Err(err) => Err(CheckoutError::Other {
             message: format!("Failed to remove file {}", disk_path.display()),

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -418,23 +418,6 @@ impl<'a> FileStates<'a> {
     }
 }
 
-pub struct TreeState {
-    store: Arc<Store>,
-    working_copy_path: PathBuf,
-    state_path: PathBuf,
-    tree_id: MergedTreeId,
-    file_states: FileStatesMap,
-    // Currently only path prefixes
-    sparse_patterns: Vec<RepoPathBuf>,
-    own_mtime: MillisSinceEpoch,
-    symlink_support: bool,
-
-    /// The most recent clock value returned by Watchman. Will only be set if
-    /// the repo is configured to use the Watchman filesystem monitor and
-    /// Watchman has been queried at least once.
-    watchman_clock: Option<crate::protos::working_copy::WatchmanClock>,
-}
-
 fn file_state_from_proto(proto: &crate::protos::working_copy::FileState) -> FileState {
     let file_type = match proto.file_type() {
         crate::protos::working_copy::FileType::Normal => FileType::Normal {
@@ -729,6 +712,23 @@ fn file_state(metadata: &Metadata) -> Option<FileState> {
 
 struct FsmonitorMatcher {
     matcher: Option<Box<dyn Matcher>>,
+    watchman_clock: Option<crate::protos::working_copy::WatchmanClock>,
+}
+
+pub struct TreeState {
+    store: Arc<Store>,
+    working_copy_path: PathBuf,
+    state_path: PathBuf,
+    tree_id: MergedTreeId,
+    file_states: FileStatesMap,
+    // Currently only path prefixes
+    sparse_patterns: Vec<RepoPathBuf>,
+    own_mtime: MillisSinceEpoch,
+    symlink_support: bool,
+
+    /// The most recent clock value returned by Watchman. Will only be set if
+    /// the repo is configured to use the Watchman filesystem monitor and
+    /// Watchman has been queried at least once.
     watchman_clock: Option<crate::protos::working_copy::WatchmanClock>,
 }
 

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1963,6 +1963,39 @@ struct CheckoutState {
     workspace_name: WorkspaceNameBuf,
 }
 
+impl CheckoutState {
+    fn load(state_path: &Path) -> CheckoutState {
+        let buf = fs::read(state_path.join("checkout")).unwrap();
+        let proto = crate::protos::working_copy::Checkout::decode(&*buf).unwrap();
+        CheckoutState {
+            operation_id: OperationId::new(proto.operation_id),
+            workspace_name: if proto.workspace_name.is_empty() {
+                // For compatibility with old working copies.
+                // TODO: Delete in mid 2022 or so
+                WorkspaceName::DEFAULT.to_owned()
+            } else {
+                proto.workspace_name.into()
+            },
+        }
+    }
+
+    #[instrument(skip_all)]
+    fn save(&self, state_path: &Path) {
+        let proto = crate::protos::working_copy::Checkout {
+            operation_id: self.operation_id.to_bytes(),
+            workspace_name: (*self.workspace_name).into(),
+        };
+        let mut temp_file = NamedTempFile::new_in(state_path).unwrap();
+        temp_file
+            .as_file_mut()
+            .write_all(&proto.encode_to_vec())
+            .unwrap();
+        // TODO: Retry if persisting fails (it will on Windows if the file happened to
+        // be open for read).
+        temp_file.persist(state_path.join("checkout")).unwrap();
+    }
+}
+
 pub struct LocalWorkingCopy {
     store: Arc<Store>,
     working_copy_path: PathBuf,
@@ -2085,37 +2118,9 @@ impl LocalWorkingCopy {
         &self.state_path
     }
 
-    fn write_proto(&self, proto: crate::protos::working_copy::Checkout) {
-        let mut temp_file = NamedTempFile::new_in(&self.state_path).unwrap();
-        temp_file
-            .as_file_mut()
-            .write_all(&proto.encode_to_vec())
-            .unwrap();
-        // TODO: Retry if persisting fails (it will on Windows if the file happened to
-        // be open for read).
-        temp_file.persist(self.state_path.join("checkout")).unwrap();
-    }
-
     fn checkout_state(&self) -> &CheckoutState {
-        self.checkout_state.get_or_init(|| {
-            let buf = fs::read(self.state_path.join("checkout")).unwrap();
-            let proto = crate::protos::working_copy::Checkout::decode(&*buf).unwrap();
-            CheckoutState {
-                operation_id: OperationId::new(proto.operation_id),
-                workspace_name: if proto.workspace_name.is_empty() {
-                    // For compatibility with old working copies.
-                    // TODO: Delete in mid 2022 or so
-                    WorkspaceName::DEFAULT.to_owned()
-                } else {
-                    proto.workspace_name.into()
-                },
-            }
-        })
-    }
-
-    fn checkout_state_mut(&mut self) -> &mut CheckoutState {
-        self.checkout_state(); // ensure loaded
-        self.checkout_state.get_mut().unwrap()
+        self.checkout_state
+            .get_or_init(|| CheckoutState::load(&self.state_path))
     }
 
     #[instrument(skip_all)]
@@ -2141,14 +2146,6 @@ impl LocalWorkingCopy {
 
     pub fn file_states(&self) -> Result<FileStates<'_>, WorkingCopyStateError> {
         Ok(self.tree_state()?.file_states())
-    }
-
-    #[instrument(skip_all)]
-    fn save(&mut self) {
-        self.write_proto(crate::protos::working_copy::Checkout {
-            operation_id: self.operation_id().to_bytes(),
-            workspace_name: self.workspace_name().into(),
-        });
     }
 
     #[cfg(feature = "watchman")]
@@ -2351,11 +2348,16 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
                 })?;
         }
         if self.old_operation_id != operation_id || self.new_workspace_name.is_some() {
-            if let Some(new_name) = self.new_workspace_name {
-                self.wc.checkout_state_mut().workspace_name = new_name;
-            }
-            self.wc.checkout_state_mut().operation_id = operation_id;
-            self.wc.save();
+            let workspace_name = self.new_workspace_name.unwrap_or_else(
+                // Only read the filesystem if we're missing the workspace name.
+                || CheckoutState::load(&self.wc.state_path).workspace_name,
+            );
+            let checkout_state = CheckoutState {
+                operation_id,
+                workspace_name,
+            };
+            checkout_state.save(&self.wc.state_path);
+            self.wc.checkout_state = OnceCell::with_value(checkout_state);
         }
         // TODO: Clear the "pending_checkout" file here.
         Ok(Box::new(self.wc))

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -2017,11 +2017,11 @@ impl WorkingCopy for LocalWorkingCopy {
         let old_tree_id = wc.tree_id()?.clone();
         Ok(Box::new(LockedLocalWorkingCopy {
             wc,
-            lock,
             old_operation_id,
             old_tree_id,
             tree_state_dirty: false,
             new_workspace_name: None,
+            _lock: lock,
         }))
     }
 }
@@ -2216,12 +2216,11 @@ impl WorkingCopyFactory for LocalWorkingCopyFactory {
 /// `finish()` or `discard()`.
 pub struct LockedLocalWorkingCopy {
     wc: LocalWorkingCopy,
-    #[expect(dead_code)]
-    lock: FileLock,
     old_operation_id: OperationId,
     old_tree_id: MergedTreeId,
     tree_state_dirty: bool,
     new_workspace_name: Option<WorkspaceNameBuf>,
+    _lock: FileLock,
 }
 
 impl LockedWorkingCopy for LockedLocalWorkingCopy {

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -2100,6 +2100,8 @@ impl LocalWorkingCopy {
         })
     }
 
+    /// "Load" the working copy lazily to avoid work. This uses an empty
+    /// `OnceCell` to load the states in the future as needed.
     pub fn load(
         store: Arc<Store>,
         working_copy_path: PathBuf,
@@ -2139,8 +2141,9 @@ impl LocalWorkingCopy {
             })
     }
 
-    fn tree_state_mut(&mut self) -> Result<&mut TreeState, WorkingCopyStateError> {
-        self.tree_state()?; // ensure loaded
+    fn tree_state_mut(&mut self) -> Result<&mut TreeState, (String, Box<dyn Error + Send + Sync>)> {
+        self.tree_state() // Ensure loaded.
+            .map_err(|WorkingCopyStateError { message, err }| (message, err))?;
         Ok(self.tree_state.get_mut().unwrap())
     }
 
@@ -2244,10 +2247,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         let tree_state = self
             .wc
             .tree_state_mut()
-            .map_err(|err| SnapshotError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?;
+            .map_err(|(message, err)| SnapshotError::Other { message, err })?;
         let (is_dirty, stats) = tree_state.snapshot(options)?;
         self.tree_state_dirty |= is_dirty;
         Ok((tree_state.current_tree_id().clone(), stats))
@@ -2264,10 +2264,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         let tree_state = self
             .wc
             .tree_state_mut()
-            .map_err(|err| CheckoutError::Other {
-                message: "Failed to load the working copy state".to_string(),
-                err: err.into(),
-            })?;
+            .map_err(|(message, err)| CheckoutError::Other { message, err })?;
         if tree_state.tree_id != *commit.tree_id() {
             let stats = tree_state.check_out(&new_tree, options)?;
             self.tree_state_dirty = true;
@@ -2285,10 +2282,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         let new_tree = commit.tree()?;
         self.wc
             .tree_state_mut()
-            .map_err(|err| ResetError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?
+            .map_err(|(message, err)| ResetError::Other { message, err })?
             .reset(&new_tree)
             .block_on()?;
         self.tree_state_dirty = true;
@@ -2299,10 +2293,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         let new_tree = commit.tree()?;
         self.wc
             .tree_state_mut()
-            .map_err(|err| ResetError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?
+            .map_err(|(message, err)| ResetError::Other { message, err })?
             .recover(&new_tree)
             .block_on()?;
         self.tree_state_dirty = true;
@@ -2323,10 +2314,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         let stats = self
             .wc
             .tree_state_mut()
-            .map_err(|err| CheckoutError::Other {
-                message: "Failed to load the working copy state".to_string(),
-                err: err.into(),
-            })?
+            .map_err(|(message, err)| CheckoutError::Other { message, err })?
             .set_sparse_patterns(new_sparse_patterns, options)?;
         self.tree_state_dirty = true;
         Ok(stats)
@@ -2340,7 +2328,8 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         assert!(self.tree_state_dirty || &self.old_tree_id == self.wc.tree_id()?);
         if self.tree_state_dirty {
             self.wc
-                .tree_state_mut()?
+                .tree_state_mut()
+                .map_err(|(message, err)| WorkingCopyStateError { message, err })?
                 .save()
                 .map_err(|err| WorkingCopyStateError {
                     message: "Failed to write working copy state".to_string(),
@@ -2368,10 +2357,7 @@ impl LockedLocalWorkingCopy {
     pub fn reset_watchman(&mut self) -> Result<(), SnapshotError> {
         self.wc
             .tree_state_mut()
-            .map_err(|err| SnapshotError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?
+            .map_err(|(message, err)| SnapshotError::Other { message, err })?
             .reset_watchman();
         self.tree_state_dirty = true;
         Ok(())

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -27,14 +27,12 @@ use std::fs::OpenOptions;
 use std::io;
 use std::io::Read;
 use std::io::Write as _;
-use std::iter;
 use std::mem;
 use std::ops::Range;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
 use std::path::PathBuf;
-use std::slice;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
@@ -408,7 +406,7 @@ impl<'a> FileStates<'a> {
     }
 
     /// Iterates file state entries sorted by path.
-    pub fn iter(&self) -> FileStatesIter<'a> {
+    pub fn iter(&self) -> impl Iterator<Item = (&'_ RepoPath, FileState)> {
         self.data.iter().map(file_state_entry_from_proto)
     }
 
@@ -417,20 +415,6 @@ impl<'a> FileStates<'a> {
         self.data
             .iter()
             .map(|entry| RepoPath::from_internal_string(&entry.path).unwrap())
-    }
-}
-
-type FileStatesIter<'a> = iter::Map<
-    slice::Iter<'a, crate::protos::working_copy::FileStateEntry>,
-    fn(&crate::protos::working_copy::FileStateEntry) -> (&RepoPath, FileState),
->;
-
-impl<'a> IntoIterator for FileStates<'a> {
-    type Item = (&'a RepoPath, FileState);
-    type IntoIter = FileStatesIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
     }
 }
 
@@ -1340,7 +1324,7 @@ impl FileSnapshotter<'_> {
 
     /// Visits only paths we're already tracking.
     fn visit_tracked_files(&self, file_states: FileStates<'_>) -> Result<(), SnapshotError> {
-        for (tracked_path, current_file_state) in file_states {
+        for (tracked_path, current_file_state) in file_states.iter() {
             if current_file_state.file_type == FileType::GitSubmodule {
                 continue;
             }

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -35,7 +35,6 @@ use crate::config::ConfigValue;
 use crate::config::StackedConfig;
 use crate::config::ToConfigNamePath;
 use crate::fmt_util::binary_prefix;
-use crate::fsmonitor::FsmonitorSettings;
 use crate::signing::SignBehavior;
 
 #[derive(Debug, Clone)]
@@ -186,10 +185,6 @@ impl UserSettings {
 
     pub fn user_email(&self) -> &str {
         &self.data.user_email
-    }
-
-    pub fn fsmonitor_settings(&self) -> Result<FsmonitorSettings, ConfigGetError> {
-        FsmonitorSettings::from_settings(self)
     }
 
     // Must not be changed to avoid git pushing older commits with no set email

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -133,7 +133,7 @@ impl SshBackend {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             command.creation_flags(CREATE_NO_WINDOW);
         }

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -57,7 +57,6 @@ use crate::simple_backend::SimpleBackend;
 use crate::store::Store;
 use crate::transaction::TransactionCommitError;
 use crate::working_copy::CheckoutError;
-use crate::working_copy::CheckoutOptions;
 use crate::working_copy::CheckoutStats;
 use crate::working_copy::LockedWorkingCopy;
 use crate::working_copy::WorkingCopy;
@@ -448,7 +447,6 @@ impl Workspace {
         operation_id: OperationId,
         old_tree_id: Option<&MergedTreeId>,
         commit: &Commit,
-        options: &CheckoutOptions,
     ) -> Result<CheckoutStats, CheckoutError> {
         let mut locked_ws =
             self.start_working_copy_mutation()
@@ -465,7 +463,7 @@ impl Workspace {
                 return Err(CheckoutError::ConcurrentCheckout);
             }
         }
-        let stats = locked_ws.locked_wc().check_out(commit, options)?;
+        let stats = locked_ws.locked_wc().check_out(commit)?;
         locked_ws
             .finish(operation_id)
             .map_err(|err| CheckoutError::Other {

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -44,11 +44,12 @@ use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::secret_backend::SecretBackend;
 use jj_lib::working_copy::CheckoutError;
 use jj_lib::working_copy::CheckoutStats;
+use jj_lib::working_copy::SnapshotError;
 use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::working_copy::UntrackedReason;
 use jj_lib::working_copy::WorkingCopy as _;
+use jj_lib::working_copy::WorkingCopySettings;
 use jj_lib::workspace::default_working_copy_factories;
-use jj_lib::workspace::LockedWorkspace;
 use jj_lib::workspace::Workspace;
 use pollster::FutureExt as _;
 use test_case::test_case;
@@ -1816,13 +1817,16 @@ fn test_check_out_reserved_file_path_vfat(vfat_path_str: &str, file_path_strs: &
 
 #[test]
 fn test_fsmonitor() {
-    let mut test_workspace = TestWorkspace::init();
+    let test_workspace = TestWorkspace::init();
     let repo = &test_workspace.repo;
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
 
-    let ws = &mut test_workspace.workspace;
     assert_eq!(
-        ws.working_copy().sparse_patterns().unwrap(),
+        test_workspace
+            .workspace
+            .working_copy()
+            .sparse_patterns()
+            .unwrap(),
         vec![RepoPathBuf::root()]
     );
 
@@ -1838,32 +1842,34 @@ fn test_fsmonitor() {
     testutils::write_working_copy_file(&workspace_root, ignored_path, "ignored\n");
     testutils::write_working_copy_file(&workspace_root, gitignore_path, "to/ignored\n");
 
-    let snapshot = |locked_ws: &mut LockedWorkspace, paths: &[&RepoPath]| {
+    let snapshot = |paths: &[&RepoPath]| {
         let fs_paths = paths
             .iter()
             .map(|p| p.to_fs_path_unchecked(Path::new("")))
             .collect();
-        let (tree_id, _stats) = locked_ws
-            .locked_wc()
-            .snapshot(&SnapshotOptions {
+        let mut locked_wc = test_workspace
+            .workspace
+            .working_copy()
+            .start_mutation(WorkingCopySettings {
                 fsmonitor_settings: FsmonitorSettings::Test {
                     changed_files: fs_paths,
                 },
-                ..SnapshotOptions::empty_for_test()
+                ..WorkingCopySettings::empty_for_test()
             })
             .unwrap();
-        tree_id
+        let (tree_id, _stats) = locked_wc
+            .snapshot(&SnapshotOptions::empty_for_test())
+            .unwrap();
+        (locked_wc, tree_id)
     };
 
     {
-        let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-        let tree_id = snapshot(&mut locked_ws, &[]);
+        let (_locked_wc, tree_id) = snapshot(&[]);
         assert_eq!(tree_id, repo.store().empty_merged_tree_id());
     }
 
     {
-        let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-        let tree_id = snapshot(&mut locked_ws, &[foo_path]);
+        let (_locked_wc, tree_id) = snapshot(&[foo_path]);
         insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree d5e38c0a1b0ee5de47c5
           file "foo" (e99c2057c15160add351): "foo\n"
@@ -1871,25 +1877,20 @@ fn test_fsmonitor() {
     }
 
     {
-        let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-        let tree_id = snapshot(
-            &mut locked_ws,
-            &[foo_path, bar_path, nested_path, ignored_path],
-        );
+        let (locked_wc, tree_id) = snapshot(&[foo_path, bar_path, nested_path, ignored_path]);
         insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree f408c8d080414f8e90e1
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "foo" (e99c2057c15160add351): "foo\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
         "#);
-        locked_ws.finish(repo.op_id().clone()).unwrap();
+        locked_wc.finish(repo.op_id().clone()).unwrap();
     }
 
     {
         testutils::write_working_copy_file(&workspace_root, foo_path, "updated foo\n");
         testutils::write_working_copy_file(&workspace_root, bar_path, "updated bar\n");
-        let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-        let tree_id = snapshot(&mut locked_ws, &[foo_path]);
+        let (_locked_wc, tree_id) = snapshot(&[foo_path]);
         insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree e994a93c46f41dc91704
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
@@ -1900,20 +1901,19 @@ fn test_fsmonitor() {
 
     {
         std::fs::remove_file(foo_path.to_fs_path_unchecked(&workspace_root)).unwrap();
-        let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-        let tree_id = snapshot(&mut locked_ws, &[foo_path]);
+        let (locked_wc, tree_id) = snapshot(&[foo_path]);
         insta::assert_snapshot!(testutils::dump_tree(repo.store(), &tree_id), @r#"
         tree 1df764981d4d74a4ecfa
           file "bar" (94cc973e7e1aefb7eff6): "bar\n"
           file "path/to/nested" (6209060941cd770c8d46): "nested\n"
         "#);
-        locked_ws.finish(repo.op_id().clone()).unwrap();
+        locked_wc.finish(repo.op_id().clone()).unwrap();
     }
 }
 
 #[test]
 fn test_snapshot_max_new_file_size() {
-    let mut test_workspace = TestWorkspace::init();
+    let test_workspace = TestWorkspace::init();
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
     let small_path = repo_path("small");
     let large_path = repo_path("large");
@@ -1923,21 +1923,31 @@ fn test_snapshot_max_new_file_size() {
         vec![0; limit],
     )
     .unwrap();
-    let options = SnapshotOptions {
+    let wc_settings = WorkingCopySettings {
         max_new_file_size: limit as u64,
-        ..SnapshotOptions::empty_for_test()
+        ..WorkingCopySettings::empty_for_test()
     };
-    test_workspace
-        .snapshot_with_options(&options)
-        .expect("files exactly matching the size limit should succeed");
+
+    let snapshot = || {
+        let mut locked_wc = test_workspace
+            .workspace
+            .working_copy()
+            .start_mutation(wc_settings.clone())
+            .unwrap();
+        let (tree_id, stats) = locked_wc.snapshot(&SnapshotOptions::empty_for_test())?;
+        let op_id = test_workspace.repo.op_id().clone(); // arbitrary operation id
+        locked_wc.finish(op_id).unwrap();
+        let tree = test_workspace.repo.store().get_root_tree(&tree_id).unwrap();
+        Result::<_, SnapshotError>::Ok((tree, stats))
+    };
+
+    snapshot().expect("files exactly matching the size limit should succeed");
     std::fs::write(
         small_path.to_fs_path_unchecked(&workspace_root),
         vec![0; limit + 1],
     )
     .unwrap();
-    let (old_tree, _stats) = test_workspace
-        .snapshot_with_options(&options)
-        .expect("existing files may grow beyond the size limit");
+    let (old_tree, _stats) = snapshot().expect("existing files may grow beyond the size limit");
 
     // A new file of 1KiB + 1 bytes should be left untracked
     std::fs::write(
@@ -1945,9 +1955,8 @@ fn test_snapshot_max_new_file_size() {
         vec![0; limit + 1],
     )
     .unwrap();
-    let (new_tree, stats) = test_workspace
-        .snapshot_with_options(&options)
-        .expect("snapshot should not fail because of new files beyond the size limit");
+    let (new_tree, stats) =
+        snapshot().expect("snapshot should not fail because of new files beyond the size limit");
     assert_eq!(new_tree, old_tree);
     assert_eq!(
         stats
@@ -1976,9 +1985,8 @@ fn test_snapshot_max_new_file_size() {
         sub_large_path.to_fs_path_unchecked(&workspace_root),
     )
     .unwrap();
-    let (new_tree, stats) = test_workspace
-        .snapshot_with_options(&options)
-        .expect("snapshot should not fail because of new files beyond the size limit");
+    let (new_tree, stats) =
+        snapshot().expect("snapshot should not fail because of new files beyond the size limit");
     assert_eq!(new_tree, old_tree);
     assert_eq!(
         stats

--- a/lib/tests/test_local_working_copy_concurrent.rs
+++ b/lib/tests/test_local_working_copy_concurrent.rs
@@ -18,7 +18,6 @@ use std::thread;
 use assert_matches::assert_matches;
 use jj_lib::repo::Repo as _;
 use jj_lib::working_copy::CheckoutError;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::workspace::default_working_copy_factories;
 use jj_lib::workspace::Workspace;
@@ -51,13 +50,7 @@ fn test_concurrent_checkout() {
     // Check out tree1
     let ws1 = &mut test_workspace1.workspace;
     // The operation ID is not correct, but that doesn't matter for this test
-    ws1.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws1.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
     // Check out tree2 from another process (simulated by another workspace
     // instance)
@@ -72,23 +65,13 @@ fn test_concurrent_checkout() {
         // Reload commit from the store associated with the workspace
         let repo = ws2.repo_loader().load_at(repo.operation()).unwrap();
         let commit2 = repo.store().get_commit(commit2.id()).unwrap();
-        ws2.check_out(
-            repo.op_id().clone(),
-            Some(&tree_id1),
-            &commit2,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+        ws2.check_out(repo.op_id().clone(), Some(&tree_id1), &commit2)
+            .unwrap();
     }
 
     // Checking out another tree (via the first workspace instance) should now fail.
     assert_matches!(
-        ws1.check_out(
-            repo.op_id().clone(),
-            Some(&tree_id1),
-            &commit3,
-            &CheckoutOptions::empty_for_test()
-        ),
+        ws1.check_out(repo.op_id().clone(), Some(&tree_id1), &commit3),
         Err(CheckoutError::ConcurrentCheckout)
     );
 
@@ -126,12 +109,7 @@ fn test_checkout_parallel() {
     let commit = commit_with_tree(repo.store(), tree.id());
     test_workspace
         .workspace
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(repo.op_id().clone(), None, &commit)
         .unwrap();
 
     thread::scope(|s| {
@@ -154,9 +132,7 @@ fn test_checkout_parallel() {
                 let repo = workspace.repo_loader().load_at(repo.operation()).unwrap();
                 let commit = repo.store().get_commit(commit.id()).unwrap();
                 // The operation ID is not correct, but that doesn't matter for this test
-                let stats = workspace
-                    .check_out(op_id, None, &commit, &CheckoutOptions::empty_for_test())
-                    .unwrap();
+                let stats = workspace.check_out(op_id, None, &commit).unwrap();
                 assert_eq!(stats.updated_files, 0);
                 assert_eq!(stats.added_files, 1);
                 assert_eq!(stats.removed_files, 1);
@@ -190,13 +166,7 @@ fn test_racy_checkout() {
     let mut num_matches = 0;
     for _ in 0..100 {
         let ws = &mut test_workspace.workspace;
-        ws.check_out(
-            op_id.clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+        ws.check_out(op_id.clone(), None, &commit).unwrap();
         assert_eq!(
             std::fs::read(path.to_fs_path_unchecked(&workspace_root)).unwrap(),
             b"1".to_vec()

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -19,7 +19,6 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::repo::Repo as _;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::WorkingCopy as _;
 use jj_lib::working_copy::WorkingCopySettings;
@@ -64,12 +63,7 @@ fn test_sparse_checkout() {
 
     test_workspace
         .workspace
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(repo.op_id().clone(), None, &commit)
         .unwrap();
     let ws = &mut test_workspace.workspace;
 
@@ -78,7 +72,7 @@ fn test_sparse_checkout() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     let stats = locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns.clone(), &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns.clone())
         .unwrap();
     assert_eq!(
         stats,
@@ -139,7 +133,7 @@ fn test_sparse_checkout() {
         .unwrap();
     let sparse_patterns = to_owned_path_vec(&[root_file1_path, dir1_subdir1_path, dir2_path]);
     let stats = locked_wc
-        .set_sparse_patterns(sparse_patterns.clone(), &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns.clone())
         .unwrap();
     assert_eq!(
         stats,
@@ -203,12 +197,7 @@ fn test_sparse_commit() {
     let commit = commit_with_tree(repo.store(), tree.id());
     test_workspace
         .workspace
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(repo.op_id().clone(), None, &commit)
         .unwrap();
 
     // Set sparse patterns to only dir1/
@@ -219,7 +208,7 @@ fn test_sparse_commit() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns)
         .unwrap();
     locked_ws.finish(repo.op_id().clone()).unwrap();
 
@@ -260,7 +249,7 @@ fn test_sparse_commit() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path, dir2_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns)
         .unwrap();
     locked_ws.finish(op_id).unwrap();
 
@@ -295,7 +284,7 @@ fn test_sparse_commit_gitignore() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns)
         .unwrap();
     locked_ws.finish(repo.op_id().clone()).unwrap();
 

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -22,6 +22,7 @@ use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::WorkingCopy as _;
+use jj_lib::working_copy::WorkingCopySettings;
 use pollster::FutureExt as _;
 use testutils::commit_with_tree;
 use testutils::create_tree;
@@ -133,7 +134,9 @@ fn test_sparse_checkout() {
     assert_eq!(wc.sparse_patterns().unwrap(), sparse_patterns);
 
     // Set sparse patterns to file2, dir1/subdir1/ and dir2/
-    let mut locked_wc = wc.start_mutation().unwrap();
+    let mut locked_wc = wc
+        .start_mutation(WorkingCopySettings::empty_for_test())
+        .unwrap();
     let sparse_patterns = to_owned_path_vec(&[root_file1_path, dir1_subdir1_path, dir2_path]);
     let stats = locked_wc
         .set_sparse_patterns(sparse_patterns.clone(), &CheckoutOptions::empty_for_test())

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -109,6 +109,7 @@ pub fn base_user_config() -> StackedConfig {
         operation.username = "test-username"
         operation.hostname = "host.example.com"
         ui.conflict-marker-style = "diff"
+        snapshot.max-new-file-size = "1MiB"
         debug.randomness-seed = 42
     "#;
     let mut config = StackedConfig::with_defaults();

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -108,6 +108,7 @@ pub fn base_user_config() -> StackedConfig {
         user.email = "test.user@example.com"
         operation.username = "test-username"
         operation.hostname = "host.example.com"
+        ui.conflict-marker-style = "diff"
         debug.randomness-seed = 42
     "#;
     let mut config = StackedConfig::with_defaults();


### PR DESCRIPTION
As requested, I'm splitting up the commits in the executable bit PR into smaller stacked PRs so they can be reviewed separately.

See https://github.com/jj-vcs/jj/pull/4478#pullrequestreview-2746646793 for context.

---

This PR is focused on updating the way settings are passed to the working copy. We split out configurations from `SnapshotOptions` and `CheckoutOptions` that can be loaded solely from `UserSettings` into a new `WorkingCopySettings` struct, which is in to `start_working_copy_mutation`.