### PR TITLE
nix flake: include package version in derivation attributes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
         ];
       };
 
+      packageVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+
       filterSrc = src: regexes:
         pkgs.lib.cleanSourceWith {
           inherit src;
@@ -90,7 +92,7 @@
       packages = {
         jujutsu = rustMinimalPlatform.buildRustPackage {
           pname = "jujutsu";
-          version = "unstable-${self.shortRev or "dirty"}";
+          version = "${packageVersion}-unstable-${self.shortRev or "dirty"}";
 
           cargoBuildFlags = ["--bin" "jj"]; # don't build and install the fake editors
           useNextest = true;

--- a/lib/tests/test_gpg.rs
+++ b/lib/tests/test_gpg.rs
@@ -68,7 +68,7 @@ struct GpgEnvironment {
 impl GpgEnvironment {
     fn new() -> Result<Self, std::process::Output> {
         let dir = tempfile::Builder::new()
-            .prefix("jj-gpg-signing-test-")
+            .prefix("gpg-test-")
             .tempdir()
             .unwrap();
 
@@ -114,7 +114,7 @@ struct GpgsmEnvironment {
 impl GpgsmEnvironment {
     fn new() -> Result<Self, std::process::Output> {
         let dir = tempfile::Builder::new()
-            .prefix("jj-gpgsm-signing-test-")
+            .prefix("gpgsm-test-")
             .tempdir()
             .unwrap();
 


### PR DESCRIPTION
This allows the logic in
https://github.com/nix-community/home-manager/pull/6994 to be applied.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
