### PR TITLE
docs/templates: fix section heading for `List<Trailer>` type

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -248,7 +248,7 @@ defined.
 * `.map(|item| expression) -> ListTemplate`: Apply template `expression`
   to each element. Example: `parents.map(|c| c.commit_id().short())`
 
-### List<Trailer> type
+### List<Trailer\> type
 
 The following methods are defined. See also the `List` type.
 


### PR DESCRIPTION
Before (note the apparent duplication of the headings):

<img width="725" alt="Screenshot 2025-05-11 at 10 19 54 pm" src="https://github.com/user-attachments/assets/de364b17-1ee1-455c-b9c0-cdcbdafdd472" />

After:

<img width="726" alt="Screenshot 2025-05-11 at 10 23 18 pm" src="https://github.com/user-attachments/assets/abfa01ad-5495-4f54-a441-f269fc5f6891" />

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
