### PR TITLE
rename `--destination` to `--onto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj split` has gained a `--message` option to set the description of the
   commit with the selected changes.
 
+* `jj split` has gained the ability to place the revision with the selected changes
+  anywhere in the revision tree with the `--insert-before`, `--insert-after` and
+  `--destination` command line flags.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -70,18 +70,20 @@ pub(crate) struct DuplicateArgs {
     /// commit)
     #[arg(
         long,
-        short,
+        short = 't',
+        visible_alias = "destination",
+        visible_short_alias = 'd',
         value_name = "REVSETS",
-        add = ArgValueCompleter::new(complete::revset_expression_all),
+        add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert after (can be repeated to create a merge
     /// commit)
     #[arg(
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
@@ -92,7 +94,7 @@ pub(crate) struct DuplicateArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
@@ -123,21 +125,19 @@ pub(crate) fn cmd_duplicate(
         return Err(user_error("Cannot duplicate the root commit"));
     }
 
-    let location = if args.destination.is_none()
-        && args.insert_after.is_none()
-        && args.insert_before.is_none()
-    {
-        None
-    } else {
-        Some(compute_commit_location(
-            ui,
-            &workspace_command,
-            args.destination.as_deref(),
-            args.insert_after.as_deref(),
-            args.insert_before.as_deref(),
-            "duplicated commits",
-        )?)
-    };
+    let location =
+        if args.onto.is_none() && args.insert_after.is_none() && args.insert_before.is_none() {
+            None
+        } else {
+            Some(compute_commit_location(
+                ui,
+                &workspace_command,
+                args.onto.as_deref(),
+                args.insert_after.as_deref(),
+                args.insert_before.as_deref(),
+                "duplicated commits",
+            )?)
+        };
 
     let mut tx = workspace_command.start_transaction();
 

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -562,6 +562,7 @@ fn print_move_commits_stats(ui: &Ui, stats: &MoveCommitsStats) -> std::io::Resul
         num_rebased_descendants,
         num_skipped_rebases,
         num_abandoned,
+        rebased_commits: _,
     } = stats;
     if num_skipped_rebases > 0 {
         writeln!(

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -333,18 +333,20 @@ pub struct RebaseDestinationArgs {
     /// commit)
     #[arg(
         long,
-        short,
+        short = 't',
+        visible_alias = "destination",
+        visible_short_alias = 'd',
         value_name = "REVSETS",
-        add = ArgValueCompleter::new(complete::revset_expression_all),
+        add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert after (can be repeated to create a merge
     /// commit)
     #[arg(
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
@@ -355,7 +357,7 @@ pub struct RebaseDestinationArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
@@ -416,12 +418,12 @@ fn plan_rebase_revisions(
     let (new_parent_ids, new_child_ids) = compute_commit_location(
         ui,
         workspace_command,
-        rebase_destination.destination.as_deref(),
+        rebase_destination.onto.as_deref(),
         rebase_destination.insert_after.as_deref(),
         rebase_destination.insert_before.as_deref(),
         "rebased commits",
     )?;
-    if rebase_destination.destination.is_some() && new_child_ids.is_empty() {
+    if rebase_destination.onto.is_some() && new_child_ids.is_empty() {
         for id in &target_commit_ids {
             if new_parent_ids.contains(id) {
                 return Err(user_error(format!(
@@ -451,12 +453,12 @@ fn plan_rebase_source(
     let (new_parent_ids, new_child_ids) = compute_commit_location(
         ui,
         workspace_command,
-        rebase_destination.destination.as_deref(),
+        rebase_destination.onto.as_deref(),
         rebase_destination.insert_after.as_deref(),
         rebase_destination.insert_before.as_deref(),
         "rebased commits",
     )?;
-    if rebase_destination.destination.is_some() && new_child_ids.is_empty() {
+    if rebase_destination.onto.is_some() && new_child_ids.is_empty() {
         for id in &source_commit_ids {
             let commit = workspace_command.repo().store().get_commit(id)?;
             check_rebase_destinations(workspace_command.repo(), &new_parent_ids, &commit)?;
@@ -491,7 +493,7 @@ fn plan_rebase_branch(
     let (new_parent_ids, new_child_ids) = compute_commit_location(
         ui,
         workspace_command,
-        rebase_destination.destination.as_deref(),
+        rebase_destination.onto.as_deref(),
         rebase_destination.insert_after.as_deref(),
         rebase_destination.insert_before.as_deref(),
         "rebased commits",
@@ -505,7 +507,7 @@ fn plan_rebase_branch(
         .iter()
         .try_collect()?;
     workspace_command.check_rewritable(&root_commit_ids)?;
-    if rebase_destination.destination.is_some() && new_child_ids.is_empty() {
+    if rebase_destination.onto.is_some() && new_child_ids.is_empty() {
         for id in &root_commit_ids {
             let commit = workspace_command.repo().store().get_commit(id)?;
             check_rebase_destinations(workspace_command.repo(), &new_parent_ids, &commit)?;

--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -42,7 +42,7 @@ use crate::ui::Ui;
 /// The description of the new revisions can be customized with the
 /// `templates.revert_description` config variable.
 #[derive(clap::Args, Clone, Debug)]
-#[command(group(ArgGroup::new("location").args(&["destination", "insert_after", "insert_before"]).required(true).multiple(true)))]
+#[command(group(ArgGroup::new("location").args(&["onto", "insert_after", "insert_before"]).required(true).multiple(true)))]
 pub(crate) struct RevertArgs {
     /// The revision(s) to apply the reverse of
     #[arg(
@@ -53,18 +53,21 @@ pub(crate) struct RevertArgs {
     revisions: Vec<RevisionArg>,
     /// The revision(s) to apply the reverse changes on top of
     #[arg(
-        long, short,
+        long,
+        short = 't',
+        visible_alias = "destination",
+        visible_short_alias = 'd',
         value_name = "REVSETS",
-        add = ArgValueCompleter::new(complete::revset_expression_all),
+        add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert the reverse changes after (can be repeated to
     /// create a merge commit)
     #[arg(
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
@@ -75,7 +78,7 @@ pub(crate) struct RevertArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
@@ -100,7 +103,7 @@ pub(crate) fn cmd_revert(
     let (new_parent_ids, new_child_ids) = compute_commit_location(
         ui,
         &workspace_command,
-        args.destination.as_deref(),
+        args.onto.as_deref(),
         args.insert_after.as_deref(),
         args.insert_before.as_deref(),
         "reverted commits",

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -11,16 +11,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::collections::HashMap;
 use std::io::Write as _;
 
 use clap_complete::ArgValueCompleter;
+use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
 use jj_lib::matchers::Matcher;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
+use jj_lib::rewrite::move_commits;
 use jj_lib::rewrite::CommitWithSelection;
+use jj_lib::rewrite::EmptyBehaviour;
+use jj_lib::rewrite::MoveCommitsLocation;
+use jj_lib::rewrite::MoveCommitsTarget;
+use jj_lib::rewrite::RebaseOptions;
+use jj_lib::rewrite::RebasedCommit;
+use jj_lib::rewrite::RewriteRefsOptions;
 use tracing::instrument;
 
+use crate::cli_util::compute_commit_location;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::DiffSelector;
 use crate::cli_util::RevisionArg;
@@ -70,6 +80,40 @@ pub(crate) struct SplitArgs {
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
     revision: RevisionArg,
+    /// The revision(s) to rebase onto (can be repeated to create a merge
+    /// commit)
+    #[arg(
+        long,
+        short,
+        conflicts_with = "parallel",
+        value_name = "REVSETS",
+        add = ArgValueCompleter::new(complete::revset_expression_mutable),
+    )]
+    destination: Option<Vec<RevisionArg>>,
+    /// The revision(s) to insert after (can be repeated to create a merge
+    /// commit)
+    #[arg(
+        long,
+        short = 'A',
+        visible_alias = "after",
+        conflicts_with = "destination",
+        conflicts_with = "parallel",
+        value_name = "REVSETS",
+        add = ArgValueCompleter::new(complete::revset_expression_mutable),
+    )]
+    insert_after: Option<Vec<RevisionArg>>,
+    /// The revision(s) to insert before (can be repeated to create a merge
+    /// commit)
+    #[arg(
+        long,
+        short = 'B',
+        visible_alias = "before",
+        conflicts_with = "destination",
+        conflicts_with = "parallel",
+        value_name = "REVSETS",
+        add = ArgValueCompleter::new(complete::revset_expression_mutable),
+    )]
+    insert_before: Option<Vec<RevisionArg>>,
     /// The change description to use (don't open editor)
     ///
     /// The description is used for the commit with the selected changes. The
@@ -116,11 +160,29 @@ impl SplitArgs {
             self.tool.as_deref(),
             self.interactive || self.paths.is_empty(),
         )?;
+        let use_move_flags = self.destination.is_some()
+            || self.insert_after.is_some()
+            || self.insert_before.is_some();
+        let (new_parent_ids, new_child_ids) = if use_move_flags {
+            compute_commit_location(
+                ui,
+                workspace_command,
+                self.destination.as_deref(),
+                self.insert_after.as_deref(),
+                self.insert_before.as_deref(),
+                "split-out commit",
+            )?
+        } else {
+            Default::default()
+        };
         Ok(ResolvedSplitArgs {
             target_commit,
             matcher,
             diff_selector,
             parallel: self.parallel,
+            use_move_flags,
+            new_parent_ids,
+            new_child_ids,
         })
     }
 }
@@ -130,6 +192,9 @@ struct ResolvedSplitArgs {
     matcher: Box<dyn Matcher>,
     diff_selector: DiffSelector,
     parallel: bool,
+    use_move_flags: bool,
+    new_parent_ids: Vec<CommitId>,
+    new_child_ids: Vec<CommitId>,
 }
 
 #[instrument(skip_all)]
@@ -144,6 +209,9 @@ pub(crate) fn cmd_split(
         matcher,
         diff_selector,
         parallel,
+        use_move_flags,
+        new_parent_ids,
+        new_child_ids,
     } = args.resolve(ui, &workspace_command)?;
     let text_editor = workspace_command.text_editor()?;
     let mut tx = workspace_command.start_transaction();
@@ -155,6 +223,12 @@ pub(crate) fn cmd_split(
     let first_commit = {
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder.set_tree_id(target.selected_tree.id());
+        if use_move_flags {
+            commit_builder
+                // Generate a new change id so that the commit being split doesn't
+                // become divergent.
+                .generate_new_change_id();
+        }
         let description = if !args.message_paragraphs.is_empty() {
             let description = join_message_paragraphs(&args.message_paragraphs);
             if !description.is_empty() {
@@ -183,7 +257,7 @@ pub(crate) fn cmd_split(
     // select.
     let second_commit = {
         let target_tree = target.commit.tree()?;
-        let new_tree = if args.parallel {
+        let new_tree = if parallel {
             // Merge the original commit tree with its parent using the tree
             // containing the user selected changes as the base for the merge.
             // This results in a tree with the changes the user didn't select.
@@ -199,10 +273,13 @@ pub(crate) fn cmd_split(
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder
             .set_parents(parents)
-            .set_tree_id(new_tree.id())
-            // Generate a new change id so that the commit being split doesn't
-            // become divergent.
-            .generate_new_change_id();
+            .set_tree_id(new_tree.id());
+        if !use_move_flags {
+            commit_builder
+                // Generate a new change id so that the commit being split doesn't
+                // become divergent.
+                .generate_new_change_id();
+        }
         let description = if target.commit.description().is_empty() {
             // If there was no description before, don't ask for one for the
             // second commit.
@@ -226,6 +303,111 @@ pub(crate) fn cmd_split(
         commit_builder.write(tx.repo_mut())?
     };
 
+    if use_move_flags {
+        new(
+            ui,
+            tx,
+            target,
+            first_commit,
+            second_commit,
+            new_parent_ids,
+            new_child_ids,
+        )
+    } else {
+        legacy(ui, tx, target, first_commit, second_commit, parallel)
+    }
+}
+
+fn new(
+    ui: &mut Ui,
+    mut tx: WorkspaceCommandTransaction,
+    target: CommitWithSelection,
+    mut first_commit: Commit,
+    mut second_commit: Commit,
+    new_parent_ids: Vec<CommitId>,
+    new_child_ids: Vec<CommitId>,
+) -> Result<(), CommandError> {
+    let mut rewritten_commits: HashMap<CommitId, CommitId> = HashMap::new();
+    tx.repo_mut()
+        .set_rewritten_commit(target.commit.id().clone(), second_commit.id().clone());
+    rewritten_commits.insert(target.commit.id().clone(), second_commit.id().clone());
+    tx.repo_mut()
+        .transform_descendants(vec![target.commit.id().clone()], |rewriter| {
+            let old_commit_id = rewriter.old_commit().id().clone();
+            let new_commit = rewriter.rebase()?.write()?;
+            rewritten_commits.insert(old_commit_id, new_commit.id().clone());
+            Ok(())
+        })?;
+
+    let new_parent_ids: Vec<_> = new_parent_ids
+        .iter()
+        .map(|commit_id| rewritten_commits.get(commit_id).unwrap_or(commit_id))
+        .cloned()
+        .collect();
+    let new_child_ids: Vec<_> = new_child_ids
+        .iter()
+        .map(|commit_id| rewritten_commits.get(commit_id).unwrap_or(commit_id))
+        .cloned()
+        .collect();
+    let stats = move_commits(
+        tx.repo_mut(),
+        &MoveCommitsLocation {
+            new_parent_ids,
+            new_child_ids,
+            target: MoveCommitsTarget::Commits(vec![first_commit.id().clone()]),
+        },
+        &RebaseOptions {
+            empty: EmptyBehaviour::Keep,
+            rewrite_refs: RewriteRefsOptions {
+                delete_abandoned_bookmarks: false,
+            },
+            simplify_ancestor_merge: false,
+        },
+    )?;
+
+    let mut num_new_rebased = 1;
+    if let Some(RebasedCommit::Rewritten(commit)) = stats.rebased_commits.get(first_commit.id()) {
+        first_commit = commit.clone();
+        num_new_rebased += 1;
+    }
+    if let Some(RebasedCommit::Rewritten(commit)) = stats.rebased_commits.get(second_commit.id()) {
+        second_commit = commit.clone();
+    }
+
+    if let Some(mut formatter) = ui.status_formatter() {
+        let mut num_rebased_descendants = rewritten_commits.len() + stats.rebased_commits.len();
+        // don't count the commit generated by the split in the rebased commits
+        num_rebased_descendants -= num_new_rebased;
+        for (_, ref rewritten) in rewritten_commits {
+            if stats.rebased_commits.contains_key(rewritten) {
+                // only count once a commit that may have been rewritten twice in the process
+                num_rebased_descendants -= 1;
+            }
+        }
+        if num_rebased_descendants > 0 {
+            writeln!(
+                formatter,
+                "Rebased {num_rebased_descendants} descendant commits"
+            )?;
+        }
+        write!(formatter, "First part: ")?;
+        tx.write_commit_summary(formatter.as_mut(), &first_commit)?;
+        write!(formatter, "\nSecond part: ")?;
+        tx.write_commit_summary(formatter.as_mut(), &second_commit)?;
+        writeln!(formatter)?;
+    }
+    tx.finish(ui, format!("split commit {}", target.commit.id().hex()))?;
+    Ok(())
+}
+
+fn legacy(
+    ui: &mut Ui,
+    mut tx: WorkspaceCommandTransaction,
+    target: CommitWithSelection,
+    first_commit: Commit,
+    second_commit: Commit,
+    parallel: bool,
+) -> Result<(), CommandError> {
     let legacy_bookmark_behavior = tx.settings().get_bool("split.legacy-bookmark-behavior")?;
     if legacy_bookmark_behavior {
         // Mark the commit being split as rewritten to the second commit. This

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -84,19 +84,21 @@ pub(crate) struct SplitArgs {
     /// commit)
     #[arg(
         long,
-        short,
+        short = 't',
+        visible_alias = "destination",
+        visible_short_alias = 'd',
         conflicts_with = "parallel",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert after (can be repeated to create a merge
     /// commit)
     #[arg(
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         conflicts_with = "parallel",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
@@ -108,7 +110,7 @@ pub(crate) struct SplitArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         conflicts_with = "parallel",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
@@ -160,14 +162,13 @@ impl SplitArgs {
             self.tool.as_deref(),
             self.interactive || self.paths.is_empty(),
         )?;
-        let use_move_flags = self.destination.is_some()
-            || self.insert_after.is_some()
-            || self.insert_before.is_some();
+        let use_move_flags =
+            self.onto.is_some() || self.insert_after.is_some() || self.insert_before.is_some();
         let (new_parent_ids, new_child_ids) = if use_move_flags {
             compute_commit_location(
                 ui,
                 workspace_command,
-                self.destination.as_deref(),
+                self.onto.as_deref(),
                 self.insert_after.as_deref(),
                 self.insert_before.as_deref(),
                 "split-out commit",

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2465,6 +2465,9 @@ Splitting an empty commit is not supported because the same effect can be achiev
 * `-r`, `--revision <REVSET>` — The revision to split
 
   Default value: `@`
+* `-d`, `--destination <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
+* `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
+* `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
 
    The description is used for the commit with the selected changes. The source commit description is kept unchanged.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -850,7 +850,7 @@ By default, the duplicated commits retain the descriptions of the originals. Thi
 
 ###### **Options:**
 
-* `-d`, `--destination <REVSETS>` — The revision(s) to duplicate onto (can be repeated to create a merge commit)
+* `-t`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to duplicate onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 
@@ -2186,7 +2186,7 @@ K |         K |
 J           J
 ```
 
-**Usage:** `jj rebase [OPTIONS] <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
+**Usage:** `jj rebase [OPTIONS] <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
 
 ###### **Options:**
 
@@ -2205,7 +2205,7 @@ J           J
    Unlike `-s` or `-b`, you may `jj rebase -r` a revision `A` onto a descendant of `A`.
 
    If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
-* `-d`, `--destination <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
+* `-t`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to rebase onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `--skip-emptied` — If true, when rebasing would produce an empty commit, the commit is abandoned. It will not be abandoned if it was already empty before the rebase. Will never skip merge commits with multiple non-empty parents
@@ -2279,12 +2279,12 @@ The reverse of each of the given revisions is applied sequentially in reverse to
 
 The description of the new revisions can be customized with the `templates.revert_description` config variable.
 
-**Usage:** `jj revert [OPTIONS] <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
+**Usage:** `jj revert [OPTIONS] <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
 
 ###### **Options:**
 
 * `-r`, `--revisions <REVSETS>` — The revision(s) to apply the reverse of
-* `-d`, `--destination <REVSETS>` — The revision(s) to apply the reverse changes on top of
+* `-t`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to apply the reverse changes on top of
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert the reverse changes after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert the reverse changes before (can be repeated to create a merge commit)
 
@@ -2465,7 +2465,7 @@ Splitting an empty commit is not supported because the same effect can be achiev
 * `-r`, `--revision <REVSET>` — The revision to split
 
   Default value: `@`
-* `-d`, `--destination <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
+* `-t`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to rebase onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -31,9 +31,9 @@ fn test_rebase_invalid() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+      <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
-    Usage: jj rebase <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -46,7 +46,7 @@ fn test_rebase_invalid() {
     ------- stderr -------
     error: the argument '--revisions <REVSETS>' cannot be used with '--source <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -59,7 +59,7 @@ fn test_rebase_invalid() {
     ------- stderr -------
     error: the argument '--branch <REVSETS>' cannot be used with '--source <REVSETS>'
 
-    Usage: jj rebase --branch <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --branch <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -70,9 +70,9 @@ fn test_rebase_invalid() {
     let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b", "--after", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: the argument '--destination <REVSETS>' cannot be used with '--insert-after <REVSETS>'
+    error: the argument '--onto <REVSETS>' cannot be used with '--insert-after <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -83,9 +83,9 @@ fn test_rebase_invalid() {
     let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b", "--before", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: the argument '--destination <REVSETS>' cannot be used with '--insert-before <REVSETS>'
+    error: the argument '--onto <REVSETS>' cannot be used with '--insert-before <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -48,9 +48,9 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+      <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
-    Usage: jj revert --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj revert --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]


### PR DESCRIPTION
The flag `--onto` more accurately conveys the target location onto which
the commit will be rebased. Furthermore, it ensures greater consistency
with the other location flags, `--after` and `--before`, both of which
function as prepositions.

There is still a lot of documentation to update and testing to do. I've mostly modified the commands with a `--destination`/`-d` to ensure there wouldn't be any collision with an existing short flag. Moreover I'm not sure that setting `--destination`/`-d` as an alias is the right way to go.

I'm not willing to push another controversial change, so if anyone thinks that's not a good change, please tell me before I spend more time on it!

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [ ] I have added tests to cover my changes
