### PR TITLE
feat: hide .jj directory on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ dependencies = [
  "tracing",
  "version_check",
  "watchman_client",
+ "winapi",
  "winreg",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ version_check = "0.9.5"
 watchman_client = { version = "0.9.0" }
 whoami = "1.6.0"
 winreg = "0.52"
-
+winapi= {version = "0.3.9", features = ["winuser"] }
 # put all inter-workspace libraries, i.e. those that use 'path = ...' here in
 # their own (alphabetically sorted) block
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -79,6 +79,7 @@ rustix = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = { workspace = true }
+winapi = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![warn(missing_docs)]
 #![deny(unused_must_use)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 // Needed so that proc macros can be used inside jj_lib and by external crates
 // that depend on it.


### PR DESCRIPTION
<!--
feat: hide .jj directory on Windows

On macOS and Linux, directories starting with a dot (.) are hidden by default.
However, on Windows, we need to set additional attributes to achieve the same behavior.
To maintain consistency across platforms, we now hide the .jj directory on Windows as well.

Note: This change requires using unsafe code to call Windows FFI functions.
Therefore, we had to relax the unsafe code restrictions in lib/src/lib.rs.

-->
Closes: #6513
# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes

This is my first attempt to contribute to the jj project. I have read https://jj-vcs.github.io/jj/prerelease/contributing/, but it's still unclear, which caused me to encounter many issues (and I'm not sure how to resolve them) while trying to use jj to manage this contribution. If there's anything I've overlooked, any suggestions are welcome.