### PR TITLE
cli git init: show `jj bookmark track` command on new line

### DIFF
--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use std::str;
 use std::sync::Arc;
 
+use indoc::writedoc;
 use itertools::Itertools as _;
 use jj_lib::file_util;
 use jj_lib::git;
@@ -279,10 +280,13 @@ fn print_trackable_remote_bookmarks(ui: &Ui, view: &View) -> io::Result<()> {
             write!(formatter, "  ")?;
             writeln!(formatter.labeled("bookmark"), "{symbol}")?;
         }
-        writeln!(
+        writedoc!(
             formatter.labeled("hint").with_heading("Hint: "),
-            "Run `jj bookmark track {syms}` to keep local bookmarks updated on future pulls.",
-            syms = remote_bookmark_symbols.iter().join(" "),
+            "
+            Run the following command to keep local bookmarks updated on future pulls:
+              jj bookmark track {syms}
+            ",
+            syms = remote_bookmark_symbols.iter().join(" ")
         )?;
     }
     Ok(())

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -582,7 +582,8 @@ fn test_git_init_colocated_via_git_repo_path_imported_refs() {
     Done importing changes from the underlying Git repo.
     Hint: The following remote bookmarks aren't associated with the existing local bookmarks:
       local-remote@origin
-    Hint: Run `jj bookmark track local-remote@origin` to keep local bookmarks updated on future pulls.
+    Hint: Run the following command to keep local bookmarks updated on future pulls:
+      jj bookmark track local-remote@origin
     Initialized repo in "."
     [EOF]
     "#);


### PR DESCRIPTION
I often copy and run this command after running `jj git init --colocate`. Having it on a separate line makes it stand out more and easier to copy, especially if there are many bookmarks listed.

# Checklist

If applicable:
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (README.md, docs/, demos/)
- [ ] I have updated the config schema (cli/src/config-schema.json)
- [x] I have added tests to cover my changes
