### PR TITLE
commit: show a hint if `--message` is not provided and the description is empty

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -43,7 +43,7 @@ pub(crate) struct CommitArgs {
     message_paragraphs: Vec<String>,
     /// Put these paths in the first commit
     #[arg(
-        value_name = "FILESETS", 
+        value_name = "FILESETS",
         value_hint = clap::ValueHint::AnyPath,
         add = ArgValueCompleter::new(complete::modified_files),
     )]

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -509,7 +509,7 @@ fn test_commit_trailers() {
         format!("-----\n{editor0}-----\n"), @r#"
     -----
 
-    
+
     Reviewed-by: foo@bar.org
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -138,6 +138,9 @@ fn test_commit_with_empty_description_from_editor() {
     );
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Hint: The commit message was left empty.
+    If this was not intentional, run `jj undo` to restore the previous state.
+    Or run `jj desc @-` to add a description to the parent commit.
     Working copy  (@) now at: rlvkpnrz 51b556e2 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm cc8ff228 (empty) (no description set)
     [EOF]


### PR DESCRIPTION
This implements something akin to what's described in @arxanas's suggestion at <https://github.com/jj-vcs/jj/issues/4414#issuecomment-2359123535>, with the exception that the editor contents don’t need to be completely cleared, since whether cleared or not it is not obvious whether the user intended to add an empty description or abort entirely.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
