### PR TITLE
config: clarify warning

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -287,8 +287,8 @@ impl UnresolvedConfigEnv {
                 Self::warn_for_deprecated_path(
                     ui,
                     path.as_path(),
-                    "~/Library/Application Support",
-                    "~/.config",
+                    "~/Library/Application Support/jj",
+                    "~/.config/jj",
                 );
                 paths.push(path);
             }
@@ -298,8 +298,8 @@ impl UnresolvedConfigEnv {
                 Self::warn_for_deprecated_path(
                     ui,
                     path.as_path(),
-                    "~/Library/Application Support",
-                    "~/.config",
+                    "~/Library/Application Support/jj",
+                    "~/.config/jj",
                 );
                 paths.push(path);
             }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -945,6 +945,65 @@ fn test_config_edit_user_new_file() {
     );
 }
 
+// TODO: remove after deprecation period in 0.35
+// NOTE: macOS-only test
+#[test]
+fn test_config_edit_user_deprecated_file() {
+    if !cfg!(target_os = "macos") {
+        return;
+    }
+    let test_env = TestEnvironment::default();
+    let user_config_path = test_env
+        .home_dir()
+        .join("Library/Application Support/jj/config.toml");
+    std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+
+    std::fs::write(
+        &user_config_path,
+        indoc! {b"
+        [foo]
+        bar = 'Make sure I can pick this up'
+        "},
+    )
+    .unwrap();
+
+    let output = test_env.run_jj_with(|cmd| {
+        cmd.env_remove("JJ_CONFIG")
+            .args(["config", "get", "foo.bar"])
+    });
+    insta::assert_snapshot!(output, @r"
+    Make sure I can pick this up
+    [EOF]
+    ------- stderr -------
+    Warning: Deprecated configuration file `$TEST_ENV/home/Library/Application Support/jj/config.toml`.
+    Configuration files in `~/Library/Application Support/jj` are deprecated, and support will be removed in a future release.
+    Instead, move your configuration files to `~/.config/jj`.
+    [EOF]
+    ");
+
+    // if you set JJ_CONFIG, you shouldn't get a warning
+    let output = test_env.run_jj_with(|cmd| {
+        cmd.env("JJ_CONFIG", &user_config_path)
+            .args(["config", "get", "foo.bar"])
+    });
+    insta::assert_snapshot!(output, @r"
+    Make sure I can pick this up
+    [EOF]
+    ");
+
+    let new_path = test_env.home_dir().join(".config/jj/config.toml");
+    std::fs::create_dir_all(new_path.parent().unwrap()).unwrap();
+    std::fs::rename(&user_config_path, &new_path).unwrap();
+    let output = test_env.run_jj_with(|cmd| {
+        cmd.env_remove("JJ_CONFIG")
+            .args(["config", "get", "foo.bar"])
+    });
+    insta::assert_snapshot!(output, @r"
+    Make sure I can pick this up
+    [EOF]
+    ");
+}
+
 #[test]
 fn test_config_edit_repo() {
     let mut test_env = TestEnvironment::default();


### PR DESCRIPTION
Instead of saying to move configuration files from `~/Library/Application Support` to `~/.config`, jj now tells you to move configuration files from `~/Library/Application Support/jj` to `~/.config/jj`.

Fixes #6533

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
