### PR TITLE
templater: add arithmetic operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added `git.track-default-bookmark-on-clone` setting to control whether to
   track the default remote bookmark on `jj git clone`.
 
+* Templates can now do arithmetic on integers with the `+`, `-`, `*`, `/`, and `%`
+  infix operators.
+
 ### Fixed bugs
 
 * Work around a git issue that could cause subprocess operations to hang if the

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -46,6 +46,11 @@ ge_op = { ">=" }
 gt_op = { ">" }
 le_op = { "<=" }
 lt_op = { "<" }
+add_op = { "+" }
+sub_op = { "-" }
+mul_op = { "*" }
+div_op = { "/" }
+rem_op = { "%" }
 logical_not_op = { "!" }
 negate_op = { "-" }
 prefix_ops = _{ logical_not_op | negate_op }
@@ -58,6 +63,11 @@ infix_ops = _{
   | gt_op
   | le_op
   | lt_op
+  | add_op
+  | sub_op
+  | mul_op
+  | div_op
+  | rem_op
 }
 
 function = { identifier ~ "(" ~ whitespace* ~ function_arguments ~ whitespace* ~ ")" }

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -33,7 +33,7 @@ fn test_templater_parse_error() {
     1 | description ()
       |             ^---
       |
-      = expected <EOI>, `++`, `||`, `&&`, `==`, `!=`, `>=`, `>`, `<=`, or `<`
+      = expected <EOI>, `++`, `||`, `&&`, `==`, `!=`, `>=`, `>`, `<=`, `<`, `+`, `-`, `*`, `/`, or `%`
     [EOF]
     [exit status: 1]
     ");

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -31,6 +31,9 @@ The following operators are supported.
 * `x.f()`: Method call.
 * `-x`: Negate integer value.
 * `!x`: Logical not.
+* `x * y`, `x / y`, `x % y`: Multiplication/division/remainder. Operands must
+  be `Integer`s.
+* `x + y`, `x - y`: Addition/subtraction. Operands must be `Integer`s.
 * `x >= y`, `x > y`, `x <= y`, `x < y`: Greater than or equal/greater than/
   lesser than or equal/lesser than. Operands must be `Integer`s.
 * `x == y`, `x != y`: Equal/not equal. Operands must be either `Boolean`,


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Adds arithmetic operators on integers. Fixes #5982.

I ran into this when trying to do some alignment-type things inside a template. I'm currently using
```
'len(template)' = 'stringify(template).len()'
'repeat(str, int)' = 'stringify(pad_end(int, "", str))'
'spaces(int)' = 'repeat(" ", int)'

'add(a, b)' = '''
len(concat(spaces(a), spaces(b)))
'''

'sub(a, b)' = '''
len(spaces(a).substr(0, -b))
'''
```

~~I have not yet added tests, as I am unsure of the best place to put them. `test_templater.rs` seems the most applicable, although it seems currently to mostly test higher-level functionality and not specific templating operations.~~

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
