### PR TITLE
cli: improve hint to abandon commits when divergent change appears

### DIFF
--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -319,8 +319,8 @@ fn format_multiple_revisions_error(
             write_commits_summary(formatter)
         });
         cmd_err.add_hint(
-            "Some of these commits have the same change id. Abandon one of them with `jj abandon \
-             -r <REVISION>`.",
+            "Some of these commits have the same change id. Abandon the unneeded commits with `jj \
+             abandon <commit_id>`.",
         );
     } else if let Some(bookmark_name) = expression.as_symbol() {
         // Separate hint if there's a conflicted bookmark

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -681,7 +681,7 @@ fn test_new_conflicting_change_ids() {
     Hint: The revset `qpvuntsm` resolved to these revisions:
       qpvuntsm?? 2f175dfc (empty) two
       qpvuntsm?? 401ea16f (empty) one
-    Hint: Some of these commits have the same change id. Abandon one of them with `jj abandon -r <REVISION>`.
+    Hint: Some of these commits have the same change id. Abandon the unneeded commits with `jj abandon <commit_id>`.
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
