### PR TITLE
git: export git ref to parent branch when possible

### DIFF
--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -93,6 +93,14 @@ impl Commit {
         &self.data.parents
     }
 
+    pub fn single_parent(&self) -> Option<&CommitId> {
+        if self.data.parents.len() == 1 {
+            Some(&self.data.parents[0])
+        } else {
+            None
+        }
+    }
+
     pub fn parents(&self) -> impl Iterator<Item = BackendResult<Commit>> + use<'_> {
         self.data.parents.iter().map(|id| self.store.get_commit(id))
     }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -950,7 +950,7 @@ pub fn export_some_refs(
                 update_git_head(
                     &git_repo,
                     gix::refs::transaction::PreviousValue::MustExistAndMatch(old_target),
-                    current_oid,
+                    current_oid.map(gix::refs::Target::Object),
                 )
                 .map_err(GitExportError::from_git)?;
             }
@@ -1191,11 +1191,11 @@ fn update_git_ref(
 fn update_git_head(
     git_repo: &gix::Repository,
     expected_ref: gix::refs::transaction::PreviousValue,
-    new_oid: Option<gix::ObjectId>,
+    new_target: Option<gix::refs::Target>,
 ) -> Result<(), gix::reference::edit::Error> {
     let mut ref_edits = Vec::new();
-    let new_target = if let Some(oid) = new_oid {
-        gix::refs::Target::Object(oid)
+    let new_target = if let Some(target) = new_target {
+        target
     } else {
         // Can't detach HEAD without a commit. Use placeholder ref to nullify
         // the HEAD. The placeholder ref isn't a normal branch ref. Git CLI
@@ -1259,7 +1259,7 @@ pub fn reset_head(mut_repo: &mut MutableRepo, wc_commit: &Commit) -> Result<(), 
 
     // If the first parent of the working copy has changed, reset the Git HEAD.
     let old_head_target = mut_repo.git_head();
-    if old_head_target != new_head_target {
+    if old_head_target != new_head_target || true {
         let expected_ref = if let Some(id) = old_head_target.as_normal() {
             // We have to check the actual HEAD state because we don't record a
             // symbolic ref as such.
@@ -1276,9 +1276,38 @@ pub fn reset_head(mut_repo: &mut MutableRepo, wc_commit: &Commit) -> Result<(), 
             // Just overwrite if unborn (or conflict), which is also unusual.
             gix::refs::transaction::PreviousValue::MustExist
         };
-        let new_oid = new_head_target
-            .as_normal()
-            .map(|id| gix::ObjectId::from_bytes_or_panic(id.as_bytes()));
+
+        let new_oid = new_head_target.as_normal().map(|id| {
+            let single_parent_bookmark = wc_commit
+                .single_parent()
+                .and_then(|_| {
+                    mut_repo
+                        .view()
+                        .bookmarks()
+                        .filter(|(_, bookmark)| bookmark.local_target == &new_head_target)
+                        .exactly_one()
+                        .ok()
+                })
+                .and_then(|(name, _)| {
+                    to_git_ref_name(
+                        GitRefKind::Bookmark,
+                        name.to_remote_symbol(REMOTE_NAME_FOR_LOCAL_GIT_REPO),
+                    )
+                    .and_then(|name| {
+                        gix::refs::FullName::try_from(BString::from(name.into_string())).ok()
+                    })
+                    .map(gix::refs::Target::Symbolic)
+                });
+
+            match single_parent_bookmark {
+                Some(target) => target,
+                None => {
+                    let id = gix::ObjectId::from_bytes_or_panic(id.as_bytes());
+                    gix::refs::Target::Object(id)
+                }
+            }
+        });
+
         update_git_head(&git_repo, expected_ref, new_oid)
             .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
         mut_repo.set_git_head_target(new_head_target);


### PR DESCRIPTION
This is helpful for
- editors with git integration that show a warning when on an detached head (intellij etc.)
- using git and jj together on a repository

It is only done if there is a single parent with a single bookmark, otherwise it wouldn't be obvious which one to pick.

# Checklist

- [ ] I have updated `CHANGELOG.md`
- [ ] I have added/updated tests to cover my changes
