### PR TITLE
docs: Don't include unnecessary shebangs

### DIFF
--- a/cli/src/commands/util/exec.rs
+++ b/cli/src/commands/util/exec.rs
@@ -50,7 +50,6 @@ use crate::ui::Ui;
 /// ```toml
 /// [aliases]
 /// my-inline-script = ["util", "exec", "--", "bash", "-c", """
-/// #!/usr/bin/env bash
 /// set -euo pipefail
 /// echo "Look Ma, everything in one file!"
 /// echo "args: $@"
@@ -59,6 +58,9 @@ use crate::ui::Ui;
 /// # This last empty string will become "$0" in bash, so your actual arguments
 /// # are all included in "$@" and start at "$1" as expected.
 /// ```
+///
+/// > Note: Shebangs (e.g. `#!/usr/bin/env`) aren't necessary since you're
+/// > already explicitly passing your script into the right shell.
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]
 pub(crate) struct UtilExecArgs {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2658,7 +2658,6 @@ inline it into your config file:
 ```toml
 [aliases]
 my-inline-script = ["util", "exec", "--", "bash", "-c", """
-#!/usr/bin/env bash
 set -euo pipefail
 echo "Look Ma, everything in one file!"
 echo "args: $@"
@@ -2667,6 +2666,9 @@ echo "args: $@"
 # This last empty string will become "$0" in bash, so your actual arguments
 # are all included in "$@" and start at "$1" as expected.
 ```
+
+> Note: Shebangs (e.g. `#!/usr/bin/env`) aren't necessary since you're
+> already explicitly passing your script into the right shell.
 
 **Usage:** `jj util exec <COMMAND> [ARGS]...`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -844,7 +844,6 @@ my-script = ["util", "exec", "--", "my-jj-script"]
 #                            ^^^^
 # This makes sure that flags are passed to your script instead of parsed by jj.
 my-inline-script = ["util", "exec", "--", "bash", "-c", """
-#!/usr/bin/env bash
 set -euo pipefail
 echo "Look Ma, everything in one file!"
 echo "args: $@"
@@ -853,6 +852,9 @@ echo "args: $@"
 # This last empty string will become "$0" in bash, so your actual arguments
 # are all included in "$@" and start at "$1" as expected.
 ```
+
+> Note: Shebangs (e.g. `#!/usr/bin/env`) aren't necessary since you're already
+> explicitly passing your script into the right shell.
 
 ## Editor
 


### PR DESCRIPTION
It isn't necessary to include shebangs in scripts passed into `util exec` since you're already explicitly calling out the shell you'd like to use. This change removes shebangs from examples for `util exec` and adds a note below calling this out.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
