### PR TITLE
cli bookmark move: move `names` argument before `--from` argument

### DIFF
--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -43,6 +43,20 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(clap::ArgGroup::new("source").multiple(true).required(true)))]
 pub struct BookmarkMoveArgs {
+    /// Move bookmarks matching the given name patterns
+    ///
+    /// By default, the specified name matches exactly. Use `glob:` prefix to
+    /// select bookmarks by [wildcard pattern].
+    ///
+    /// [wildcard pattern]:
+    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    #[arg(
+        group = "source",
+        value_parser = StringPattern::parse,
+        add = ArgValueCandidates::new(complete::local_bookmarks),
+    )]
+    names: Vec<StringPattern>,
+
     /// Move bookmarks from the given revisions
     #[arg(
         long, short,
@@ -66,20 +80,6 @@ pub struct BookmarkMoveArgs {
     /// Allow moving bookmarks backwards or sideways
     #[arg(long, short = 'B')]
     allow_backwards: bool,
-
-    /// Move bookmarks matching the given name patterns
-    ///
-    /// By default, the specified name matches exactly. Use `glob:` prefix to
-    /// select bookmarks by [wildcard pattern].
-    ///
-    /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
-    #[arg(
-        group = "source",
-        value_parser = StringPattern::parse,
-        add = ArgValueCandidates::new(complete::local_bookmarks),
-    )]
-    names: Vec<StringPattern>,
 }
 
 pub fn cmd_bookmark_move(

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -418,7 +418,7 @@ Example: pull up the nearest bookmarks to the working-copy parent
 
 $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 
-**Usage:** `jj bookmark move [OPTIONS] <--from <REVSETS>|NAMES>`
+**Usage:** `jj bookmark move [OPTIONS] <NAMES|--from <REVSETS>>`
 
 **Command Alias:** `m`
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -407,9 +407,9 @@ fn test_bookmark_move_matching() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <--from <REVSETS>|NAMES>
+      <NAMES|--from <REVSETS>>
 
-    Usage: jj bookmark move --to <REVSET> <--from <REVSETS>|NAMES>
+    Usage: jj bookmark move --to <REVSET> <NAMES|--from <REVSETS>>
 
     For more information, try '--help'.
     [EOF]


### PR DESCRIPTION
The usage line originally showed `--from <REVSETS>|NAMES`, which was confusing as it could be parsed as `--from (<REVSETS> or NAMES)`, rather than the correct `(--from <REVSETS>) or NAMES`.

The order of the two arguments are now swapped, so that Clap displays it as `NAMES|--from <REVSETS>` instead. Using bookmark names as the move targets should be more common anyway. This is also consistent with the order in which the two arguments are described in the command's doc comment.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
