### PR TITLE
templater: split ChangeId/CommitId types, deprecate CommitId::normal_hex()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `ui.diff-formatter`. The builtin format can be specified as `:<format>`
   (e.g. `ui.diff-formatter=":git"` for Git diffs.)
 
+* The `.normal_hex()` method will be removed from the `CommitId` template type.
+  It's useful only for the `ChangeId` type.
+
 ### New features
 
 * `jj split` has gained a `--message` option to set the description of the

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -63,13 +63,13 @@ fn test_templater_parse_error() {
     ");
     insta::assert_snapshot!(render(r#"commit_id.shorter()"#), @r"
     ------- stderr -------
-    Error: Failed to parse template: Method `shorter` doesn't exist for type `CommitOrChangeId`
+    Error: Failed to parse template: Method `shorter` doesn't exist for type `CommitId`
     Caused by:  --> 1:11
       |
     1 | commit_id.shorter()
       |           ^-----^
       |
-      = Method `shorter` doesn't exist for type `CommitOrChangeId`
+      = Method `shorter` doesn't exist for type `CommitId`
     Hint: Did you mean `short`, `shortest`?
     [EOF]
     [exit status: 1]
@@ -115,7 +115,7 @@ fn test_templater_parse_error() {
     1 | id.sort()
       |    ^--^
       |
-      = Method `sort` doesn't exist for type `CommitOrChangeId`
+      = Method `sort` doesn't exist for type `CommitId`
     Hint: Did you mean `short`, `shortest`?
     [EOF]
     [exit status: 1]

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -145,12 +145,19 @@ This type cannot be printed. The following methods are defined.
   likely to change in future version to respect the command line path arguments.
 * `.root() -> Boolean`: True if the commit is the root commit.
 
-### `CommitId` / `ChangeId` type
+### `ChangeId` type
 
 The following methods are defined.
 
-* `.normal_hex() -> String`: Normal hex representation (0-9a-f), useful for
-  ChangeId, whose canonical hex representation is "reversed" (z-k).
+* `.normal_hex() -> String`: Normal hex representation (0-9a-f) instead of the
+  canonical "reversed" (z-k) representation.
+* `.short([len: Integer]) -> String`
+* `.shortest([min_len: Integer]) -> ShortestIdPrefix`: Shortest unique prefix.
+
+### `CommitId` type
+
+The following methods are defined.
+
 * `.short([len: Integer]) -> String`
 * `.shortest([min_len: Integer]) -> ShortestIdPrefix`: Shortest unique prefix.
 


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
