### PR TITLE
test: use `--at-op` and templates instead of manually parsing op ids from op log output

### DIFF
--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -213,7 +213,7 @@ fn test_concurrent_snapshot_wc_reloadable() {
     let previous_op_id = op_log_lines[6].split_once("  ").unwrap().1;
 
     // Another process started from the "initial" operation, but snapshots after
-    // the "child1" checkout has been completed.
+    // the "child1" checkout have been completed.
     std::fs::rename(
         op_heads_dir.join(current_op_id),
         op_heads_dir.join(previous_op_id),

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -96,9 +96,9 @@ fn test_concurrent_operations_auto_rebase() {
     // We should be informed about the concurrent modification
     let output = get_log_output(&work_dir);
     insta::assert_snapshot!(output, @r"
-    ○  b748b7189c0b301be205ebaf74b941c4ec209e69 new child
-    @  084d39fe0ab1cd01a6b7fd21fdea3a8dcc9a48fc rewritten
-    ◆  0000000000000000000000000000000000000000
+    ○  new child
+    @  rewritten
+    ◆
     [EOF]
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
@@ -129,11 +129,11 @@ fn test_concurrent_operations_wc_modified() {
     // We should be informed about the concurrent modification
     let output = get_log_output(&work_dir);
     insta::assert_snapshot!(output, @r"
-    @  fe9f87c5ee87d9cbc9a81fa1ebc600bb85471fd5 new child1
-    │ ○  7fd594798328855ba9ca64f2f3708f8e61ea771d new child2
+    @  new child1
+    │ ○  new child2
     ├─╯
-    ○  4a8d8ea817a416777a551d7f41d9dfaf5dc2db5d initial
-    ◆  0000000000000000000000000000000000000000
+    ○  initial
+    ◆
     [EOF]
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
@@ -230,22 +230,20 @@ fn test_concurrent_snapshot_wc_reloadable() {
 
     // Since the repo can be reloaded before snapshotting, "child2" should be
     // a child of "child1", not of "initial".
-    let template = r#"commit_id ++ " " ++ description"#;
-    let output = work_dir.run_jj(["log", "-T", template, "-s"]);
+    let output = work_dir.run_jj(["log", "-T", "description", "-s"]);
     insta::assert_snapshot!(output, @r"
-    @  5a2a6177e84f2e9e67b896421155ded751801da6 new child2
+    @  new child2
     │  A child2
-    ○  15bd889d60e9f054f5b163a697041a1dad1edfa3 new child1
+    ○  new child1
     │  A child1
-    ○  064f230b16b2bd6435a713d7f3363f562fb0d80f initial
+    ○  initial
     │  A base
-    ◆  0000000000000000000000000000000000000000
+    ◆
     [EOF]
     ");
 }
 
 #[must_use]
 fn get_log_output(work_dir: &TestWorkDir) -> CommandOutput {
-    let template = r#"commit_id ++ " " ++ description"#;
-    work_dir.run_jj(["log", "-T", template])
+    work_dir.run_jj(["log", "-T", "description"])
 }

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -52,7 +52,7 @@ fn test_concurrent_operation_divergence() {
     ");
 
     // We should be informed about the concurrent modification
-    let output = work_dir.run_jj(["log", "-T", "description"]);
+    let output = get_log_output(&work_dir);
     insta::assert_snapshot!(output, @r"
     @  message 1
     │ ○  message 2

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -207,14 +207,15 @@ fn test_concurrent_snapshot_wc_reloadable() {
     [EOF]
     ");
     let op_log_lines = output.stdout.raw().lines().collect_vec();
-    let current_op_id = op_log_lines[0].split_once("  ").unwrap().1;
-    let previous_op_id = op_log_lines[6].split_once("  ").unwrap().1;
+    let op_id_after_snapshot = op_log_lines[0].split_once("  ").unwrap().1;
+    let op_id_before_snapshot = op_log_lines[6].split_once("  ").unwrap().1;
 
-    // Another process started from the "initial" operation, but snapshots after
-    // the "child1" checkout have been completed.
+    // Simulate a concurrent operation that began from the "initial" operation
+    // (before the "child1" snapshot) but finished after the "child1"
+    // snapshot and commit.
     std::fs::rename(
-        op_heads_dir.join(current_op_id),
-        op_heads_dir.join(previous_op_id),
+        op_heads_dir.join(op_id_after_snapshot),
+        op_heads_dir.join(op_id_before_snapshot),
     )
     .unwrap();
     work_dir.write_file("child2", "");

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -167,24 +167,24 @@ fn test_concurrent_snapshot_wc_reloadable() {
     work_dir.write_file("child1", "");
     work_dir.run_jj(["commit", "-m", "new child1"]).success();
 
-    let template = r#"id ++ "\n" ++ description ++ "\n" ++ tags"#;
+    let template = r#"id.short() ++ "\n" ++ description ++ "\n" ++ tags"#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
     insta::assert_snapshot!(output, @r"
-    @  9009349b5198b481138bc77a268145474c016cd218f1f038317f2fa6f25e4e896e0c4c4e3271b188cb2726938b92ba8135ee2fb62ddf82b2bd41a9c839337b04
+    @  9009349b5198
     │  commit c91a0909a9d3f3d8392ba9fab88f4b40fc0810ee
     │  args: jj commit -m 'new child1'
-    ○  0b8f20a1bd79d95aa49a517fbeb0b58caa024ba887c4b8da5b0feee6e2376757fa78fec2a07ee593f61d43eb3487c1ff389df5fb2c9489c313819193ccc0e401
+    ○  0b8f20a1bd79
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ○  b544b8f44a8b084f965cdb3e5f32b4f3423899c1ac004036567125cb596f3eded7f4141561078463e31e7b3dd5832912348d970c78ed2468d118efe584f6e9f0
+    ○  b544b8f44a8b
     │  commit 9af4c151edead0304de97ce3a0b414552921a425
     │  args: jj commit -m initial
-    ○  8b49a5a258dd19ac6ea757de66f57933978e6e7af948da48247ac98d5933ea6d0f78ee2a3c08757ded39ad87805a2e528dd55fd2e1da71da28e501c0c3454d9a
+    ○  8b49a5a258dd
     │  snapshot working copy
     │  args: jj commit -m initial
-    ○  2affa702525487ca490c4bc8a9a365adf75f972efb5888dd58716de7603e822ba1ed1ed0a50132ee44572bb9d819f37589d0ceb790b397ddcc88c976fde2bf02
+    ○  2affa7025254
     │  add workspace 'default'
-    ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+    ○  000000000000
 
     [EOF]
     ");

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -118,9 +118,7 @@ fn test_concurrent_operations_wc_modified() {
     let output = work_dir.run_jj(["op", "log"]).success();
     let op_id_hex = output.stdout.raw()[3..15].to_string();
 
-    work_dir
-        .run_jj(["new", "--at-op", &op_id_hex, "-m", "new child1"])
-        .success();
+    work_dir.run_jj(["new", "-m", "new child1"]).success();
     work_dir
         .run_jj(["new", "--at-op", &op_id_hex, "-m", "new child2"])
         .success();

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -28,8 +28,6 @@ fn test_undo_rewrite_with_child() {
 
     work_dir.run_jj(["describe", "-m", "initial"]).success();
     work_dir.run_jj(["describe", "-m", "modified"]).success();
-    let output = work_dir.run_jj(["op", "log"]).success();
-    let op_id_hex = output.stdout.raw()[3..15].to_string();
     work_dir.run_jj(["new", "-m", "child"]).success();
     let output = work_dir.run_jj(["log", "-T", "description"]);
     insta::assert_snapshot!(output, @r"
@@ -38,7 +36,7 @@ fn test_undo_rewrite_with_child() {
     ◆
     [EOF]
     ");
-    work_dir.run_jj(["undo", &op_id_hex]).success();
+    work_dir.run_jj(["undo", "@-"]).success();
 
     // Since we undid the description-change, the child commit should now be on top
     // of the initial commit
@@ -477,9 +475,11 @@ fn test_shows_no_warning_when_undoing_a_specific_undo_change() {
 
     work_dir.run_jj(["new"]).success();
     work_dir.run_jj(["undo"]).success();
-    let output = work_dir.run_jj(["op", "log"]).success();
-    let op_id_hex = output.stdout.raw()[3..15].to_string();
-    let output = work_dir.run_jj(["undo", &op_id_hex]);
+    let output = work_dir
+        .run_jj(["op", "log", "--no-graph", "-T=id.short()", "-n=1"])
+        .success();
+    let op_id_hex = output.stdout.raw();
+    let output = work_dir.run_jj(["undo", op_id_hex]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Undid operation: 94337eb25498 (2001-02-03 08:05:09) undo operation c7b028ea7b47461d4328dde306e13337ea9000b6abfde4cb751902fae3124d578f2e0082cbd1e1d32b5e64afc001a933be5acc81a015a7f15d62d90750eaa9ca


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
