### PR TITLE
lib: Fix a typo in the `RepoLoader` docs

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -634,7 +634,7 @@ pub enum RepoLoaderError {
     TransactionCommit(#[from] TransactionCommitError),
 }
 
-/// Helps create `ReadonlyRepoo` instances of a repo at the head operation or at
+/// Helps create `ReadonlyRepo` instances of a repo at the head operation or at
 /// a given operation.
 #[derive(Clone)]
 pub struct RepoLoader {


### PR DESCRIPTION
This PR fixes a small typo in the `RepoLoader` docs that I noticed when viewing the `jj-lib` documentation on docs.rs.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
