### PR TITLE
cli describe: remove redundant assertion of conflicting flags

### DIFF
--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -152,11 +152,6 @@ pub(crate) fn cmd_describe(
         None
     };
 
-    // edit and no_edit are conflicting arguments and therefore it should not
-    // be possible for both to be true at the same time.
-    assert!(!(args.edit && args.no_edit));
-    let use_editor = args.edit || (shared_description.is_none() && !args.no_edit);
-
     let mut commit_builders = commits
         .iter()
         .map(|commit| {
@@ -179,6 +174,11 @@ pub(crate) fn cmd_describe(
             commit_builder
         })
         .collect_vec();
+
+    // edit and no_edit are conflicting arguments and therefore it should not
+    // be possible for both to be true at the same time.
+    assert!(!(args.edit && args.no_edit));
+    let use_editor = args.edit || (shared_description.is_none() && !args.no_edit);
 
     if let Some(trailer_template) = parse_trailers_template(ui, &tx)? {
         for commit_builder in &mut commit_builders {

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -175,9 +175,6 @@ pub(crate) fn cmd_describe(
         })
         .collect_vec();
 
-    // edit and no_edit are conflicting arguments and therefore it should not
-    // be possible for both to be true at the same time.
-    assert!(!(args.edit && args.no_edit));
     let use_editor = args.edit || (shared_description.is_none() && !args.no_edit);
 
     if let Some(trailer_template) = parse_trailers_template(ui, &tx)? {


### PR DESCRIPTION
This assertion is redundant given both the `conflicts_with = "edit"` declaration on the `no_edit` flag and the passing `test_edit_cannot_be_used_with_no_edit` test.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
