### PR TITLE
lib: return correct op set subexpression when reporting multiple operations found

### DIFF
--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -592,12 +592,29 @@ fn test_resolve_op_parents_children() {
     let parent_op_ids = repo.operation().parent_ids();
 
     let op5_id_hex = repo.operation().id().hex();
-    let op_str = format!("{op5_id_hex}-");
-    let error = op_walk::resolve_op_with_repo(&repo, &op_str).unwrap_err();
+    let parents_op_str = format!("{op5_id_hex}-");
+    let error = op_walk::resolve_op_with_repo(&repo, &parents_op_str).unwrap_err();
     assert_eq!(
         extract_multiple_operations_error(&error).unwrap(),
-        (&op_str, parent_op_ids)
+        (&parents_op_str, parent_op_ids)
     );
+    let grandparents_op_str = format!("{op5_id_hex}--");
+    let error = op_walk::resolve_op_with_repo(&repo, &grandparents_op_str).unwrap_err();
+    // FIXME: The intermediate expression should be `parents_op_str`, resolving to
+    // `parent_op_ids`.
+    assert_eq!(
+        extract_multiple_operations_error(&error).unwrap(),
+        (&grandparents_op_str, parent_op_ids)
+    );
+    let children_of_parents_op_str = format!("{op5_id_hex}-+");
+    let error = op_walk::resolve_op_with_repo(&repo, &children_of_parents_op_str).unwrap_err();
+    // FIXME: The intermediate expression should be `parents_op_str`, resolving to
+    // `parent_op_ids`.
+    assert_eq!(
+        extract_multiple_operations_error(&error).unwrap(),
+        (&children_of_parents_op_str, parent_op_ids)
+    );
+
     let op2_id_hex = operations[2].id().hex();
     let op_str = format!("{op2_id_hex}+");
     let error = op_walk::resolve_op_with_repo(&repo, &op_str).unwrap_err();

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -588,19 +588,25 @@ fn test_resolve_op_parents_children() {
     let tx1 = repo.start_transaction();
     let tx2 = repo.start_transaction();
     let repo = testutils::commit_transactions(vec![tx1, tx2]);
+    let parent_op_ids = repo.operation().parent_ids();
+
     let op5_id_hex = repo.operation().id().hex();
+    let op_str = format!("{op5_id_hex}-");
     assert_matches!(
-        op_walk::resolve_op_with_repo(&repo, &format!("{op5_id_hex}-")),
+        op_walk::resolve_op_with_repo(&repo, &op_str),
         Err(OpsetEvaluationError::OpsetResolution(
-            OpsetResolutionError::MultipleOperations { .. }
+            OpsetResolutionError::MultipleOperations { expr, candidates }
         ))
+        if expr == *op_str && candidates == parent_op_ids
     );
     let op2_id_hex = operations[2].id().hex();
+    let op_str = format!("{op2_id_hex}+");
     assert_matches!(
-        op_walk::resolve_op_with_repo(&repo, &format!("{op2_id_hex}+")),
+        op_walk::resolve_op_with_repo(&repo, &op_str),
         Err(OpsetEvaluationError::OpsetResolution(
-            OpsetResolutionError::MultipleOperations { .. }
+            OpsetResolutionError::MultipleOperations { expr, candidates }
         ))
+        if expr == *op_str && candidates == parent_op_ids
     );
 }
 

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -591,6 +591,8 @@ fn test_resolve_op_parents_children() {
     let repo = testutils::commit_transactions(vec![tx1, tx2]);
     let parent_op_ids = repo.operation().parent_ids();
 
+    // The subexpression that resolves to multiple operations (i.e. the accompanying
+    // op ids) should be reported, not the full expression provided by the user.
     let op5_id_hex = repo.operation().id().hex();
     let parents_op_str = format!("{op5_id_hex}-");
     let error = op_walk::resolve_op_with_repo(&repo, &parents_op_str).unwrap_err();
@@ -600,19 +602,15 @@ fn test_resolve_op_parents_children() {
     );
     let grandparents_op_str = format!("{op5_id_hex}--");
     let error = op_walk::resolve_op_with_repo(&repo, &grandparents_op_str).unwrap_err();
-    // FIXME: The intermediate expression should be `parents_op_str`, resolving to
-    // `parent_op_ids`.
     assert_eq!(
         extract_multiple_operations_error(&error).unwrap(),
-        (&grandparents_op_str, parent_op_ids)
+        (&parents_op_str, parent_op_ids)
     );
     let children_of_parents_op_str = format!("{op5_id_hex}-+");
     let error = op_walk::resolve_op_with_repo(&repo, &children_of_parents_op_str).unwrap_err();
-    // FIXME: The intermediate expression should be `parents_op_str`, resolving to
-    // `parent_op_ids`.
     assert_eq!(
         extract_multiple_operations_error(&error).unwrap(),
-        (&children_of_parents_op_str, parent_op_ids)
+        (&parents_op_str, parent_op_ids)
     );
 
     let op2_id_hex = operations[2].id().hex();


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
