### PR TITLE
cli: resolve: show a hint towards editing the conflict markers manually if the conflict has >2 sides

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -441,6 +441,9 @@ impl From<ConflictResolveError> for CommandError {
             ConflictResolveError::Io(err) => err.into(),
             _ => {
                 let hint = match &err {
+                    ConflictResolveError::ConflictTooComplicated { .. } => {
+                        Some("Edit the conflict markers manually to resolve this.".to_owned())
+                    }
                     ConflictResolveError::ExecutableConflict { .. } => {
                         Some("Use `jj file chmod` to update the executable bit.".to_owned())
                     }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -645,6 +645,7 @@ fn test_too_many_parents() {
     Hint: Using default editor ':builtin'; run `jj config set --user ui.merge-editor :builtin` to disable this message.
     Error: Failed to resolve conflicts
     Caused by: The conflict at "file" has 3 sides. At most 2 sides are supported.
+    Hint: Edit the conflict markers manually to resolve this.
     [EOF]
     [exit status: 1]
     "#);


### PR DESCRIPTION
As suggested in Discord: https://discord.com/channels/968932220549103686/1370632916169920523

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
