### PR TITLE
cleanup: remove unused `mut`

### DIFF
--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -168,7 +168,7 @@ pub fn persist_content_addressed_temp_file<P: AsRef<Path>>(
 /// Reads from an async source and writes to a sync destination. Does not spawn
 /// a task, so writes will block.
 pub async fn copy_async_to_sync<R: AsyncRead, W: Write + ?Sized>(
-    mut reader: R,
+    reader: R,
     writer: &mut W,
 ) -> io::Result<usize> {
     let mut buf = vec![0; 16 << 10];


### PR DESCRIPTION
Introduced in b970939804b865729a1d14cedb6ea045411882b8 and caught by `cargo check`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
