### PR TITLE
docs: fix minimum fish version with dynamic completions enabled by default

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -245,7 +245,7 @@ source <(COMPLETE=zsh jj)
 
 !!! note
 
-    No configuration is required with fish >= 4.1 which loads dynamic completions by default.
+    No configuration is required with fish >= 4.0.2 which loads dynamic completions by default.
 
 #### Standard
 


### PR DESCRIPTION
Dynamic completions were added to fish [4.0.2]. To date there is no 4.1 yet.

[4.0.2]: https://github.com/fish-shell/fish-shell/releases/tag/4.0.2

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
