### PR TITLE
cli: use more precise wording in conflict resolution hint

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2301,14 +2301,20 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
             .try_collect()?;
 
         if !root_conflict_commits.is_empty() {
-            let instruction = if only_one_conflicted_commit {
-                "To resolve the conflicts, start by updating to it"
+            let suggested_change = if only_one_conflicted_commit {
+                "the conflicted commit"
             } else if root_conflict_commits.len() == 1 {
-                "To resolve the conflicts, start by updating to the first one"
+                "the first conflicted commit"
             } else {
-                "To resolve the conflicts, start by updating to one of the first ones"
+                "one of the first conflicted commits"
             };
-            writeln!(fmt.labeled("hint").with_heading("Hint: "), "{instruction}:")?;
+            writedoc!(
+                fmt.labeled("hint").with_heading("Hint: "),
+                "
+                To resolve the conflicts, start by creating a commit on top of
+                {suggested_change}:
+                "
+            )?;
             let format_short_change_id = self.short_change_id_template();
             fmt.with_label("hint", |fmt| {
                 for commit in &root_conflict_commits {
@@ -2318,11 +2324,13 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
                 }
                 io::Result::Ok(())
             })?;
-            writeln!(
+            writedoc!(
                 fmt.labeled("hint"),
-                r#"Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
-Then run `jj squash` to move the resolution into the conflicted commit."#,
+                "
+                Then use `jj resolve`, or edit the conflict markers in the file directly.
+                Once the conflicts are resolved, you can inspect the result with `jj diff`.
+                Then run `jj squash` to move the resolution into the conflicted commit.
+                ",
             )?;
         }
         Ok(())

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -173,7 +173,7 @@ fn test_absorb_replace_single_line_hunk() {
     work_dir.run_jj(["new"]).success();
     work_dir.write_file("file1", "2a\n1A\n2b\n");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       qpvuntsm 5bdb5ca1 (conflict) 1
@@ -182,13 +182,14 @@ fn test_absorb_replace_single_line_hunk() {
     Parent commit (@-)      : kkmpptxz 6068e8fc 2
     New conflicts appeared in 1 commits:
       qpvuntsm 5bdb5ca1 (conflict) 1
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new qpvuntsm
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
     @  mzvwutvl 804fe9d9 (empty) (no description set)
@@ -420,7 +421,7 @@ fn test_absorb_conflict() {
     work_dir.run_jj(["new", "root()"]).success();
     work_dir.write_file("file1", "2a\n2b\n");
     let output = work_dir.run_jj(["rebase", "-r@", "-ddescription(1)"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 1 commits to destination
     Working copy  (@) now at: kkmpptxz 66d44b8c (conflict) (no description set)
@@ -430,13 +431,14 @@ fn test_absorb_conflict() {
     file1    2-sided conflict
     New conflicts appeared in 1 commits:
       kkmpptxz 66d44b8c (conflict) (no description set)
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new kkmpptxz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     let conflict_content = work_dir.read_file("file1");
     insta::assert_snapshot!(conflict_content, @r"
@@ -545,7 +547,7 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     work_dir.remove_file("file1");
     work_dir.remove_file("file2");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Absorbed changes into 2 revisions:
       kkmpptxz 8407ab95 (conflict) 2
@@ -556,15 +558,16 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     New conflicts appeared in 2 commits:
       kkmpptxz 8407ab95 (conflict) 2
       qpvuntsm f1473264 (conflict) 1
-    Hint: To resolve the conflicts, start by updating to the first one:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the first conflicted commit:
       jj new qpvuntsm
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Remaining changes:
     D file2
     [EOF]
-    ");
+    "###);
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
     @  zsuskuln b56f0c39 (no description set)

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -194,7 +194,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "chmod", "x", "file", "-r=file_deletion"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Working copy  (@) now at: kmkuslsw dc89f9e7 file_deletion | (conflict) file_deletion
     Parent commit (@-)      : zsuskuln bc9cdea1 file | file
@@ -204,13 +204,14 @@ fn test_chmod_file_dir_deletion_conflicts() {
     file    2-sided conflict including 1 deletion and an executable
     New conflicts appeared in 1 commits:
       kmkuslsw dc89f9e7 file_deletion | (conflict) file_deletion
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new kmkuslsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     let output = work_dir.run_jj(["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(output, @r#"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: true }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true }), None]))

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -28,7 +28,7 @@ fn test_report_conflicts() {
     work_dir.run_jj(["commit", "-m=C"]).success();
 
     let output = work_dir.run_jj(["rebase", "-s=description(B)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 3 commits to destination
     Working copy  (@) now at: zsuskuln dd37d4a5 (conflict) (empty) (no description set)
@@ -39,13 +39,14 @@ fn test_report_conflicts() {
     New conflicts appeared in 2 commits:
       kkmpptxz c7f5d6e5 (conflict) C
       rlvkpnrz 032a8668 (conflict) B
-    Hint: To resolve the conflicts, start by updating to the first one:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the first conflicted commit:
       jj new rlvkpnrz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     let output = work_dir.run_jj(["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(output, @r"
@@ -60,7 +61,7 @@ fn test_report_conflicts() {
 
     // Can get hint about multiple root commits
     let output = work_dir.run_jj(["rebase", "-r=description(B)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 2 descendant commits
@@ -72,14 +73,15 @@ fn test_report_conflicts() {
     New conflicts appeared in 2 commits:
       kkmpptxz 0252a7f0 (conflict) C
       rlvkpnrz fcfd7304 (conflict) B
-    Hint: To resolve the conflicts, start by updating to one of the first ones:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    one of the first conflicted commits:
       jj new kkmpptxz
       jj new rlvkpnrz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     // Resolve one of the conflicts by (mostly) following the instructions
     let output = work_dir.run_jj(["new", "rlvkpnrzqnoo"]);
@@ -121,7 +123,7 @@ fn test_report_conflicts_with_divergent_commits() {
         .success();
 
     let output = work_dir.run_jj(["rebase", "-s=description(B)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits to destination
@@ -134,13 +136,14 @@ fn test_report_conflicts_with_divergent_commits() {
       zsuskuln?? df34134a (conflict) C3
       zsuskuln?? 08a31f4f (conflict) C2
       kkmpptxz 099d6624 (conflict) B
-    Hint: To resolve the conflicts, start by updating to the first one:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the first conflicted commit:
       jj new kkmpptxz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     let output = work_dir.run_jj(["rebase", "-d=description(A)"]);
     insta::assert_snapshot!(output, @r"
@@ -155,7 +158,7 @@ fn test_report_conflicts_with_divergent_commits() {
 
     // Same thing when rebasing the divergent commits one at a time
     let output = work_dir.run_jj(["rebase", "-s=description(C2)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 1 commits to destination
     Working copy  (@) now at: zsuskuln?? dfe73891 (conflict) C2
@@ -165,27 +168,29 @@ fn test_report_conflicts_with_divergent_commits() {
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 1 commits:
       zsuskuln?? dfe73891 (conflict) C2
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new zsuskuln
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     let output = work_dir.run_jj(["rebase", "-s=description(C3)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 1 commits to destination
     New conflicts appeared in 1 commits:
       zsuskuln?? 02834578 (conflict) C3
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new zsuskuln
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     let output = work_dir.run_jj(["rebase", "-s=description(C2)", "-d=description(B)"]);
     insta::assert_snapshot!(output, @r"

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -211,7 +211,7 @@ fn test_resolution() {
         "resolve",
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv 0d40d2b8 conflict | (conflict) conflict
@@ -222,13 +222,14 @@ fn test_resolution() {
     file    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv 0d40d2b8 conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
@@ -354,7 +355,7 @@ fn test_resolution() {
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
         "--config=merge-tools.fake-editor.conflict-marker-style=git",
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv d5f058ec conflict | (conflict) conflict
@@ -365,13 +366,14 @@ fn test_resolution() {
     file    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv d5f058ec conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor4")).unwrap(), @r"
     <<<<<<< Side #1 (Conflict 1 of 1)
@@ -432,7 +434,7 @@ fn test_resolution() {
         "resolve",
         "--config=merge-tools.fake-editor.merge-conflict-exit-codes=[1]",
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv 6c205356 conflict | (conflict) conflict
@@ -443,13 +445,14 @@ fn test_resolution() {
     file    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv 6c205356 conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor5")).unwrap(), @"");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
@@ -736,7 +739,7 @@ fn test_simplify_conflict_sides() {
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
         "fileB",
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: fileB
     Working copy  (@) now at: nkmrtpmo 25c5dd0b conflict | (conflict) conflict
@@ -748,13 +751,14 @@ fn test_simplify_conflict_sides() {
     fileB    2-sided conflict
     New conflicts appeared in 1 commits:
       nkmrtpmo 25c5dd0b conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new nkmrtpmo
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.read_file("fileB"), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
@@ -968,7 +972,7 @@ fn test_resolve_conflicts_with_executable() {
     // Test resolving the conflict in "file1", which should produce an executable
     std::fs::write(&editor_script, b"write\nresolution1\n").unwrap();
     let output = work_dir.run_jj(["resolve", "file1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file1
     Working copy  (@) now at: znkkpsqq 8ab9c54e conflict | (conflict) conflict
@@ -979,13 +983,14 @@ fn test_resolve_conflicts_with_executable() {
     file2    2-sided conflict including an executable
     New conflicts appeared in 1 commits:
       znkkpsqq 8ab9c54e conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new znkkpsqq
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100755
@@ -1011,7 +1016,7 @@ fn test_resolve_conflicts_with_executable() {
     work_dir.run_jj(["undo"]).success();
     std::fs::write(&editor_script, b"write\nresolution2\n").unwrap();
     let output = work_dir.run_jj(["resolve", "file2"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file2
     Working copy  (@) now at: znkkpsqq d47830a6 conflict | (conflict) conflict
@@ -1022,13 +1027,14 @@ fn test_resolve_conflicts_with_executable() {
     file1    2-sided conflict including an executable
     New conflicts appeared in 1 commits:
       znkkpsqq d47830a6 conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new znkkpsqq
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file2 b/file2
     index 0000000000..775f078581 100755
@@ -1410,7 +1416,7 @@ fn test_resolve_long_conflict_markers() {
     )
     .unwrap();
     let output = work_dir.run_jj(["resolve"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv 1e254ee3 conflict | (conflict) conflict
@@ -1421,13 +1427,14 @@ fn test_resolve_long_conflict_markers() {
     file    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv 1e254ee3 conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
@@ -1479,7 +1486,7 @@ fn test_resolve_long_conflict_markers() {
         "resolve",
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv 2481a401 conflict | (conflict) conflict
@@ -1490,13 +1497,14 @@ fn test_resolve_long_conflict_markers() {
     file    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv 2481a401 conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r"
     <<<<<<<<<<< Conflict 1 of 1
@@ -1554,7 +1562,7 @@ fn test_resolve_long_conflict_markers() {
         "resolve",
         r#"--config=merge-tools.fake-editor.merge-args=["$output", "$marker_length"]"#,
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv 2cf0bfd3 conflict | (conflict) conflict
@@ -1565,13 +1573,14 @@ fn test_resolve_long_conflict_markers() {
     file    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv 2cf0bfd3 conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
@@ -1685,7 +1694,7 @@ fn test_multiple_conflicts() {
     // Check that we can manually pick which of the conflicts to resolve first
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     let output = work_dir.run_jj(["resolve", "another_file"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: another_file
     Working copy  (@) now at: vruxwmqv d3584f6e conflict | (conflict) conflict
@@ -1696,13 +1705,14 @@ fn test_multiple_conflicts() {
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv d3584f6e conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/another_file b/another_file
     index 0000000000..a9fcc7d486 100644
@@ -1854,7 +1864,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let output = work_dir.run_jj(["resolve"]);
-    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r"
+    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r###"
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
@@ -1866,16 +1876,17 @@ fn test_multiple_conflicts_with_error() {
     file2    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv 98296abe conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Error: Stopped due to error after resolving 1 conflicts
     Caused by: The output file is either unchanged or empty after the editor quit (run with --debug to see the exact invocation).
     [EOF]
     [exit status: 1]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644
@@ -1905,7 +1916,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let output = work_dir.run_jj(["resolve"]);
-    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r"
+    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r###"
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
@@ -1917,16 +1928,17 @@ fn test_multiple_conflicts_with_error() {
     file2    2-sided conflict
     New conflicts appeared in 1 commits:
       vruxwmqv 7daa6406 conflict | (conflict) conflict
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new vruxwmqv
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     Error: Stopped due to error after resolving 1 conflicts
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     [EOF]
     [exit status: 1]
-    ");
+    "###);
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -62,7 +62,7 @@ fn test_restore() {
     [EOF]
     ");
     let output = work_dir.run_jj(["restore", "-c=@-"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 1 descendant commits
     Working copy  (@) now at: kkmpptxz c1d65a0f (conflict) (no description set)
@@ -72,13 +72,14 @@ fn test_restore() {
     file2    2-sided conflict including 1 deletion
     New conflicts appeared in 1 commits:
       kkmpptxz c1d65a0f (conflict) (no description set)
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new kkmpptxz
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     let output = work_dir.run_jj(["diff", "-s", "-r=@-"]);
     insta::assert_snapshot!(output, @"");
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -805,20 +805,21 @@ fn test_squash_from_multiple() {
 
     // Squash a few commits sideways
     let output = work_dir.run_jj(["squash", "--from=b", "--from=c", "--into=d"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 2 descendant commits
     Working copy  (@) now at: kpqxywon 703c6f0c f | (no description set)
     Parent commit (@-)      : yostqsxw 3d6a1899 e | (no description set)
     New conflicts appeared in 1 commits:
       yqosqzyt a3221d7a d | (conflict) (no description set)
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new yqosqzyt
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
     @  703c6f0cae6f f
     ○    3d6a18995cae e
@@ -947,20 +948,21 @@ fn test_squash_from_multiple_partial() {
 
     // Partially squash a few commits sideways
     let output = work_dir.run_jj(["squash", "--from=b|c", "--into=d", "file1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 2 descendant commits
     Working copy  (@) now at: kpqxywon f3ae0274 f | (no description set)
     Parent commit (@-)      : yostqsxw 45ad30bd e | (no description set)
     New conflicts appeared in 1 commits:
       yqosqzyt 15efa8c0 d | (conflict) (no description set)
-    Hint: To resolve the conflicts, start by updating to it:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
       jj new yqosqzyt
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
     @  f3ae0274fb6c f
     ○      45ad30bdccc6 e

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -172,34 +172,36 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ");
 
     let output = work_dir.run_jj(["status"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     The working copy has no changes.
     Working copy  (@) : yqosqzyt 7e0bc4cf (conflict) (empty) boom-cont-2
     Parent commit (@-): royxmykx 681c71af (conflict) (empty) boom-cont
     Warning: There are unresolved conflicts at these paths:
     conflicted.txt    2-sided conflict
-    Hint: To resolve the conflicts, start by updating to the first one:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the first conflicted commit:
       jj new mzvwutvl
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 
     let output = work_dir.run_jj(["status", "--color=always"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     The working copy has no changes.
     Working copy  (@) : [1m[38;5;13my[38;5;8mqosqzyt[39m [38;5;12m7[38;5;8me0bc4cf[39m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
     Parent commit (@-): [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m6[0m[38;5;8m81c71af[39m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
     [1m[38;5;3mWarning: [39mThere are unresolved conflicts at these paths:[0m
     conflicted.txt    [38;5;3m2-sided conflict[39m
-    [1m[38;5;6mHint: [0m[39mTo resolve the conflicts, start by updating to the first one:[39m
+    [1m[38;5;6mHint: [0m[39mTo resolve the conflicts, start by creating a commit on top of[39m
+    [39mthe first conflicted commit:[39m
     [39m  jj new [1m[38;5;5mm[0m[38;5;8mzvwutvl[39m[39m
     [39mThen use `jj resolve`, or edit the conflict markers in the file directly.[39m
-    [39mOnce the conflicts are resolved, you may want to inspect the result with `jj diff`.[39m
+    [39mOnce the conflicts are resolved, you can inspect the result with `jj diff`.[39m
     [39mThen run `jj squash` to move the resolution into the conflicted commit.[39m
     [EOF]
-    ");
+    "###);
 
     let output = work_dir.run_jj(["status", "--config=hints.resolving-conflicts=false"]);
     insta::assert_snapshot!(output, @r"
@@ -352,7 +354,7 @@ fn test_status_simplify_conflict_sides() {
     create_commit_with_files(&work_dir, "conflict", &["conflictA", "conflictB"], &[]);
 
     insta::assert_snapshot!(work_dir.run_jj(["status"]),
-    @r"
+    @r###"
     The working copy has no changes.
     Working copy  (@) : nkmrtpmo a5a545ce conflict | (conflict) (empty) conflict
     Parent commit (@-): kmkuslsw ccb05364 conflictA | (conflict) (empty) conflictA
@@ -360,14 +362,15 @@ fn test_status_simplify_conflict_sides() {
     Warning: There are unresolved conflicts at these paths:
     fileA    2-sided conflict
     fileB    2-sided conflict
-    Hint: To resolve the conflicts, start by updating to one of the first ones:
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    one of the first conflicted commits:
       jj new lylxulpl
       jj new kmkuslsw
     Then use `jj resolve`, or edit the conflict markers in the file directly.
-    Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    ");
+    "###);
 }
 
 #[test]

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -277,10 +277,11 @@ file1    2-sided conflict
 New conflicts appeared in 2 commits:
   qzvqqupx 1978b534 (conflict) C
   puqltutt f7fb5943 (conflict) B2
-Hint: To resolve the conflicts, start by updating to the first one:
+Hint: To resolve the conflicts, start by creating a commit on top of
+the first conflicted commit:
   jj new puqltutt
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 
 $ jj log
@@ -325,10 +326,11 @@ Working copy  (@) : zxoosnnp c7068d1c (conflict) (empty) (no description set)
 Parent commit (@-): puqltutt f7fb5943 (conflict) B2
 Warning: There are unresolved conflicts at these paths:
 file1    2-sided conflict
-Hint: To resolve the conflicts, start by updating to it:
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
   jj new puqltutt
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 
 $ cat file1
@@ -414,10 +416,11 @@ Parent commit (@-)      : puqltutt f7fb5943 (conflict) B2
 New conflicts appeared in 2 commits:
   qzvqqupx 1978b534 (conflict) C
   puqltutt f7fb5943 (conflict) B2
-Hint: To resolve the conflicts, start by updating to the first one:
+Hint: To resolve the conflicts, start by creating a commit on top of
+the first conflicted commit:
   jj new nprznkxy
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 
 $ jj log
@@ -550,10 +553,11 @@ Warning: There are unresolved conflicts at these paths:
 file    2-sided conflict
 New conflicts appeared in 1 commits:
   mrxqplyk 1c72cd50 (conflict) ABCD
-Hint: To resolve the conflicts, start by updating to it:
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
   jj new mrxqplyk
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want to inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 ```
 


### PR DESCRIPTION
We already use "conflicted commit" at the very end of the hint, so I've reused that term here.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
