### PR TITLE
cli rebase: remove deprecated `--skip-empty` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   no longer produces Bash completions by default. The deprecated optional arguments for
   different shells have been removed.
 
+* The deprecated `--skip-empty` flag for `jj rebase` has been removed. Use the
+  `--skip-emptied` flag instead.
+
 ### Deprecations
 
 * The `ui.diff.format` and `ui.diff.tool` config options have been merged as

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -40,7 +40,6 @@ use crate::cli_util::short_commit_hash;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::WorkspaceCommandHelper;
-use crate::command_error::cli_error;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::complete;
@@ -316,10 +315,6 @@ pub(crate) struct RebaseArgs {
     #[command(flatten)]
     destination: RebaseDestinationArgs,
 
-    /// Deprecated. Use --skip-emptied instead.
-    #[arg(long, conflicts_with = "revisions", hide = true)]
-    skip_empty: bool,
-
     /// If true, when rebasing would produce an empty commit, the commit is
     /// abandoned. It will not be abandoned if it was already empty before the
     /// rebase. Will never skip merge commits with multiple non-empty
@@ -378,12 +373,6 @@ pub(crate) fn cmd_rebase(
     command: &CommandHelper,
     args: &RebaseArgs,
 ) -> Result<(), CommandError> {
-    if args.skip_empty {
-        return Err(cli_error(
-            "--skip-empty is deprecated, and has been renamed to --skip-emptied.",
-        ));
-    }
-
     let rebase_options = RebaseOptions {
         empty: match args.skip_emptied {
             true => EmptyBehaviour::AbandonNewlyEmpty,


### PR DESCRIPTION
Deprecated in b57dd4d2 (#4014) and v0.20.0.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
