### PR TITLE
test: replace `cfg!` macro with `cfg_attr` attribute

### DIFF
--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -946,12 +946,9 @@ fn test_config_edit_user_new_file() {
 }
 
 // TODO: remove after deprecation period in 0.35
-// NOTE: macOS-only test
+#[cfg_attr(not(target_os = "macos"), ignore)]
 #[test]
 fn test_config_edit_user_deprecated_file() {
-    if !cfg!(target_os = "macos") {
-        return;
-    }
     let test_env = TestEnvironment::default();
     let user_config_path = test_env
         .home_dir()


### PR DESCRIPTION
Using the `cfg` attribute means the test is not compiled at all in non-macOS environments.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
