### PR TITLE
parallelize: only check to-be-rewritten commits for rewritability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `core.fsmonitor` gitconfig is set in the global or system gitconfigs.
   [#6440](https://github.com/jj-vcs/jj/issues/6440)
 
+* `jj parallelize` can now parallelize groups of changes that _start_ with an
+  immutable change, but do not contain any other immutable changes.
+
 ### Packaging changes
 
 * Due to the removal of the `libgit2` code path, packagers should

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -380,7 +380,7 @@ fn test_rewrite_immutable_commands() {
     Hint: For more information, see:
           - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
-    Hint: This operation would rewrite 2 immutable commits.
+    Hint: This operation would rewrite 1 immutable commits.
     [EOF]
     [exit status: 1]
     "#);


### PR DESCRIPTION
closes #6587

Given a commit history like this:
```
○  ccc
○  bbb
◆  aaa
```

Parallelize *should* be able to create this:
```
○  ccc
│ ○  bbb
├─╯
│ ◆  aaa
├─╯
```

This is fine because `aaa` will not be rewritten --- its children will, but neither `aaa`'s parents nor author information needs to be changed.

However, the current implementation checks _all_ commits in the target set for rewritability, instead of only the commits that will be rewritten.

This commit changes that. Now, only the commits whose parents *will* change are checked for rewritability.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
