### PR TITLE
diff: Add color config for external diff tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates can now do arithmetic on integers with the `+`, `-`, `*`, `/`, and `%`
   infix operators.
 
+* Added config settings for passing colorization arguments (eg. `--color
+  always`) to external diff tools.
+
 ### Fixed bugs
 
 * Work around a git issue that could cause subprocess operations to hang if the

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -513,6 +513,18 @@
                       ],
                       "default": "dir"
                     },
+                    "enable-color-args": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "disable-color-args": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "edit-args": {
                         "type": "array",
                         "items": {

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -517,6 +517,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",
@@ -548,6 +550,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "--edit",
                     "args",
@@ -595,6 +599,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",
@@ -622,6 +628,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "-l",
                     "$left",
@@ -651,6 +659,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "--diff",
                     "$left",
@@ -684,6 +694,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "--edit",
                     "args",
@@ -718,6 +730,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",
@@ -744,6 +758,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",
@@ -801,6 +817,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",
@@ -858,6 +876,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",
@@ -892,6 +912,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",
@@ -929,6 +951,8 @@ mod tests {
                 ],
                 diff_invocation_mode: Dir,
                 diff_do_chdir: true,
+                enable_color_args: [],
+                disable_color_args: [],
                 edit_args: [
                     "$left",
                     "$right",

--- a/docs/config.md
+++ b/docs/config.md
@@ -374,6 +374,21 @@ diff-formatter = "vimdiff"
 diff-invocation-mode = "file-by-file"
 ```
 
+External diff tools can be configured with command line arguments to
+enable or disable colorization. The argument list configured in
+`enable-color-args` is passed in when color is enabled (whether
+automatically, in the configuration file, or on the command line), and
+`disable-color-args` is used when color is disabled.  If the diff-args
+list contains `$args`, the color argument is injected there; otherwise
+it is added to the end of the command line.
+
+```toml
+[merge-tools.git]
+diff-args = ["$args", "$left", "$right"]
+enable-color-args = ["--color=always"]
+disable-color-args = ["--color=never"]
+```
+
 By default `jj` will display a warning when the command exits with a non-success
 error code. The `diff-expected-exit-codes` config can suppress this warning
 message for specific exit codes:


### PR DESCRIPTION
Add config settings to enable and disable color in external diff tools, and pass them on the command line when the tool is invoked. This PR was inspired by the TODO comment in `external.rs`.

(Using the US spelling of colour is _killing me_)
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
