### PR TITLE
repo: store commit predecessors in Operation object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates can now do arithmetic on integers with the `+`, `-`, `*`, `/`, and `%`
   infix operators.
 
+* Evolution history is now stored in the operation log.
+
 ### Fixed bugs
 
 * Work around a git issue that could cause subprocess operations to hang if the

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -927,58 +927,59 @@ fn test_operations() {
         .split('\t')
         .next()
         .unwrap();
-    insta::assert_snapshot!(add_workspace_id, @"09a518cf68a5");
+    insta::assert_snapshot!(add_workspace_id, @"12f7cbba4278");
 
     let output = work_dir.complete_fish(["op", "show", "8"]);
     insta::assert_snapshot!(output, @r"
-    8862eab31bc3	(2001-02-03 08:05:13) describe commit aa0b3230e3787076f232a08c8b1c7f54948a2d7a
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
+    8f47435a3990	(2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     // make sure global --at-op flag is respected
-    let output = work_dir.complete_fish(["--at-op", "8a1fa92a2a6a", "op", "show", "8"]);
+    let output = work_dir.complete_fish(["--at-op", "8ed8c16786e6", "op", "show", "8"]);
     insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
+    8f47435a3990	(2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["--at-op", "8a"]);
+    let output = work_dir.complete_fish(["--at-op", "8e"]);
     insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "abandon", "8a"]);
+    let output = work_dir.complete_fish(["op", "abandon", "8e"]);
     insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "diff", "--op", "8a"]);
+    let output = work_dir.complete_fish(["op", "diff", "--op", "8e"]);
     insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
-    let output = work_dir.complete_fish(["op", "diff", "--from", "8a"]);
+    let output = work_dir.complete_fish(["op", "diff", "--from", "8e"]);
     insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
-    let output = work_dir.complete_fish(["op", "diff", "--to", "8a"]);
+    let output = work_dir.complete_fish(["op", "diff", "--to", "8e"]);
     insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
-    [EOF]
-    ");
-
-    let output = work_dir.complete_fish(["op", "restore", "8a"]);
-    insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "undo", "8a"]);
+    let output = work_dir.complete_fish(["op", "restore", "8e"]);
     insta::assert_snapshot!(output, @r"
-    8a1fa92a2a6a	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
+    [EOF]
+    ");
+
+    let output = work_dir.complete_fish(["op", "undo", "8e"]);
+    insta::assert_snapshot!(output, @r"
+    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 }

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -34,18 +34,18 @@ fn test_concurrent_operation_divergence() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: c4991b0d765d, 9087f4bfa0de
+    Hint: Try specifying one of the operations by ID: b2cffe4f3026, d8ced2ea64a8
     [EOF]
     [exit status: 1]
     "#);
 
     // "op log --at-op" should work without merging the head operations
-    let output = work_dir.run_jj(["op", "log", "--at-op=9087f4bfa0de"]);
+    let output = work_dir.run_jj(["op", "log", "--at-op=d8ced2ea64a8"]);
     insta::assert_snapshot!(output, @r"
-    @  9087f4bfa0de test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  d8ced2ea64a8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'message 2' --at-op @-
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -170,19 +170,19 @@ fn test_concurrent_snapshot_wc_reloadable() {
     let template = r#"id.short() ++ "\n" ++ description ++ "\n" ++ tags"#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
     insta::assert_snapshot!(output, @r"
-    @  9009349b5198
+    @  a631dcf37fea
     │  commit c91a0909a9d3f3d8392ba9fab88f4b40fc0810ee
     │  args: jj commit -m 'new child1'
-    ○  0b8f20a1bd79
+    ○  2b8e6f8683dc
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ○  b544b8f44a8b
+    ○  2e1c4ffb74ca
     │  commit 9af4c151edead0304de97ce3a0b414552921a425
     │  args: jj commit -m initial
-    ○  8b49a5a258dd
+    ○  cfe73d1664ae
     │  snapshot working copy
     │  args: jj commit -m initial
-    ○  2affa7025254
+    ○  8f47435a3990
     │  add workspace 'default'
     ○  000000000000
 
@@ -192,8 +192,8 @@ fn test_concurrent_snapshot_wc_reloadable() {
     let output = work_dir.run_jj(["op", "log", "--no-graph", "-T", template]);
     let [op_id_after_snapshot, _, op_id_before_snapshot] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(op_id_after_snapshot[..12], @"9009349b5198");
-    insta::assert_snapshot!(op_id_before_snapshot[..12], @"b544b8f44a8b");
+    insta::assert_snapshot!(op_id_after_snapshot[..12], @"a631dcf37fea");
+    insta::assert_snapshot!(op_id_before_snapshot[..12], @"2e1c4ffb74ca");
 
     // Simulate a concurrent operation that began from the "initial" operation
     // (before the "child1" snapshot) but finished after the "child1"

--- a/cli/tests/test_debug_command.rs
+++ b/cli/tests/test_debug_command.rs
@@ -237,7 +237,7 @@ fn test_debug_operation_id() {
     let work_dir = test_env.work_dir("repo");
     let output = work_dir.run_jj(["debug", "operation", "--display", "id"]);
     assert_snapshot!(filter_index_stats(output), @r"
-    2affa702525487ca490c4bc8a9a365adf75f972efb5888dd58716de7603e822ba1ed1ed0a50132ee44572bb9d819f37589d0ceb790b397ddcc88c976fde2bf02
+    8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752
     [EOF]
     ");
 }

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -73,7 +73,7 @@ fn test_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: f7e53fd15b35 (2001-02-03 08:05:17) duplicate 1 commit(s)
+    Undid operation: 76386e059136 (2001-02-03 08:05:17) duplicate 1 commit(s)
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate" /* duplicates `c` */]);
@@ -2349,7 +2349,7 @@ fn test_undo_after_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: b5fd81616e0d (2001-02-03 08:05:11) duplicate 1 commit(s)
+    Undid operation: a6a20a8e5a46 (2001-02-03 08:05:11) duplicate 1 commit(s)
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @r"

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -601,7 +601,7 @@ fn test_git_clone_ignore_working_copy() {
     let output = clone_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 2affa7025254).
+    Error: The working copy is stale (not updated since operation 8f47435a3990).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -898,7 +898,7 @@ fn test_git_clone_malformed() {
     let output = clone_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation c3cc6408625b).
+    Error: The working copy is stale (not updated since operation 01e1362cd2e1).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
     [EOF]

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -962,7 +962,7 @@ fn test_git_colocated_undo_head_move() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 7b91bd9df087 (2001-02-03 08:05:13) new empty commit
+    Undid operation: f349e313234e (2001-02-03 08:05:13) new empty commit
     Working copy  (@) now at: royxmykx e7d0d5fd (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1186,7 +1186,7 @@ fn test_git_fetch_undo() {
     let output = target_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: e99f84378887 (2001-02-03 08:05:18) fetch from git remote(s) origin
+    Undid operation: 158b589e0e15 (2001-02-03 08:05:18) fetch from git remote(s) origin
     [EOF]
     ");
     // The undo works as expected
@@ -1275,7 +1275,7 @@ fn test_fetch_undo_what() {
     let output = work_dir.run_jj(["op", "restore", "--what", "repo", &base_operation_id]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Restored to operation: 2affa7025254 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
@@ -1306,7 +1306,7 @@ fn test_fetch_undo_what() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Restored to operation: 2affa7025254 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -116,7 +116,7 @@ fn test_git_export_undo() {
     let output = work_dir.run_jj(["op", "undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 5892a7e5aee4 (2001-02-03 08:05:10) export git refs
+    Undid operation: b718f970b78c (2001-02-03 08:05:10) export git refs
     [EOF]
     ");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
@@ -191,7 +191,7 @@ fn test_git_import_undo() {
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Restored to operation: 2affa7025254 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
@@ -273,7 +273,7 @@ fn test_git_import_move_export_with_default_undo() {
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Restored to operation: 2affa7025254 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
     Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -35,10 +35,10 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @  09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -81,7 +81,7 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff"]);
     insta::assert_snapshot!(output, @r"
-    @  09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
     │
@@ -92,7 +92,7 @@ fn test_op_log() {
     │  Changed working copy default@:
     │  + qpvuntsm 3ae22e7f (empty) description 0
     │  - qpvuntsm hidden e8849ae1 (empty) (no description set)
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -107,7 +107,7 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--color=always"]);
     insta::assert_snapshot!(output, @r"
-    [1m[38;5;2m@[0m  [1m[38;5;12m09a518cf68a5[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;12m12f7cbba4278[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
     │  [1mdescribe commit e8849ae12c709f2321908879bc724fdb2ab8a781[0m
     │  [1m[38;5;13margs: jj describe -m 'description 0'[39m[0m
     │
@@ -118,7 +118,7 @@ fn test_op_log() {
     │  Changed working copy [38;5;2mdefault@[39m:
     │  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
     │  [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[39m hidden [1m[38;5;4me[0m[38;5;8m8849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ○  [38;5;4m2affa7025254[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
+    ○  [38;5;4m8f47435a3990[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -146,7 +146,7 @@ fn test_op_log() {
     insta::assert_snapshot!(work_dir.run_jj(["log", "--at-op", "@-"]), @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: ca1431ae8aca, f392182c5ff4
+    Hint: Try specifying one of the operations by ID: a57c1debcef0, 6a23c2d6dc15
     [EOF]
     [exit status: 1]
     "#);
@@ -167,10 +167,10 @@ fn test_op_log_with_custom_symbols() {
         "--config=templates.op_log_node='if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
     ]);
     insta::assert_snapshot!(output, @r"
-    $  09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    $  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ┝  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ┝  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ┴  000000000000 root()
     [EOF]
@@ -237,7 +237,7 @@ fn test_op_log_no_graph() {
 
     let output = work_dir.run_jj(["op", "log", "--no-graph", "--color=always"]);
     insta::assert_snapshot!(output, @r"
-    [1m[38;5;12m2affa7025254[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
+    [1m[38;5;12m8f47435a3990[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
     [1madd workspace 'default'[0m
     [38;5;4m000000000000[39m [38;5;2mroot()[39m
     [EOF]
@@ -245,7 +245,7 @@ fn test_op_log_no_graph() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--no-graph"]);
     insta::assert_snapshot!(output, @r"
-    2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     Changed commits:
@@ -271,9 +271,9 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
     insta::assert_snapshot!(output, @r"
     ○  000000000000 root()
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    @  09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
        describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
        args: jj describe -m 'description 0'
     [EOF]
@@ -287,15 +287,15 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
     insta::assert_snapshot!(output, @r"
     ○  000000000000 root()
-    ○    2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     ├─╮  add workspace 'default'
-    │ ○  c04227b01598 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  39f59ea3ec6e test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -m 'description 1' --at-op @-
-    ○ │  09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○ │  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  6238cd3bc6e9 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -308,15 +308,15 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed", "--no-graph"]);
     insta::assert_snapshot!(output, @r"
     000000000000 root()
-    2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
-    c04227b01598 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    39f59ea3ec6e test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 1' --at-op @-
-    09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    6238cd3bc6e9 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -325,13 +325,13 @@ fn test_op_log_reversed() {
     // Should work correctly with `--limit`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=3"]);
     insta::assert_snapshot!(output, @r"
-    ○  c04227b01598 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  39f59ea3ec6e test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 1' --at-op @-
-    │ ○  09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ ○  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  6238cd3bc6e9 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -340,10 +340,10 @@ fn test_op_log_reversed() {
     // Should work correctly with `--limit` and `--no-graph`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=2", "--no-graph"]);
     insta::assert_snapshot!(output, @r"
-    09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    6238cd3bc6e9 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -367,7 +367,7 @@ fn test_op_log_no_graph_null_terminated() {
             r#"id.short(4) ++ "\0""#,
         ])
         .success();
-    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""4dc1\07ad0\02aff\00000\0""#);
+    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""a9e5\00265\08f47\00000\0""#);
 }
 
 #[test]
@@ -378,14 +378,14 @@ fn test_op_log_template() {
     let render = |template| work_dir.run_jj(["op", "log", "-T", template]);
 
     insta::assert_snapshot!(render(r#"id ++ "\n""#), @r"
-    @  2affa702525487ca490c4bc8a9a365adf75f972efb5888dd58716de7603e822ba1ed1ed0a50132ee44572bb9d819f37589d0ceb790b397ddcc88c976fde2bf02
+    @  8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     [EOF]
     ");
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
                                 time.start(), time.end(), time.duration()) ++ "\n""#), @r"
-    @  2affa true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
+    @  8f474 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     ○  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
     [EOF]
     ");
@@ -410,7 +410,7 @@ fn test_op_log_template() {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(
         output.normalize_stdout_with(|s| regex.replace_all(&s, "NN years").into_owned()), @r"
-    @  2affa7025254 test-username@host.example.com NN years ago, lasted less than a microsecond
+    @  8f47435a3990 test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -429,21 +429,21 @@ fn test_op_log_builtin_templates() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r"
-    09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
     000000000000 root()
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r"
-    09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
 
-    2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     000000000000 root()
@@ -452,8 +452,8 @@ fn test_op_log_builtin_templates() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @r"
-    09a518cf68a5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
-    2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
+    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
     000000000000 root()
     [EOF]
     ");
@@ -478,22 +478,22 @@ fn test_op_log_word_wrap() {
 
     // ui.log-word-wrap option works
     insta::assert_snapshot!(render(&["op", "log"], 40, false), @r"
-    @  fc2ccf751a9d test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  2144f9621985 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log"], 40, true), @r"
-    @  fc2ccf751a9d
+    @  2144f9621985
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
     │  2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  2affa7025254
+    ○  8f47435a3990
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -504,7 +504,7 @@ fn test_op_log_word_wrap() {
 
     // Nested graph should be wrapped
     insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @r"
-    @  fc2ccf751a9d
+    @  2144f9621985
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
     │  2001-02-03 04:05:08.000 +07:00
@@ -522,7 +522,7 @@ fn test_op_log_word_wrap() {
     │  set)
     │  - qpvuntsm hidden e8849ae1 (empty)
     │  (no description set)
-    ○  2affa7025254
+    ○  8f47435a3990
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -542,7 +542,7 @@ fn test_op_log_word_wrap() {
 
     // Nested diff stat shouldn't exceed the terminal width
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @r"
-    @  fc2ccf751a9d
+    @  2144f9621985
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
     │  2001-02-03 04:05:08.000 +07:00
@@ -565,7 +565,7 @@ fn test_op_log_word_wrap() {
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @r"
-    fc2ccf751a9d
+    2144f9621985
     test-username@host.example.com
     2001-02-03 04:05:08.000 +07:00 -
     2001-02-03 04:05:08.000 +07:00
@@ -631,7 +631,7 @@ fn test_op_log_configurable() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @  84cd00547aac my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    @  906f45b6b2a8 my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -647,13 +647,13 @@ fn test_op_abandon_ancestors() {
     work_dir.run_jj(["commit", "-m", "commit 1"]).success();
     work_dir.run_jj(["commit", "-m", "commit 2"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  d9fb2978c3b3 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  3fc56f6bb4db test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
-    ○  2808265c0ab7 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  c815486340d5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -667,12 +667,12 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("bd36ef949d8184d6cb0846eadac00951b2fbd35b6fccc11bf800c9af8874b83dd4de3e2a34466b39b96a82f1ad2410454e061c56292b2550fc6635ece65bcf9f")
+    Current operation: OperationId("10a84113804fa7989bcbad93da85a8cd7e05fcd1a17612a380fc2ce5a1f1196d5c09cf928c4ceffdccbf851d9aed244fa226d48c1f06b4a048bfa9d88b8f23cb")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  bd36ef949d81 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  10a84113804f test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -690,10 +690,10 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  ebbdcdbf0e20 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    @  117e859b7a18 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit 2f3e935ade915272ccdce9e43e5a5c82fc336aee
     │  args: jj commit -m 'commit 5'
-    ○  bd36ef949d81 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  10a84113804f test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -704,7 +704,7 @@ fn test_op_abandon_ancestors() {
     let output = work_dir.run_jj(["op", "abandon", "..@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Cannot abandon the current operation ebbdcdbf0e20
+    Error: Cannot abandon the current operation 117e859b7a18
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -728,15 +728,15 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("c9115c490c0e2c45bebed8af0ca748885a636f33dfdd543e71693dafb9c773e42dd001c3c76054026e3ca0f6f5b778c6377997dca65ec99ed8a0b17f4aa8998c")
+    Current operation: OperationId("e77f5bacd23306272e980a7d59b3a60e8bdfa3da7a67e93b72d4f0bd3c945cd4b43b7c18aa338013ba06eccf40e817706acea65c4d6c513651f7d9a70d204e18")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  c9115c490c0e test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  undo operation ebbdcdbf0e202b089f99e95477270a87d72dda2660942e16c75f700307384d88374a3d0b8a3e717dcb5f398ac524f5c7a8f4a87a677a167d52f258dd9a3daceb
+    @  e77f5bacd233 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  undo operation 117e859b7a18a5a0867c2113191303c2deb78b27d6f2831164d152487b98b407b0ab70f817f2c74f7a3f21c25ddfb45c3778465f4a2ab48b0b6aeaf5766a5f47
     │  args: jj undo
-    ○  bd36ef949d81 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  10a84113804f test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -751,8 +751,8 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1"]), @r"
-    @  c9115c490c0e test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  undo operation ebbdcdbf0e202b089f99e95477270a87d72dda2660942e16c75f700307384d88374a3d0b8a3e717dcb5f398ac524f5c7a8f4a87a677a167d52f258dd9a3daceb
+    @  e77f5bacd233 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  undo operation 117e859b7a18a5a0867c2113191303c2deb78b27d6f2831164d152487b98b407b0ab70f817f2c74f7a3f21c25ddfb45c3778465f4a2ab48b0b6aeaf5766a5f47
     │  args: jj undo
     [EOF]
     ");
@@ -776,12 +776,12 @@ fn test_op_abandon_without_updating_working_copy() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("b440809cf32014e1c2bc327377fe51286a6dab610841337110f0b795510668ff4e44d3d53cea1efb31730355529a8eb0dd5a718277d80d6be51d917ff0fcb392")
+    Current operation: OperationId("0d4bb8e4a2babc4c216be0f9bde32aeef888abebde0062aeb1c204dde5e1f476fa951fcbeceb2263cf505008ba87a834849469dede30dfc589f37d5073aedfbe")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @r"
-    @  e9fed929c83b test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  bdfd901af5dd test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -794,16 +794,16 @@ fn test_op_abandon_without_updating_working_copy() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Abandoned 1 operations and reparented 1 descendant operations.
-    Warning: The working copy operation b440809cf320 is not updated because it differs from the repo e9fed929c83b.
+    Warning: The working copy operation 0d4bb8e4a2ba is not updated because it differs from the repo bdfd901af5dd.
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("b440809cf32014e1c2bc327377fe51286a6dab610841337110f0b795510668ff4e44d3d53cea1efb31730355529a8eb0dd5a718277d80d6be51d917ff0fcb392")
+    Current operation: OperationId("0d4bb8e4a2babc4c216be0f9bde32aeef888abebde0062aeb1c204dde5e1f476fa951fcbeceb2263cf505008ba87a834849469dede30dfc589f37d5073aedfbe")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @r"
-    @  8733d4bde6d4 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  58a15e02bb4b test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -824,8 +824,8 @@ fn test_op_abandon_multiple_heads() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, prev_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"b440809cf320");
-    insta::assert_snapshot!(prev_op_id, @"d9fb2978c3b3");
+    insta::assert_snapshot!(head_op_id, @"0d4bb8e4a2ba");
+    insta::assert_snapshot!(prev_op_id, @"3fc56f6bb4db");
 
     // Create 1 other concurrent operation.
     work_dir
@@ -837,19 +837,19 @@ fn test_op_abandon_multiple_heads() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: b440809cf320, 7d1bec914282
+    Hint: Try specifying one of the operations by ID: 0d4bb8e4a2ba, 56b918336386
     [EOF]
     [exit status: 1]
     "#);
     let (_, other_head_op_id) = output.stderr.raw().trim_end().rsplit_once(", ").unwrap();
-    insta::assert_snapshot!(other_head_op_id, @"7d1bec914282");
+    insta::assert_snapshot!(other_head_op_id, @"56b918336386");
     assert_ne!(head_op_id, other_head_op_id);
 
     // Can't abandon one of the head operations.
     let output = work_dir.run_jj(["op", "abandon", head_op_id]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Cannot abandon the current operation b440809cf320
+    Error: Cannot abandon the current operation 0d4bb8e4a2ba
     [EOF]
     [exit status: 1]
     ");
@@ -858,7 +858,7 @@ fn test_op_abandon_multiple_heads() {
     let output = work_dir.run_jj(["op", "abandon", other_head_op_id]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Cannot abandon the current operation 7d1bec914282
+    Error: Cannot abandon the current operation 56b918336386
     [EOF]
     [exit status: 1]
     ");
@@ -875,19 +875,19 @@ fn test_op_abandon_multiple_heads() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @    a266ee1233f7 test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    @    6aa2b158f53c test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  e9fed929c83b test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  bdfd901af5dd test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │ │  args: jj commit -m 'commit 3'
-    │ ○  7d1bec914282 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  341f3ae94078 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │    args: jj commit '--at-op=@--' -m 'commit 4'
-    ○  2808265c0ab7 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  c815486340d5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -921,8 +921,8 @@ fn test_op_recover_from_bad_gc() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, _, _, bad_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"b4fa5b4308c8");
-    insta::assert_snapshot!(bad_op_id, @"361e02cfaa19");
+    insta::assert_snapshot!(head_op_id, @"9a34044af622");
+    insta::assert_snapshot!(bad_op_id, @"65860cfb750d");
 
     // Corrupt the repo by removing hidden but reachable commit object.
     let output = work_dir
@@ -948,7 +948,7 @@ fn test_op_recover_from_bad_gc() {
     let output = work_dir.run_jj(["--at-op", head_op_id, "debug", "reindex"]);
     insta::assert_snapshot!(output.strip_stderr_last_line(), @r"
     ------- stderr -------
-    Internal error: Failed to index commits at operation 361e02cfaa1994f71140d7d08a588829f5ca72f856eefae48ed8d0c809727003713a772aab1faf7c6e9efd315879251f0386ad2b5a9f59791991265af3c354a8
+    Internal error: Failed to index commits at operation 65860cfb750d760cabfc2ba588b16b1619e048bbd2dcb0295d0d32442da72beee0675a5ea07c47e28e297572d385826f6286e16efd885f2f94114692688fb87f
     Caused by:
     1: Object 4e123bae951c3216a145dbcd56d60522739d362e of type commit not found
     [EOF]
@@ -958,22 +958,22 @@ fn test_op_recover_from_bad_gc() {
     // "op log" should still be usable.
     let output = work_dir.run_jj(["op", "log", "--ignore-working-copy", "--at-op", head_op_id]);
     insta::assert_snapshot!(output, @r"
-    @  b4fa5b4308c8 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  9a34044af622 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  describe commit a053bc8736064a739ab73f2c775a6ac2851bf1a3
     │  args: jj describe -m4
-    ○  212c79e1e844 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  c08e984b3923 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new -m3
-    ○  70899ef22ee9 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  9988649fbebb test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  abandon commit 4e123bae951c3216a145dbcd56d60522739d362e
     │  args: jj abandon
-    ○  361e02cfaa19 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  65860cfb750d test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 884fe9b9c65602d724c7c0f2a238d5549efbe5e6
     │  args: jj describe -m2
-    ○  541be72f8ee2 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  0a7467a95483 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m1
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1014,7 +1014,7 @@ fn test_op_corrupted_operation_file() {
         .join(PathBuf::from_iter([".jj", "repo", "op_store"]));
 
     let op_id = work_dir.current_operation_id();
-    insta::assert_snapshot!(op_id, @"2affa702525487ca490c4bc8a9a365adf75f972efb5888dd58716de7603e822ba1ed1ed0a50132ee44572bb9d819f37589d0ceb790b397ddcc88c976fde2bf02");
+    insta::assert_snapshot!(op_id, @"8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752");
 
     let op_file_path = op_store_path.join("operations").join(&op_id);
     assert!(op_file_path.exists());
@@ -1026,7 +1026,7 @@ fn test_op_corrupted_operation_file() {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 2affa702525487ca490c4bc8a9a365adf75f972efb5888dd58716de7603e822ba1ed1ed0a50132ee44572bb9d819f37589d0ceb790b397ddcc88c976fde2bf02 of type operation
+    1: Error when reading object 8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752 of type operation
     2: Invalid hash length (expected 64 bytes, got 0 bytes)
     [EOF]
     [exit status: 255]
@@ -1039,7 +1039,7 @@ fn test_op_corrupted_operation_file() {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 2affa702525487ca490c4bc8a9a365adf75f972efb5888dd58716de7603e822ba1ed1ed0a50132ee44572bb9d819f37589d0ceb790b397ddcc88c976fde2bf02 of type operation
+    1: Error when reading object 8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752 of type operation
     2: failed to decode Protobuf message: invalid tag value: 0
     [EOF]
     [exit status: 255]
@@ -1059,7 +1059,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "undo", "--color=always"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: [38;5;4m5881546f5a5c[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
+    Undid operation: [38;5;4m8c2682708d2e[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1073,7 +1073,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @r"
     From operation: [38;5;4m000000000000[39m [38;5;2mroot()[39m
-      To operation: [38;5;4m4d601e03331c[39m ([38;5;6m2001-02-03 08:05:09[39m) undo operation 5881546f5a5c322f0f5ced5216d4eb1110570617786292c2e3c102fabb6eb74c3a1183349eee2371ba24ebda7801bf43b6382957756040198384e3a0deeb34fa
+      To operation: [38;5;4m5b09d908ed2f[39m ([38;5;6m2001-02-03 08:05:09[39m) undo operation 8c2682708d2e786e9c489d18b4cfc68c675d0d49b9be85de9540a973b775c7ef715c0a37c760fe74ee6a31e50487f6d64e392944124a1d288ca31493bf9e36f2
 
     Changed commits:
     ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
@@ -1091,7 +1091,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "undo", "--color=debug"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: [38;5;4m<<operation id short::496308a90c9d>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
+    Undid operation: [38;5;4m<<operation id short::0f553bee92fc>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1105,7 +1105,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @r"
     From operation: [38;5;4m<<op_diff operation id short::000000000000>>[39m<<op_diff operation:: >>[38;5;2m<<op_diff operation root::root()>>[39m
-      To operation: [38;5;4m<<op_diff operation id short::dfdb600231fe>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::undo operation 496308a90c9da4609359f773ea4b4eae56ee1939b00bc9c5a52d4ce96517e7d936b5c3f4b76d6539f873f71908c84c72e7840f2e16a127a0cd6d79b83016ea96>>
+      To operation: [38;5;4m<<op_diff operation id short::8840c54e3995>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::undo operation 0f553bee92fc9d54642c987c93e78aa1f391225cf8b82a5a0198782a4e49753e65fae15bc648b81b913f514a11ca15840e9a6a083e2e3a9198cebf09ebde06f2>>
 
     Changed commits:
     ○  [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[38;5;8m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[39m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[38;5;8m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
@@ -1135,13 +1135,13 @@ fn test_op_diff() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @  845057a2b174 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  f63e1950e7be test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1@origin
-    ○  5446f7f2752a test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  e922d994bdc4 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1156,8 +1156,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--from", "@", "--to", "@"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 845057a2b174 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
-      To operation: 845057a2b174 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: f63e1950e7be (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: f63e1950e7be (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
     [EOF]
     ");
 
@@ -1166,8 +1166,8 @@ fn test_op_diff() {
     // @- --to @` (if `@` is not a merge commit).
     let output = work_dir.run_jj(["op", "diff", "--from", "@-", "--to", "@"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 5446f7f2752a (2001-02-03 08:05:09) fetch from git remote(s) origin
-      To operation: 845057a2b174 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: e922d994bdc4 (2001-02-03 08:05:09) fetch from git remote(s) origin
+      To operation: f63e1950e7be (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed local bookmarks:
     bookmark-1:
@@ -1187,7 +1187,7 @@ fn test_op_diff() {
     let output = work_dir.run_jj(["op", "diff", "--from", "0000000"]);
     insta::assert_snapshot!(output, @r"
     From operation: 000000000000 root()
-      To operation: 845057a2b174 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: f63e1950e7be (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed commits:
     ○  + rnnslrkn 4ff62539 bookmark-2@origin | Commit 2
@@ -1220,7 +1220,7 @@ fn test_op_diff() {
     // Diff from latest operation to root operation
     let output = work_dir.run_jj(["op", "diff", "--to", "0000000"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 845057a2b174 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: f63e1950e7be (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
       To operation: 000000000000 root()
 
     Changed commits:
@@ -1277,19 +1277,19 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @    ef4d1dc2a922 test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    @    913172f3f51a test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  845057a2b174 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  f63e1950e7be test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  track remote bookmark bookmark-1@origin
     │ │  args: jj bookmark track bookmark-1@origin
-    │ ○  6dae22d68667 test-username@host.example.com 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
+    │ ○  5a866c412d4a test-username@host.example.com 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
     ├─╯  point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
     │    args: jj bookmark set bookmark-1 -r bookmark-2@origin --at-op @-
-    ○  5446f7f2752a test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  e922d994bdc4 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1302,8 +1302,8 @@ fn test_op_diff() {
     // Diff between the first parent of the merge operation and the merge operation.
     let output = work_dir.run_jj(["op", "diff", "--from", first_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @r"
-    From operation: 845057a2b174 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
-      To operation: ef4d1dc2a922 (2001-02-03 08:05:19) reconcile divergent operations
+    From operation: f63e1950e7be (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: 913172f3f51a (2001-02-03 08:05:19) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1317,8 +1317,8 @@ fn test_op_diff() {
     // operation.
     let output = work_dir.run_jj(["op", "diff", "--from", second_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @r"
-    From operation: 6dae22d68667 (2001-02-03 08:05:18) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
-      To operation: ef4d1dc2a922 (2001-02-03 08:05:19) reconcile divergent operations
+    From operation: 5a866c412d4a (2001-02-03 08:05:18) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
+      To operation: 913172f3f51a (2001-02-03 08:05:19) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1346,8 +1346,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: ef4d1dc2a922 (2001-02-03 08:05:19) reconcile divergent operations
-      To operation: 1656b0111f05 (2001-02-03 08:05:23) fetch from git remote(s) origin
+    From operation: 913172f3f51a (2001-02-03 08:05:19) reconcile divergent operations
+      To operation: 0e0a422f79d9 (2001-02-03 08:05:23) fetch from git remote(s) origin
 
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
@@ -1389,8 +1389,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 1656b0111f05 (2001-02-03 08:05:23) fetch from git remote(s) origin
-      To operation: d21b0264dff8 (2001-02-03 08:05:25) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+    From operation: 0e0a422f79d9 (2001-02-03 08:05:23) fetch from git remote(s) origin
+      To operation: f39e1e8ef9e6 (2001-02-03 08:05:25) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
 
     Changed local bookmarks:
     bookmark-2:
@@ -1408,8 +1408,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: d21b0264dff8 (2001-02-03 08:05:25) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: 5ca5744f2259 (2001-02-03 08:05:27) track remote bookmark bookmark-2@origin
+    From operation: f39e1e8ef9e6 (2001-02-03 08:05:25) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: 691bbfe04a96 (2001-02-03 08:05:27) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1429,8 +1429,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: d21b0264dff8 (2001-02-03 08:05:25) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: 5ca5744f2259 (2001-02-03 08:05:27) track remote bookmark bookmark-2@origin
+    From operation: f39e1e8ef9e6 (2001-02-03 08:05:25) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: 691bbfe04a96 (2001-02-03 08:05:27) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1450,8 +1450,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 5ca5744f2259 (2001-02-03 08:05:27) track remote bookmark bookmark-2@origin
-      To operation: f20c0544f339 (2001-02-03 08:05:31) new empty commit
+    From operation: 691bbfe04a96 (2001-02-03 08:05:27) track remote bookmark bookmark-2@origin
+      To operation: 60a91a8c707a (2001-02-03 08:05:31) new empty commit
 
     Changed commits:
     ○  + xlzxqlsl 731ab199 (empty) new commit
@@ -1472,8 +1472,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: f20c0544f339 (2001-02-03 08:05:31) new empty commit
-      To operation: 6a8bb2bf7d13 (2001-02-03 08:05:33) point bookmark bookmark-1 to commit 731ab19950fc6fc1199b9ea73cb8b9016f22e8f3
+    From operation: 60a91a8c707a (2001-02-03 08:05:31) new empty commit
+      To operation: 9f7576674264 (2001-02-03 08:05:33) point bookmark bookmark-1 to commit 731ab19950fc6fc1199b9ea73cb8b9016f22e8f3
 
     Changed local bookmarks:
     bookmark-1:
@@ -1492,8 +1492,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 6a8bb2bf7d13 (2001-02-03 08:05:33) point bookmark bookmark-1 to commit 731ab19950fc6fc1199b9ea73cb8b9016f22e8f3
-      To operation: 7d9da7123281 (2001-02-03 08:05:35) delete bookmark bookmark-2
+    From operation: 9f7576674264 (2001-02-03 08:05:33) point bookmark bookmark-1 to commit 731ab19950fc6fc1199b9ea73cb8b9016f22e8f3
+      To operation: 9b51b9c5a5ee (2001-02-03 08:05:35) delete bookmark bookmark-2
 
     Changed local bookmarks:
     bookmark-2:
@@ -1513,8 +1513,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 7d9da7123281 (2001-02-03 08:05:35) delete bookmark bookmark-2
-      To operation: 04f37ad84c4b (2001-02-03 08:05:37) push all tracked bookmarks to git remote origin
+    From operation: 9b51b9c5a5ee (2001-02-03 08:05:35) delete bookmark bookmark-2
+      To operation: 7a434343b4ad (2001-02-03 08:05:37) push all tracked bookmarks to git remote origin
 
     Changed remote bookmarks:
     bookmark-1@origin:
@@ -1544,8 +1544,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@-", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 2affa7025254 (2001-02-03 08:05:07) add workspace 'default'
-      To operation: 7829688c6706 (2001-02-03 08:05:08) snapshot working copy
+    From operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: 688a949038f6 (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + qpvuntsm 6b57e33c (no description set)
@@ -1565,8 +1565,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 7829688c6706 (2001-02-03 08:05:08) snapshot working copy
-      To operation: 94a56ee3a1fe (2001-02-03 08:05:08) new empty commit
+    From operation: 688a949038f6 (2001-02-03 08:05:08) snapshot working copy
+      To operation: ed6f6674bcf8 (2001-02-03 08:05:08) new empty commit
 
     Changed commits:
     ○  + rlvkpnrz c1c924b8 (empty) (no description set)
@@ -1588,8 +1588,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    From operation: c9a2a852af45 (2001-02-03 08:05:11) snapshot working copy
-      To operation: 08dd88f26b33 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+    From operation: 36a5d140ea10 (2001-02-03 08:05:11) snapshot working copy
+      To operation: cfb8edbeae42 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
 
     Changed commits:
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
@@ -1629,8 +1629,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    From operation: 08dd88f26b33 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
-      To operation: 515e816ea876 (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
+    From operation: cfb8edbeae42 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+      To operation: dd1ab16f2720 (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
@@ -1653,7 +1653,7 @@ fn test_op_diff_sibling() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let base_op_id = output.stdout.raw().lines().next().unwrap();
-    insta::assert_snapshot!(base_op_id, @"2affa7025254");
+    insta::assert_snapshot!(base_op_id, @"8f47435a3990");
 
     // Create merge commit at one operation side. The parent trees will have to
     // be merged when diffing, which requires the commit index of this side.
@@ -1670,28 +1670,28 @@ fn test_op_diff_sibling() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @    f44cd62223a1 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @    0fce99d88f9f test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  b62d3f39feb4 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  9f1e89c03a5b test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'all:@-+' -mA
-    ○ │  539020bb231c test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  1f3ff302e831 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new 'all:@-+' -mA
-    ○ │  d84dbfe11c65 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  a625f0ff4f09 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.2
-    ○ │  6087b15e5d31 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  1e7f1f82a257 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new 'root()' -mA.2
-    ○ │  47d7f09c45b7 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  3f5210eaa799 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.1
-    │ ○  b948d5e4b967 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  252ff3a5a0e6 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    │    args: jj describe --at-op 2affa7025254 -mB
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │    args: jj describe --at-op 8f47435a3990 -mB
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1704,9 +1704,9 @@ fn test_op_diff_sibling() {
         .success();
     let [head_op_id, p1_op_id, _, _, _, _, p2_op_id] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"f44cd62223a1");
-    insta::assert_snapshot!(p1_op_id, @"b62d3f39feb4");
-    insta::assert_snapshot!(p2_op_id, @"b948d5e4b967");
+    insta::assert_snapshot!(head_op_id, @"0fce99d88f9f");
+    insta::assert_snapshot!(p1_op_id, @"9f1e89c03a5b");
+    insta::assert_snapshot!(p2_op_id, @"252ff3a5a0e6");
 
     // Diff between p1 and p2 operations should work no matter if p2 is chosen
     // as a base operation.
@@ -1722,8 +1722,8 @@ fn test_op_diff_sibling() {
         "--summary",
     ]);
     insta::assert_snapshot!(output, @r"
-    From operation: b62d3f39feb4 (2001-02-03 08:05:11) new empty commit
-      To operation: b948d5e4b967 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: 9f1e89c03a5b (2001-02-03 08:05:11) new empty commit
+      To operation: 252ff3a5a0e6 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
 
     Changed commits:
     ○  + qpvuntsm b1ca67e2 (empty) B
@@ -1751,8 +1751,8 @@ fn test_op_diff_sibling() {
         "--summary",
     ]);
     insta::assert_snapshot!(output, @r"
-    From operation: b948d5e4b967 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: b62d3f39feb4 (2001-02-03 08:05:11) new empty commit
+    From operation: 252ff3a5a0e6 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: 9f1e89c03a5b (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     ○    + mzvwutvl 08c63613 (empty) A
@@ -1794,8 +1794,8 @@ fn test_op_diff_word_wrap() {
 
     // ui.log-word-wrap option works, and diff stat respects content width
     insta::assert_snapshot!(render(&["op", "diff", "--from=@---", "--stat"], 40, true), @r"
-    From operation: 2affa7025254 (2001-02-03 08:05:07) add workspace 'default'
-      To operation: 5d3e8c16cd1f (2001-02-03 08:05:08) snapshot working copy
+    From operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: 4fe1b71ec70b (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + sqpuoqvx f6f32c19 (no description
@@ -1849,8 +1849,8 @@ fn test_op_diff_word_wrap() {
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
         render(&["op", "diff", "--from=@---", "--config", config], 10, true), @r"
-    From operation: 2affa7025254 (2001-02-03 08:05:07) add workspace 'default'
-      To operation: 5d3e8c16cd1f (2001-02-03 08:05:08) snapshot working copy
+    From operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: 4fe1b71ec70b (2001-02-03 08:05:08) snapshot working copy
 
     Changed
     commits:
@@ -1938,13 +1938,13 @@ fn test_op_show() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @  845057a2b174 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  f63e1950e7be test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1@origin
-    ○  5446f7f2752a test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  e922d994bdc4 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1960,7 +1960,7 @@ fn test_op_show() {
     // Showing the latest operation.
     let output = work_dir.run_jj(["op", "show", "@"]);
     insta::assert_snapshot!(output, @r"
-    845057a2b174 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    f63e1950e7be test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     track remote bookmark bookmark-1@origin
     args: jj bookmark track bookmark-1@origin
 
@@ -1982,7 +1982,7 @@ fn test_op_show() {
     // Showing a given operation.
     let output = work_dir.run_jj(["op", "show", "@-"]);
     insta::assert_snapshot!(output, @r"
-    5446f7f2752a test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    e922d994bdc4 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
 
@@ -2031,7 +2031,7 @@ fn test_op_show() {
     // Showing a merge operation is empty.
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    ef2d9a73a2ef test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    d1cef38569e5 test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2050,7 +2050,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    1279f6806f48 test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    25f087162efe test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
 
@@ -2094,7 +2094,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    414022582096 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    3f01d2bbe9da test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
     args: jj bookmark create bookmark-2 -r bookmark-2@origin
 
@@ -2114,7 +2114,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    469e72ad2feb test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    b9fec1580033 test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2@origin
 
@@ -2135,7 +2135,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    469e72ad2feb test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    b9fec1580033 test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2@origin
 
@@ -2157,7 +2157,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    e15c5bb81b65 test-username@host.example.com 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
+    de4c030a0bc0 test-username@host.example.com 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
 
@@ -2180,7 +2180,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    cddf6d16be85 test-username@host.example.com 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
+    3719246c9ba5 test-username@host.example.com 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
     point bookmark bookmark-1 to commit 8f340dd76dc637e4deac17f30056eef7d8eaf682
     args: jj bookmark set bookmark-1 -r @
 
@@ -2201,7 +2201,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    093a28c30650 test-username@host.example.com 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    5dc28083437f test-username@host.example.com 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     delete bookmark bookmark-2
     args: jj bookmark delete bookmark-2
 
@@ -2223,7 +2223,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    f9e1dd8479de test-username@host.example.com 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
+    7d47c561dcb4 test-username@host.example.com 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
     push all tracked bookmarks to git remote origin
     args: jj git push --tracked --deleted
 
@@ -2255,7 +2255,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "@-", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    7829688c6706 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    688a949038f6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     snapshot working copy
     args: jj new
 
@@ -2277,7 +2277,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    94a56ee3a1fe test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ed6f6674bcf8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     new empty commit
     args: jj new
 
@@ -2301,7 +2301,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    08dd88f26b33 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    cfb8edbeae42 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     args: jj squash
 
@@ -2343,7 +2343,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @r"
-    515e816ea876 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    dd1ab16f2720 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     args: jj abandon
 
@@ -2360,7 +2360,7 @@ fn test_op_show_patch() {
     // Try again with "op log".
     let output = work_dir.run_jj(["op", "log", "--git"]);
     insta::assert_snapshot!(output, @r"
-    @  515e816ea876 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @  dd1ab16f2720 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     │  args: jj abandon
     │
@@ -2371,7 +2371,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + yqosqzyt c97a8573 (empty) (no description set)
     │  - mzvwutvl hidden 6cbd01ae (empty) (no description set)
-    ○  08dd88f26b33 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  cfb8edbeae42 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     │  args: jj squash
     │
@@ -2398,7 +2398,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + mzvwutvl 6cbd01ae (empty) (no description set)
     │  - rlvkpnrz hidden 05a2969e (no description set)
-    ○  c9a2a852af45 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  36a5d140ea10 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash
     │
@@ -2416,7 +2416,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz 05a2969e (no description set)
     │  - rlvkpnrz hidden c1c924b8 (empty) (no description set)
-    ○  94a56ee3a1fe test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  ed6f6674bcf8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new
     │
@@ -2426,7 +2426,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz c1c924b8 (empty) (no description set)
     │  - qpvuntsm 6b57e33c (no description set)
-    ○  7829688c6706 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  688a949038f6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj new
     │
@@ -2444,7 +2444,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + qpvuntsm 6b57e33c (no description set)
     │  - qpvuntsm hidden e8849ae1 (empty) (no description set)
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -667,12 +667,12 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("10a84113804fa7989bcbad93da85a8cd7e05fcd1a17612a380fc2ce5a1f1196d5c09cf928c4ceffdccbf851d9aed244fa226d48c1f06b4a048bfa9d88b8f23cb")
+    Current operation: OperationId("1675333b7de89b5da012c696d797345bad2a6ce55a4b605e85c3897f818f05e11e8c53de19d34c2fee38a36528dc95bd2a378f72ac0877f8bec2513a68043253")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  10a84113804f test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  1675333b7de8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -690,10 +690,10 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  117e859b7a18 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    @  9df33337d494 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit 2f3e935ade915272ccdce9e43e5a5c82fc336aee
     │  args: jj commit -m 'commit 5'
-    ○  10a84113804f test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  1675333b7de8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -704,7 +704,7 @@ fn test_op_abandon_ancestors() {
     let output = work_dir.run_jj(["op", "abandon", "..@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Cannot abandon the current operation 117e859b7a18
+    Error: Cannot abandon the current operation 9df33337d494
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -728,15 +728,15 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("e77f5bacd23306272e980a7d59b3a60e8bdfa3da7a67e93b72d4f0bd3c945cd4b43b7c18aa338013ba06eccf40e817706acea65c4d6c513651f7d9a70d204e18")
+    Current operation: OperationId("4666f57b051cb0d73145999d689331e34224bf6bad69c367498d7fc25f0d89d230146e7234526004426d515b396b13b9de8daadf54003eaf678f4264c0a7d992")
     Current tree: Merge(Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")))
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  e77f5bacd233 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  undo operation 117e859b7a18a5a0867c2113191303c2deb78b27d6f2831164d152487b98b407b0ab70f817f2c74f7a3f21c25ddfb45c3778465f4a2ab48b0b6aeaf5766a5f47
+    @  4666f57b051c test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  undo operation 9df33337d49450b21bf694025557ede1ac4c63c7b17f593add0d7adc81b394d363f1edffa025b323f88ec947dcd9214f46e82e742e7a74adbfff4c2d96321133
     │  args: jj undo
-    ○  10a84113804f test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  1675333b7de8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -751,8 +751,8 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1"]), @r"
-    @  e77f5bacd233 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  undo operation 117e859b7a18a5a0867c2113191303c2deb78b27d6f2831164d152487b98b407b0ab70f817f2c74f7a3f21c25ddfb45c3778465f4a2ab48b0b6aeaf5766a5f47
+    @  4666f57b051c test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  undo operation 9df33337d49450b21bf694025557ede1ac4c63c7b17f593add0d7adc81b394d363f1edffa025b323f88ec947dcd9214f46e82e742e7a74adbfff4c2d96321133
     │  args: jj undo
     [EOF]
     ");
@@ -781,7 +781,7 @@ fn test_op_abandon_without_updating_working_copy() {
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @r"
-    @  bdfd901af5dd test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  f5e2d13c1aac test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -794,7 +794,7 @@ fn test_op_abandon_without_updating_working_copy() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Abandoned 1 operations and reparented 1 descendant operations.
-    Warning: The working copy operation 0d4bb8e4a2ba is not updated because it differs from the repo bdfd901af5dd.
+    Warning: The working copy operation 0d4bb8e4a2ba is not updated because it differs from the repo f5e2d13c1aac.
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
@@ -803,7 +803,7 @@ fn test_op_abandon_without_updating_working_copy() {
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @r"
-    @  58a15e02bb4b test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  aa53bfb9a190 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -875,13 +875,13 @@ fn test_op_abandon_multiple_heads() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @    6aa2b158f53c test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    @    4bc6ca79dcdc test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  bdfd901af5dd test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  f5e2d13c1aac test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │ │  args: jj commit -m 'commit 3'
-    │ ○  341f3ae94078 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  56b918336386 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │    args: jj commit '--at-op=@--' -m 'commit 4'
     ○  c815486340d5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -705,7 +705,7 @@ fn test_rebase_revision_onto_descendant() {
     let output = work_dir.run_jj(["op", "restore", &setup_opid]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Restored to operation: e386a698bc2d (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
+    Restored to operation: cb005d7a588c (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
     Working copy  (@) now at: vruxwmqv 08c0951b merge | merge
     Parent commit (@-)      : royxmykx 6a7081ef b | b
     Parent commit (@-)      : zsuskuln 68fbc443 a | a

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -479,7 +479,7 @@ fn test_undo_latest_undo_implicitly() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 94337eb25498 (2001-02-03 08:05:09) undo operation c7b028ea7b47461d4328dde306e13337ea9000b6abfde4cb751902fae3124d578f2e0082cbd1e1d32b5e64afc001a933be5acc81a015a7f15d62d90750eaa9ca
+    Undid operation: 6de77c1b46a3 (2001-02-03 08:05:09) undo operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
     Working copy  (@) now at: rlvkpnrz 43444d88 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
@@ -493,7 +493,7 @@ fn test_undo_latest_undo_implicitly() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 0456966dabcb (2001-02-03 08:05:12) undo operation aea8c90f370bd851b9b66a6542aeff24f01418d745efcd7a94c7399afe4ce9aaf79903cd1feb34a9d091bfad3b3680e138ec90ecbed759cf2f6eacdb5c34e4e6
+    Undid operation: b77c991c5a2f (2001-02-03 08:05:12) undo operation 58f57841c00da755413d291ed9e1a1d9a58dd4311b5000a8703f1bf93339dd12cdbc2c6e1c8cd5f43cb584cabddcf8366153a007c244d89ee80a4e42e513058d
     Working copy  (@) now at: mzvwutvl 8afc18ff (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
@@ -517,7 +517,7 @@ fn test_undo_latest_undo_explicitly() {
     let output = work_dir.run_jj(["undo", op_id_hex]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 94337eb25498 (2001-02-03 08:05:09) undo operation c7b028ea7b47461d4328dde306e13337ea9000b6abfde4cb751902fae3124d578f2e0082cbd1e1d32b5e64afc001a933be5acc81a015a7f15d62d90750eaa9ca
+    Undid operation: 6de77c1b46a3 (2001-02-03 08:05:09) undo operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
     Working copy  (@) now at: rlvkpnrz 43444d88 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
@@ -528,7 +528,7 @@ fn test_undo_latest_undo_explicitly() {
     let output = work_dir.run_jj(["undo", "@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 38e14f528fb2 (2001-02-03 08:05:13) undo operation a479f2846c170617a366097141d14c2ce78a7d2ae730f137a28bda493edbd17f40b334fb9344fd54915dcc8f30f1a3e7feeb0ea17ecc3d1d599f1fb9b54f7cfe
+    Undid operation: c99ea8473832 (2001-02-03 08:05:13) undo operation 09cbd5c994ee9e437950a49fa4400d3c6e9d5c1e44ea55b38806a9692317716647578328c53b887a758a40270ad8ab6d5b67c1675d088281879cc7c74a2da6cc
     Working copy  (@) now at: royxmykx ba0e5dca (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 43444d88 (empty) (no description set)
     Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
@@ -554,7 +554,7 @@ fn test_undo_an_older_undo() {
     let output = work_dir.run_jj(["undo", op_id_hex]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 94337eb25498 (2001-02-03 08:05:09) undo operation c7b028ea7b47461d4328dde306e13337ea9000b6abfde4cb751902fae3124d578f2e0082cbd1e1d32b5e64afc001a933be5acc81a015a7f15d62d90750eaa9ca
+    Undid operation: 6de77c1b46a3 (2001-02-03 08:05:09) undo operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
     [EOF]
     ");
 
@@ -565,7 +565,7 @@ fn test_undo_an_older_undo() {
     let output = work_dir.run_jj(["undo", "@-"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 4653f935d392 (2001-02-03 08:05:14) undo operation de46f96595ec455388b0e35d59df3e1ffaaeba420c8333e8ee88f78fc5b799a42313e734a4ba6f3c0efb2dd866ba0e9a2c814e7f85b718340dfb6087dff5e8f3
+    Undid operation: ffea82d2bf89 (2001-02-03 08:05:14) undo operation 2b3480d4ece49d59f5da51e1284b742773e6b858935f122bebab625430137f9aae1aaebf7a8c081e0715e9cd24deee9d0d039743fbb1dd61804c633c9c7f17a2
     [EOF]
     ");
 }
@@ -581,7 +581,7 @@ fn test_undo_an_undo_multiple_times() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 94337eb25498 (2001-02-03 08:05:09) undo operation c7b028ea7b47461d4328dde306e13337ea9000b6abfde4cb751902fae3124d578f2e0082cbd1e1d32b5e64afc001a933be5acc81a015a7f15d62d90750eaa9ca
+    Undid operation: 6de77c1b46a3 (2001-02-03 08:05:09) undo operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
     Working copy  (@) now at: rlvkpnrz 43444d88 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
@@ -591,7 +591,7 @@ fn test_undo_an_undo_multiple_times() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: a43b6dc67d14 (2001-02-03 08:05:10) undo operation 94337eb25498c16c342e4c270978d856b34ab6a669ffa4631a9ca6d940377e0a310e67a1f1911407b28500bdfd0f7d866f761eff434594f9d9dc7d63d8b51610
+    Undid operation: f17b43a603fd (2001-02-03 08:05:10) undo operation 6de77c1b46a39115938845d2fffb5780a49a4991d1f8f99b60509705faa38d496b06cdbb427a497ff22d1f2b81613ac80a8dd6b97ca2fa35d7cc66d2a33059e4
     Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
@@ -604,7 +604,7 @@ fn test_undo_an_undo_multiple_times() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 1d6091bcbe71 (2001-02-03 08:05:13) undo operation 407478e37f74d99a9284168a0c8c8aa3c9afcbc741a8d03948212864d64fe30f8c75d2f570bc82b2772b9a47b72b651058acbdb2384ce5de31acb46a35e9d77b
+    Undid operation: 1eee1feca2d3 (2001-02-03 08:05:13) undo operation 18ee4719e7c7a2da3fbeec66678dfb03c4f3deebbe887dbc46270102c86894615a07a223713981d12b3ddc757e5104c7e9f7b391202747cd1868e0d2ac01f35d
     Working copy  (@) now at: royxmykx e7d0d5fd (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
@@ -614,7 +614,7 @@ fn test_undo_an_undo_multiple_times() {
     let output = work_dir.run_jj(["undo", "@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: b16c5dfbbafc (2001-02-03 08:05:14) undo operation 1d6091bcbe71afd3fd33a4e397597b6867649cdd7d22013675c8895bd3406257de86a9dfc4a9dc118db70f76f631ea5e0adf9bb2eb0f32f9e67a4fb227bdd3e1
+    Undid operation: 079cb7121929 (2001-02-03 08:05:14) undo operation 1eee1feca2d334e1c7c956048eec1e54a35d58b39aaec88c8a48ce7ce216b30e287f49c0305c51ad86292c6a2e11dd98ed97d8ef0a497e7114cf2aea99d4e71d
     Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
@@ -636,7 +636,7 @@ fn test_undo_bookmark_deletion() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Undid operation: 1075351137a2 (2001-02-03 08:05:09) delete bookmark foo
+    Undid operation: e1bcf7cd8080 (2001-02-03 08:05:09) delete bookmark foo
     [EOF]
     ");
 }

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -94,7 +94,7 @@ fn test_gc_operation_log() {
     let output = work_dir.run_jj(["debug", "operation", &op_to_remove]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: No operation ID matching "31c378f62742a80562c8fe790e46895882ed618d1ac06ceeddc182b3f676fc926f07f577cc505059b5345a5111982a193bb25b0601c518b88fd5c0fdac4e229d"
+    Error: No operation ID matching "b50d0a8f111a9d30d45d429d62c8e54016cc7c891706921a6493756c8074e883671cf3dac0ac9f94ef0fa8c79738a3dfe38c3e1f6c5e1a4a4d0857d266ef2040"
     [EOF]
     [exit status: 1]
     "#);

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -365,7 +365,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // Working copy should contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("48a1ea616c63af21072ac9efb7a027770537f8f1a73e60db707f339d0f1a3e0719e2721f73b62a96153fd6e7fd56aa24dbf470292bfa4587661039639d2334aa")
+    Current operation: OperationId("da3b34243efe5ea04830cd2211b5be79444fbc2ef23681361fd2f551ebb86772bff21695da95b72388306e028bf04c6d76db10bf4cbd3a08eb34bf744c8900c7")
     Current tree: Merge(Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]))
     Normal { <executable> }           249 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -428,7 +428,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // Working copy should still contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("cc8300e781c597dc3efe658a25485f6c9b811e35ea30467a0b762bbbbdc22e8f373a4a521f6bb4cc93a2d08973c535e98a2544a7f03a2ed473b85bc818495db3")
+    Current operation: OperationId("85725298062bdfe1d00333e7b3c5af27891e8e59acb236e8499b5712699cf77f91e3b3664e3433771b096fe781113bfe4cf1b88887aae02af733ba40963d5015")
     Current tree: Merge(Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]))
     Normal { <executable> }           289 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -463,7 +463,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // working copy
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("93b119e5cb434c1ded5ace206be37c99ab8a5aeefd3b9d1f6443edaf8a410e4240d021ebc5a9199fcc60993d8252c19ceeb21343b30a175ce19b5086d4976592")
+    Current operation: OperationId("683acb91a6165a95b02bcc8ea2133982ba6f244ec006634447e074ccc5a3c4df0bd955e4f628a406059edaa30e9c5af88f3fd06b0c5e9e48df93556da6fe410c")
     Current tree: Merge(Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")))
     Normal { <executable> }           130 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -528,7 +528,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 09c578c227de).
+    Error: The working copy is stale (not updated since operation bd4f780d0422).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -538,7 +538,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 09c578c227de).
+    Error: The working copy is stale (not updated since operation bd4f780d0422).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -629,7 +629,7 @@ fn test_workspaces_updated_by_other() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 09c578c227de).
+    Error: The working copy is stale (not updated since operation bd4f780d0422).
     Hint: Run `jj workspace update-stale` to update it.
     See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -779,14 +779,14 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
     ]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(output, @r"
-        @  e426bb88ce abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
-        ○  c1d0d40e1f create initial working-copy commit in workspace secondary
-        ○  5869a42f65 add workspace 'secondary'
-        ○  72b8205d96 new empty commit
-        ○  6e671162a7 snapshot working copy
-        ○  5213f1e3a9 new empty commit
-        ○  b1bf0cc848 snapshot working copy
-        ○  2affa70252 add workspace 'default'
+        @  b0789def13 abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
+        ○  778c9aae54 create initial working-copy commit in workspace secondary
+        ○  219d4aca5c add workspace 'secondary'
+        ○  31ad55e98c new empty commit
+        ○  4ba7680cbe snapshot working copy
+        ○  9739176f19 new empty commit
+        ○  4b5baa44b7 snapshot working copy
+        ○  8f47435a39 add workspace 'default'
         ○  0000000000
         [EOF]
         ");
@@ -821,7 +821,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         Parent commit (@-): rzvqmyuk 891f0006 (empty) (no description set)
         [EOF]
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object c1d0d40e1f9ef1e820a494113c16a66dd3550fe2d1a3231027f4305ad1f85956697de9ffdd2ec1e714a1e6ec419c6369c8a2abf91223b4732358e6929acf5ae8 of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 778c9aae54957e842bede2223fda227be33e08061732276a4cfb7b431a3e146e5c62187d640aa883095d3b2c6cf43d31ad5fde72076bb9a88b8594fb8b5e6606 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -839,7 +839,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         let output = secondary_dir.run_jj(["workspace", "update-stale"]);
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object c1d0d40e1f9ef1e820a494113c16a66dd3550fe2d1a3231027f4305ad1f85956697de9ffdd2ec1e714a1e6ec419c6369c8a2abf91223b4732358e6929acf5ae8 of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 778c9aae54957e842bede2223fda227be33e08061732276a4cfb7b431a3e146e5c62187d640aa883095d3b2c6cf43d31ad5fde72076bb9a88b8594fb8b5e6606 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1070,7 +1070,7 @@ fn test_workspaces_forget_multi_transaction() {
     // the op log should have multiple workspaces forgotten in a single tx
     let output = main_dir.run_jj(["op", "log", "--limit", "1"]);
     insta::assert_snapshot!(output, @r"
-    @  ccedd4f34298 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  d3aded9a10b6 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third
     [EOF]
@@ -1239,10 +1239,10 @@ fn test_debug_snapshot() {
     work_dir.run_jj(["debug", "snapshot"]).success();
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @  05a77f06d585 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  594dfebf2565 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1250,13 +1250,13 @@ fn test_debug_snapshot() {
     work_dir.run_jj(["describe", "-m", "initial"]).success();
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @r"
-    @  2c73e89e3beb test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  81e4a0f2e793 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit 006bd1130b84e90ab082adeabd7409270d5a86da
     │  args: jj describe -m initial
-    ○  05a77f06d585 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  594dfebf2565 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  2affa7025254 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -351,6 +351,7 @@ impl DetachedCommitBuilder {
     pub fn write(self, mut_repo: &mut MutableRepo) -> BackendResult<Commit> {
         let commit = write_to_store(&self.store, self.commit, &self.sign_settings)?;
         mut_repo.add_head(&commit)?;
+        mut_repo.set_predecessors(commit.id().clone(), commit.predecessor_ids().to_vec());
         if let Some(rewrite_source) = self.rewrite_source {
             if rewrite_source.change_id() == commit.change_id() {
                 mut_repo.set_rewritten_commit(rewrite_source.id().clone(), commit.id().clone());

--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -263,6 +263,8 @@ impl DefaultIndexStore {
                 .map(|(commit_id, op_id)| get_commit_with_op(commit_id, op_id)),
             |(CommitByCommitterTimestamp(commit), _)| commit.id().clone(),
             |(CommitByCommitterTimestamp(commit), op_id)| {
+                // TODO: preserve operation.commit_predecessors.keys() instead
+                // of commit.predecessor_ids().
                 itertools::chain(commit.parent_ids(), commit.predecessor_ids())
                     .filter(|&id| !parent_file_has_id(id))
                     .map(|commit_id| get_commit_with_op(commit_id, op_id))

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -369,6 +369,20 @@ pub struct Operation {
     pub view_id: ViewId,
     pub parents: Vec<OperationId>,
     pub metadata: OperationMetadata,
+    /// Mapping from new commit to its predecessors, or `None` if predecessors
+    /// weren't recorded when the operation was written.
+    ///
+    /// * `commit_id: []` if the commit was newly created.
+    /// * `commit_id: [predecessor_id, ..]` if the commit was rewritten.
+    ///
+    /// This mapping may contain transitive predecessors if a commit was
+    /// rewritten multiple times within the same transaction.
+    ///
+    /// Existing commits (including commits imported from Git) aren't tracked
+    /// even if they became visible at this operation.
+    // BTreeMap for ease of deterministic serialization. If the deserialization
+    // cost matters, maybe this can be changed to sorted Vec.
+    pub commit_predecessors: Option<BTreeMap<CommitId, Vec<CommitId>>>,
 }
 
 impl Operation {
@@ -390,6 +404,10 @@ impl Operation {
             view_id: root_view_id,
             parents: vec![],
             metadata,
+            // The root operation is guaranteed to have no new commits.
+            // TODO: Alternatively, the root commit could be "created" at the
+            // root operation?
+            commit_predecessors: Some(BTreeMap::new()),
         }
     }
 }

--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -22,6 +22,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 
+use crate::backend::CommitId;
 use crate::op_store;
 use crate::op_store::OpStore;
 use crate::op_store::OpStoreResult;
@@ -115,6 +116,19 @@ impl Operation {
 
     pub fn metadata(&self) -> &OperationMetadata {
         &self.data.metadata
+    }
+
+    /// Returns true if predecessors are recorded in this operation.
+    ///
+    /// This returns false only if the operation was written by old jj.
+    pub fn stores_commit_predecessors(&self) -> bool {
+        self.data.commit_predecessors.is_some()
+    }
+
+    /// Returns predecessors of the specified commit if recorded.
+    pub fn predecessors_by_commit(&self, commit_id: &CommitId) -> Option<&[CommitId]> {
+        let map = self.data.commit_predecessors.as_ref()?;
+        Some(map.get(commit_id)?)
     }
 
     pub fn store_operation(&self) -> &op_store::Operation {

--- a/lib/src/protos/op_store.proto
+++ b/lib/src/protos/op_store.proto
@@ -96,6 +96,10 @@ message Operation {
   bytes view_id = 1;
   repeated bytes parents = 2;
   OperationMetadata metadata = 3;
+  // Introduced in jj 0.30.
+  repeated CommitPredecessors commit_predecessors = 4;
+  // Whether or not `commit_predecessors` is recorded.
+  bool stores_commit_predecessors = 5;
 }
 
 // TODO: Share with store.proto? Do we even need the timezone here?
@@ -112,4 +116,9 @@ message OperationMetadata {
   string username = 5;
   bool is_snapshot = 7;
   map<string, string> tags = 6;
+}
+
+message CommitPredecessors {
+  bytes commit_id = 1;
+  repeated bytes predecessor_ids = 2;
 }

--- a/lib/src/protos/op_store.rs
+++ b/lib/src/protos/op_store.rs
@@ -121,6 +121,12 @@ pub struct Operation {
     pub parents: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     #[prost(message, optional, tag = "3")]
     pub metadata: ::core::option::Option<OperationMetadata>,
+    /// Introduced in jj 0.30.
+    #[prost(message, repeated, tag = "4")]
+    pub commit_predecessors: ::prost::alloc::vec::Vec<CommitPredecessors>,
+    /// Whether or not `commit_predecessors` is recorded.
+    #[prost(bool, tag = "5")]
+    pub stores_commit_predecessors: bool,
 }
 /// TODO: Share with store.proto? Do we even need the timezone here?
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
@@ -149,6 +155,13 @@ pub struct OperationMetadata {
         ::prost::alloc::string::String,
         ::prost::alloc::string::String,
     >,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommitPredecessors {
+    #[prost(bytes = "vec", tag = "1")]
+    pub commit_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub predecessor_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -485,6 +485,7 @@ fn operation_from_proto(
         view_id,
         parents,
         metadata,
+        commit_predecessors: None, // TODO
     })
 }
 
@@ -832,6 +833,7 @@ mod tests {
                     "key2".to_string() => "value2".to_string(),
                 },
             },
+            commit_predecessors: None, // TODO
         }
     }
 
@@ -849,7 +851,7 @@ mod tests {
         // Test exact output so we detect regressions in compatibility
         assert_snapshot!(
             OperationId::new(blake2b_hash(&create_operation()).to_vec()).hex(),
-            @"a721c8bfe6d30b4279437722417743c2c5d9efe731942663e3e7d37320e0ab6b49a7c1452d101cc427ceb8927a4cab03d49dabe73c0677bb9edf5c8b2aa83585"
+            @"ae75bd059ed8a7710d34c79eb0ad157f6f4a8f6f73c0ed9905219ac6a6d7fe9b2edd27efb045204abbe9f60c1e1c457dcefe5e50d6fda41330159384a0c0c86c"
         );
     }
 

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -136,7 +136,7 @@ impl Transaction {
             "BUG: Descendants have not been rebased after the last rewrites."
         );
         let base_repo = mut_repo.base_repo().clone();
-        let (mut_index, view) = mut_repo.consume();
+        let (mut_index, view, predecessors) = mut_repo.consume();
 
         let operation = {
             let view_id = base_repo.op_store().write_view(view.store_view())?;
@@ -147,6 +147,7 @@ impl Transaction {
                 view_id,
                 parents,
                 metadata: self.op_metadata,
+                commit_predecessors: Some(predecessors),
             };
             let new_op_id = base_repo.op_store().write_operation(&store_operation)?;
             Operation::new(base_repo.op_store().clone(), new_op_id, store_operation)

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use assert_matches::assert_matches;
 use futures::StreamExt as _;
 use indoc::indoc;
 use itertools::Itertools as _;
@@ -113,7 +114,7 @@ fn test_initial(backend: TestRepoBackend) {
     assert_eq!(builder.author(), &author_signature);
     assert_eq!(builder.committer(), &committer_signature);
     let commit = builder.write().unwrap();
-    tx.commit("test").unwrap();
+    let repo = tx.commit("test").unwrap();
 
     let parents: Vec<_> = commit.parents().try_collect().unwrap();
     assert_eq!(parents, vec![store.root_commit()]);
@@ -127,6 +128,10 @@ fn test_initial(backend: TestRepoBackend) {
             &commit.tree().unwrap(),
         ),
         to_owned_path_vec(&[dir_file_path, root_file_path]),
+    );
+    assert_matches!(
+        repo.operation().predecessors_by_commit(commit.id()),
+        Some([])
     );
 }
 
@@ -188,7 +193,7 @@ fn test_rewrite(backend: TestRepoBackend) {
         .write()
         .unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
-    tx.commit("test").unwrap();
+    let repo = tx.commit("test").unwrap();
     let parents: Vec<_> = rewritten_commit.parents().try_collect().unwrap();
     assert_eq!(parents, vec![store.root_commit()]);
     let predecessors: Vec<_> = rewritten_commit.predecessors().try_collect().unwrap();
@@ -216,6 +221,14 @@ fn test_rewrite(backend: TestRepoBackend) {
             &rewritten_commit.tree().unwrap(),
         ),
         to_owned_path_vec(&[dir_file_path]),
+    );
+    assert_matches!(
+        repo.operation().predecessors_by_commit(rewritten_commit.id()),
+        Some([id]) if id == initial_commit.id()
+    );
+    assert_matches!(
+        repo.operation().predecessors_by_commit(initial_commit.id()),
+        None
     );
 }
 

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use assert_matches::assert_matches;
 use jj_lib::config::StackedConfig;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::ref_name::WorkspaceName;
@@ -179,4 +180,8 @@ fn test_init_checkout(backend: TestRepoBackend) {
     assert_eq!(wc_commit.author().email, settings.user_email());
     assert_eq!(wc_commit.committer().name, settings.user_name());
     assert_eq!(wc_commit.committer().email, settings.user_email());
+    assert_matches!(
+        repo.operation().predecessors_by_commit(wc_commit.id()),
+        Some([])
+    );
 }

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -439,20 +439,20 @@ fn test_resolve_op_id() {
     let mut operations = Vec::new();
     // The actual value of `i` doesn't matter, we just need to make sure we end
     // up with hashes with ambiguous prefixes.
-    for i in (1..5).chain([39, 62]) {
+    for i in (1..5).chain([9, 27]) {
         let tx = repo.start_transaction();
         let repo = tx.commit(format!("transaction {i}")).unwrap();
         operations.push(repo.operation().clone());
     }
-    // "b" and "0" are ambiguous
+    // "6" and "0" are ambiguous
     insta::assert_debug_snapshot!(operations.iter().map(|op| op.id().hex()).collect_vec(), @r#"
     [
-        "bb1ea76bb194556214b1259568d5f3381fb4209f10b86d6c3c7d162a9b8ee1a5d98da57cf21ceadeecd2416c20508348ed4c1a24226c708f035b138fc7a97d5b",
-        "5c35c6506eedd9c74ffab46940129cb3b66e5e1968b4eea5bb38701d6d3462b4a34d78efcaa81d41fabf6937d79c4431e2adc4361095c9fb795004da420d8a26",
-        "b43387cf7a5808ebb6cdacd5c95de9d4b315c6edc465a49ff290b731da1c3d57315af49686e5ffd4c2fc4478af40b4a70cba7334bbca8e3d4e69176de807a916",
-        "fcd828a3033f9a9f44c8f06cd0d7f79570d53895c9d7d794ea51a7ee4b7871c8fe245ec18d2ece76ec7b51a998b04da811c232668c7c2c53f72b5baf0ad20797",
-        "091574d16d89ab848ac08c9a8e35276484c5e332ea97f1fad7b794763aa280ce5b663d835b555b5b763cbdbb6d8dba5a35ad1f2780ebdca5e598f07f82dcd3c7",
-        "06e9f38473578a4b1a8672ab474eb2741269fffb2f765a610de47fddafc60a88c002f7cdb9d82a9d1dfdbdd3b4045cd62e34215e7a781ed149332980e90227f1",
+        "ff7608ec55acf1ccb44bee52a0972f8b36864540ee6547d5e124a30bafd3bfbe00418446d5581cf71debac912a091dd2f93a2dd3bcb34bc53c61604aa9c129d6",
+        "b83ded05e46bef569737b8c1293c59af3fe89f72bc2cecd017b5eb96f5c69e50205069eedf144ca4fa9e55ac0c27842dce874b371a752223c5f85c4b6faadf96",
+        "6412c4e33f791b71f440817d3d16c0ee1b7640845db8f5e4146c58e8c3f4329df4662b0edeab5860c86b4679b150f38318a6e3d4ada5803176f9c5273d97f4dd",
+        "6838be3a934e1b8fc966dcf43796a3cc639a3d26edb1e9af94a285f4ce7edaecfe9e101dd7f0338af22e1632f36d634916015b72b026e1529a7b600566c29067",
+        "0ecccbdd90dd12a592dd0de010feda8bf23e4a5650f1946a82df854fc28791ad046b2d42b38060103db7fb99c00787689df98a7d2166d8180666b745cc32b172",
+        "065be6feb0ab573f0638e952ead8482899307d211f80af5dc90952a6171cc7122d5af9f13fde2ce3e37fc5e7776d5e3bc4236d82ce7d2ecbf1f63373c20772e4",
     ]
     "#);
 
@@ -473,7 +473,7 @@ fn test_resolve_op_id() {
     );
     // Ambiguous id
     assert_matches!(
-        resolve("b"),
+        resolve("6"),
         Err(OpsetEvaluationError::OpsetResolution(
             OpsetResolutionError::AmbiguousIdPrefix(_)
         ))
@@ -496,7 +496,7 @@ fn test_resolve_op_id() {
     let root_operation = loader.root_operation();
     assert_eq!(resolve(&root_operation.id().hex()).unwrap(), root_operation);
     assert_eq!(resolve("00").unwrap(), root_operation);
-    assert_eq!(resolve("09").unwrap(), operations[4]);
+    assert_eq!(resolve("0e").unwrap(), operations[4]);
     assert_matches!(
         resolve("0"),
         Err(OpsetEvaluationError::OpsetResolution(

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -213,6 +213,38 @@ fn test_isolation() {
 }
 
 #[test]
+fn test_stored_commit_predecessors() {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+    let loader = repo.loader();
+
+    let mut tx = repo.start_transaction();
+    let commit1 = create_random_commit(tx.repo_mut()).write().unwrap();
+    let commit2 = tx
+        .repo_mut()
+        .rewrite_commit(&commit1)
+        .set_description("rewritten")
+        .write()
+        .unwrap();
+    tx.repo_mut().rebase_descendants().unwrap();
+    let repo = tx.commit("test").unwrap();
+
+    // Reload operation from disk.
+    let op = loader.load_operation(repo.op_id()).unwrap();
+    assert!(op.stores_commit_predecessors());
+    assert_matches!(op.predecessors_by_commit(commit1.id()), Some([]));
+    assert_matches!(op.predecessors_by_commit(commit2.id()), Some([id]) if id == commit1.id());
+
+    // Save operation without the predecessors as old jj would do.
+    let mut data = op.store_operation().clone();
+    data.commit_predecessors = None;
+    let op_id = loader.op_store().write_operation(&data).unwrap();
+    assert_ne!(&op_id, op.id());
+    let op = loader.load_operation(&op_id).unwrap();
+    assert!(!op.stores_commit_predecessors());
+}
+
+#[test]
 fn test_reparent_range_linear() {
     let test_repo = TestRepo::init();
     let repo_0 = test_repo.repo;


### PR DESCRIPTION

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
