### PR TITLE
Add metadata to build .deb package with cargo-deb

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -127,3 +127,21 @@ pkg-url = "{ repo }/releases/download/v{ version }/jj-v{ version }-{ target }.{ 
 
 [lints]
 workspace = true
+
+[package.metadata.deb]
+# Install `cargo-deb` and run `cargo deb` to create a package in `target/debian/`
+name = "jj"
+maintainer = "Unspecified Debian Maintainer <nobody@example.com>"
+copyright = "Copyright 2025 The Jujutsu Authors"
+license-file = "LICENSE"
+section = "vcs"
+priority = "optional"
+extended-description = "Distributed Version Control System inspired by Git, Mercurial and Darcs."
+assets = [
+    { source = "docs/*", dest = "usr/share/doc/jj/", mode = "644"},
+# TODO: It'd be nice to package the output of `MKDOCS_OFFLINE=true uv run mkdocs build` in the docs dir as well, but this is not trivial.
+    { source = "docs/*/*", dest = "usr/share/doc/jj/", mode = "644"},
+    { source = "target/release/jj", dest = "usr/bin/", mode = "755"},
+]
+default-features = true
+


### PR DESCRIPTION
With these additons you can quickly and easily build a .deb package for ubuntu.
Just `cargo deb --features="test-fakes"` and .deb is ready in `target/debian`.

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
