### PR TITLE
show: Accept short forms of ignore-space options

### DIFF
--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -26,6 +26,8 @@ use crate::ui::Ui;
 
 /// Show commit description and changes in a revision
 #[derive(clap::Args, Clone, Debug)]
+#[command(mut_arg("ignore_all_space", |a| a.short('w')))]
+#[command(mut_arg("ignore_space_change", |a| a.short('b')))]
 pub(crate) struct ShowArgs {
     /// Show changes in this revision, compared to its parent(s)
     #[arg(

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2350,9 +2350,9 @@ Show commit description and changes in a revision
 
    A builtin format can also be specified as `:<name>`. For example, `--tool=:git` is equivalent to `--git`.
 * `--context <CONTEXT>` — Number of lines of context to show
-* `--ignore-all-space` — Ignore whitespace when comparing lines
-* `--ignore-space-change` — Ignore changes in amount of whitespace when comparing lines
 * `--no-patch` — Do not show the patch
+* `-w`, `--ignore-all-space` — Ignore whitespace when comparing lines
+* `-b`, `--ignore-space-change` — Ignore changes in amount of whitespace when comparing lines
 
 
 


### PR DESCRIPTION
Make `jj show` accept the same short forms, `-b` and `-w`, as `jj diff` for the `--ignore-space-change` and `--ignore-all-space` options.

This is a tiny paper cut when coming from git, where `show` takes the same arguments as `diff`, but it's _just_ annoying enough to submit a PR for.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
