### PR TITLE
Do not warn about deprecated config path if XDG_CONFIG_HOME is configured there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj parallelize` can now parallelize groups of changes that _start_ with an
   immutable change, but do not contain any other immutable changes.
 
+* `jj` will no longer warn about deprecated paths on macOS if the configured
+  XDG directory is the deprecated one (~/Library/Application Support).
+
 ### Packaging changes
 
 * Due to the removal of the `libgit2` code path, packagers should

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -347,6 +347,10 @@ impl ConfigEnv {
                     // Library/Preferences is supposed to be exclusively plists
                     s.data_dir()
                 })
+                .filter(|data_dir| {
+                    // User might've purposefully set their config dir to the deprecated one
+                    Some(data_dir) != config_dir.as_ref()
+                })
         } else {
             None
         };

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -978,6 +978,21 @@ fn test_config_edit_user_deprecated_file() {
     [EOF]
     ");
 
+    // if XDG_CONFIG_HOME is ~/Library/Application Support,
+    // you shouldn't get a warning
+    let output = test_env.run_jj_with(|cmd| {
+        cmd.env_remove("JJ_CONFIG")
+            .env(
+                "XDG_CONFIG_HOME",
+                test_env.home_dir().join("Library/Application Support"),
+            )
+            .args(["config", "get", "foo.bar"])
+    });
+    insta::assert_snapshot!(output, @r"
+    Make sure I can pick this up
+    [EOF]
+    ");
+
     // if you set JJ_CONFIG, you shouldn't get a warning
     let output = test_env.run_jj_with(|cmd| {
         cmd.env("JJ_CONFIG", &user_config_path)


### PR DESCRIPTION
When `XDG_CONFIG_HOME` is specifically configured to `~/Library/Application Support`, jj will still warn about deprecated paths. This PR introduces an additional check to prevent this

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
