### PR TITLE
feat: add workspace-level configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1439,6 +1439,10 @@ Thanks to the people who made this release happen!
 
 * `jj describe` can now update the description of multiple commits.
 
+* Workspaces may have an additional layered configuration, located at
+  `.jj/config.toml`. `jj config` subcommands which took layer options like
+  `--repo` now also support `--workspace`.
+
 ### Fixed bugs
 
 * `jj status` will show different messages in a conflicted tree, depending

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3866,17 +3866,24 @@ impl<'a> CliRunner<'a> {
                 jj_lib::config::migrate(config, &self.config_migrations)?;
             Ok(())
         };
+
+         // Initial load: user, repo, and workspace-level configs for alias/default-command resolution
+         let workspace_root = find_workspace_dir(&cwd);
         // Use cwd-relative workspace configs to resolve default command and
         // aliases. WorkspaceLoader::init() won't do any heavy lifting other
         // than the path resolution.
         let maybe_cwd_workspace_loader = self
             .workspace_loader_factory
-            .create(find_workspace_dir(&cwd))
+            .create(workspace_root)
             .map_err(|err| map_workspace_load_error(err, Some(".")));
         config_env.reload_user_config(&mut raw_config)?;
         if let Ok(loader) = &maybe_cwd_workspace_loader {
             config_env.reset_repo_path(loader.repo_path());
             config_env.reload_repo_config(&mut raw_config)?;
+            // register workspace config directory: .jj/config.toml
+            let ws_conf_dir = workspace_root.join(".jj");
+            config_env.reset_workspace_path(&ws_conf_dir);
+            config_env.reload_workspace_config(&mut raw_config)?;
         }
         let mut config = config_env.resolve_config(&raw_config)?;
         migrate_config(&mut config)?;
@@ -3927,6 +3934,10 @@ impl<'a> CliRunner<'a> {
                 .map_err(|err| map_workspace_load_error(err, Some(path)))?;
             config_env.reset_repo_path(loader.repo_path());
             config_env.reload_repo_config(&mut raw_config)?;
+            // update workspace path too
+            let ws_conf_dir = workspace_root.join(".jj");
+            config_env.reset_workspace_path(&ws_conf_dir);
+            config_env.reload_workspace_config(&mut raw_config)?;
             Ok(loader)
         } else {
             maybe_cwd_workspace_loader

--- a/cli/src/commands/config/edit.rs
+++ b/cli/src/commands/config/edit.rs
@@ -18,6 +18,7 @@ use tracing::instrument;
 use super::ConfigLevelArgs;
 use crate::cli_util::CommandHelper;
 use crate::command_error::print_error_sources;
+use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -38,37 +39,55 @@ pub fn cmd_config_edit(
     args: &ConfigEditArgs,
 ) -> Result<(), CommandError> {
     let editor = command.text_editor()?;
-    let file = args.level.edit_config_file(ui, command)?;
+
+    // Determine which config file to edit (user, repo, or workspace)
+    let file = if args.level.workspace {
+        // Workspace-level: set up workspace path and reload
+        let mut temp_env = command.config_env().clone();
+        let cwd = std::env::current_dir()
+            .map_err(|e| user_error(format!("Unable to get cwd: {}", e)))?;
+        let ws_dir = cwd.join(".jj");
+        temp_env.reset_workspace_path(&ws_dir);
+        let mut raw = command.raw_config().clone();
+        temp_env
+            .reload_workspace_config(&mut raw)
+            .map_err(|e| user_error(format!("Failed to load workspace config: {}", e)))?;
+        let mut files = temp_env
+            .workspace_config_files(&raw)
+            .map_err(|e| user_error(format!("No workspace config path: {}", e)))?;
+        if files.is_empty() {
+            return Err(user_error("No workspace config path found"));
+        }
+        files.remove(0)
+    } else {
+        // User or repo-level
+        args.level.edit_config_file(ui, command)?
+    };
+
+    // Create the file if it doesn't exist yet
     if !file.path().exists() {
         file.save()?;
     }
 
-    // Editing again and again until either of these conditions is met
-    // 1. The config is OK
-    // 2. The user restores previous one
     writeln!(ui.status(), "Editing file: {}", file.path().display())?;
     loop {
         editor.edit_file(file.path())?;
 
-        // Trying to load back config. If error, prompt to continue editing
-        if let Err(e) = ConfigLayer::load_from_file(file.layer().source, file.path().to_path_buf())
-        {
-            writeln!(
-                ui.warning_default(),
-                "An error has been found inside the config:"
-            )?;
+        // Validate the edited config
+        if let Err(e) = ConfigLayer::load_from_file(file.layer().source, file.path().to_path_buf()) {
+            writeln!(ui.warning_default(), "An error has been found inside the config:")?;
             print_error_sources(ui, Some(&e))?;
             let continue_editing = ui.prompt_yes_no(
                 "Do you want to keep editing the file? If not, previous config will be restored.",
                 Some(true),
             )?;
             if !continue_editing {
-                // Saving back previous config
+                // Restore previous content
                 file.save()?;
                 break;
             }
         } else {
-            // config is OK
+            // Config is valid
             break;
         }
     }

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -54,6 +54,10 @@ pub(crate) struct ConfigLevelArgs {
     /// Target the repo-level config
     #[arg(long)]
     repo: bool,
+
+    /// Target the workspace-level config
+    #[arg(long)]
+    workspace: bool,
 }
 
 impl ConfigLevelArgs {
@@ -62,6 +66,8 @@ impl ConfigLevelArgs {
             Some(ConfigSource::User)
         } else if self.repo {
             Some(ConfigSource::Repo)
+        } else if self.workspace {
+            Some(ConfigSource::Workspace)
         } else {
             None
         }
@@ -79,6 +85,11 @@ impl ConfigLevelArgs {
                 .repo_config_path()
                 .map(|p| vec![p])
                 .ok_or_else(|| user_error("No repo config path found"))
+        } else if self.workspace {
+            config_env
+                .workspace_config_path()
+                .map(|p| vec![p])
+                .ok_or_else(|| user_error("No workspace config path found"))
         } else {
             panic!("No config_level provided")
         }
@@ -115,6 +126,11 @@ impl ConfigLevelArgs {
             pick_one(
                 config_env.repo_config_files(config)?,
                 "No repo config path found to edit",
+            )
+        } else if self.workspace {
+            pick_one(
+                config_env.workspace_config_files(config)?,
+                "No workspace config path found to edit",
             )
         } else {
             panic!("No config_level provided")

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -146,6 +146,7 @@ fn warn_user_redefined_builtin(
         ConfigSource::EnvBase
         | ConfigSource::User
         | ConfigSource::Repo
+        | ConfigSource::Workspace
         | ConfigSource::EnvOverrides
         | ConfigSource::CommandArg => {
             let checked_mutability_builtins =

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -575,7 +575,7 @@ Start an editor on a jj config file.
 
 Creates the file if it doesn't already exist regardless of what the editor does.
 
-**Usage:** `jj config edit <--user|--repo>`
+**Usage:** `jj config edit <--user|--repo|--workspace>`
 
 **Command Alias:** `e`
 
@@ -583,6 +583,7 @@ Creates the file if it doesn't already exist regardless of what the editor does.
 
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
+* `--workspace` — Target the workspace-level config
 
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,10 @@ config path --user`.
 - The repo settings. These can be edited with `jj config edit --repo` and are
 located in `.jj/repo/config.toml`.
 
+- The workspace settings. These can be edited with `jj config edit --workspace`
+and are located in `.jj/config.toml` in the workspace root. The first working
+directory created in a fresh `jj` repo is itself a workspace.
+
 - Settings [specified in the command-line](#specifying-config-on-the-command-line).
 
 These are listed in the order they are loaded; the settings from earlier items

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -288,6 +288,8 @@ pub enum ConfigSource {
     User,
     /// Repo configuration files.
     Repo,
+    /// Workspace configuration files.
+    Workspace,
     /// Override environment variables.
     EnvOverrides,
     /// Command-line arguments (which has the highest precedence.)
@@ -301,6 +303,7 @@ impl Display for ConfigSource {
             Default => "default",
             User => "user",
             Repo => "repo",
+            Workspace => "workspace",
             CommandArg => "cli",
             EnvBase | EnvOverrides => "env",
         };


### PR DESCRIPTION
This update introduces support for workspace-level configuration in the `jj` command-line tool. Users can now edit workspace-specific settings using the `jj config edit --workspace` command, which targets the `.jj/config.toml` file in the workspace root. The configuration system has been enhanced to handle loading and saving workspace configurations, allowing for a layered configuration approach alongside user and repo settings. Additionally, the documentation has been updated to reflect these changes.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
