### PR TITLE
str_util: parse regex-i:pattern as case-insensitive regex

### DIFF
--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -2075,6 +2075,10 @@ fn test_evaluate_expression_bookmarks() {
         resolve_commit_ids(mut_repo, "bookmarks(regex:'^[Bb]ookmark1$')"),
         vec![commit1.id().clone()]
     );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "bookmarks(regex-i:'BOOKmark')"),
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
     // Can silently resolve to an empty set if there's no matches
     assert_eq!(resolve_commit_ids(mut_repo, "bookmarks(bookmark3)"), vec![]);
     assert_eq!(


### PR DESCRIPTION
Closes #6653


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
