### PR TITLE
squash: use the authors of the squashed commit as co-authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Unquoted `*` is now allowed in revsets. `bookmarks(glob:foo*)` no longer
   needs quoting.
 
+* `jj squash` stores the co-authors of the squashed commits in the destination
+  commit when using the `--co-authors` command line option or the
+  `squash.co-authors = true` configuration.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -25,7 +25,7 @@ use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
 use crate::complete;
-use crate::description_util::add_trailers;
+use crate::description_util::add_config_trailers;
 use crate::description_util::description_template;
 use crate::description_util::edit_description;
 use crate::description_util::join_message_paragraphs;
@@ -182,11 +182,11 @@ new working-copy commit.
             // can be discarded as soon as it's no longer the working copy. Adding a
             // trailer to an empty description would break that logic.
             commit_builder.set_description(description);
-            description = add_trailers(ui, &tx, &commit_builder)?;
+            description = add_config_trailers(ui, &tx, &commit_builder)?;
         }
         description
     } else {
-        add_trailers(ui, &tx, &commit_builder)?
+        add_config_trailers(ui, &tx, &commit_builder)?
     };
     let description = if args.message_paragraphs.is_empty() || args.editor {
         commit_builder.set_description(description);

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -228,7 +228,8 @@ pub(crate) fn cmd_describe(
             // trailer to an empty description would break that logic.
             if use_editor || !commit_builder.description().is_empty() {
                 let temp_commit = commit_builder.write_hidden()?;
-                let new_description = add_trailers_with_template(&trailer_template, &temp_commit)?;
+                let new_description =
+                    add_trailers_with_template(&trailer_template, &temp_commit, &[])?;
                 commit_builder.set_description(new_description);
             }
         }

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -29,7 +29,7 @@ use crate::cli_util::RevisionArg;
 use crate::cli_util::compute_commit_location;
 use crate::command_error::CommandError;
 use crate::complete;
-use crate::description_util::add_trailers;
+use crate::description_util::add_config_trailers;
 use crate::description_util::join_message_paragraphs;
 use crate::ui::Ui;
 
@@ -199,7 +199,7 @@ pub(crate) fn cmd_new(
         // can be discarded as soon as it's no longer the working copy. Adding a
         // trailer to an empty description would break that logic.
         commit_builder.set_description(description);
-        description = add_trailers(ui, &tx, &commit_builder)?;
+        description = add_config_trailers(ui, &tx, &commit_builder)?;
     }
     commit_builder.set_description(&description);
     let new_commit = commit_builder.write(tx.repo_mut())?;

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -42,7 +42,7 @@ use crate::cli_util::print_unmatched_explicit_paths;
 use crate::command_error::CommandError;
 use crate::command_error::user_error_with_hint;
 use crate::complete;
-use crate::description_util::add_trailers;
+use crate::description_util::add_config_trailers;
 use crate::description_util::description_template;
 use crate::description_util::edit_description;
 use crate::description_util::join_message_paragraphs;
@@ -262,7 +262,7 @@ pub(crate) fn cmd_split(
         };
         let description = if !description.is_empty() || args.editor {
             commit_builder.set_description(description);
-            add_trailers(ui, &tx, &commit_builder)?
+            add_config_trailers(ui, &tx, &commit_builder)?
         } else {
             description
         };
@@ -317,7 +317,7 @@ pub(crate) fn cmd_split(
             commit_builder.description().to_owned()
         };
         let description = if show_editor {
-            let new_description = add_trailers(ui, &tx, &commit_builder)?;
+            let new_description = add_config_trailers(ui, &tx, &commit_builder)?;
             commit_builder.set_description(new_description);
             let temp_commit = commit_builder.write_hidden()?;
             let intro = "Enter a description for the remaining changes.";

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -836,6 +836,17 @@
                 }
             }
         },
+        "squash": {
+            "type": "object",
+            "description": "Settings for jj squash",
+            "properties": {
+                "co-authors": {
+                    "type": "boolean",
+                    "description": "If true, the co-authors will be collected from the source commits.",
+                    "default": false
+                }
+            }
+        },
         "hints": {
             "type": "object",
             "description": "Various hints in jj's UI that can be disabled",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -57,3 +57,6 @@ auto-update-stale = false
 # in the future.
 [split]
 legacy-bookmark-behavior = true
+
+[squash]
+co-authors = false

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2852,6 +2852,8 @@ An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. T
    Forces an editor to open when using `--message` to allow the message to be edited afterwards.
 * `-i`, `--interactive` — Interactively choose which parts to squash
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
+* `--co-authors` — Set the authors of the squashed commits as co-authors of the destination commit
+* `--no-co-authors` — Don't set the authors of the squashed commits as co-authors of the destination commit
 * `-k`, `--keep-emptied` — The source revision will not be abandoned
 
 

--- a/lib/src/trailer.rs
+++ b/lib/src/trailer.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 
 /// A key-value pair representing a trailer in a commit message, of the
 /// form `Key: Value`.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Trailer {
     /// trailer key
     pub key: String,


### PR DESCRIPTION

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
