### PR TITLE
revset: optimize heads of a range with filters

### DIFF
--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1133,6 +1133,29 @@ fn test_evaluate_expression_heads() {
         resolve_commit_ids(mut_repo, "heads(all())"),
         resolve_commit_ids(mut_repo, "visible_heads()")
     );
+
+    // Heads of a range returns correct commit
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("heads({}..{})", commit4.id(), commit3.id())
+        ),
+        vec![commit3.id().clone()]
+    );
+
+    // Heads of a range with filter returns correct commit
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!(
+                "heads({}..{} & ~{})",
+                commit4.id(),
+                commit3.id(),
+                commit3.id()
+            )
+        ),
+        vec![commit2.id().clone()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Resolves #6656. Suggested by @yuja.

Currently, evaluating an expression like `heads(::@ ~ empty())` requires iterating over all commits in `::@` and checking the predicate against each commit, which can be very slow. This PR implements an optimization to convert expressions to the form `heads(x..y & filter)` when it is possible to do so efficiently. Expressions of this form can be evaluated using a specialized algorithm which terminates iteration early without checking all commits.

Benchmark results on Git repo:

```
revsets/heads(author(peff))     97.248% improvement
revsets/heads(::v2.40.0)        98.467% improvement
```

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
