### PR TITLE
CHANGELOG fixup: move diff-do-chdir entry to 0.30, add check in `releasing.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   argument and no longer produces Bash completions by default. The deprecated
   optional arguments for different shells have been removed.
 
+* External diff tools are now run in the temporary directory containing
+  the before (`left`) and after (`right`) directories, making diffs appear
+  more pleasing for tools that display file paths prominently. Users can
+  opt out of this by setting `merge-tools.<tool>.diff-do-chdir = false`,
+  but this will likely be removed in a future release. Please report any
+  issues you run into.
+
 ### Deprecations
 
 * The `ui.diff.format` and `ui.diff.tool` config options have been merged as
@@ -220,13 +227,6 @@ Thanks to the people who made this release happen!
   in more complex expressions. For example, typing
   `jj log -r first-bookmark..sec` and then pressing Tab could complete the
   expression to `first-bookmark..second-bookmark`.
-
-* External diff tools are now run in the temporary directory containing
-  the before (`left`) and after (`right`) directories, making diffs appear
-  more pleasing for tools that display file paths prominently. Users can
-  opt out of this by setting `merge-tools.<tool>.diff-do-chdir = false`,
-  but this will likely be removed in a future release. Please report any
-  issues you run into.
 
 ### Fixed bugs
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,6 +8,14 @@ copy-edit the changelog in order to:
 * Populate "Release highlights" if relevant
 * Put more important items first so the reader doesn't miss them
 * Make items consistent when it comes to language and formatting
+* Catch any misplaced changelog items by looking at the CHANGELOG diff.
+
+To get the CHANGELOG diff, you can run
+
+```shell
+jj log -r 'heads(tags())'  # Check that this shows the previous version
+jj diff --from 'heads(tags())' --to main CHANGELOG.md
+```
 
 Producing the list of contributors is a bit annoying. The current suggestion is
 to run something like this:


### PR DESCRIPTION
I'm also planning to update the release notes for 0.30 at https://github.com/jj-vcs/jj/releases/tag/v0.30.0 after I merge this, let me know if you think we should handle it differently.

I can't think of a better (simple) technical solution than just looking at the diff before every release. I briefly considered a presubmit check for this, but it doesn't seem fun or worth it to write or maintain (though people are welcome to if they feel otherwise). I think that, as long as it's part of a checklist, it shouldn't be onerous.

I noticed this because of https://github.com/keanemind/jjk/issues/127#issuecomment-2949223664.