### PR TITLE
clippy: fix clippy error

### DIFF
--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -64,7 +64,7 @@ pub enum ConfigLoadError {
     Parse {
         /// Source error.
         #[source]
-        error: toml_edit::TomlError,
+        error: Box<toml_edit::TomlError>,
         /// Source file path.
         source_path: Option<PathBuf>,
     },
@@ -337,7 +337,7 @@ impl ConfigLayer {
     /// Parses TOML document `text` into new layer.
     pub fn parse(source: ConfigSource, text: &str) -> Result<Self, ConfigLoadError> {
         let data = ImDocument::parse(text).map_err(|error| ConfigLoadError::Parse {
-            error,
+            error: Box::new(error),
             source_path: None,
         })?;
         Ok(Self::with_data(source, data.into_mut()))
@@ -349,7 +349,7 @@ impl ConfigLayer {
             .context(&path)
             .map_err(ConfigLoadError::Read)?;
         let data = ImDocument::parse(text).map_err(|error| ConfigLoadError::Parse {
-            error,
+            error: Box::new(error),
             source_path: Some(path.clone()),
         })?;
         Ok(ConfigLayer {

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -101,7 +101,7 @@ impl<'a> GitSubprocessContext<'a> {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             git_cmd.creation_flags(CREATE_NO_WINDOW);
         }

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -163,7 +163,7 @@ impl GpgBackend {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             command.creation_flags(CREATE_NO_WINDOW);
         }
@@ -251,7 +251,7 @@ impl GpgsmBackend {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             command.creation_flags(CREATE_NO_WINDOW);
         }

--- a/lib/src/ssh_signing.rs
+++ b/lib/src/ssh_signing.rs
@@ -133,7 +133,7 @@ impl SshBackend {
         // Hide console window on Windows (https://stackoverflow.com/a/60958956)
         #[cfg(windows)]
         {
-            use std::os::windows::process::CommandExt;
+            use std::os::windows::process::CommandExt as _;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             command.creation_flags(CREATE_NO_WINDOW);
         }


### PR DESCRIPTION
* ~Add `#[allow(clippy::result_large_err)]` for functions that return `Result<T, ConfigLoadError>`.~
* Change `std::os::windows::process::CommandExt` to underscore imports.
* ~Change `&[target_commit.clone()]` to `std::slice::from_ref(target_commit)`.~

I just silence the clippy error for the large error type `ConfigLoadError` instead of fixing it, because fixing can introduce breaking changes in the API: `ConfigLoadError` is a public type used in public methods, e.g., `ConfigFile::load_or_empty`. I am Ok to further update this PR to fix that clippy error, but I need more instructions on:
* Can I just create a new `#[derive(Error)] struct ConfigLoadError(#[error(transparent)] Box<ConfigLoadErrorImpl>)` type to fix the clippy error or it would be better if I dig in the enum variants and change fields to `Box` as needed?
* That's a breaking change. What's the complete list of actions I need to take for a breaking change? e.g., should I bump the version? should I mention that in the CHANGELOG.md?

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`: N/A. clippy fix, no actual changes.
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`). clippy fix, no need for documentation update.
- [x] I have updated the config schema (`cli/src/config-schema.json`): N/A. No change to the config schema.
- [x] I have added/updated tests to cover my changes: N/A. No new logic added for testing.
