### PR TITLE
cleanup: use slice::from_ref() in non-test code

### DIFF
--- a/cli/src/commands/bench/common_ancestors.rs
+++ b/cli/src/commands/bench/common_ancestors.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::slice;
+
 use jj_lib::repo::Repo as _;
 
 use super::run_bench;
@@ -39,7 +41,8 @@ pub fn cmd_bench_common_ancestors(
     let commit1 = workspace_command.resolve_single_rev(ui, &args.revision1)?;
     let commit2 = workspace_command.resolve_single_rev(ui, &args.revision2)?;
     let index = workspace_command.repo().index();
-    let routine = || index.common_ancestors(&[commit1.id().clone()], &[commit2.id().clone()]);
+    let routine =
+        || index.common_ancestors(slice::from_ref(commit1.id()), slice::from_ref(commit2.id()));
     run_bench(
         ui,
         &format!("common-ancestors-{}-{}", args.revision1, args.revision2),

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::slice;
 use std::sync::Arc;
 
 use futures::StreamExt as _;
@@ -1270,7 +1271,7 @@ pub fn find_duplicate_divergent_commits(
 
             let ancestor_candidate = repo.store().get_commit(&ancestor_candidate_id)?;
             let new_tree =
-                rebase_to_dest_parent(repo, &[target_commit.clone()], &ancestor_candidate)?;
+                rebase_to_dest_parent(repo, slice::from_ref(target_commit), &ancestor_candidate)?;
             // Check whether the rebased commit would have the same tree as the existing
             // commit if they had the same parents. If so, we can skip this rebased commit.
             if new_tree.id() == *ancestor_candidate.tree_id() {


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
