### PR TITLE
Don't blame libgit2 for lack of partial clone support

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -59,8 +59,7 @@ a comparison with Git, including how workflows are different, see the
   create a repo backed by a bare Git repo.
 * **Submodules: No.** They will not show up in the working copy, but they will
   not be lost either.
-* **Partial clones: No.** We use the [libgit2](https://libgit2.org/) library,
-  which [doesn't have support for partial clones](https://github.com/libgit2/libgit2/issues/5564).
+* **Partial clones: No.**
 * **Shallow clones: Kind of.** Shallow commits all have the virtual root commit as
   their parent. However, deepening or fully unshallowing a repository is currently not yet
   supported and will cause issues.


### PR DESCRIPTION
`jj` no longer uses libgit2, so the lack of support can't be blamed on it. We [still don't support partial clones](https://github.com/jj-vcs/jj/issues/6690#issuecomment-2946785320) though.

There's no real tracking issue for this. [This PR](https://github.com/jj-vcs/jj/pull/6451/) is as close as it gets, but it doesn't feel appropriate to link in the docs.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

PS. Thanks for the detailed reply to my question @anguslees