### PR TITLE
revset: do not reinterpret `set&filter` intersection as filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj file annotate` can now process files at a hidden revision.
+
 * `jj op log --op-diff` no longer fails at displaying "reconcile divergent
   operations." [#4465](https://github.com/jj-vcs/jj/issues/4465)
 

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -206,8 +206,8 @@ fn test_annotate_abandoned() {
 
     let output = work_dir.run_jj(["file", "annotate", "-rat_operation(@-, @)", "file.txt"]);
     insta::assert_snapshot!(output, @r"
-    zzzzzzzz          1970-01-01 11:00:00    1: line1
-    zzzzzzzz          1970-01-01 11:00:00    2: line2
+    qpvuntsm test.use 2001-02-03 08:05:08    1: line1
+    rlvkpnrz test.use 2001-02-03 08:05:09    2: line2
     [EOF]
     ");
 }

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -194,6 +194,25 @@ fn test_annotate_merge_one_sided_conflict_resolution() {
 }
 
 #[test]
+fn test_annotate_abandoned() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file.txt", "line1\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file.txt", "line1\nline2\n");
+    work_dir.run_jj(["abandon"]).success();
+
+    let output = work_dir.run_jj(["file", "annotate", "-rat_operation(@-, @)", "file.txt"]);
+    insta::assert_snapshot!(output, @r"
+    zzzzzzzz          1970-01-01 11:00:00    1: line1
+    zzzzzzzz          1970-01-01 11:00:00    2: line2
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_annotate_with_template() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
Fixes #6713

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes

cc @scott2000 as this might have conflicts with your patch.
