### PR TITLE
split: keep a single entry in the evolog

### DIFF
--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -382,6 +382,7 @@ pub(crate) fn cmd_rebase(
             delete_abandoned_bookmarks: false,
         },
         simplify_ancestor_merge: false,
+        preserve_predecessors: false,
     };
     let mut workspace_command = command.workspace_helper(ui)?;
     let loc = if !args.revisions.is_empty() {

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -362,6 +362,7 @@ fn move_first_commit(
                 delete_abandoned_bookmarks: false,
             },
             simplify_ancestor_merge: false,
+            preserve_predecessors: true,
         },
     )?;
 

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -1271,10 +1271,7 @@ fn test_split_move_first_commit() {
     insta::assert_snapshot!(evolog_1, @r"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:17 76ebcbb8
     │  file2
-    │  -- operation 45cf98ff360e (2001-02-03 08:05:17) split commit 5dad33447a74e157748fc8122486b2c1a5f093c6
-    ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:17 bd58c2c3
-    │  file2
-    │  -- operation 45cf98ff360e (2001-02-03 08:05:17) split commit 5dad33447a74e157748fc8122486b2c1a5f093c6
+    │  -- operation bd9f517355ee (2001-02-03 08:05:17) split commit 5dad33447a74e157748fc8122486b2c1a5f093c6
     ○  qpvuntsm hidden test.user@example.com 2001-02-03 08:05:08 5dad3344
     │  file2
     │  -- operation 16bbaf3acf2d (2001-02-03 08:05:08) commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -940,6 +940,10 @@ impl MutableRepo {
         // `self.rewritten_commits`
     }
 
+    pub(crate) fn predecessors(&self) -> &BTreeMap<CommitId, Vec<CommitId>> {
+        &self.commit_predecessors
+    }
+
     pub(crate) fn set_predecessors(&mut self, id: CommitId, predecessors: Vec<CommitId>) {
         self.commit_predecessors.insert(id, predecessors);
     }

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -1716,6 +1716,7 @@ fn test_empty_commit_option(empty_behavior: EmptyBehaviour) {
                 delete_abandoned_bookmarks: false,
             },
             simplify_ancestor_merge: true,
+            preserve_predecessors: false,
         },
     );
 
@@ -1851,6 +1852,7 @@ fn test_rebase_abandoning_empty() {
             delete_abandoned_bookmarks: false,
         },
         simplify_ancestor_merge: true,
+        preserve_predecessors: false,
     };
     let rewriter = CommitRewriter::new(tx.repo_mut(), commit_b, vec![commit_b2.id().clone()]);
     rebase_commit_with_options(rewriter, &rebase_options).unwrap();


### PR DESCRIPTION
This is an alternative implementation of #6661 that continues to rewrite the commit multiple times, but manipulates the commit predecessors in order to keep a single entry for the split in the evolog.
Plus it's much simpler.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
