### PR TITLE
cli: fix typo in `jj diff -r` doc comment

### DIFF
--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -50,7 +50,7 @@ use crate::ui::Ui;
 pub(crate) struct DiffArgs {
     /// Show changes in these revisions
     ///
-    /// If there are multiple revisions, then then total diff for all of them
+    /// If there are multiple revisions, then the total diff for all of them
     /// will be shown. For example, if you have a linear chain of revisions
     /// A..D, then `jj diff -r B::D` equals `jj diff --from A --to D`. Multiple
     /// heads and/or roots are supported, but gaps in the revset are not

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -770,7 +770,7 @@ If no option is specified, it defaults to `-r @`.
 
 * `-r`, `--revisions <REVSETS>` — Show changes in these revisions
 
-   If there are multiple revisions, then then total diff for all of them will be shown. For example, if you have a linear chain of revisions A..D, then `jj diff -r B::D` equals `jj diff --from A --to D`. Multiple heads and/or roots are supported, but gaps in the revset are not supported (e.g. `jj diff -r 'A|C'` in a linear chain A..C).
+   If there are multiple revisions, then the total diff for all of them will be shown. For example, if you have a linear chain of revisions A..D, then `jj diff -r B::D` equals `jj diff --from A --to D`. Multiple heads and/or roots are supported, but gaps in the revset are not supported (e.g. `jj diff -r 'A|C'` in a linear chain A..C).
 
    If a revision is a merge commit, this shows changes *from* the automatic merge of the contents of all of its parents *to* the contents of the revision itself.
 


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
