### PR TITLE
Add Send bounds to the AsyncRead future returned by read_file

### DIFF
--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -153,7 +153,7 @@ impl Backend for JitBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
-    ) -> BackendResult<Pin<Box<dyn AsyncRead>>> {
+    ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         self.inner.read_file(path, id).await
     }
 

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -462,7 +462,7 @@ pub trait Backend: Send + Sync + Debug {
         &self,
         path: &RepoPath,
         id: &FileId,
-    ) -> BackendResult<Pin<Box<dyn AsyncRead>>>;
+    ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>>;
 
     async fn write_file(
         &self,

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -984,7 +984,7 @@ impl Backend for GitBackend {
         &self,
         _path: &RepoPath,
         id: &FileId,
-    ) -> BackendResult<Pin<Box<dyn AsyncRead>>> {
+    ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         let data = self.read_file_sync(id)?;
         Ok(Box::pin(Cursor::new(data)))
     }

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -125,7 +125,7 @@ impl Backend for SecretBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
-    ) -> BackendResult<Pin<Box<dyn AsyncRead>>> {
+    ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         if path.as_internal_file_string().contains("secret")
             || SECRET_CONTENTS_HEX.contains(&id.hex().as_ref())
         {

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -194,7 +194,7 @@ impl Backend for SimpleBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
-    ) -> BackendResult<Pin<Box<dyn AsyncRead>>> {
+    ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         let disk_path = self.file_path(id);
         let mut file = File::open(disk_path).map_err(|err| map_not_found_err(err, id))?;
         let mut buf = vec![];

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -239,7 +239,7 @@ impl Store {
         &self,
         path: &RepoPath,
         id: &FileId,
-    ) -> BackendResult<Pin<Box<dyn AsyncRead>>> {
+    ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         self.backend.read_file(path, id).await
     }
 

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -193,7 +193,7 @@ impl Backend for TestBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
-    ) -> BackendResult<Pin<Box<dyn AsyncRead>>> {
+    ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         match self
             .locked_data()
             .files


### PR DESCRIPTION
This is closer aligned to the type signature for `write_file` as well, which is currently:

```
    async fn write_file(
        &self,
        path: &RepoPath,
        contents: &mut (dyn AsyncRead + Send + Unpin),
    ) -> BackendResult<FileId>;
```


This change enables the jj-lib api to be used in multi-threaded executor contexts.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
