### PR TITLE
cargo: set `toml_edit = "=0.22.26"` constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ textwrap = "0.16.2"
 thiserror = "2.0.12"
 timeago = { version = "0.4.2", default-features = false }
 tokio = { version = "1.45.1", features = ["io-util"] }
-toml_edit = { version = "0.22.26", features = ["serde"] }
+toml_edit = { version = "=0.22.26", features = ["serde"] } # FIXME(aseipp): 0.22.27 broke somehow?
 tracing = "0.1.41"
 tracing-chrome = "0.7.2"
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [


### PR DESCRIPTION
Apparently this broke a dependabot update. Stop the bleeding for now.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
