### PR TITLE
revset: add `All` filter predicate

### DIFF
--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1144,6 +1144,7 @@ fn build_predicate_fn(
     predicate: &RevsetFilterPredicate,
 ) -> Box<dyn ToPredicateFn> {
     match predicate {
+        RevsetFilterPredicate::All => box_pure_predicate_fn(|_, _| Ok(true)),
         RevsetFilterPredicate::ParentCount(parent_count_range) => {
             let parent_count_range = parent_count_range.clone();
             box_pure_predicate_fn(move |index, pos| {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -156,6 +156,8 @@ pub trait RevsetFilterExtension: std::fmt::Debug + Any {
 
 #[derive(Clone, Debug)]
 pub enum RevsetFilterPredicate {
+    /// Matches all commits unconditionally.
+    All,
     /// Commits with number of parents in the range.
     ParentCount(Range<u32>),
     /// Commits with description matching the pattern.
@@ -2421,9 +2423,13 @@ impl VisibilityResolutionContext<'_> {
         expression: &ResolvedRevsetExpression,
     ) -> ResolvedPredicateExpression {
         match expression {
-            RevsetExpression::None
-            | RevsetExpression::All
-            | RevsetExpression::VisibleHeads
+            RevsetExpression::None => ResolvedPredicateExpression::NotIn(
+                ResolvedPredicateExpression::Filter(RevsetFilterPredicate::All).into(),
+            ),
+            RevsetExpression::All => {
+                ResolvedPredicateExpression::Filter(RevsetFilterPredicate::All)
+            }
+            RevsetExpression::VisibleHeads
             | RevsetExpression::Root
             | RevsetExpression::Commits(_)
             | RevsetExpression::CommitRef(_)

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1889,6 +1889,11 @@ fn test_evaluate_expression_none() {
 
     // none() is empty (doesn't include the checkout, for example)
     assert_eq!(resolve_commit_ids(repo.as_ref(), "none()"), vec![]);
+    // Testing `none()` as a filter predicate due to union with a filter
+    assert_eq!(
+        resolve_commit_ids(repo.as_ref(), "none() | author_name(nobody)"),
+        vec![]
+    );
 }
 
 #[test]
@@ -1912,7 +1917,18 @@ fn test_evaluate_expression_all() {
             commit3.id().clone(),
             commit2.id().clone(),
             commit1.id().clone(),
-            root_commit_id,
+            root_commit_id.clone(),
+        ]
+    );
+    // Testing `all()` as a filter predicate due to union with a filter
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "all() | author_name(nobody)"),
+        vec![
+            commit4.id().clone(),
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+            root_commit_id.clone(),
         ]
     );
 }


### PR DESCRIPTION
Useful for optimizing the filter in #6679.

This allows `all()` to be efficiently represented as a filter predicate, and I think having a way to represent a predicate that always returns true makes the language more consistent.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
