### PR TITLE
6738 path display

### DIFF
--- a/lib/src/repo_path.rs
+++ b/lib/src/repo_path.rs
@@ -602,9 +602,8 @@ impl RepoPathUiConverter {
         match self {
             RepoPathUiConverter::Fs { cwd, base } => {
                 file_util::relative_path(cwd, &file.to_fs_path_unchecked(base))
-                    .to_str()
-                    .unwrap()
-                    .to_owned()
+                    .display()
+                    .to_string()
             }
         }
     }
@@ -649,7 +648,7 @@ impl RepoPathUiConverter {
                     .min(target_components.len().saturating_sub(1));
 
                 fn format_components(c: &[std::path::Component]) -> String {
-                    c.iter().collect::<PathBuf>().to_str().unwrap().to_owned()
+                    c.iter().collect::<PathBuf>().display().to_string()
                 }
 
                 if prefix_count > 0 {


### PR DESCRIPTION
There are also quite a few instances of calling `Path::to_str()` in the test, where they can be just dropped (where the expected type of argument is `impl AsRef<Path>`, but as discussed in the ticket (#6738) I didn't touch those. If necessary this can be done as additional PR.

I used clippy lint `disallowed-methods = ["std::path::Path::to_str"]` to spot the usage of the `to_str` method. And I think there a couple of places where I left them untouched (besides tests) - I didn't feel that the change there would be appropriate or at least it won't be non-controversial.

Anyway, feel free to review and comment.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
