### PR TITLE
lib: Retry locking on ESTALE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj util gc --expire=now` now passes the corresponding flag to `git gc`.
 
+* Fixed lockfile issue on stale file handles observed with NFS.
+
 ### Packaging changes
 
 * `aarch64-windows` builds (release binaries and `main` snapshots) are now provided.


### PR DESCRIPTION
This caused some issues with the Google internal NFS filesystem. Treating `ESTALE` (stale file handle) as a file deletion should be the right thing to do.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
