### PR TITLE
Prepend `backout` description with '(deprecated; use `revert`) '

### DIFF
--- a/cli/src/commands/backout.rs
+++ b/cli/src/commands/backout.rs
@@ -26,7 +26,8 @@ use crate::complete;
 use crate::formatter::PlainTextFormatter;
 use crate::ui::Ui;
 
-/// Apply the reverse of given revisions on top of another revision
+/// (deprecated; use `revert`) Apply the reverse of given revisions on top of
+/// another revision
 ///
 /// The description of the new revisions can be customized with the
 /// `templates.backout_description` config variable.


### PR DESCRIPTION
Hi!

This builds on #6290 - I probably should have just tried `jj backout` before reading through many `--help` pages trying to understand when I'd rather use `backout` over `revert` and vice versa, but I think it'd be an improvement to simply put this at the top and in the tab completion help.

WDYT?

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
