### PR TITLE
formatter: add support for ANSI 256-color palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -774,7 +774,7 @@ Thanks to the people who made this release happen!
 * Added `--into` flag to `jj restore`, similarly to `jj squash` and `jj
   absorb`. It is equivalent to `--to`, but `--into` is the recommended name.
 
-* Italic text is now supported. You can set e.g. `color.error = { fg = "red",
+* Italic text is now supported. You can set e.g. `colors.error = { fg = "red",
   italic = true }` in your config.
 
 * New `author_name`/`author_email`/`committer_name`/`committer_email(pattern)`
@@ -3015,7 +3015,7 @@ Thanks to the people who made this release happen!
 * Per-repository configuration is now read from `.jj/repo/config.toml`.
 
 * Background colors, bold text, and underlining are now supported. You can set
-  e.g. `color.error = { bg = "red", bold = true, underline = true }` in your
+  e.g. `colors.error = { bg = "red", bold = true, underline = true }` in your
   `~/.jjconfig.toml`.
 
 * The `empty` condition in templates is true when the commit makes no change to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Templates now support `json(x)` function to serialize values in JSON format.
 
+* The ANSI 256-color palette can be used when configuring colors. For example,
+  `colors."diff removed token" = { bg = "ansi-color-52", underline = false }`
+  will apply a dark red background on removed words in diffs.
+
 ### Fixed bugs
 
 * `jj file annotate` can now process files at a hidden revision.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -322,6 +322,10 @@
                         "bright white"
                     ]
                 },
+                "ansi256Color": {
+                    "type": "string",
+                    "pattern": "^ansi-color-([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+                },
                 "hexColor": {
                     "type": "string",
                     "pattern": "^#[0-9a-fA-F]{6}$"
@@ -330,6 +334,9 @@
                   "oneOf": [
                     {
                         "$ref": "#/properties/colors/definitions/colorNames"
+                    },
+                    {
+                        "$ref": "#/properties/colors/definitions/ansi256Color"
                     },
                     {
                         "$ref": "#/properties/colors/definitions/hexColor"

--- a/docs/config.md
+++ b/docs/config.md
@@ -128,6 +128,16 @@ You can also use a 6-digit hex code for more control over the exact color used:
 change_id = "#ff1525"
 ```
 
+`jj` also supports colors from the [ANSI 256-color palette] as `ansi-color-<N>`,
+where `<N>` is a number between 0 and 255:
+
+```toml
+[colors]
+commit_id = "ansi-color-81"
+```
+
+[ANSI 256-color palette]: https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
+
 If you use a string value for a color, as in the examples above, it will be used
 for the foreground color. You can also set the background color, reverse colors
 (swap foreground and background), or make the text bold, italic, or underlined.


### PR DESCRIPTION
Fixes #6691, using @ilyagr's proposed syntax. My first instinct would have been a shorter `ansi<N>`, but I see that would be ambiguous with other escape codes.

Since the 256-color palette isn't well-known and hard to reason about without a lookup table, I included a link to [Wikipedia's article](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit). It goes around a bit with technical details, but the compact layout of the table itself is very nice for lookup. The best contender would be [Ditig's 256 colors cheat sheet](https://www.ditig.com/256-colors-cheat-sheet), which is the top result in most search engines, but AFAIK not a well-known website otherwise, and I find its vertical layout not very practical.

I'm also including fixes for typos I spotted in the changelog.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
