### PR TITLE
cli: add `json()` template functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj evolog` can now follow changes from multiple revisions such as divergent
   revisions.
 
+* A new pair of default template language functions, `json(commit)` and
+  `ndjson(commit)` can be used to output information about a commit in JSON
+  format. Default aliases `json()` and `ndjson()` are also included, which
+  simply call the function with `self`. This allows you to pass `-T 'ndjson()'`
+  to get full newline-delimited JSON output that you can pass to other tools like
+  jq, gron, etc.
+
 ### Fixed bugs
 
 * `jj file annotate` can now process files at a hidden revision.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -433,3 +433,33 @@ git_format_patch_email_headers = '''
 # Gerrit change id is 40 chars, jj change id is 32, so we need some padding.
 # `6a6a6964` is the hexadecimal of `jjid` in ASCII, just to not pad with zeros.
 "format_gerrit_change_id_trailer(commit)" = '"Change-Id: I6a6a6964" ++ commit.change_id().normal_hex() ++ "\n"'
+
+# JSON formatting function(s)
+'json()' = 'json(self)'
+'json(commit)' = '''concat("{",
+  separate(",",
+    '"commit_id":"' ++ stringify(commit.commit_id()) ++ '"',
+    '"change_id":"' ++ stringify(commit.change_id()) ++ '"',
+    '"parents":' ++ "[" ++ commit.parents().map(|p| '"' ++ stringify(p.commit_id()) ++ '"').join(",") ++ "]",
+    '"author":{' ++ separate(",",
+      '"name":"' ++ coalesce(commit.author().name(), "") ++ '"',
+      '"email":"' ++ coalesce(commit.author().email(), "") ++ '"',
+      '"timestamp":"' ++ commit.author().timestamp().format("%Y-%m-%dT%H:%M:%S%:z") ++ '"'
+    ) ++ "}",
+    '"committer":{' ++ separate(",",
+      '"name":"' ++ coalesce(commit.committer().name(), "") ++ '"',
+      '"email":"' ++ coalesce(commit.committer().email(), "") ++ '"',
+      '"timestamp":"' ++ commit.committer().timestamp().format("%Y-%m-%dT%H:%M:%S%:z") ++ '"'
+    ) ++ "}",
+    '"description":' ++ commit.description().escape_json(),
+    '"empty":' ++ if(commit.empty(), "true", "false"),
+    '"conflict":' ++ if(commit.conflict(), "true", "false"),
+    '"divergent":' ++ if(commit.divergent(), "true", "false"),
+    '"hidden":' ++ if(commit.hidden(), "true", "false"),
+    '"current_working_copy":' ++ if(commit.current_working_copy(), "true", "false"),
+    '"immutable":' ++ if(commit.immutable(), "true", "false"),
+    '"bookmarks":' ++ "[" ++ commit.bookmarks().map(|b| '"' ++ b ++ '"').join(",") ++ "]",
+    '"tags":' ++ "[" ++ commit.tags().map(|t| '"' ++ t ++ '"').join(",") ++ "]",
+    '"remote_bookmarks":' ++ "[" ++ commit.remote_bookmarks().map(|b| '"' ++ b ++ '"').join(",") ++ "]"
+  ),
+"}\n")'''


### PR DESCRIPTION
These template functions just emit the given commit objects as JSON, allowing you to do something like this:

    jj --no-graph --ignore-working-copy -T 'json()' | jq

The `json()` function has two specific things I optimized for usability:

- It always outputs a newline after an object
- `json() = json(self)`

The reasons for these are pretty simple; it is overwhelmingly the case that JSON is taken and redirected elsewhere, and requiring users to always remember a `++ "\n"` at the end is fairly unfriendly. In contrast, just including it changes nothing about parsing, and even helps the users terminal when they only write out a single commit. And the other thing is that the 99% of uses will be for `jj log`, so it makes sense to optimize for the common case when the commit object is `self`.

In practice this means the output is actually 'ndjson' but requiring the user to remember that or care is also pointless, IMO.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
