### PR TITLE
github: bump `taiki-e/install-action` to 2.53.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
       with:
         toolchain: 1.84
-    - uses: taiki-e/install-action@cfe1303741c2e620e5f7daa667105e0da1316db9
+    - uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb
       with:
         tool: nextest,taplo-cli
     - name: Install mold


### PR DESCRIPTION
Apparently there is a bug in the 2.53.0 version of `install-action` that means it will get a 403 from crates.io when it tries to download nextest. Ideally this should fix that, because we need it to unblock the CI pipeline.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
