### PR TITLE
docs/working-copy: fix missing link annotation

### DIFF
--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -52,7 +52,7 @@ resolutions.
 With the `jj resolve` command, you can use an external merge tool to resolve
 conflicts that have 2 sides and a base.  There is not yet a good way of
 resolving conflicts between directories, files, and symlinks
-(https://github.com/jj-vcs/jj/issues/19). You can use `jj restore` to choose
+(<https://github.com/jj-vcs/jj/issues/19>). You can use `jj restore` to choose
 one side of the conflict, but there's no way to even see where the involved
 parts came from.
 


### PR DESCRIPTION
Probably a bad regex that didn't catch this parenthesized URL that *wasn't* a markdown alias.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
