### PR TITLE
config-schema: fix missing private-commits setting

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -457,6 +457,11 @@
                         }
                     ]
                 },
+                "private-commits": {
+                    "type": "string",
+                    "description": "Revset of commits to refuse to push to remotes",
+                    "default": "none()"
+                },
                 "push": {
                     "type": "string",
                     "description": "The remote to which commits are pushed",


### PR DESCRIPTION
I would really like a more principled way to ensure that the schema is up to date; could we somehow ban retrieving undocumented config settings?

Change-Id: I6a6a69640755c60467c1be0eb362307c2c22e0ff

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
