### PR TITLE
revset: optimize `~all()` and `~none()`

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1849,6 +1849,8 @@ fn fold_redundant_expression<St: ExpressionState>(
     transform_expression_bottom_up(expression, |expression| match expression.as_ref() {
         RevsetExpression::NotIn(outer) => match outer.as_ref() {
             RevsetExpression::NotIn(inner) => Some(inner.clone()),
+            RevsetExpression::None => Some(RevsetExpression::all()),
+            RevsetExpression::All => Some(RevsetExpression::none()),
             _ => None,
         },
         RevsetExpression::Union(expression1, expression2) => {
@@ -4359,7 +4361,11 @@ mod tests {
         insta::assert_debug_snapshot!(optimize(parse("root() & all()").unwrap()), @"Root");
         insta::assert_debug_snapshot!(optimize(parse("none() | root()").unwrap()), @"Root");
         insta::assert_debug_snapshot!(optimize(parse("none() & root()").unwrap()), @"None");
+        insta::assert_debug_snapshot!(optimize(parse("~none()").unwrap()), @"All");
         insta::assert_debug_snapshot!(optimize(parse("~~none()").unwrap()), @"None");
+        insta::assert_debug_snapshot!(optimize(parse("~all()").unwrap()), @"None");
+        insta::assert_debug_snapshot!(optimize(parse("~~all()").unwrap()), @"All");
+        insta::assert_debug_snapshot!(optimize(parse("~~foo").unwrap()), @r#"CommitRef(Symbol("foo"))"#);
         insta::assert_debug_snapshot!(
             optimize(parse("(root() | none()) & (visible_heads() | ~~all())").unwrap()), @"Root");
     }


### PR DESCRIPTION
Now that `all()` contains all referenced commits, we can optimize `~all()` to `none()` and `~none()` to `all()`.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
