### PR TITLE
cli: Remove hard-coding of log symbols and put them in default templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `colors."diff removed token" = { bg = "ansi-color-52", underline = false }`
   will apply a dark red background on removed words in diffs.
 
+* Log node templates are now specified in toml rather than hardcoded.
+
 ### Fixed bugs
 
 * `jj file annotate` can now process files at a hidden revision.

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -25,7 +25,6 @@ use jj_lib::graph::TopoGroupedGraphIterator;
 use jj_lib::matchers::EverythingMatcher;
 use tracing::instrument;
 
-use super::log::get_node_template;
 use crate::cli_util::format_template;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
@@ -123,7 +122,9 @@ pub(crate) fn cmd_evolog(
             .parse_template(
                 ui,
                 &language,
-                &get_node_template(graph_style, workspace_command.settings())?,
+                &workspace_command
+                    .settings()
+                    .get_string("templates.log_node")?,
             )?
             .labeled(["log", "commit", "node"]);
     }

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -17,8 +17,6 @@ use clap_complete::ArgValueCompleter;
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
-use jj_lib::config::ConfigGetError;
-use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::graph::reverse_graph;
 use jj_lib::graph::GraphEdge;
 use jj_lib::graph::GraphEdgeType;
@@ -28,7 +26,6 @@ use jj_lib::revset::RevsetEvaluationError;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetFilterPredicate;
 use jj_lib::revset::RevsetIteratorExt as _;
-use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
 use crate::cli_util::format_template;
@@ -176,7 +173,7 @@ pub(crate) fn cmd_log(
             .parse_template(ui, &language, &template_string)?
             .labeled(["log", "commit"]);
         node_template = workspace_command
-            .parse_template(ui, &language, &get_node_template(graph_style, settings)?)?
+            .parse_template(ui, &language, &settings.get_string("templates.log_node")?)?
             .labeled(["log", "commit", "node"]);
     }
 
@@ -335,17 +332,4 @@ pub(crate) fn cmd_log(
     }
 
     Ok(())
-}
-
-pub fn get_node_template(
-    style: GraphStyle,
-    settings: &UserSettings,
-) -> Result<String, ConfigGetError> {
-    let symbol = settings.get_string("templates.log_node").optional()?;
-    let default = if style.is_ascii() {
-        "builtin_log_node_ascii"
-    } else {
-        "builtin_log_node"
-    };
-    Ok(symbol.unwrap_or_else(|| default.to_owned()))
 }

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -16,15 +16,12 @@ use std::slice;
 
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
-use jj_lib::config::ConfigGetError;
-use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::graph::reverse_graph;
 use jj_lib::graph::GraphEdge;
 use jj_lib::op_store::OpStoreError;
 use jj_lib::op_walk;
 use jj_lib::operation::Operation;
 use jj_lib::repo::RepoLoader;
-use jj_lib::settings::UserSettings;
 
 use super::diff::show_op_diff;
 use crate::cli_util::format_template;
@@ -138,7 +135,11 @@ fn do_op_log(
             .parse_template(ui, &language, &text)?
             .labeled(["op_log", "operation"]);
         op_node_template = workspace_env
-            .parse_template(ui, &language, &get_node_template(graph_style, settings)?)?
+            .parse_template(
+                ui,
+                &language,
+                &settings.get_string("templates.op_log_node")?,
+            )?
             .labeled(["op_log", "operation", "node"]);
     }
 
@@ -253,14 +254,4 @@ fn do_op_log(
     }
 
     Ok(())
-}
-
-fn get_node_template(style: GraphStyle, settings: &UserSettings) -> Result<String, ConfigGetError> {
-    let symbol = settings.get_string("templates.op_log_node").optional()?;
-    let default = if style.is_ascii() {
-        "builtin_op_log_node_ascii"
-    } else {
-        "builtin_op_log_node"
-    };
-    Ok(symbol.unwrap_or_else(|| default.to_owned()))
 }

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -70,6 +70,22 @@ separate(" ",
 )
 '''
 
+log_node = '''
+if(
+  config("ui.graph.style").as_string().starts_with("ascii"),
+  builtin_log_node_ascii,
+  builtin_log_node
+)
+'''
+
+op_log_node = '''
+if(
+  config("ui.graph.style").as_string().starts_with("ascii"),
+  builtin_op_log_node_ascii,
+  builtin_op_log_node
+)
+'''
+
 [template-aliases]
 
 'format_config_item(x)' = '''

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -216,6 +216,8 @@ fn test_templater_alias() {
     'deprecated()' = 'author.username()'
     'builtin_log_node' = '"#"'
     'builtin_op_log_node' = '"#"'
+    'builtin_log_node_ascii' = '"#"'
+    'builtin_op_log_node_ascii' = '"#"'
     "###,
     );
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This was noted in the discord. Back then we couldn't have implemented this logic in templates, but we now have the machinery to do so. So let's clean this thing up.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] ~~I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
- [ ] ~~I have updated the config schema (`cli/src/config-schema.json`)~~
- [x] I have added/updated tests to cover my changes
