### PR TITLE
cli: remove GraphStyle::is_ascii() which has been inlined in templates

### DIFF
--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -107,13 +107,6 @@ impl GraphStyle {
     pub fn from_settings(settings: &UserSettings) -> Result<Self, ConfigGetError> {
         settings.get("ui.graph.style")
     }
-
-    pub fn is_ascii(self) -> bool {
-        match self {
-            GraphStyle::Ascii | GraphStyle::AsciiLarge => true,
-            GraphStyle::Curved | GraphStyle::Square => false,
-        }
-    }
 }
 
 pub fn get_graphlog<'a, K: Clone + Eq + Hash + 'a>(


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
