### PR TITLE
id_prefix: check conflicting bookmarks/tags when calculating shortest length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj util gc --expire=now` now passes the corresponding flag to `git gc`.
 
+* `change_id`/`commit_id.shortest()` template functions now take conflicting
+  bookmark and tag names into account.
+  [#2416](https://github.com/jj-vcs/jj/issues/2416)
+
 * Fixed lockfile issue on stale file handles observed with NFS.
 
 ### Packaging changes

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -484,6 +484,16 @@ fn test_log_shortest_accessors() {
     zzz[zzzzzzzzz] 00[0000000000]
     [EOF]
     ");
+
+    // The shortest prefix "zzz" is shadowed by bookmark
+    work_dir
+        .run_jj(["bookmark", "set", "-r@", "z", "zz", "zzz"])
+        .success();
+    insta::assert_snapshot!(
+        render("root()", r#"format_id(change_id) ++ " " ++ format_id(commit_id) ++ "\n""#), @r"
+    zzzz[zzzzzzzz] 00[0000000000]
+    [EOF]
+    ");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2416

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
