### PR TITLE
Migrate `Path` and `PathBuf` to `Utf8Path` and `Utf8PathBuf` from `camino`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,9 @@ name = "camino"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cassowary"
@@ -2394,6 +2397,7 @@ dependencies = [
  "async-trait",
  "blake2",
  "bstr",
+ "camino",
  "chrono",
  "clru",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "bstr",
+ "camino",
  "chrono",
  "clap",
  "clap-markdown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
 name = "gen-protos"
 version = "0.30.0"
 dependencies = [
+ "camino",
  "prost-build",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3989,6 +3989,7 @@ version = "0.30.0"
 dependencies = [
  "async-trait",
  "bstr",
+ "camino",
  "futures 0.3.31",
  "gix",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ assert_matches = "1.5.0"
 async-trait = "0.1.88"
 blake2 = "0.10.6"
 bstr = "1.11.3"
+camino = { version = "1.1", features = ["serde1"] }
 clap = { version = "4.5.40", features = [
     "derive",
     "deprecated",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,6 +54,7 @@ harness = false
 
 [dependencies]
 bstr = { workspace = true }
+camino = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 clap-markdown = { workspace = true }
@@ -116,6 +117,9 @@ testutils = { workspace = true }
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987
 jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 
+[build-dependencies]
+camino = { workspace = true }
+
 [features]
 default = ["watchman", "git"]
 bench = ["dep:criterion"]
@@ -141,9 +145,9 @@ section = "vcs"
 priority = "optional"
 extended-description = "Distributed Version Control System inspired by Git, Mercurial and Darcs."
 assets = [
-    { source = "docs/*", dest = "usr/share/doc/jj/", mode = "644"},
-# TODO: It'd be nice to package the output of `MKDOCS_OFFLINE=true uv run mkdocs build` in the docs dir as well, but this is not trivial.
-    { source = "docs/*/*", dest = "usr/share/doc/jj/", mode = "644"},
-    { source = "target/release/jj", dest = "usr/bin/", mode = "755"},
+    { source = "docs/*", dest = "usr/share/doc/jj/", mode = "644" },
+    # TODO: It'd be nice to package the output of `MKDOCS_OFFLINE=true uv run mkdocs build` in the docs dir as well, but this is not trivial.
+    { source = "docs/*/*", dest = "usr/share/doc/jj/", mode = "644" },
+    { source = "target/release/jj", dest = "usr/bin/", mode = "755" },
 ]
 default-features = true

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
 use std::process::Command;
 use std::str;
+
+use camino::Utf8Path;
 
 const GIT_HEAD_PATH: &str = "../.git/HEAD";
 const JJ_OP_HEADS_PATH: &str = "../.jj/repo/op_heads/heads";
@@ -22,10 +23,10 @@ const JJ_OP_HEADS_PATH: &str = "../.jj/repo/op_heads/heads";
 fn main() {
     let version = std::env::var("CARGO_PKG_VERSION").unwrap();
 
-    if Path::new(GIT_HEAD_PATH).exists() {
+    if Utf8Path::new(GIT_HEAD_PATH).exists() {
         // In colocated repo, .git/HEAD should reflect the working-copy parent.
         println!("cargo:rerun-if-changed={GIT_HEAD_PATH}");
-    } else if Path::new(JJ_OP_HEADS_PATH).exists() {
+    } else if Utf8Path::new(JJ_OP_HEADS_PATH).exists() {
         // op_heads changes when working-copy files are mutated, which is way more
         // frequent than .git/HEAD.
         println!("cargo:rerun-if-changed={JJ_OP_HEADS_PATH}");
@@ -38,8 +39,8 @@ fn main() {
         println!("cargo:rustc-env=JJ_VERSION={version}");
     }
 
-    let docs_symlink_path = Path::new("docs");
-    println!("cargo:rerun-if-changed={}", docs_symlink_path.display());
+    let docs_symlink_path = Utf8Path::new("docs");
+    println!("cargo:rerun-if-changed={docs_symlink_path}");
     if docs_symlink_path.join("index.md").exists() {
         println!("cargo:rustc-env=JJ_DOCS_DIR=docs/");
     } else {

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::path::Path;
 use std::pin::Pin;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use camino::Utf8Path;
 use futures::stream::BoxStream;
 use jj_cli::cli_util::CliRunner;
 use jj_cli::cli_util::CommandHelper;
@@ -104,12 +104,12 @@ struct JitBackend {
 }
 
 impl JitBackend {
-    fn init(settings: &UserSettings, store_path: &Path) -> Result<Self, BackendInitError> {
+    fn init(settings: &UserSettings, store_path: &Utf8Path) -> Result<Self, BackendInitError> {
         let inner = GitBackend::init_internal(settings, store_path)?;
         Ok(JitBackend { inner })
     }
 
-    fn load(settings: &UserSettings, store_path: &Path) -> Result<Self, BackendLoadError> {
+    fn load(settings: &UserSettings, store_path: &Utf8Path) -> Result<Self, BackendLoadError> {
         let inner = GitBackend::load(settings, store_path)?;
         Ok(JitBackend { inner })
     }

--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
 
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use itertools::Itertools as _;
 use jj_cli::cli_util::CliRunner;
 use jj_cli::cli_util::CommandHelper;
@@ -65,7 +65,7 @@ fn run_custom_command(
         CustomCommand::InitConflicts => {
             let wc_path = command_helper.cwd();
             let settings = command_helper.settings_for_new_workspace(wc_path)?;
-            let backend_initializer = |settings: &UserSettings, store_path: &Path| {
+            let backend_initializer = |settings: &UserSettings, store_path: &Utf8Path| {
                 let backend: Box<dyn Backend> =
                     Box::new(GitBackend::init_internal(settings, store_path)?);
                 Ok(backend)
@@ -109,7 +109,7 @@ fn main() -> std::process::ExitCode {
 /// file to the working copy.
 struct ConflictsWorkingCopy {
     inner: Box<dyn WorkingCopy>,
-    working_copy_path: PathBuf,
+    working_copy_path: Utf8PathBuf,
 }
 
 impl ConflictsWorkingCopy {
@@ -119,8 +119,8 @@ impl ConflictsWorkingCopy {
 
     fn init(
         store: Arc<Store>,
-        working_copy_path: PathBuf,
-        state_path: PathBuf,
+        working_copy_path: Utf8PathBuf,
+        state_path: Utf8PathBuf,
         operation_id: OperationId,
         workspace_name: WorkspaceNameBuf,
     ) -> Result<Self, WorkingCopyStateError> {
@@ -137,7 +137,7 @@ impl ConflictsWorkingCopy {
         })
     }
 
-    fn load(store: Arc<Store>, working_copy_path: PathBuf, state_path: PathBuf) -> Self {
+    fn load(store: Arc<Store>, working_copy_path: Utf8PathBuf, state_path: Utf8PathBuf) -> Self {
         let inner = LocalWorkingCopy::load(store, working_copy_path.clone(), state_path);
         ConflictsWorkingCopy {
             inner: Box::new(inner),
@@ -186,8 +186,8 @@ impl WorkingCopyFactory for ConflictsWorkingCopyFactory {
     fn init_working_copy(
         &self,
         store: Arc<Store>,
-        working_copy_path: PathBuf,
-        state_path: PathBuf,
+        working_copy_path: Utf8PathBuf,
+        state_path: Utf8PathBuf,
         operation_id: OperationId,
         workspace_name: WorkspaceNameBuf,
     ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError> {
@@ -203,8 +203,8 @@ impl WorkingCopyFactory for ConflictsWorkingCopyFactory {
     fn load_working_copy(
         &self,
         store: Arc<Store>,
-        working_copy_path: PathBuf,
-        state_path: PathBuf,
+        working_copy_path: Utf8PathBuf,
+        state_path: Utf8PathBuf,
     ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError> {
         Ok(Box::new(ConflictsWorkingCopy::load(
             store,
@@ -215,7 +215,7 @@ impl WorkingCopyFactory for ConflictsWorkingCopyFactory {
 }
 
 struct LockedConflictsWorkingCopy {
-    wc_path: PathBuf,
+    wc_path: Utf8PathBuf,
     inner: Box<dyn LockedWorkingCopy>,
 }
 
@@ -243,7 +243,7 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
         let options = SnapshotOptions {
             base_ignores: options.base_ignores.chain(
                 "",
-                Path::new(""),
+                Utf8Path::new(""),
                 "/.conflicts".as_bytes(),
             )?,
             ..options.clone()

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -272,7 +272,7 @@ impl From<ConfigLoadError> for CommandError {
             ConfigLoadError::Read(_) => None,
             ConfigLoadError::Parse { source_path, .. } => source_path
                 .as_ref()
-                .map(|path| format!("Check the config file: {}", path.display())),
+                .map(|path| format!("Check the config file: {path}")),
         };
         let mut cmd_err = config_error(err);
         cmd_err.extend_hints(hint);
@@ -285,7 +285,7 @@ impl From<ConfigMigrateError> for CommandError {
         let hint = err
             .source_path
             .as_ref()
-            .map(|path| format!("Check the config file: {}", path.display()));
+            .map(|path| format!("Check the config file: {path}"));
         let mut cmd_err = config_error(err);
         cmd_err.extend_hints(hint);
         cmd_err
@@ -503,7 +503,7 @@ impl From<TempTextEditError> for CommandError {
     fn from(err: TempTextEditError) -> Self {
         let hint = err.path.as_ref().map(|path| {
             let name = err.name.as_deref().unwrap_or("file");
-            format!("Edited {name} is left in {path}", path = path.display())
+            format!("Edited {name} is left in {path}")
         });
         let mut cmd_err = user_error(err);
         cmd_err.extend_hints(hint);
@@ -778,7 +778,7 @@ fn config_get_error_hint(err: &ConfigGetError) -> Option<String> {
         ConfigGetError::NotFound { .. } => None,
         ConfigGetError::Type { source_path, .. } => source_path
             .as_ref()
-            .map(|path| format!("Check the config file: {}", path.display())),
+            .map(|path| format!("Check the config file: {path}")),
     }
 }
 

--- a/cli/src/commands/config/edit.rs
+++ b/cli/src/commands/config/edit.rs
@@ -46,13 +46,12 @@ pub fn cmd_config_edit(
     // Editing again and again until either of these conditions is met
     // 1. The config is OK
     // 2. The user restores previous one
-    writeln!(ui.status(), "Editing file: {}", file.path().display())?;
+    writeln!(ui.status(), "Editing file: {}", file.path())?;
     loop {
         editor.edit_file(file.path())?;
 
         // Trying to load back config. If error, prompt to continue editing
-        if let Err(e) = ConfigLayer::load_from_file(file.layer().source, file.path().to_path_buf())
-        {
+        if let Err(e) = ConfigLayer::load_from_file(file.layer().source, file.path()) {
             writeln!(
                 ui.warning_default(),
                 "An error has been found inside the config:"

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -146,7 +146,7 @@ fn config_template_language(settings: &UserSettings) -> ConfigTemplateLanguage {
             annotated
                 .path
                 .as_ref()
-                .map_or_else(String::new, |path| path.to_string_lossy().into_owned())
+                .map_or_else(String::new, |path| path.to_string())
         });
         Ok(out_property.into_dyn_wrapped())
     });

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -19,8 +19,7 @@ mod path;
 mod set;
 mod unset;
 
-use std::path::Path;
-
+use camino::Utf8Path;
 use itertools::Itertools as _;
 use jj_lib::config::ConfigFile;
 use jj_lib::config::ConfigSource;
@@ -67,7 +66,10 @@ impl ConfigLevelArgs {
         }
     }
 
-    fn config_paths<'a>(&self, config_env: &'a ConfigEnv) -> Result<Vec<&'a Path>, CommandError> {
+    fn config_paths<'a>(
+        &self,
+        config_env: &'a ConfigEnv,
+    ) -> Result<Vec<&'a Utf8Path>, CommandError> {
         if self.user {
             let paths = config_env.user_config_paths().collect_vec();
             if paths.is_empty() {
@@ -96,7 +98,7 @@ impl ConfigLevelArgs {
                 let mut choices = vec![];
                 let mut formatter = ui.stderr_formatter();
                 for (i, file) in files.iter().enumerate() {
-                    writeln!(formatter, "{}: {}", i + 1, file.path().display())?;
+                    writeln!(formatter, "{}: {}", i + 1, file.path())?;
                     choices.push((i + 1).to_string());
                 }
                 drop(formatter);

--- a/cli/src/commands/config/path.rs
+++ b/cli/src/commands/config/path.rs
@@ -18,7 +18,6 @@ use tracing::instrument;
 
 use super::ConfigLevelArgs;
 use crate::cli_util::CommandHelper;
-use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -40,13 +39,7 @@ pub fn cmd_config_path(
     args: &ConfigPathArgs,
 ) -> Result<(), CommandError> {
     for config_path in args.level.config_paths(command.config_env())? {
-        writeln!(
-            ui.stdout(),
-            "{}",
-            config_path
-                .to_str()
-                .ok_or_else(|| user_error("The config path is not valid UTF-8"))?
-        )?;
+        writeln!(ui.stdout(), "{config_path}")?;
     }
     Ok(())
 }

--- a/cli/src/commands/debug/init_simple.rs
+++ b/cli/src/commands/debug/init_simple.rs
@@ -54,16 +54,12 @@ pub(crate) fn cmd_debug_init_simple(
     let cwd = command.cwd();
     let wc_path = cwd.join(&args.destination);
     let wc_path = file_util::create_or_reuse_dir(&wc_path)
-        .and_then(|_| dunce::canonicalize(wc_path))
+        .and_then(|_| file_util::canonicalize_path(wc_path))
         .map_err(|e| user_error_with_message("Failed to create workspace", e))?;
 
     Workspace::init_simple(&command.settings_for_new_workspace(&wc_path)?, &wc_path)?;
 
     let relative_wc_path = file_util::relative_path(cwd, &wc_path);
-    writeln!(
-        ui.status(),
-        "Initialized repo in \"{}\"",
-        relative_wc_path.display()
-    )?;
+    writeln!(ui.status(), "Initialized repo in \"{relative_wc_path}\"")?;
     Ok(())
 }

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -14,9 +14,9 @@
 
 use std::collections::HashMap;
 use std::io::Write as _;
-use std::path::Path;
 use std::process::Stdio;
 
+use camino::Utf8Path;
 use clap_complete::ArgValueCompleter;
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
@@ -177,7 +177,7 @@ pub(crate) fn cmd_fix(
 /// TODO: Better error handling so we can tell the user what went wrong with
 /// each failed input.
 async fn fix_one_file(
-    workspace_root: &Path,
+    workspace_root: &Utf8Path,
     tools_config: &ToolsConfig,
     store: &Store,
     file_to_fix: &FileToFix,
@@ -230,7 +230,7 @@ async fn fix_one_file(
 /// unless the command introduced changes. Returns `None` if there were any
 /// failures when starting, stopping, or communicating with the subprocess.
 fn run_tool(
-    workspace_root: &Path,
+    workspace_root: &Utf8Path,
     tool_command: &CommandNameAndArgs,
     file_to_fix: &FileToFix,
     old_content: &[u8],

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -21,8 +21,7 @@ mod push;
 mod remote;
 mod root;
 
-use std::path::Path;
-
+use camino::Utf8Path;
 use clap::Subcommand;
 use jj_lib::config::ConfigFile;
 use jj_lib::config::ConfigSource;
@@ -119,7 +118,7 @@ fn get_single_remote(store: &Store) -> Result<Option<RemoteNameBuf>, UnexpectedG
 /// Sets repository level `trunk()` alias to the specified remote symbol.
 fn write_repository_level_trunk_alias(
     ui: &Ui,
-    repo_path: &Path,
+    repo_path: &Utf8Path,
     symbol: RemoteRefSymbol<'_>,
 ) -> Result<(), CommandError> {
     let mut file = ConfigFile::load_or_empty(ConfigSource::Repo, repo_path.join("config.toml"))?;

--- a/cli/src/commands/git/root.rs
+++ b/cli/src/commands/git/root.rs
@@ -18,7 +18,6 @@ use jj_lib::repo::Repo as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
-use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -35,10 +34,7 @@ pub fn cmd_git_root(
     let workspace_command = command.workspace_helper(ui)?;
     let store = workspace_command.repo().store();
     let git_backend = jj_lib::git::get_git_backend(store)?;
-    let root = git_backend
-        .git_repo_path()
-        .to_str()
-        .ok_or_else(|| user_error("The workspace root is not valid UTF-8"))?;
+    let root = git_backend.git_repo_path();
     writeln!(ui.stdout(), "{root}")?;
     Ok(())
 }

--- a/cli/src/commands/root.rs
+++ b/cli/src/commands/root.rs
@@ -17,7 +17,6 @@ use std::io::Write as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
-use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -31,11 +30,7 @@ pub(crate) fn cmd_root(
     command: &CommandHelper,
     RootArgs {}: &RootArgs,
 ) -> Result<(), CommandError> {
-    let root = command
-        .workspace_loader()?
-        .workspace_root()
-        .to_str()
-        .ok_or_else(|| user_error("The workspace root is not valid UTF-8"))?;
+    let root = command.workspace_loader()?.workspace_root();
     writeln!(ui.stdout(), "{root}")?;
     Ok(())
 }

--- a/cli/src/commands/sparse/edit.rs
+++ b/cli/src/commands/sparse/edit.rs
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 use std::fmt::Write as _;
-use std::path::Path;
 
+use camino::Utf8Path;
 use itertools::Itertools as _;
 use jj_lib::repo_path::RepoPathBuf;
 use tracing::instrument;
 
 use super::update_sparse_patterns_with;
 use crate::cli_util::CommandHelper;
-use crate::command_error::internal_error;
 use crate::command_error::user_error_with_message;
 use crate::command_error::CommandError;
 use crate::description_util::TextEditor;
@@ -54,14 +53,8 @@ fn edit_sparse(
     let mut content = String::new();
     for sparse_path in sparse {
         // Invalid path shouldn't block editing. Edited paths will be validated.
-        let workspace_relative_sparse_path = sparse_path.to_fs_path_unchecked(Path::new(""));
-        let path_string = workspace_relative_sparse_path.to_str().ok_or_else(|| {
-            internal_error(format!(
-                "Stored sparse path is not valid utf-8: {}",
-                workspace_relative_sparse_path.display()
-            ))
-        })?;
-        writeln!(&mut content, "{path_string}").unwrap();
+        let workspace_relative_sparse_path = sparse_path.to_fs_path_unchecked(Utf8Path::new(""));
+        writeln!(&mut content, "{workspace_relative_sparse_path}").unwrap();
     }
 
     let content = editor

--- a/cli/src/commands/sparse/list.rs
+++ b/cli/src/commands/sparse/list.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::io::Write as _;
-use std::path::Path;
 
+use camino::Utf8Path;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -40,7 +40,7 @@ pub fn cmd_sparse_list(
         writeln!(
             ui.stdout(),
             "{}",
-            path.to_fs_path_unchecked(Path::new("")).display()
+            path.to_fs_path_unchecked(Utf8Path::new(""))
         )?;
     }
     Ok(())

--- a/cli/src/commands/util/install_man_pages.rs
+++ b/cli/src/commands/util/install_man_pages.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
@@ -24,7 +24,7 @@ pub struct UtilInstallManPagesArgs {
     /// The path where manpages will installed. An example path might be
     /// `/usr/share/man`. The provided path will be appended with `man1`,
     /// etc., as appropriate
-    path: PathBuf,
+    path: Utf8PathBuf,
 }
 
 pub fn cmd_util_install_man_pages(

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -92,10 +92,7 @@ pub fn cmd_workspace_add(
         name.to_owned()
     } else {
         let file_name = destination_path.file_name().unwrap();
-        file_name
-            .to_str()
-            .ok_or_else(|| user_error("Destination path is not valid UTF-8"))?
-            .into()
+        file_name.into()
     };
     let repo = old_workspace_command.repo();
     if repo.view().get_wc_commit_id(&workspace_name).is_some() {
@@ -119,7 +116,7 @@ pub fn cmd_workspace_add(
     writeln!(
         ui.status(),
         "Created workspace in \"{}\"",
-        file_util::relative_path(command.cwd(), &destination_path).display()
+        file_util::relative_path(command.cwd(), &destination_path)
     )?;
     // Show a warning if the user passed a path without a separator, since they
     // may have intended the argument to only be the name for the workspace.

--- a/cli/src/commands/workspace/root.rs
+++ b/cli/src/commands/workspace/root.rs
@@ -17,7 +17,6 @@ use std::io::Write as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
-use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
@@ -31,11 +30,7 @@ pub fn cmd_workspace_root(
     command: &CommandHelper,
     _args: &WorkspaceRootArgs,
 ) -> Result<(), CommandError> {
-    let root = command
-        .workspace_loader()?
-        .workspace_root()
-        .to_str()
-        .ok_or_else(|| user_error("The workspace root is not valid UTF-8"))?;
+    let root = command.workspace_loader()?.workspace_root();
     writeln!(ui.stdout(), "{root}")?;
     Ok(())
 }

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2374,9 +2374,9 @@ fn builtin_trailer_list_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use std::sync::Arc;
 
+    use camino::Utf8Path;
     use jj_lib::config::ConfigLayer;
     use jj_lib::config::ConfigSource;
     use jj_lib::revset::RevsetAliasesMap;
@@ -2438,7 +2438,7 @@ mod tests {
             }
         }
 
-        fn set_cwd(&mut self, path: impl AsRef<Path>) {
+        fn set_cwd(&mut self, path: impl AsRef<Utf8Path>) {
             self.path_converter = RepoPathUiConverter::Fs {
                 cwd: self.test_workspace.workspace.workspace_root().join(path),
                 base: self.test_workspace.workspace.workspace_root().to_owned(),

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -18,11 +18,11 @@ use std::io;
 use std::iter;
 use std::mem;
 use std::ops::Range;
-use std::path::Path;
-use std::path::PathBuf;
 
 use bstr::BStr;
 use bstr::BString;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use futures::executor::block_on_stream;
 use futures::stream::BoxStream;
 use futures::StreamExt as _;
@@ -1390,9 +1390,9 @@ pub async fn show_file_by_file_diff(
     conflict_marker_style: ConflictMarkerStyle,
 ) -> Result<(), DiffRenderError> {
     let create_file = |path: &RepoPath,
-                       wc_dir: &Path,
+                       wc_dir: &Utf8Path,
                        value: MaterializedTreeValue|
-     -> Result<PathBuf, DiffRenderError> {
+     -> Result<Utf8PathBuf, DiffRenderError> {
         let fs_path = path.to_fs_path(wc_dir)?;
         std::fs::create_dir_all(fs_path.parent().unwrap())?;
         let content = diff_content(path, value, conflict_marker_style)?;
@@ -1435,10 +1435,10 @@ pub async fn show_file_by_file_diff(
         let patterns = &maplit::hashmap! {
             "left" => left_path
                 .strip_prefix(temp_dir.path()).expect("path should be relative to temp_dir")
-                .to_str().expect("temp_dir should be valid utf-8"),
+                .as_str(),
             "right" => right_path
                 .strip_prefix(temp_dir.path()).expect("path should be relative to temp_dir")
-                .to_str().expect("temp_dir should be valid utf-8"),
+                .as_str(),
         };
 
         let mut writer = formatter.raw()?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -50,3 +50,9 @@ pub mod templater;
 pub mod text_util;
 pub mod time_util;
 pub mod ui;
+
+fn home_dir() -> Result<camino::Utf8PathBuf, etcetera::HomeDirError> {
+    etcetera::home_dir()?
+        .try_into()
+        .map_err(|_err| etcetera::HomeDirError)
+}

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
-use std::path::Path;
 use std::sync::Arc;
 
+use camino::Utf8Path;
 use futures::stream::BoxStream;
 use futures::StreamExt as _;
 use itertools::Itertools as _;
@@ -367,7 +367,11 @@ async fn make_diff_files(
         files.push(scm_record::File {
             old_path: None,
             // Path for displaying purposes, not for file access.
-            path: Cow::Owned(right_path.to_fs_path_unchecked(Path::new(""))),
+            path: Cow::Owned(
+                right_path
+                    .to_fs_path_unchecked(Utf8Path::new(""))
+                    .into_std_path_buf(),
+            ),
             file_mode: left_info.file_mode,
             sections,
         });
@@ -657,7 +661,8 @@ fn make_merge_file(
         path: Cow::Owned(
             merge_tool_file
                 .repo_path
-                .to_fs_path_unchecked(Path::new("")),
+                .to_fs_path_unchecked(Utf8Path::new(""))
+                .into_std_path_buf(),
         ),
         file_mode,
         sections,

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::io;
 use std::io::Write;
-use std::path::Path;
 use std::process::Command;
 use std::process::ExitStatus;
 use std::process::Stdio;
 use std::sync::Arc;
 
 use bstr::BString;
+use camino::Utf8Path;
 use itertools::Itertools as _;
 use jj_lib::backend::CopyId;
 use jj_lib::backend::MergedTreeId;
@@ -459,27 +459,17 @@ pub fn invoke_external_diff(
     ui: &Ui,
     writer: &mut dyn Write,
     tool: &ExternalMergeTool,
-    diff_dir: &Path,
+    diff_dir: &Utf8Path,
     patterns: &HashMap<&str, &str>,
 ) -> Result<(), DiffGenerateError> {
     // TODO: Somehow propagate --color to the external command?
     let mut cmd = Command::new(&tool.program);
     let mut patterns = patterns.clone();
-    let absolute_left_path = Path::new(diff_dir).join(patterns["left"]);
-    let absolute_right_path = Path::new(diff_dir).join(patterns["right"]);
+    let absolute_left_path = Utf8Path::new(diff_dir).join(patterns["left"]);
+    let absolute_right_path = Utf8Path::new(diff_dir).join(patterns["right"]);
     if !tool.diff_do_chdir {
-        patterns.insert(
-            "left",
-            absolute_left_path
-                .to_str()
-                .expect("temp_dir should be valid utf-8"),
-        );
-        patterns.insert(
-            "right",
-            absolute_right_path
-                .to_str()
-                .expect("temp_dir should be valid utf-8"),
-        );
+        patterns.insert("left", absolute_left_path.as_str());
+        patterns.insert("right", absolute_right_path.as_str());
     } else {
         cmd.current_dir(diff_dir);
     }

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 
+use camino::Utf8Path;
 use crossterm::terminal::Clear;
 use crossterm::terminal::ClearType;
 use jj_lib::repo_path::RepoPath;
@@ -52,9 +52,8 @@ pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + use<>> {
 
         let line_width = state.output.term_width().map(usize::from).unwrap_or(80);
         let max_path_width = line_width.saturating_sub(13); // Account for "Snapshotting "
-        let fs_path = path.to_fs_path_unchecked(Path::new(""));
-        let (display_path, _) =
-            text_util::elide_start(fs_path.to_str().unwrap(), "...", max_path_width);
+        let fs_path = path.to_fs_path_unchecked(Utf8Path::new(""));
+        let (display_path, _) = text_util::elide_start(fs_path.as_str(), "...", max_path_width);
 
         _ = write!(
             state.output,

--- a/cli/testing/fake-formatter.rs
+++ b/cli/testing/fake-formatter.rs
@@ -14,9 +14,9 @@
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
-use std::path::PathBuf;
 use std::process::ExitCode;
 
+use camino::Utf8PathBuf;
 use clap::arg;
 use clap::Parser;
 use itertools::Itertools as _;
@@ -63,7 +63,7 @@ struct Args {
 
     /// Duplicate stdout into this file.
     #[arg(long)]
-    tee: Option<PathBuf>,
+    tee: Option<Utf8PathBuf>,
 }
 
 fn main() -> ExitCode {

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -1,10 +1,10 @@
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 mod common;
 
 #[test]
 fn test_no_forgotten_test_files() {
-    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let test_dir = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
     testutils::assert_no_forgotten_test_files(&test_dir);
 }
 

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -328,7 +328,7 @@ fn test_alias_in_repo_config() {
     ");
 
     // Aliases can't be loaded from the -R path due to chicken and egg problem.
-    let output = work_dir2.run_jj(["l", "-R", work_dir1.root().to_str().unwrap()]);
+    let output = work_dir2.run_jj(["l", "-R", work_dir1.root().as_str()]);
     insta::assert_snapshot!(output, @r"
     user alias
     [EOF]
@@ -338,7 +338,7 @@ fn test_alias_in_repo_config() {
     ");
 
     // Aliases are loaded from the cwd-relative workspace even with -R.
-    let output = work_dir1.run_jj(["l", "-R", work_dir2.root().to_str().unwrap()]);
+    let output = work_dir1.run_jj(["l", "-R", work_dir2.root().as_str()]);
     insta::assert_snapshot!(output, @r"
     repo1 alias
     [EOF]
@@ -348,18 +348,12 @@ fn test_alias_in_repo_config() {
     ");
 
     // No warning if the expanded command is identical.
-    let output = work_dir1.run_jj(["file", "list", "-R", work_dir2.root().to_str().unwrap()]);
+    let output = work_dir1.run_jj(["file", "list", "-R", work_dir2.root().as_str()]);
     insta::assert_snapshot!(output, @"");
 
     // Config loaded from the cwd-relative workspace shouldn't persist. It's
     // used only for command arguments expansion.
-    let output = work_dir1.run_jj([
-        "config",
-        "list",
-        "aliases",
-        "-R",
-        work_dir2.root().to_str().unwrap(),
-    ]);
+    let output = work_dir1.run_jj(["config", "list", "aliases", "-R", work_dir2.root().as_str()]);
     insta::assert_snapshot!(output, @r#"
     aliases.l = ['log', '-r@', '--no-graph', '-T"user alias\n"']
     [EOF]

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1531,10 +1531,7 @@ fn test_bookmark_list() {
     let mut remote_git_path = remote_dir.root().to_owned();
     remote_git_path.extend([".jj", "repo", "store", "git"]);
     test_env
-        .run_jj_in(
-            ".",
-            ["git", "clone", remote_git_path.to_str().unwrap(), "local"],
-        )
+        .run_jj_in(".", ["git", "clone", remote_git_path.as_str(), "local"])
         .success();
     let local_dir = test_env.work_dir("local");
     local_dir
@@ -1739,10 +1736,7 @@ fn test_bookmark_list_filtered() {
     let mut remote_git_path = remote_dir.root().to_owned();
     remote_git_path.extend([".jj", "repo", "store", "git"]);
     test_env
-        .run_jj_in(
-            ".",
-            ["git", "clone", remote_git_path.to_str().unwrap(), "local"],
-        )
+        .run_jj_in(".", ["git", "clone", remote_git_path.as_str(), "local"])
         .success();
     let local_dir = test_env.work_dir("local");
     local_dir
@@ -1995,10 +1989,7 @@ fn test_bookmark_list_much_remote_divergence() {
     let mut remote_git_path = remote_dir.root().to_owned();
     remote_git_path.extend([".jj", "repo", "store", "git"]);
     test_env
-        .run_jj_in(
-            ".",
-            ["git", "clone", remote_git_path.to_str().unwrap(), "local"],
-        )
+        .run_jj_in(".", ["git", "clone", remote_git_path.as_str(), "local"])
         .success();
     let local_dir = test_env.work_dir("local");
     local_dir
@@ -2065,7 +2056,7 @@ fn test_bookmark_list_tracked() {
                 "git",
                 "clone",
                 "--colocate",
-                remote_git_path.to_str().unwrap(),
+                remote_git_path.as_str(),
                 "local",
             ],
         )
@@ -2097,7 +2088,7 @@ fn test_bookmark_list_tracked() {
             "remote",
             "add",
             "upstream",
-            upstream_git_path.to_str().unwrap(),
+            upstream_git_path.as_str(),
         ])
         .success();
     local_dir

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -46,7 +46,7 @@ fn set_up(trunk_name: &str) -> TestEnvironment {
                 "git",
                 "clone",
                 "--config=git.auto-local-bookmark=true",
-                origin_git_repo_path.to_str().unwrap(),
+                origin_git_repo_path.as_str(),
                 "local",
             ],
         )

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use crate::common::CommandOutput;
 use crate::common::TestEnvironment;
@@ -88,11 +88,11 @@ fn test_commit_with_editor_avoids_unc() {
     work_dir.run_jj(["commit"]).success();
 
     let edited_path =
-        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+        Utf8PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
     // While `assert!(!edited_path.starts_with("//?/"))` could work here in most
     // cases, it fails when it is not safe to strip the prefix, such as paths
     // over 260 chars.
-    assert_eq!(edited_path, dunce::simplified(&edited_path));
+    assert_eq!(edited_path, dunce::simplified(edited_path.as_ref()));
 }
 
 #[test]

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -627,12 +627,7 @@ fn test_log_bookmarks() {
     test_env
         .run_jj_in(
             ".",
-            [
-                "git",
-                "clone",
-                origin_git_repo_path.to_str().unwrap(),
-                "local",
-            ],
+            ["git", "clone", origin_git_repo_path.as_str(), "local"],
         )
         .success();
     let work_dir = test_env.work_dir("local");

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -159,7 +159,7 @@ fn test_bookmark_names() {
             "remote",
             "add",
             "origin",
-            origin_git_repo_path.to_str().unwrap(),
+            origin_git_repo_path.as_str(),
         ])
         .success();
     work_dir
@@ -652,7 +652,7 @@ fn test_aliases_are_completed(shell: Shell) {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let repo_path = work_dir.root().to_str().unwrap();
+    let repo_path = work_dir.root().as_str();
 
     // user config alias
     test_env.add_config(r#"aliases.user-alias = ["bookmark"]"#);
@@ -735,7 +735,7 @@ fn test_revisions() {
             "remote",
             "add",
             "origin",
-            origin_git_repo_path.to_str().unwrap(),
+            origin_git_repo_path.as_str(),
         ])
         .success();
     origin_dir

--- a/cli/tests/test_config_schema.rs
+++ b/cli/tests/test_config_schema.rs
@@ -37,12 +37,12 @@ fn test_config_schema_default_values_are_consistent_with_schema() {
     };
 
     // Taplo requires an absolute URL to the schema :/
-    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root = camino::Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut taplo_child = Command::new("taplo")
         .args([
             "check",
             "--schema",
-            &format!("file://{}/src/config-schema.json", root.display()),
+            &format!("file://{root}/src/config-schema.json"),
             "-", // read from stdin
         ])
         .stdin(Stdio::piped())

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use indoc::indoc;
 
 use crate::common::CommandOutput;
@@ -834,11 +833,11 @@ fn test_describe_avoids_unc() {
     work_dir.run_jj(["describe"]).success();
 
     let edited_path =
-        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+        Utf8PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
     // While `assert!(!edited_path.starts_with("//?/"))` could work here in most
     // cases, it fails when it is not safe to strip the prefix, such as paths
     // over 260 chars.
-    assert_eq!(edited_path, dunce::simplified(&edited_path));
+    assert_eq!(edited_path, dunce::simplified(edited_path.as_ref()));
 }
 
 #[test]
@@ -1118,7 +1117,7 @@ fn test_add_trailer_committer() {
         format!("-----\n{editor0}-----\n"), @r#"
     -----
 
-    
+
     Signed-off-by: test.user@example.com
 
     JJ: Lines starting with "JJ:" (like this one) will be removed.

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -578,7 +578,8 @@ fn test_diff_types() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        use std::path::PathBuf;
+
+        use camino::Utf8PathBuf;
 
         // Executable
         work_dir
@@ -593,7 +594,8 @@ fn test_diff_types() {
 
         // Symlink
         work_dir.run_jj(["new", "root()", "-m=symlink"]).success();
-        std::os::unix::fs::symlink(PathBuf::from("."), work_dir.root().join(file_path)).unwrap();
+        std::os::unix::fs::symlink(Utf8PathBuf::from("."), work_dir.root().join(file_path))
+            .unwrap();
     }
 
     let diff = |from: &str, to: &str| {

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -76,7 +76,7 @@ fn test_edit() {
 // Windows says "Access is denied" when trying to delete the object file.
 #[cfg(unix)]
 fn test_edit_current_wc_commit_missing() {
-    use std::path::PathBuf;
+    use camino::Utf8PathBuf;
 
     // Test that we get a reasonable error message when the current working-copy
     // commit is missing
@@ -99,7 +99,7 @@ fn test_edit_current_wc_commit_missing() {
         .stdout
         .into_raw();
     // Make the Git backend fail to read the current working copy commit
-    let commit_object_path = PathBuf::from_iter([
+    let commit_object_path = Utf8PathBuf::from_iter([
         ".jj",
         "repo",
         "store",

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -14,11 +14,12 @@
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
-use std::path::Path;
+
+use camino::Utf8Path;
 
 use crate::common::TestEnvironment;
 
-fn append_to_file(file_path: &Path, contents: &str) {
+fn append_to_file(file_path: &Utf8Path, contents: &str) {
     let mut options = OpenOptions::new();
     options.append(true);
     let mut file = options.open(file_path).unwrap();

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -14,8 +14,8 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
-use std::path::PathBuf;
 
+use camino::Utf8PathBuf;
 use indoc::formatdoc;
 use indoc::indoc;
 use jj_lib::file_util::try_symlink;
@@ -943,8 +943,8 @@ fn test_deduplication() {
     ");
 }
 
-fn sorted_lines(path: PathBuf) -> String {
-    let mut log: Vec<_> = std::fs::read_to_string(path.as_os_str())
+fn sorted_lines(path: Utf8PathBuf) -> String {
+    let mut log: Vec<_> = std::fs::read_to_string(path)
         .unwrap()
         .lines()
         .map(String::from)

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -758,7 +758,7 @@ fn test_git_clone_conditional_config() {
         user.email = 'new-repo@example.org'
         operation.username = 'new-repo'
         ",
-        new_workspace_root = to_toml_value(new_workspace_dir.root().to_str().unwrap()),
+        new_workspace_root = to_toml_value(new_workspace_dir.root().as_str()),
     });
 
     // Override operation.hostname by repo config, which should be loaded into
@@ -938,7 +938,7 @@ fn test_git_clone_with_global_git_remote_config() {
     );
     test_env.add_env_var(
         "GIT_CONFIG_GLOBAL",
-        test_env.env_root().join("git-config").to_str().unwrap(),
+        test_env.env_root().join("git-config").as_str(),
     );
 
     let root_dir = test_env.work_dir("");
@@ -985,7 +985,7 @@ fn test_git_clone_no_git_executable_with_path() {
     let invalid_git_executable_path = test_env.env_root().join("invalid").join("path");
     test_env.add_config(format!(
         "git.executable-path = {}",
-        to_toml_value(invalid_git_executable_path.to_str().unwrap())
+        to_toml_value(invalid_git_executable_path.as_str())
     ));
     let git_repo_path = test_env.env_root().join("source");
     let git_repo = git::init(git_repo_path);

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::fmt::Write as _;
-use std::path::Path;
 
+use camino::Utf8Path;
 use testutils::git;
 
 use crate::common::CommandOutput;
@@ -638,7 +638,7 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
         .success();
 
     let clone_dir = test_env.work_dir("clone");
-    git::clone(clone_dir.root(), origin_dir.root().to_str().unwrap(), None);
+    git::clone(clone_dir.root(), origin_dir.root().as_str(), None);
     clone_dir.run_jj(["git", "init", "--git-repo=."]).success();
     clone_dir.run_jj(["new", "A"]).success();
     insta::assert_snapshot!(get_log_output(&clone_dir), @r"
@@ -1411,7 +1411,7 @@ fn get_log_output(work_dir: &TestWorkDir) -> CommandOutput {
     work_dir.run_jj(["log", "-T", template, "-r=all()"])
 }
 
-fn update_git_index(repo_path: &Path) {
+fn update_git_index(repo_path: &Utf8Path) {
     let mut iter = git::open(repo_path)
         .status(gix::progress::Discard)
         .unwrap()
@@ -1431,7 +1431,7 @@ fn update_git_index(repo_path: &Path) {
         .unwrap();
 }
 
-fn get_index_state(repo_path: &Path) -> String {
+fn get_index_state(repo_path: &Utf8Path) -> String {
     let git_repo = gix::open(repo_path).expect("git repo should exist");
     let mut buffer = String::new();
     // We can't use the real time from disk, since it would change each time the

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use camino::Utf8Path;
 use testutils::git;
 
 use crate::common::create_commit;
@@ -74,7 +75,7 @@ fn clone_git_remote_into(
 ) -> gix::Repository {
     let upstream_path = test_env.env_root().join(upstream);
     let fork_path = test_env.env_root().join(fork);
-    let fork_repo = git::clone(&fork_path, upstream_path.to_str().unwrap(), Some(upstream));
+    let fork_repo = git::clone(&fork_path, upstream_path.as_str(), Some(upstream));
 
     // create local branch mirroring the upstream
     let upstream_head = fork_repo
@@ -1700,8 +1701,9 @@ fn test_git_fetch_preserve_commits_across_repos() {
     ");
 
     // merge fork/feature into the upstream/upstream
-    git::add_remote(upstream_repo.git_dir(), "fork", fork_path.to_str().unwrap());
-    git::fetch(upstream_repo.git_dir(), "fork");
+    let upstream_repo_git_dir = Utf8Path::from_path(upstream_repo.git_dir()).unwrap();
+    git::add_remote(upstream_repo_git_dir, "fork", fork_path.as_str());
+    git::fetch(upstream_repo_git_dir, "fork");
 
     let base_id = upstream_repo
         .find_reference("refs/heads/upstream")

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -39,7 +39,7 @@ fn set_up(test_env: &TestEnvironment) {
                 "git",
                 "clone",
                 "--config=git.auto-local-bookmark=true",
-                origin_git_repo_path.to_str().unwrap(),
+                origin_git_repo_path.as_str(),
                 "local",
             ],
         )
@@ -62,7 +62,7 @@ fn set_up_remote_at_main(test_env: &TestEnvironment, work_dir: &TestWorkDir, rem
             "remote",
             "add",
             remote_name,
-            other_git_repo_path.to_str().unwrap(),
+            other_git_repo_path.as_str(),
         ])
         .success();
     work_dir

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use camino::Utf8PathBuf;
 use testutils::git;
 
 use crate::common::CommandOutput;
 use crate::common::TestEnvironment;
 use crate::common::TestWorkDir;
 
-fn git_repo_dir_for_jj_repo(work_dir: &TestWorkDir<'_>) -> std::path::PathBuf {
+fn git_repo_dir_for_jj_repo(work_dir: &TestWorkDir<'_>) -> Utf8PathBuf {
     work_dir
         .root()
         .join(".jj")
@@ -53,7 +54,7 @@ fn set_up(test_env: &TestEnvironment) {
                 "git",
                 "clone",
                 "--config=git.auto-local-bookmark=true",
-                origin_git_repo_path.to_str().unwrap(),
+                origin_git_repo_path.as_str(),
                 "local",
             ],
         )
@@ -238,13 +239,7 @@ fn test_git_push_other_remote_has_bookmark() {
         .join("store")
         .join("git");
     work_dir
-        .run_jj([
-            "git",
-            "remote",
-            "add",
-            "other",
-            other_remote_path.to_str().unwrap(),
-        ])
+        .run_jj(["git", "remote", "add", "other", other_remote_path.as_str()])
         .success();
     // Modify bookmark1 and push it to `origin`
     work_dir.run_jj(["edit", "bookmark1"]).success();
@@ -1023,7 +1018,7 @@ fn test_git_push_changes_with_name_deleted_tracked() {
             "remote",
             "add",
             "another_remote",
-            another_remote_git_repo_path.to_str().unwrap(),
+            another_remote_git_repo_path.as_str(),
         ])
         .success();
     work_dir.run_jj(["describe", "-m", "foo"]).success();

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -14,15 +14,15 @@
 
 use std::fs;
 use std::io::Write as _;
-use std::path::Path;
-use std::path::PathBuf;
 
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use indoc::indoc;
 use testutils::git;
 
 use crate::common::TestEnvironment;
 
-fn read_git_config(repo_path: &Path) -> String {
+fn read_git_config(repo_path: &Utf8Path) -> String {
     let git_config = fs::read_to_string(repo_path.join(".jj/repo/store/git/config"))
         .or_else(|_| fs::read_to_string(repo_path.join(".git/config")))
         .unwrap();
@@ -188,9 +188,9 @@ fn test_git_remote_relative_path() {
     let work_dir = test_env.work_dir("repo");
 
     // Relative path using OS-native separator
-    let path = PathBuf::from_iter(["..", "native", "sep"]);
+    let path = Utf8PathBuf::from_iter(["..", "native", "sep"]);
     work_dir
-        .run_jj(["git", "remote", "add", "foo", path.to_str().unwrap()])
+        .run_jj(["git", "remote", "add", "foo", path.as_str()])
         .success();
     let output = work_dir.run_jj(["git", "remote", "list"]);
     insta::assert_snapshot!(output, @r"
@@ -478,7 +478,7 @@ fn test_git_remote_with_global_git_remote_config() {
     );
     test_env.add_env_var(
         "GIT_CONFIG_GLOBAL",
-        test_env.env_root().join("git-config").to_str().unwrap(),
+        test_env.env_root().join("git-config").as_str(),
     );
 
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_git_root.rs
+++ b/cli/tests/test_git_root.rs
@@ -73,7 +73,7 @@ fn test_git_root_git_backend_external_git_dir() {
             "git",
             "init",
             "--git-repo",
-            git_repo_work_dir.root().to_str().unwrap(),
+            git_repo_work_dir.root().as_str(),
         ])
         .success();
 

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -885,7 +885,7 @@ fn test_log_filtered_by_path() {
         [
             "log",
             "-R",
-            work_dir.root().to_str().unwrap(),
+            work_dir.root().as_str(),
             "-Tdescription",
             "-s",
             "root:file1",

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-use std::path::PathBuf;
-
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use itertools::Itertools as _;
 use regex::Regex;
 use testutils::git;
@@ -1011,7 +1010,7 @@ fn test_op_corrupted_operation_file() {
     let work_dir = test_env.work_dir("repo");
     let op_store_path = work_dir
         .root()
-        .join(PathBuf::from_iter([".jj", "repo", "op_store"]));
+        .join(Utf8PathBuf::from_iter([".jj", "repo", "op_store"]));
 
     let op_id = work_dir.current_operation_id();
     insta::assert_snapshot!(op_id, @"8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752");
@@ -2711,7 +2710,7 @@ fn test_op_show_patch() {
     ");
 }
 
-fn init_bare_git_repo(git_repo_path: &Path) -> gix::Repository {
+fn init_bare_git_repo(git_repo_path: &Utf8Path) -> gix::Repository {
     let git_repo = git::init_bare(git_repo_path);
     let commit_result = git::add_commit(
         &git_repo,

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-
+use camino::Utf8Path;
 use indoc::indoc;
 
 use crate::common::create_commit_with_files;
@@ -516,7 +515,7 @@ fn test_resolution() {
 
 fn check_resolve_produces_input_file(
     test_env: &mut TestEnvironment,
-    root: impl AsRef<Path>,
+    root: impl AsRef<Utf8Path>,
     filename: &str,
     role: &str,
     expected_content: &str,

--- a/cli/tests/test_root.rs
+++ b/cli/tests/test_root.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-
+use camino::Utf8Path;
 use test_case::test_case;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
@@ -29,16 +28,13 @@ fn test_root(backend: TestRepoBackend) {
     let subdir = root.join("subdir");
     std::fs::create_dir(&subdir).unwrap();
     let output = test_env.run_jj_in(&subdir, ["root"]).success();
-    assert_eq!(
-        output.stdout.raw(),
-        &[root.to_str().unwrap(), "\n"].concat()
-    );
+    assert_eq!(output.stdout.raw(), &[root.as_str(), "\n"].concat());
 }
 
 #[test]
 fn test_root_outside_a_repo() {
     let test_env = TestEnvironment::default();
-    let output = test_env.run_jj_in(Path::new("/"), ["root"]);
+    let output = test_env.run_jj_in(Utf8Path::new("/"), ["root"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: There is no jj repo in "."

--- a/cli/tests/test_sparse_command.rs
+++ b/cli/tests/test_sparse_command.rs
@@ -184,7 +184,7 @@ fn test_sparse_manage_patterns() {
 
 #[test]
 fn test_sparse_editor_avoids_unc() {
-    use std::path::PathBuf;
+    use camino::Utf8PathBuf;
 
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_editor();
@@ -195,9 +195,9 @@ fn test_sparse_editor_avoids_unc() {
     work_dir.run_jj(["sparse", "edit"]).success();
 
     let edited_path =
-        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+        Utf8PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
     // While `assert!(!edited_path.starts_with("//?/"))` could work here in most
     // cases, it fails when it is not safe to strip the prefix, such as paths
     // over 260 chars.
-    assert_eq!(edited_path, dunce::simplified(&edited_path));
+    assert_eq!(edited_path, dunce::simplified(edited_path.as_ref()));
 }

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use test_case::test_case;
 
 use crate::common::CommandOutput;
@@ -767,11 +766,11 @@ fn test_split_message_editor_avoids_unc() {
     work_dir.run_jj(["split", "file2"]).success();
 
     let edited_path =
-        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+        Utf8PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
     // While `assert!(!edited_path.starts_with("//?/"))` could work here in most
     // cases, it fails when it is not safe to strip the prefix, such as paths
     // over 260 chars.
-    assert_eq!(edited_path, dunce::simplified(&edited_path));
+    assert_eq!(edited_path, dunce::simplified(edited_path.as_ref()));
 }
 
 #[test]

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 use crate::common::CommandOutput;
 use crate::common::TestEnvironment;
@@ -1448,11 +1448,11 @@ fn test_squash_description_editor_avoids_unc() {
     work_dir.run_jj(["squash"]).success();
 
     let edited_path =
-        PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
+        Utf8PathBuf::from(std::fs::read_to_string(test_env.env_root().join("path")).unwrap());
     // While `assert!(!edited_path.starts_with("//?/"))` could work here in most
     // cases, it fails when it is not safe to strip the prefix, such as paths
     // over 260 chars.
-    assert_eq!(edited_path, dunce::simplified(&edited_path));
+    assert_eq!(edited_path, dunce::simplified(edited_path.as_ref()));
 }
 
 #[test]

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -260,7 +260,7 @@ fn test_git_push_undo_colocated() {
     let git_repo_path = test_env.env_root().join("git-repo");
     git::init_bare(git_repo_path.clone());
     let work_dir = test_env.work_dir("clone");
-    git::clone(work_dir.root(), git_repo_path.to_str().unwrap(), None);
+    git::clone(work_dir.root(), git_repo_path.as_str(), None);
 
     work_dir.run_jj(["git", "init", "--git-repo=."]).success();
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-types = [
+    { path = "std::path::Path", replacement = "camino::Utf8Path", reason = "Prefer UTF8-only counterpart" },
+    { path = "std::path::PathBuf", replacement = "camino::Utf8PathBuf", reason = "Prefer UTF8-only counterpart" },
+]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -36,6 +36,7 @@ version_check = { workspace = true }
 async-trait = { workspace = true }
 blake2 = { workspace = true }
 bstr = { workspace = true }
+camino = { workspace = true }
 chrono = { workspace = true }
 clru = { workspace = true }
 digest = { workspace = true }

--- a/lib/gen-protos/Cargo.toml
+++ b/lib/gen-protos/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+camino = { workspace = true }
 prost-build = { workspace = true }
 
 [lints]

--- a/lib/gen-protos/src/main.rs
+++ b/lib/gen-protos/src/main.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Result;
-use std::path::Path;
+use std::io;
 
-fn main() -> Result<()> {
+use camino::Utf8Path;
+
+fn main() -> io::Result<()> {
     let input = [
         "git_store.proto",
         "simple_store.proto",
@@ -23,7 +24,7 @@ fn main() -> Result<()> {
         "working_copy.proto",
     ];
 
-    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let root = Utf8Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
     let protos_dir = root.join("src").join("protos");
 
     prost_build::Config::new()

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -21,10 +21,10 @@ use std::collections::HashMap;
 use std::io;
 use std::io::Write as _;
 use std::ops::Bound;
-use std::path::Path;
 use std::sync::Arc;
 
 use blake2::Blake2b512;
+use camino::Utf8Path;
 use digest::Digest as _;
 use itertools::Itertools as _;
 use smallvec::smallvec;
@@ -348,11 +348,15 @@ impl MutableIndexSegment {
         squashed
     }
 
-    pub(super) fn save_in(self, dir: &Path) -> io::Result<Arc<ReadonlyIndexSegment>> {
+    pub(super) fn save_in(
+        self,
+        dir: impl AsRef<Utf8Path>,
+    ) -> io::Result<Arc<ReadonlyIndexSegment>> {
         if self.num_local_commits() == 0 && self.parent_file.is_some() {
             return Ok(self.parent_file.unwrap());
         }
 
+        let dir = dir.as_ref();
         let mut buf = Vec::new();
         buf.extend(INDEX_SEGMENT_FILE_FORMAT_VERSION.to_le_bytes());
         self.serialize_parent_filename(&mut buf);
@@ -479,7 +483,10 @@ impl DefaultMutableIndex {
         self.0.add_commit_data(commit_id, change_id, parent_ids);
     }
 
-    pub(super) fn squash_and_save_in(self, dir: &Path) -> io::Result<Arc<ReadonlyIndexSegment>> {
+    pub(super) fn squash_and_save_in(
+        self,
+        dir: impl AsRef<Utf8Path>,
+    ) -> io::Result<Arc<ReadonlyIndexSegment>> {
         self.0.maybe_squash_with_ancestors().save_in(dir)
     }
 }

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -21,9 +21,9 @@ use std::fmt::Formatter;
 use std::fs::File;
 use std::io;
 use std::io::Read;
-use std::path::Path;
 use std::sync::Arc;
 
+use camino::Utf8Path;
 use smallvec::smallvec;
 use thiserror::Error;
 
@@ -249,7 +249,7 @@ impl Debug for ReadonlyIndexSegment {
 impl ReadonlyIndexSegment {
     /// Loads both parent segments and local entries from the given file `name`.
     pub(super) fn load(
-        dir: &Path,
+        dir: &Utf8Path,
         name: String,
         commit_id_length: usize,
         change_id_length: usize,
@@ -262,7 +262,7 @@ impl ReadonlyIndexSegment {
     /// Loads both parent segments and local entries from the given `file`.
     pub(super) fn load_from(
         file: &mut dyn Read,
-        dir: &Path,
+        dir: &Utf8Path,
         name: String,
         commit_id_length: usize,
         change_id_length: usize,

--- a/lib/src/default_submodule_store.rs
+++ b/lib/src/default_submodule_store.rs
@@ -14,26 +14,26 @@
 
 #![allow(missing_docs)]
 
-use std::path::Path;
-use std::path::PathBuf;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 
 use crate::submodule_store::SubmoduleStore;
 
 #[derive(Debug)]
 pub struct DefaultSubmoduleStore {
     #[expect(dead_code)]
-    path: PathBuf,
+    path: Utf8PathBuf,
 }
 
 impl DefaultSubmoduleStore {
     /// Load an existing SubmoduleStore
-    pub fn load(store_path: &Path) -> Self {
+    pub fn load(store_path: &Utf8Path) -> Self {
         DefaultSubmoduleStore {
             path: store_path.to_path_buf(),
         }
     }
 
-    pub fn init(store_path: &Path) -> Self {
+    pub fn init(store_path: &Utf8Path) -> Self {
         DefaultSubmoduleStore {
             path: store_path.to_path_buf(),
         }

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -495,7 +495,7 @@ pub fn parse_maybe_bare(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use camino::Utf8PathBuf;
 
     use super::*;
 
@@ -526,8 +526,8 @@ mod tests {
         let settings = insta_settings();
         let _guard = settings.bind_to_scope();
         let path_converter = RepoPathUiConverter::Fs {
-            cwd: PathBuf::from("/ws/cur"),
-            base: PathBuf::from("/ws"),
+            cwd: Utf8PathBuf::from("/ws/cur"),
+            base: Utf8PathBuf::from("/ws"),
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
@@ -571,8 +571,8 @@ mod tests {
         let _guard = settings.bind_to_scope();
         let path_converter = RepoPathUiConverter::Fs {
             // meta character in cwd path shouldn't be expanded
-            cwd: PathBuf::from("/ws/cur*"),
-            base: PathBuf::from("/ws"),
+            cwd: Utf8PathBuf::from("/ws/cur*"),
+            base: Utf8PathBuf::from("/ws"),
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
@@ -744,8 +744,8 @@ mod tests {
         let settings = insta_settings();
         let _guard = settings.bind_to_scope();
         let path_converter = RepoPathUiConverter::Fs {
-            cwd: PathBuf::from("/ws/cur"),
-            base: PathBuf::from("/ws"),
+            cwd: Utf8PathBuf::from("/ws/cur"),
+            base: Utf8PathBuf::from("/ws"),
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
@@ -772,8 +772,8 @@ mod tests {
         let settings = insta_settings();
         let _guard = settings.bind_to_scope();
         let path_converter = RepoPathUiConverter::Fs {
-            cwd: PathBuf::from("/ws/cur"),
-            base: PathBuf::from("/ws"),
+            cwd: Utf8PathBuf::from("/ws/cur"),
+            base: Utf8PathBuf::from("/ws"),
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -16,8 +16,6 @@ use std::io;
 use std::io::BufReader;
 use std::io::Read;
 use std::num::NonZeroU32;
-use std::path::Path;
-use std::path::PathBuf;
 use std::process::Child;
 use std::process::Command;
 use std::process::Output;
@@ -25,6 +23,8 @@ use std::process::Stdio;
 use std::thread;
 
 use bstr::ByteSlice as _;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use itertools::Itertools as _;
 use thiserror::Error;
 
@@ -53,13 +53,13 @@ pub enum GitSubprocessError {
     NoSuchRepository(String),
     #[error("Could not execute the git process, found in the OS path '{path}'")]
     SpawnInPath {
-        path: PathBuf,
+        path: Utf8PathBuf,
         #[source]
         error: std::io::Error,
     },
     #[error("Could not execute git process at specified path '{path}'")]
     Spawn {
-        path: PathBuf,
+        path: Utf8PathBuf,
         #[source]
         error: std::io::Error,
     },
@@ -76,21 +76,22 @@ pub enum GitSubprocessError {
 
 /// Context for creating Git subprocesses
 pub(crate) struct GitSubprocessContext<'a> {
-    git_dir: PathBuf,
-    git_executable_path: &'a Path,
+    git_dir: Utf8PathBuf,
+    git_executable_path: &'a Utf8Path,
 }
 
 impl<'a> GitSubprocessContext<'a> {
-    pub(crate) fn new(git_dir: impl Into<PathBuf>, git_executable_path: &'a Path) -> Self {
+    pub(crate) fn new(git_dir: &Utf8Path, git_executable_path: &'a Utf8Path) -> Self {
+        let git_dir = git_dir.to_path_buf();
         GitSubprocessContext {
-            git_dir: git_dir.into(),
+            git_dir,
             git_executable_path,
         }
     }
 
     pub(crate) fn from_git_backend(
         git_backend: &GitBackend,
-        git_executable_path: &'a Path,
+        git_executable_path: &'a Utf8Path,
     ) -> Self {
         Self::new(git_backend.git_repo_path(), git_executable_path)
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -110,6 +110,7 @@ pub mod stacked_table;
 pub mod store;
 pub mod str_util;
 pub mod submodule_store;
+pub mod tempdir;
 #[cfg(feature = "testing")]
 pub mod test_signing_backend;
 pub mod time_util;
@@ -124,14 +125,15 @@ pub mod workspace;
 
 #[cfg(test)]
 mod tests {
-    use tempfile::TempDir;
 
     /// Unlike `testutils::new_temp_dir()`, this function doesn't set up
     /// hermetic Git environment.
-    pub fn new_temp_dir() -> TempDir {
+    pub fn new_temp_dir() -> super::tempdir::Utf8TempDir {
         tempfile::Builder::new()
             .prefix("jj-test-")
             .tempdir()
+            .unwrap()
+            .try_into()
             .unwrap()
     }
 }

--- a/lib/src/lock/fallback.rs
+++ b/lib/src/lock/fallback.rs
@@ -14,15 +14,15 @@
 
 use std::fs::File;
 use std::fs::OpenOptions;
-use std::path::PathBuf;
 use std::time::Duration;
 
+use camino::Utf8PathBuf;
 use tracing::instrument;
 
 use super::FileLockError;
 
 pub struct FileLock {
-    path: PathBuf,
+    path: Utf8PathBuf,
     _file: File,
 }
 
@@ -58,7 +58,7 @@ impl Iterator for BackoffIterator {
 // Suppress warning on platforms where specialized lock impl is available
 #[cfg_attr(unix, allow(dead_code))]
 impl FileLock {
-    pub fn lock(path: PathBuf) -> Result<FileLock, FileLockError> {
+    pub fn lock(path: Utf8PathBuf) -> Result<FileLock, FileLockError> {
         let mut options = OpenOptions::new();
         options.create_new(true);
         options.write(true);

--- a/lib/src/lock/mod.rs
+++ b/lib/src/lock/mod.rs
@@ -19,8 +19,8 @@ mod fallback;
 mod unix;
 
 use std::io;
-use std::path::PathBuf;
 
+use camino::Utf8PathBuf;
 use thiserror::Error;
 
 #[cfg(not(unix))]
@@ -32,7 +32,7 @@ pub use self::unix::FileLock;
 #[error("{message}: {path}")]
 pub struct FileLockError {
     pub message: &'static str,
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
     #[source]
     pub err: io::Error,
 }
@@ -51,7 +51,7 @@ mod tests {
 
     #[test_case(FileLock::lock)]
     #[cfg_attr(unix, test_case(fallback::FileLock::lock))]
-    fn lock_basic<T>(lock_fn: fn(PathBuf) -> Result<T, FileLockError>) {
+    fn lock_basic<T>(lock_fn: fn(Utf8PathBuf) -> Result<T, FileLockError>) {
         let temp_dir = new_temp_dir();
         let lock_path = temp_dir.path().join("test.lock");
         assert!(!lock_path.exists());
@@ -64,7 +64,7 @@ mod tests {
 
     #[test_case(FileLock::lock)]
     #[cfg_attr(unix, test_case(fallback::FileLock::lock))]
-    fn lock_concurrent<T>(lock_fn: fn(PathBuf) -> Result<T, FileLockError>) {
+    fn lock_concurrent<T>(lock_fn: fn(Utf8PathBuf) -> Result<T, FileLockError>) {
         let temp_dir = new_temp_dir();
         let data_path = temp_dir.path().join("test");
         let lock_path = temp_dir.path().join("test.lock");

--- a/lib/src/lock/unix.rs
+++ b/lib/src/lock/unix.rs
@@ -15,20 +15,20 @@
 #![allow(missing_docs)]
 
 use std::fs::File;
-use std::path::PathBuf;
 
+use camino::Utf8PathBuf;
 use rustix::fs::FlockOperation;
 use tracing::instrument;
 
 use super::FileLockError;
 
 pub struct FileLock {
-    path: PathBuf,
+    path: Utf8PathBuf,
     file: File,
 }
 
 impl FileLock {
-    pub fn lock(path: PathBuf) -> Result<FileLock, FileLockError> {
+    pub fn lock(path: Utf8PathBuf) -> Result<FileLock, FileLockError> {
         loop {
             // Create lockfile, or open pre-existing one
             let file = File::create(&path).map_err(|err| FileLockError {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3090,9 +3090,8 @@ pub fn format_remote_symbol(name: &str, remote: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use assert_matches::assert_matches;
+    use camino::Utf8PathBuf;
 
     use super::*;
 
@@ -3133,8 +3132,8 @@ mod tests {
     ) -> Result<Rc<UserRevsetExpression>, RevsetParseError> {
         // Set up pseudo context to resolve `workspace_name@` and `file(path)`
         let path_converter = RepoPathUiConverter::Fs {
-            cwd: PathBuf::from("/"),
-            base: PathBuf::from("/"),
+            cwd: Utf8PathBuf::from("/"),
+            base: Utf8PathBuf::from("/"),
         };
         let workspace_ctx = RevsetWorkspaceContext {
             path_converter: &path_converter,

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -15,11 +15,11 @@
 //! Provides a backend for testing ACLs
 
 use std::any::Any;
-use std::path::Path;
 use std::pin::Pin;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use camino::Utf8Path;
 use futures::stream::BoxStream;
 use tokio::io::AsyncRead;
 
@@ -67,14 +67,14 @@ impl SecretBackend {
     }
 
     /// Loads the backend from the given path.
-    pub fn load(settings: &UserSettings, store_path: &Path) -> Result<Self, BackendLoadError> {
+    pub fn load(settings: &UserSettings, store_path: &Utf8Path) -> Result<Self, BackendLoadError> {
         let inner = GitBackend::load(settings, store_path)?;
         Ok(SecretBackend { inner })
     }
 
     /// Convert a git repo to using `SecretBackend`
     // TODO: Avoid this hack
-    pub fn adopt_git_repo(workspace_path: &Path) {
+    pub fn adopt_git_repo(workspace_path: &Utf8Path) {
         std::fs::write(
             workspace_path
                 .join(".jj")

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -14,11 +14,11 @@
 
 #![allow(missing_docs)]
 
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use camino::Utf8PathBuf;
 use chrono::DateTime;
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
@@ -61,7 +61,7 @@ struct UserSettingsData {
 pub struct GitSettings {
     pub auto_local_bookmark: bool,
     pub abandon_unreachable_commits: bool,
-    pub executable_path: PathBuf,
+    pub executable_path: Utf8PathBuf,
     pub write_change_id_header: bool,
 }
 
@@ -81,7 +81,7 @@ impl Default for GitSettings {
         GitSettings {
             auto_local_bookmark: false,
             abandon_unreachable_commits: true,
-            executable_path: PathBuf::from("git"),
+            executable_path: Utf8PathBuf::from("git"),
             write_change_id_header: true,
         }
     }

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -21,14 +21,14 @@ use std::fs::File;
 use std::io::Cursor;
 use std::io::Read as _;
 use std::io::Write as _;
-use std::path::Path;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
 use blake2::Blake2b512;
 use blake2::Digest as _;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use futures::stream;
 use futures::stream::BoxStream;
 use pollster::FutureExt as _;
@@ -95,7 +95,7 @@ fn to_other_err(err: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Bac
 
 #[derive(Debug)]
 pub struct SimpleBackend {
-    path: PathBuf,
+    path: Utf8PathBuf,
     root_commit_id: CommitId,
     root_change_id: ChangeId,
     empty_tree_id: TreeId,
@@ -106,7 +106,7 @@ impl SimpleBackend {
         "Simple"
     }
 
-    pub fn init(store_path: &Path) -> Self {
+    pub fn init(store_path: &Utf8Path) -> Self {
         fs::create_dir(store_path.join("commits")).unwrap();
         fs::create_dir(store_path.join("trees")).unwrap();
         fs::create_dir(store_path.join("files")).unwrap();
@@ -121,7 +121,7 @@ impl SimpleBackend {
         backend
     }
 
-    pub fn load(store_path: &Path) -> Self {
+    pub fn load(store_path: &Utf8Path) -> Self {
         let root_commit_id = CommitId::from_bytes(&[0; COMMIT_ID_LENGTH]);
         let root_change_id = ChangeId::from_bytes(&[0; CHANGE_ID_LENGTH]);
         let empty_tree_id = TreeId::from_hex(
@@ -135,23 +135,23 @@ impl SimpleBackend {
         }
     }
 
-    fn file_path(&self, id: &FileId) -> PathBuf {
+    fn file_path(&self, id: &FileId) -> Utf8PathBuf {
         self.path.join("files").join(id.hex())
     }
 
-    fn symlink_path(&self, id: &SymlinkId) -> PathBuf {
+    fn symlink_path(&self, id: &SymlinkId) -> Utf8PathBuf {
         self.path.join("symlinks").join(id.hex())
     }
 
-    fn tree_path(&self, id: &TreeId) -> PathBuf {
+    fn tree_path(&self, id: &TreeId) -> Utf8PathBuf {
         self.path.join("trees").join(id.hex())
     }
 
-    fn commit_path(&self, id: &CommitId) -> PathBuf {
+    fn commit_path(&self, id: &CommitId) -> Utf8PathBuf {
         self.path.join("commits").join(id.hex())
     }
 
-    fn conflict_path(&self, id: &ConflictId) -> PathBuf {
+    fn conflict_path(&self, id: &ConflictId) -> Utf8PathBuf {
         self.path.join("conflicts").join(id.hex())
     }
 }

--- a/lib/src/simple_op_heads_store.rs
+++ b/lib/src/simple_op_heads_store.rs
@@ -19,9 +19,9 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fs;
 use std::io;
-use std::path::Path;
-use std::path::PathBuf;
 
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use thiserror::Error;
 
 use crate::backend::BackendInitError;
@@ -46,7 +46,7 @@ impl From<SimpleOpHeadsStoreInitError> for BackendInitError {
 }
 
 pub struct SimpleOpHeadsStore {
-    dir: PathBuf,
+    dir: Utf8PathBuf,
 }
 
 impl Debug for SimpleOpHeadsStore {
@@ -62,13 +62,13 @@ impl SimpleOpHeadsStore {
         "simple_op_heads_store"
     }
 
-    pub fn init(dir: &Path) -> Result<Self, SimpleOpHeadsStoreInitError> {
+    pub fn init(dir: &Utf8Path) -> Result<Self, SimpleOpHeadsStoreInitError> {
         let op_heads_dir = dir.join("heads");
         fs::create_dir(&op_heads_dir).context(&op_heads_dir)?;
         Ok(Self { dir: op_heads_dir })
     }
 
-    pub fn load(dir: &Path) -> Self {
+    pub fn load(dir: &Utf8Path) -> Self {
         let op_heads_dir = dir.join("heads");
         Self { dir: op_heads_dir }
     }

--- a/lib/src/stacked_table.rs
+++ b/lib/src/stacked_table.rs
@@ -29,12 +29,12 @@ use std::fs::File;
 use std::io;
 use std::io::Read;
 use std::io::Write as _;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
 
 use blake2::Blake2b512;
 use blake2::Digest as _;
+use camino::Utf8PathBuf;
 use tempfile::NamedTempFile;
 use thiserror::Error;
 
@@ -399,13 +399,13 @@ pub enum TableStoreError {
 pub type TableStoreResult<T> = Result<T, TableStoreError>;
 
 pub struct TableStore {
-    dir: PathBuf,
+    dir: Utf8PathBuf,
     key_size: usize,
     cached_tables: RwLock<HashMap<String, Arc<ReadonlyTable>>>,
 }
 
 impl TableStore {
-    pub fn init(dir: PathBuf, key_size: usize) -> Self {
+    pub fn init(dir: Utf8PathBuf, key_size: usize) -> Self {
         std::fs::create_dir(dir.join("heads")).unwrap();
         TableStore {
             dir,
@@ -423,7 +423,7 @@ impl TableStore {
         self.key_size
     }
 
-    pub fn load(dir: PathBuf, key_size: usize) -> Self {
+    pub fn load(dir: Utf8PathBuf, key_size: usize) -> Self {
         TableStore {
             dir,
             key_size,

--- a/lib/src/tempdir.rs
+++ b/lib/src/tempdir.rs
@@ -1,0 +1,181 @@
+// Copyright 2024 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides UTF-8 `tempfile::TempDir` counterpart.
+
+use std::io;
+use std::ops;
+
+use camino::FromPathBufError;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use tempfile::NamedTempFile;
+use tempfile::PersistError;
+use tempfile::TempDir;
+
+/// UTF-8 valid `tempfile::env::temp_dir` counterpart
+pub fn temp_dir() -> io::Result<Utf8PathBuf> {
+    tempfile::env::temp_dir()
+        .try_into()
+        .map_err(|err: FromPathBufError| err.into_io_error())
+}
+
+/// UTF-8 valid `tempfile::NamedTempFile` counterpart
+#[derive(Debug)]
+pub struct Utf8NamedTempFile<F = std::fs::File> {
+    path: Utf8PathBuf,
+    temp: NamedTempFile<F>,
+}
+
+impl<F> Utf8NamedTempFile<F> {
+    /// Access underlying `Utf8Path`
+    pub fn path(&self) -> &Utf8Path {
+        self.path.as_path()
+    }
+
+    /// Access underlying `tempfile::NamedTempFile`
+    pub fn temp(&self) -> &NamedTempFile<F> {
+        &self.temp
+    }
+
+    /// UTF-8 counterpart of `tempfile::NamedTempFile::keep`
+    pub fn keep(self) -> Result<(F, Utf8PathBuf), PersistError<F>> {
+        self.temp.keep().map(|(f, _path)| (f, self.path))
+    }
+}
+
+impl<F> TryFrom<NamedTempFile<F>> for Utf8NamedTempFile<F> {
+    type Error = io::Error;
+
+    fn try_from(temp: NamedTempFile<F>) -> Result<Self, Self::Error> {
+        temp.path()
+            .to_path_buf()
+            .try_into()
+            .map(|path| Self { path, temp })
+            .map_err(|err| err.into_io_error())
+    }
+}
+
+impl AsRef<Utf8Path> for Utf8NamedTempFile {
+    fn as_ref(&self) -> &Utf8Path {
+        &self.path
+    }
+}
+
+impl AsRef<NamedTempFile> for Utf8NamedTempFile {
+    fn as_ref(&self) -> &NamedTempFile {
+        &self.temp
+    }
+}
+
+impl AsMut<NamedTempFile> for Utf8NamedTempFile {
+    fn as_mut(&mut self) -> &mut NamedTempFile {
+        &mut self.temp
+    }
+}
+
+impl ops::Deref for Utf8NamedTempFile {
+    type Target = NamedTempFile;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl ops::DerefMut for Utf8NamedTempFile {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut()
+    }
+}
+
+/// UTF-8 valid `tempfile::TempDir` counterpart
+#[derive(Debug)]
+pub struct Utf8TempDir {
+    path: Utf8PathBuf,
+    temp: TempDir,
+}
+
+impl Utf8TempDir {
+    /// Creates new `Utf8TempDir` object
+    pub fn new() -> io::Result<Self> {
+        let temp = TempDir::new()?;
+        temp.path()
+            .to_path_buf()
+            .try_into()
+            .map(|dir| Self { path: dir, temp })
+            .map_err(|err| err.into_io_error())
+    }
+
+    /// Access underlying `Utf8Path`
+    pub fn path(&self) -> &Utf8Path {
+        self.path.as_path()
+    }
+
+    /// Access underlying `tempfile::Tempdir`
+    pub fn temp(&self) -> &tempfile::TempDir {
+        &self.temp
+    }
+
+    /// Creates new `Utf8TempDir` from `tempfile::TempDir` containing valid
+    /// UTF-8 characters.
+    ///
+    /// Errors with the original `tempfile::TempDir` if it is not valid UTF-8.
+    pub fn from_tempdir(temp: TempDir) -> Result<Self, TempDir> {
+        if let Some(path) = Utf8Path::from_path(temp.path()) {
+            let dir = path.to_path_buf();
+            Ok(Self { path: dir, temp })
+        } else {
+            Err(temp)
+        }
+    }
+}
+
+impl TryFrom<TempDir> for Utf8TempDir {
+    type Error = io::Error;
+
+    fn try_from(temp: TempDir) -> Result<Self, Self::Error> {
+        temp.path()
+            .to_path_buf()
+            .try_into()
+            .map(|path| Self { path, temp })
+            .map_err(|err| err.into_io_error())
+    }
+}
+
+impl AsRef<Utf8Path> for Utf8TempDir {
+    fn as_ref(&self) -> &Utf8Path {
+        self.path()
+    }
+}
+
+impl AsRef<TempDir> for Utf8TempDir {
+    fn as_ref(&self) -> &tempfile::TempDir {
+        self.temp()
+    }
+}
+
+#[expect(clippy::disallowed_types)]
+impl AsRef<std::path::Path> for Utf8TempDir {
+    fn as_ref(&self) -> &std::path::Path {
+        self.path().as_std_path()
+    }
+}
+
+impl ops::Deref for Utf8TempDir {
+    type Target = Utf8Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -18,9 +18,9 @@
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::path::PathBuf;
 use std::sync::Arc;
 
+use camino::Utf8PathBuf;
 use itertools::Itertools as _;
 use thiserror::Error;
 use tracing::instrument;
@@ -84,8 +84,8 @@ pub trait WorkingCopyFactory {
     fn init_working_copy(
         &self,
         store: Arc<Store>,
-        working_copy_path: PathBuf,
-        state_path: PathBuf,
+        working_copy_path: Utf8PathBuf,
+        state_path: Utf8PathBuf,
         operation_id: OperationId,
         workspace_name: WorkspaceNameBuf,
     ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError>;
@@ -94,8 +94,8 @@ pub trait WorkingCopyFactory {
     fn load_working_copy(
         &self,
         store: Arc<Store>,
-        working_copy_path: PathBuf,
-        state_path: PathBuf,
+        working_copy_path: Utf8PathBuf,
+        state_path: Utf8PathBuf,
     ) -> Result<Box<dyn WorkingCopy>, WorkingCopyStateError>;
 }
 
@@ -176,7 +176,7 @@ pub enum SnapshotError {
     InvalidUtf8SymlinkTarget {
         /// The path of the symlink that has a target that's not valid UTF-8.
         /// This path itself is valid UTF-8.
-        path: PathBuf,
+        path: Utf8PathBuf,
     },
     /// Reading or writing from the commit backend failed.
     #[error(transparent)]
@@ -316,7 +316,7 @@ pub enum CheckoutError {
     #[error("Reserved path component {name} in {path}")]
     ReservedPathComponent {
         /// The file or directory path.
-        path: PathBuf,
+        path: Utf8PathBuf,
         /// The reserved path component.
         name: &'static str,
     },

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 
 #[test]
 fn test_no_forgotten_test_files() {
-    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let test_dir = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
     testutils::assert_no_forgotten_test_files(&test_dir);
 }
 

--- a/lib/tests/test_git_backend.rs
+++ b/lib/tests/test_git_backend.rs
@@ -14,11 +14,11 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 
+use camino::Utf8Path;
 use futures::executor::block_on_stream;
 use jj_lib::backend::CommitId;
 use jj_lib::backend::CopyRecord;
@@ -52,7 +52,7 @@ fn get_git_backend(repo: &Arc<ReadonlyRepo>) -> &GitBackend {
         .unwrap()
 }
 
-fn collect_no_gc_refs(git_repo_path: &Path) -> HashSet<CommitId> {
+fn collect_no_gc_refs(git_repo_path: &Utf8Path) -> HashSet<CommitId> {
     // Load fresh git repo to isolate from false caching issue. Here we want to
     // ensure that the underlying data is correct. We could test the in-memory
     // data as well, but we don't have any special handling in our code.

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-use std::path::PathBuf;
-
 use assert_matches::assert_matches;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use jj_lib::config::StackedConfig;
+use jj_lib::file_util::canonicalize_path;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::ref_name::WorkspaceName;
 use jj_lib::repo::Repo as _;
@@ -28,9 +28,9 @@ use testutils::write_random_commit;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
 
-fn canonicalize(input: &Path) -> (PathBuf, PathBuf) {
+fn canonicalize(input: &Utf8Path) -> (Utf8PathBuf, Utf8PathBuf) {
     let uncanonical = input.join("..").join(input.file_name().unwrap());
-    let canonical = dunce::canonicalize(&uncanonical).unwrap();
+    let canonical = canonicalize_path(&uncanonical).unwrap();
     (canonical, uncanonical)
 }
 
@@ -67,7 +67,7 @@ fn test_init_internal_git() {
     assert_eq!(workspace.workspace_root(), &canonical);
     assert_eq!(
         git_backend.git_repo_path(),
-        canonical.join(PathBuf::from_iter([".jj", "repo", "store", "git"])),
+        canonical.join(Utf8PathBuf::from_iter([".jj", "repo", "store", "git"])),
     );
     assert!(git_backend.git_workdir().is_none());
     assert_eq!(

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -16,11 +16,11 @@
 use std::os::unix::fs::PermissionsExt as _;
 #[cfg(unix)]
 use std::os::unix::net::UnixListener;
-use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use indoc::indoc;
 use itertools::Itertools as _;
 use jj_lib::backend::CopyId;
@@ -64,7 +64,7 @@ use testutils::write_random_commit;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
 
-fn check_icase_fs(dir: &Path) -> bool {
+fn check_icase_fs(dir: &Utf8Path) -> bool {
     let test_file = tempfile::Builder::new()
         .prefix("icase-")
         .tempfile_in(dir)
@@ -77,7 +77,7 @@ fn check_icase_fs(dir: &Path) -> bool {
 
 /// Returns true if the directory appears to ignore some unicode zero-width
 /// characters, as in HFS+.
-fn check_hfs_plus(dir: &Path) -> bool {
+fn check_hfs_plus(dir: &Utf8Path) -> bool {
     let test_file = tempfile::Builder::new()
         .prefix("hfs-plus-\u{200c}-")
         .tempfile_in(dir)
@@ -89,7 +89,7 @@ fn check_hfs_plus(dir: &Path) -> bool {
 }
 
 /// Returns true if the directory appears to support Windows short file names.
-fn check_vfat(dir: &Path) -> bool {
+fn check_vfat(dir: &Utf8Path) -> bool {
     let _test_file = tempfile::Builder::new()
         .prefix("vfattest-")
         .tempfile_in(dir)
@@ -1347,7 +1347,7 @@ fn test_git_submodule(gitignore_content: &str) {
     let store = repo.store().clone();
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
     let base_ignores = GitIgnoreFile::empty()
-        .chain("", Path::new(""), gitignore_content.as_bytes())
+        .chain("", Utf8Path::new(""), gitignore_content.as_bytes())
         .unwrap();
     let snapshot_options = SnapshotOptions {
         base_ignores,
@@ -1632,7 +1632,7 @@ fn test_check_out_existing_file_symlink_icase_fs(victim_exists: bool) {
     // Creates a symlink in working directory, and a tree that will overwrite
     // the symlink content.
     try_symlink(
-        PathBuf::from_iter(["..", "pwned"]),
+        Utf8PathBuf::from_iter(["..", "pwned"]),
         workspace_root.join("parent"),
     )
     .unwrap();
@@ -2087,7 +2087,7 @@ fn test_fsmonitor() {
     let snapshot = |locked_ws: &mut LockedWorkspace, paths: &[&RepoPath]| {
         let fs_paths = paths
             .iter()
-            .map(|p| p.to_fs_path_unchecked(Path::new("")))
+            .map(|p| p.to_fs_path_unchecked(Utf8Path::new("")))
             .collect();
         let (tree_id, _stats) = locked_ws
             .locked_wc()

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
 use std::slice;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use assert_matches::assert_matches;
+use camino::Utf8Path;
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 use jj_lib::config::ConfigLayer;
@@ -35,10 +35,10 @@ use testutils::create_random_commit;
 use testutils::write_random_commit;
 use testutils::TestRepo;
 
-fn list_dir(dir: &Path) -> Vec<String> {
-    std::fs::read_dir(dir)
+fn list_dir(dir: &Utf8Path) -> Vec<String> {
+    dir.read_dir_utf8()
         .unwrap()
-        .map(|entry| entry.unwrap().file_name().to_str().unwrap().to_owned())
+        .map(|entry| entry.unwrap().file_name().to_owned())
         .sorted()
         .collect()
 }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -14,9 +14,9 @@
 
 use std::collections::HashMap;
 use std::iter;
-use std::path::Path;
 
 use assert_matches::assert_matches;
+use camino::Utf8Path;
 use chrono::DateTime;
 use itertools::Itertools as _;
 use jj_lib::backend::ChangeId;
@@ -929,7 +929,7 @@ fn resolve_commit_ids_in_workspace(
     repo: &dyn Repo,
     revset_str: &str,
     workspace: &Workspace,
-    cwd: Option<&Path>,
+    cwd: Option<&Utf8Path>,
 ) -> Vec<CommitId> {
     let settings = testutils::user_settings();
     let path_converter = RepoPathUiConverter::Fs {

--- a/lib/testutils/Cargo.toml
+++ b/lib/testutils/Cargo.toml
@@ -17,6 +17,7 @@ readme = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 bstr = { workspace = true }
+camino = { workspace = true }
 futures = { workspace = true }
 gix = { workspace = true, features = [
     "status",

--- a/lib/testutils/src/git.rs
+++ b/lib/testutils/src/git.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-use std::path::PathBuf;
-
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use gix::date::parse::TimeBuf;
 
 pub const GIT_USER: &str = "Someone";
@@ -34,13 +33,13 @@ fn open_options() -> gix::open::Options {
         .strict_config(true)
 }
 
-pub fn open(directory: impl Into<PathBuf>) -> gix::Repository {
-    gix::open_opts(directory, open_options()).unwrap()
+pub fn open(directory: impl Into<Utf8PathBuf>) -> gix::Repository {
+    gix::open_opts(directory.into(), open_options()).unwrap()
 }
 
-pub fn init(directory: impl AsRef<Path>) -> gix::Repository {
+pub fn init(directory: impl AsRef<Utf8Path>) -> gix::Repository {
     gix::ThreadSafeRepository::init_opts(
-        directory,
+        directory.as_ref(),
         gix::create::Kind::WithWorktree,
         gix::create::Options::default(),
         open_options(),
@@ -49,9 +48,9 @@ pub fn init(directory: impl AsRef<Path>) -> gix::Repository {
     .to_thread_local()
 }
 
-pub fn init_bare(directory: impl AsRef<Path>) -> gix::Repository {
+pub fn init_bare(directory: impl AsRef<Utf8Path>) -> gix::Repository {
     gix::ThreadSafeRepository::init_opts(
-        directory,
+        directory.as_ref(),
         gix::create::Kind::Bare,
         gix::create::Options::default(),
         open_options(),
@@ -60,7 +59,7 @@ pub fn init_bare(directory: impl AsRef<Path>) -> gix::Repository {
     .to_thread_local()
 }
 
-pub fn clone(dest_path: &Path, repo_url: &str, remote_name: Option<&str>) -> gix::Repository {
+pub fn clone(dest_path: &Utf8Path, repo_url: &str, remote_name: Option<&str>) -> gix::Repository {
     let remote_name = remote_name.unwrap_or("origin");
     // gitoxide doesn't write the remote HEAD as a symbolic link, which prevents
     // `jj` from getting it.
@@ -84,13 +83,9 @@ pub fn clone(dest_path: &Path, repo_url: &str, remote_name: Option<&str>) -> gix
 }
 
 /// Writes out gitlink entry pointing to the `target_repo`.
-pub fn create_gitlink(src_repo: impl AsRef<Path>, target_repo: impl AsRef<Path>) {
+pub fn create_gitlink(src_repo: impl AsRef<Utf8Path>, target_repo: impl AsRef<Utf8Path>) {
     let git_link_path = src_repo.as_ref().join(".git");
-    std::fs::write(
-        git_link_path,
-        format!("gitdir: {}\n", target_repo.as_ref().display()),
-    )
-    .unwrap();
+    std::fs::write(git_link_path, format!("gitdir: {}\n", target_repo.as_ref())).unwrap();
 }
 
 pub fn remove_config_value(mut repo: gix::Repository, section: &str, key: &str) {
@@ -356,9 +351,9 @@ impl<'a> IndexManager<'a> {
     }
 }
 
-pub fn add_remote(repo_dir: impl AsRef<Path>, remote_name: &str, url: &str) {
+pub fn add_remote(repo_dir: impl AsRef<Utf8Path>, remote_name: &str, url: &str) {
     let output = std::process::Command::new("git")
-        .current_dir(repo_dir)
+        .current_dir(repo_dir.as_ref())
         .args(["remote", "add", remote_name, url])
         .output()
         .unwrap();
@@ -371,9 +366,9 @@ pub fn add_remote(repo_dir: impl AsRef<Path>, remote_name: &str, url: &str) {
     );
 }
 
-pub fn rename_remote(repo_dir: impl AsRef<Path>, original: &str, new: &str) {
+pub fn rename_remote(repo_dir: impl AsRef<Utf8Path>, original: &str, new: &str) {
     let output = std::process::Command::new("git")
-        .current_dir(repo_dir)
+        .current_dir(repo_dir.as_ref())
         .args(["remote", "rename", original, new])
         .output()
         .unwrap();
@@ -386,9 +381,9 @@ pub fn rename_remote(repo_dir: impl AsRef<Path>, original: &str, new: &str) {
     );
 }
 
-pub fn fetch(repo_dir: impl AsRef<Path>, remote: &str) {
+pub fn fetch(repo_dir: impl AsRef<Utf8Path>, remote: &str) {
     let output = std::process::Command::new("git")
-        .current_dir(repo_dir)
+        .current_dir(repo_dir.as_ref())
         .args(["fetch", remote])
         .output()
         .unwrap();

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -18,8 +18,6 @@ use std::fmt::Debug;
 use std::fmt::Error;
 use std::fmt::Formatter;
 use std::io::Cursor;
-use std::path::Path;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -27,6 +25,8 @@ use std::sync::MutexGuard;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use futures::stream;
 use futures::stream::BoxStream;
 use jj_lib::backend::make_root_commit;
@@ -62,7 +62,7 @@ const CHANGE_ID_LENGTH: usize = 16;
 // rely on on the file system to resolve two different uncanonicalized paths to
 // the same real path (as we would if we just used the path with `std::fs`
 // functions).
-type TestBackendDataMap = HashMap<PathBuf, Arc<Mutex<TestBackendData>>>;
+type TestBackendDataMap = HashMap<Utf8PathBuf, Arc<Mutex<TestBackendData>>>;
 
 #[derive(Default)]
 pub struct TestBackendData {
@@ -80,21 +80,21 @@ pub struct TestBackendFactory {
 }
 
 impl TestBackendFactory {
-    pub fn init(&self, store_path: &Path) -> TestBackend {
+    pub fn init(&self, store_path: &Utf8Path) -> TestBackend {
         let data = Arc::new(Mutex::new(TestBackendData::default()));
         self.backend_data
             .lock()
             .unwrap()
-            .insert(store_path.canonicalize().unwrap(), data.clone());
+            .insert(store_path.canonicalize_utf8().unwrap(), data.clone());
         TestBackend::with_data(data)
     }
 
-    pub fn load(&self, store_path: &Path) -> TestBackend {
+    pub fn load(&self, store_path: &Utf8Path) -> TestBackend {
         let data = self
             .backend_data
             .lock()
             .unwrap()
-            .get(&store_path.canonicalize().unwrap())
+            .get(&store_path.canonicalize_utf8().unwrap())
             .unwrap()
             .clone();
         TestBackend::with_data(data)


### PR DESCRIPTION
This is experimental migration to `camino` for UTF-8 valid path handling. The purpose is to use this PR to get discussion going (see #6808)