### PR TITLE
status: omit untracked files with --ignore-untracked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Log node templates are now specified in toml rather than hardcoded.
 
+* `jj status` now accepts `--ignore-untracked` to hide the "Untracked paths"
+  section.
+
 ### Fixed bugs
 
 * `jj file annotate` can now process files at a hidden revision.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2544,13 +2544,17 @@ This includes:
 
 [Conflicted bookmarks]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
 
-**Usage:** `jj status [FILESETS]...`
+**Usage:** `jj status [OPTIONS] [FILESETS]...`
 
 **Command Alias:** `st`
 
 ###### **Arguments:**
 
 * `<FILESETS>` — Restrict the status display to these paths
+
+###### **Options:**
+
+* `--ignore-untracked` — Ignore untracked files
 
 
 


### PR DESCRIPTION
I have a repo with a lot of untracked files, so `jj st` displays many untracked paths. This hides these paths. There were a lot of alternatives I considered, but I went for the simplest solution:

1. What should the option be named? `--ignore-untracked`? `--hide-untracked`? `--no-untracked`? `--only-tracked`? `--tracked-only`?
1. Should the default change to ignore untracked files instead? In which case this would be `--keep-untracked`, `--include-untracked`, ...
1. Instead of a boolean, we could have `--untracked-paths-limit <n>`, so users have an overview of untracked files without it being overwhelming.
1. Instead of only hiding files in the output of `jj status`, we could instead modify the implementation of `workspace_helper_with_stats()` to completely ignore untracked paths, which I assume could speed up the command if there are many untracked files. After a quick look at `workspace_helper_with_stats()`, this seems much harder to implement.
1. Instead of displaying "4 untracked paths ignored", we could display nothing, or "Untracked paths: 4", or "Ignored 4 untracked paths".

Feel free to comment on any of the above points (or any other point), I'm absolutely fine with making further changes.

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
