### PR TITLE
FAQ: Answer on how to revert merge commits

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -515,6 +515,27 @@ by `jj rebase` to rebase the changes in a commit. It's used in `jj log` to
 indicate which commits are empty. It's used in the `files()` revset function
 (and by `jj log <path>`) to find commits that modify a certain path. And so on.
 
+## How do I revert a merge commit? `jj revert <merge>` does nothing
+
+Instead use `jj restore --from <first parent>` to revert the changes merged
+from the second parent.
+
+Example:
+```text
+@
+|
+C
+| \
+B D
+|/
+A
+```
+To revert the merge in `C`, create a new commit with `jj new` and
+then `jj restore --from B` and then describe the message
+with something like `jj desc -m "Revert the merge of B into D`. Now, commit `@`
+undoes the merge of `D` into  C`. If necessary, you can now rebase it
+elsewhere, e.g. `jj rebase -r @ -d main`.
+
 ### How do I deal with divergent changes ('??' after the [change ID])?
 
 A [divergent change][glossary_divergent_change] represents a change that has two


### PR DESCRIPTION
This is idiosyncratic to new users coming from Git, since `jj revert <merge>` does not  usually do what users want. Maybe a followup could be adding a warning in `jj revert`.

The explanation is from a Discord message from Austin.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
