### PR TITLE
docs: update mention of deprecated config `ui.diff.format` to `ui.diff-formatter`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -810,14 +810,12 @@ pager = ["sh", "-c", "diff-so-fancy | less -RFX"]
 
 Some formatters (like [`delta`](https://github.com/dandavison/delta)) require
 git style diffs for formatting. You can configure this style of
-diff as the default with the `ui.diff` setting. For example:
+diff as the default with the `ui.diff-formatter` setting. For example:
 
 ```toml
 [ui]
 pager = "delta"
-
-[ui.diff]
-format = "git"
+diff-formatter = ":git"
 ```
 
 ## Aliases


### PR DESCRIPTION
As per the warning when using `ui.diff.format`:

```
Warning: Deprecated user-level config: ui.diff.format is updated to ui.diff-formatter = ":git"
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
