### PR TITLE
templater: add renderer.format_plain_text() for convenience

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -167,7 +167,6 @@ use crate::diff_util::DiffFormatArgs;
 use crate::diff_util::DiffRenderer;
 use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
-use crate::formatter::PlainTextFormatter;
 use crate::merge_tools::DiffEditor;
 use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
@@ -1773,10 +1772,7 @@ to the current parents may contain changes from multiple commits.
     /// Use `write_commit_summary()` to get colorized output. Use
     /// `commit_summary_template()` if you have many commits to process.
     pub fn format_commit_summary(&self, commit: &Commit) -> String {
-        let mut output = Vec::new();
-        self.write_commit_summary(&mut PlainTextFormatter::new(&mut output), commit)
-            .expect("write() to PlainTextFormatter should never fail");
-        // Template output is usually UTF-8, but it can contain file content.
+        let output = self.commit_summary_template().format_plain_text(commit);
         output.into_string_lossy()
     }
 
@@ -2430,10 +2426,7 @@ impl WorkspaceCommandTransaction<'_> {
     }
 
     pub fn format_commit_summary(&self, commit: &Commit) -> String {
-        let mut output = Vec::new();
-        self.write_commit_summary(&mut PlainTextFormatter::new(&mut output), commit)
-            .expect("write() to PlainTextFormatter should never fail");
-        // Template output is usually UTF-8, but it can contain file content.
+        let output = self.commit_summary_template().format_plain_text(commit);
         output.into_string_lossy()
     }
 

--- a/cli/src/commands/backout.rs
+++ b/cli/src/commands/backout.rs
@@ -23,7 +23,6 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
 use crate::complete;
-use crate::formatter::PlainTextFormatter;
 use crate::ui::Ui;
 
 /// (deprecated; use `revert`) Apply the reverse of given revisions on top of
@@ -101,12 +100,7 @@ pub(crate) fn cmd_backout(
         to_back_out
             .into_iter()
             .map(|commit| {
-                let mut output = Vec::new();
-                template
-                    .format(&commit, &mut PlainTextFormatter::new(&mut output))
-                    .expect("write() to vec backed formatter should never fail");
-                // Template output is usually UTF-8, but it can contain file content.
-                let commit_description = output.into_string_lossy();
+                let commit_description = template.format_plain_text(&commit).into_string_lossy();
                 (commit, commit_description)
             })
             .collect_vec()

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -32,7 +32,6 @@ use crate::cli_util::RevisionArg;
 use crate::command_error::user_error;
 use crate::command_error::CommandError;
 use crate::complete;
-use crate::formatter::PlainTextFormatter;
 use crate::ui::Ui;
 
 /// Create new changes with the same content as existing ones
@@ -180,12 +179,8 @@ pub(crate) fn cmd_duplicate(
         to_duplicate
             .iter()
             .map(|commit_id| -> BackendResult<_> {
-                let mut output = Vec::new();
                 let commit = tx.repo().store().get_commit(commit_id)?;
-                parsed
-                    .format(&commit, &mut PlainTextFormatter::new(&mut output))
-                    .expect("write() to vec backed formatter should never fail");
-
+                let output = parsed.format_plain_text(&commit);
                 Ok((commit_id.clone(), output.into_string_lossy()))
             })
             .try_collect()?

--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -31,7 +31,6 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
 use crate::complete;
-use crate::formatter::PlainTextFormatter;
 use crate::ui::Ui;
 
 /// Apply the reverse of the given revision(s)
@@ -123,12 +122,7 @@ pub(crate) fn cmd_revert(
         to_revert
             .into_iter()
             .map(|commit| {
-                let mut output = Vec::new();
-                template
-                    .format(&commit, &mut PlainTextFormatter::new(&mut output))
-                    .expect("write() to vec backed formatter should never fail");
-                // Template output is usually UTF-8, but it can contain file content.
-                let commit_description = output.into_string_lossy();
+                let commit_description = template.format_plain_text(&commit).into_string_lossy();
                 (commit, commit_description)
             })
             .collect_vec()

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2406,7 +2406,6 @@ mod tests {
     use testutils::TestWorkspace;
 
     use super::*;
-    use crate::formatter::PlainTextFormatter;
     use crate::template_parser::TemplateAliasesMap;
     use crate::templater::TemplateRenderer;
     use crate::templater::WrapTemplateProperty;
@@ -2517,9 +2516,7 @@ mod tests {
             CommitTemplatePropertyKind<'a>: WrapTemplateProperty<'a, C>,
         {
             let template = self.parse(text).unwrap();
-            let mut output = Vec::new();
-            let mut formatter = PlainTextFormatter::new(&mut output);
-            template.format(context, &mut formatter).unwrap();
+            let output = template.format_plain_text(context);
             String::from_utf8(output).unwrap()
         }
     }

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -342,11 +342,8 @@ pub fn combine_messages_for_editing(
             .flat_map(|commit| parse_description_trailers(commit.description()))
             .collect();
         let commit = commit_builder.write_hidden()?;
-        let mut output = Vec::new();
-        template
-            .format(&commit, &mut PlainTextFormatter::new(&mut output))
-            .expect("write() to vec backed formatter should never fail");
-        let trailer_lines = output
+        let trailer_lines = template
+            .format_plain_text(&commit)
             .into_string()
             .map_err(|_| user_error("Trailers should be valid utf-8"))?;
         let new_trailers = parse_trailers(&trailer_lines)?;
@@ -401,11 +398,8 @@ pub fn add_trailers_with_template(
     commit: &Commit,
 ) -> Result<String, CommandError> {
     let trailers = parse_description_trailers(commit.description());
-    let mut output = Vec::new();
-    template
-        .format(commit, &mut PlainTextFormatter::new(&mut output))
-        .expect("write() to vec backed formatter should never fail");
-    let trailer_lines = output
+    let trailer_lines = template
+        .format_plain_text(commit)
         .into_string()
         .map_err(|_| user_error("Trailers should be valid utf-8"))?;
     let new_trailers = parse_trailers(&trailer_lines)?;

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -745,6 +745,17 @@ impl<'a, C: Clone> TemplateRenderer<'a, C> {
             format_labeled(&mut wrapper, &self.template, &self.labels)
         })
     }
+
+    /// Renders template into buffer ignoring any color labels.
+    ///
+    /// The output is usually UTF-8, but it can contain arbitrary bytes such as
+    /// file content.
+    pub fn format_plain_text(&self, context: &C) -> Vec<u8> {
+        let mut output = Vec::new();
+        self.format(context, &mut PlainTextFormatter::new(&mut output))
+            .expect("write() to vec backed formatter should never fail");
+        output
+    }
 }
 
 /// Wrapper to pass around `Formatter` and error handler.


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
