### PR TITLE
revset: add `parents(x, depth)` and `children(x, depth)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Log node templates are now specified in toml rather than hardcoded.
 
+* The `parents()` and `children()` revset functions now accept an optional
+  `depth` argument. For instance, `parents(x, 3)` is equivalent to `x---`, and
+  `children(x, 3)` is equivalent to `x+++`.
+
 ### Fixed bugs
 
 * `jj file annotate` can now process files at a hidden revision.

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -104,27 +104,27 @@ fn test_bad_function_call() {
     let output = work_dir.run_jj(["log", "-r", "parents()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Failed to parse revset: Function `parents`: Expected 1 arguments
+    Error: Failed to parse revset: Function `parents`: Expected 1 to 2 arguments
     Caused by:  --> 1:9
       |
     1 | parents()
       |         ^
       |
-      = Function `parents`: Expected 1 arguments
+      = Function `parents`: Expected 1 to 2 arguments
     [EOF]
     [exit status: 1]
     ");
 
-    let output = work_dir.run_jj(["log", "-r", "parents(foo, bar)"]);
+    let output = work_dir.run_jj(["log", "-r", "parents(foo, bar, baz)"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Failed to parse revset: Function `parents`: Expected 1 arguments
+    Error: Failed to parse revset: Function `parents`: Expected 1 to 2 arguments
     Caused by:  --> 1:9
       |
-    1 | parents(foo, bar)
-      |         ^------^
+    1 | parents(foo, bar, baz)
+      |         ^-----------^
       |
-      = Function `parents`: Expected 1 arguments
+      = Function `parents`: Expected 1 to 2 arguments
     [EOF]
     [exit status: 1]
     ");

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -185,9 +185,13 @@ You can use parentheses to control evaluation order, such as `(x & y) | z` or
 You can also specify revisions by using functions. Some functions take other
 revsets (expressions) as arguments.
 
-* `parents(x)`: Same as `x-`.
+* `parents(x[, depth])`: `parents(x)` is the same as `x-`.
+  `parents(x, depth)` returns the parents of `x` at the given `depth`. For
+  instance, `parents(x, 3)` is equivalent to `x---`.
 
-* `children(x)`: Same as `x+`.
+* `children(x[, depth])`: `children(x)` is the same as `x+`.
+  `children(x, depth)` returns the children of `x` at the given `depth`. For
+  instance, `children(x, 3)` is equivalent to `x+++`.
 
 * `ancestors(x[, depth])`: `ancestors(x)` is the same as `::x`.
   `ancestors(x, depth)` returns the ancestors of `x` limited to the given

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1294,6 +1294,32 @@ fn test_evaluate_expression_parents() {
         ),
         vec![commit1.id().clone(), root_commit.id().clone()]
     );
+
+    // `parents(x, 0)` is equivalent to `x`
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("parents({}, 0)", commit5.id())),
+        vec![commit5.id().clone()]
+    );
+
+    // `parents(x, 2)` is equivalent to `x--`
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("parents({}, 2)", commit4.id())),
+        vec![commit1.id().clone(), root_commit.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("parents({} | {}, 2)", commit4.id(), commit5.id())
+        ),
+        vec![commit1.id().clone(), root_commit.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("parents({} | {}, 2)", commit4.id(), commit2.id())
+        ),
+        vec![commit1.id().clone(), root_commit.id().clone()]
+    );
 }
 
 #[test]
@@ -1373,6 +1399,34 @@ fn test_evaluate_expression_children() {
 
     // Empty root
     assert_eq!(resolve_commit_ids(mut_repo, "none()+"), vec![]);
+
+    // `children(x, 0)` is equivalent to `x`
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("children({}, 0)", commit1.id())),
+        vec![commit1.id().clone()]
+    );
+
+    // `children(x, 2)` is equivalent to `x++`
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "children(root(), 2)"),
+        vec![commit4.id().clone(), commit2.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, &format!("children(root() | {}, 2)", commit1.id())),
+        vec![
+            commit5.id().clone(),
+            commit4.id().clone(),
+            commit3.id().clone(),
+            commit2.id().clone(),
+        ]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!("children({} | {}, 2)", commit4.id(), commit2.id())
+        ),
+        vec![commit6.id().clone(), commit5.id().clone()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Resolves #3337.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
