### PR TITLE
templater: rename PlainText pseudo type to Stringify

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -77,7 +77,7 @@ use crate::diff_util::DiffStats;
 use crate::formatter::Formatter;
 use crate::revset_util;
 use crate::template_builder;
-use crate::template_builder::expect_plain_text_expression;
+use crate::template_builder::expect_stringify_expression;
 use crate::template_builder::merge_fn_map;
 use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
@@ -475,9 +475,9 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
         }
     }
 
-    fn try_into_plain_text(self) -> Option<BoxedTemplateProperty<'repo, String>> {
+    fn try_into_stringify(self) -> Option<BoxedTemplateProperty<'repo, String>> {
         match self {
-            Self::Core(property) => property.try_into_plain_text(),
+            Self::Core(property) => property.try_into_stringify(),
             Self::RefSymbol(property) => Some(property.map(|RefSymbolBuf(s)| s).into_dyn()),
             Self::RefSymbolOpt(property) => Some(
                 property
@@ -2381,7 +2381,7 @@ fn builtin_trailer_list_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo
         |language, diagnostics, build_ctx, self_property, function| {
             let [key_node] = function.expect_exact_arguments()?;
             let key_property =
-                expect_plain_text_expression(language, diagnostics, build_ctx, key_node)?;
+                expect_stringify_expression(language, diagnostics, build_ctx, key_node)?;
             let out_property = (self_property, key_property)
                 .map(|(trailers, key)| trailers.iter().any(|t| t.key == key));
             Ok(out_property.into_dyn_wrapped())
@@ -2536,7 +2536,7 @@ mod tests {
         let mut env = CommitTemplateTestEnv::init();
         env.add_function("sym", |language, diagnostics, build_ctx, function| {
             let [value_node] = function.expect_exact_arguments()?;
-            let value = expect_plain_text_expression(language, diagnostics, build_ctx, value_node)?;
+            let value = expect_stringify_expression(language, diagnostics, build_ctx, value_node)?;
             let out_property = value.map(RefSymbolBuf);
             Ok(out_property.into_dyn_wrapped())
         });

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -191,9 +191,9 @@ impl<'a, C> CoreTemplatePropertyVar<'a> for GenericTemplatePropertyKind<'a, C> {
         }
     }
 
-    fn try_into_plain_text(self) -> Option<BoxedTemplateProperty<'a, String>> {
+    fn try_into_stringify(self) -> Option<BoxedTemplateProperty<'a, String>> {
         match self {
-            Self::Core(property) => property.try_into_plain_text(),
+            Self::Core(property) => property.try_into_stringify(),
             Self::Self_(_) => None,
         }
     }

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -180,9 +180,9 @@ impl CoreTemplatePropertyVar<'static> for OperationTemplatePropertyKind {
         }
     }
 
-    fn try_into_plain_text(self) -> Option<BoxedTemplateProperty<'static, String>> {
+    fn try_into_stringify(self) -> Option<BoxedTemplateProperty<'static, String>> {
         match self {
-            Self::Core(property) => property.try_into_plain_text(),
+            Self::Core(property) => property.try_into_stringify(),
             _ => {
                 let template = self.try_into_template()?;
                 Some(PlainTextFormattedProperty::new(template).into_dyn())

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -70,14 +70,14 @@ The following functions are defined.
   Truncate `content` by removing trailing characters. The `content` shouldn't
   have newline character. If `ellipsis` is provided and `content` was truncated,
   append the `ellipsis` to the result.
-* `label(label: PlainText, content: Template) -> Template`: Apply label to
+* `label(label: Stringify, content: Template) -> Template`: Apply label to
   the content. The `label` is evaluated as a space-separated string.
 * `raw_escape_sequence(content: Template) -> Template`: Preserves any escape
   sequences in `content` (i.e., bypasses sanitization) and strips labels.
   Note: This function is intended for escape sequences and as such, its output
   is expected to be invisible / of no display width. Outputting content with
   nonzero display width may break wrapping, indentation etc.
-* `stringify(content: PlainText) -> String`: Format `content` to string. This
+* `stringify(content: Stringify) -> String`: Format `content` to string. This
   effectively removes color labels.
 * `json(value: Serialize) -> String`: Serialize `value` in JSON format.
 * `if(condition: Boolean, then: Template[, else: Template]) -> Template`:
@@ -287,7 +287,7 @@ defined.
 
 The following methods are defined. See also the `List` type.
 
-* `.contains_key(key: PlainText) -> Boolean`: True if the commit description
+* `.contains_key(key: Stringify) -> Boolean`: True if the commit description
   contains at least one trailer with the key `key`.
 
 ### `ListTemplate` type
@@ -331,10 +331,6 @@ invoked. If not set, an error will be reported inline on method call.
 
 On comparison between two optional values or optional and non-optional values,
 unset value is not an error. Unset value is considered less than any set values.
-
-### `PlainText` type
-
-A `String`, or any expression that can be converted to `Template`.
 
 ### `RefSymbol` type
 
@@ -407,16 +403,16 @@ A string can be implicitly converted to `Boolean`. The following methods are
 defined.
 
 * `.len() -> Integer`: Length in UTF-8 bytes.
-* `.contains(needle: PlainText) -> Boolean`
+* `.contains(needle: Stringify) -> Boolean`
 * `.first_line() -> String`
 * `.lines() -> List<String>`: Split into lines excluding newline characters.
 * `.upper() -> String`
 * `.lower() -> String`
-* `.starts_with(needle: PlainText) -> Boolean`
-* `.ends_with(needle: PlainText) -> Boolean`
-* `.remove_prefix(needle: PlainText) -> String`: Removes the passed prefix, if
+* `.starts_with(needle: Stringify) -> Boolean`
+* `.ends_with(needle: Stringify) -> Boolean`
+* `.remove_prefix(needle: Stringify) -> String`: Removes the passed prefix, if
   present.
-* `.remove_suffix(needle: PlainText) -> String`: Removes the passed suffix, if
+* `.remove_suffix(needle: Stringify) -> String`: Removes the passed suffix, if
   present.
 * `.trim() -> String`: Removes leading and trailing whitespace
 * `.trim_start() -> String`: Removes leading whitespace
@@ -449,6 +445,10 @@ that don't form a valid escape sequence.
 
 A single-quoted string literal has no escape syntax. `'` can't be expressed
 inside a single-quoted string literal.
+
+### `Stringify` type
+
+A `String`, or any expression that can be converted to `Template`.
 
 ### `Template` type
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -448,7 +448,10 @@ inside a single-quoted string literal.
 
 ### `Stringify` type
 
-A `String`, or any expression that can be converted to `Template`.
+An expression that can be converted to a `String`.
+
+Any types that can be converted to `Template` can also be `Stringify`. Unlike
+`Template`, color labels are stripped.
 
 ### `Template` type
 


### PR DESCRIPTION
cc @ilyagr

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
