### PR TITLE
make diff --stat show byte counts for binary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj git remote add` and `jj git clone` now support `--fetch-tags` to control
   when tags are fetched
 
+* `jj diff --stat` now shows the change in size to binary files.
+
 ### Fixed bugs
 
 ### Packaging changes


### PR DESCRIPTION
This makes `jj diff --stat` show text like `(binary) +123 bytes` for binary files, rather than the current behavior of counting the newlines within the binary files.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
