### PR TITLE
templater: serialize map literal by `json({..})`

### DIFF
--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -89,6 +89,13 @@ formal_parameters = {
   | ""
 }
 
+map = { "{" ~ map_entries ~ "}" }
+map_entries = _{
+  map_entry ~ ("," ~ map_entry)* ~ ","?
+  | ""
+}
+map_entry = { template ~ "=>" ~ template }
+
 // NOTE: Pattern identifiers additionally allow "-" in them, which results in
 // some oddness with the `-` operator.
 pattern_identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
@@ -99,6 +106,7 @@ primary = {
   ("(" ~ template ~ ")")
   | function
   | lambda
+  | map
   | pattern
   | identifier
   | string_literal

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -2782,6 +2782,10 @@ pub fn build_expression<'a, L: TemplateLanguage<'a> + ?Sized>(
             "Lambda cannot be defined here",
             node.span,
         )),
+        ExpressionKind::Map(_) => Err(TemplateParseError::expression(
+            "Map cannot be defined here",
+            node.span,
+        )),
         ExpressionKind::AliasExpanded(..) => unreachable!(),
     })
 }

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -69,6 +69,7 @@ use crate::templater::RawEscapeSequenceTemplate;
 use crate::templater::ReformatTemplate;
 use crate::templater::RegexCaptures;
 use crate::templater::SeparateTemplate;
+use crate::templater::SerializeMapProperty;
 use crate::templater::SizeHint;
 use crate::templater::Template;
 use crate::templater::TemplateFormatter;
@@ -2471,9 +2472,7 @@ fn builtin_functions<'a, L: TemplateLanguage<'a> + ?Sized>() -> TemplateBuildFun
         Ok(L::Property::wrap_property(content))
     });
     map.insert("json", |language, diagnostics, build_ctx, function| {
-        // TODO: Add pretty=true|false? or json(key=value, ..)? The latter might
-        // be implemented as a map constructor/literal if we add support for
-        // heterogeneous list/map types.
+        // TODO: Add pretty=true|false?
         let [value_node] = function.expect_exact_arguments()?;
         let value = expect_serialize_expression(language, diagnostics, build_ctx, value_node)?;
         let out_property = value.and_then(|v| Ok(serde_json::to_string(&v)?));
@@ -2940,14 +2939,28 @@ pub fn expect_serialize_expression<'a, L: TemplateLanguage<'a> + ?Sized>(
     build_ctx: &BuildContext<L::Property>,
     node: &ExpressionNode,
 ) -> TemplateParseResult<BoxedSerializeProperty<'a>> {
-    expect_expression_of_type(
-        language,
-        diagnostics,
-        build_ctx,
-        node,
-        "Serialize",
-        |expression| expression.try_into_serialize(),
-    )
+    template_parser::catch_aliases(diagnostics, node, |diagnostics, node| match &node.kind {
+        ExpressionKind::Map(entries) => {
+            let entries = entries
+                .iter()
+                .map(|(key_node, value_node)| -> TemplateParseResult<_> {
+                    let key =
+                        expect_serialize_expression(language, diagnostics, build_ctx, key_node)?;
+                    let value =
+                        expect_serialize_expression(language, diagnostics, build_ctx, value_node)?;
+                    Ok((key, value))
+                })
+                .try_collect()?;
+            Ok(SerializeMapProperty::new(entries).into_serialize())
+        }
+        _ => {
+            let expression = build_expression(language, diagnostics, build_ctx, node)?;
+            let actual_type = expression.type_name();
+            expression.try_into_serialize().ok_or_else(|| {
+                TemplateParseError::expected_type("Serialize", actual_type, node.span)
+            })
+        }
+    })
 }
 
 pub fn expect_template_expression<'a, L: TemplateLanguage<'a> + ?Sized>(
@@ -5261,6 +5274,25 @@ mod tests {
           |
           = Expected expression of type `Serialize`, but actual type is `Any`
         "###);
+
+        // Map literal
+        insta::assert_snapshot!(env.render_ok("json({})"), @"{}");
+        insta::assert_snapshot!(
+            env.render_ok("json({'a' => 'b', 'c' => {'d' => 'e'}})"),
+            @r#"{"a":"b","c":{"d":"e"}}"#);
+        insta::assert_snapshot!(
+            env.render_ok("json({email => size_hint})"),
+            @r#"{"foo@bar":[5,null]}"#);
+
+        // Template isn't serializable
+        insta::assert_snapshot!(env.parse_err("json({'a' => label('b', 'c')})"), @"
+         --> 1:14
+          |
+        1 | json({'a' => label('b', 'c')})
+          |              ^-------------^
+          |
+          = Expected expression of type `Serialize`, but actual type is `Template`
+        ");
     }
 
     #[test]

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -97,6 +97,9 @@ impl Rule {
             Self::function_arguments => None,
             Self::lambda => None,
             Self::formal_parameters => None,
+            Self::map => None,
+            Self::map_entries => None,
+            Self::map_entry => None,
             Self::pattern_identifier => None,
             Self::pattern => None,
             Self::pattern_value_expression => None,
@@ -300,6 +303,7 @@ pub enum ExpressionKind<'i> {
     FunctionCall(Box<FunctionCallNode<'i>>),
     MethodCall(Box<MethodCallNode<'i>>),
     Lambda(Box<LambdaNode<'i>>),
+    Map(Vec<MapNodeEntry<'i>>),
     /// Identity node to preserve the span in the source template text.
     AliasExpanded(AliasId<'i>, Box<ExpressionNode<'i>>),
 }
@@ -341,6 +345,17 @@ impl<'i> FoldableExpression<'i> for ExpressionKind<'i> {
                     body: folder.fold_expression(lambda.body)?,
                 });
                 Ok(Self::Lambda(lambda))
+            }
+            Self::Map(entries) => {
+                let entries = entries
+                    .into_iter()
+                    .map(|(key, value)| {
+                        let key = folder.fold_expression(key)?;
+                        let value = folder.fold_expression(value)?;
+                        Ok((key, value))
+                    })
+                    .try_collect()?;
+                Ok(ExpressionKind::Map(entries))
             }
             Self::AliasExpanded(id, subst) => {
                 let subst = Box::new(folder.fold_expression(*subst)?);
@@ -423,6 +438,8 @@ pub struct LambdaNode<'i> {
     pub body: ExpressionNode<'i>,
 }
 
+pub type MapNodeEntry<'i> = (ExpressionNode<'i>, ExpressionNode<'i>);
+
 fn parse_identifier_or_literal(pair: Pair<Rule>) -> ExpressionKind {
     assert!(matches!(
         pair.as_rule(),
@@ -474,6 +491,19 @@ fn parse_lambda_node(pair: Pair<Rule>) -> TemplateParseResult<LambdaNode> {
         params_span,
         body,
     })
+}
+
+fn parse_map_node(entries_pair: Pair<Rule>) -> TemplateParseResult<Vec<MapNodeEntry>> {
+    assert_eq!(entries_pair.as_rule(), Rule::map);
+    entries_pair
+        .into_inner()
+        .map(|pair| {
+            let [key_pair, value_pair] = pair.into_inner().collect_array().unwrap();
+            let key = parse_template_node(key_pair)?;
+            let value = parse_template_node(value_pair)?;
+            Ok((key, value))
+        })
+        .try_collect()
 }
 
 fn parse_string_literal(pair: Pair<Rule>) -> String {
@@ -531,6 +561,7 @@ fn parse_term_node(pair: Pair<Rule>) -> TemplateParseResult<ExpressionNode> {
             let lambda = Box::new(parse_lambda_node(expr)?);
             ExpressionKind::Lambda(lambda)
         }
+        Rule::map => ExpressionKind::Map(parse_map_node(expr)?),
         // Ignore inner span to preserve parenthesized expression as such.
         Rule::template => parse_template_node(expr)?.kind,
         other => panic!("unexpected term: {other:?}"),
@@ -938,6 +969,13 @@ mod tests {
                 });
                 ExpressionKind::Lambda(lambda)
             }
+            ExpressionKind::Map(entries) => {
+                let entries = entries
+                    .into_iter()
+                    .map(|(key, value)| (normalize_tree(key), normalize_tree(value)))
+                    .collect();
+                ExpressionKind::Map(entries)
+            }
             ExpressionKind::AliasExpanded(_, subst) => normalize_tree(*subst).kind,
         };
         ExpressionNode {
@@ -1156,6 +1194,50 @@ mod tests {
         // Boolean literal cannot be used as a parameter name
         assert!(parse_template("|false| a").is_err());
         Ok(())
+    }
+
+    #[test]
+    fn test_map_syntax() {
+        fn unwrap_map(node: ExpressionNode<'_>) -> Vec<MapNodeEntry<'_>> {
+            match node.kind {
+                ExpressionKind::Map(entries) => entries,
+                _ => panic!("unexpected expression: {node:?}"),
+            }
+        }
+
+        let entries = unwrap_map(parse_template("{}").unwrap());
+        assert_eq!(entries.len(), 0);
+        let entries = unwrap_map(parse_template("{a => b, c => d}").unwrap());
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0.kind, ExpressionKind::Identifier("a"));
+        assert_eq!(entries[0].1.kind, ExpressionKind::Identifier("b"));
+        assert_eq!(entries[1].0.kind, ExpressionKind::Identifier("c"));
+        assert_eq!(entries[1].1.kind, ExpressionKind::Identifier("d"));
+
+        // Binding
+        assert_eq!(
+            parse_normalized("{a ++ b => c ++ d, e => f}"),
+            parse_normalized("{(a ++ b) => (c ++ d), (e) => (f)}"),
+        );
+        assert_eq!(
+            parse_normalized("{{a => b} => {c => d}}"),
+            parse_normalized("{({a => b}) => ({c => d})}"),
+        );
+        assert_eq!(
+            parse_normalized("{a:'b' => c:'d'}"),
+            parse_normalized("{(a:'b') => (c:'d')}"),
+        );
+
+        // Trailing comma
+        assert!(parse_template("{,}").is_err());
+        assert!(parse_template("{a => b,}").is_ok());
+        assert!(parse_template("{a => b,,}").is_err());
+        assert!(parse_template("{a => b,,c => d}").is_err());
+        assert!(parse_template("{, a => b}").is_err());
+        assert!(parse_template("{ a=>b , c => d , }").is_ok());
+
+        // Key-value pair cannot be parenthesized
+        assert!(parse_template("{(a => b)}").is_err());
     }
 
     #[test]
@@ -1488,6 +1570,12 @@ mod tests {
         assert_eq!(
             with_aliases([("A", "a ++ b")]).parse_normalized("|A| A"),
             parse_normalized("|A| (a ++ b)"),
+        );
+
+        // Map entries should be expanded.
+        assert_eq!(
+            with_aliases([("A", "a"), ("B", "b")]).parse_normalized("{A => !B}"),
+            parse_normalized("{a => !b}"),
         );
 
         // Infinite recursion, where the top-level error isn't of RecursiveAlias kind.

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -27,6 +27,7 @@ use std::rc::Rc;
 
 use bstr::BStr;
 use bstr::BString;
+use itertools::Itertools as _;
 use jj_lib::backend::Signature;
 use jj_lib::backend::Timestamp;
 use jj_lib::config::ConfigValue;
@@ -655,6 +656,44 @@ impl<T: Template> TemplateProperty for PlainTextFormattedProperty<T> {
         let mut wrapper = TemplateFormatter::new(&mut formatter, propagate_property_error);
         self.template.format(&mut wrapper)?;
         Ok(BString::new(output))
+    }
+}
+
+/// Wrapper for `(key, value)` property pairs that can be evaluated to
+/// serializable objects.
+pub struct SerializeMapProperty<'a> {
+    entries: Vec<(BoxedSerializeProperty<'a>, BoxedSerializeProperty<'a>)>,
+}
+
+impl<'a> SerializeMapProperty<'a> {
+    pub fn new(entries: Vec<(BoxedSerializeProperty<'a>, BoxedSerializeProperty<'a>)>) -> Self {
+        SerializeMapProperty { entries }
+    }
+}
+
+impl<'a> TemplateProperty for SerializeMapProperty<'a> {
+    type Output = SerializeMap<'a>;
+
+    fn extract(&self) -> Result<Self::Output, TemplatePropertyError> {
+        let entries = self.entries.iter().map(|e| e.extract()).try_collect()?;
+        Ok(SerializeMap { entries })
+    }
+}
+
+/// Wrapper for serializable `(key, value)` pairs.
+pub struct SerializeMap<'a> {
+    entries: Vec<(
+        Box<dyn erased_serde::Serialize + 'a>,
+        Box<dyn erased_serde::Serialize + 'a>,
+    )>,
+}
+
+impl serde::Serialize for SerializeMap<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_map(self.entries.iter().map(|(k, v)| (k, v)))
     }
 }
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -116,7 +116,9 @@ The following functions are defined.
   including capture group 0 for the full match.
 * `stringify(content: Stringify) -> String`: Format `content` to string. This
   effectively removes color labels.
-* `json(value: Serialize) -> String`: Serialize `value` in JSON format.
+* `json(value: Serialize) -> String`: Serialize `value` in JSON format. To
+  serialize multiple values as a JSON object, use `json({key => value, ..})`.
+  For example, `json({"commit_id" => commit_id, "tags" => tags})`.
 * `if(condition: Boolean, then: Any, [else: Any]) -> Any`:
   Conditionally evaluates to `then` / `else` content.
 * `coalesce(content: Template...) -> Template`: Returns the first **non-empty**


### PR DESCRIPTION
I don't have strong feeling whether we should add this syntax, but it would be
tedious to concatenate multiple serializable values (such as commit, tags, and
bookmarks) manually as JSON object.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
