### PR TITLE
Update `trait Backend::name()` comment to match reality

### DIFF
--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -478,7 +478,7 @@ pub trait Backend: Send + Sync + Debug {
     fn as_any(&self) -> &dyn Any;
 
     /// A unique name that identifies this backend. Written to
-    /// `.jj/repo/store/backend` when the repo is created.
+    /// `.jj/repo/store/type` when the repo is created.
     fn name(&self) -> &str;
 
     /// The length of commit IDs in bytes.


### PR DESCRIPTION
`.jj/repo/store/backend` -> `.jj/repo/store/type`

It looks like this comment was the last place where `backend` is mentioned.
All the other places are pointing to `type`. However, that comment might be
the first place where a person is looking - as it appears in the docs.rs.
Anyway, just thought it is good to fix this to reflect the actual path.
