### PR TITLE
Make diff --stat fill screen width

### DIFF
--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -2025,6 +2025,13 @@ pub fn show_diff_stats(
             }
         })
         .collect_vec();
+
+    // Entries format like:
+    //   path/to/file | 123 ++--
+    //
+    // Depending on display widths, we can elide part of the path,
+    // and the the ++-- bar will adjust its scale to fill the rest.
+
     let max_path_width = ui_paths.iter().map(|s| s.width()).max().unwrap_or(0);
     let max_diffs = stats
         .entries()
@@ -2033,12 +2040,13 @@ pub fn show_diff_stats(
         .max()
         .unwrap_or(0);
 
-    let number_padding = max_diffs.to_string().len();
-    // 4 characters padding for the graph
-    let available_width = display_width.saturating_sub(4 + " | ".len() + number_padding);
-    // Always give at least a tiny bit of room
+    let number_width = max_diffs.to_string().len();
+    // Available width to distribute between path and bar:
+    let available_width = display_width.saturating_sub(" | ".len() + number_width + " ".len());
+    // Always use at least a tiny bit of room
     let available_width = max(available_width, 5);
-    let max_path_width = max_path_width.clamp(3, (0.7 * available_width as f64) as usize);
+
+    let max_path_width = max_path_width.min((0.7 * available_width as f64) as usize);
     let max_bar_length = available_width.saturating_sub(max_path_width);
     let factor = if max_diffs < max_bar_length {
         1.0
@@ -2047,14 +2055,23 @@ pub fn show_diff_stats(
     };
 
     for (stat, ui_path) in iter::zip(stats.entries(), &ui_paths) {
-        let bar_added = (stat.added as f64 * factor).ceil() as usize;
-        let bar_removed = (stat.removed as f64 * factor).ceil() as usize;
+        let bar_length = ((stat.added + stat.removed) as f64 * factor) as usize;
+        // Ensure that any fractional space after scaling is given to whichever
+        // of adds/removes is smaller.  This ensures we always show at least one
+        // tick even for small counts.
+        let (bar_added, bar_removed) = if stat.added < stat.removed {
+            let len = (stat.added as f64 * factor).ceil() as usize;
+            (len, bar_length - len)
+        } else {
+            let len = (stat.removed as f64 * factor).ceil() as usize;
+            (bar_length - len, len)
+        };
         // replace start of path with ellipsis if the path is too long
         let (path, path_width) = text_util::elide_start(ui_path, "...", max_path_width);
         let path_pad_width = max_path_width - path_width;
         write!(
             formatter,
-            "{path}{:path_pad_width$} | {:>number_padding$}{}",
+            "{path}{:path_pad_width$} | {:>number_width$}{}",
             "", // pad to max_path_width
             stat.added + stat.removed,
             if bar_added + bar_removed > 0 { " " } else { "" },

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1451,11 +1451,11 @@ fn test_log_diff_stat_width() {
     insta::assert_snapshot!(render(&["log", "--stat", "--no-graph"], 30), @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:09 9490cfd3
     (no description set)
-    file2 | 100 +++++++++++++++
+    file2 | 100 ++++++++++++++++++
     1 file changed, 100 insertions(+), 0 deletions(-)
     qpvuntsm test.user@example.com 2001-02-03 08:05:08 79f0968d
     (no description set)
-    file1 | 100 +++++++++++++++
+    file1 | 100 ++++++++++++++++++
     1 file changed, 100 insertions(+), 0 deletions(-)
     zzzzzzzz root() 00000000
     0 files changed, 0 insertions(+), 0 deletions(-)
@@ -1466,11 +1466,11 @@ fn test_log_diff_stat_width() {
     insta::assert_snapshot!(render(&["log", "--stat"], 30), @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:09 9490cfd3
     │  (no description set)
-    │  file2 | 100 ++++++++++++
+    │  file2 | 100 +++++++++++++++
     │  1 file changed, 100 insertions(+), 0 deletions(-)
     │ ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 79f0968d
     ├─╯  (no description set)
-    │    file1 | 100 ++++++++++
+    │    file1 | 100 +++++++++++++
     │    1 file changed, 100 insertions(+), 0 deletions(-)
     ◆  zzzzzzzz root() 00000000
        0 files changed, 0 insertions(+), 0 deletions(-)

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -560,7 +560,7 @@ fn test_op_log_word_wrap() {
     │     description set)
     │     - qpvuntsm hidden e8849ae1 (empty)
     │     (no description set)
-    │     file1 | 100 +++++++++++++++++++
+    │     file1 | 100 ++++++++++++++++++++++
     │     1 file changed, 100 insertions(+), 0 deletions(-)
     │
     │  Changed working copy default@:
@@ -582,7 +582,7 @@ fn test_op_log_word_wrap() {
     + qpvuntsm 79f0968d (no description set)
     - qpvuntsm hidden e8849ae1 (empty) (no
     description set)
-    file1 | 100 +++++++++++++++++++++++++
+    file1 | 100 ++++++++++++++++++++++++++++
     1 file changed, 100 insertions(+), 0 deletions(-)
 
     Changed working copy default@:
@@ -2080,7 +2080,7 @@ fn test_op_diff_word_wrap() {
     Changed commits:
     ○  + sqpuoqvx f6f32c19 (no description
     │  set)
-    │  file1 | 100 ++++++++++++++++++++++
+    │  file1 | 100 +++++++++++++++++++++++++
     │  1 file changed, 100 insertions(+), 0 deletions(-)
     ○  + pukowqtp 0cb7e07e bookmark-1 |
        Commit 1


### PR DESCRIPTION
(Two commits, can be reviewed separately; pre-refactoring before I make the larger change of #6866)

Using jj 0.30.0 and a narrow terminal, see how "diffstat" is slightly wider (filling my terminal).
After this change jj matches diffstat.

<img width="517" alt="image" src="https://github.com/user-attachments/assets/4c927a34-e78b-4fad-96d5-14a83c4b4f1d" />

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes

(Not sure if this belongs in CHANGELOG.md, let me know)