### PR TITLE
Introduce async version of `Commit::tree()`

### DIFF
--- a/lib/src/absorb.rs
+++ b/lib/src/absorb.rs
@@ -97,7 +97,7 @@ pub async fn split_hunks_to_trees(
     let mut selected_trees = SelectedTrees::default();
 
     let left_tree = &source.parent_tree;
-    let right_tree = source.commit.tree()?;
+    let right_tree = source.commit.tree_async().await?;
     // TODO: enable copy tracking if we add support for annotate and merge
     let copy_records = CopyRecords::default();
     let tree_diff = left_tree.diff_stream_with_copies(&right_tree, matcher, &copy_records);

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -23,6 +23,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 
 use crate::backend;
 use crate::backend::BackendResult;
@@ -101,7 +102,11 @@ impl Commit {
     }
 
     pub fn tree(&self) -> BackendResult<MergedTree> {
-        self.store.get_root_tree(&self.data.root_tree)
+        self.tree_async().block_on()
+    }
+
+    pub async fn tree_async(&self) -> BackendResult<MergedTree> {
+        self.store.get_root_tree_async(&self.data.root_tree).await
     }
 
     pub fn tree_id(&self) -> &MergedTreeId {

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1321,7 +1321,8 @@ async fn has_diff_from_parent(
     }
 
     // Conflict resolution is expensive, try that only for matched files.
-    let from_tree = rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents)?;
+    let from_tree =
+        rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents).await?;
     let to_tree = commit.tree()?;
     // TODO: handle copy tracking
     let mut tree_diff = from_tree.diff_stream(&to_tree, matcher);
@@ -1346,7 +1347,8 @@ async fn matches_diff_from_parent(
 ) -> BackendResult<bool> {
     let parents: Vec<_> = commit.parents().try_collect()?;
     // Conflict resolution is expensive, try that only for matched files.
-    let from_tree = rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents)?;
+    let from_tree =
+        rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents).await?;
     let to_tree = commit.tree()?;
     // TODO: handle copy tracking
     let mut tree_diff = from_tree.diff_stream(&to_tree, files_matcher);

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1323,7 +1323,7 @@ async fn has_diff_from_parent(
     // Conflict resolution is expensive, try that only for matched files.
     let from_tree =
         rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents).await?;
-    let to_tree = commit.tree()?;
+    let to_tree = commit.tree_async().await?;
     // TODO: handle copy tracking
     let mut tree_diff = from_tree.diff_stream(&to_tree, matcher);
     // TODO: Resolve values concurrently
@@ -1349,7 +1349,7 @@ async fn matches_diff_from_parent(
     // Conflict resolution is expensive, try that only for matched files.
     let from_tree =
         rewrite::merge_commit_trees_no_resolve_without_repo(store, &index, &parents).await?;
-    let to_tree = commit.tree()?;
+    let to_tree = commit.tree_async().await?;
     // TODO: handle copy tracking
     let mut tree_diff = from_tree.diff_stream(&to_tree, files_matcher);
     // TODO: Resolve values concurrently

--- a/lib/src/fix.rs
+++ b/lib/src/fix.rs
@@ -228,7 +228,7 @@ pub async fn fix_files(
             commit.parent_tree(repo_mut)?
         };
         // TODO: handle copy tracking
-        let mut diff_stream = parent_tree.diff_stream(&commit.tree()?, &matcher);
+        let mut diff_stream = parent_tree.diff_stream(&commit.tree_async().await?, &matcher);
         while let Some(TreeDiffEntry {
             path: repo_path,
             values,

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -72,7 +72,7 @@ pub async fn merge_commit_trees_no_resolve_without_repo(
             .get_root_tree_async(&store.empty_merged_tree_id())
             .await?)
     } else {
-        let mut new_tree = commits[0].tree()?;
+        let mut new_tree = commits[0].tree_async().await?;
         let commit_ids = commits
             .iter()
             .map(|commit| commit.id().clone())
@@ -85,7 +85,7 @@ pub async fn merge_commit_trees_no_resolve_without_repo(
                 store, index, &ancestors,
             ))
             .await?;
-            let other_tree = other_commit.tree()?;
+            let other_tree = other_commit.tree_async().await?;
             new_tree = new_tree.merge_no_resolve(&ancestor_tree, &other_tree);
         }
         Ok(new_tree)

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -68,7 +68,9 @@ pub async fn merge_commit_trees_no_resolve_without_repo(
     commits: &[Commit],
 ) -> BackendResult<MergedTree> {
     if commits.is_empty() {
-        Ok(store.get_root_tree(&store.empty_merged_tree_id())?)
+        Ok(store
+            .get_root_tree_async(&store.empty_merged_tree_id())
+            .await?)
     } else {
         let mut new_tree = commits[0].tree()?;
         let commit_ids = commits

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -208,13 +208,22 @@ impl Store {
     }
 
     pub fn get_root_tree(self: &Arc<Self>, id: &MergedTreeId) -> BackendResult<MergedTree> {
+        self.get_root_tree_async(id).block_on()
+    }
+
+    pub async fn get_root_tree_async(
+        self: &Arc<Self>,
+        id: &MergedTreeId,
+    ) -> BackendResult<MergedTree> {
         match &id {
             MergedTreeId::Legacy(id) => {
-                let tree = self.get_tree(RepoPathBuf::root(), id)?;
+                let tree = self.get_tree_async(RepoPathBuf::root(), id).await?;
                 MergedTree::from_legacy_tree(tree)
             }
             MergedTreeId::Merge(ids) => {
-                let trees = ids.try_map(|id| self.get_tree(RepoPathBuf::root(), id))?;
+                let trees = ids
+                    .try_map_async(|id| self.get_tree_async(RepoPathBuf::root(), id))
+                    .await?;
                 Ok(MergedTree::new(trees))
             }
         }


### PR DESCRIPTION
This is to prepare for making `annotate.rs` read trees concurrently across multiple commits.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
