### PR TITLE
cli fetch: put all not-found branches into one warning

### DIFF
--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -189,6 +189,7 @@ fn warn_if_branches_not_found(
     branches: &[StringPattern],
     remotes: &[&RemoteName],
 ) -> Result<(), CommandError> {
+    let mut missing_branches = vec![];
     for branch in branches {
         let matches = remotes.iter().any(|&remote| {
             let remote = StringPattern::exact(remote);
@@ -205,11 +206,16 @@ fn warn_if_branches_not_found(
                     .is_some()
         });
         if !matches {
-            writeln!(
-                ui.warning_default(),
-                "No branch matching `{branch}` found on any specified/configured remote",
-            )?;
+            missing_branches.push(branch);
         }
+    }
+
+    if !missing_branches.is_empty() {
+        writeln!(
+            ui.warning_default(),
+            "No branch matching {} found on any specified/configured remote",
+            missing_branches.iter().map(|b| format!("`{b}`")).join(", ")
+        )?;
     }
 
     Ok(())

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1038,8 +1038,7 @@ fn test_git_fetch_bookmarks_some_missing() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Warning: No branch matching `noexist1` found on any specified/configured remote
-    Warning: No branch matching `noexist2` found on any specified/configured remote
+    Warning: No branch matching `noexist1`, `noexist2` found on any specified/configured remote
     Nothing changed.
     [EOF]
     ");


### PR DESCRIPTION
I often use the following command, sometimes in a loop over different repos. It's annoying when it prints several lines of warnings. One line should be enough.

```sh
jj git fetch && jj git fetch --remote upstream --branch main  --branch master \
   --branch 'glob:gh-readonly-queue*' --branch 'glob:ig/*'
```
# Checklist

If applicable:

- n/a I have updated `CHANGELOG.md`
- n/a I have updated the documentation (`README.md`, `docs/`, `demos/`)
- n/a I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
