### PR TITLE
build.rs: separate commit ids if compiling at a merge commit

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -61,12 +61,16 @@ fn get_git_hash() -> Option<String> {
             "log",
             "--no-graph",
             "-r=@-",
-            "-T=commit_id",
+            "-T=commit_id ++ '-'",
         ])
         .output()
     {
         if output.status.success() {
-            return Some(String::from_utf8(output.stdout).unwrap());
+            let mut parent_commits = String::from_utf8(output.stdout).unwrap();
+            // TODO(ilyagr): The `test_version` integration test shoult be fixed
+            // to succeed even if there is more than one parent commit.
+            parent_commits.truncate(parent_commits.trim_end_matches('-').len());
+            return Some(parent_commits);
         }
     }
 


### PR DESCRIPTION
This makes the `test_version` test failure when run at a merge commit less confusing. The test could be fixed, but I'm not sure it's worth it, as we probably don't want to release a version of `jj` compiled at a merge commit.

Admittedly, this is a bit of a quick hack, but I've been confused by `jj --version` output when compiled at a merge commit enough times to want it.

Prior art: https://github.com/jj-vcs/jj/pull/6311 and https://github.com/jj-vcs/jj/pull/4033 both pick one commit id hash to print. I think I prefer printing all of them, even if it will fail tests at a merge commit. After this commit, the failure will at least be easy to understand.

However, if we prefer to merge one of the above ones, I'm OK with that too.