### PR TITLE
status: collapse entirely untracked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj fix` now buffers lines from subprocesses' stderr streams and emits them a
   complete line at a time. Each line is prepended with the file name.
 
+* `jj status` now collapses fully untracked directories into one line.
+  It still fully traverses them while snapshotting but they won't clutter up
+  the output with all of their contents.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io;
-
 use itertools::Itertools as _;
 use jj_lib::copies::CopyRecords;
+use jj_lib::merged_tree::MergedTree;
 use jj_lib::repo::Repo as _;
+use jj_lib::repo_path::RepoPath;
+use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetFilterPredicate;
+use pollster::FutureExt as _;
 use tracing::instrument;
 
 use crate::cli_util::print_conflicted_paths;
@@ -104,11 +106,24 @@ pub(crate) fn cmd_status(
             if wc_has_untracked {
                 writeln!(formatter, "Untracked paths:")?;
                 formatter.with_label("diff", |formatter| {
-                    for path in snapshot_stats.untracked_paths.keys() {
-                        let ui_path = workspace_command.path_converter().format_file_path(path);
-                        writeln!(formatter.labeled("untracked"), "? {ui_path}")?;
-                    }
-                    io::Result::Ok(())
+                    visit_collapsed_untracked_files(
+                        snapshot_stats.untracked_paths.keys(),
+                        tree,
+                        |path, is_dir| {
+                            let ui_path = workspace_command.path_converter().format_file_path(path);
+                            writeln!(
+                                formatter.labeled("untracked"),
+                                "? {ui_path}{}",
+                                if is_dir {
+                                    std::path::MAIN_SEPARATOR_STR
+                                } else {
+                                    ""
+                                }
+                            )?;
+                            Ok(())
+                        },
+                    )
+                    .block_on()
                 })?;
             }
         }
@@ -211,4 +226,136 @@ pub(crate) fn cmd_status(
     }
 
     Ok(())
+}
+
+async fn visit_collapsed_untracked_files(
+    untracked_paths: impl IntoIterator<Item = impl AsRef<RepoPath>>,
+    tree: MergedTree,
+    mut on_path: impl FnMut(&RepoPath, bool) -> Result<(), CommandError>,
+) -> Result<(), CommandError> {
+    let mut stack = vec![tree];
+
+    // TODO: This loop can be improved with BTreeMap cursors once that's stable,
+    // would remove the need for the whole `skip_prefixed_by` thing and turn it
+    // into a B-tree lookup.
+    let mut skip_prefixed_by_dir: Option<RepoPathBuf> = None;
+    'untracked: for path in untracked_paths {
+        let path = path.as_ref();
+        if skip_prefixed_by_dir
+            .as_ref()
+            .is_some_and(|p| path.starts_with(p))
+        {
+            continue;
+        } else {
+            skip_prefixed_by_dir = None;
+        }
+
+        let mut it = path.components().dropping_back(1);
+        let first_mismatch = it.by_ref().enumerate().find(|(i, component)| {
+            stack.get(i + 1).is_none_or(|tree| {
+                tree.dir()
+                    .components()
+                    .next_back()
+                    .expect("should always have at least one element (the root)")
+                    != *component
+            })
+        });
+
+        if let Some((i, component)) = first_mismatch {
+            stack.truncate(i + 1);
+            for component in std::iter::once(component).chain(it) {
+                let parent = stack
+                    .last()
+                    .expect("should always have at least one element (the root)");
+
+                if let Some(subtree) = parent.sub_tree(component).await? {
+                    stack.push(subtree);
+                } else {
+                    let dir = parent.dir().join(component);
+
+                    on_path(&dir, true)?;
+                    skip_prefixed_by_dir = Some(dir);
+
+                    continue 'untracked;
+                }
+            }
+        }
+
+        on_path(path, false)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use testutils::repo_path;
+    use testutils::TestRepo;
+    use testutils::TestTreeBuilder;
+
+    use super::*;
+
+    fn collect_collapsed_untracked_files_string(
+        untracked_paths: &[&RepoPath],
+        tree: MergedTree,
+    ) -> String {
+        let mut result = String::new();
+        visit_collapsed_untracked_files(untracked_paths, tree, |path, is_dir| {
+            result.push_str("? ");
+            if is_dir {
+                result.push_str(&path.to_internal_dir_string());
+            } else {
+                result.push_str(path.as_internal_file_string());
+            }
+            result.push('\n');
+            Ok(())
+        })
+        .block_on()
+        .unwrap();
+        result
+    }
+
+    #[test]
+    fn test_collapsed_untracked_files() {
+        let repo = TestRepo::init();
+
+        let tracked = {
+            let mut builder = TestTreeBuilder::new(repo.repo.store().clone());
+
+            builder.file(repo_path("top_level_file"), "");
+            // ? "untracked_top_level_file"
+            // ? "dir"
+            // ? "dir2/c"
+            builder.file(repo_path("dir2/d"), "");
+            // ? "dir3/partially_tracked/e"
+            builder.file(repo_path("dir3/partially_tracked/f"), "");
+            // ? "dir3/fully_untracked/"
+            builder.file(repo_path("dir3/j"), "");
+            // ? "dir3/k"
+
+            builder.write_merged_tree()
+        };
+        let untracked = &[
+            repo_path("untracked_top_level_file"),
+            repo_path("dir/a"),
+            repo_path("dir/b"),
+            repo_path("dir2/c"),
+            repo_path("dir3/partially_tracked/e"),
+            repo_path("dir3/fully_untracked/g"),
+            repo_path("dir3/fully_untracked/h"),
+            repo_path("dir3/k"),
+        ];
+
+        insta::assert_snapshot!(
+            collect_collapsed_untracked_files_string(untracked, tracked),
+            @r"
+        ? untracked_top_level_file
+        ? dir/
+        ? dir2/c
+        ? dir3/partially_tracked/e
+        ? dir3/fully_untracked/
+        ? dir3/k
+        "
+        );
+    }
 }

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -392,8 +392,7 @@ fn test_status_untracked_files() {
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file
-    ? sub/always-untracked
-    ? sub/initially-untracked
+    ? sub/
     Working copy  (@) : qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
@@ -449,8 +448,7 @@ fn test_status_untracked_files() {
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file
-    ? sub/always-untracked
-    ? sub/initially-untracked
+    ? sub/
     Working copy  (@) : mzvwutvl 240f261a (no description set)
     Parent commit (@-): qpvuntsm b8c1286d (no description set)
     [EOF]
@@ -463,8 +461,18 @@ fn test_status_untracked_files() {
     Untracked paths:
     ? always-untracked-file
     ? initially-untracked-file
-    ? sub/always-untracked
-    ? sub/initially-untracked
+    ? sub/
+    Working copy  (@) : yostqsxw 50beac0d (empty) (no description set)
+    Parent commit (@-): mzvwutvl 240f261a (no description set)
+    [EOF]
+    ");
+
+    let output = work_dir.dir("sub").run_jj(["status"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    Untracked paths:
+    ? ../always-untracked-file
+    ? ../initially-untracked-file
+    ? ./
     Working copy  (@) : yostqsxw 50beac0d (empty) (no description set)
     Parent commit (@-): mzvwutvl 240f261a (no description set)
     [EOF]


### PR DESCRIPTION
I wanted to try out `jj` since it seemed cool, was happy that `snapshot.auto-track` was added since I keep many untracked files in my repos, however once I ran `jj st` it spat out a line for every single file in my untracked directories into a pager which is not optimal. This PR collapses directories which consist entirely of untracked files (i.e. without any files that are tracked in the working copy inside).

Note that this is purely a `jj status` post processing step and does not affect how untracked files are collected. It may also be nice to do something like this in other places. ~~I think git also does this for stuff like added files too so if you add a directory it just shows the directory, that just seems a bit more involved and is not a problem for me right now~~. git does not do this.

Not sure where in the changelog this would go (New features or bug fixes?) or whether any docs need to be updated.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes