### PR TITLE
Drop defunct Sturdy from related-work

### DIFF
--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -21,5 +21,3 @@ Similar tools:
 * [Breezy](https://www.breezy-vcs.org/): Another VCS that's similar in that it
   has multiple storage backends, including its own format as well as .git
   support.
-* [Sturdy](https://getsturdy.com/): A Git backed GUI that eliminates local and
-  remote as well as the idea of an "index"/"staging area".


### PR DESCRIPTION
* HTTPS can't connect
* HTTP has cloudfront 403 error page - [as per web archive at least since 2023-10-18](https://web.archive.org/web/20231018153827/https://getsturdy.com/)
* Uncommented [issue ticket](https://github.com/sturdy-dev/sturdy/issues/1360) since 2024-02-18

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
