### PR TITLE
cleanup: remove &'static lifetime that can be implied

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -210,7 +210,7 @@ pub struct TracingSubscription {
 }
 
 impl TracingSubscription {
-    const ENV_VAR_NAME: &'static str = "JJ_LOG";
+    const ENV_VAR_NAME: &str = "JJ_LOG";
 
     /// Initializes tracing with the default configuration. This should be
     /// called as early as possible.

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -385,21 +385,20 @@ type FilesetFunction = fn(
     &FunctionCallNode,
 ) -> FilesetParseResult<FilesetExpression>;
 
-static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&'static str, FilesetFunction>> =
-    LazyLock::new(|| {
-        // Not using maplit::hashmap!{} or custom declarative macro here because
-        // code completion inside macro is quite restricted.
-        let mut map: HashMap<&'static str, FilesetFunction> = HashMap::new();
-        map.insert("none", |_diagnostics, _path_converter, function| {
-            function.expect_no_arguments()?;
-            Ok(FilesetExpression::none())
-        });
-        map.insert("all", |_diagnostics, _path_converter, function| {
-            function.expect_no_arguments()?;
-            Ok(FilesetExpression::all())
-        });
-        map
+static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, FilesetFunction>> = LazyLock::new(|| {
+    // Not using maplit::hashmap!{} or custom declarative macro here because
+    // code completion inside macro is quite restricted.
+    let mut map: HashMap<&str, FilesetFunction> = HashMap::new();
+    map.insert("none", |_diagnostics, _path_converter, function| {
+        function.expect_no_arguments()?;
+        Ok(FilesetExpression::none())
     });
+    map.insert("all", |_diagnostics, _path_converter, function| {
+        function.expect_no_arguments()?;
+        Ok(FilesetExpression::all())
+    });
+    map
+});
 
 fn resolve_function(
     diagnostics: &mut FilesetDiagnostics,

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -182,7 +182,7 @@ impl UserSettings {
     }
 
     // Must not be changed to avoid git pushing older commits with no set name
-    pub const USER_NAME_PLACEHOLDER: &'static str = "(no name configured)";
+    pub const USER_NAME_PLACEHOLDER: &str = "(no name configured)";
 
     pub fn user_email(&self) -> &str {
         &self.data.user_email
@@ -194,7 +194,7 @@ impl UserSettings {
 
     // Must not be changed to avoid git pushing older commits with no set email
     // address
-    pub const USER_EMAIL_PLACEHOLDER: &'static str = "(no email configured)";
+    pub const USER_EMAIL_PLACEHOLDER: &str = "(no email configured)";
 
     pub fn commit_timestamp(&self) -> Option<Timestamp> {
         self.data.commit_timestamp


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
