### PR TITLE
Buffer stderr from fix tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Added `templates.workspace_list` template to customize the output of `jj workspace list`.
 
+* `jj fix` now buffers lines from subprocesses' stderr streams and emits them a
+  complete line at a time. Each line is prepended with the file name.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -1029,6 +1029,7 @@ fn test_stderr_success() {
     let output = work_dir.run_jj(["fix", "-s", "@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    file:
     error
     Fixed 1 commits of 1 checked.
     Working copy  (@) now at: qpvuntsm cb75cbcb (no description set)
@@ -1054,6 +1055,7 @@ fn test_stderr_failure() {
     let output = work_dir.run_jj(["fix", "-s", "@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    file:
     error
     Fixed 0 commits of 1 checked.
     Nothing changed.

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -1029,7 +1029,8 @@ fn test_stderr_success() {
     let output = work_dir.run_jj(["fix", "-s", "@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    errorFixed 1 commits of 1 checked.
+    error
+    Fixed 1 commits of 1 checked.
     Working copy  (@) now at: qpvuntsm cb75cbcb (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
@@ -1053,7 +1054,8 @@ fn test_stderr_failure() {
     let output = work_dir.run_jj(["fix", "-s", "@"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    errorFixed 0 commits of 1 checked.
+    error
+    Fixed 0 commits of 1 checked.
     Nothing changed.
     [EOF]
     ");


### PR DESCRIPTION
The stderr from fix tools is currently all mixed together. I think the problem is worse on Windows: I regularly see line noise as multiple stderr streams are interleaved character-by-character. On Windows, this is _extremely_ slow and can make `jj fix` very annoying, if not unusable.

This change buffers the stderr output line-by-line, so at least there's some hope of reading it. I'm also prefixing the file name.

Ways this could be improved:

- Maybe prefix the commit ID and/or tool name as well as the file name: `path/to/file:clippy:a8b9c3d:This is some output`
- Instead of releasing the mutex holding the main process's Stderr after emitting each line, it would be nice to emit all available lines from a process before releasing the mutex. However, I didn't see a way to `read_line_if_ready()` on a BufReader. If there's an obvious way to do this, I'd love to improve it.

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
