### PR TITLE
config-schema: add missing commit_trailers setting

### DIFF
--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -810,6 +810,10 @@
                     "type": "string",
                     "description": "The short commit summary used by many commands"
                 },
+                "commit_trailers": {
+                    "type": "string",
+                    "description": "Trailers that will be appended to a commit's description"
+                },
                 "file_annotate": {
                     "type": "string",
                     "description": "`jj file annotate`'s output"


### PR DESCRIPTION
The title is self-documenting I guess :slightly_smiling_face: Completely open to feedback if anyone thinks of a better description.
This pull request introduces a new configuration option to the `cli/src/config-schema.json` file, allowing users to specify commit trailers that will be appended to a commit's description.

----

I also noticed that the `config-schema.json` file is not consistently formatted (there's inconsistent indentation for example). I tried both `biome`, `prettier`, `jq`, and the `json-lsp` and all cause a huge diff. I'll be happy to setup a formatter in a followup PR if the maintainers agree! I'm thinking `jq` might be the path of least resistance as it's already used for tests and it's present in the devShell.


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`) :wink: 
- [ ] I have added/updated tests to cover my changes
