### PR TITLE
Make `jj file annotate` faster with slow backends

### DIFF
--- a/lib/src/annotate.rs
+++ b/lib/src/annotate.rs
@@ -135,7 +135,7 @@ impl FileAnnotator {
     ///
     /// If the file is not found, the result would be empty.
     pub fn from_commit(starting_commit: &Commit, file_path: &RepoPath) -> BackendResult<Self> {
-        let source = Source::load(starting_commit, file_path)?;
+        let source = Source::load(starting_commit, file_path).block_on()?;
         Ok(Self::with_source(starting_commit.id(), file_path, source))
     }
 
@@ -231,10 +231,10 @@ impl Source {
         }
     }
 
-    fn load(commit: &Commit, file_path: &RepoPath) -> Result<Self, BackendError> {
-        let tree = commit.tree()?;
-        let file_value = tree.path_value_async(file_path).block_on()?;
-        let text = get_file_contents(commit.store(), file_path, file_value).block_on()?;
+    async fn load(commit: &Commit, file_path: &RepoPath) -> Result<Self, BackendError> {
+        let tree = commit.tree_async().await?;
+        let file_value = tree.path_value_async(file_path).await?;
+        let text = get_file_contents(commit.store(), file_path, file_value).await?;
         Ok(Self::new(text))
     }
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
