### PR TITLE
Allow new bookmarks to be pushed if there's only one remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj fix` now buffers lines from subprocesses' stderr streams and emits them a
   complete line at a time. Each line is prepended with the file name.
 
+* Pushing new bookmarks is now allowed by default if there is only one remote,
+  i.e. the flag `--allow-new` is not required anymore
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   planned to be removed in a future release.
   [#6016](https://github.com/jj-vcs/jj/issues/6016)
 
+* The `--allow-new` flag on `jj git push` is deprecated in favor of `--remote origin`.
+
 ### New features
 
 * `jj workspace list` now accepts `-T`/`--template` option to customize its output via templates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * The `--allow-new` flag on `jj git push` is deprecated in favor of `--remote origin`.
 
+* The `git.push-new-bookmarks` config option is deprecated without replacement.
+  If there is only one remote, new bookmark can now be pushed by default without
+  this configuration option. If there is more than one remote, you must specify
+  `--remote` to push new bookmarks.
+
 ### New features
 
 * `jj workspace list` now accepts `-T`/`--template` option to customize its output via templates.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -434,8 +434,7 @@
                 },
                 "push-new-bookmarks": {
                     "type": "boolean",
-                    "description": "Allow pushing new bookmarks without --allow-new",
-                    "default": false
+                    "description": "Allow pushing new bookmarks without --allow-new (deprecated: Pushing new bookmarks is now allowed by default if there is only one remote.)"
                 },
                 "fetch": {
                     "description": "The remote(s) from which commits are fetched",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -752,6 +752,11 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
                 Ok(format!(r#""{escaped}" ++ change_id.short()"#).into())
             },
         ),
+        // TODO: Delete in jj 0.38+
+        ConfigMigrationRule::custom(
+            |layer| matches!(layer.look_up_item("git.push-new-bookmarks"), Ok(Some(_))),
+            |_| Ok("git.push-new-bookmarks is ignored".into()),
+        ),
     ]
 }
 

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -15,7 +15,6 @@ context = 3
 
 [git]
 private-commits = "none()"
-push-new-bookmarks = false
 sign-on-push = false
 track-default-bookmark-on-clone = true
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1307,11 +1307,13 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 * `--deleted` — Push all deleted bookmarks
 
    Only tracked bookmarks can be successfully deleted on the remote. A warning will be printed if any untracked bookmarks on the remote correspond to missing local bookmarks.
-* `-N`, `--allow-new` — Allow pushing new bookmarks
+* `-N`, `--allow-new` — Allow pushing new bookmarks (DEPRECATED)
 
    Newly-created remote bookmarks will be tracked automatically.
 
-   This can also be turned on by the `git.push-new-bookmarks` setting. If it's set to `true`, `--allow-new` is no-op.
+   This is now the default behavior, `--allow-new` is a no-op.
+
+   Newly-created remote bookmarks still won't be tracked automatically if there are multiple remotes, to prevent accidentally pushing changes to the wrong remote. Use `--remote` to resolve the ambiguity.
 * `--allow-empty-description` — Allow pushing commits with empty descriptions
 * `--allow-private` — Allow pushing commits that are private
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1321,8 +1321,6 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 
    The created bookmark will be tracked automatically. Use the `templates.git_push_bookmark` setting to customize the generated bookmark name. The default is `"push-" ++ change_id.short()`.
 * `--named <NAME=REVISION>` — Specify a new bookmark name and a revision to push under that name, e.g. '--named myfeature=@'
-
-   Does not require --allow-new.
 * `--dry-run` — Only display what will change on the remote
 
 

--- a/cli/tests/sample-configs/valid/git.toml
+++ b/cli/tests/sample-configs/valid/git.toml
@@ -2,7 +2,6 @@
 [git]
 auto-local-bookmark = true
 abandon-unreachable-commits = false
-push-new-bookmarks = true
 fetch = ["origin", "fork"]
 push = "fork"
 sign-on-push = true

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -321,9 +321,7 @@ fn test_bookmark_move() {
 
     // Delete bookmark locally, but is still tracking remote
     work_dir.run_jj(["describe", "@-", "-mcommit"]).success();
-    work_dir
-        .run_jj(["git", "push", "--allow-new", "-r@-"])
-        .success();
+    work_dir.run_jj(["git", "push", "-r@-"]).success();
     work_dir.run_jj(["bookmark", "delete", "foo"]).success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     foo (deleted)
@@ -620,9 +618,7 @@ fn test_bookmark_rename() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "bremote"])
         .success();
-    work_dir
-        .run_jj(["git", "push", "--allow-new", "-b=bremote"])
-        .success();
+    work_dir.run_jj(["git", "push", "-b=bremote"]).success();
     let output = work_dir.run_jj(["bookmark", "rename", "bremote", "bremote2"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
@@ -1332,9 +1328,7 @@ fn test_bookmark_track_conflict() {
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
     work_dir.run_jj(["describe", "-m", "a"]).success();
-    work_dir
-        .run_jj(["git", "push", "--allow-new", "-b", "main"])
-        .success();
+    work_dir.run_jj(["git", "push", "-b", "main"]).success();
     work_dir
         .run_jj(["bookmark", "untrack", "main@origin"])
         .success();
@@ -2139,7 +2133,6 @@ fn test_bookmark_list_tracked() {
         .run_jj([
             "git",
             "push",
-            "--allow-new",
             "--remote",
             "upstream",
             "--bookmark",

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -175,7 +175,7 @@ fn test_bookmark_names() {
         .run_jj(["desc", "-r", "bbb-tracked", "-m", "x"])
         .success();
     work_dir
-        .run_jj(["git", "push", "--allow-new", "--bookmark", "glob:*-tracked"])
+        .run_jj(["git", "push", "--bookmark", "glob:*-tracked"])
         .success();
 
     origin_dir

--- a/cli/tests/test_git_private_commits.rs
+++ b/cli/tests/test_git_private_commits.rs
@@ -66,14 +66,7 @@ fn set_up_remote_at_main(test_env: &TestEnvironment, work_dir: &TestWorkDir, rem
         ])
         .success();
     work_dir
-        .run_jj([
-            "git",
-            "push",
-            "--allow-new",
-            "--remote",
-            remote_name,
-            "-b=main",
-        ])
+        .run_jj(["git", "push", "--remote", remote_name, "-b=main"])
         .success();
 }
 
@@ -192,7 +185,7 @@ fn test_git_private_commits_not_directly_in_line_block_pushing() {
         .success();
 
     test_env.add_config(r#"git.private-commits = "description(glob:'private*')""#);
-    let output = work_dir.run_jj(["git", "push", "--allow-new", "-b=bookmark1"]);
+    let output = work_dir.run_jj(["git", "push", "-b=bookmark1"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Won't push commit 613114f44bdd since it is private
@@ -243,7 +236,7 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     work_dir
         .run_jj(["bookmark", "set", "main", "-r@"])
         .success();
-    let output = work_dir.run_jj(["git", "push", "--allow-new", "-b=main", "-b=bookmark1"]);
+    let output = work_dir.run_jj(["git", "push", "-b=main", "-b=bookmark1"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:
@@ -277,7 +270,7 @@ fn test_git_private_commits_already_on_the_remote_do_not_block_push() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "bookmark2"])
         .success();
-    let output = work_dir.run_jj(["git", "push", "--allow-new", "-b=bookmark2"]);
+    let output = work_dir.run_jj(["git", "push", "-b=bookmark2"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to origin:

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -273,7 +273,7 @@ fn test_git_push_other_remote_has_bookmark() {
     // as it is on the remote. This would also work for a descendant.
     //
     // TODO: Saner test?
-    let output = work_dir.run_jj(["git", "push", "--allow-new", "--remote=other"]);
+    let output = work_dir.run_jj(["git", "push", "--remote=other"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to other:
@@ -823,7 +823,7 @@ fn test_git_push_changes() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Bookmark already exists: push-yostqsxwqrlt
-    Hint: Use 'jj bookmark move' to move it, and 'jj git push -b push-yostqsxwqrlt [--allow-new]' to push it
+    Hint: Use 'jj bookmark move' to move it, and 'jj git push -b push-yostqsxwqrlt' to push it
     [EOF]
     [exit status: 1]
     ");
@@ -970,7 +970,7 @@ fn test_git_push_changes_with_name() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Bookmark already exists: b1
-    Hint: Use 'jj bookmark move' to move it, and 'jj git push -b b1 [--allow-new]' to push it
+    Hint: Use 'jj bookmark move' to move it, and 'jj git push -b b1' to push it
     [EOF]
     [exit status: 1]
     ");
@@ -2192,19 +2192,13 @@ fn test_git_push_to_ambiguous_remote() {
     let output = work_dir.run_jj(["git", "push", "-bbookmark3"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Refusing to create new remote bookmark bookmark3@origin
-    Hint: Use --allow-new to push new bookmark. Use --remote to specify the remote to push to.
+    Error: Refusing to create new remote bookmark bookmark3@origin; remote is ambiguous
+    Hint: Use --remote to specify the remote to push to.
     [EOF]
     [exit status: 1]
     ");
-    // This works because the remote and --allow-new is specified.
-    let output = work_dir.run_jj([
-        "git",
-        "push",
-        "-bbookmark3",
-        "--remote=other",
-        "--allow-new",
-    ]);
+    // This works because the remote is specified.
+    let output = work_dir.run_jj(["git", "push", "-bbookmark3", "--remote=other"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Changes to push to other:

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -100,7 +100,7 @@ fn test_git_push_undo() {
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
     work_dir.run_jj(["describe", "-m", "AA"]).success();
-    work_dir.run_jj(["git", "push", "--allow-new"]).success();
+    work_dir.run_jj(["git", "push"]).success();
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     work_dir.run_jj(["describe", "-m", "BB"]).success();
     //   Refs at this point look as follows (-- means no ref)
@@ -181,7 +181,7 @@ fn test_git_push_undo_with_import() {
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
     work_dir.run_jj(["describe", "-m", "AA"]).success();
-    work_dir.run_jj(["git", "push", "--allow-new"]).success();
+    work_dir.run_jj(["git", "push"]).success();
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     work_dir.run_jj(["describe", "-m", "BB"]).success();
     //   Refs at this point look as follows (-- means no ref)
@@ -269,7 +269,7 @@ fn test_git_push_undo_colocated() {
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
     work_dir.run_jj(["describe", "-m", "AA"]).success();
-    work_dir.run_jj(["git", "push", "--allow-new"]).success();
+    work_dir.run_jj(["git", "push"]).success();
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
     work_dir.run_jj(["describe", "-m", "BB"]).success();
     //   Refs at this point look as follows (-- means no ref)
@@ -357,7 +357,7 @@ fn test_git_push_undo_repo_only() {
         .run_jj(["bookmark", "create", "-r@", "main"])
         .success();
     work_dir.run_jj(["describe", "-m", "AA"]).success();
-    work_dir.run_jj(["git", "push", "--allow-new"]).success();
+    work_dir.run_jj(["git", "push"]).success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm 3a44d6c5 (empty) AA
       @origin: qpvuntsm 3a44d6c5 (empty) AA
@@ -408,7 +408,7 @@ fn test_bookmark_track_untrack_undo() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "feature1", "feature2"])
         .success();
-    work_dir.run_jj(["git", "push", "--allow-new"]).success();
+    work_dir.run_jj(["git", "push"]).success();
     work_dir
         .run_jj(["bookmark", "delete", "feature2"])
         .success();

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -194,8 +194,8 @@ makes several safety checks.
 
 3. If the remote bookmark already exists on the remote, it must be
    [tracked](#remotes-and-tracked-bookmarks). If the bookmark does not already
-   exist on the remote, there is no problem; `jj git push --allow-new` will
-   create the remote bookmark and mark it as tracked.
+   exist on the remote, there is no problem; `jj git push` will create the
+   remote bookmark and mark it as tracked.
 
 [^known-issue]: See "A general note on safety" in
     <https://git-scm.com/docs/git-push#Documentation/git-push.txt---no-force-with-lease>

--- a/docs/github.md
+++ b/docs/github.md
@@ -41,7 +41,7 @@ $ jj commit -m 'feat(bar): add support for bar'
 # on the working-copy commit's *parent* because the working copy itself is empty.
 $ jj bookmark create bar -r @- # `bar` now contains the previous two commits.
 # Push the bookmark to GitHub (pushes only `bar`)
-$ jj git push --allow-new
+$ jj git push
 ```
 
 While it's possible to create a bookmark in advance and commit on top of it in a
@@ -73,7 +73,7 @@ $ # Do some more work.
 $ jj commit -m "Update tutorial"
 # Create a bookmark on the working-copy commit's parent
 $ jj bookmark create doc-update -r @-
-$ jj git push --allow-new
+$ jj git push
 ```
 
 ## Working in a Jujutsu repository


### PR DESCRIPTION
**IMPORTANT:** There is no concensus on these changes yet. This is just a proposal of mine for reference. Code review might be a waste of time.

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
