### PR TITLE
cli: move `desc` and `st` aliases to config

### DIFF
--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -39,12 +39,11 @@ use crate::description_util::ParsedBulkEditMessage;
 use crate::text_util::parse_author;
 use crate::ui::Ui;
 
-/// Update the change description or other metadata
+/// Update the change description or other metadata [default alias: desc]
 ///
 /// Starts an editor to let you edit the description of changes. The editor
 /// will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
 #[derive(clap::Args, Clone, Debug)]
-#[command(visible_aliases = &["desc"])]
 pub(crate) struct DescribeArgs {
     /// The revision(s) whose description to edit (default: @)
     #[arg(

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -29,7 +29,7 @@ use crate::diff_util::get_copy_records;
 use crate::diff_util::DiffFormat;
 use crate::ui::Ui;
 
-/// Show high-level repo status
+/// Show high-level repo status [default alias: st]
 ///
 /// This includes:
 ///
@@ -41,7 +41,6 @@ use crate::ui::Ui;
 /// [Conflicted bookmarks]:
 ///     https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
 #[derive(clap::Args, Clone, Debug)]
-#[command(visible_alias = "st")]
 pub(crate) struct StatusArgs {
     /// Restrict the status display to these paths
     #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -4,6 +4,8 @@
 amend = ["squash"]
 b = ["bookmark"]
 ci = ["commit"]
+desc = ["describe"]
+st = ["status"]
 
 [diff.color-words]
 conflict = "materialize"

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -129,7 +129,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
 * `bookmark` — Manage bookmarks [default alias: b]
 * `commit` — Update the description and create a new change on top
 * `config` — Manage config options
-* `describe` — Update the change description or other metadata
+* `describe` — Update the change description or other metadata [default alias: desc]
 * `diff` — Compare file contents between two revisions
 * `diffedit` — Touch up the content changes in a revision with a diff editor
 * `duplicate` — Create new changes with the same content as existing ones
@@ -157,7 +157,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
 * `sparse` — Manage which paths from the working-copy commit are present in the working copy
 * `split` — Split a revision in two
 * `squash` — Move changes from a revision into another revision
-* `status` — Show high-level repo status
+* `status` — Show high-level repo status [default alias: st]
 * `tag` — Manage tags
 * `undo` — Undo an operation (shortcut for `jj op undo`)
 * `unsign` — Drop a cryptographic signature
@@ -711,13 +711,11 @@ Update a config file to unset the given option
 
 ## `jj describe`
 
-Update the change description or other metadata
+Update the change description or other metadata [default alias: desc]
 
 Starts an editor to let you edit the description of changes. The editor will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
 
 **Usage:** `jj describe [OPTIONS] [REVSETS]...`
-
-**Command Alias:** `desc`
 
 ###### **Arguments:**
 
@@ -2535,7 +2533,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 ## `jj status`
 
-Show high-level repo status
+Show high-level repo status [default alias: st]
 
 This includes:
 
@@ -2544,8 +2542,6 @@ This includes:
 [Conflicted bookmarks]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
 
 **Usage:** `jj status [FILESETS]...`
-
-**Command Alias:** `st`
 
 ###### **Arguments:**
 

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1817,7 +1817,7 @@ fn test_op_diff_divergent_change() {
     ]);
     insta::assert_snapshot!(output, @r"
     From operation: ef75d88dd5fe (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: 80381a6750a7 (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
+      To operation: 8bd3751c26de (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
 
     Changed commits:
     ○  + rlvkpnrz?? 82ad1ba9 2b
@@ -1841,8 +1841,8 @@ fn test_op_diff_divergent_change() {
         &resolved_op_id,
     ]);
     insta::assert_snapshot!(output, @r"
-    From operation: 80381a6750a7 (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
-      To operation: 366c90c8bc44 (2001-02-03 08:05:15) squash commits into 82ad1ba9ded407bab6fea1524b207f49a02779a0
+    From operation: 8bd3751c26de (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
+      To operation: 6a444a3d42e6 (2001-02-03 08:05:15) squash commits into 82ad1ba9ded407bab6fea1524b207f49a02779a0
 
     Changed commits:
     ○  + rlvkpnrz da3f472d 2ab
@@ -1867,7 +1867,7 @@ fn test_op_diff_divergent_change() {
     ]);
     insta::assert_snapshot!(output, @r"
     From operation: ef75d88dd5fe (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: 80381a6750a7 (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
+      To operation: 8bd3751c26de (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
 
     Changed commits:
     ○  + rlvkpnrz?? 82ad1ba9 2b
@@ -1906,8 +1906,8 @@ fn test_op_diff_divergent_change() {
         &resolved_op_id,
     ]);
     insta::assert_snapshot!(output, @r"
-    From operation: 80381a6750a7 (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
-      To operation: 366c90c8bc44 (2001-02-03 08:05:15) squash commits into 82ad1ba9ded407bab6fea1524b207f49a02779a0
+    From operation: 8bd3751c26de (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
+      To operation: 6a444a3d42e6 (2001-02-03 08:05:15) squash commits into 82ad1ba9ded407bab6fea1524b207f49a02779a0
 
     Changed commits:
     ○  + rlvkpnrz da3f472d 2ab
@@ -1930,8 +1930,8 @@ fn test_op_diff_divergent_change() {
         &divergent_op_id,
     ]);
     insta::assert_snapshot!(output, @r"
-    From operation: 366c90c8bc44 (2001-02-03 08:05:15) squash commits into 82ad1ba9ded407bab6fea1524b207f49a02779a0
-      To operation: 80381a6750a7 (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
+    From operation: 6a444a3d42e6 (2001-02-03 08:05:15) squash commits into 82ad1ba9ded407bab6fea1524b207f49a02779a0
+      To operation: 8bd3751c26de (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
 
     Changed commits:
     ○  + rlvkpnrz?? 82ad1ba9 2b
@@ -1955,7 +1955,7 @@ fn test_op_diff_divergent_change() {
         &initial_op_id,
     ]);
     insta::assert_snapshot!(output, @r"
-    From operation: 80381a6750a7 (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
+    From operation: 8bd3751c26de (2001-02-03 08:05:12) describe commit 105ead440de2cf759d89f951c6def56bde950ef7
       To operation: ef75d88dd5fe (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
 
     Changed commits:
@@ -1999,9 +1999,9 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     // FIXME: the diff should be empty
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @r"
-    From operation: e6d8f40ac61c (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    From operation: 2842b640d1cb (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
-      To operation: 1b4a05d4dd99 (2001-02-03 08:05:11) reconcile divergent operations
+    From operation: 69ec49158b0e (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: 0c5076ddf77d (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
+      To operation: ac3c7e679e31 (2001-02-03 08:05:11) reconcile divergent operations
 
     Changed commits:
     ○  + rlvkpnrz?? 8f35f6a6 (empty) 2b
@@ -2011,7 +2011,7 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @r"
-    1b4a05d4dd99 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ac3c7e679e31 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2019,12 +2019,12 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--limit=3"]);
     insta::assert_snapshot!(output, @r"
-    @    1b4a05d4dd99 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    ac3c7e679e31 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  e6d8f40ac61c test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  69ec49158b0e test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    │ │  args: jj desc -r@- -m1
+    │ │  args: jj describe -r@- -m1
     │ │
     │ │  Changed commits:
     │ │  ○  + rlvkpnrz 7ed5a610 (empty) 2a
@@ -2035,9 +2035,9 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     │ │  Changed working copy default@:
     │ │  + rlvkpnrz 7ed5a610 (empty) 2a
     │ │  - rlvkpnrz hidden ab92d1a8 (empty) 2a
-    │ ○  2842b640d1cb test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  0c5076ddf77d test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
-    │    args: jj desc '--at-op=@-' -m2b
+    │    args: jj describe '--at-op=@-' -m2b
     │
     │    Changed commits:
     │    ○  + rlvkpnrz 50ec12eb (empty) 2b

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -428,7 +428,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // Working copy should still contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("85725298062bdfe1d00333e7b3c5af27891e8e59acb236e8499b5712699cf77f91e3b3664e3433771b096fe781113bfe4cf1b88887aae02af733ba40963d5015")
+    Current operation: OperationId("3de33bbfe3a9df8a052cc243aeedac6a3240d6115cb88f2779a1b6f1289288c6e78153875e48e41c17c098418f681bc872c54743e76b9e210f08533c50fc5a26")
     Current tree: Merge(Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]))
     Normal { <executable> }           289 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -463,7 +463,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // working copy
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("683acb91a6165a95b02bcc8ea2133982ba6f244ec006634447e074ccc5a3c4df0bd955e4f628a406059edaa30e9c5af88f3fd06b0c5e9e48df93556da6fe410c")
+    Current operation: OperationId("2676b66a8d17cf7913d2260285abe6f3ca4c8dc8f3fdfb3f54a4d566c9199670f80123a7174b553ff67c13c20c6827cde2429847a7949c19bc52f2397139e4c9")
     Current tree: Merge(Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")))
     Normal { <executable> }           130 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -890,7 +890,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         insta::assert_snapshot!(output, @r"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation 90fc02cc90ab (2001-02-03 08:05:18) snapshot working copy
+        │  -- operation 0a26da4b0149 (2001-02-03 08:05:18) snapshot working copy
         ○  kmkuslsw hidden test.user@example.com 2001-02-03 08:05:18 866928d1
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
            -- operation 83f707034db1 (2001-02-03 08:05:18) recovery commit


### PR DESCRIPTION
I'm sorry if we have already discussed this and rejected the idea for some reason.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
