### PR TITLE
config: Allow both user-managed and repo-managed configs per repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj util exec` sets the environment variable `JJ_WORKSPACE_ROOT`
 
+* Introduced an additional config layer `repo-managed` between `user` and
+  `repo`. This layer is stored in version control, and if it ever changes,
+  we recommend to the user to review the changes (for security reasons) by
+  running the new command `jj config review-managed`. This can be used to
+  create config shared between all users who use a repository (eg.
+  [fix commands](https://chromium-review.googlesource.com/c/chromium/src/+/6703030))
+
 ### Fixed bugs
 
 * Fetching repositories that have submodules no longer errors even if

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -359,9 +359,11 @@ impl CommandHelper {
         let mut config_env = self.data.config_env.clone();
         let mut raw_config = self.data.raw_config.clone();
         let repo_path = workspace_root.join(".jj").join("repo");
-        config_env.reset_repo_path(&repo_path);
+        config_env.reset_repo_path(&repo_path, workspace_root);
+        // Since it's a new workspace, we don't need to bother loading the
+        // repo-managed config.
         config_env.reload_repo_config(&mut raw_config)?;
-        let mut config = config_env.resolve_config(&raw_config)?;
+        let mut config = config_env.resolve_config_without_repo_managed(&raw_config)?;
         // No migration messages here, which would usually be emitted before.
         jj_lib::config::migrate(&mut config, &self.data.config_migrations)?;
         Ok(self.data.settings.with_new_config(config)?)
@@ -3820,10 +3822,10 @@ impl<'a> CliRunner<'a> {
             .map_err(|err| map_workspace_load_error(err, Some(".")));
         config_env.reload_user_config(&mut raw_config)?;
         if let Ok(loader) = &maybe_cwd_workspace_loader {
-            config_env.reset_repo_path(loader.repo_path());
+            config_env.reset_repo_path(loader.repo_path(), loader.workspace_root());
             config_env.reload_repo_config(&mut raw_config)?;
         }
-        let mut config = config_env.resolve_config(&raw_config)?;
+        let mut config = config_env.resolve_config(ui, &mut raw_config)?;
         migrate_config(&mut config)?;
         ui.reset(&config)?;
 
@@ -3835,7 +3837,7 @@ impl<'a> CliRunner<'a> {
         let (args, config_layers) = parse_early_args(&self.app, &string_args)?;
         if !config_layers.is_empty() {
             raw_config.as_mut().extend_layers(config_layers);
-            config = config_env.resolve_config(&raw_config)?;
+            config = config_env.resolve_config(ui, &mut raw_config)?;
             migrate_config(&mut config)?;
             ui.reset(&config)?;
         }
@@ -3864,7 +3866,7 @@ impl<'a> CliRunner<'a> {
                 .workspace_loader_factory
                 .create(&abs_path)
                 .map_err(|err| map_workspace_load_error(err, Some(path)))?;
-            config_env.reset_repo_path(loader.repo_path());
+            config_env.reset_repo_path(loader.repo_path(), loader.workspace_root());
             config_env.reload_repo_config(&mut raw_config)?;
             Ok(loader)
         } else {
@@ -3872,7 +3874,7 @@ impl<'a> CliRunner<'a> {
         };
 
         // Apply workspace configs, --config arguments, and --when.commands.
-        config = config_env.resolve_config(&raw_config)?;
+        config = config_env.resolve_config(ui, &mut raw_config)?;
         migrate_config(&mut config)?;
         ui.reset(&config)?;
 
@@ -3882,6 +3884,7 @@ impl<'a> CliRunner<'a> {
                 ConfigSource::Default => "default-provided",
                 ConfigSource::EnvBase | ConfigSource::EnvOverrides => "environment-provided",
                 ConfigSource::User => "user-level",
+                ConfigSource::RepoManaged => "repo-managed-level",
                 ConfigSource::Repo => "repo-level",
                 ConfigSource::CommandArg => "CLI-provided",
             };

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -16,6 +16,7 @@ mod edit;
 mod get;
 mod list;
 mod path;
+mod review_managed;
 mod set;
 mod unset;
 
@@ -34,6 +35,8 @@ use self::list::ConfigListArgs;
 use self::list::cmd_config_list;
 use self::path::ConfigPathArgs;
 use self::path::cmd_config_path;
+use self::review_managed::ConfigReviewManagedArgs;
+use self::review_managed::cmd_review_managed;
 use self::set::ConfigSetArgs;
 use self::set::cmd_config_set;
 use self::unset::ConfigUnsetArgs;
@@ -146,6 +149,8 @@ pub(crate) enum ConfigCommand {
     Set(ConfigSetArgs),
     #[command(visible_alias("u"))]
     Unset(ConfigUnsetArgs),
+    #[command()]
+    ReviewManaged(ConfigReviewManagedArgs),
 }
 
 #[instrument(skip_all)]
@@ -161,5 +166,6 @@ pub(crate) fn cmd_config(
         ConfigCommand::Path(args) => cmd_config_path(ui, command, args),
         ConfigCommand::Set(args) => cmd_config_set(ui, command, args),
         ConfigCommand::Unset(args) => cmd_config_unset(ui, command, args),
+        ConfigCommand::ReviewManaged(args) => cmd_review_managed(ui, command, args),
     }
 }

--- a/cli/src/commands/config/review_managed.rs
+++ b/cli/src/commands/config/review_managed.rs
@@ -1,0 +1,125 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::command_error::internal_error_with_message;
+use crate::command_error::user_error;
+use crate::command_error::user_error_with_message;
+use crate::merge_tools::make_diff_sections;
+use crate::repo_managed_config::MANAGED_PATH;
+use crate::repo_managed_config::RepoManagedConfig;
+use crate::ui::Ui;
+
+/// Reviews and updates configuration stored in version control.
+/// You should never need to run this command unless jj tells you to.
+/// This command needs to be run when the config checked in to the repo is
+/// changed, and allows you to approve or reject said changes on a line-by-line
+/// basis.
+#[derive(clap::Args, Clone, Debug)]
+pub struct ConfigReviewManagedArgs {
+    /// Trust the repository's config and skip review of it.
+    /// Use this when you absolutely trust the repo config (eg. you're the only
+    /// contributor).
+    #[arg(long)]
+    trust: bool,
+}
+
+#[instrument(skip_all)]
+pub fn cmd_review_managed(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &ConfigReviewManagedArgs,
+) -> Result<(), CommandError> {
+    if let Some(repo_config) = command.config_env().repo_managed_config()? {
+        let workspace_command = command.workspace_helper(ui)?;
+        let workspace_root = workspace_command.workspace_root();
+        let vcs = match repo_config.get_vcs_config(workspace_root)? {
+            Some(vcs) => vcs,
+            None => {
+                // We don't need the user to review this since it's not a security issue.
+                writeln!(ui.status(), "Your config doesn't need review")?;
+                return Ok(());
+            }
+        };
+
+        let new_config = if args.trust {
+            vcs.clone()
+        } else {
+            let old_config = repo_config
+                .last_approved()
+                .ok()
+                .flatten()
+                .and_then(|last_approved| std::fs::read_to_string(last_approved).ok())
+                .unwrap_or_default();
+            let sections = make_diff_sections(
+                &old_config,
+                &String::from_utf8(vcs.clone()).map_err(|e| {
+                    user_error_with_message("Config stored in VCS was not utf-8", e)
+                })?,
+            )
+            .map_err(|e| internal_error_with_message("Failed to create diff sections", e))?;
+            // Ideally we'd use the user's chosen diff selector, but that
+            // heavily relies on jj's objects such as Tree and Store.
+            let recorded = scm_record::Recorder::new(
+                scm_record::RecordState {
+                    is_read_only: false,
+                    commits: vec![],
+                    files: vec![scm_record::File {
+                        old_path: None,
+                        path: std::borrow::Cow::Borrowed(Path::new(MANAGED_PATH)),
+                        // This doesn't do anything.
+                        file_mode: scm_record::FileMode::Unix(0o777),
+                        sections,
+                    }],
+                },
+                &mut scm_record::helpers::CrosstermInput,
+            )
+            .run()
+            .map_err(|_| user_error("Failed to select changes"))?;
+
+            // There's always precisely one file.
+            reconstruct(&recorded.files[0].sections).into_bytes()
+        };
+        repo_config.approve_content(&RepoManagedConfig::digest(&vcs), &new_config)?;
+        writeln!(ui.status(), "Updated repo config file")?;
+        Ok(())
+    } else {
+        Err(user_error(
+            "Unable to detect location of config files. Are you in a repo?",
+        ))
+    }
+}
+
+fn reconstruct(sections: &[scm_record::Section]) -> String {
+    let mut out: Vec<&str> = Default::default();
+    for section in sections {
+        match section {
+            scm_record::Section::Unchanged { lines } => out.extend(lines.iter().map(AsRef::as_ref)),
+            scm_record::Section::Changed { lines } => {
+                for line in lines {
+                    if line.is_checked == (line.change_type == scm_record::ChangeType::Added) {
+                        out.push(&line.line);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out.join("")
+}

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -939,10 +939,10 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
     let maybe_cwd_workspace_loader = DefaultWorkspaceLoaderFactory.create(find_workspace_dir(&cwd));
     let _ = config_env.reload_user_config(&mut raw_config);
     if let Ok(loader) = &maybe_cwd_workspace_loader {
-        config_env.reset_repo_path(loader.repo_path());
+        config_env.reset_repo_path(loader.repo_path(), loader.workspace_root());
         let _ = config_env.reload_repo_config(&mut raw_config);
     }
-    let mut config = config_env.resolve_config(&raw_config)?;
+    let mut config = config_env.resolve_config(&ui, &mut raw_config)?;
     // skip 2 because of the clap_complete prelude: jj -- jj <actual args...>
     let args = std::env::args_os().skip(2);
     let args = expand_args(&ui, &app, args, &config)?;
@@ -957,9 +957,9 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
     if let Some(repository) = args.repository {
         // Try to update repo-specific config on a best-effort basis.
         if let Ok(loader) = DefaultWorkspaceLoaderFactory.create(&cwd.join(&repository)) {
-            config_env.reset_repo_path(loader.repo_path());
+            config_env.reset_repo_path(loader.repo_path(), loader.workspace_root());
             let _ = config_env.reload_repo_config(&mut raw_config);
-            if let Ok(new_config) = config_env.resolve_config(&raw_config) {
+            if let Ok(new_config) = config_env.resolve_config(&ui, &mut raw_config) {
                 config = new_config;
             }
         }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -943,6 +943,17 @@
                 }
             }
         },
+        "repo-managed-config": {
+            "type": "object",
+            "description": "Settings controlling the repo-managed config feature which loads configuration from .config/jj/config.toml",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable this feature",
+                    "default": false
+                }
+            }
+        },
         "--when": {
             "type": "object",
             "description": "Conditions restriction the application of the configuration",

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -950,7 +950,7 @@
                 "enabled": {
                     "type": "boolean",
                     "description": "Whether to enable this feature",
-                    "default": false
+                    "default": true
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -59,4 +59,4 @@ auto-update-stale = false
 legacy-bookmark-behavior = true
 
 [repo-managed-config]
-enabled = false
+enabled = true

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -57,3 +57,6 @@ auto-update-stale = false
 # in the future.
 [split]
 legacy-bookmark-behavior = true
+
+[repo-managed-config]
+enabled = false

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -43,6 +43,7 @@ pub mod merge_tools;
 pub mod movement_util;
 pub mod operation_templater;
 mod progress;
+pub mod repo_managed_config;
 pub mod revset_util;
 pub mod template_builder;
 pub mod template_parser;

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -212,7 +212,7 @@ fn make_section_changed_lines(
         .collect()
 }
 
-fn make_diff_sections(
+pub fn make_diff_sections(
     left_contents: &str,
     right_contents: &str,
 ) -> Result<Vec<scm_record::Section<'static>>, BuiltinToolError> {

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -47,6 +47,7 @@ use thiserror::Error;
 use self::builtin::BuiltinToolError;
 use self::builtin::edit_diff_builtin;
 use self::builtin::edit_merge_builtin;
+pub use self::builtin::make_diff_sections;
 use self::diff_working_copies::DiffCheckoutError;
 pub(crate) use self::diff_working_copies::new_utf8_temp_dir;
 pub use self::external::DiffToolMode;

--- a/cli/src/repo_managed_config.rs
+++ b/cli/src/repo_managed_config.rs
@@ -1,0 +1,220 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::io::Write as _;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+
+use jj_lib::config::ConfigLayer;
+use jj_lib::config::ConfigSource;
+use jj_lib::content_hash::blake2b_hash;
+use jj_lib::file_util;
+use jj_lib::file_util::BadPathEncoding;
+use jj_lib::file_util::IoResultExt as _;
+use jj_lib::file_util::PathError;
+use jj_lib::file_util::persist_temp_file;
+use jj_lib::hex_util;
+use jj_lib::repo_path::RepoPathBuf;
+use tempfile::NamedTempFile;
+
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+pub const MANAGED_PATH: &str = ".config/jj/config.toml";
+pub const LAST_APPROVED: &str = "last_approved";
+
+/// Manages the repo-managed config. The file structure for the repo-managed
+/// config for a repo contained at /path/to/repo is:
+/// ~/.local/state/jj/repos/hash(/path/to/repo)/last_approved:
+///   hash(config1)
+/// ~/.local/state/jj/repos/hash(/path/to/repo)/last_approved_hash(workspace):
+///   hash(config1)
+/// ~/.local/state/jj/repos/hash(/path/to/repo)/hash(config1):
+///   approved content for config1
+/// ~/.local/state/jj/repos/hash(/path/to/repo)/hash(config2):
+///   approved content for config2
+pub struct RepoManagedConfig {
+    config_dir: PathBuf,
+    repo_path: PathBuf,
+    last_approved_name: String,
+}
+
+static PRINTED_WARNING: AtomicBool = AtomicBool::new(false);
+
+impl RepoManagedConfig {
+    pub fn new(
+        state_dir: &Path,
+        repo_path: &Path,
+        workspace_path: &Path,
+    ) -> Result<Self, BadPathEncoding> {
+        Ok(Self {
+            config_dir: state_dir
+                .join("repos")
+                .join(Self::digest(file_util::path_to_bytes(repo_path)?)),
+            repo_path: repo_path.to_path_buf(),
+            last_approved_name: format!(
+                "{LAST_APPROVED}_{}",
+                Self::digest(file_util::path_to_bytes(workspace_path)?)
+            ),
+        })
+    }
+
+    fn write(path: &Path, content: &[u8]) -> Result<(), PathError> {
+        let mut temp_file = NamedTempFile::new_in(path.parent().unwrap()).context(path)?;
+        temp_file.as_file_mut().write_all(content).context(path)?;
+        persist_temp_file(temp_file, path).context(path)?;
+        Ok(())
+    }
+
+    fn approved_config(&self, digest: &str) -> PathBuf {
+        self.config_dir.join(format!("{digest}.toml"))
+    }
+
+    pub fn last_approved(&self) -> Result<Option<PathBuf>, PathError> {
+        let read = |path: &Path| match std::fs::read_to_string(path) {
+            Ok(content) => Ok(Some(self.approved_config(&content))),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e).context(path),
+        };
+
+        Ok(
+            if let Some(last_approved) = read(&self.config_dir.join(&self.last_approved_name))? {
+                Some(last_approved)
+            } else {
+                read(&self.config_dir.join(LAST_APPROVED))?
+            },
+        )
+    }
+
+    /// Updates last-approved to the current digest.
+    fn approve(&self, digest: &str) -> Result<(), PathError> {
+        // Do not use a symlink since they don't play nice with windows.
+        // Apparently it's requires privilege escalation on windows.
+        Self::write(
+            &self.config_dir.join(&self.last_approved_name),
+            digest.as_bytes(),
+        )?;
+        Self::write(&self.config_dir.join(LAST_APPROVED), digest.as_bytes())
+    }
+
+    /// Sets the approved config to content for the given digest.
+    pub fn approve_content(&self, digest: &str, content: &[u8]) -> Result<(), PathError> {
+        // This never removes old ones. This is by design. In the future, we
+        // might want to do some kind of TTL or some way to cleanup old ones.
+        // It doesn't matter that much though, since configs are likely small
+        // and infrequently changed.
+        std::fs::create_dir_all(&self.config_dir).context(&self.config_dir)?;
+        // This isn't used right now, but it may be used in the future to clean
+        // up deleted repos.
+        Self::write(
+            &self.config_dir.join("repo_path"),
+            self.repo_path.as_os_str().as_encoded_bytes(),
+        )?;
+        Self::write(&self.approved_config(digest), content)?;
+        self.approve(digest)
+    }
+
+    pub fn get_vcs_config(&self, workspace_root: &Path) -> Result<Option<Vec<u8>>, CommandError> {
+        let managed = RepoPathBuf::from_internal_string(MANAGED_PATH)
+            .unwrap()
+            .to_fs_path_unchecked(workspace_root);
+        Ok(match std::fs::read(&managed) {
+            Ok(val) => {
+                if !val.is_empty() {
+                    Some(val)
+                } else {
+                    None
+                }
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+            Err(e) => Err(e).context(&managed)?,
+        })
+    }
+
+    pub fn digest(content: &[u8]) -> String {
+        let hash: &[u8] = &blake2b_hash(content);
+        // There are two digests in a path (digest of repo path and digest of config
+        // file). Each digest is 512 bits, and is encoded as hex, so takes up
+        // 128 characters. This means that the pathname has 256 characters of
+        // hashes. On windows, the maximum path length is 260 characters, so we
+        // use xor to compress 512 bits into 256 so that it fits within the
+        // maximum path length.
+        #[cfg(windows)]
+        let hash = &hash
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|[lhs, rhs]| lhs ^ rhs)
+            .collect::<Vec<_>>();
+        hex_util::encode_hex(hash)
+    }
+
+    /// If the digest of MANAGED_PATH exists in the cache, returns
+    /// (config_file, true). Otherwise, returns
+    /// (the most recent content passed to `approve_content`, false)
+    pub fn get_config_file(
+        &self,
+        workspace_root: &Path,
+    ) -> Result<(Option<PathBuf>, bool), CommandError> {
+        let config = self.get_vcs_config(workspace_root)?;
+        if let Some(config) = config
+            && !config.is_empty()
+        {
+            let digest = Self::digest(&config);
+            let out = self.approved_config(&digest);
+            let last_approved = self.last_approved()?;
+            if out.try_exists()? {
+                // This particular config was previously approved, but we need to reset
+                // last_approved.
+                if Some(&out) != last_approved.as_ref() {
+                    self.approve(&digest)?;
+                }
+                return Ok((Some(out), true));
+            } else {
+                return Ok((last_approved, false));
+            }
+        }
+        Ok((None, true))
+    }
+
+    /// Creates the configuration layer for the repo managed config.
+    /// This layer is best-effort based on the approved repo config.
+    /// If we don't get a perfect match, it will print a warning that your
+    /// config is out of date.
+    pub fn create_layer(
+        &self,
+        ui: &Ui,
+        workspace_root: &Path,
+    ) -> Result<Option<ConfigLayer>, CommandError> {
+        let (last_approved, up_to_date) = self.get_config_file(workspace_root)?;
+        if !up_to_date && !PRINTED_WARNING.swap(true, std::sync::atomic::Ordering::AcqRel) {
+            writeln!(
+                ui.warning_default(),
+                "Your repo-managed config is out of date"
+            )?;
+            writeln!(ui.hint_default(), "Run `jj config review-managed`")?;
+        }
+
+        let last_approved = match last_approved {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+        match ConfigLayer::load_from_file(ConfigSource::RepoManaged, last_approved) {
+            Ok(layer) => Ok(Some(layer)),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -144,6 +144,7 @@ fn warn_user_redefined_builtin(
         ConfigSource::Default => (),
         ConfigSource::EnvBase
         | ConfigSource::User
+        | ConfigSource::RepoManaged
         | ConfigSource::Repo
         | ConfigSource::EnvOverrides
         | ConfigSource::CommandArg => {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -33,6 +33,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj config path`↴](#jj-config-path)
 * [`jj config set`↴](#jj-config-set)
 * [`jj config unset`↴](#jj-config-unset)
+* [`jj config review-managed`↴](#jj-config-review-managed)
 * [`jj describe`↴](#jj-describe)
 * [`jj diff`↴](#jj-diff)
 * [`jj diffedit`↴](#jj-diffedit)
@@ -621,6 +622,7 @@ See [`jj help -k config`] to know more about file locations, supported config op
 * `path` — Print the paths to the config files
 * `set` — Update a config file to set the given option to a given value
 * `unset` — Update a config file to unset the given option
+* `review-managed` — Reviews and updates configuration stored in version control. You should never need to run this command unless jj tells you to. This command needs to be run when the config checked in to the repo is changed, and allows you to approve or reject said changes on a line-by-line basis
 
 
 
@@ -761,6 +763,18 @@ Update a config file to unset the given option
 
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
+
+
+
+## `jj config review-managed`
+
+Reviews and updates configuration stored in version control. You should never need to run this command unless jj tells you to. This command needs to be run when the config checked in to the repo is changed, and allows you to approve or reject said changes on a line-by-line basis
+
+**Usage:** `jj config review-managed [OPTIONS]`
+
+###### **Options:**
+
+* `--trust` — Trust the repository's config and skip review of it. Use this when you absolutely trust the repo config (eg. you're the only contributor)
 
 
 

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -148,6 +148,7 @@ impl TestEnvironment {
             if let Ok(tmp_var) = std::env::var("TEMP") {
                 cmd.env("TEMP", tmp_var);
             }
+            cmd.env("USERPROFILE", self.home_dir.to_str().unwrap());
         }
 
         cmd

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -62,6 +62,7 @@ mod test_operations;
 mod test_parallelize_command;
 mod test_rebase_command;
 mod test_repo_change_report;
+mod test_repo_managed_config;
 mod test_resolve_command;
 mod test_restore_command;
 mod test_revert_command;

--- a/cli/tests/test_repo_managed_config.rs
+++ b/cli/tests/test_repo_managed_config.rs
@@ -1,0 +1,271 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+#[test]
+fn test_repo_managed_config() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    test_env.add_config(r#"ui.pager = "user pager""#);
+
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    "###);
+
+    work_dir.write_file(
+        ".config/jj/config.toml",
+        r#"repo-managed-config.enabled = false"#,
+    );
+
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+
+    // We have to use the --trust flag here because we can't interact with the TUI.
+    let output = work_dir.run_jj(["config", "review-managed", "--trust"]);
+    insta::assert_snapshot!(output, @r###"
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    Updated repo config file
+    [EOF]
+    "###);
+
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    "###);
+
+    test_env.add_config(r"repo-managed-config.enabled = false");
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    "###);
+
+    test_env.add_config(
+        r###"
+    [[--scope]]
+    --when.commands = ["config get"]
+    [--scope.repo-managed-config]
+    enabled = true
+    "###,
+    );
+    work_dir.write_file(
+        ".config/jj/config.toml",
+        r#"ui.pager = "repo-managed pager""#,
+    );
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+
+    let other_dir = test_env.work_dir(".");
+    let output = other_dir.run_jj([
+        "-R",
+        work_dir.root().to_str().unwrap(),
+        "config",
+        "get",
+        "ui.pager",
+    ]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+
+    // If the repo says to enable repo-managed config, but the user disallows it,
+    // it should definitely not be enabled.
+    work_dir.write_file(
+        ".jj/repo/config.toml",
+        r#"repo-managed-config.enabled = false"#,
+    );
+    work_dir.write_file(
+        ".config/jj/config.toml",
+        r#"repo-managed-config.enabled = true"#,
+    );
+    other_dir.write_file(
+        ".config/jj/config.toml",
+        r#"repo-managed-config.enabled = true"#,
+    );
+    let output = other_dir.run_jj([
+        "-R",
+        work_dir.root().to_str().unwrap(),
+        "config",
+        "get",
+        "ui.pager",
+    ]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    "###);
+
+    work_dir.write_file(".jj/repo/config.toml", "");
+
+    // We have to use the --trust flag here because we can't interact with the TUI.
+    let output = work_dir.run_jj(["config", "review-managed", "--trust"]);
+    insta::assert_snapshot!(output, @r###"
+    ------- stderr -------
+    Updated repo config file
+    [EOF]
+    "###);
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    "###);
+}
+
+#[test]
+fn test_multi_workspace_config() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    test_env
+        .run_jj_in("repo", ["workspace", "add", "../second"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+    let second_dir = test_env.work_dir("second");
+    test_env.add_config(r#"ui.pager = "user pager""#);
+
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    "###);
+
+    work_dir.write_file(".config/jj/config.toml", r#"ui.pager = "repo pager""#);
+
+    // The config should be out of date in the main repo
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+
+    // But the second repo should still rely on its own local config
+    let output = second_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    "###);
+
+    second_dir.write_file(".config/jj/config.toml", r#"ui.pager = "repo pager""#);
+
+    // Now the second dir is out of date
+    let output = second_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    user pager
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+
+    work_dir
+        .run_jj(["config", "review-managed", "--trust"])
+        .success();
+
+    // We should now be using the new config.
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    repo pager
+    [EOF]
+    "###);
+
+    // Approving the same content for one workspace should approve it for the other.
+    let output = second_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    repo pager
+    [EOF]
+    "###);
+
+    // Now we update them divergently
+    work_dir.write_file(".config/jj/config.toml", r#"ui.pager = "repo pager v2""#);
+    second_dir.write_file(".config/jj/config.toml", r#"ui.pager = "second pager v2""#);
+
+    // Both directories should use the last approved config.
+    // This is despite the fact that the the second workspace doesn't have a
+    // last approved config, so it needs to use the global last approved config
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    repo pager
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+    let output = second_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    repo pager
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+
+    // This time we update them divergently, but both have a last approved config.
+    work_dir
+        .run_jj(["config", "review-managed", "--trust"])
+        .success();
+    second_dir
+        .run_jj(["config", "review-managed", "--trust"])
+        .success();
+    work_dir.write_file(".config/jj/config.toml", r#"ui.pager = "repo pager v3""#);
+    second_dir.write_file(".config/jj/config.toml", r#"ui.pager = "second pager v3""#);
+
+    let output = work_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    repo pager v2
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+    let output = second_dir.run_jj(["config", "get", "ui.pager"]);
+    insta::assert_snapshot!(output, @r###"
+    second pager v2
+    [EOF]
+    ------- stderr -------
+    Warning: Your repo-managed config is out of date
+    Hint: Run `jj config review-managed`
+    [EOF]
+    "###);
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,8 +14,12 @@ These are the config settings available to jj/Jujutsu.
 settings are located in [the user config files], which can be found with `jj
 config path --user`.
 
-- The repo settings. These can be edited with `jj config edit --repo` and are
-located in `.jj/repo/config.toml`.
+- The repo-managed settings. These are stored in `<repo>/.config/jj/config.toml`.
+  For security reasons, they are not trusted and the user will need to approve
+  any updates to this file.
+
+- The repo settings. These can be edited with `jj config edit --repo` and
+  are located in `.jj/repo/config.toml`.
 
 - Settings [specified in the command-line](#specifying-config-on-the-command-line).
 

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -286,6 +286,8 @@ pub enum ConfigSource {
     EnvBase,
     /// User configuration files.
     User,
+    /// Checked in to version control and managed by repo owners.
+    RepoManaged,
     /// Repo configuration files.
     Repo,
     /// Override environment variables.
@@ -300,6 +302,7 @@ impl Display for ConfigSource {
         let c = match self {
             Default => "default",
             User => "user",
+            RepoManaged => "repo-managed",
             Repo => "repo",
             CommandArg => "cli",
             EnvBase | EnvOverrides => "env",


### PR DESCRIPTION
Fixes #3684

This adds the following workflow to jj to support repo-level workflows:
1) Repo updates config.toml in the VCS
2) User retrieves changes
3) User runs jj command, gets a warning saying "please run `jj config update-repo`"
4) `jj config update-repo` adds a TUI requesting the user to approve the diff
5) The approved changes are copied to a permanent config file.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
