### PR TITLE
config: add --when.config to match previously-set config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   It still fully traverses them while snapshotting but they won't clutter up
   the output with all of their contents.
 
+* Added `--when.config` scope condition to match on previously-set config values.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/docs/config.md
+++ b/docs/config.md
@@ -1734,6 +1734,16 @@ paginate = "never"
 --when.commands = ["diff", "show"]
 [--scope.ui]
 pager = "delta"
+
+# override user.email based on a custom config value,
+# ..which can be set per-repository
+[[--scope]]
+--when.config.org = 'work'
+user.email = "YOUR_WORK_EMAIL@example.org"
+
+[[--scope]]
+--when.config.org = 'oss'
+user.email = "YOUR_OSS_EMAIL@example.org"
 ```
 
 #### Using multiple files
@@ -1785,4 +1795,21 @@ wip = ["log", "-r", "work"]
   --when.commands = ["file"]        # matches `jj file show`, `jj file list`, etc
   --when.commands = ["file show"]   # matches `jj file show` but *NOT* `jj file list`
   --when.commands = ["file", "log"] # matches `jj file` *OR* `jj log` (or subcommand of either)
+  ```
+
+
+* `--when.config`: Table of config values to match.
+
+  Only matches values from previous scopes/layers.
+
+  ```toml
+  foo = 'bar'
+
+  [[--scope]]
+  --when.config.foo = 'bar'
+  foo = 'baz'
+
+  [[--scope]]
+  --when.config.foo = 'bar'
+  # this never runs because the condition applies after the previous scope
   ```


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

I wanted to be able to set my user.name and user.email based on a single per-repo value:
```toml
[[--scope]]
--when.config.org = 'work'
user.email = "YOUR_WORK_EMAIL@example.org"

[[--scope]]
--when.config.org = 'oss'
user.email = "YOUR_OSS_EMAIL@example.org"
```

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`) Not Applicable (?)
- [x] I have added/updated tests to cover my changes
