### PR TITLE
fix: Revise description of how stderr is handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Added `templates.workspace_list` template to customize the output of `jj workspace list`.
 
-* `jj fix` now buffers lines from subprocesses' stderr streams and emits them a
-  complete line at a time. Each line is prepended with the file name.
+* `jj fix` now buffers the standard error stream from subprocesses and emits
+  the output from each all at once. The file name is printed before the output.
 
 * `jj status` now collapses fully untracked directories into one line.
   It still fully traverses them while snapshotting but they won't clutter up


### PR DESCRIPTION
I originally prepended the filename to each line of stderr output, but during PR it changed to just printing once before each subprocess' output.

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
