### PR TITLE
template: commit trailers respect JJ: prefixes when not using an editor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj fix` now buffers lines from subprocesses' stderr streams and emits them a
   complete line at a time. Each line is prepended with the file name.
 
+* commit trailers now respect `JJ:` prefixes and ignore them when not using an
+  editor.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -922,7 +922,7 @@ fn test_add_trailer() {
         "-m",
         "Message from CLI",
         "--config",
-        r#"templates.commit_trailers='"Signed-off-by: " ++ committer'"#,
+        r#"templates.commit_trailers='"JJ: Ignore\nSigned-off-by: " ++ committer'"#,
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------


### PR DESCRIPTION
This will allow users to write instructions in their commit trailers such as:

```
JJ: Feel free to modify this if you did any local testing
Test: CI/CQ
```

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
