### PR TITLE
Add parents() method for Operation template type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `core.autocrlf` config. A heuristics is used to detect if a file is a binary
   file to prevent the EOL conversion from changing binary files unexpectedly.
 
+* Add a `.parents()` method to the
+  [`Operation`](docs/templates.md#operation-type) type in the templating
+  language.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -312,6 +312,7 @@ This type cannot be printed. The following methods are defined.
 * `.user() -> String`
 * `.snapshot() -> Boolean`: True if the operation is a snapshot operation.
 * `.root() -> Boolean`: True if the operation is the root operation.
+* `.parents() -> List<Operation>`
 
 ### `OperationId` type
 


### PR DESCRIPTION
Add a parents method for Operation, as requested in #6979 

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
