### PR TITLE
Improve discoverability and documentation of `jj file track`

### DIFF
--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -31,11 +31,12 @@ use crate::ui::Ui;
 ///
 /// Without arguments, all paths that are not ignored will be tracked.
 ///
-/// New files in the working copy can be automatically tracked.  
+/// By default, new files in the working copy are automatically tracked, so
+/// this command has no effect.
 /// You can configure which paths to automatically track by setting
 /// `snapshot.auto-track` (e.g. to `"none()"` or `"glob:**/*.rs"`). Files that
 /// don't match the pattern can be manually tracked using this command. The
-/// default pattern is `all()` and this command has no effect.
+/// default pattern is `all()`.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct FileTrackArgs {
     /// Paths to track

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1053,7 +1053,7 @@ Start tracking specified paths in the working copy
 
 Without arguments, all paths that are not ignored will be tracked.
 
-New files in the working copy can be automatically tracked. You can configure which paths to automatically track by setting `snapshot.auto-track` (e.g. to `"none()"` or `"glob:**/*.rs"`). Files that don't match the pattern can be manually tracked using this command. The default pattern is `all()` and this command has no effect.
+By default, new files in the working copy are automatically tracked, so this command has no effect. You can configure which paths to automatically track by setting `snapshot.auto-track` (e.g. to `"none()"` or `"glob:**/*.rs"`). Files that don't match the pattern can be manually tracked using this command. The default pattern is `all()`.
 
 **Usage:** `jj file track <FILESETS>...`
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -196,7 +196,8 @@ To squash or split commits, use `jj squash` and `jj split`.
 
 You can set `snapshot.auto-track` to only start tracking new files matching the
 configured pattern (e.g. `"none()"`). Changes to already tracked files will
-still be snapshotted by every command.
+still be snapshotted by every command. Files not matching the pattern can be
+tracked with `jj file track`.
 
 You can keep your notes and other scratch files in the repository, if you add
 a wildcard pattern to either the repo's `gitignore` or your global `gitignore`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1562,6 +1562,9 @@ get automatically tracked when they're added to the working copy. See the
 [fileset documentation](filesets.md) for the syntax. Files with paths matching
 [ignore files](working-copy.md#ignored-files) are never tracked automatically.
 
+If you set `snapshot.auto-track` to a non-default value, untracked files can be
+tracked with `jj file track`.
+
 You can use `jj file untrack` to untrack a file while keeping it in the working
 copy. However, first [ignore](working-copy.md#ignored-files) them or remove them
 from the `snapshot.auto-track` patterns; otherwise they will be immediately

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -22,6 +22,9 @@ tracked when they're added to the working copy. See the
 [fileset documentation](filesets.md) for the syntax. Files with paths matching
 [ignore files](#ignored-files) are never tracked automatically.
 
+If you set `snapshot.auto-track` to a non-default value, untracked files can be
+tracked with `jj file track`.
+
 You can use `jj file untrack` to untrack a file while keeping it in the working
 copy. However, first [ignore](#ignored-files) them or remove them from the
 `snapshot.auto-track` patterns; otherwise they will be immediately tracked again.


### PR DESCRIPTION
1. `snapshot.auto-track` is described in several places, with its ability to disable auto-tracking of files. Next to it, `jj file untrack` is mentioned.

   That sounded cool to me, but I couldn't figure out how to track files. One could make the connection between `untrack` and `track`, but I think it should be more explicit.

    (BTW, the FAQ item where the "don't track anything" option is mentioned is discussing scratch files, but I think this option is enticing enough to people familiar with other VCS tools to deserve its own entry)

2. The documentation of `jj file track` starts with:
    > New files in the working copy can be automatically tracked.

    That "can" feels wrong to me - new files *are* automatically tracked by default. I changed the phrasing a bit, to move the default behavior to the top. Now the description says "default" twice, which isn't great, so please suggest improvements (or insist on keeping the old description).