### PR TITLE
absorb: complete only changed files

### DIFF
--- a/cli/src/commands/absorb.rs
+++ b/cli/src/commands/absorb.rs
@@ -60,7 +60,11 @@ pub(crate) struct AbsorbArgs {
     )]
     into: Vec<RevisionArg>,
     /// Move only changes to these paths (instead of all paths)
-    #[arg(value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
+    #[arg(
+        value_name = "FILESETS",
+        value_hint = clap::ValueHint::AnyPath,
+        add = ArgValueCompleter::new(complete::modified_from_files),
+    )]
     paths: Vec<String>,
 }
 

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -821,6 +821,12 @@ pub fn modified_range_files(current: &std::ffi::OsStr) -> Vec<CompletionCandidat
     }
 }
 
+/// Completes files in `@` *or* the `--from` revision (not the diff between
+/// `--from` and `@`)
+pub fn modified_from_files(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    modified_files_from_rev((parse::from_or_wc(), None), current)
+}
+
 pub fn modified_revision_or_range_files(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
     if let Some(rev) = parse::revision() {
         return modified_files_from_rev((rev, None), current);
@@ -1055,6 +1061,12 @@ mod parse {
 
     pub fn revision_or_wc() -> String {
         revision().unwrap_or_else(|| "@".into())
+    }
+
+    pub fn from_or_wc() -> String {
+        parse_flag(&["-f", "--from"], std::env::args())
+            .next()
+            .unwrap_or_else(|| "@".into())
     }
 
     pub fn parse_range_impl<T>(args: impl Fn() -> T) -> Option<(String, String)>

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1454,4 +1454,19 @@ fn test_files() {
     let outside_repo = test_env.env_root();
     let output = test_env.work_dir(outside_repo).complete_fish(["log", "f_"]);
     insta::assert_snapshot!(output, @"");
+
+    let output = work_dir.complete_fish(["absorb", "f_"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    f_added_2	Added
+    f_modified	Modified
+    [EOF]
+    ");
+
+    let output = work_dir.complete_fish(["absorb", "-f=conflicted", "f_"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    f_added_2	Added
+    f_dir/
+    f_modified	Modified
+    [EOF]
+    ");
 }


### PR DESCRIPTION
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
