### PR TITLE
merge tools: allow specifying that a tool does not support diff editing or viewing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   language.
 
 * Merge tools config can now explicitly forbid using them as diff editors or
-  diff formatters.
+  diff formatters. Built-in tools that do not function well as diff editing
+  tools or as diff formatters will now report an error when used as such.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [`Operation`](docs/templates.md#operation-type) type in the templating
   language.
 
+* Merge tools config can now explicitly forbid using them as diff editors.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [`Operation`](docs/templates.md#operation-type) type in the templating
   language.
 
-* Merge tools config can now explicitly forbid using them as diff editors.
+* Merge tools config can now explicitly forbid using them as diff editors or
+  diff formatters.
 
 ### Fixed bugs
 

--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -7,16 +7,17 @@ program="diffedit3"
 # We use a random port as a fallback if all 5 of the preferred port numbers are
 # busy.
 edit-args = ["$left", "$right", "$output", "--port", "17376-17380", "--port", "0"]
+# Not the best diff viewer, but functional. It's possible to hide the 3rd pane in the UI.
+diff-args = ["$left", "$right", "--port", "17376-17380", "--port", "0"]
 
 [merge-tools.diffedit3-ssh]
 program="diffedit3"
-# 17376 is a verified random number, as in https://xkcd.com/221/ :). I am trying
-# to avoid 8000 or 8080 in case those, more commonly used, port numbers are used
-# for something else.
+# See comments for `diffedit3` above.
 #
-# We do NOT use a random port as a fallback since we recommend that the user
-# configure SSH to forward these 5 ports
+# Unlike `diffedit3`, `diffedit3-ssh` does NOT use a random port as a fallback
+# since we recommend that the user configure SSH to forward these 5 ports
 edit-args = ["$left", "$right", "$output", "--port", "17376-17380", "--no-browser"]
+diff-args = ["$left", "$right", "--port", "17376-17380", "--no-browser"]
 
 [merge-tools.difft]
 diff-args = ["--color=always", "$left", "$right"]
@@ -70,10 +71,19 @@ merge-args = ["--wait", "--merge", "$left", "$right", "$base", "$output"]
 merge-tool-edits-conflict-markers = true
 # VS Code prefers Git-style conflict markers
 conflict-marker-style = "git"
+# Not recommended, but functional. Without `--wait`, the behavior may be more
+# convenient, but is also more confusing and brittle (all files get deleted).
+# TODO: We could consider a "file-by-file-keep-files" invocation mode to make it
+# work better.
+diff-args=["--diff", "$left", "$right", "--wait"]
+diff-invocation-mode="file-by-file"
 
 # free/libre distribution of vscode, functionally more or less the same
 [merge-tools.vscodium]
 program = "codium"
 merge-args = ["--wait", "--merge", "$left", "$right", "$base", "$output"]
+# See notes for vscode above
 merge-tool-edits-conflict-markers = true
 conflict-marker-style = "git"
+diff-args=["--diff", "$left", "$right", "--wait"]
+diff-invocation-mode="file-by-file"

--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -21,6 +21,7 @@ diff-args = ["$left", "$right", "--port", "17376-17380", "--no-browser"]
 
 [merge-tools.difft]
 diff-args = ["--color=always", "$left", "$right"]
+edit-args = []  # Non-interactive diff formatter
 
 [merge-tools.kdiff3]
 # --merge to open output pane, CreateBakFiles=0 to not include backup files in commit
@@ -33,6 +34,7 @@ merge-args = ["$left", "$base", "$right", "-o", "$output", "--auto-merge"]
 
 [merge-tools.meld-3]
 program="meld"
+diff-args = ["$left", "$right"]  # Same as the default value
 # If using this as a template, note that `$output` is repeated twice below
 edit-args = ["$left", "$output", "$right", "-o", "$output"]
 
@@ -43,10 +45,18 @@ edit-args = ["$left", "$output", "$right", "-o", "$output"]
 program = "mergiraf"
 merge-args = ["merge", "$base", "$left", "$right", "-o", "$output", "-l", "$marker_length", "--fast"]
 merge-conflict-exit-codes = [1]
+# Non-interactive merge tool
+edit-args = []
+diff-args = []
 
 [merge-tools.smerge]
 merge-args = ["mergetool", "$base", "$left", "$right", "-o", "$output"]
 conflict-marker-style = "git"
+# Does not support diff editing as of this writing. See also
+# https://github.com/sublimehq/sublime_merge/issues/1939
+# https://www.sublimemerge.com/docs/command_line
+edit-args = []
+diff-args = []
 
 [merge-tools.vimdiff]
 program = "vim"
@@ -56,10 +66,11 @@ merge-args = ["-f", "-d", "$output", "-M", "$left", "$base", "$right",
               "-c", "wincmd J", "-c", "set modifiable", "-c", "set write",
               "-c", "/<<<<<</+2"]
 merge-tool-edits-conflict-markers = true
-# Using vimdiff as a diff editor is not recommended. For instructions on configuring
-# the DirDiff Vim plugin for a better experience, see
-# https://gist.github.com/ilyagr/5d6339fb7dac5e7ab06fe1561ec62d45
+# Using vimdiff as a diff editor is possible but not recommended. For
+# instructions on configuring the DirDiff Vim plugin for a better experience,
+# see https://gist.github.com/ilyagr/5d6339fb7dac5e7ab06fe1561ec62d45
 edit-args = ["-f", "-d", "$left", "$right"]
+diff-args = []  # Corrupts terminal state, non-functional
 
 # if you change the settings for vscode, please do the same for vscodium
 [merge-tools.vscode]
@@ -77,6 +88,8 @@ conflict-marker-style = "git"
 # work better.
 diff-args=["--diff", "$left", "$right", "--wait"]
 diff-invocation-mode="file-by-file"
+# `code --diff` does not support dir-diff
+edit-args = []
 
 # free/libre distribution of vscode, functionally more or less the same
 [merge-tools.vscodium]
@@ -87,3 +100,4 @@ merge-tool-edits-conflict-markers = true
 conflict-marker-style = "git"
 diff-args=["--diff", "$left", "$right", "--wait"]
 diff-invocation-mode="file-by-file"
+edit-args = []

--- a/docs/config.md
+++ b/docs/config.md
@@ -929,6 +929,8 @@ edit-args = ["--newtab", "$left", "$right"]
 
 - If no `edit-args` are specified, `["$left", "$right"]` are set by default.
 
+- If `edit-args = []`, `jj` will refuse to use this tool for diff editing. This is a way to explicitly state that a certain tool (e.g. `mergiraf`) does not work for diff editing.
+
 Finally, `ui.diff-editor` can be a list that specifies a command and its arguments.
 
 Some examples:

--- a/docs/config.md
+++ b/docs/config.md
@@ -374,6 +374,10 @@ diff-args = ["--color=always", "$left", "$right"]
 
 - If `diff-args` is not specified, `["$left", "$right"]` will be used by default.
 
+- If `diff-args = []`, `jj` will refuse to use this tool for diff formatting.
+  This is a way to explicitly state that a certain tool (e.g. `mergiraf`) does
+  not work for viewing diffs.
+
 By default `jj` will invoke external tools with a directory containing the left
 and right sides.  The `diff-invocation-mode` config can change this to file by file
 invocations as follows:

--- a/docs/config.md
+++ b/docs/config.md
@@ -372,6 +372,8 @@ diff-args = ["--color=always", "$left", "$right"]
 - `$left` and `$right` are replaced with the paths to the left and right
   directories to diff respectively.
 
+- If `diff-args` is not specified, `["$left", "$right"]` will be used by default.
+
 By default `jj` will invoke external tools with a directory containing the left
 and right sides.  The `diff-invocation-mode` config can change this to file by file
 invocations as follows:
@@ -1118,6 +1120,10 @@ merge-tool-edits-conflict-markers = true    # See below for an explanation
   should be used for the file. This can be useful if the merge tool parses
   and/or generates conflict markers. Usually, `jj` uses conflict markers of
   length 7, but they can be longer if necessary to make parsing unambiguous.
+
+Unlike `diff-args` or `edit-args`, there is no default value for `merge-args`.
+If `merge-args` are not specified, the tool cannot be used for conflict
+resolution.
 
 ### Editing conflict markers with a tool or a text editor
 


### PR DESCRIPTION
If `diff-args` or `edit-args` are unset, default values are used.

This PR makes it so that explicitly setting them to `[]` causes them
to error. The last commit includes many examples where this is useful.

https://github.com/jj-vcs/jj/issues/4549

The first few commits are related touch-ups that could be independently
useful.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- n/a (?) I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
