### PR TITLE
cli help: document the `ci` alias

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -31,7 +31,7 @@ use crate::description_util::join_message_paragraphs;
 use crate::text_util::parse_author;
 use crate::ui::Ui;
 
-/// Update the description and create a new change on top.
+/// Update the description and create a new change on top [default alias: ci]
 ///
 /// This command is very similar to `jj split`. Differences include:
 ///

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -1,6 +1,8 @@
 # The code assumes that this table exists, so don't delete it even if you remove
 # all aliases from here.
 [aliases]
+# The aliases here should be kept in sync with the `[default alias: blah]` notes
+# in the first line of the relevant commands' help text.
 b = ["bookmark"]
 ci = ["commit"]
 desc = ["describe"]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -127,7 +127,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
 * `abandon` — Abandon a revision
 * `absorb` — Move changes from a revision into the stack of mutable revisions
 * `bookmark` — Manage bookmarks [default alias: b]
-* `commit` — Update the description and create a new change on top
+* `commit` — Update the description and create a new change on top [default alias: ci]
 * `config` — Manage config options
 * `describe` — Update the change description or other metadata [default alias: desc]
 * `diff` — Compare file contents between two revisions
@@ -520,7 +520,7 @@ If you want to forget a local bookmark while also untracking the corresponding r
 
 ## `jj commit`
 
-Update the description and create a new change on top.
+Update the description and create a new change on top [default alias: ci]
 
 This command is very similar to `jj split`. Differences include:
 


### PR DESCRIPTION
Follows up on 59de83a.

Now, all of the aliases from `cli/src/config/misc.toml` will be documented in the same way. I think I was previously unsure whether we'll keep them, but they seem to be doing no harm.
