### PR TITLE
cli: remove `amend` alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `commit.working_copies()` template method now returns `List<WorkspaceRef>`
 
+* The previously predefined `amend` alias has been removed. You can restore it
+  by setting the config `aliases.amend = ["squash"]`.
+
 ### Deprecations
 
 * The `all:` revset modifier and `ui.always-allow-large-revsets` setting is

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -1,7 +1,6 @@
 # The code assumes that this table exists, so don't delete it even if you remove
 # all aliases from here.
 [aliases]
-amend = ["squash"]
 b = ["bookmark"]
 ci = ["commit"]
 desc = ["describe"]


### PR DESCRIPTION
This also adds a helpful message to the error if the user does `jj amend`. I don't think this is absolutely necessary, but I also don't see any harm in it.

------


We do use the term "the commit gets amended" in the docs a few times, but there's no mention of `jj amend` except in old changelog entries, I think.

I'm not sure this needs a test. It looks like this:

```console
$ cargo run -- amend --help
error: unrecognized subcommand 'amend'

For more information, try '--help'.
Hint: You probably want `jj squash`. You can configure `aliases.amend = ["squash"]` if you want `jj amend` to work.
```

# Checklist

- [x] I have updated `CHANGELOG.md`
- n/a? I have updated the documentation (`README.md`, `docs/`, `demos/`)
- n/a I have updated the config schema (`cli/src/config-schema.json`)
- [?] I have added/updated tests to cover my changes
