### PR TITLE
revset_engine: evaluate `X` as predicate in `reachable(X, Y)`

### DIFF
--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -919,6 +919,9 @@ impl EvaluationContext<'_> {
                         }
                     }
                 }
+                // `UnionFind::find` is somewhat slow, so it's faster to only do this once and
+                // then cache the result.
+                let domain_reps = domain_vec.iter().map(|&pos| sets.find(pos)).collect_vec();
 
                 // Identify disjoint sets reachable from sources. Using a predicate here can be
                 // significantly faster for cases like `reachable(filter, X)`, since the filter
@@ -927,15 +930,20 @@ impl EvaluationContext<'_> {
                 let sources_revset = self.evaluate(sources)?;
                 let mut sources_predicate = sources_revset.to_predicate_fn();
                 let mut set_reps = HashSet::new();
-                for &pos in &domain_vec {
+                for (&pos, &rep) in domain_vec.iter().zip(&domain_reps) {
+                    // Skip evaluating predicate if `rep` has already been added.
+                    if set_reps.contains(&rep) {
+                        continue;
+                    }
                     if sources_predicate(index, pos)? {
-                        set_reps.insert(sets.find(pos));
+                        set_reps.insert(rep);
                     }
                 }
 
                 let positions = domain_vec
                     .into_iter()
-                    .filter(|pos| set_reps.contains(&sets.find(*pos)))
+                    .zip(domain_reps)
+                    .filter_map(|(pos, rep)| set_reps.contains(&rep).then_some(pos))
                     .collect_vec();
                 Ok(Box::new(EagerRevset { positions }))
             }

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -920,15 +920,18 @@ impl EvaluationContext<'_> {
                     }
                 }
 
-                // Identify disjoint sets reachable from sources.
-                let set_reps: HashSet<_> = intersection_by(
-                    self.evaluate(sources)?.positions(),
-                    EagerRevWalk::new(domain_vec.iter().copied().map(Ok)),
-                    |pos1, pos2| pos1.cmp(pos2).reverse(),
-                )
-                .attach(index)
-                .map_ok(|pos| sets.find(pos))
-                .try_collect()?;
+                // Identify disjoint sets reachable from sources. Using a predicate here can be
+                // significantly faster for cases like `reachable(filter, X)`, since the filter
+                // can be checked for only commits in `X` instead of for all visible commits,
+                // and the difference is usually negligible for non-filter revsets.
+                let sources_revset = self.evaluate(sources)?;
+                let mut sources_predicate = sources_revset.to_predicate_fn();
+                let mut set_reps = HashSet::new();
+                for &pos in &domain_vec {
+                    if sources_predicate(index, pos)? {
+                        set_reps.insert(sets.find(pos));
+                    }
+                }
 
                 let positions = domain_vec
                     .into_iter()

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -1850,21 +1850,24 @@ fn test_evaluate_expression_reachable() {
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
 
-    // Construct 3 separate subgraphs off the root commit.
+    // Construct 3 separate subgraphs off the root commit. The creation of subgraphs
+    // 1 and 2 is interleaved so that their index positions are also interleaved.
+    // This makes it more likely that the tests will fail if we evaluate the revset
+    // predicate in the wrong order (e.g. if we check all of subgraph 1 before 2).
     // 1 is a chain, 2 is a merge, 3 is a pyramidal monstrosity
     let graph1commit1 = write_random_commit(mut_repo);
+    let graph2commit1 = write_random_commit(mut_repo);
+    let graph2commit2 = write_random_commit(mut_repo);
+    let graph2commit3 = create_random_commit(mut_repo)
+        .set_parents(vec![graph2commit1.id().clone(), graph2commit2.id().clone()])
+        .write()
+        .unwrap();
     let graph1commit2 = create_random_commit(mut_repo)
         .set_parents(vec![graph1commit1.id().clone()])
         .write()
         .unwrap();
     let graph1commit3 = create_random_commit(mut_repo)
         .set_parents(vec![graph1commit2.id().clone()])
-        .write()
-        .unwrap();
-    let graph2commit1 = write_random_commit(mut_repo);
-    let graph2commit2 = write_random_commit(mut_repo);
-    let graph2commit3 = create_random_commit(mut_repo)
-        .set_parents(vec![graph2commit1.id().clone(), graph2commit2.id().clone()])
         .write()
         .unwrap();
     let graph3commit1 = write_random_commit(mut_repo);
@@ -1886,6 +1889,47 @@ fn test_evaluate_expression_reachable() {
         .set_parents(vec![graph3commit4.id().clone(), graph3commit5.id().clone()])
         .write()
         .unwrap();
+
+    // Test predicate involving ancestors, which can produce incorrect results if
+    // evaluated in the wrong order. The first example fails if subgraph 1 is
+    // evaluated before subgraph 2, and the second example fails if subgraph 2 is
+    // evaluated before subgraph 1.
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!(
+                "reachable(ancestors({} | {}), root()..)",
+                graph1commit1.id(),
+                graph2commit1.id(),
+            )
+        ),
+        vec![
+            graph1commit3.id().clone(),
+            graph1commit2.id().clone(),
+            graph2commit3.id().clone(),
+            graph2commit2.id().clone(),
+            graph2commit1.id().clone(),
+            graph1commit1.id().clone(),
+        ]
+    );
+    assert_eq!(
+        resolve_commit_ids(
+            mut_repo,
+            &format!(
+                "reachable(ancestors({} | {}), {}..)",
+                graph1commit2.id(),
+                graph2commit1.id(),
+                graph1commit1.id(),
+            )
+        ),
+        vec![
+            graph1commit3.id().clone(),
+            graph1commit2.id().clone(),
+            graph2commit3.id().clone(),
+            graph2commit2.id().clone(),
+            graph2commit1.id().clone(),
+        ]
+    );
 
     // Domain is respected.
     assert_eq!(


### PR DESCRIPTION
From Discord discussion: https://discord.com/channels/968932220549103686/968932220549103689/1396106445153374249

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
