### PR TITLE
docs: fix fork_point example

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -434,7 +434,7 @@ revsets (expressions) as arguments.
     * `fork_point(E|B)` ⇒ `{B}`
     * `fork_point(E|A)` ⇒ `{A}`
     * `fork_point(D|C)` ⇒ `{C}`
-    * `fork_point(D|B)` ⇒ `{A}`
+    * `fork_point(D|B)` ⇒ `{B}`
     * `fork_point(B|C)` ⇒ `{A}`
     * `fork_point(A)` ⇒ `{A}`
     * `fork_point(none())` ⇒ `{}`


### PR DESCRIPTION
```
o E
|
| o D
|/|
| o C
| |
o | B
|/
o A
|
o root()


* `fork_point(E|D)` ⇒ `{B}`
* `fork_point(E|B)` ⇒ `{B}`
* `fork_point(D|B)` ⇒ `{A}`
```

As discussed on Discord: `fork_point(D|B)` should be  `{B}`

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated ONLY the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
