### PR TITLE
revset: add naive version of `bisect()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Glob patterns now support `{foo,bar}` syntax. There may be subtle behavior
   changes as we use the [globset](https://crates.io/crates/globset) library now.
 
+* The new `bisect(x)` revset function can help bisect a range of commits to
+  find when a bug was introduced.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -289,6 +289,10 @@ revsets (expressions) as arguments.
   the revset `heads(::x_1 & ::x_2 & ... & ::x_N)`, where `x_{1..N}` are commits
   in `x`. If `x` resolves to a single commit, `fork_point(x)` resolves to `x`.
 
+* `bisect(x)`: Finds commits in the input set for which about half of the input
+  set are descendants. The current implementation deals somewhat poorly with
+  non-linear history.
+
 * `merges()`: Merge commits.
 
 * `description(pattern)`: Commits that have a description matching the given

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1022,6 +1022,17 @@ impl EvaluationContext<'_> {
                 }
                 Ok(Box::new(EagerRevset { positions }))
             }
+            ResolvedExpression::Bisect(candidates) => {
+                let set = self.evaluate(candidates)?;
+                // TODO: Make this more correct in non-linear history
+                let candidate_positions: Vec<_> = set.positions().attach(index).try_collect()?;
+                let positions = if candidate_positions.is_empty() {
+                    candidate_positions
+                } else {
+                    vec![candidate_positions[candidate_positions.len() / 2]]
+                };
+                Ok(Box::new(EagerRevset { positions }))
+            }
             ResolvedExpression::Latest { candidates, count } => {
                 let candidate_set = self.evaluate(candidates)?;
                 Ok(Box::new(self.take_latest_revset(&*candidate_set, *count)?))


### PR DESCRIPTION

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
