### PR TITLE
rebase: improve error messages when rebasing a change onto itself

### DIFF
--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -543,6 +543,12 @@ fn check_rebase_destinations(
     commit: &Commit,
 ) -> Result<(), CommandError> {
     for parent_id in new_parents {
+        if parent_id == commit.id() {
+            return Err(user_error(format!(
+                "Cannot rebase {} onto itself",
+                short_commit_hash(commit.id()),
+            )));
+        }
         if repo.index().is_ancestor(commit.id(), parent_id) {
             return Err(user_error(format!(
                 "Cannot rebase {} onto descendant {}",

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -119,6 +119,15 @@ fn test_rebase_invalid() {
     [EOF]
     [exit status: 1]
     ");
+
+    // Rebase onto itself with -s
+    let output = work_dir.run_jj(["rebase", "-s", "a", "-d", "a"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Error: Cannot rebase 7d980be7a1d4 onto itself
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 #[test]


### PR DESCRIPTION
When mistakenly rebasing a change to itself, I go prompted by a message that I think could be simpler.
```bash
# Before
$ jj rebase -s @- -d o
Error: Cannot rebase f896310b3287 onto descendant f896310b3287

# What I suggest
$ jj rebase -s @- -d o
Error: Cannot rebase f896310b3287 onto itself
```

I used the same message used for `-r` when the same pattern arrise.
https://github.com/jj-vcs/jj/blob/e9eb3a014239bffd7b7d6ee0336da56c7c198641/cli/src/commands/rebase.rs#L446

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have added/updated tests to cover my changes
