### PR TITLE
cli: make `split` behave more like `commit`

### DIFF
--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -38,7 +38,6 @@ use crate::cli_util::DiffSelector;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::WorkspaceCommandTransaction;
-use crate::command_error::user_error_with_hint;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::description_util::add_trailers;
@@ -61,9 +60,6 @@ use crate::ui::Ui;
 /// change description for each commit. If the change did not have a
 /// description, the remaining changes will not get a description, and you will
 /// be asked for a description only for the selected changes.
-///
-/// Splitting an empty commit is not supported because the same effect can be
-/// achieved with `jj new`.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct SplitArgs {
     /// Interactively choose which parts to split
@@ -148,15 +144,6 @@ impl SplitArgs {
         workspace_command: &WorkspaceCommandHelper,
     ) -> Result<ResolvedSplitArgs, CommandError> {
         let target_commit = workspace_command.resolve_single_rev(ui, &self.revision)?;
-        if target_commit.is_empty(workspace_command.repo().as_ref())? {
-            return Err(user_error_with_hint(
-                format!(
-                    "Refusing to split empty commit {}.",
-                    target_commit.id().hex()
-                ),
-                "Use `jj new` if you want to create another empty commit.",
-            ));
-        }
         workspace_command.check_rewritable([target_commit.id()])?;
         let matcher = workspace_command
             .parse_file_patterns(ui, &self.paths)?

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2485,8 +2485,6 @@ Starts a [diff editor] on the changes in the revision. Edit the right side of th
 
 If the change you split had a description, you will be asked to enter a change description for each commit. If the change did not have a description, the remaining changes will not get a description, and you will be asked for a description only for the selected changes.
 
-Splitting an empty commit is not supported because the same effect can be achieved with `jj new`.
-
 **Usage:** `jj split [OPTIONS] [FILESETS]...`
 
 ###### **Arguments:**

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -733,24 +733,6 @@ fn test_split_parallel_with_merge_child() {
     ");
 }
 
-// Make sure `jj split` would refuse to split an empty commit.
-#[test]
-fn test_split_empty() {
-    let test_env = TestEnvironment::default();
-    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let work_dir = test_env.work_dir("repo");
-    work_dir.run_jj(["describe", "--message", "abc"]).success();
-
-    let output = work_dir.run_jj(["split"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Error: Refusing to split empty commit 64eaeeb3e846248efc8b599a2b583b708104fc01.
-    Hint: Use `jj new` if you want to create another empty commit.
-    [EOF]
-    [exit status: 1]
-    ");
-}
-
 #[test]
 fn test_split_message_editor_avoids_unc() {
     let mut test_env = TestEnvironment::default();


### PR DESCRIPTION
(This was a private stack I had and am publishing for some discussion.)

There was some talk on the Discord about how `jj commit` is actually just `jj split` in disguise and the differences are mostly artificial. This removes two of them:

1. It re-allows splitting an empty commit; this was disallowed in https://github.com/jj-vcs/jj/pull/3663 and thus is mostly a revert.
2. It does not warn when one side of the split contains all files; `jj commit` is roughly equivalent to `jj split 'all()'`, but split warns in this case.

But I'm leaving this as draft; I'm not sure if we actually want to do this. I personally think it's nice but there are probably more arguments to be had.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
