### PR TITLE
rustfmt.toml: don't format generated files

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,3 +5,4 @@ format_strings = true
 error_on_line_overflow = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Item"
+format_generated_files = false


### PR DESCRIPTION
This mostly affects the files in `lib/src/protos`, and makes it so that `rustfmt` invoked via `jj fix --include-unchanged-files` does not format those.

This avoids errors like
https://github.com/jj-vcs/jj/actions/runs/16586832790/job/46913734860?pr=7117

An interesting fact is that this commit does *not* affect `cargo fmt`. `cargo fmt` skips those files either way because they are not proper modules, but are rather `include!`-d in their `mod.rs`.
