### PR TITLE
CLI: add a --use-pager option that overrides the pager being disabled in the config.toml.

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3256,10 +3256,13 @@ pub struct EarlyArgs {
     // Option<bool>.
     pub quiet: Option<bool>,
     /// Disable the pager
-    #[arg(long, global = true, action = ArgAction::SetTrue)]
+    #[arg(long, global = true, action = ArgAction::SetTrue, conflicts_with = "use_pager")]
     // Parsing with ignore_errors will crash if this is bool, so use
     // Option<bool>.
     pub no_pager: Option<bool>,
+    /// Sets the pager to auto if the pager is disabled in the config
+    #[arg(long, global = true, action = ArgAction::SetTrue, conflicts_with = "no_pager")]
+    pub use_pager: Option<bool>,
     /// Additional configuration options (can be repeated)
     ///
     /// The name should be specified as TOML dotted keys. The value should be
@@ -3506,6 +3509,9 @@ fn parse_early_args(
     }
     if args.no_pager.unwrap_or_default() {
         layer.set_value("ui.paginate", "never").unwrap();
+    }
+    else if args.use_pager.unwrap_or_default() {
+        layer.set_value("ui.paginate", "auto").unwrap();
     }
     if !layer.is_empty() {
         config_layers.push(layer);

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -202,6 +202,8 @@ To get started, see the tutorial [`jj help -k tutorial`].
 
    Warnings and errors will still be printed.
 * `--no-pager` — Disable the pager
+* `--use-pager` — Enable the pager If the pager is disabled in the config, this will set it to auto. If the pager is enabled in the config, this will not change it.
+
 * `--config <NAME=VALUE>` — Additional configuration options (can be repeated)
 
    The name should be specified as TOML dotted keys. The value should be specified as a TOML expression. If string value isn't enclosed by any TOML constructs (such as array notation), quotes can be omitted.


### PR DESCRIPTION
This adds a --use-pager cli option that will set the pagination mode to auto. This is useful if it is turned off by default in the config.toml, and you would like to use a pager. 

Also adds an explanation in the cli-reference. 
