### PR TITLE
revset: don't reorder `~first_ancestors(x)` to start

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -1883,13 +1883,17 @@ fn sort_negations_and_ancestors<St: ExpressionState>(
         RevsetExpression::Intersection(expression1, expression2) => {
             sort_intersection_by_key(expression1, expression2, |expression| match expression {
                 RevsetExpression::Ancestors {
+                    heads: _,
                     generation: Range { end: u64::MAX, .. },
-                    ..
+                    parents_range: _,
                 } => AncestorsOrder::Ancestors,
                 RevsetExpression::NotIn(complement) => match complement.as_ref() {
                     RevsetExpression::Ancestors {
+                        heads: _,
                         generation: Range { end: u64::MAX, .. },
-                        ..
+                        // We only want to move negated ancestors with a full parents range, since
+                        // these are the only negated ancestors which can be converted to a range.
+                        parents_range: PARENTS_RANGE_FULL,
                     } => AncestorsOrder::NegatedAncestors,
                     _ => AncestorsOrder::NegatedOther,
                 },
@@ -4743,6 +4747,23 @@ mod tests {
                 heads: CommitRef(Symbol("d")),
                 generation: 0..18446744073709551615,
                 parents_range: 0..4294967295,
+            },
+        )
+        "#);
+
+        // Negated `first_ancestors()` doesn't prevent re-folding.
+        insta::assert_debug_snapshot!(optimize(parse("foo..bar ~ first_ancestors(baz)").unwrap()), @r#"
+        Difference(
+            Range {
+                roots: CommitRef(Symbol("foo")),
+                heads: CommitRef(Symbol("bar")),
+                generation: 0..18446744073709551615,
+                parents_range: 0..4294967295,
+            },
+            Ancestors {
+                heads: CommitRef(Symbol("baz")),
+                generation: 0..18446744073709551615,
+                parents_range: 0..1,
             },
         )
         "#);


### PR DESCRIPTION
Negated `first_ancestors()` can't be converted to a range currently, so it doesn't make sense to move it to the start when optimizing the order of an intersection.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
