### PR TITLE
Allow changing the author date from describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   precedence over `origin` if both exist.
 
 * Add the `jj touch` command, which modifies a revision's metadata. This can be
-  used to generate a new change-id, which may help resolve some divergences.
+  used to generate a new change-id, which may help resolve some divergences. It also has options to modify author name, email and time stamp.
 
 * Filesets now support case-insensitive glob patterns with the `glob-i:`,
   `cwd-glob-i:`, and `root-glob-i:` pattern kinds. For example, `glob-i:"*.rs"`

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2687,7 +2687,7 @@ Modify the metadata of a revision without changing its content
    This generates a new change-id for the revision.
 * `--update-author-timestamp` — Update the author timestamp
 
-   This update the author date to now, without modifying the author.
+   This updates the author date to now, without modifying the author.
 * `--update-author` — Update the author to the configured user
 
    This updates the author name and email. The author timestamp is not modified – use --update-author-timestamp to update the author timestamp.
@@ -2698,6 +2698,7 @@ Modify the metadata of a revision without changing its content
 * `--author <AUTHOR>` — Set author to the provided string
 
    This changes author name and email while retaining author timestamp for non-discardable commits.
+* `--author-timestamp <AUTHOR_TIMESTAMP>` — Set the author date to the given date either human readable, eg Sun, 23 Jan 2000 01:23:45 JST) or as a time stamp, eg 2000-01-23T01:23:45+09:00)
 
 
 

--- a/cli/tests/test_touch_command.rs
+++ b/cli/tests/test_touch_command.rs
@@ -240,6 +240,59 @@ fn test_touch() {
 
     [EOF]
     ");
+
+    // new author date
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    work_dir
+        .run_jj(["touch", "--author-timestamp", "1995-12-19T16:39:57-08:00"])
+        .success();
+    insta::assert_snapshot!(get_log(&work_dir), @r"
+    @  Commit ID: a527219f85839d58ddb6115fbc4f0f8bc6649266
+    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    │  Bookmarks: c
+    │  Author   : Test User <test.user@example.com> (1995-12-19 16:39:57.000 -08:00)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:26.000 +07:00)
+    │
+    │      (no description set)
+    │
+    ○  Commit ID: 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    │  Bookmarks: b
+    │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
+    │
+    │      (no description set)
+    │
+    ○  Commit ID: e6086990958c236d72030f0a2651806aa629f5dd
+    │  Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    │  Bookmarks: a
+    │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:09.000 +07:00)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:09.000 +07:00)
+    │
+    │      (no description set)
+    │
+    ◆  Commit ID: 0000000000000000000000000000000000000000
+       Change ID: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+       Author   : (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+       Committer: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+
+           (no description set)
+
+    [EOF]
+    ");
+
+    // invalid date gives an error
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    let command_result = work_dir.run_jj(["touch", "--author-timestamp", "aaaaaa"]);
+    assert!(!command_result.status.success());
+    insta::assert_snapshot!(command_result, @r"
+    ------- stderr -------
+    error: invalid value 'aaaaaa' for '--author-timestamp <AUTHOR_TIMESTAMP>': input contains invalid characters
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
 }
 
 #[test]

--- a/lib/src/time_util.rs
+++ b/lib/src/time_util.rs
@@ -122,6 +122,16 @@ impl DatePattern {
     }
 }
 
+// @TODO ideally we would have this unified with the other parsing code. However
+// we use the interim crate which does not handle explicitly given time zone
+// information
+/// Parse a string with time zone information into a `Timestamp`
+pub fn parse_datetime(s: &str) -> chrono::ParseResult<Timestamp> {
+    Ok(Timestamp::from_datetime(
+        DateTime::parse_from_rfc2822(s).or_else(|_| DateTime::parse_from_rfc3339(s))?,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,5 +198,11 @@ mod tests {
         test_equal(now, "yesterday 5pm", "2024-01-01T01:00:00Z");
         test_equal(now, "yesterday 10am", "2023-12-31T18:00:00Z");
         test_equal(now, "yesterday 10:30", "2023-12-31T18:30:00Z");
+    }
+
+    #[test]
+    fn test_parse_datetime_non_sense_yields_error() {
+        let parse_error = parse_datetime("aaaaa").err().unwrap();
+        assert_eq!(parse_error.kind(), chrono::format::ParseErrorKind::Invalid);
     }
 }


### PR DESCRIPTION
This is unfinished as it needs tests, probably breaks tests and has room for improvement but I first want to evaluate whether this change has change to land before polishing. Also the CLI is up for debate (should this be its own command or is describe the right place?) (Also should similar nobs be introduced for committer information)

Proof it works
~~~
❯ jj show wpltwvzr
Commit ID: 10c39be28a519cfb067bc0fd616d06d091eb43c09d30dcb5fe138c2182fc6bfa2a99c0c105778ec317acb3007c3a9bfba6fa51fc6f4743acb08f20bdbe95f8e8
Change ID: wpltwvzrrymrzszypnnlywkyulqwtoyq
Author   : …  (1985-12-20 02:39:57)
Committer: … (2025-07-30 18:29:04)

    tests 2

Modified regular file test.txt:
   1    1: ugl<dugflguflzg
        2: lufgl<uaszgduoz
        3: iuglugl
        4: 
        5: öyfiuvhöydiuvg
        6: yfuvöiufgv
        7: iuguig
        8: 
        9: dsuvpuidgv

~/trasch/testj on ☁️  🥋 wplt | tests 2 
❯ ~/trasch/cargo/debug/jj desc -r wpltwvzr --author-date 1995-12-19T16:39:57-08:00 --no-edit
Working copy  (@) now at: wpltwvzr 2b8d46f1 tests 2
Parent commit (@-)      : rppnmuxk b7004367 test 1

~/trasch/testj on ☁️  🥋 wplt | tests 2 
❯ jj show wpltwvzr
Commit ID: 2b8d46f110a6fb71fc9788b8e166a3e38c2047fa696f60be9ddae6b1955449bbf023809281b9af81e7cc913209a2a9c349d5ebb211d6ab053c2fa4c9c41bc011
Change ID: wpltwvzrrymrzszypnnlywkyulqwtoyq
Author: … (1995-12-20 02:39:57)
Committer: … (2025-07-30 18:29:55)

    tests 2

Modified regular file test.txt:
   1    1: ugl<dugflguflzg
        2: lufgl<uaszgduoz
        3: iuglugl
        4: 
        5: öyfiuvhöydiuvg
        6: yfuvöiufgv
        7: iuguig
        8: 
        9: dsuvpuidgv
~~~


# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
