### PR TITLE
cli: op diff: show content diffs from first predecessor only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fixed an error in `jj util gc` caused by the empty blob being missing from
   the Git store. [#7062](https://github.com/jj-vcs/jj/issues/7062)
 
+* `jj op diff -p` and `jj op log -p` now show content diffs from the first
+  predecessor only. [#7090](https://github.com/jj-vcs/jj/issues/7090)
+
 ### Packaging changes
 
 

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -583,7 +583,12 @@ fn show_change_diff(
             diff_renderer.show_inter_diff(
                 ui,
                 formatter,
-                predecessors,
+                // TODO: It's technically wrong to show diffs from the first
+                // predecessor, but diff of partial "squash" operation would be
+                // unreadable otherwise. We have the same problem in "evolog",
+                // but it's less of an issue there because "evolog" shows the
+                // predecessors recursively.
+                predecessors.get(..1).unwrap_or(&[]),
                 commit,
                 &EverythingMatcher,
                 width,

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1602,6 +1602,13 @@ fn test_op_diff_patch() {
     ○  + qpvuntsm 7aa2ec5d (no description set)
        - qpvuntsm hidden 6b57e33c (no description set)
        - rlvkpnrz hidden 05a2969e (no description set)
+       diff --git a/file b/file
+       index 7898192261..6178079822 100644
+       --- a/file
+       +++ b/file
+       @@ -1,1 +1,1 @@
+       -a
+       +b
 
     Changed working copy default@:
     + mzvwutvl 6cbd01ae (empty) (no description set)
@@ -1913,6 +1920,14 @@ fn test_op_diff_divergent_change() {
     ○  + rlvkpnrz da3f472d 2ab
        - rlvkpnrz hidden 82ad1ba9 2b
        - rlvkpnrz hidden a7e9a63b 2a
+       diff --git a/file b/file
+       index 5e0f51b37b..60327514e0 100644
+       --- a/file
+       +++ b/file
+       @@ -1,2 +1,3 @@
+       +2a
+        1
+        2b
 
     Changed working copy default@:
     + rlvkpnrz da3f472d 2ab
@@ -2590,6 +2605,13 @@ fn test_op_show_patch() {
     ○  + qpvuntsm 7aa2ec5d (no description set)
        - qpvuntsm hidden 6b57e33c (no description set)
        - rlvkpnrz hidden 05a2969e (no description set)
+       diff --git a/file b/file
+       index 7898192261..6178079822 100644
+       --- a/file
+       +++ b/file
+       @@ -1,1 +1,1 @@
+       -a
+       +b
 
     Changed working copy default@:
     + mzvwutvl 6cbd01ae (empty) (no description set)
@@ -2646,6 +2668,13 @@ fn test_op_show_patch() {
     │  ○  + qpvuntsm 7aa2ec5d (no description set)
     │     - qpvuntsm hidden 6b57e33c (no description set)
     │     - rlvkpnrz hidden 05a2969e (no description set)
+    │     diff --git a/file b/file
+    │     index 7898192261..6178079822 100644
+    │     --- a/file
+    │     +++ b/file
+    │     @@ -1,1 +1,1 @@
+    │     -a
+    │     +b
     │
     │  Changed working copy default@:
     │  + mzvwutvl 6cbd01ae (empty) (no description set)


### PR DESCRIPTION
Closes #7090

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
