### PR TITLE
revset: insert `HeadsRange` in `Ancestors` for nested range/filter 

### DIFF
--- a/cli/testing/bench-revsets-git.txt
+++ b/cli/testing/bench-revsets-git.txt
@@ -42,6 +42,9 @@ heads(author(peff))
 # Roots and heads of range
 roots(::v2.40.0)
 heads(::v2.40.0)
+# Ancestors and ranges of large subsets
+::(v1.0.0..v2.40.0)
+author(peff)..
 # Parents and ancestors of old commit
 v1.0.0-
 v1.0.0---

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2391,8 +2391,8 @@ pub fn optimize<St: ExpressionState>(
     let expression = fold_generation(&expression).unwrap_or(expression);
     let expression = flatten_intersections(&expression).unwrap_or(expression);
     let expression = sort_negations_and_ancestors(&expression).unwrap_or(expression);
-    let expression = internalize_filter(&expression).unwrap_or(expression);
     let expression = fold_ancestors_union(&expression).unwrap_or(expression);
+    let expression = internalize_filter(&expression).unwrap_or(expression);
     let expression = fold_heads_range(&expression).unwrap_or(expression);
     let expression = fold_difference(&expression).unwrap_or(expression);
     fold_not_in_ancestors(&expression).unwrap_or(expression)
@@ -5331,6 +5331,20 @@ mod tests {
                 ),
             ),
         )
+        "#);
+
+        // Filters can be merged after ancestor unions are folded.
+        insta::assert_debug_snapshot!(optimize(parse("::foo | ::author_name(bar)").unwrap()), @r#"
+        Ancestors {
+            heads: AsFilter(
+                Union(
+                    CommitRef(Symbol("foo")),
+                    Filter(AuthorName(Substring("bar"))),
+                ),
+            ),
+            generation: 0..18446744073709551615,
+            parents_range: 0..4294967295,
+        }
         "#);
     }
 


### PR DESCRIPTION
This allows evaluating ancestors/ranges involving filters significantly faster. For instance, naively evaluating `::mine()` requires reading every commit in the repo to check `mine()` on each commit, then finding the ancestors of that set. This optimization rewrites `::mine()` to `::heads(mine())`, since `heads(mine())` can be evaluated more efficiently by only reading commits until the first successful match.

If someone is unaware of how revsets are implemented, this case can come up pretty easily, such as by including `~mine()` in `immutable_heads()` to make other people's commits immutable. In my local `jj` repo, this optimization reduces the runtime of `jj log` with `~mine()` in `immutable_heads()` from about 800ms down to about 50ms.

Benchmark results on Git repo:

```
::(v1.0.0..v2.40.0)     55.5% faster
author(peff)..          96.8% faster
```

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
