### PR TITLE
restore: adjust error message for `--revision`

### DIFF
--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -117,11 +117,13 @@ pub(crate) fn cmd_restore(
     let mut workspace_command = command.workspace_helper(ui)?;
     let (from_commits, from_tree, to_commit);
     if args.revision.is_some() {
-        return Err(user_error(
-            "`jj restore` does not have a `--revision`/`-r` option. If you'd like to modify\nthe \
-             *current* revision, use `--from`. If you'd like to modify a *different* \
-             revision,\nuse `--into` or `--changes-in`.",
-        ));
+        return Err(
+            user_error("`jj restore` does not have a `--revision`/`-r` option.")
+                .hinted("To modify the current revision, use `--from`.")
+                .hinted(
+                    "To undo changes in a revision compared to its parents, use `--changes-in`.",
+                ),
+        );
     }
     if args.from.is_some() || args.into.is_some() {
         to_commit = workspace_command

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -35,9 +35,9 @@ fn test_restore() {
     let output = work_dir.run_jj(["restore", "-r=@-"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: `jj restore` does not have a `--revision`/`-r` option. If you'd like to modify
-    the *current* revision, use `--from`. If you'd like to modify a *different* revision,
-    use `--into` or `--changes-in`.
+    Error: `jj restore` does not have a `--revision`/`-r` option.
+    Hint: To modify the current revision, use `--from`.
+    Hint: To undo changes in a revision compared to its parents, use `--changes-in`.
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
Commands like `diff`, `squash` and `restore` are directional, taking `--from` and `--to`/`--into` parameters. The former two also support `-r`, as a shortcut when one wishes to operate on a revision in relation to its parent(s).

Users who know that might deduce then that `restore` would also support `-r`, but it doesn’t — at some point it was decided that `-r` would be ambiguous, and people could attempt `restore -r <revision>` when they actually mean `-f`. Searching for “restore r” on Discord, I found a few old messages where people seemingly made this exact mistake, so I presume it’s a fair concern, particularly for a command that could be so critical to newcomers.

The command does know people may try to use `-r`, though, and rathern than showing a generic “unexpected argument” error, it shows a specific message:

```
Error: `jj restore` does not have a `--revision`/`-r` option. If you'd like to modify
the *current* revision, use `--from`. If you'd like to modify a *different* revision,
use `--into` or `--changes-in`.
```

Looking at my shell history, over the last 5 months I’ve typed `jj restore -r` at least 12 times, and *not once* did I read the error message, or I would have realized there’s `--changes-in`/`-c`. Personal embarrassments aside, I suspect the reason I always skipped the message without even skimming is that it feels like a wall of text.

This PR changes the message to:

```
Error: `jj restore` does not have a `--revision`/`-r` option.
Hint: If you'd like to modify the current revision, use `--from`.
Hint: To undo changes in a revision compared to its parents, use `--changes-in`.
```

- The “Error” part is significantly shorter and more objective.
- Each line is self-contained, and the “Hint:” headings (in cyan, not shown here) should help grab the user’s attention if they were looking for one of the alternatives.
- The mention of `--into` was removed, as it doesn’t seem like anyone confuses `-r` with that.
- The longest line is exactly 80 characters with the “Hint:” header, so it shouldn’t wrap in most terminals — worst case it fills the line and the user gets a blank line after.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes

---

I also considered highlighting `--from` and `--changes-in`, but I don’t think any of the defined labels would fit — we’d have to define a new label, e.g.:

```toml
[colors]
"highlight" = { bold = true }
```
