### PR TITLE
fix: add `$root` variable that can be used in commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `signing.backends.ssh.revocation-list` config for specifying a list of revoked
   public keys for commit signature verification.
 
+* `jj fix` commands now replace `$root` with the workspace's root path. This is
+  useful for tools stored inside the workspace.
+
 ### Fixed bugs
 
 * Fixed an error in `jj util gc` caused by the empty blob being missing from

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1115,11 +1115,14 @@ error will be passed through to the terminal.
 Tools are defined in a table where the keys are arbitrary identifiers and
 the values have the following properties:
  - `command`: The arguments used to run the tool. The first argument is the
-   path to an executable file. Arguments can contain the substring `$path`,
-   which will be replaced with the repo-relative path of the file being
-   fixed. It is useful to provide the path to tools that include the path in
-   error messages, or behave differently based on the directory or file
-   name.
+   path to an executable file. Arguments can contain these variables that
+   will be replaced:
+   - `$root` will be replaced with the workspace root path (the directory
+     containing the .jj directory).
+   - `$path` will be replaced with the repo-relative path of the file being
+     fixed. It is useful to provide the path to tools that include the path
+     in error messages, or behave differently based on the directory or file
+     name.
  - `patterns`: Determines which files the tool will affect. If this list is
    empty, no files will be affected by the tool. If there are multiple
    patterns, the tool is applied only once to each file in the union of the

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -514,6 +514,82 @@ fn test_relative_paths() {
 }
 
 #[test]
+fn test_relative_tool_path_from_subdirectory() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Copy the fake-formatter into the workspace as a relative tool
+    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_name = formatter_path.file_name().unwrap().to_str().unwrap();
+    let tool_dir = work_dir.create_dir("tools");
+    let workspace_formatter_path = tool_dir.root().join(formatter_name);
+    std::fs::copy(&formatter_path, &workspace_formatter_path).unwrap();
+    work_dir.write_file(".gitignore", "tools/\n");
+    let formatter_relative_path = PathBuf::from_iter(["$root", "tools", formatter_name]);
+    test_env.add_config(format!(
+        r###"
+        [fix.tools.a]
+        command = [{path}, "--uppercase"]
+        patterns = ['glob:"**/*.txt"']
+        "###,
+        path = to_toml_value(formatter_relative_path.to_str().unwrap())
+    ));
+
+    // Create a test file and subdirectory
+    work_dir.write_file("test.txt", "hello world\n");
+    let sub_dir = work_dir.create_dir("subdir");
+    work_dir.write_file("subdir/nested.txt", "nested content\n");
+
+    // Run fix from workspace root
+    let output = work_dir.run_jj(["fix"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Fixed 1 commits of 1 checked.
+    Working copy  (@) now at: qpvuntsm 58961e98 (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 2 files, removed 0 files
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["file", "show", "test.txt", "-r", "@"]);
+    insta::assert_snapshot!(output, @r###"
+    HELLO WORLD
+    [EOF]
+    "###);
+    let output = work_dir.run_jj(["file", "show", "subdir/nested.txt", "-r", "@"]);
+    insta::assert_snapshot!(output, @r###"
+    NESTED CONTENT
+    [EOF]
+    "###);
+
+    // Reset so the fix tools should have an effect again
+    work_dir.run_jj(["undo"]).success();
+
+    // Run fix from the subdirectory
+    let output = sub_dir.run_jj(["fix"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Fixed 1 commits of 1 checked.
+    Working copy  (@) now at: qpvuntsm 380c1b78 (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 2 files, removed 0 files
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["file", "show", "test.txt", "-r", "@"]);
+    insta::assert_snapshot!(output, @r###"
+    HELLO WORLD
+    [EOF]
+    "###);
+    let output = work_dir.run_jj(["file", "show", "subdir/nested.txt", "-r", "@"]);
+    insta::assert_snapshot!(output, @r###"
+    NESTED CONTENT
+    [EOF]
+    "###);
+}
+
+#[test]
 fn test_fix_empty_commit() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/docs/config.md
+++ b/docs/config.md
@@ -1216,6 +1216,22 @@ command = ["sort", "-u"]
 patterns = ["word_list.txt"]
 ```
 
+### Tools stored inside the workspace
+
+Some fix tools may be stored inside the workspace. For example, a binary may be
+stored inside `node_modules`. Use the `$root` variable to create an absolute
+path to such a program:
+
+```toml
+[fix.tools.biome]
+
+# Linux and macOS
+command = ["$root/node_modules/@biomejs/cli-linux-x64/biome"]
+
+# Windows
+command = ["$root\\node_modules\\@biomejs\\cli-win32-x64\\biome.exe"]
+```
+
 ### Execution order of tools
 
 If two or more tools affect the same file, they are executed in the ascending


### PR DESCRIPTION
On Windows, spawning a child process finds the command relative to the parent's working directory. If a command is specified as `["path/inside/repo/tool.exe"]`, then tool won't be found if `jj fix` is run somewhere besides the workspace root.

There doesn't seem to be a good way to change this behavior, nor does it seem easy to convert `program` into an absolute path because `["tool.exe"]` could refer either to a file on the PATH or a file committed at the root of the repository.

So, we add a new variable `$root` that can be used in this situation. Workspace-relative tools on Windows should be defined using this variable:

```toml
# Tools on the path
command = ["tool.exe"]

# Workspace-relative tools
command = ["$root/tool.exe"]
command = ["$root/nested/dir/tool.exe"]
```

On Unix, the command is relative to the child's working directory, so this isn't an issue.

Fixes #7144

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
