### PR TITLE
git: avoid division by zero in overall progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj op diff -p` and `jj op log -p` now show content diffs from the first
   predecessor only. [#7090](https://github.com/jj-vcs/jj/issues/7090)
 
+* `jj git fetch` no longer shows `NaN%` progress when connecting to slow remotes.
+  [#7155](https://github.com/jj-vcs/jj/issues/7155)
+
 ### Packaging changes
 
 

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -625,7 +625,11 @@ impl GitProgress {
     fn to_progress(&self) -> Progress {
         Progress {
             bytes_downloaded: None,
-            overall: self.fraction() as f32 / self.total() as f32,
+            overall: if self.total() != 0 {
+                self.fraction() as f32 / self.total() as f32
+            } else {
+                0.0
+            },
         }
     }
 
@@ -973,5 +977,10 @@ Done";
             "abc".to_string()
         );
         assert!(parse_unknown_option(b"error: unknown option: 'abc'").is_none());
+    }
+
+    #[test]
+    fn test_initial_overall_progress_is_zero() {
+        assert_eq!(GitProgress::default().to_progress().overall, 0.0);
     }
 }


### PR DESCRIPTION
When no progress has been made, indicate that as 0.0 progress rather than dividing by zero. Avoids in particular a display issue where the progress bar indicates NaN% progress when fetching from slow remotes.

Fixes #7155

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
