### PR TITLE
github: Enforce commit subject line format

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,79 @@
+name: Validate pull request
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-pr:
+    name: Commit subject lines
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run validation script
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pullRequest = {
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            };
+
+            const { data: commits } = await github.rest.pulls.listCommits(pullRequest);
+            const { data: reviews } = await github.rest.pulls.listReviews(pullRequest);
+
+            // Get latest review by `github-actions[bot]`
+            const githubActionsBot = 41898282;
+            const latestReview = reviews
+              .filter(r => r.user.id === githubActionsBot)
+              .at(-1);
+
+            // Ensure commit subject lines are in the form `area or areas: Description`
+            const subjectLineFormat = /^.+:\s.+$/;
+            const badCommits = commits
+              .map(c => [c.sha.slice(0, 8), c.commit.message.split('\n')[0]])
+              .filter(([_, s]) => !subjectLineFormat.test(s))
+              .map(([sha, title]) => `- ${sha}: ${title}`);
+
+            if (badCommits.length > 0) {
+              // One or commits are bad, make sure changes are requested.
+              const body = 'The following commits do not follow our format for subject lines:\n\n'
+                + `${badCommits.join('\n')}\n\nCommits should have a subject line following the `
+                + 'format `<topic>: <description>`. Please review the [commit guidelines]'
+                + '(https://jj-vcs.github.io/jj/prerelease/contributing/#commit-guidelines) for '
+                + 'more information.';
+                
+              if (latestReview.state !== 'CHANGES_REQUESTED') {
+                await github.rest.pulls.createReview({
+                  event: 'REQUEST_CHANGES',
+                  ...pullRequest,
+                  body,
+                });
+              }
+              else {
+                await github.rest.pulls.updateReview({
+                  review_id: latestReview.id,
+                  ...pullRequest,
+                  body,
+                });
+              }
+
+              await core.setFailed('One or more commits were not formatted correctly.');
+            }
+            else {
+              // All commits are formatted correctly, dismiss any change requests.
+              if (latestReview) {
+                await github.rest.pulls.dismissReview({
+                  message: 'All commits are now correctly formatted. Thank you for your contribution!',
+                  review_id: latestReview.id,
+                  ...pullRequest,
+                });
+              }
+
+              console.log('All commits were correctly formatted.');
+            }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Adds a CI workflow that ensures commits within pull requests have subject lines formatted as `area or areas: Description of changes`.

When commits are not properly formatted, fails CI and leaves a review comment with the bad commits. The message is updated with all bad commits each push.

When commits are properly formatted, passes CI and dismisses any existing review from the workflow.

Thanks @thoughtpolice for the prior art: https://github.com/thoughtpolice/buck2-nix/blob/main/.github/workflows/pr.yml

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
