### PR TITLE
cli: evolog: add --no-operation flag to disable printing operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `signing.backends.ssh.revocation-list` config for specifying a list of revoked
   public keys for commit signature verification.
 
+* `jj evolog` now accepts `--no-operation` to suppress the display of associated
+  operations.
+
 ### Fixed bugs
 
 * Fixed an error in `jj util gc` caused by the empty blob being missing from

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -222,7 +222,8 @@ pub(crate) fn cmd_evolog(
             with_content_format.write(formatter, |formatter| {
                 template.format(&entry.commit, formatter)?;
                 if let Some(op) = &entry.operation {
-                    write!(formatter, "-- operation ")?;
+                    write!(formatter.labeled("separator"), "--")?;
+                    write!(formatter, " operation ")?;
                     op_summary_template.format(op, formatter)?;
                     writeln!(formatter)?;
                 }

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -64,6 +64,9 @@ pub(crate) struct EvologArgs {
     /// Don't show the graph, show a flat list of revisions
     #[arg(long)]
     no_graph: bool,
+    /// Don't show the associated operation for each commit
+    #[arg(long)]
+    no_operation: bool,
     /// Render each revision using the given template
     ///
     /// Run `jj log -T` to list the built-in templates.
@@ -177,7 +180,9 @@ pub(crate) fn cmd_evolog(
                 with_content_format.sub_width(graph.width(entry.commit.id(), &edges));
             within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
                 template.format(&entry.commit, formatter)?;
-                if let Some(op) = &entry.operation {
+                if !args.no_operation
+                    && let Some(op) = &entry.operation
+                {
                     write!(formatter.labeled("separator"), "--")?;
                     write!(formatter, " operation ")?;
                     op_summary_template.format(op, formatter)?;
@@ -221,7 +226,9 @@ pub(crate) fn cmd_evolog(
             let entry = entry?;
             with_content_format.write(formatter, |formatter| {
                 template.format(&entry.commit, formatter)?;
-                if let Some(op) = &entry.operation {
+                if !args.no_operation
+                    && let Some(op) = &entry.operation
+                {
                     write!(formatter.labeled("separator"), "--")?;
                     write!(formatter, " operation ")?;
                     op_summary_template.format(op, formatter)?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -913,6 +913,7 @@ Lists the previous commits which a change has pointed to. The current commit of 
    Applied after revisions are reordered topologically, but before being reversed.
 * `--reversed` — Show revisions in the opposite order (older revisions first)
 * `--no-graph` — Don't show the graph, show a flat list of revisions
+* `--no-operation` — Don't show the associated operation for each commit
 * `-T`, `--template <TEMPLATE>` — Render each revision using the given template
 
    Run `jj log -T` to list the built-in templates.

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -47,6 +47,20 @@ fn test_evolog_with_or_without_diff() {
     [EOF]
     ");
 
+    // Test `--no-operation`
+    let output = work_dir.run_jj(["evolog", "--no-operation"]);
+    insta::assert_snapshot!(output, @r"
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
+    │  my description
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    │  my description
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
+    │  my description
+    ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
+       (empty) my description
+    [EOF]
+    ");
+
     // Color
     let output = work_dir.run_jj(["--color=always", "evolog"]);
     insta::assert_snapshot!(output, @r"


### PR DESCRIPTION
I have a script that parses the output of `jj evolog` in order to find the most recent version of a change on a remote. However, it's been broken since the change that added `-- operation xyz` display. The script could be fixed with some `sed` magic to strip out the unused information, but I think it's generally to be able to disable the information.

In lieu of adding a `CommitAndOperation` template type, this adds a flag similar to the `--no-patch` flag to `jj show`. Show the operation information by default, elide if asked.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
