### PR TITLE
revset_graph_iterator: fix E0700

### DIFF
--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -338,7 +338,7 @@ impl RevWalk<CompositeIndex> for RevsetGraphWalk<'_> {
 
 fn reachable_positions(
     edges: &[CommitGraphEdge],
-) -> impl DoubleEndedIterator<Item = GlobalCommitPosition> {
+) -> impl DoubleEndedIterator<Item = GlobalCommitPosition> + use<'_> {
     edges
         .iter()
         .filter(|edge| !edge.is_missing())


### PR DESCRIPTION
We noticed this at work. I can't reproduce this with `cargo +nightly build` so I'm not sure what's going on - maybe someone reading this knows.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
