### PR TITLE
cli: evolog: add `--operation-template` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `signing.backends.ssh.revocation-list` config for specifying a list of revoked
   public keys for commit signature verification.
 
+* `jj evolog` now accepts `--operation-template` to customize operation display.
+  The default can be configured with the `templates.evolog_operation` config
+  option.
+
 ### Fixed bugs
 
 * Fixed an error in `jj util gc` caused by the empty blob being missing from

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -819,6 +819,10 @@
                     "type": "string",
                     "description": "Trailers that will be appended to a commit's description"
                 },
+                "evolog_operation": {
+                    "type": "string",
+                    "description": "The default for `jj evolog --operation-template`"
+                },
                 "file_annotate": {
                     "type": "string",
                     "description": "`jj file annotate`'s output"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -65,14 +65,13 @@ workspace_list = '''
 name ++ ": " ++ format_commit_summary_with_refs(target, target.bookmarks()) ++ "\n"
 '''
 
-op_summary = '''
+op_summary = 'builtin_op_summary(self)'
+
+evolog_operation = '''
 separate(" ",
-  self.id().short(),
-  if(root,
-    label("root", "root()"),
-    surround("(", ")", format_timestamp(self.time().end())),
-  ),
-  self.description().first_line(),
+  label("separator", "--"),
+  "operation",
+  builtin_op_summary(self),
 )
 '''
 
@@ -222,6 +221,17 @@ label(if(current_operation, "current_operation"),
     if(root, format_root_operation(self)),
     format_operation_oneline(self),
   )
+)
+'''
+
+'builtin_op_summary(x)' = '''
+separate(" ",
+  format_short_operation_id(x.id()),
+  if(x.root(),
+    label("root", "root()"),
+    surround("(", ")", format_timestamp(x.time().end())),
+  ),
+  x.description().first_line(),
 )
 '''
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -922,6 +922,11 @@ Lists the previous commits which a change has pointed to. The current commit of 
    [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
 
    [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+* `--operation-template <OPERATION_TEMPLATE>` — Render each revision's corresponding operation with the given template
+
+   The template's `self` type is [`Operation`].
+
+   [`Operation`]: https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
 * `-p`, `--patch` — Show patch compared to the previous version of this change
 
    If the previous version has different parents, it will be temporarily rebased to the parents of the new version, so the diff is not contaminated by unrelated changes.

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -47,6 +47,22 @@ fn test_evolog_with_or_without_diff() {
     [EOF]
     ");
 
+    // no separation inserted between `--template` and `--operation-template`
+    let output = work_dir.run_jj([
+        "evolog",
+        "--template",
+        "change_id.short(8)",
+        "--operation-template",
+        "'|'++id.short()",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    @  rlvkpnrz|3499115d3831
+    ×  rlvkpnrz|eb87ec366530
+    ○  rlvkpnrz|18a971ce330a
+    ○  rlvkpnrz|e0f8e58b3800
+    [EOF]
+    ");
+
     // Color
     let output = work_dir.run_jj(["--color=always", "evolog"]);
     insta::assert_snapshot!(output, @r"

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -14,15 +14,15 @@ object can be referenced as `self`.
 
 ### Commit keywords
 
-In `jj log`/`jj evolog` templates, all 0-argument methods of [the `Commit`
+In `jj log`/`jj evolog -T` templates, all 0-argument methods of [the `Commit`
 type](#commit-type) are available as keywords. For example, `commit_id` is
 equivalent to `self.commit_id()`.
 
 ### Operation keywords
 
-In `jj op log` templates, all 0-argument methods of [the `Operation`
-type](#operation-type) are available as keywords. For example,
-`current_operation` is equivalent to `self.current_operation()`.
+In `jj op log`/`jj evolog --operation-template` templates, all 0-argument
+methods of [the `Operation` type](#operation-type) are available as keywords.
+For example, `current_operation` is equivalent to `self.current_operation()`.
 
 ## Operators
 


### PR DESCRIPTION
As an alternative to #7167.

The operation template is responsible for any separator. The output is
rendered exactly as:

```
[node]  [template][operation template][\n]
```

That is, there is no space inserted between the templates.

The default depends on the `templates.evolog_operation` config option.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
