### PR TITLE
copy-tracking: fix path tracking for nested directories with equal names

### DIFF
--- a/lib/src/repo_path.rs
+++ b/lib/src/repo_path.rs
@@ -640,8 +640,9 @@ impl RepoPathUiConverter {
 
                 let suffix_count = source_components
                     .iter()
+                    .skip(prefix_count)
                     .rev()
-                    .zip(target_components.iter().rev())
+                    .zip(target_components.iter().skip(prefix_count).rev())
                     .take_while(|(source_component, target_component)| {
                         source_component == target_component
                     })
@@ -1205,5 +1206,13 @@ mod tests {
         assert_eq!(format("two", "four"), "{two => four}");
         assert_eq!(format("file1", "file2"), "{file1 => file2}");
         assert_eq!(format("file-1", "file-2"), "{file-1 => file-2}");
+        assert_eq!(
+            format("x/something/something/2to1.txt", "x/something/2to1.txt"),
+            "x/something/{something => }/2to1.txt"
+        );
+        assert_eq!(
+            format("x/something/1to2.txt", "x/something/something/1to2.txt"),
+            "x/something/{ => something}/1to2.txt"
+        );
     }
 }


### PR DESCRIPTION
The problem was that the calculation of the suffix was overlapping into the the prefix for nested directories with the same name. We skipped the prefix to avoid this issue.

Closes: #6853

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] ~~I have updated `CHANGELOG.md`~~
- [ ] ~~I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
- [ ] ~~I have updated the config schema (`cli/src/config-schema.json`)~~
- [x] I have added/updated tests to cover my changes
