### PR TITLE
git: add `git.colocate` to colocate repos by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj file show` now accepts `-T`/`--template` option to insert file metadata.
 
+* The new configuration option `git.colocate=boolean` controls whether or not
+  Git repositories are colocated by default.
+
+* Both `jj git clone` and `jj git init` now take a `--no-colocate` flag to
+  disable colocation (in case `git.colocate` is set to `true`.)
+
 ### Fixed bugs
 
 ## [0.32.0] - 2025-08-06

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -482,6 +482,11 @@
                     "type": "string",
                     "description": "Path to the git executable",
                     "default": "git"
+                },
+                "colocate": {
+                    "type": "boolean",
+                    "description": "Whether to colocate the working copy with the git repository",
+                    "default": false
                 }
             }
         },

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1219,6 +1219,7 @@ The Git repo will be a bare git repo stored inside the `.jj/` directory.
 
   Default value: `origin`
 * `--colocate` — Whether or not to colocate the Jujutsu repo with the git repo
+* `--no-colocate` — Disable colocation of the Jujutsu repo with the git repo
 * `--depth <DEPTH>` — Create a shallow clone of the given depth
 
 
@@ -1288,6 +1289,7 @@ Create a new Git backed repo
    This is done by placing the backing git repo into a `.git` directory in the root of the `jj` repo along with the `.jj` directory. If the `.git` directory already exists, all the existing commits will be imported.
 
    This option is mutually exclusive with `--git-repo`.
+* `--no-colocate` — Disable colocation of the Jujutsu repo with the git repo
 * `--git-repo <GIT_REPO>` — Specifies a path to an **existing** git repository to be used as the backing git repo for the newly created `jj` repo.
 
    If the specified `--git-repo` path happens to be the same as the `jj` repo path (both .jj and .git directories are in the same working directory), then both `jj` and `git` commands will work on the same repo. This is called a co-located repo.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1440,6 +1440,19 @@ signature details.
 
 ## Git settings
 
+### Default colocation
+
+When creating a git-backed Jujutsu repository, you can enable "colocation" which
+places the `.git` directory next to the `.jj` directory, allowing some amount of
+two-way interoperability.
+
+The setting `git.colocate` is a boolean option that controls whether or not the
+`jj git init` and `jj git clone` commands should create colocated repositories
+by default. By default, `git.colocate` is set to `false`.
+
+See [Co-located Jujutsu/Git repos](./
+git-compatibility.md#co-located-jujutsugit-repos) for more information.
+
 ### Default remotes for `jj git fetch` and `jj git push`
 
 By default, if a single remote exists it is used for `jj git fetch` and `jj git

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -14,6 +14,7 @@ abandon-unreachable-commits = true
 auto-local-bookmark = false
 executable-path = "git"
 write-change-id-header = true
+colocate = false
 
 [operation]
 hostname = ""

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -63,6 +63,7 @@ pub struct GitSettings {
     pub abandon_unreachable_commits: bool,
     pub executable_path: PathBuf,
     pub write_change_id_header: bool,
+    pub colocate: bool,
 }
 
 impl GitSettings {
@@ -72,6 +73,7 @@ impl GitSettings {
             abandon_unreachable_commits: settings.get_bool("git.abandon-unreachable-commits")?,
             executable_path: settings.get("git.executable-path")?,
             write_change_id_header: settings.get("git.write-change-id-header")?,
+            colocate: settings.get("git.colocate")?,
         })
     }
 }
@@ -83,6 +85,7 @@ impl Default for GitSettings {
             abandon_unreachable_commits: true,
             executable_path: PathBuf::from("git"),
             write_change_id_header: true,
+            colocate: false,
         }
     }
 }


### PR DESCRIPTION
Closes #2507.

This is based on #2512.
That PR hasn't seen any love in a year, so I'm opening this to nudge it along :slightly_smiling_face:
The only things I changed compared to Austin's work are:
- Rebase on main, resolve merge conflicts and other breakages.
- Add two tests, one for `init` and one for `clone`.

@thoughtpolice Please let me know if you'd like me to handle your Signed-off-by trailer differently, I kept it as is for now.

Also related: My FR to colocate repos by default (#7189).
Apparantly the plan was to do that anyway once this config option lands.
I would be very happy about that!

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
