### PR TITLE
cli describe: Clarify short description for `--reset-author`

### DIFF
--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -86,9 +86,10 @@ pub(crate) struct DescribeArgs {
     /// allow the message to be edited afterwards.
     #[arg(long)]
     edit: bool,
-    /// Reset the author to the configured user
+    /// Reset the author name, email, and timestamp
     ///
-    /// This resets the author name, email, and timestamp.
+    /// This resets the author name and email to the configured user and sets
+    /// the author timestamp to the current time.
     ///
     /// You can use it in combination with the JJ_USER and JJ_EMAIL
     /// environment variables to set a different author:

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -745,9 +745,9 @@ Starts an editor to let you edit the description of changes. The editor will be 
 * `--edit` — Open an editor
 
    Forces an editor to open when using `--stdin` or `--message` to allow the message to be edited afterwards.
-* `--reset-author` — Reset the author to the configured user
+* `--reset-author` — Reset the author name, email, and timestamp
 
-   This resets the author name, email, and timestamp.
+   This resets the author name and email to the configured user and sets the author timestamp to the current time.
 
    You can use it in combination with the JJ_USER and JJ_EMAIL environment variables to set a different author:
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This change adds a note about `--reset-author` also updating the author timestamp to the short description, rather than it only being buried in the long description. This came up from a discussion on Discord.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
