### PR TITLE
docs: fix nested list rendering as top level

### DIFF
--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -69,12 +69,12 @@ use crate::ui::Ui;
 ///  - `command`: The arguments used to run the tool. The first argument is the
 ///    path to an executable file. Arguments can contain these variables that
 ///    will be replaced:
-///    - `$root` will be replaced with the workspace root path (the directory
-///      containing the .jj directory).
-///    - `$path` will be replaced with the repo-relative path of the file being
-///      fixed. It is useful to provide the path to tools that include the path
-///      in error messages, or behave differently based on the directory or file
-///      name.
+///      - `$root` will be replaced with the workspace root path (the directory
+///        containing the .jj directory).
+///      - `$path` will be replaced with the repo-relative path of the file
+///        being fixed. It is useful to provide the path to tools that include
+///        the path in error messages, or behave differently based on the
+///        directory or file name.
 ///  - `patterns`: Determines which files the tool will affect. If this list is
 ///    empty, no files will be affected by the tool. If there are multiple
 ///    patterns, the tool is applied only once to each file in the union of the

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1126,12 +1126,12 @@ the values have the following properties:
  - `command`: The arguments used to run the tool. The first argument is the
    path to an executable file. Arguments can contain these variables that
    will be replaced:
-   - `$root` will be replaced with the workspace root path (the directory
-     containing the .jj directory).
-   - `$path` will be replaced with the repo-relative path of the file being
-     fixed. It is useful to provide the path to tools that include the path
-     in error messages, or behave differently based on the directory or file
-     name.
+     - `$root` will be replaced with the workspace root path (the directory
+       containing the .jj directory).
+     - `$path` will be replaced with the repo-relative path of the file
+       being fixed. It is useful to provide the path to tools that include
+       the path in error messages, or behave differently based on the
+       directory or file name.
  - `patterns`: Determines which files the tool will affect. If this list is
    empty, no files will be affected by the tool. If there are multiple
    patterns, the tool is applied only once to each file in the union of the


### PR DESCRIPTION
This PR fixes the `jj fix` docs indentation.

| Before | After |
|-|-|
| <img width="973" height="619" alt="Screenshot From 2025-08-09 14-39-24" src="https://github.com/user-attachments/assets/d1d8deb8-9e4c-4282-9528-bce9728639ad" /> | <img width="973" height="619" alt="image" src="https://github.com/user-attachments/assets/a5fd57b6-e1c4-4e45-85ae-31c9e54c3059" /> |

I am unsure of _why_ this change was necessary, as the generated documentation has a valid, nested, markdown list. I played around with the `mkdocs` options (mainly, disabling some combination of `mdx_truly_sane_lists`, `mdx_breakless_lists`, and `sane_lists`), but none worked. 

I think this is probably caused by `mdx_breakless_lists`. When the list has linebreaks around it the rendered markdown looks fine, so I think it's interfering somehow.

I checked all other possible nested lists generated from rustdoc comments (`rg '\/\/\/\s+-'`) and couldn't find anything else affected by this issue.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
