### PR TITLE
cli: provide file completion for `util exec` args

### DIFF
--- a/cli/src/commands/util/exec.rs
+++ b/cli/src/commands/util/exec.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap_complete::ArgValueCompleter;
+use clap_complete::PathCompleter;
+
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
@@ -67,6 +70,7 @@ pub(crate) struct UtilExecArgs {
     /// External command to execute
     command: String,
     /// Arguments to pass to the external command
+    #[arg(add = ArgValueCompleter::new(PathCompleter::file()))]
     args: Vec<String>,
 }
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1467,3 +1467,25 @@ fn test_files() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_command_alias_with_exec() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    test_env.add_config(r#"aliases.my-script = ["util", "exec", "--", "my-jj-script"]"#);
+
+    work_dir.write_file("file1", "contents");
+    work_dir.write_file("file2", "contents");
+    work_dir.create_dir("folder");
+    work_dir.write_file("folder/subfile", "contents");
+
+    let output = work_dir.complete_fish(["my-script", "f"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    file1
+    file2
+    folder/
+    [EOF]
+    ");
+}


### PR DESCRIPTION
Makes command aliases provide similar completion to the shell's default. Right now an alias that uses `util exec` effectively disables shell completion.

(There's a related issue: despite the `--` in the alias, completions for options like `--config` are offered, but I believe this needs to be fixed in `clap`)

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
