### PR TITLE
commit_builder: make .generate_new_change_id() not imply commit is duplicated

### DIFF
--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -230,10 +230,10 @@ pub(crate) fn cmd_split(
         let mut commit_builder = tx.repo_mut().rewrite_commit(&target.commit).detach();
         commit_builder.set_tree_id(target.selected_tree.id());
         if use_move_flags {
-            commit_builder
-                // Generate a new change id so that the commit being split doesn't
-                // become divergent.
-                .generate_new_change_id();
+            commit_builder.clear_rewrite_source();
+            // Generate a new change id so that the commit being split doesn't
+            // become divergent.
+            commit_builder.generate_new_change_id();
         }
         let description = if !args.message_paragraphs.is_empty() {
             let description = join_message_paragraphs(&args.message_paragraphs);
@@ -279,10 +279,10 @@ pub(crate) fn cmd_split(
             .set_parents(parents)
             .set_tree_id(new_tree.id());
         if !use_move_flags {
-            commit_builder
-                // Generate a new change id so that the commit being split doesn't
-                // become divergent.
-                .generate_new_change_id();
+            commit_builder.clear_rewrite_source();
+            // Generate a new change id so that the commit being split doesn't
+            // become divergent.
+            commit_builder.generate_new_change_id();
         }
         let description = if target.commit.description().is_empty() {
             // If there was no description before, don't ask for one for the

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -940,6 +940,7 @@ pub async fn duplicate_commits(
         let mut new_commit_builder = CommitRewriter::new(mut_repo, original_commit, new_parent_ids)
             .rebase()
             .await?
+            .clear_rewrite_source()
             .generate_new_change_id();
         if let Some(desc) = target_descriptions.get(original_commit_id) {
             new_commit_builder = new_commit_builder.set_description(desc);
@@ -1026,6 +1027,7 @@ pub fn duplicate_commits_onto_parents(
             .collect();
         let mut new_commit_builder = mut_repo
             .rewrite_commit(&original_commit)
+            .clear_rewrite_source()
             .generate_new_change_id()
             .set_parents(new_parent_ids);
         if let Some(desc) = target_descriptions.get(original_commit_id) {

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -458,6 +458,7 @@ fn test_commit_builder_descendants(backend: TestRepoBackend) {
     let mut tx = repo.start_transaction();
     tx.repo_mut()
         .rewrite_commit(&commit2)
+        .clear_rewrite_source()
         .generate_new_change_id()
         .write()
         .unwrap();


### PR DESCRIPTION
…plicated

This will allow us to "touch" change id without duplicating commits. The caller should also do .generate_new_change_id() to not make commits divergent. Another option is to add .duplicate() function that will unset rewrite_source and generate new change id.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
