### PR TITLE
working_copy: mark unused `conflict_id` proto field reserved

### DIFF
--- a/lib/src/protos/working_copy.proto
+++ b/lib/src/protos/working_copy.proto
@@ -33,9 +33,8 @@ message FileState {
   int64 mtime_millis_since_epoch = 1;
   uint64 size = 2;
   FileType file_type = 3;
-  // Set only if file_type is Conflict
-  bytes conflict_id = 4 [deprecated = true];
   MaterializedConflictData materialized_conflict_data = 5;
+  reserved 4;
 }
 
 message FileStateEntry {

--- a/lib/src/protos/working_copy.rs
+++ b/lib/src/protos/working_copy.rs
@@ -5,7 +5,7 @@ pub struct MaterializedConflictData {
     #[prost(uint32, tag = "1")]
     pub conflict_marker_len: u32,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct FileState {
     #[prost(int64, tag = "1")]
     pub mtime_millis_since_epoch: i64,
@@ -13,10 +13,6 @@ pub struct FileState {
     pub size: u64,
     #[prost(enumeration = "FileType", tag = "3")]
     pub file_type: i32,
-    /// Set only if file_type is Conflict
-    #[deprecated]
-    #[prost(bytes = "vec", tag = "4")]
-    pub conflict_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "5")]
     pub materialized_conflict_data: ::core::option::Option<MaterializedConflictData>,
 }


### PR DESCRIPTION
The field has been unused since it was deprecated in 97b81a0f (~2 years ago). It should have been marked reserved instead of deprecated already then.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
