### PR TITLE
working_copy: Use `impl Iterator` to avoid naming iterator type

### DIFF
--- a/cli/src/commands/debug/local_working_copy.rs
+++ b/cli/src/commands/debug/local_working_copy.rs
@@ -37,7 +37,7 @@ pub fn cmd_debug_local_working_copy(
     let wc = check_local_disk_wc(workspace_command.working_copy().as_any())?;
     writeln!(ui.stdout(), "Current operation: {:?}", wc.operation_id())?;
     writeln!(ui.stdout(), "Current tree: {:?}", wc.tree_id()?)?;
-    for (file, state) in wc.file_states()? {
+    for (file, state) in wc.file_states()?.iter() {
         writeln!(
             ui.stdout(),
             "{:?} {:13?} {:10?} {:?} {:?}",


### PR DESCRIPTION
This had been commented on before by @yuja here: https://github.com/jj-vcs/jj/pull/6442#discussion_r2072496672. In response to that, I would like to reiterate that this change is motivated solely by local code clarity and Rust style. No code change I have proposed or will propose would affect the need to iterate over file states. This commit is wholly local, and I propose it only because it improves code clarity and is good style.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
