### PR TITLE
revset: add new `exactly(x, n)` expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj log`, `jj evolog` and `jj op log` output can now be anonymized with the
   `builtin_log_redacted` and `builtin_op_log_redacted` templates.
 
+* The revset function `exactly(x, n)` will now evaluate `x` and error if it does
+  not have exactly `n` elements.
+
 ### Fixed bugs
 
 ### Packaging changes

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -318,6 +318,10 @@ revsets (expressions) as arguments.
   set are descendants. The current implementation deals somewhat poorly with
   non-linear history.
 
+* `exactly(x, count)`: Evaluates `x`, and errors if it is not of exactly size
+  `count`. Otherwise, returns `x`. This is useful in particular with `count=1`
+  when you want to ensure that some revset expression has exactly one target.
+
 * `merges()`: Merge commits.
 
 * `description(pattern)`: Commits that have a description matching the given

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -1047,6 +1047,22 @@ impl EvaluationContext<'_> {
                 let candidate_set = self.evaluate(candidates)?;
                 Ok(Box::new(self.take_latest_revset(&*candidate_set, *count)?))
             }
+            ResolvedExpression::Exactly { candidates, count } => {
+                let set = self.evaluate(candidates)?;
+                let positions: Vec<_> = set.positions().attach(index).try_collect()?;
+                if positions.len() != *count {
+                    return Err(RevsetEvaluationError::Other(
+                        format!(
+                            "The given revset '{:?}' was expected to have {} elements, but has {}",
+                            set,
+                            count,
+                            positions.len()
+                        )
+                        .into(),
+                    ));
+                }
+                Ok(set)
+            }
             ResolvedExpression::Coalesce(expression1, expression2) => {
                 let set1 = self.evaluate(expression1)?;
                 if set1.positions().attach(index).next().is_some() {


### PR DESCRIPTION
With `all:` going away soon, some users (including me) had been using it to enforce an invariant: by omitting it, an expression was guaranteed to yield exactly one result. For example, this is important when using tools like `jj rebase -B/-A`

Instead, let's fix that case by building that functionality into the revset language itself. The previous behavior can now be enforced via the term `exactly(x, 1)`

In the future, `n` could also be a range.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
