### PR TITLE
lib: rename mut_repo() to repo_mut() in the rewriter

### DIFF
--- a/lib/src/fix.rs
+++ b/lib/src/fix.rs
@@ -314,7 +314,7 @@ pub async fn fix_files(
         summary.num_checked_commits += 1;
         if has_changes {
             summary.num_fixed_commits += 1;
-            let new_tree = tree_builder.write_tree(rewriter.mut_repo().store())?;
+            let new_tree = tree_builder.write_tree(rewriter.repo_mut().store())?;
             let builder = rewriter.reparent();
             let new_commit = builder.set_tree_id(new_tree).write()?;
             summary

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -153,7 +153,7 @@ impl<'repo> CommitRewriter<'repo> {
     }
 
     /// Returns the `MutableRepo`.
-    pub fn mut_repo(&mut self) -> &mut MutableRepo {
+    pub fn repo_mut(&mut self) -> &mut MutableRepo {
         self.mut_repo
     }
 


### PR DESCRIPTION
As a follow-up to https://github.com/jj-vcs/jj/pull/7184#discussion_r2272345293

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
