### PR TITLE
template: add `any` and `all` methods to lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Templates now support `any()` and `all()` methods on lists to check whether
+  any or all elements satisfy a predicate. Example: `parents.any(|c| c.mine())`
+  returns true if any parent commit is authored by the user.
+
 * Add experimental support for indexing changed paths, which will speed up `jj
   log PATH` query, `jj file annotate`, etc. The changed-path index can be
   enabled by `jj debug index-changed-paths` command. Indexing may take tens of

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -288,6 +288,10 @@ defined.
   `expression`. Example: `description.lines().filter(|s| s.contains("#"))`
 * `.map(|item| expression) -> ListTemplate`: Apply template `expression`
   to each element. Example: `parents.map(|c| c.commit_id().short())`
+* `.any(|item| expression) -> Boolean`: Returns true if any element satisfies
+  the predicate `expression`. Example: `parents.any(|c| c.description().contains("fix"))`
+* `.all(|item| expression) -> Boolean`: Returns true if all elements satisfy
+  the predicate `expression`. Example: `parents.all(|c| c.mine())`
 
 ### `List<Trailer>` type
 


### PR DESCRIPTION
Add support for `.any(|item| expression)` and `.all(|item| expression)` boolean methods to lists, mirroring the [Python](https://docs.python.org/3/library/functions.html#any) [equivalents](https://docs.python.org/3/library/functions.html#all).