### PR TITLE
git init: prefer `upstream` over `origin` for `trunk()` alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj log`, `jj evolog` and `jj op log` output can now be anonymized with the
   `builtin_log_redacted` and `builtin_op_log_redacted` templates.
 
+* `jj git init` now checks for an `upstream` remote in addition to `origin` when
+  setting the repository-level `trunk()` alias. The `upstream` remote takes
+  precedence over `origin` if both exist.
+
 * Add the `jj touch` command, which modifies a revision's metadata. This can be
   used to generate a new change-id, which may help resolve some divergences.
 


### PR DESCRIPTION
Resolves #7228