### PR TITLE
cli: git fetch: fall back to remote fetch refspecs when -b not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   many people to be negatively affected, because running `jj undo` twice was
   previously a no-op.
 
+* `jj git fetch` will now only fetch the refspec patterns configured on remotes
+  when the `--bookmark` option is omitted. Only simple refspec patterns
+  are currently supported, and anything else (like refspecs which rename
+  branches) will be ignored.
+
 ### Deprecations
 
 * The on-disk index format has changed. `jj` will write index files in both old

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -518,6 +518,7 @@ impl From<TrailerParseError> for CommandError {
 
 #[cfg(feature = "git")]
 mod git {
+    use jj_lib::git::GitDefaultRefspecError;
     use jj_lib::git::GitExportError;
     use jj_lib::git::GitFetchError;
     use jj_lib::git::GitImportError;
@@ -574,6 +575,15 @@ jj currently does not support partial clones. To use jj with this repository, tr
                 ),
                 GitFetchError::InvalidBranchPattern(_) => user_error(err),
                 GitFetchError::Subprocess(_) => user_error(err),
+            }
+        }
+    }
+
+    impl From<GitDefaultRefspecError> for CommandError {
+        fn from(err: GitDefaultRefspecError) -> Self {
+            match err {
+                GitDefaultRefspecError::NoSuchRemote(_) => user_error(err),
+                GitDefaultRefspecError::InvalidRemoteConfiguration(_, _) => user_error(err),
             }
         }
     }

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use jj_lib::git;
 use jj_lib::git::FetchTagsOverride;
 use jj_lib::git::GitFetch;
+use jj_lib::git::expand_fetch_refspecs;
 use jj_lib::ref_name::RefNameBuf;
 use jj_lib::ref_name::RemoteName;
 use jj_lib::ref_name::RemoteNameBuf;
@@ -268,7 +269,7 @@ fn fetch_new_remote(
     with_remote_git_callbacks(ui, |cb| {
         git_fetch.fetch(
             remote_name,
-            &[StringPattern::everything()],
+            expand_fetch_refspecs(remote_name, vec![StringPattern::everything()])?,
             cb,
             depth,
             match fetch_tags {

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -21,6 +21,7 @@ mod push;
 mod remote;
 mod root;
 
+use std::io::Write as _;
 use std::path::Path;
 
 use clap::Subcommand;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1259,8 +1259,6 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 * `-b`, `--branch <BRANCH>` — Fetch only some of the branches
 
    By default, the specified name matches exactly. Use `glob:` prefix to expand `*` as a glob, e.g. `--branch 'glob:push-*'`. Other wildcard characters such as `?` are *not* supported. Can be repeated to specify multiple branches.
-
-  Default value: `glob:*`
 * `--tracked` — Fetch only tracked bookmarks
 
    This fetches only bookmarks that are already tracked from the specified remote(s).

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -2213,7 +2213,7 @@ pub fn expand_default_fetch_refspecs(
 
     let mut ignored_refspecs = Vec::with_capacity(remote_refspecs.len());
     let mut expected_branch_names = Vec::with_capacity(remote_refspecs.len());
-    let negative_refspecs = Vec::new();
+    let mut negative_refspecs = Vec::new();
 
     let refspecs = remote_refspecs
         .iter()
@@ -2244,15 +2244,17 @@ pub fn expand_default_fetch_refspecs(
                         return None;
                     }
 
-                    // TODO: these need to be included, but we currently have no way to express
-                    // negative refspecs
-                    gix::refspec::instruction::Fetch::Exclude { src: _ } => return None,
-
                     gix::refspec::instruction::Fetch::AndUpdate {
                         src,
                         dst,
                         allow_non_fast_forward: _, // Already captured above
                     } => (ensure_utf8(src)?, ensure_utf8(dst)?),
+
+                    gix::refspec::instruction::Fetch::Exclude { src } => {
+                        let src = ensure_utf8(src)?;
+                        negative_refspecs.push(NegativeRefSpec::new(src));
+                        return None;
+                    }
                 },
             };
 

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -30,6 +30,7 @@ use thiserror::Error;
 
 use crate::git::FetchTagsOverride;
 use crate::git::GitPushStats;
+use crate::git::NegativeRefSpec;
 use crate::git::Progress;
 use crate::git::RefSpec;
 use crate::git::RefToPush;
@@ -160,6 +161,7 @@ impl<'a> GitSubprocessContext<'a> {
         &self,
         remote_name: &RemoteName,
         refspecs: &[RefSpec],
+        negative_refspecs: &[NegativeRefSpec],
         callbacks: &mut RemoteCallbacks<'_>,
         depth: Option<NonZeroU32>,
         fetch_tags_override: Option<FetchTagsOverride>,
@@ -188,7 +190,12 @@ impl<'a> GitSubprocessContext<'a> {
             None => {}
         }
         command.arg("--").arg(remote_name.as_str());
-        command.args(refspecs.iter().map(|x| x.to_git_format()));
+        command.args(
+            refspecs
+                .iter()
+                .map(|x| x.to_git_format())
+                .chain(negative_refspecs.iter().map(|x| x.to_git_format())),
+        );
 
         let output = wait_with_progress(self.spawn_cmd(command)?, callbacks)?;
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -3231,6 +3231,7 @@ fn test_expand_default_fetch_refspecs() {
                 destination: "refs/remotes/origin/main",
             },
         ],
+        negative_refspecs: [],
     }
     "#);
 }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -3163,6 +3163,8 @@ fn test_expand_default_fetch_refspecs() {
             # Valid
             fetch = +refs/heads/main:refs/remotes/origin/main
             fetch = +refs/heads/foo*:refs/remotes/origin/foo*
+            fetch = ^refs/heads/excluded
+            fetch = ^refs/heads/fooqux
             # Invalid
             fetch = +refs/heads/src-only
             fetch = refs/heads/non-forced
@@ -3231,7 +3233,14 @@ fn test_expand_default_fetch_refspecs() {
                 destination: "refs/remotes/origin/main",
             },
         ],
-        negative_refspecs: [],
+        negative_refspecs: [
+            NegativeRefSpec {
+                source: "refs/heads/excluded",
+            },
+            NegativeRefSpec {
+                source: "refs/heads/fooqux",
+            },
+        ],
     }
     "#);
 }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

Fixes https://github.com/jj-vcs/jj/issues/5323

Only fetch refspecs matching a very conservative set of patterns (i.e. no branch or remote renames, must be a forced refspec for `refs/heads/`, etc) is supported and everything outside of that will be (warned about) and ignored. We can always expand these in the future but for now it would be good to avoid ambiguities about how branch renaming ought to be handled.

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
