### PR TITLE
undo: revert progressively older operations with repeated calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Add the `jj touch` command, which modifies a revision's metadata. This can be
   used to generate a new change-id, which may help resolve some divergences.
 
-* Filesets now support case-insensitive glob patterns with the `glob-i:`, 
-  `cwd-glob-i:`, and `root-glob-i:` pattern kinds. For example, `glob-i:"*.rs"` 
+* Filesets now support case-insensitive glob patterns with the `glob-i:`,
+  `cwd-glob-i:`, and `root-glob-i:` pattern kinds. For example, `glob-i:"*.rs"`
   will match both `file.rs` and `FILE.RS`.
 
 * `jj op show` now accepts `-T`/`--template` option to customize the operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The deprecated `--config-toml` flag has been removed. Use
   `--config=NAME=VALUE` or `--config-file=PATH` instead.
 
+* `jj undo` can now undo multiple operations progressively by calling it
+  repeatedly. While this is technically a breaking change, we don't expect
+  many people to be negatively affected, because running `jj undo` twice was
+  previously a no-op.
+
 ### Deprecations
 
 * The on-disk index format has changed. `jj` will write index files in both old
@@ -33,8 +38,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   files. This compatibility layer will be removed in a future release.
 
 * `jj op undo` is deprecated in favor of `jj op revert`. (`jj undo` is still
-  available unchanged, but we plan to enable undoing multiple operations
-  progressively by repeated calls to `jj undo`.)
+  available, but with new semantics. See also the breaking changes above.)
 
 * The argument `<operation>` of `jj undo` is deprecated in favor of
   `jj op revert <operation>`.

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ commit message of any commit (defaults to the working-copy commit).
 ### Entire repo is under version control
 
 All operations you perform in the repo are recorded, along with a snapshot of
-the repo state after the operation. This means that you can easily revert to an
-earlier repo state, or to simply undo a particular operation (which does not
-necessarily have to be the most recent operation).
+the repo state after the operation. This means that you can easily restore to
+an earlier repo state, simply undo your operations one-by-one or even _revert_ a
+particular operation which does not have to be the most recent one.
 
 <img src="demos/operation_log.png" />
 

--- a/cli/src/commands/operation/mod.rs
+++ b/cli/src/commands/operation/mod.rs
@@ -93,7 +93,7 @@ pub(crate) const DEFAULT_REVERT_WHAT: [RevertWhatToRestore; 2] = [
 ];
 
 /// Restore only the portions of the view specified by the `what` argument
-fn view_with_desired_portions_restored(
+pub(crate) fn view_with_desired_portions_restored(
     view_being_restored: &jj_lib::op_store::View,
     current_view: &jj_lib::op_store::View,
     what: &[RevertWhatToRestore],

--- a/cli/src/commands/operation/revert.rs
+++ b/cli/src/commands/operation/revert.rs
@@ -46,7 +46,7 @@ pub struct OperationRevertArgs {
     pub(crate) what: Vec<RevertWhatToRestore>, // pub for `jj undo`
 }
 
-pub(crate) fn tx_description(op: &Operation) -> String {
+fn tx_description(op: &Operation) -> String {
     format!("revert operation {}", op.id().hex())
 }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2695,7 +2695,7 @@ Modify the metadata of a revision without changing its content
 
 Undo the last operation
 
-This undoes the last operation by applying its inverse as a new operation.
+This undoes the last operation by restoring its parent operation.
 
 **Usage:** `jj undo [OPTIONS] [OPERATION]`
 

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -73,7 +73,7 @@ fn test_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Reverted operation: 76386e059136 (2001-02-03 08:05:17) duplicate 1 commit(s)
+    Restored to operation: 9fdb56d75a27 (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate" /* duplicates `c` */]);
@@ -2349,7 +2349,7 @@ fn test_undo_after_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Reverted operation: a6a20a8e5a46 (2001-02-03 08:05:11) duplicate 1 commit(s)
+    Restored to operation: 73a36404358e (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @r"

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -966,7 +966,7 @@ fn test_git_colocated_undo_head_move() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Reverted operation: f0843f81aac4 (2001-02-03 08:05:13) new empty commit
+    Restored to operation: 28f10852fc94 (2001-02-03 08:05:12) new empty commit
     Working copy  (@) now at: royxmykx e7d0d5fd (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1193,7 +1193,7 @@ fn test_git_fetch_undo() {
     let output = target_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Reverted operation: 158b589e0e15 (2001-02-03 08:05:18) fetch from git remote(s) origin
+    Restored to operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     // The undo works as expected

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -116,7 +116,7 @@ fn test_git_export_undo() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Reverted operation: b718f970b78c (2001-02-03 08:05:10) export git refs
+    Restored to operation: 503f3c779aff (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"

--- a/cli/tests/test_touch_command.rs
+++ b/cli/tests/test_touch_command.rs
@@ -289,7 +289,7 @@ fn test_touch() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "nmzmmo"]), @r"
     ○  nmzmmopx test.user@example.com 2001-02-03 08:05:26 b f4388b00
     │  (no description set)
-    │  -- operation 536f450806c8 (2001-02-03 08:05:26) touch commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation 71593b9bb78f (2001-02-03 08:05:26) touch commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:11 75591b18
     │  (no description set)
     │  -- operation 4b33c26502f8 (2001-02-03 08:05:11) snapshot working copy
@@ -301,7 +301,7 @@ fn test_touch() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "mzvwut"]), @r"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:26 c d35b7dc2
     │  (no description set)
-    │  -- operation 536f450806c8 (2001-02-03 08:05:26) touch commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation 71593b9bb78f (2001-02-03 08:05:26) touch commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  mzvwutvl hidden test.user@example.com 2001-02-03 08:05:13 22be6c4e
     │  (no description set)
     │  -- operation a424b73ab8eb (2001-02-03 08:05:13) snapshot working copy

--- a/cli/tests/test_undo.rs
+++ b/cli/tests/test_undo.rs
@@ -16,17 +16,20 @@ use crate::common::TestEnvironment;
 
 #[test]
 fn test_undo_root_operation() {
-    // TODO: Adapt to future "undo" functionality: What happens if the user
-    // progressively undoes everything all the way back to the root operation?
-
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
-    let output = work_dir.run_jj(["undo", "000000000000"]);
+    let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Warning: `jj undo <operation>` is deprecated; use `jj op revert <operation>` instead
+    Restored to operation: 000000000000 root()
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["undo"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
     Error: Cannot undo root operation
     [EOF]
     [exit status: 1]
@@ -35,19 +38,6 @@ fn test_undo_root_operation() {
 
 #[test]
 fn test_undo_merge_operation() {
-    // TODO: What should future "undo" do with a merge operation? The
-    // answer is probably not improbably not important, because users
-    // who create merge operations will also be able to `op revert`
-    // and `op restore` to achieve their goals on their own.
-    // Possibilities:
-    // - Fail and block any further attempt to undo anything.
-    // - Restore directly to the fork point of the merge, ignoring any intermediate
-    //   operations.
-    // - Pick any path and walk only that backwards, ignoring the other paths.
-    //   (Which path to pick?)
-    // At first, it will be best to simply fail, before there is
-    // agreement that doing anything else is not actively harmful.
-
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -65,178 +55,85 @@ fn test_undo_merge_operation() {
 }
 
 #[test]
-fn test_undo_latest_undo_implicitly() {
+fn test_undo_jump_old_undo_stack() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
-    // Double-undo creation of child
-    work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["undo"]).success();
-    let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: 5b31042c020b (2001-02-03 08:05:09) revert operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
-    Working copy  (@) now at: rlvkpnrz 43444d88 (empty) (no description set)
-    Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
-    Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
-    Hint: To undo multiple operations, use `jj op log` to see past states and `jj op restore` to restore one of these states.
-    [EOF]
-    ");
+    // create a few normal operations
+    for state in 'A'..='D' {
+        work_dir.write_file("state", state.to_string());
+        work_dir.run_jj(["debug", "snapshot"]).success();
+    }
+    assert_eq!(work_dir.read_file("state"), "D");
 
-    // Double-undo creation of sibling
-    work_dir.run_jj(["new", "@-"]).success();
+    // undo operations D and C, restoring the state of B
     work_dir.run_jj(["undo"]).success();
-    let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: e83fef84da56 (2001-02-03 08:05:12) revert operation c9a93954e94b008f7295813623c4c12aeffd2cb81728e8d7813a37c8b6252b8f9a15ddfc6e496b393de355bd07405e740a05178cf8845af0087fb02223e4c404
-    Working copy  (@) now at: mzvwutvl 8afc18ff (empty) (no description set)
-    Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
-    Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
-    Hint: To undo multiple operations, use `jj op log` to see past states and `jj op restore` to restore one of these states.
-    [EOF]
-    ");
+    assert_eq!(work_dir.read_file("state"), "C");
+    work_dir.run_jj(["undo"]).success();
+    assert_eq!(work_dir.read_file("state"), "B");
+
+    // create operations E and F
+    work_dir.write_file("state", "E");
+    work_dir.run_jj(["debug", "snapshot"]).success();
+    work_dir.write_file("state", "F");
+    work_dir.run_jj(["debug", "snapshot"]).success();
+    assert_eq!(work_dir.read_file("state"), "F");
+
+    // undo operations F, E and B, restoring the state of A while skipping the
+    // undo-stack of C and D in the op log
+    work_dir.run_jj(["undo"]).success();
+    assert_eq!(work_dir.read_file("state"), "E");
+    work_dir.run_jj(["undo"]).success();
+    assert_eq!(work_dir.read_file("state"), "B");
+    work_dir.run_jj(["undo"]).success();
+    assert_eq!(work_dir.read_file("state"), "A");
 }
 
 #[test]
-fn test_undo_latest_undo_explicitly() {
+fn test_op_revert_is_ignored() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
-    work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["undo"]).success();
-    let output = work_dir
-        .run_jj(["op", "log", "--no-graph", "-T=id.short()", "-n=1"])
-        .success();
-    let op_id_hex = output.stdout.raw();
-    let output = work_dir.run_jj(["undo", op_id_hex]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: `jj undo <operation>` is deprecated; use `jj op revert <operation>` instead
-    Reverted operation: 5b31042c020b (2001-02-03 08:05:09) revert operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
-    Working copy  (@) now at: rlvkpnrz 43444d88 (empty) (no description set)
-    Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
-    [EOF]
-    ");
+    // create a few normal operations
+    work_dir.write_file("state", "A");
+    work_dir.run_jj(["debug", "snapshot"]).success();
+    work_dir.write_file("state", "B");
+    work_dir.run_jj(["debug", "snapshot"]).success();
+    assert_eq!(work_dir.read_file("state"), "B");
 
-    work_dir.run_jj(["new"]).success();
+    // `op revert` works the same way as `undo` initially, but running `undo`
+    // afterwards will result in a no-op. `undo` does not recognize operations
+    // created by `op revert` as undo-operations on which an undo-stack can
+    // be grown.
+    work_dir.run_jj(["op", "revert"]).success();
+    assert_eq!(work_dir.read_file("state"), "A");
     work_dir.run_jj(["undo"]).success();
-    let output = work_dir.run_jj(["undo", "@"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: f344a2234512 (2001-02-03 08:05:13) revert operation a6365efd7a8958525e22cd7b4fb01f308260464facdc3f03c82a151892a073e0fbf6b4d9ad49991ab7ee4f05c55c147c74841714710c87ce7a990e112fe782b8
-    Working copy  (@) now at: royxmykx ba0e5dca (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz 43444d88 (empty) (no description set)
-    Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
-    Hint: To undo multiple operations, use `jj op log` to see past states and `jj op restore` to restore one of these states.
-    [EOF]
-    ");
+    assert_eq!(work_dir.read_file("state"), "B");
 }
 
 #[test]
-fn test_undo_an_older_undo() {
+fn test_undo_with_rev_arg_falls_back_to_revert() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
     work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["undo"]).success();
-    let output = work_dir
-        .run_jj(["op", "log", "--no-graph", "-T=id.short()", "-n=1"])
-        .success();
-    let op_id_hex = output.stdout.raw();
-    work_dir.run_jj(["new"]).success();
-    // Undo an older undo operation that is not the immediately preceding operation.
-    let output = work_dir.run_jj(["undo", op_id_hex]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Warning: `jj undo <operation>` is deprecated; use `jj op revert <operation>` instead
-    Reverted operation: 5b31042c020b (2001-02-03 08:05:09) revert operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
-    [EOF]
-    ");
-
-    work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["undo"]).success();
-    work_dir.run_jj(["new"]).success();
-    // Undo an older undo operation that is not the immediately preceding operation.
     let output = work_dir.run_jj(["undo", "@-"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: `jj undo <operation>` is deprecated; use `jj op revert <operation>` instead
-    Reverted operation: f2c360817b17 (2001-02-03 08:05:14) revert operation 20e354c3f097e96da28c0470b2d9e38c07370ebbae6c01b33c62a44bee913603086b66c97cb8a24a6b1df284b64a82edea14b7fa3cb124da55ebc4d743a92475
-    [EOF]
-    ");
-}
-
-#[test]
-fn test_undo_an_undo_multiple_times() {
-    let test_env = TestEnvironment::default();
-    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let work_dir = test_env.work_dir("repo");
-
-    work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["undo"]).success();
-    let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: 5b31042c020b (2001-02-03 08:05:09) revert operation dbcb2561b6fee72ea6de79511b6b62f1fff2424f79d16dd30339f94621100f77c86ca7450f7b1ec1bd95d4d56b7a54fe3f3e612353e62cedc682366211b4144e
-    Working copy  (@) now at: rlvkpnrz 43444d88 (empty) (no description set)
-    Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
-    Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
-    Hint: To undo multiple operations, use `jj op log` to see past states and `jj op restore` to restore one of these states.
-    [EOF]
-    ");
-    let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: 91cc66ce7fb2 (2001-02-03 08:05:10) revert operation 5b31042c020bd6090d52b932c998a263655cd541b7922c2f56e372a0ee367aa4f7dfb0ccb89c55d2fa232ba8ff6fb22276607ccd12f03844841e6a3888f5972d
-    Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
-    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
-    Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
-    Hint: To undo multiple operations, use `jj op log` to see past states and `jj op restore` to restore one of these states.
+    Reverted operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
+    Rebased 1 descendant commits
     [EOF]
     ");
 
-    work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["undo"]).success();
-    let output = work_dir.run_jj(["undo"]);
+    let output = work_dir.run_jj(["op", "log", "-n1"]);
     insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: e26664a8b05f (2001-02-03 08:05:13) revert operation 3ac3dec981c7b97070849ee22a468ec4d16b2dbb1f3df26092ea2c11289b61bc3a38a1b5e3f5a91f576feb8769e171c1905f70f39e0284648c68c7a21f439817
-    Working copy  (@) now at: royxmykx e7d0d5fd (empty) (no description set)
-    Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
-    Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
-    Hint: To undo multiple operations, use `jj op log` to see past states and `jj op restore` to restore one of these states.
-    [EOF]
-    ");
-    let output = work_dir.run_jj(["undo", "@"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: cd5fdc0df497 (2001-02-03 08:05:14) revert operation e26664a8b05f2380b6857ea564f389363bc150ddbdc6cf087908787fc3831b3aa95575baed369581f8709c5cfc63f4787ff7b601e51639e8badc8251b8b2b9f9
-    Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
-    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
-    Warning: The second-last `jj undo` was reverted by the latest `jj undo`. The repo is now in the same state as it was before the second-last `jj undo`.
-    Hint: To undo multiple operations, use `jj op log` to see past states and `jj op restore` to restore one of these states.
-    [EOF]
-    ");
-}
-
-#[test]
-fn test_undo_bookmark_deletion() {
-    let test_env = TestEnvironment::default();
-    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let work_dir = test_env.work_dir("repo");
-
-    work_dir
-        .run_jj(["bookmark", "create", "foo", "-r=@"])
-        .success();
-    work_dir.run_jj(["bookmark", "delete", "foo"]).success();
-    let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Reverted operation: e1bcf7cd8080 (2001-02-03 08:05:09) delete bookmark foo
+    @  20c0ef5cef23 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  revert operation 8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752
+    │  args: jj undo @-
     [EOF]
     ");
 }

--- a/demos/operation_log.svg
+++ b/demos/operation_log.svg
@@ -118,14 +118,14 @@
 </tspan><tspan xml:space="preserve" x="10" y="1454" class="output">│  describe commit 8756f29849ccaf0024ff98c0605bbb1289c2992f
 </tspan><tspan xml:space="preserve" x="10" y="1472" class="output">│  <tspan class="fg5">args: jj describe -m stuff</tspan>
 </tspan><tspan xml:space="preserve" x="10" y="1490" class="output">
-</tspan><tspan xml:space="preserve" x="10" y="1508" class="output"><tspan class="fg2"># Let's undo that rebase operation:</tspan>
+</tspan><tspan xml:space="preserve" x="10" y="1508" class="output"><tspan class="fg2"># Let's revert that rebase operation:</tspan>
 </tspan><tspan xml:space="preserve" x="10" y="1526" class="output">
-</tspan><tspan xml:space="preserve" x="10" y="1544" class="output">$ jj undo 78f44
+</tspan><tspan xml:space="preserve" x="10" y="1544" class="output">$ jj op revert 78f44
 </tspan><tspan xml:space="preserve" x="10" y="1562" class="output">Reverted operation: <tspan class="fg4">78f44786ada8</tspan> (<tspan class="fg6">2024-10-13 19:54:55</tspan>) rebase commit ae764306f7544e<tspan class="hard-br" rotate="45" dx=".1em" dy="-.2em">↓</tspan>
 </tspan><tspan xml:space="preserve" x="10" y="1580" class="output">76e049d0a271449fa986e22de9 and descendants
 </tspan><tspan xml:space="preserve" x="10" y="1598" class="output">
-</tspan><tspan xml:space="preserve" x="10" y="1616" class="output"><tspan class="fg2"># Note that only the rebase was undone, and the</tspan>
-</tspan><tspan xml:space="preserve" x="10" y="1634" class="output"><tspan class="fg2"># subsequent "other stuff" change was not undone:</tspan>
+</tspan><tspan xml:space="preserve" x="10" y="1616" class="output"><tspan class="fg2"># Note that only the rebase was reverted, and the</tspan>
+</tspan><tspan xml:space="preserve" x="10" y="1634" class="output"><tspan class="fg2"># subsequent "other stuff" change was not:</tspan>
 </tspan><tspan xml:space="preserve" x="10" y="1652" class="output">
 </tspan><tspan xml:space="preserve" x="10" y="1670" class="output">$ jj log
 </tspan><tspan xml:space="preserve" x="10" y="1688" class="output"><tspan class="bold fg2">@</tspan>  <tspan class="bold fg13">t</tspan><tspan class="bold fg8">soomuvq</tspan><tspan class="bold"> </tspan><tspan class="bold fg3">jjfan@example.com</tspan><tspan class="bold"> </tspan><tspan class="bold fg14">2024-10-13 19:54:55</tspan><tspan class="bold"> </tspan><tspan class="bold fg12">1</tspan><tspan class="bold fg8">44081d4</tspan>

--- a/docs/operation-log.md
+++ b/docs/operation-log.md
@@ -13,9 +13,10 @@ and the current working-copy commit in each workspace. The operation object also
 before it, as well as metadata about the operation, such as timestamps,
 username, hostname, description.
 
-The operation log allows you to undo an operation (`jj undo`), which doesn't
-need to be the most recent one. It also lets you restore the entire repo to the
-way it looked at an earlier point (`jj op restore`).
+The operation log allows you to undo operations one-by-one (`jj undo`) or even
+revert a specific one which isn't the most recent operation (`jj op revert`). It
+also lets you restore the entire repo to the way it looked at an earlier point
+(`jj op restore`).
 
 When referring to operations, you can use `@` to represent the current
 operation.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -405,8 +405,7 @@ $ jj op log
 [many more lines]
 ```
 
-The most useful command is `jj undo`, which will undo
-an operation. By default, it will undo the most recent operation. Let's try it:
+The most useful command is `jj undo`, which will undo your last operation.
 
 ```shell
 $ jj undo


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
