### PR TITLE
working_copy: Add `WorkingCopyStateError` conversions for ergonomics

### DIFF
--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -2370,13 +2370,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         &mut self,
         options: &SnapshotOptions,
     ) -> Result<(MergedTreeId, SnapshotStats), SnapshotError> {
-        let tree_state = self
-            .wc
-            .tree_state_mut()
-            .map_err(|err| SnapshotError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?;
+        let tree_state = self.wc.tree_state_mut()?;
         let (is_dirty, stats) = tree_state.snapshot(options)?;
         self.tree_state_dirty |= is_dirty;
         Ok((tree_state.current_tree_id().clone(), stats))
@@ -2386,13 +2380,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         // TODO: Write a "pending_checkout" file with the new TreeId so we can
         // continue an interrupted update if we find such a file.
         let new_tree = commit.tree()?;
-        let tree_state = self
-            .wc
-            .tree_state_mut()
-            .map_err(|err| CheckoutError::Other {
-                message: "Failed to load the working copy state".to_string(),
-                err: err.into(),
-            })?;
+        let tree_state = self.wc.tree_state_mut()?;
         if tree_state.tree_id != *commit.tree_id() {
             let stats = tree_state.check_out(&new_tree)?;
             self.tree_state_dirty = true;
@@ -2408,28 +2396,14 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
 
     fn reset(&mut self, commit: &Commit) -> Result<(), ResetError> {
         let new_tree = commit.tree()?;
-        self.wc
-            .tree_state_mut()
-            .map_err(|err| ResetError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?
-            .reset(&new_tree)
-            .block_on()?;
+        self.wc.tree_state_mut()?.reset(&new_tree).block_on()?;
         self.tree_state_dirty = true;
         Ok(())
     }
 
     fn recover(&mut self, commit: &Commit) -> Result<(), ResetError> {
         let new_tree = commit.tree()?;
-        self.wc
-            .tree_state_mut()
-            .map_err(|err| ResetError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?
-            .recover(&new_tree)
-            .block_on()?;
+        self.wc.tree_state_mut()?.recover(&new_tree).block_on()?;
         self.tree_state_dirty = true;
         Ok(())
     }
@@ -2446,11 +2420,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
         // continue an interrupted update if we find such a file.
         let stats = self
             .wc
-            .tree_state_mut()
-            .map_err(|err| CheckoutError::Other {
-                message: "Failed to load the working copy state".to_string(),
-                err: err.into(),
-            })?
+            .tree_state_mut()?
             .set_sparse_patterns(new_sparse_patterns)?;
         self.tree_state_dirty = true;
         Ok(stats)
@@ -2485,13 +2455,7 @@ impl LockedWorkingCopy for LockedLocalWorkingCopy {
 
 impl LockedLocalWorkingCopy {
     pub fn reset_watchman(&mut self) -> Result<(), SnapshotError> {
-        self.wc
-            .tree_state_mut()
-            .map_err(|err| SnapshotError::Other {
-                message: "Failed to read the working copy state".to_string(),
-                err: err.into(),
-            })?
-            .reset_watchman();
+        self.wc.tree_state_mut()?.reset_watchman();
         self.tree_state_dirty = true;
         Ok(())
     }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -181,6 +181,9 @@ pub enum SnapshotError {
     /// Checking path with ignore patterns failed.
     #[error(transparent)]
     GitIgnoreError(#[from] GitIgnoreError),
+    /// Failed to load the working copy state.
+    #[error(transparent)]
+    WorkingCopyStateError(#[from] WorkingCopyStateError),
     /// Some other error happened while snapshotting the working copy.
     #[error("{message}")]
     Other {
@@ -301,6 +304,9 @@ pub enum CheckoutError {
     /// Reading or writing from the commit backend failed.
     #[error("Internal backend error")]
     InternalBackendError(#[from] BackendError),
+    /// Failed to load the working copy state.
+    #[error(transparent)]
+    WorkingCopyStateError(#[from] WorkingCopyStateError),
     /// Some other error happened while checking out the working copy.
     #[error("{message}")]
     Other {
@@ -325,7 +331,10 @@ pub enum ResetError {
     /// Reading or writing from the commit backend failed.
     #[error("Internal error")]
     InternalBackendError(#[from] BackendError),
-    /// Some other error happened while checking out the working copy.
+    /// Failed to load the working copy state.
+    #[error(transparent)]
+    WorkingCopyStateError(#[from] WorkingCopyStateError),
+    /// Some other error happened while resetting the working copy.
     #[error("{message}")]
     Other {
         /// Error message.

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -430,12 +430,7 @@ impl Workspace {
         old_tree_id: Option<&MergedTreeId>,
         commit: &Commit,
     ) -> Result<CheckoutStats, CheckoutError> {
-        let mut locked_ws =
-            self.start_working_copy_mutation()
-                .map_err(|err| CheckoutError::Other {
-                    message: "Failed to start editing the working copy state".to_string(),
-                    err: err.into(),
-                })?;
+        let mut locked_ws = self.start_working_copy_mutation()?;
         // Check if the current working-copy commit has changed on disk compared to what
         // the caller expected. It's safe to check out another commit
         // regardless, but it's probably not what  the caller wanted, so we let


### PR DESCRIPTION
I originally just added these with a `From` impl like below. But I figure that just extending the enums is prefered. Let me know if the `From` impl would be better instead.

```rust
impl From<WorkingCopyStateError> for SnapshotError {
    fn from(WorkingCopyStateError { message, err }: WorkingCopyStateError) -> Self {
        Self::Other { message, err }
    }
}
```

I also have two TODO comments where I wasn't sure whether converting the error type automatically would be an improvement. I would appreciate feedback on those.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
