### PR TITLE
template: always consider `@git` bookmark synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   explicitly specified, in which case the specified option will apply for both
   the initial clone and subsequent fetches.
 
+* `jj bookmark move` no longer always displays the moved bookmark as unsynced in
+  colocated repos.
+
 ### Packaging changes
 
 * The test suite no longer optionally uses Taplo CLI or jq, and packagers can

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -214,11 +214,7 @@ pub fn cmd_bookmark_list(
 
         let include_local_only = !args.tracked && args.remotes.is_none();
         if include_local_only && local_target.is_present() || !tracked_remote_refs.is_empty() {
-            let primary = CommitRef::local(
-                name,
-                local_target.clone(),
-                remote_refs.iter().map(|&(_, remote_ref)| remote_ref),
-            );
+            let primary = CommitRef::local(name, local_target.clone(), remote_refs.iter());
             let tracked = tracked_remote_refs
                 .iter()
                 .map(|&(remote, remote_ref)| {

--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -119,7 +119,7 @@ pub fn cmd_bookmark_track(
             let commit_ref = CommitRef::local(
                 name,
                 local_target.clone(),
-                bookmark_target.remote_refs.iter().map(|x| x.1),
+                bookmark_target.remote_refs.iter(),
             );
             template.format(&commit_ref, formatter.as_mut())?;
 


### PR DESCRIPTION
As the user can never interact with `@git` tracking bookmarks, and they are an implementation detail, it doesn't make any sense to tell the user that it is unsynced.

Additionally, the docs for the `synced` property only mention remotes, not `@git` tracking bookmarks.

```
/// Local ref is synchronized with all tracking remotes, or tracking remote
/// ref is synchronized with the local.
```

Fixes: #7270

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

(This is my first time contributing, if I messed something up or broke something by accident please tell me.)

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] (n/a) I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] (n/a) I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
