### PR TITLE
docs: update description of `trunk()` revset

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -527,14 +527,15 @@ are defined as aliases in order to allow you to overwrite them as needed.
 See [revsets.toml](https://github.com/jj-vcs/jj/blob/main/cli/src/config/revsets.toml)
 for a comprehensive list.
 
-* `trunk()`: Resolves to the head commit for the trunk bookmark of the remote
-  named `origin` or `upstream`. The bookmarks `main`, `master`, and `trunk` are
-  tried. If more than one potential trunk commit exists, the newest one is
-  chosen. If none of the bookmarks exist, the revset evaluates to `root()`.
+* `trunk()`: Resolves to the head commit for the default bookmark of the default
+  remote, or the remote named `upstream` or `origin`. This is set at the
+  repository level upon initialization of a Jujutsu repository.
 
-  When working with an existing Git repository (via `jj git clone` or
-  `jj git init`), `trunk()` will be overridden at the repository level
-  to the default bookmark of the remote `origin`.
+  If the default bookmark cannot be resolved during initialization, the default
+  global configuration tries the bookmarks `main`, `master`, and `trunk` on the
+  `upstream` and `origin` remotes. If more than one potential trunk commit
+  exists, the newest one is chosen. If none of the bookmarks exist, the revset
+  evaluates to `root()`.
 
   You can [override](./config.md) this as appropriate. If you do, make sure it
   always resolves to exactly one commit. For example:


### PR DESCRIPTION
This commit clarifies the order in which `trunk()` is resolved following commit 5fedd36 (git init: prefer `upstream` over `origin` for `trunk()` alias).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
