### PR TITLE
Hint at lack of access as a possible reason to error

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3802,7 +3802,8 @@ impl<'a> CliRunner<'a> {
             .map_err(|_| {
                 user_error_with_hint(
                     "Could not determine current directory",
-                    "Did you update to a commit where the directory doesn't exist?",
+                    "Did you update to a commit where the directory doesn't exist or can't be \
+                     accessed?",
                 )
             })?;
         let mut config_env = ConfigEnv::from_environment(ui);

--- a/docs/paid_contributors.md
+++ b/docs/paid_contributors.md
@@ -34,6 +34,7 @@ contribute or not.
 * martinvonz
 * matts1
 * matttproud
+* michaelchirico
 * mlcui-corp
 * orthros
 * prattmic


### PR DESCRIPTION
As discussed internally, there might be some rare cases where `jj` tries to update to an error lacking permissions for the current user at the current time.