### PR TITLE
Improve Bidirectional text hygiene

### DIFF
--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -594,11 +594,18 @@ impl<W: Write> Formatter for ColorFormatter<W> {
 
     fn push_label(&mut self, label: &str) -> io::Result<()> {
         self.labels.push(label.to_owned());
+        if label.eq("name") {
+            self.write_all("\u{2068}".as_bytes())?; // FSI. First Strong Isolate (Bidi algo)
+        }
         Ok(())
     }
 
     fn pop_label(&mut self) -> io::Result<()> {
-        self.labels.pop();
+        if let Some(label) = self.labels.pop() {
+            if label.eq("name") {
+                self.write_all("\u{2069}".as_bytes())?; // PDI . Pop Directional Isolate
+            }
+        }
         if self.labels.is_empty() {
             self.write_new_style()?;
         }


### PR DESCRIPTION
This PR adds two zero-width characters, FSI and PDI, to isolate the direction of the text inside them from the directionality of the surrounding text. That is similar to the `bdi` tag in browsers.

- For reference <https://www.unicode.org/reports/tr9/>
- Example <https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdi>

One point: due to the dire lack of support for bidirectional texts in terminal, this has a very small fix radius. The only terminal I have that supports Bidi decently is Terminal.app, and honestly I couldn't find a difference in output, implying they might not actually implement the algorithm properly either. If you decide to reject this PR on this basis, it would be understandable but I would be (slightly) miffed.

Note that Terminals that do not support these characters simply ignore them.

Potential issues.

1. These characters are for display, and I *think* they should not be piped to other apps. Perhaps this should be stripped along with ANSI color info? 
2. This currently wraps *every* single string invocation with these characters. When they're only really needed around user-provided strings (name, commit message, ideally email but nobody uses Arabic domains). Putting them in the templates themselves is, I felt, was unneeded noise to users, but I could not figure out how to only contain the change to names (especially in `jj show` and similar templates.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
