### PR TITLE
docs: use commit ids in divergence example commands

### DIFF
--- a/docs/guides/divergence.md
+++ b/docs/guides/divergence.md
@@ -60,8 +60,8 @@ it:
 jj abandon <unwanted-commit-id>
 
 # You can abandon several at once with:
-# jj abandon xyz wxy vwx
-# jj abandon xyz::
+# jj abandon abc def 123
+# jj abandon abc::
 ```
 
 This is the simplest solution when you know which version to keep.


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

I found it confusing that the example commit ids in this guide seemed like they are change ids instead of commit ids. Using change ids doesn't work here because you only want to abandon some of the underlying commits instead of the changes. And `xyz wxy vwx` look more like change ids instead of commit ids, so I changed them to `abc def 123`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
