### PR TITLE
releasing: publish to flakehub

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -1,0 +1,28 @@
+name: "Publish tags to FlakeHub"
+on:
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The existing tag to publish to FlakeHub"
+        type: "string"
+        required: true
+jobs:
+  flakehub-publish:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
+      - uses: "DeterminateSystems/determinate-nix-action@v3"
+      - uses: "DeterminateSystems/flakehub-push@main"
+        with:
+          visibility: "public"
+          name: "jj-vcs/jj"
+          tag: "${{ inputs.tag }}"
+          include-output-paths: true


### PR DESCRIPTION
By request of @grahamc.

I went through the steps (https://flakehub.com/new), but I'm not sure what the result of turning on this action will be (**Update:** and zizmor is unhappy about it). 

(To be clear, IMO we should absolutely not merge this until one of us actually understands what's happening inside this action and feels they can maintain it)

We'd have to find out whether it works during the next release. For example, I had to sign in to Flakehub to generate this file, but I see nothing in it that associates me to it.

[Discord discussion](https://discord.com/channels/968932220549103686/1408086921531621499)

TODO: Commit description if we're moving forward.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
