### PR TITLE
cli `squash`: mark `-A`/`-B`/`-d` options as experimental, add brief doc pointer to use them with `--from`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,9 +101,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   output using template expressions, similar to `jj op log`. Also added
   `--no-op-diff` flag to suppress the operation diff.
 
-* `jj squash` has gained `--insert-before`, `--insert-after`, and `--destination`
-  options.
-
 * The new command `jj redo` can progressively redo operations that were
   previously undone by multiple calls to `jj undo`.
 

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -67,9 +67,16 @@ use crate::ui::Ui;
 ///
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
+///
+/// EXPERIMENTAL FEATURES
+///
+/// An alternative squashing UI is available via the `-d`, `-A`, and `-B`
+/// options. They can be used together with one or more `--from` options
+/// (if no `--from` is specified, `--from @` is assumed).
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct SquashArgs {
-    /// Revision to squash into its parent (default: @)
+    /// Revision to squash into its parent (default: @). Incompatible with the
+    /// experimental `-d`/`-A`/`-B` options.
     #[arg(
         long,
         short,

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -97,8 +97,8 @@ pub(crate) struct SquashArgs {
     )]
     into: Option<RevisionArg>,
 
-    /// The revision(s) to use as parent for the new commit (can be repeated
-    /// to create a merge commit)
+    /// (Experimental) The revision(s) to use as parent for the new commit (can
+    /// be repeated to create a merge commit)
     #[arg(
         long,
         short,
@@ -109,8 +109,8 @@ pub(crate) struct SquashArgs {
     )]
     destination: Option<Vec<RevisionArg>>,
 
-    /// The revision(s) to insert the new commit after (can be repeated to
-    /// create a merge commit)
+    /// (Experimental) The revision(s) to insert the new commit after (can be
+    /// repeated to create a merge commit)
     #[arg(
         long,
         short = 'A',
@@ -123,8 +123,8 @@ pub(crate) struct SquashArgs {
     )]
     insert_after: Option<Vec<RevisionArg>>,
 
-    /// The revision(s) to insert the new commit before (can be repeated to
-    /// create a merge commit)
+    /// (Experimental) The revision(s) to insert the new commit before (can be
+    /// repeated to create a merge commit)
     #[arg(
         long,
         short = 'B',

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2601,9 +2601,9 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 * `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @)
 * `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
 * `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
-* `-d`, `--destination <REVSETS>` — The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)
-* `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert the new commit after (can be repeated to create a merge commit)
-* `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert the new commit before (can be repeated to create a merge commit)
+* `-d`, `--destination <REVSETS>` — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)
+* `-A`, `--insert-after <REVSETS>` [alias: `after`] — (Experimental) The revision(s) to insert the new commit after (can be repeated to create a merge commit)
+* `-B`, `--insert-before <REVSETS>` [alias: `before`] — (Experimental) The revision(s) to insert the new commit before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
 * `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
 * `-i`, `--interactive` — Interactively choose which parts to squash

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2590,6 +2590,10 @@ If the source was abandoned and both the source and destination had a non-empty 
 
 If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
 
+EXPERIMENTAL FEATURES
+
+An alternative squashing UI is available via the `-d`, `-A`, and `-B` options. They can be used together with one or more `--from` options (if no `--from` is specified, `--from @` is assumed).
+
 **Usage:** `jj squash [OPTIONS] [FILESETS]...`
 
 ###### **Arguments:**
@@ -2598,7 +2602,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 ###### **Options:**
 
-* `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @)
+* `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @). Incompatible with the experimental `-d`/`-A`/`-B` options
 * `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
 * `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
 * `-d`, `--destination <REVSETS>` — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)


### PR DESCRIPTION
See also https://github.com/jj-vcs/jj/pull/7162#issuecomment-3212555183

@glehmann, thanks for making this feature! Would you be OK with marking it as experimental for now?

As explained in the above link, I think the UI you created is great for experimenting with this feature, but not as good for new users learning how to `squash`. At the same one, improving the it does not seem trivial, and to do it well, we could benefit from people taking some time to experiment with the feature.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- (n/a) I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
