### PR TITLE
cli: use clap::ValueHint over PathCompleter

### DIFF
--- a/cli/src/commands/util/exec.rs
+++ b/cli/src/commands/util/exec.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap_complete::ArgValueCompleter;
-use clap_complete::PathCompleter;
-
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
@@ -70,7 +67,7 @@ pub(crate) struct UtilExecArgs {
     /// External command to execute
     command: String,
     /// Arguments to pass to the external command
-    #[arg(add = ArgValueCompleter::new(PathCompleter::file()))]
+    #[arg(value_hint = clap::ValueHint::FilePath)]
     args: Vec<String>,
 }
 

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -14,8 +14,6 @@
 
 use std::fs;
 
-use clap_complete::ArgValueCompleter;
-use clap_complete::PathCompleter;
 use itertools::Itertools as _;
 use jj_lib::commit::CommitIteratorExt as _;
 use jj_lib::file_util;
@@ -52,7 +50,7 @@ enum SparseInheritance {
 #[derive(clap::Args, Clone, Debug)]
 pub struct WorkspaceAddArgs {
     /// Where to create the new workspace
-    #[arg(add = ArgValueCompleter::new(PathCompleter::dir()))]
+    #[arg(value_hint = clap::ValueHint::DirPath)]
     destination: String,
     /// A name for the workspace
     ///


### PR DESCRIPTION
The only two cases where PathCompleter was used were simple enough to be replaced with clap::ValueHint directly (which is more consistent with all the other completion hints used everywhere else)

Follow up from https://github.com/jj-vcs/jj/pull/7335#discussion_r2296383976

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
