### PR TITLE
working_copy: Break out `TreeStateConfig` struct and move to `LocalWcSettings`

### DIFF
--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -36,7 +36,6 @@ use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
 use jj_lib::store::Store;
 use jj_lib::working_copy::CheckoutError;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
 use jj_lib::working_copy::ResetError;
@@ -263,18 +262,14 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
         self.inner.snapshot(&options)
     }
 
-    fn check_out(
-        &mut self,
-        commit: &Commit,
-        options: &CheckoutOptions,
-    ) -> Result<CheckoutStats, CheckoutError> {
+    fn check_out(&mut self, commit: &Commit) -> Result<CheckoutStats, CheckoutError> {
         let conflicts = commit
             .tree()?
             .conflicts()
             .map(|(path, _value)| format!("{}\n", path.as_internal_file_string()))
             .join("");
         std::fs::write(self.wc_path.join(".conflicts"), conflicts).unwrap();
-        self.inner.check_out(commit, options)
+        self.inner.check_out(commit)
     }
 
     fn rename_workspace(&mut self, new_name: WorkspaceNameBuf) {
@@ -296,9 +291,8 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
     fn set_sparse_patterns(
         &mut self,
         new_sparse_patterns: Vec<RepoPathBuf>,
-        options: &CheckoutOptions,
     ) -> Result<CheckoutStats, CheckoutError> {
-        self.inner.set_sparse_patterns(new_sparse_patterns, options)
+        self.inner.set_sparse_patterns(new_sparse_patterns)
     }
 
     fn finish(

--- a/cli/src/commands/sparse/mod.rs
+++ b/cli/src/commands/sparse/mod.rs
@@ -65,12 +65,11 @@ fn update_sparse_patterns_with(
     workspace_command: &mut WorkspaceCommandHelper,
     f: impl FnOnce(&mut Ui, &[RepoPathBuf]) -> Result<Vec<RepoPathBuf>, CommandError>,
 ) -> Result<(), CommandError> {
-    let checkout_options = workspace_command.checkout_options();
     let (mut locked_ws, wc_commit) = workspace_command.start_working_copy_mutation()?;
     let new_patterns = f(ui, locked_ws.locked_wc().sparse_patterns()?)?;
     let stats = locked_ws
         .locked_wc()
-        .set_sparse_patterns(new_patterns, &checkout_options)
+        .set_sparse_patterns(new_patterns)
         .map_err(|err| internal_error_with_message("Failed to update working copy paths", err))?;
     let operation_id = locked_ws.locked_wc().old_operation_id().clone();
     locked_ws.finish(operation_id)?;

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -149,11 +149,10 @@ pub fn cmd_workspace_add(
     };
 
     if let Some(sparse_patterns) = sparsity {
-        let checkout_options = new_workspace_command.checkout_options();
         let (mut locked_ws, _wc_commit) = new_workspace_command.start_working_copy_mutation()?;
         locked_ws
             .locked_wc()
-            .set_sparse_patterns(sparse_patterns, &checkout_options)
+            .set_sparse_patterns(sparse_patterns)
             .map_err(|err| internal_error_with_message("Failed to set sparse patterns", err))?;
         let operation_id = locked_ws.locked_wc().old_operation_id().clone();
         locked_ws.finish(operation_id)?;

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -24,7 +24,6 @@ use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree::MergedTreeBuilder;
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::store::Store;
-use jj_lib::working_copy::CheckoutOptions;
 use pollster::FutureExt as _;
 use thiserror::Error;
 
@@ -388,9 +387,6 @@ pub fn edit_diff_external(
     let conflict_marker_style = editor
         .conflict_marker_style
         .unwrap_or(default_conflict_marker_style);
-    let options = CheckoutOptions {
-        conflict_marker_style,
-    };
 
     let got_output_field = find_all_variables(&editor.edit_args).contains(&"output");
     let diff_type = if got_output_field {
@@ -406,7 +402,7 @@ pub fn edit_diff_external(
         matcher,
         diff_type,
         instructions,
-        &options,
+        conflict_marker_style,
     )?;
 
     let patterns = diffedit_wc.working_copies.to_command_variables(false);
@@ -425,7 +421,7 @@ pub fn edit_diff_external(
         }));
     }
 
-    diffedit_wc.snapshot_results(base_ignores, options.conflict_marker_style)
+    diffedit_wc.snapshot_results(base_ignores)
 }
 
 /// Generates textual diff by the specified `tool` and writes into `writer`.
@@ -441,9 +437,6 @@ pub fn generate_diff(
     let conflict_marker_style = tool
         .conflict_marker_style
         .unwrap_or(default_conflict_marker_style);
-    let options = CheckoutOptions {
-        conflict_marker_style,
-    };
     let store = left_tree.store();
     let diff_wc = check_out_trees(
         store,
@@ -451,7 +444,7 @@ pub fn generate_diff(
         right_tree,
         matcher,
         DiffType::TwoWay,
-        &options,
+        conflict_marker_style,
     )?;
     diff_wc.set_left_readonly()?;
     diff_wc.set_right_readonly()?;

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -37,6 +37,9 @@ program = "gpgsm"
 # allowed-signers = <unknown>
 program = "ssh-keygen"
 
+[ui]
+conflict-marker-style = "diff"
+
 [user]
 email = ""
 name = ""

--- a/lib/src/eol.rs
+++ b/lib/src/eol.rs
@@ -19,16 +19,7 @@ use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt as _;
 
 use crate::config::ConfigGetError;
-use crate::local_working_copy::TreeStateSettings;
 use crate::settings::UserSettings;
-
-pub(crate) fn create_target_eol_strategy(
-    tree_state_settings: &TreeStateSettings,
-) -> TargetEolStrategy {
-    TargetEolStrategy {
-        eol_conversion_mode: tree_state_settings.eol_conversion_mode,
-    }
-}
 
 fn is_binary(bytes: &[u8]) -> bool {
     // TODO(06393993): align the algorithm with git so that the git config autocrlf
@@ -55,6 +46,12 @@ pub(crate) struct TargetEolStrategy {
 }
 
 impl TargetEolStrategy {
+    pub(crate) fn new(eol_conversion_mode: EolConversionMode) -> Self {
+        Self {
+            eol_conversion_mode,
+        }
+    }
+
     /// The limit is to probe whether the file is binary is 8KB.
     const PROBE_LIMIT: u64 = 8 << 10;
 

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -55,7 +55,6 @@ use crate::signing::Signer;
 use crate::simple_backend::SimpleBackend;
 use crate::transaction::TransactionCommitError;
 use crate::working_copy::CheckoutError;
-use crate::working_copy::CheckoutOptions;
 use crate::working_copy::CheckoutStats;
 use crate::working_copy::LockedWorkingCopy;
 use crate::working_copy::WorkingCopy;
@@ -430,7 +429,6 @@ impl Workspace {
         operation_id: OperationId,
         old_tree_id: Option<&MergedTreeId>,
         commit: &Commit,
-        options: &CheckoutOptions,
     ) -> Result<CheckoutStats, CheckoutError> {
         let mut locked_ws =
             self.start_working_copy_mutation()
@@ -447,7 +445,7 @@ impl Workspace {
                 return Err(CheckoutError::ConcurrentCheckout);
             }
         }
-        let stats = locked_ws.locked_wc().check_out(commit, options)?;
+        let stats = locked_ws.locked_wc().check_out(commit)?;
         locked_ws
             .finish(operation_id)
             .map_err(|err| CheckoutError::Other {

--- a/lib/tests/test_eol.rs
+++ b/lib/tests/test_eol.rs
@@ -22,7 +22,6 @@ use jj_lib::repo::Repo as _;
 use jj_lib::repo::StoreFactories;
 use jj_lib::rewrite::merge_commit_trees;
 use jj_lib::settings::UserSettings;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::workspace::Workspace;
 use jj_lib::workspace::default_working_copy_factories;
 use pollster::FutureExt as _;
@@ -146,7 +145,6 @@ fn test_eol_conversion_snapshot(
             test_workspace.repo.op_id().clone(),
             None,
             &file_removed_commit,
-            &CheckoutOptions::empty_for_test(),
         )
         .unwrap();
     assert!(!file_disk_path.exists());
@@ -174,7 +172,6 @@ fn test_eol_conversion_snapshot(
             test_workspace.repo.op_id().clone(),
             None,
             &file_added_commit,
-            &CheckoutOptions::empty_for_test(),
         )
         .unwrap();
     assert!(file_disk_path.exists());
@@ -229,12 +226,7 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
 
     test_workspace
         .workspace
-        .check_out(
-            test_workspace.repo.op_id().clone(),
-            None,
-            &root_commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(test_workspace.repo.op_id().clone(), None, &root_commit)
         .unwrap();
     testutils::write_working_copy_file(
         test_workspace.workspace.workspace_root(),
@@ -261,12 +253,7 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
     // conflict markers.
     test_workspace
         .workspace
-        .check_out(
-            test_workspace.repo.op_id().clone(),
-            None,
-            &merge_commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(test_workspace.repo.op_id().clone(), None, &merge_commit)
         .unwrap();
     let mut file = File::options().append(true).open(&file_disk_path).unwrap();
     file.write_all(b"c\r\n").unwrap();
@@ -309,7 +296,6 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
             test_workspace.repo.op_id().clone(),
             None,
             &test_workspace.workspace.repo_loader().store().root_commit(),
-            &CheckoutOptions::empty_for_test(),
         )
         .unwrap();
     // We have to query the Commit again. The Workspace is backed by a different
@@ -322,12 +308,7 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
         .expect("Failed to find the commit with the test file");
     test_workspace
         .workspace
-        .check_out(
-            test_workspace.repo.op_id().clone(),
-            None,
-            &merge_commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(test_workspace.repo.op_id().clone(), None, &merge_commit)
         .unwrap();
 
     assert!(std::fs::exists(&file_disk_path).unwrap());
@@ -462,12 +443,7 @@ fn test_eol_conversion_update_conflicts(
     // Checkout the merge commit.
     test_workspace
         .workspace
-        .check_out(
-            test_workspace.repo.op_id().clone(),
-            None,
-            &merge_commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(test_workspace.repo.op_id().clone(), None, &merge_commit)
         .unwrap();
     let contents = std::fs::read(&file_disk_path).unwrap();
     for line in contents.lines_with_terminator() {
@@ -575,7 +551,6 @@ fn test_eol_conversion_checkout(
             test_workspace.repo.op_id().clone(),
             None,
             &test_workspace.workspace.repo_loader().store().root_commit(),
-            &CheckoutOptions::empty_for_test(),
         )
         .unwrap();
     assert!(!std::fs::exists(&file_disk_path).unwrap());
@@ -603,12 +578,7 @@ fn test_eol_conversion_checkout(
     // EOL accordingly.
     test_workspace
         .workspace
-        .check_out(
-            test_workspace.repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(test_workspace.repo.op_id().clone(), None, &commit)
         .unwrap();
 
     // When we take a snapshot now, the tree may not be clean, because the EOL our

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -43,7 +43,6 @@ use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::secret_backend::SecretBackend;
 use jj_lib::tree_builder::TreeBuilder;
 use jj_lib::working_copy::CheckoutError;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::working_copy::UntrackedReason;
@@ -292,20 +291,10 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
     let right_commit = commit_with_tree(&store, right_tree_id.clone());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &left_commit,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &right_commit,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &left_commit)
+        .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &right_commit)
+        .unwrap();
 
     // Check that the working copy is clean.
     let new_tree = test_workspace.snapshot().unwrap();
@@ -399,13 +388,7 @@ fn test_checkout_no_op() {
     let commit2 = commit_with_tree(repo.store(), tree.id());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
     // Test the setup: the file should exist on in the tree state.
     let wc: &LocalWorkingCopy = ws.working_copy().as_any().downcast_ref().unwrap();
@@ -413,14 +396,7 @@ fn test_checkout_no_op() {
 
     // Update to commit2 (same tree as commit1)
     let new_op_id = OperationId::from_bytes(b"whatever");
-    let stats = ws
-        .check_out(
-            new_op_id.clone(),
-            None,
-            &commit2,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(new_op_id.clone(), None, &commit2).unwrap();
     assert_eq!(stats, CheckoutStats::default());
 
     // The tree state is unchanged but the recorded operation id is updated.
@@ -444,20 +420,9 @@ fn test_conflict_subdirectory() {
     let merged_commit = commit_with_tree(repo.store(), merged_tree.id());
     let repo = &test_workspace.repo;
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &merged_commit,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
+    ws.check_out(repo.op_id().clone(), None, &merged_commit)
+        .unwrap();
 }
 
 #[test]
@@ -507,13 +472,7 @@ fn test_acl() {
     let commit1 = repo.store().get_commit(commit1.id()).unwrap();
     let commit2 = repo.store().get_commit(commit2.id()).unwrap();
 
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
     assert!(
         !secret_modified_path
             .to_fs_path_unchecked(&workspace_root)
@@ -539,13 +498,7 @@ fn test_acl() {
             .to_fs_path_unchecked(&workspace_root)
             .is_file()
     );
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit2,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit2).unwrap();
     assert!(
         !secret_modified_path
             .to_fs_path_unchecked(&workspace_root)
@@ -583,13 +536,7 @@ fn test_tree_builder_file_directory_transition() {
     let mut check_out_tree = |tree_id: &TreeId| {
         let tree = repo.store().get_tree(RepoPathBuf::root(), tree_id).unwrap();
         let commit = commit_with_tree(repo.store(), MergedTreeId::Legacy(tree.id().clone()));
-        ws.check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+        ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
     };
 
     let parent_path = repo_path("foo/bar");
@@ -688,14 +635,7 @@ fn test_conflicting_changes_on_disk() {
     )
     .unwrap();
 
-    let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
     assert_eq!(
         stats,
         CheckoutStats {
@@ -745,13 +685,7 @@ fn test_reset() {
 
     let ws = &mut test_workspace.workspace;
     let commit = commit_with_tree(repo.store(), tree_with_file.id());
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
 
     // Test the setup: the file should exist on disk and in the tree state.
     assert!(ignored_path.to_fs_path_unchecked(&workspace_root).is_file());
@@ -802,13 +736,7 @@ fn test_checkout_discard() {
     let commit2 = commit_with_tree(repo.store(), tree2.id());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
     let wc: &LocalWorkingCopy = ws.working_copy().as_any().downcast_ref().unwrap();
     let state_path = wc.state_path().to_path_buf();
 
@@ -819,10 +747,7 @@ fn test_checkout_discard() {
 
     // Start a checkout
     let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-    locked_ws
-        .locked_wc()
-        .check_out(&commit2, &CheckoutOptions::empty_for_test())
-        .unwrap();
+    locked_ws.locked_wc().check_out(&commit2).unwrap();
     // The change should be reflected in the working copy but not saved
     assert!(!file1_path.to_fs_path_unchecked(&workspace_root).is_file());
     assert!(file2_path.to_fs_path_unchecked(&workspace_root).is_file());
@@ -854,7 +779,6 @@ fn test_snapshot_file_directory_transition() {
     let mut test_workspace = TestWorkspace::init();
     let repo = test_workspace.repo.clone();
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
-    let checkout_options = CheckoutOptions::empty_for_test();
     let to_ws_path = |path: &RepoPath| path.to_fs_path(&workspace_root).unwrap();
 
     // file <-> directory transition at root and sub directories
@@ -869,8 +793,7 @@ fn test_snapshot_file_directory_transition() {
     let commit2 = commit_with_tree(repo.store(), tree2.id());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(repo.op_id().clone(), None, &commit1, &checkout_options)
-        .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
     // file -> directory
     std::fs::remove_file(to_ws_path(file1p_path)).unwrap();
@@ -883,8 +806,7 @@ fn test_snapshot_file_directory_transition() {
     assert_eq!(new_tree.id(), tree2.id());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(repo.op_id().clone(), None, &commit2, &checkout_options)
-        .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit2).unwrap();
 
     // directory -> file
     std::fs::remove_file(to_ws_path(file1_path)).unwrap();
@@ -924,14 +846,7 @@ fn test_materialize_snapshot_conflicted_files() {
         .unwrap();
     let commit = commit_with_tree(repo.store(), merged_tree.id());
 
-    let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
     assert_eq!(
         stats,
         CheckoutStats {
@@ -1178,13 +1093,7 @@ fn test_gitignores_in_ignored_dir() {
     let tree1 = create_tree(&test_workspace.repo, &[(gitignore_path, "ignored\n")]);
     let commit1 = commit_with_tree(test_workspace.repo.store(), tree1.id());
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        op_id.clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(op_id.clone(), None, &commit1).unwrap();
 
     testutils::write_working_copy_file(&workspace_root, nested_gitignore_path, "!file\n");
     testutils::write_working_copy_file(&workspace_root, ignored_path, "contents");
@@ -1235,15 +1144,7 @@ fn test_gitignores_checkout_never_overwrites_ignored() {
     // "contents". The exiting contents ("garbage") shouldn't be replaced in the
     // working copy.
     let ws = &mut test_workspace.workspace;
-    assert!(
-        ws.check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test()
-        )
-        .is_ok()
-    );
+    assert!(ws.check_out(repo.op_id().clone(), None, &commit,).is_ok());
 
     // Check that the old contents are in the working copy
     let path = workspace_root.join("modified");
@@ -1292,13 +1193,7 @@ fn test_gitignores_ignored_directory_already_tracked() {
 
     // Check out the tree with the files in `ignored/`
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
 
     // Make some changes inside the ignored directory and check that they are
     // detected when we snapshot. The files that are still there should not be
@@ -1420,13 +1315,7 @@ fn test_git_submodule(gitignore_content: &str) {
     let commit2 = commit_with_tree(repo.store(), tree_id2.clone());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
     std::fs::create_dir(submodule_path.to_fs_path_unchecked(&workspace_root)).unwrap();
 
@@ -1453,13 +1342,7 @@ fn test_git_submodule(gitignore_content: &str) {
     // Check out new commit updating the submodule, which shouldn't fail because
     // of existing submodule files
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit2,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit2).unwrap();
 
     // Check that the files in the submodule are not deleted
     let file_in_submodule_path = added_submodule_path.to_fs_path_unchecked(&workspace_root);
@@ -1478,12 +1361,7 @@ fn test_git_submodule(gitignore_content: &str) {
     // Check out the empty tree, which shouldn't fail
     let ws = &mut test_workspace.workspace;
     let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &store.root_commit(),
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(repo.op_id().clone(), None, &store.root_commit())
         .unwrap();
     assert_eq!(stats.skipped_files, 1);
 }
@@ -1501,13 +1379,7 @@ fn test_check_out_existing_file_cannot_be_removed() {
     let commit2 = commit_with_tree(repo.store(), tree2.id());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
     // Make the parent directory readonly.
     let writable_dir_perm = workspace_root.symlink_metadata().unwrap().permissions();
@@ -1515,12 +1387,7 @@ fn test_check_out_existing_file_cannot_be_removed() {
     readonly_dir_perm.set_readonly(true);
 
     std::fs::set_permissions(&workspace_root, readonly_dir_perm).unwrap();
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit2,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit2);
     std::fs::set_permissions(&workspace_root, writable_dir_perm).unwrap();
 
     // TODO: find a way to trigger the error on Windows
@@ -1545,26 +1412,13 @@ fn test_check_out_existing_file_replaced_with_directory() {
     let commit2 = commit_with_tree(repo.store(), tree2.id());
 
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
     std::fs::remove_file(file_path.to_fs_path_unchecked(&workspace_root)).unwrap();
     std::fs::create_dir(file_path.to_fs_path_unchecked(&workspace_root)).unwrap();
 
     // Checkout doesn't fail, but the file should be skipped.
-    let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit2,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(repo.op_id().clone(), None, &commit2).unwrap();
     assert_eq!(stats.skipped_files, 1);
     assert!(file_path.to_fs_path_unchecked(&workspace_root).is_dir());
 }
@@ -1590,14 +1444,7 @@ fn test_check_out_existing_directory_symlink() {
 
     // Checkout doesn't fail, but the file should be skipped.
     let ws = &mut test_workspace.workspace;
-    let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
     assert_eq!(stats.skipped_files, 1);
 
     // Therefore, "../escaped" shouldn't be created.
@@ -1626,14 +1473,7 @@ fn test_check_out_existing_directory_symlink_icase_fs() {
 
     // Checkout doesn't fail, but the file should be skipped on icase fs.
     let ws = &mut test_workspace.workspace;
-    let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
     if is_icase_fs {
         assert_eq!(stats.skipped_files, 1);
     } else {
@@ -1676,14 +1516,7 @@ fn test_check_out_existing_file_symlink_icase_fs(victim_exists: bool) {
 
     // Checkout doesn't fail, but the file should be skipped on icase fs.
     let ws = &mut test_workspace.workspace;
-    let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(repo.op_id().clone(), None, &commit).unwrap();
     if is_icase_fs {
         assert_eq!(stats.skipped_files, 1);
     } else {
@@ -1717,13 +1550,7 @@ fn test_check_out_file_removal_over_existing_directory_symlink() {
 
     // Check out "parent/escaped".
     let ws = &mut test_workspace.workspace;
-    ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    )
-    .unwrap();
+    ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
     // Pretend that "parent" was a symlink, which might be created by
     // e.g. checking out "PARENT" on case-insensitive fs. The file
@@ -1736,14 +1563,7 @@ fn test_check_out_file_removal_over_existing_directory_symlink() {
     assert!(file_path.to_fs_path_unchecked(&workspace_root).exists());
 
     // Check out empty tree, which tries to remove "parent/escaped".
-    let stats = ws
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit2,
-            &CheckoutOptions::empty_for_test(),
-        )
-        .unwrap();
+    let stats = ws.check_out(repo.op_id().clone(), None, &commit2).unwrap();
     assert_eq!(stats.skipped_files, 1);
 
     // "../escaped" shouldn't be removed.
@@ -1763,12 +1583,7 @@ fn test_check_out_malformed_file_path(file_path_str: &str) {
 
     // Checkout should fail
     let ws = &mut test_workspace.workspace;
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit);
     assert_matches!(result, Err(CheckoutError::InvalidRepoPath(_)));
 
     // Therefore, "pwned" file shouldn't be created.
@@ -1789,12 +1604,7 @@ fn test_check_out_malformed_file_path_windows(file_path_str: &str) {
 
     // Checkout should fail on Windows
     let ws = &mut test_workspace.workspace;
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit);
     if cfg!(windows) {
         assert_matches!(result, Err(CheckoutError::InvalidRepoPath(_)));
     } else {
@@ -1831,12 +1641,7 @@ fn test_check_out_reserved_file_path(file_path_str: &str) {
 
     // Checkout should fail.
     let ws = &mut test_workspace.workspace;
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit1);
     assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
 
     // Therefore, "pwned" file shouldn't be created.
@@ -1858,12 +1663,7 @@ fn test_check_out_reserved_file_path(file_path_str: &str) {
     }
 
     // Check out empty tree, which tries to remove the file.
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit2,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit2);
     assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
 
     // The existing file shouldn't be removed.
@@ -1892,12 +1692,7 @@ fn test_check_out_reserved_file_path_icase_fs(file_path_str: &str) {
 
     // Checkout should fail on icase fs.
     let ws = &mut test_workspace.workspace;
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit1);
     if is_icase_fs {
         assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
     } else {
@@ -1921,12 +1716,7 @@ fn test_check_out_reserved_file_path_icase_fs(file_path_str: &str) {
     std::fs::write(&disk_path, "").unwrap();
 
     // Check out empty tree, which tries to remove the file.
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit2,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit2);
     if is_icase_fs {
         assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
     } else {
@@ -1963,12 +1753,7 @@ fn test_check_out_reserved_file_path_hfs_plus(file_path_str: &str) {
 
     // Checkout should fail on HFS+-like fs.
     let ws = &mut test_workspace.workspace;
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit1);
     if is_hfs_plus {
         assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
     } else {
@@ -1992,12 +1777,7 @@ fn test_check_out_reserved_file_path_hfs_plus(file_path_str: &str) {
     std::fs::write(&disk_path, "").unwrap();
 
     // Check out empty tree, which tries to remove the file.
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit2,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit2);
     if is_hfs_plus {
         assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
     } else {
@@ -2039,12 +1819,7 @@ fn test_check_out_reserved_file_path_vfat(vfat_path_str: &str, file_path_strs: &
 
     // Checkout should fail on VFAT-like fs.
     let ws = &mut test_workspace.workspace;
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit1,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit1);
     if is_vfat {
         assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
     } else {
@@ -2070,12 +1845,7 @@ fn test_check_out_reserved_file_path_vfat(vfat_path_str: &str, file_path_strs: &
     }
 
     // Check out empty tree, which tries to remove the file.
-    let result = ws.check_out(
-        repo.op_id().clone(),
-        None,
-        &commit2,
-        &CheckoutOptions::empty_for_test(),
-    );
+    let result = ws.check_out(repo.op_id().clone(), None, &commit2);
     if is_vfat {
         assert_matches!(result, Err(CheckoutError::ReservedPathComponent { .. }));
     } else {

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -19,7 +19,6 @@ use jj_lib::matchers::EverythingMatcher;
 use jj_lib::repo::Repo as _;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
-use jj_lib::working_copy::CheckoutOptions;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::WorkingCopy as _;
 use pollster::FutureExt as _;
@@ -63,12 +62,7 @@ fn test_sparse_checkout() {
 
     test_workspace
         .workspace
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(repo.op_id().clone(), None, &commit)
         .unwrap();
     let ws = &mut test_workspace.workspace;
 
@@ -77,7 +71,7 @@ fn test_sparse_checkout() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     let stats = locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns.clone(), &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns.clone())
         .unwrap();
     assert_eq!(
         stats,
@@ -150,7 +144,7 @@ fn test_sparse_checkout() {
     let mut locked_wc = wc.start_mutation().unwrap();
     let sparse_patterns = to_owned_path_vec(&[root_file1_path, dir1_subdir1_path, dir2_path]);
     let stats = locked_wc
-        .set_sparse_patterns(sparse_patterns.clone(), &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns.clone())
         .unwrap();
     assert_eq!(
         stats,
@@ -226,12 +220,7 @@ fn test_sparse_commit() {
     let commit = commit_with_tree(repo.store(), tree.id());
     test_workspace
         .workspace
-        .check_out(
-            repo.op_id().clone(),
-            None,
-            &commit,
-            &CheckoutOptions::empty_for_test(),
-        )
+        .check_out(repo.op_id().clone(), None, &commit)
         .unwrap();
 
     // Set sparse patterns to only dir1/
@@ -242,7 +231,7 @@ fn test_sparse_commit() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns)
         .unwrap();
     locked_ws.finish(repo.op_id().clone()).unwrap();
 
@@ -283,7 +272,7 @@ fn test_sparse_commit() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path, dir2_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns)
         .unwrap();
     locked_ws.finish(op_id).unwrap();
 
@@ -318,7 +307,7 @@ fn test_sparse_commit_gitignore() {
     let sparse_patterns = to_owned_path_vec(&[dir1_path]);
     locked_ws
         .locked_wc()
-        .set_sparse_patterns(sparse_patterns, &CheckoutOptions::empty_for_test())
+        .set_sparse_patterns(sparse_patterns)
         .unwrap();
     locked_ws.finish(repo.op_id().clone()).unwrap();
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

This was reworked from #7244 

This would be the foundation for moving the `fsmonitor_settings` (and friends) out of the `SnapshotOptions`, however doing so requires updating the way we use it while testing and I'd prefer to avoid adding a new testing interface for that without prior design work. And I may leave that for another contributor

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
