### PR TITLE
templater: map stringify() of unset RefSymbol value to empty string

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -557,8 +557,7 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
             Self::RefSymbol(property) => Some(property.map(|RefSymbolBuf(s)| s).into_dyn()),
             Self::RefSymbolOpt(property) => Some(
                 property
-                    .try_unwrap("RefSymbol")
-                    .map(|RefSymbolBuf(s)| s)
+                    .map(|opt| opt.map_or_else(String::new, |RefSymbolBuf(s)| s))
                     .into_dyn(),
             ),
             _ => {
@@ -2827,9 +2826,7 @@ mod tests {
         // string type were quoted/escaped. (e.g. `"foo".contains(bookmark)`)
         insta::assert_snapshot!(env.render_ok("stringify(self)", &sym("a b")), @"a b");
         insta::assert_snapshot!(env.render_ok("stringify(self)", &Some(sym("a b"))), @"a b");
-        insta::assert_snapshot!(
-            env.render_ok("stringify(self)", &None::<RefSymbolBuf>),
-            @"<Error: No RefSymbol available>");
+        insta::assert_snapshot!(env.render_ok("stringify(self)", &None::<RefSymbolBuf>), @"");
 
         // string methods
         insta::assert_snapshot!(env.render_ok("self.len()", &sym("a b")), @"3");

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -3471,10 +3471,12 @@ mod tests {
     #[test]
     fn test_stringify_function() {
         let mut env = TestTemplateEnv::new();
+        env.add_keyword("none_i64", || literal(None::<i64>));
         env.add_color("error", crossterm::style::Color::DarkRed);
 
         insta::assert_snapshot!(env.render_ok("stringify(false)"), @"false");
         insta::assert_snapshot!(env.render_ok("stringify(42).len()"), @"2");
+        insta::assert_snapshot!(env.render_ok("stringify(none_i64)"), @"");
         insta::assert_snapshot!(env.render_ok("stringify(label('error', 'text'))"), @"text");
     }
 


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
