### PR TITLE
cli: move Command::Evolog to right place in order in run_command()

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -177,6 +177,7 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Diffedit(args) => diffedit::cmd_diffedit(ui, command_helper, args),
         Command::Duplicate(args) => duplicate::cmd_duplicate(ui, command_helper, args),
         Command::Edit(args) => edit::cmd_edit(ui, command_helper, args),
+        Command::Evolog(args) => evolog::cmd_evolog(ui, command_helper, args),
         Command::File(args) => file::cmd_file(ui, command_helper, args),
         Command::Fix(args) => fix::cmd_fix(ui, command_helper, args),
         #[cfg(feature = "git")]
@@ -186,7 +187,6 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Log(args) => log::cmd_log(ui, command_helper, args),
         Command::New(args) => new::cmd_new(ui, command_helper, args),
         Command::Next(args) => next::cmd_next(ui, command_helper, args),
-        Command::Evolog(args) => evolog::cmd_evolog(ui, command_helper, args),
         Command::Operation(args) => operation::cmd_operation(ui, command_helper, args),
         Command::Parallelize(args) => parallelize::cmd_parallelize(ui, command_helper, args),
         Command::Prev(args) => prev::cmd_prev(ui, command_helper, args),


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
