### PR TITLE
dev: add mise config

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,0 +1,93 @@
+#:schema https://mise.jdx.dev/schema/mise.json
+
+# Mise support is experimental.
+# See https://jj-vcs.github.io/jj/latest/contributing/#alternative-development-setup-with-mise
+
+[vars]
+bacon_version = "3.16.0"
+cargo_insta_version = "1.43.1"
+cargo_nextest_version = "0.9.103"
+rust_version = "1.85"
+uv_version = "0.8.13"
+
+[tools]
+# We need cargo-binstall so that Mise would download "cargo:" tools instead of building them.
+"cargo-binstall" = "latest"
+
+[tasks."build:cli-reference"]
+description = "Build the command line reference (cli/tests/cli-reference@.md.snap)"
+tools.rust = "{{vars.rust_version}}"
+tools."cargo:cargo-insta" = "{{vars.cargo_insta_version}}"
+run = "cargo insta test --accept --workspace -- test_generate_md_cli_help"
+
+[tasks."build:debug"]
+alias = "build"
+description = "Build jj in debug mode"
+tools.rust = "{{vars.rust_version}}"
+run = "cargo build"
+
+[tasks."build:docs"]
+description = "Build documentation into rendered-docs/ for offline use"
+tools.uv = "{{vars.uv_version}}"
+run = "uv run mkdocs build"
+
+[tasks."build:release"]
+description = "Build jj in release mode"
+tools.rust = "{{vars.rust_version}}"
+run = "cargo build --release"
+
+
+[tasks."check:clippy"]
+description = "Lint the code with Clippy"
+tools.rust = "{{vars.rust_version}}"
+run = "cargo clippy --workspace --all-targets"
+
+[tasks."check:format"]
+description = "Check the code format"
+tools.rust = "nightly"
+run = "cargo fmt --check"
+
+[tasks."check:test"]
+alias = "test"
+description = "Run the tests"
+tools.rust = "{{vars.rust_version}}"
+tools."cargo:cargo-insta" = "{{vars.cargo_insta_version}}"
+tools."cargo:cargo-nextest" = "{{vars.cargo_nextest_version}}"
+run = "cargo insta test --workspace --test-runner nextest --"
+
+[tasks."check:zizmor"]
+description = "Check GitHub workflows with Zizmor"
+tools."cargo:zizmor" = "latest"
+run = "zizmor ."
+
+
+[tasks."fix:clippy"]
+description = "Fix the clippy alerts"
+tools.rust = "{{vars.rust_version}}"
+run = "cargo clippy --fix"
+
+[tasks."fix:format"]
+description = "Format the code"
+tools.rust = "nightly"
+run = "cargo fmt"
+
+
+[tasks."serve:docs"]
+description = "Preview documentation with live reloading"
+tools.uv = "{{vars.uv_version}}"
+run = "uv run mkdocs serve"
+
+
+# not sure how to name these
+[tasks."clippy:live"]
+description = "Lint the code with Clippy when the code changes"
+tools.rust = "{{vars.rust_version}}"
+tools."cargo:bacon" = "{{vars.bacon_version}}"
+run = "bacon clippy -- --workspace --all-targets"
+
+[tasks."test:live"]
+description = "Run tests when the code changes"
+tools.rust = "{{vars.rust_version}}"
+tools."cargo:bacon" = "{{vars.bacon_version}}"
+tools."cargo:cargo-nextest" = "{{vars.cargo_nextest_version}}"
+run = "bacon nextest -- --nff --workspace"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ result
 # Per user insta settings.
 # See https://insta.rs/docs/settings/#tool-config-file for details.
 .config/insta.yaml
+# Per user mise config
+mise.local.toml
 
 # mkdocs
 /.venv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
 [workspace.package]
 version = "0.32.0"
 license = "Apache-2.0"
-rust-version = "1.85" # NOTE: remember to update CI, contributing.md, changelog.md, and install-and-setup.md
+rust-version = "1.85" # NOTE: remember to update CI, mise.toml, contributing.md, changelog.md, and install-and-setup.md
 edition = "2024"
 readme = "README.md"
 homepage = "https://github.com/jj-vcs/jj"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -291,6 +291,36 @@ We recommend at least these settings:
 }
 ```
 
+### Alternative development setup with `mise`
+
+An experimental development setup is available using
+[`mise`](https://mise.jdx.dev/). If you try it, file bugs,
+PRs, or tell us on Discord/IRC/discussions if you experience problems
+or if this config is too inflexible. If we can make it work for most
+platforms and most people's needs, including people previously unfamiliar
+with `mise`, we may make `mise` the recommended way to set up a development
+environment.
+
+This tool manages the necessary dependencies for you, eliminating the need for
+a separate setup process. `mise` automatically installs the required tools when
+they are needed.
+
+Here are some of the commands you may find yourself using frequently during
+development:
+
+  * `mise test`: Runs all tests.
+  * `mise test <string>`: Runs tests that contain a specific string. For
+    example, `mise test squash` would run tests with "squash" in their name.
+  * `mise build`: Compiles `jj`.
+  * `mise build:release`: Compiles `jj` in release mode.
+  * `mise build:docs`: Builds the documentation for `jj`.
+
+For a complete list of all available tasks, you can run `mise tasks` or review
+the configuration file at `.config/mise.toml`.
+
+You can customize this configuration using
+[a `mise.local.toml` file](https://mise.jdx.dev/configuration.html#mise-toml).
+
 ## Previewing the HTML documentation
 
 The documentation for `jj` is automatically published online at


### PR DESCRIPTION
This is a continuation of #6081

I've tried to use the task hierarchy proposed by @arxanas in https://github.com/jj-vcs/jj/pull/6081#discussion_r2019971617 and used the `[vars]` to define the tool versions in the tasks.
The tools are only declared in each task in order to be able to build the docs without installing the rust toolchain for example.

There are still a few things that could be better:
* `mise run 'check:*'`  output is completely flooded by the `nextest` output when using the recommended `cargo insta test --test-runner nextest`, and it becomes difficult to find the output of the other failed checks. Moreover, the check outputs are losing the coloring.
* I'm not sure how to name the tasks using `bacon`

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
