### PR TITLE
file_util: insert fdatasync() before persisting temporary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   explicitly specified, in which case the specified option will apply for both
   the initial clone and subsequent fetches.
 
+* Operation and working-copy state files are now synchronized to disk on save.
+  This will mitigate data corruption on system crash.
+  [#4423](https://github.com/jj-vcs/jj/issues/4423)
+
 ### Packaging changes
 
 * The test suite no longer optionally uses Taplo CLI or jq, and packagers can

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -190,7 +190,17 @@ fn to_slash_separated(path: &Path) -> OsString {
     buf
 }
 
-/// Like `NamedTempFile::persist()`, but doesn't try to overwrite the existing
+/// Persists the temporary file.
+pub fn persist_temp_file<P: AsRef<Path>>(
+    temp_file: NamedTempFile,
+    new_path: P,
+) -> io::Result<File> {
+    temp_file
+        .persist(new_path)
+        .map_err(|PersistError { error, file: _ }| error)
+}
+
+/// Like [`persist_temp_file()`], but doesn't try to overwrite the existing
 /// target on Windows.
 pub fn persist_content_addressed_temp_file<P: AsRef<Path>>(
     temp_file: NamedTempFile,


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
