### PR TITLE
config: use schema directive comment

### DIFF
--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -233,7 +233,6 @@ fn test_config_list_layer() {
 
     let output = work_dir.run_jj(["config", "list", "--user"]);
     insta::assert_snapshot!(output, @r#"
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
     test-key = "test-val"
     test-layered-key = "test-original-val"
     [EOF]
@@ -258,7 +257,6 @@ fn test_config_list_layer() {
 
     let output = work_dir.run_jj(["config", "list", "--repo"]);
     insta::assert_snapshot!(output, @r#"
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
     test-layered-key = "test-layered-val"
     [EOF]
     "#);
@@ -308,7 +306,6 @@ fn test_config_list_origin() {
     ]);
     insta::assert_snapshot!(output, @r#"
     test-key = "test-val" # user $TEST_ENV/config/config.toml
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json" # repo $TEST_ENV/repo/.jj/repo/config.toml
     test-layered-key = "test-layered-val" # repo $TEST_ENV/repo/.jj/repo/config.toml
     user.name = "Test User" # env
     user.email = "test.user@example.com" # env
@@ -622,7 +619,8 @@ fn test_config_set_for_user() {
     let user_config_toml = std::fs::read_to_string(&user_config_path)
         .unwrap_or_else(|_| panic!("Failed to read file {}", user_config_path.display()));
     insta::assert_snapshot!(user_config_toml, @r#"
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
+    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+
     test-key = "test-val"
 
     [test-table]
@@ -689,7 +687,8 @@ fn test_config_set_for_repo() {
     // Ensure test-key successfully written to user config.
     let repo_config_toml = work_dir.read_file(".jj/repo/config.toml");
     insta::assert_snapshot!(repo_config_toml, @r#"
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
+    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+
     test-key = "test-val"
 
     [test-table]
@@ -718,7 +717,7 @@ fn test_config_set_toml_types() {
     set_value("test-table.string", r#""foo""#);
     set_value("test-table.invalid", r"a + b");
     insta::assert_snapshot!(std::fs::read_to_string(&user_config_path).unwrap(), @r#"
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
+    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
 
     [test-table]
     integer = 42
@@ -813,10 +812,11 @@ fn test_config_unset_inline_table_key() {
         .run_jj(["config", "unset", "--user", "inline-table.foo"])
         .success();
     let user_config_toml = std::fs::read_to_string(&user_config_path).unwrap();
-    insta::assert_snapshot!(user_config_toml, @r#"
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
+    insta::assert_snapshot!(user_config_toml, @r"
+    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+
     inline-table = {}
-    "#);
+    ");
 }
 
 #[test]
@@ -888,11 +888,7 @@ fn test_config_unset_for_user() {
         .success();
 
     let user_config_toml = std::fs::read_to_string(&user_config_path).unwrap();
-    insta::assert_snapshot!(user_config_toml, @r#"
-    "$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
-
-    [table]
-    "#);
+    insta::assert_snapshot!(user_config_toml, @"[table]");
 }
 
 #[test]
@@ -909,7 +905,7 @@ fn test_config_unset_for_repo() {
         .success();
 
     let repo_config_toml = work_dir.read_file(".jj/repo/config.toml");
-    insta::assert_snapshot!(repo_config_toml, @r#""$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json""#);
+    insta::assert_snapshot!(repo_config_toml, @"");
 }
 
 #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,7 @@ These are listed in the order they are loaded; the settings from earlier items
 in the list are overridden by the settings from later items if they disagree.
 Every type of config except for the built-in settings is optional.
 
-You can enable JSON Schema validation in your editor by adding a `$schema`
+You can enable JSON Schema validation in your editor by adding a `#:schema`
 reference at the top of your TOML config files. See [JSON Schema
 Support] for details.
 
@@ -1766,7 +1766,7 @@ enable schema validation in your editor, add this line at the top of your TOML
 config files:
 
 ```toml
-"$schema" = "https://jj-vcs.github.io/jj/latest/config-schema.json"
+#:schema https://jj-vcs.github.io/jj/latest/config-schema.json
 ```
 
 This enables features like:

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -561,11 +561,8 @@ impl ConfigFile {
                 source: error,
             })) if error.kind() == io::ErrorKind::NotFound => {
                 let mut data = DocumentMut::new();
-                data.insert(
-                    "$schema",
-                    toml_edit::Item::Value(
-                        "https://jj-vcs.github.io/jj/latest/config-schema.json".into(),
-                    ),
+                data.decor_mut().set_prefix(
+                    "#:schema https://jj-vcs.github.io/jj/latest/config-schema.json\n\n",
                 );
                 let layer = ConfigLayer {
                     source,


### PR DESCRIPTION
I tested this manually with both taplo and tombi, both work well with the comment directive. For example, running `jj config edit --repo` in a throwaway repo will open a new config with the generated directive in your editor, which allows for testing this easily.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
