### PR TITLE
cli: deemphasize description for immutable commits

### DIFF
--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -45,6 +45,8 @@
 "elided" = "bright black"
 "root" = "green"
 
+"immutable description" = "bright black"
+
 "working_copy" = { bold = true }
 "working_copy commit_id" = "bright blue"
 "working_copy change_id" = "bright magenta"


### PR DESCRIPTION
Here's an example:
<img width="609" height="171" alt="Screenshot 2025-08-29 at 10 13 12" src="https://github.com/user-attachments/assets/e6523e00-ecf5-46c2-b326-6489552d6788" />


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
