### PR TITLE
config get: add support for displaying arrays and tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj util exec` now matches the exit status of the program it runs, and
   doesn't print anything.
 
+* `jj config get` now supports displaying array and table config values.
+
 ### Fixed bugs
 
 * Fetching repositories that have submodules no longer errors even if

--- a/cli/src/commands/config/get.rs
+++ b/cli/src/commands/config/get.rs
@@ -46,24 +46,18 @@ pub fn cmd_config_get(
     command: &CommandHelper,
     args: &ConfigGetArgs,
 ) -> Result<(), CommandError> {
-    let stringified = command
-        .settings()
-        .get_value_with(&args.name, |value| match value {
-            // Remove extra formatting from a string value
-            ConfigValue::String(v) => Ok(v.into_value()),
-            // Print other values in TOML syntax (but whitespace trimmed)
-            ConfigValue::Integer(_)
-            | ConfigValue::Float(_)
-            | ConfigValue::Boolean(_)
-            | ConfigValue::Datetime(_) => Ok(value.decorated("", "").to_string()),
-            // TODO: maybe okay to just print array or table in TOML syntax?
-            ConfigValue::Array(_) => {
-                Err("Expected a value convertible to a string, but is an array")
-            }
-            ConfigValue::InlineTable(_) => {
-                Err("Expected a value convertible to a string, but is a table")
-            }
-        })?;
+    let value = command.settings().get_value(&args.name)?;
+    let stringified = match value {
+        // Remove extra formatting from a string value
+        ConfigValue::String(v) => v.into_value(),
+        // Print other values in TOML syntax (but whitespace trimmed)
+        ConfigValue::Integer(_)
+        | ConfigValue::Float(_)
+        | ConfigValue::Boolean(_)
+        | ConfigValue::Datetime(_)
+        | ConfigValue::Array(_)
+        | ConfigValue::InlineTable(_) => value.decorated("", "").to_string(),
+    };
     writeln!(ui.stdout(), "{stringified}")?;
     Ok(())
 }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1252,26 +1252,16 @@ fn test_config_get() {
     ");
 
     let output = test_env.run_jj_in(".", ["config", "get", "table.list"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Config error: Invalid type or value for table.list
-    Caused by: Expected a value convertible to a string, but is an array
-    Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    insta::assert_snapshot!(output, @r#"
+    ["list", "value"]
     [EOF]
-    [exit status: 1]
-    ");
+    "#);
 
     let output = test_env.run_jj_in(".", ["config", "get", "table"]);
-    insta::assert_snapshot!(output, @r"
-    ------- stderr -------
-    Config error: Invalid type or value for table
-    Caused by: Expected a value convertible to a string, but is a table
-    Hint: Check the config file: $TEST_ENV/config/config0003.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    insta::assert_snapshot!(output, @r#"
+    { string = "some value 1", int = 123, list = ["list", "value"], overridden = "bar" }
     [EOF]
-    [exit status: 1]
-    ");
+    "#);
 
     let output = test_env.run_jj_in(".", ["config", "get", "table.overridden"]);
     insta::assert_snapshot!(output, @r"


### PR DESCRIPTION
Up until now, trying to get a config value that was an array or a table would fail with an error indicating that only values that can be converted to a string can be displayed. This change fixes that issue by converting arrays and tables into TOML format.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ x] I have added/updated tests to cover my changes
