### PR TITLE
config: add platforms conditional configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A new builtin `hyperlink(url, text)` template alias creates clickable
   hyperlinks using [OSC8 escape sequences](https://github.com/Alhadis/OSC8-Adoption) for terminals that support them.
 
+* Added a new conditional configuration `--when.platforms` to include
+  settings only on certain platforms.
+
 ### Fixed bugs
 
 ## [0.33.0] - 2025-09-03

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -937,6 +937,52 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "platforms": {
+                    "type": "array",
+                    "description": "List of platforms to match",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "aix",
+                            "android",
+                            "apple",
+                            "dragonfly",
+                            "emscripten",
+                            "espidf",
+                            "fortanix",
+                            "freebsd",
+                            "fuchsia",
+                            "haiku",
+                            "hermit",
+                            "hermit",
+                            "horizon",
+                            "hurd",
+                            "illumos",
+                            "ios",
+                            "itron",
+                            "l4re",
+                            "linux",
+                            "macos",
+                            "netbsd",
+                            "nto",
+                            "openbsd",
+                            "redox",
+                            "solaris",
+                            "solid_asp3",
+                            "tvos",
+                            "uefi",
+                            "unix",
+                            "visionos",
+                            "vita",
+                            "vxworks",
+                            "wasi",
+                            "wasm",
+                            "watchos",
+                            "windows",
+                            "xous"
+                        ]
+                    }
                 }
             }
         },

--- a/docs/config.md
+++ b/docs/config.md
@@ -1921,3 +1921,16 @@ wip = ["log", "-r", "work"]
   --when.commands = ["file show"]   # matches `jj file show` but *NOT* `jj file list`
   --when.commands = ["file", "log"] # matches `jj file` *OR* `jj log` (or subcommand of either)
   ```
+
+* `--when.platforms`: List of platforms to match.
+
+  The values are defined by both
+  [`std::env::consts::FAMILY](https://doc.rust-lang.org/std/env/consts/constant.FAMILY.html)
+  and
+  [`std::env::consts::OS](https://doc.rust-lang.org/std/env/consts/constant.OS.html).
+
+  ```toml
+  --when.platforms = ["windows"]            # matches only Windows
+  --when.platforms = ["linux", "freebsd"]   # matches Linux or and FreeBSD, but not macOS
+  --when.platforms = ["unix"]               # matches anything in the Unix family (Linux, FreeBSD, macOS, etc.)
+  ```


### PR DESCRIPTION
Adds a new `--when.platforms` condition for including configuration.
This is useful when someone syncs their dotfiles across machines.

The values for `platforms` are defined by `std::env::consts::FAMILY` and
``std::env::consts::OS. Any Unix-family platform can be specified using
the value `"unix"`, or individual operation systems can be chosen with
`"linux"`, `"macos"`, or `"windows"`.

Example:

```toml
ui.pager = ["less", "-FRX"]

[[--scope]]
--when.platforms = ["windows"]
ui.pager = ["C:/Program Files/Git/usr/bin/less.exe", "-FRX"]
```
