### PR TITLE
cli: add support for `jj help alias`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A nearly identical string pattern system as revsets is now supported in the
   template language, and is exposed as `string.match(pattern)`.
 
+* `jj help` and `jj util completion` now support aliases.
+
 ### Fixed bugs
 
 * `jj git clone` now correctly fetches all tags, unless `--fetch-tags` is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,6 +2433,7 @@ dependencies = [
  "scm-record",
  "serde",
  "serde_json",
+ "shlex",
  "slab",
  "strsim",
  "tempfile",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -86,6 +86,7 @@ sapling-streampager = { workspace = true }
 scm-record = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shlex = "1.3.0"
 slab = { workspace = true }
 strsim = { workspace = true }
 tempfile = { workspace = true }

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -941,7 +941,7 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
     let mut config = config_env.resolve_config(&raw_config)?;
     // skip 2 because of the clap_complete prelude: jj -- jj <actual args...>
     let args = std::env::args_os().skip(2);
-    let args = expand_args(&ui, &app, args, &config)?;
+    let (args, _) = expand_args(&ui, &app, args, &config)?;
     let arg_matches = app
         .clone()
         .disable_version_flag(true)

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -275,6 +275,8 @@ See [`jj help -k bookmarks`] for more information.
 
 **Usage:** `jj bookmark <COMMAND>`
 
+**Command Alias:** `b`
+
 ###### **Subcommands:**
 
 * `create` — Create a new bookmark
@@ -538,6 +540,8 @@ This command is very similar to `jj split`. Differences include:
 
 **Usage:** `jj commit [OPTIONS] [FILESETS]...`
 
+**Command Alias:** `ci`
+
 ###### **Arguments:**
 
 * `<FILESETS>` — Put these paths in the first commit
@@ -730,6 +734,8 @@ Update the change description or other metadata [default alias: desc]
 Starts an editor to let you edit the description of changes. The editor will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
 
 **Usage:** `jj describe [OPTIONS] [REVSETS]...`
+
+**Command Alias:** `desc`
 
 ###### **Arguments:**
 
@@ -2666,6 +2672,8 @@ This includes:
 [Conflicted bookmarks]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
 
 **Usage:** `jj status [FILESETS]...`
+
+**Command Alias:** `st`
 
 ###### **Arguments:**
 


### PR DESCRIPTION
This is just a rebase and light update of https://github.com/jj-vcs/jj/pull/3015 which seems to have stalled [waiting for a bug fix to be released in clap-markdown](https://github.com/ConnorGray/clap-markdown/issues/21).

Fixes https://github.com/jj-vcs/jj/issues/2866

---

This adds a new dependency `shlex`. This didn't seem to be controversial in the first PR, but in case it is I'll note in the original PR it was suggested that it would also be useful [elsewhere](https://github.com/lukerandall/jj/blob/0fc3462fa77f600f88e8cedc2d21d191529898ab/cli/src/cli_util.rs#L2523-L2525)

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
