### PR TITLE
conflicts: compare new hunks without fully materializing original to text

### DIFF
--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -192,10 +192,6 @@ fn run_mergetool_external_single_file(
         file,
     } = merge_tool_file;
 
-    let conflict_marker_style = editor
-        .conflict_marker_style
-        .unwrap_or(default_conflict_marker_style);
-
     let uses_marker_length = find_all_variables(&editor.merge_args).contains(&"marker_length");
 
     // If the merge tool doesn't get conflict markers pre-populated in the output
@@ -209,7 +205,9 @@ fn run_mergetool_external_single_file(
     };
     let initial_output_content = if editor.merge_tool_edits_conflict_markers {
         let options = ConflictMaterializeOptions {
-            marker_style: conflict_marker_style,
+            marker_style: editor
+                .conflict_marker_style
+                .unwrap_or(default_conflict_marker_style),
             marker_len: Some(conflict_marker_len),
         };
         materialize_merge_result_to_bytes(&file.contents, &options)
@@ -294,7 +292,6 @@ fn run_mergetool_external_single_file(
             store,
             repo_path,
             output_file_contents.as_slice(),
-            conflict_marker_style,
             conflict_marker_len,
         )
         .block_on()?

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -923,49 +923,52 @@ pub async fn update_from_content(
     store: &Store,
     path: &RepoPath,
     content: &[u8],
-    conflict_marker_style: ConflictMarkerStyle,
     conflict_marker_len: usize,
 ) -> BackendResult<Merge<Option<FileId>>> {
     let simplified_file_ids = file_ids.simplify();
 
-    // First check if the new content is unchanged compared to the old content. If
-    // it is, we don't need parse the content or write any new objects to the
-    // store. This is also a way of making sure that unchanged tree/file
-    // conflicts (for example) are not converted to regular files in the working
-    // copy.
-    let mut old_content = Vec::with_capacity(content.len());
-    let merge_hunk = extract_as_single_hunk(&simplified_file_ids, store, path).await?;
-    let materialize_options = ConflictMaterializeOptions {
-        marker_style: conflict_marker_style,
-        marker_len: Some(conflict_marker_len),
-    };
-    materialize_merge_result(&merge_hunk, &mut old_content, &materialize_options).unwrap();
-    if content == old_content {
-        return Ok(file_ids.clone());
-    }
+    let old_contents = extract_as_single_hunk(&simplified_file_ids, store, path).await?;
+    let old_hunks = files::merge_hunks(&old_contents);
 
     // Parse conflicts from the new content using the arity of the simplified
     // conflicts.
-    let Some(mut hunks) = parse_conflict(
+    let mut new_hunks = parse_conflict(
         content,
         simplified_file_ids.num_sides(),
         conflict_marker_len,
-    ) else {
-        // Either there are no markers or they don't have the expected arity
-        let file_id = store.write_file(path, &mut &content[..]).await?;
-        return Ok(Merge::normal(file_id));
-    };
+    );
 
     // If there is a conflict at the end of the file and a term ends with a newline,
     // check whether the original term ended with a newline. If it didn't, then
     // remove the newline since it was added automatically when materializing.
-    if let Some(last_hunk) = hunks.last_mut().filter(|hunk| !hunk.is_resolved()) {
-        for (original_content, term) in merge_hunk.iter().zip_eq(last_hunk.iter_mut()) {
+    if let Some(last_hunk) = new_hunks
+        .as_mut()
+        .and_then(|hunks| hunks.last_mut())
+        .filter(|hunk| !hunk.is_resolved())
+    {
+        for (original_content, term) in old_contents.iter().zip_eq(last_hunk.iter_mut()) {
             if term.last() == Some(&b'\n') && has_no_eol(original_content) {
                 term.pop();
             }
         }
     }
+
+    // Check if the new hunks are unchanged. This makes sure that unchanged file
+    // conflicts aren't updated to partially-resolved contents.
+    let unchanged = match (&old_hunks, &new_hunks) {
+        (MergeResult::Resolved(old), None) => old == content,
+        (MergeResult::Conflict(old), Some(new)) => old == new,
+        (MergeResult::Resolved(_), Some(_)) | (MergeResult::Conflict(_), None) => false,
+    };
+    if unchanged {
+        return Ok(file_ids.clone());
+    }
+
+    let Some(hunks) = new_hunks else {
+        // Either there are no markers or they don't have the expected arity
+        let file_id = store.write_file(path, &mut &content[..]).await?;
+        return Ok(Merge::normal(file_id));
+    };
 
     let mut contents = simplified_file_ids.map(|_| vec![]);
     for hunk in hunks {

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1609,7 +1609,6 @@ impl FileSnapshotter<'_> {
                 self.store(),
                 repo_path,
                 &contents,
-                self.tree_state.conflict_marker_style,
                 materialized_conflict_data.map_or(MIN_CONFLICT_MARKER_LEN, |data| {
                     data.conflict_marker_len as usize
                 }),


### PR DESCRIPTION
#7399

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
