### PR TITLE
cli: Default to nano editor on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The new command `jj bisect run` uses binary search to find a commit that
   introduced a bug.
 
+* The default editor on Unix is now `nano` instead of `pico`.
+
 ### Fixed bugs
 
 ## [0.33.0] - 2025-09-03

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -42,7 +42,7 @@ use crate::ui::Ui;
 /// Update the change description or other metadata [default alias: desc]
 ///
 /// Starts an editor to let you edit the description of changes. The editor
-/// will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
+/// will be $EDITOR, or `nano` if that's not defined (`Notepad` on Windows).
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct DescribeArgs {
     /// The revision(s) whose description to edit (default: @)

--- a/cli/src/config/unix.toml
+++ b/cli/src/config/unix.toml
@@ -1,2 +1,2 @@
 [ui]
-editor = "pico"
+editor = "nano"

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -767,7 +767,7 @@ Update a config file to unset the given option
 
 Update the change description or other metadata [default alias: desc]
 
-Starts an editor to let you edit the description of changes. The editor will be $EDITOR, or `pico` if that's not defined (`Notepad` on Windows).
+Starts an editor to let you edit the description of changes. The editor will be $EDITOR, or `nano` if that's not defined (`Notepad` on Windows).
 
 **Usage:** `jj describe [OPTIONS] [REVSETS]...`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -884,7 +884,7 @@ a `$`):
 
 `$JJ_EDITOR` > `ui.editor` > `$VISUAL` > `$EDITOR`
 
-Pico is the default editor (Notepad on Windows) in the absence of any other
+Nano is the default editor (Notepad on Windows) in the absence of any other
 setting, but you could set it explicitly too.
 
 ```toml

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,7 +7,7 @@ user.email = "YOUR_EMAIL@example.com"
 ui.color = "auto" # the default
 # ui.color = never # no color
 
-ui.editor = "pico" # the default on Unix
+ui.editor = "nano" # the default on Unix
 # ui.editor = "vim"
 
 ui.diff-editor = ":builtin" # default, internal TUI tool

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -86,7 +86,7 @@ instead of "Hello". Start by describing the change (adding a commit message) so
 we don't forget what we're working on:
 
 ```shell
-# This brings up $EDITOR (or `pico` or `Notepad` by default).
+# This brings up $EDITOR (or `nano` or `Notepad` by default).
 # Enter something like "Say goodbye" in the editor and then save the file and close
 # the editor.
 $ jj describe


### PR DESCRIPTION
follow-up to #7324

I hope I'm not stepping on @ReillyBrogan toe's here. They haven't updated their PR in two weeks and I think this is a pretty easy win. I preserved the original commit author and added myself to the footer.

# Checklist

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
