### PR TITLE
formatter: emit pending color sequence on flush() instead of pop_label()

### DIFF
--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -3395,7 +3395,7 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok(r#"indent("__", label("error", "a") ++ label("warning", "b\nc"))"#),
             @r"
-        [38;5;1m__a[39m[38;5;3mb[39m
+        [38;5;1m__a[38;5;3mb[39m
         [38;5;3m__c[39m
         ");
 
@@ -3439,13 +3439,13 @@ mod tests {
         // Labeled fill char
         insta::assert_snapshot!(
             env.render_ok(r"pad_start(5, label('red', 'foo'), fill_char=label('cyan', '='))"),
-            @"[38;5;6m==[39m[38;5;9mfoo[39m");
+            @"[38;5;6m==[38;5;9mfoo[39m");
         insta::assert_snapshot!(
             env.render_ok(r"pad_end(5, label('red', 'foo'), fill_char=label('cyan', '='))"),
-            @"[38;5;9mfoo[39m[38;5;6m==[39m");
+            @"[38;5;9mfoo[38;5;6m==[39m");
         insta::assert_snapshot!(
             env.render_ok(r"pad_centered(5, label('red', 'foo'), fill_char=label('cyan', '='))"),
-            @"[38;5;6m=[39m[38;5;9mfoo[39m[38;5;6m=[39m");
+            @"[38;5;6m=[38;5;9mfoo[38;5;6m=[39m");
 
         // Error in fill char: the output looks odd (because the error message
         // isn't 1-width character), but is still readable.
@@ -3729,7 +3729,7 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok(
                 r#"surround(label("paren", "("), label("paren", ")"), label("error", "a"))"#),
-            @"[38;5;14m([39m[38;5;1ma[39m[38;5;14m)[39m");
+            @"[38;5;14m([38;5;1ma[38;5;14m)[39m");
 
         // Keyword
         insta::assert_snapshot!(

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -806,12 +806,12 @@ impl<'a> TemplateFormatter<'a> {
         self.formatter.labeled(label)
     }
 
-    pub fn push_label(&mut self, label: &str) -> io::Result<()> {
-        self.formatter.push_label(label)
+    pub fn push_label(&mut self, label: &str) {
+        self.formatter.push_label(label);
     }
 
-    pub fn pop_label(&mut self) -> io::Result<()> {
-        self.formatter.pop_label()
+    pub fn pop_label(&mut self) {
+        self.formatter.pop_label();
     }
 
     pub fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
@@ -880,11 +880,11 @@ fn format_labeled<T: Template + ?Sized>(
     labels: &[String],
 ) -> io::Result<()> {
     for label in labels {
-        formatter.push_label(label)?;
+        formatter.push_label(label);
     }
     content.format(formatter)?;
     for _label in labels {
-        formatter.pop_label()?;
+        formatter.pop_label();
     }
     Ok(())
 }

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -747,13 +747,13 @@ mod tests {
             format_colored(|formatter| {
                 write_truncated_start(formatter, &recorder, &ellipsis_recorder, 6).map(|_| ())
             }),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| {
                 write_truncated_start(formatter, &recorder, &ellipsis_recorder, 5).map(|_| ())
             }),
-            @"[38;5;1moo[39m[38;5;6mbar[39m"
+            @"[38;5;1moo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| {
@@ -779,13 +779,13 @@ mod tests {
             format_colored(|formatter| {
                 write_truncated_end(formatter, &recorder, &ellipsis_recorder, 6).map(|_| ())
             }),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| {
                 write_truncated_end(formatter, &recorder, &ellipsis_recorder, 5).map(|_| ())
             }),
-            @"[38;5;1mfoo[39m[38;5;6mba[39m"
+            @"[38;5;1mfoo[38;5;6mba[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| {
@@ -939,7 +939,7 @@ mod tests {
             format_colored(|formatter| {
                 write_truncated_start(formatter, &recorder, &ellipsis_recorder, 6).map(|_| ())
             }),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| {
@@ -977,7 +977,7 @@ mod tests {
             format_colored(|formatter| {
                 write_truncated_end(formatter, &recorder, &ellipsis_recorder, 6).map(|_| ())
             }),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| {
@@ -1123,47 +1123,47 @@ mod tests {
         // Pad start
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_start(formatter, &recorder, &fill, 6)),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_start(formatter, &recorder, &fill, 7)),
-            @"=[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"=[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_start(formatter, &recorder, &fill, 8)),
-            @"==[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"==[38;5;1mfoo[38;5;6mbar[39m"
         );
 
         // Pad end
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_end(formatter, &recorder, &fill, 6)),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_end(formatter, &recorder, &fill, 7)),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m="
+            @"[38;5;1mfoo[38;5;6mbar[39m="
         );
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_end(formatter, &recorder, &fill, 8)),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m=="
+            @"[38;5;1mfoo[38;5;6mbar[39m=="
         );
 
         // Pad centered
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_centered(formatter, &recorder, &fill, 6)),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m"
+            @"[38;5;1mfoo[38;5;6mbar[39m"
         );
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_centered(formatter, &recorder, &fill, 7)),
-            @"[38;5;1mfoo[39m[38;5;6mbar[39m="
+            @"[38;5;1mfoo[38;5;6mbar[39m="
         );
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_centered(formatter, &recorder, &fill, 8)),
-            @"=[38;5;1mfoo[39m[38;5;6mbar[39m="
+            @"=[38;5;1mfoo[38;5;6mbar[39m="
         );
         insta::assert_snapshot!(
             format_colored(|formatter| write_padded_centered(formatter, &recorder, &fill, 13)),
-            @"===[38;5;1mfoo[39m[38;5;6mbar[39m===="
+            @"===[38;5;1mfoo[38;5;6mbar[39m===="
         );
     }
 
@@ -1428,7 +1428,7 @@ mod tests {
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 7)),
             @r"
-        [38;5;1mfoo [39m[38;5;6mbar[39m
+        [38;5;1mfoo [38;5;6mbar[39m
         [38;5;1mbaz[39m
         [38;5;6mqux[39m
         [38;5;1mquux[39m
@@ -1482,7 +1482,7 @@ mod tests {
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
             @r"
         [38;5;1mfoo bar[39m
-        [38;5;1mba[39m[38;5;6mz[39m
+        [38;5;1mba[38;5;6mz[39m
         "
         );
     }

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -737,9 +737,9 @@ mod tests {
         let ellipsis_recorder = FormatRecorder::new();
         let mut recorder = FormatRecorder::new();
         for (label, word) in [("red", "foo"), ("cyan", "bar")] {
-            recorder.push_label(label).unwrap();
+            recorder.push_label(label);
             write!(recorder, "{word}").unwrap();
-            recorder.pop_label().unwrap();
+            recorder.pop_label();
         }
 
         // Truncate start
@@ -929,9 +929,9 @@ mod tests {
         let ellipsis_recorder = FormatRecorder::with_data("..");
         let mut recorder = FormatRecorder::new();
         for (label, word) in [("red", "foo"), ("cyan", "bar")] {
-            recorder.push_label(label).unwrap();
+            recorder.push_label(label);
             write!(recorder, "{word}").unwrap();
-            recorder.pop_label().unwrap();
+            recorder.pop_label();
         }
 
         // Truncate start
@@ -1114,9 +1114,9 @@ mod tests {
     fn test_write_padded_labeled_content() {
         let mut recorder = FormatRecorder::new();
         for (label, word) in [("red", "foo"), ("cyan", "bar")] {
-            recorder.push_label(label).unwrap();
+            recorder.push_label(label);
             write!(recorder, "{word}").unwrap();
-            recorder.pop_label().unwrap();
+            recorder.pop_label();
         }
         let fill = FormatRecorder::with_data("=");
 
@@ -1171,9 +1171,9 @@ mod tests {
     fn test_write_padded_labeled_fill_char() {
         let recorder = FormatRecorder::with_data("foo");
         let mut fill = FormatRecorder::new();
-        fill.push_label("red").unwrap();
+        fill.push_label("red");
         write!(fill, "=").unwrap();
-        fill.pop_label().unwrap();
+        fill.pop_label();
 
         // Pad start
         insta::assert_snapshot!(
@@ -1405,9 +1405,9 @@ mod tests {
     fn test_write_wrapped() {
         // Split single label chunk
         let mut recorder = FormatRecorder::new();
-        recorder.push_label("red").unwrap();
+        recorder.push_label("red");
         write!(recorder, "foo bar baz\nqux quux\n").unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 7)),
             @r"
@@ -1421,9 +1421,9 @@ mod tests {
         // Multiple label chunks in a line
         let mut recorder = FormatRecorder::new();
         for (i, word) in ["foo ", "bar ", "baz\n", "qux ", "quux"].iter().enumerate() {
-            recorder.push_label(["red", "cyan"][i & 1]).unwrap();
+            recorder.push_label(["red", "cyan"][i & 1]);
             write!(recorder, "{word}").unwrap();
-            recorder.pop_label().unwrap();
+            recorder.pop_label();
         }
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 7)),
@@ -1438,9 +1438,9 @@ mod tests {
         // Empty lines should not cause panic
         let mut recorder = FormatRecorder::new();
         for (i, word) in ["", "foo", "", "bar baz", ""].iter().enumerate() {
-            recorder.push_label(["red", "cyan"][i & 1]).unwrap();
+            recorder.push_label(["red", "cyan"][i & 1]);
             writeln!(recorder, "{word}").unwrap();
-            recorder.pop_label().unwrap();
+            recorder.pop_label();
         }
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
@@ -1455,13 +1455,13 @@ mod tests {
 
         // Split at label boundary
         let mut recorder = FormatRecorder::new();
-        recorder.push_label("red").unwrap();
+        recorder.push_label("red");
         write!(recorder, "foo bar").unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         write!(recorder, " ").unwrap();
-        recorder.push_label("cyan").unwrap();
+        recorder.push_label("cyan");
         writeln!(recorder, "baz").unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
             @r"
@@ -1472,12 +1472,12 @@ mod tests {
 
         // Do not split at label boundary "ba|z" (since it's a single word)
         let mut recorder = FormatRecorder::new();
-        recorder.push_label("red").unwrap();
+        recorder.push_label("red");
         write!(recorder, "foo bar ba").unwrap();
-        recorder.pop_label().unwrap();
-        recorder.push_label("cyan").unwrap();
+        recorder.pop_label();
+        recorder.push_label("cyan");
         writeln!(recorder, "z").unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
             @r"
@@ -1490,9 +1490,9 @@ mod tests {
     #[test]
     fn test_write_wrapped_leading_labeled_whitespace() {
         let mut recorder = FormatRecorder::new();
-        recorder.push_label("red").unwrap();
+        recorder.push_label("red");
         write!(recorder, " ").unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         write!(recorder, "foo").unwrap();
         insta::assert_snapshot!(
             format_colored(|formatter| write_wrapped(formatter, &recorder, 10)),
@@ -1506,9 +1506,9 @@ mod tests {
         // line:  ---
         let mut recorder = FormatRecorder::new();
         write!(recorder, "foo").unwrap();
-        recorder.push_label("red").unwrap();
+        recorder.push_label("red");
         write!(recorder, " ").unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         assert_eq!(
             format_plain_text(|formatter| write_wrapped(formatter, &recorder, 10)),
             "foo",
@@ -1518,9 +1518,9 @@ mod tests {
         // line:  ---     -
         let mut recorder = FormatRecorder::new();
         write!(recorder, "foo").unwrap();
-        recorder.push_label("red").unwrap();
+        recorder.push_label("red");
         writeln!(recorder).unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         assert_eq!(
             format_plain_text(|formatter| write_wrapped(formatter, &recorder, 10)),
             "foo\n",
@@ -1530,9 +1530,9 @@ mod tests {
         // line:  ---    -
         let mut recorder = FormatRecorder::new();
         writeln!(recorder, "foo").unwrap();
-        recorder.push_label("red").unwrap();
+        recorder.push_label("red");
         write!(recorder, " ").unwrap();
-        recorder.pop_label().unwrap();
+        recorder.pop_label();
         assert_eq!(
             format_plain_text(|formatter| write_wrapped(formatter, &recorder, 10)),
             "foo\n",


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
