### PR TITLE
docs: use relative links to Markdown files instead of linking to GitHub

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -49,7 +49,7 @@ a comparison with Git, including how workflows are different, see the
 * **Staging area: Kind of.** The staging area will be ignored. For example,
   `jj diff` will show a diff from the Git HEAD to the working copy. There are
   [ways of fulfilling your use cases without a staging
-  area](https://github.com/jj-vcs/jj/blob/main/docs/git-comparison.md#the-index).
+  area](git-comparison.md#the-index).
 * **Garbage collection: Yes.** It should be safe to run `git gc` in the Git
   repo, but it's not tested, so it's probably a good idea to make a backup of
   the whole workspace first. There's [no garbage collection and repacking of
@@ -68,7 +68,7 @@ a comparison with Git, including how workflows are different, see the
 * **Sparse checkouts: No.** However, there's native support for sparse
   checkouts. See the `jj sparse` command.
 * **Signed commits: Yes.**
-  You can sign commits automatically [by configuration](https://github.com/jj-vcs/jj/blob/main/docs/config.md#commit-signing),
+  You can sign commits automatically [by configuration](config.md#commit-signing),
   or use the `jj sign` command.
 * **Git LFS: No.** ([#80](https://github.com/jj-vcs/jj/issues/80))
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -156,8 +156,7 @@ $ # force push
 $ jj git push --bookmark your-feature
 ```
 
-The hyphen after `your-feature` comes from the
-[revset](https://github.com/jj-vcs/jj/blob/main/docs/revsets.md) syntax.
+The hyphen after `your-feature` comes from the [revset](revsets.md) syntax.
 
 ## Working with other people's bookmarks
 


### PR DESCRIPTION
This allows links to point to other pages in the generated mkdocs documentation output instead of pointing to external GitHub URLs.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
