### PR TITLE
hooks: add support for post-{commit,squash}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The new command `jj bisect run` uses binary search to find a commit that
   introduced a bug.
 
+* New hooks system allows running arbitrary commands after successful operations.
+  Currently supports `hooks.post-commit` and `hooks.post-squash` configuration
+  options. Useful for running something like `prek --last-commit` automatically.
+
 * The default editor on Unix is now `nano` instead of `pico`.
 
 ### Fixed bugs

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -166,6 +166,7 @@ use crate::diff_util::DiffFormatArgs;
 use crate::diff_util::DiffRenderer;
 use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
+use crate::hooks::{HookEvent, run_post_hook_for_event};
 use crate::merge_tools::DiffEditor;
 use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
@@ -2447,6 +2448,17 @@ impl WorkspaceCommandTransaction<'_> {
 
     pub fn finish(self, ui: &Ui, description: impl Into<String>) -> Result<(), CommandError> {
         self.helper.finish_transaction(ui, self.tx, description)
+    }
+
+    pub fn finish_with_hook(
+        self,
+        ui: &Ui,
+        description: impl Into<String>,
+        event: HookEvent,
+    ) -> Result<(), CommandError> {
+        self.helper.finish_transaction(ui, self.tx, description)?;
+        run_post_hook_for_event(self.helper.settings(), event)?;
+        Ok(())
     }
 
     /// Returns the wrapped [`Transaction`] for circumstances where

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -28,6 +28,7 @@ use crate::description_util::add_trailers;
 use crate::description_util::description_template;
 use crate::description_util::edit_description;
 use crate::description_util::join_message_paragraphs;
+use crate::hooks::HookEvent;
 use crate::text_util::parse_author;
 use crate::ui::Ui;
 
@@ -197,6 +198,10 @@ new working-copy commit.
             tx.repo_mut().edit(name, &new_wc_commit).unwrap();
         }
     }
-    tx.finish(ui, format!("commit {}", commit.id().hex()))?;
+    tx.finish_with_hook(
+        ui,
+        format!("commit {}", commit.id().hex()),
+        HookEvent::Commit,
+    )?;
     Ok(())
 }

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -120,7 +120,7 @@ pub(crate) struct NewArgs {
     /// Example: `jj new --after A --before D`:
     ///
     /// ```text
-    /// 
+    ///
     ///     D            D
     ///     |           / \
     ///     C          |   C

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -44,6 +44,7 @@ use crate::description_util::description_template;
 use crate::description_util::edit_description;
 use crate::description_util::join_message_paragraphs;
 use crate::description_util::try_combine_messages;
+use crate::hooks::HookEvent;
 use crate::ui::Ui;
 
 /// Move changes from a revision into another revision
@@ -408,7 +409,7 @@ pub(crate) fn cmd_squash(
             }
         }
     }
-    tx.finish(ui, tx_description)?;
+    tx.finish_with_hook(ui, tx_description, HookEvent::Squash)?;
     Ok(())
 }
 

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -490,6 +490,28 @@
                 }
             }
         },
+        "hooks": {
+            "type": "object",
+            "description": "Configuration for hooks that run at certain points of jj operations",
+            "properties": {
+                "post-commit": {
+                    "type": "array",
+                    "description": "Command and arguments to run after a successful commit operation",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                "post-squash": {
+                    "type": "array",
+                    "description": "Command and arguments to run after a successful squash operation",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                }
+            }
+        },
         "merge-tools": {
             "type": "object",
             "description": "Tables of custom options to pass to the given merge tool (selected in ui.merge-editor)",

--- a/cli/src/hooks.rs
+++ b/cli/src/hooks.rs
@@ -1,0 +1,84 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::process::Command;
+
+use jj_lib::config::ConfigGetError;
+use jj_lib::config::ConfigGetResultExt;
+use jj_lib::settings::UserSettings;
+
+use crate::command_error::CommandError;
+use crate::command_error::user_error;
+use crate::command_error::user_error_with_message;
+
+#[derive(Debug)]
+pub enum HookEvent {
+    Commit,
+    Squash,
+}
+
+#[derive(Debug)]
+struct HooksSettings {
+    post_commit: Vec<String>,
+    post_squash: Vec<String>,
+}
+
+impl HooksSettings {
+    fn from_settings(settings: &UserSettings) -> Result<Self, ConfigGetError> {
+        Ok(Self {
+            post_commit: settings
+                .get("hooks.post-commit")
+                .optional()?
+                .unwrap_or_default(),
+            post_squash: settings
+                .get("hooks.post-squash")
+                .optional()?
+                .unwrap_or_default(),
+        })
+    }
+}
+
+fn run(command: &[String]) -> Result<(), CommandError> {
+    if command.is_empty() {
+        return Ok(());
+    }
+    let status = Command::new(&command[0])
+        .args(&command[1..])
+        .status()
+        .map_err(|err| {
+            user_error_with_message(format!("Hook '{}' failed to run", command[0],), err)
+        })?;
+    match status.code() {
+        Some(0) => Ok(()),
+        Some(exit_code) => Err(user_error(format!(
+            "Hook '{}' exited with code {}",
+            command[0], exit_code
+        ))),
+        None => Err(user_error(format!(
+            "Hook '{}' was terminated by {}",
+            command[0], status
+        ))),
+    }
+}
+
+pub fn run_post_hook_for_event(
+    settings: &UserSettings,
+    event: HookEvent,
+) -> Result<(), CommandError> {
+    let hooks_settings = HooksSettings::from_settings(settings)?;
+    match event {
+        HookEvent::Commit => run(&hooks_settings.post_commit),
+        HookEvent::Squash => run(&hooks_settings.post_squash),
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -39,6 +39,7 @@ pub mod git_util {
     }
 }
 pub mod graphlog;
+pub mod hooks;
 pub mod merge_tools;
 pub mod movement_util;
 pub mod operation_templater;

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -50,6 +50,7 @@ mod test_git_root;
 mod test_gitignores;
 mod test_global_opts;
 mod test_help_command;
+mod test_hooks;
 mod test_immutable_commits;
 mod test_interdiff_command;
 mod test_log_command;

--- a/cli/tests/test_hooks.rs
+++ b/cli/tests/test_hooks.rs
@@ -1,0 +1,106 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+
+#[test]
+fn test_post_commit_hook() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(
+        ".jj/repo/config.toml",
+        r#"hooks.post-commit = ["echo", "Committed successfully!"]"#,
+    );
+    work_dir.write_file("file", "text");
+    let output = work_dir.run_jj(["commit", "-m", "test commit"]);
+
+    insta::assert_snapshot!(output, @r#"
+    Committed successfully!
+    [EOF]
+    ------- stderr -------
+    Working copy  (@) now at: rlvkpnrz 6d9b7c28 (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 5ef1fd62 test commit
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_post_squash_hook() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.run_jj(["commit", "-m", "test squash"]).success();
+
+    work_dir.write_file(
+        ".jj/repo/config.toml",
+        r#"hooks.post-squash = ["echo", "Squashed successfully!"]"#,
+    );
+    work_dir.write_file("file", "text");
+    let output = work_dir.run_jj(["squash"]);
+
+    insta::assert_snapshot!(output, @r#"
+    Squashed successfully!
+    [EOF]
+    ------- stderr -------
+    Working copy  (@) now at: kkmpptxz 415c5a42 (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm dda690f8 test squash
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_hook_command_not_found() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(
+        ".jj/repo/config.toml",
+        r#"hooks.post-commit = ["nonexistent-command"]"#,
+    );
+    work_dir.write_file("file", "text");
+    let output = work_dir.run_jj(["commit", "-m", "test commit"]);
+
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Working copy  (@) now at: rlvkpnrz 6d9b7c28 (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 5ef1fd62 test commit
+    Error: Hook 'nonexistent-command' failed to run
+    Caused by: No such file or directory (os error 2)
+    [EOF]
+    [exit status: 1]
+    "#);
+}
+
+#[test]
+fn test_hook_command_failure() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file(".jj/repo/config.toml", r#"hooks.post-commit = ["false"]"#);
+    work_dir.write_file("file", "text");
+    let output = work_dir.run_jj(["commit", "-m", "test commit"]);
+
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Working copy  (@) now at: rlvkpnrz 6d9b7c28 (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 5ef1fd62 test commit
+    Error: Hook 'false' exited with code 1
+    [EOF]
+    [exit status: 1]
+    "#);
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -469,6 +469,35 @@ edit = true
 You can pass the `--no-edit` flag to `prev` and `next` if you find yourself
 needing the original behavior.
 
+
+## Hooks
+
+You can configure arbitrary commands to run at certain points of jj operations.
+
+Currently supported hook types:
+
+- `hooks.post-commit` - Runs after a successful `jj commit` operation
+- `hooks.post-squash` - Runs after a successful `jj squash` operation
+
+Each hook is configured as an array of command and arguments:
+
+```toml
+[hooks]
+post-commit = ["echo", "Committed successfully!"]
+post-squash = ["echo", "Squashed successfully!"]
+```
+
+### Common Use Cases
+
+This will run `prek --last-commit` after each successful commit or squash operation:
+
+```toml
+[hooks]
+post-commit = ["prek", "--last-commit"]
+post-squash = ["prek", "--last-commit"]
+```
+
+
 ## List
 
 ### Default Template


### PR DESCRIPTION
I'm finally working on a project using pre-commit :)

Figured I'd see if there's any interest in this as an intermediate solution
while we wait for more generalized hooks (#3577) or pre-commit (#405) support.

---

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes