### PR TITLE
cli config: suggest `metaedit` over `describe --reset-author`

### DIFF
--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -118,7 +118,7 @@ fn warn_wc_author(ui: &Ui, user_name: &str, user_email: &str) -> io::Result<()> 
     Ok(writeln!(
         ui.warning_default(),
         "This setting will only impact future commits.\nThe author of the working copy will stay \
-         \"{user_name} <{user_email}>\".\nTo change the working copy author, use \"jj describe \
-         --reset-author --no-edit\""
+         \"{user_name} <{user_email}>\".\nTo change the working copy author, use \"jj metaedit \
+         --update-author\""
     )?)
 }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1709,7 +1709,7 @@ fn test_config_author_change_warning() {
     ------- stderr -------
     Warning: This setting will only impact future commits.
     The author of the working copy will stay "Test User <test.user@example.com>".
-    To change the working copy author, use "jj describe --reset-author --no-edit"
+    To change the working copy author, use "jj metaedit --update-author"
     [EOF]
     "#);
 


### PR DESCRIPTION
# Checklist

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
