### PR TITLE
cli: deprecate metaedit-functionality of commit and describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* Various flags on `jj describe` and `jj commit` have been deprecated in favor
+  of `jj metaedit`. They are:
+  * `describe`: `--author`, `--reset-author`, `--no-edit`
+  * `commit`:   `--author`, `--reset-author`
+
 ### New features
 
 * The new command `jj bisect run` uses binary search to find a commit that

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -70,6 +70,7 @@ pub(crate) struct CommitArgs {
         add = ArgValueCompleter::new(complete::modified_files),
     )]
     paths: Vec<String>,
+    // TODO: Delete in jj 0.40.0+
     /// Reset the author to the configured user
     ///
     /// This resets the author name, email, and timestamp.
@@ -78,14 +79,16 @@ pub(crate) struct CommitArgs {
     /// environment variables to set a different author:
     ///
     /// $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj commit --reset-author
-    #[arg(long)]
+    #[arg(long, hide = true)]
     reset_author: bool,
+    // TODO: Delete in jj 0.40.0+
     /// Set author to the provided string
     ///
     /// This changes author name and email while retaining author
     /// timestamp for non-discardable commits.
     #[arg(
         long,
+        hide = true,
         conflicts_with = "reset_author",
         value_parser = parse_author
     )]
@@ -98,6 +101,18 @@ pub(crate) fn cmd_commit(
     command: &CommandHelper,
     args: &CommitArgs,
 ) -> Result<(), CommandError> {
+    if args.reset_author {
+        writeln!(
+            ui.warning_default(),
+            "`jj commit --reset-author` is deprecated; use `jj metaedit --update-author` instead"
+        )?;
+    }
+    if args.author.is_some() {
+        writeln!(
+            ui.warning_default(),
+            "`jj commit --author` is deprecated; use `jj metaedit --author` instead"
+        )?;
+    }
     let mut workspace_command = command.workspace_helper(ui)?;
 
     let commit_id = workspace_command

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -75,10 +75,11 @@ pub(crate) struct DescribeArgs {
     /// for all of them.
     #[arg(long)]
     stdin: bool,
+    // TODO: Delete in jj 0.40.0+
     /// Don't open an editor
     ///
     /// This is mainly useful in combination with e.g. `--reset-author`.
-    #[arg(long, conflicts_with = "edit")]
+    #[arg(long, hide = true, conflicts_with = "edit")]
     no_edit: bool,
     /// Open an editor
     ///
@@ -86,6 +87,7 @@ pub(crate) struct DescribeArgs {
     /// allow the message to be edited afterwards.
     #[arg(long)]
     edit: bool,
+    // TODO: Delete in jj 0.40.0+
     /// Reset the author name, email, and timestamp
     ///
     /// This resets the author name and email to the configured user and sets
@@ -95,14 +97,16 @@ pub(crate) struct DescribeArgs {
     /// environment variables to set a different author:
     ///
     /// $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj describe --reset-author
-    #[arg(long)]
+    #[arg(long, hide = true)]
     reset_author: bool,
+    // TODO: Delete in jj 0.40.0+
     /// Set author to the provided string
     ///
     /// This changes author name and email while retaining author
     /// timestamp for non-discardable commits.
     #[arg(
         long,
+        hide = true,
         conflicts_with = "reset_author",
         value_parser = parse_author
     )]
@@ -115,6 +119,24 @@ pub(crate) fn cmd_describe(
     command: &CommandHelper,
     args: &DescribeArgs,
 ) -> Result<(), CommandError> {
+    if args.no_edit {
+        writeln!(
+            ui.warning_default(),
+            "`jj describe --no-edit` is deprecated; use `jj metaedit` instead"
+        )?;
+    }
+    if args.reset_author {
+        writeln!(
+            ui.warning_default(),
+            "`jj describe --reset-author` is deprecated; use `jj metaedit --update-author` instead"
+        )?;
+    }
+    if args.author.is_some() {
+        writeln!(
+            ui.warning_default(),
+            "`jj describe --author` is deprecated; use `jj metaedit --author` instead"
+        )?;
+    }
     let mut workspace_command = command.workspace_helper(ui)?;
     let commits: Vec<_> = if !args.revisions_pos.is_empty() || !args.revisions_opt.is_empty() {
         workspace_command

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -589,16 +589,6 @@ Otherwise, this command is very similar to `jj split`. Differences include:
 * `-i`, `--interactive` — Interactively choose which changes to include in the first commit
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
-* `--reset-author` — Reset the author to the configured user
-
-   This resets the author name, email, and timestamp.
-
-   You can use it in combination with the JJ_USER and JJ_EMAIL environment variables to set a different author:
-
-   $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj commit --reset-author
-* `--author <AUTHOR>` — Set author to the provided string
-
-   This changes author name and email while retaining author timestamp for non-discardable commits.
 
 
 
@@ -785,22 +775,9 @@ Starts an editor to let you edit the description of changes. The editor will be 
 * `--stdin` — Read the change description from stdin
 
    If multiple revisions are specified, the same description will be used for all of them.
-* `--no-edit` — Don't open an editor
-
-   This is mainly useful in combination with e.g. `--reset-author`.
 * `--edit` — Open an editor
 
    Forces an editor to open when using `--stdin` or `--message` to allow the message to be edited afterwards.
-* `--reset-author` — Reset the author name, email, and timestamp
-
-   This resets the author name and email to the configured user and sets the author timestamp to the current time.
-
-   You can use it in combination with the JJ_USER and JJ_EMAIL environment variables to set a different author:
-
-   $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj describe --reset-author
-* `--author <AUTHOR>` — Set author to the provided string
-
-   This changes author name and email while retaining author timestamp for non-discardable commits.
 
 
 

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -1717,14 +1717,14 @@ fn test_config_author_change_warning() {
     // for this test, the state (user.email) is needed
     work_dir
         .run_jj_with(|cmd| {
-            cmd.args(["describe", "--reset-author", "--no-edit"])
+            cmd.args(["metaedit", "--update-author"])
                 .env_remove("JJ_EMAIL")
         })
         .success();
 
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @r"
-    @  qpvuntsm Foo 2001-02-03 08:05:09 f64cf908
+    @  qpvuntsm Foo 2001-02-03 08:05:09 c2090b51
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
     [EOF]

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -647,6 +647,8 @@ fn test_describe_default_description() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Warning: Deprecated user-level config: ui.default-description is updated to template-aliases.default_commit_description = '"\n\nTESTED=TODO\n"'
+    Warning: `jj describe --no-edit` is deprecated; use `jj metaedit` instead
+    Warning: `jj describe --reset-author` is deprecated; use `jj metaedit --update-author` instead
     Working copy  (@) now at: kkmpptxz 7118bcb8 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
@@ -913,7 +915,7 @@ fn test_edit_cannot_be_used_with_no_edit() {
     ------- stderr -------
     error: the argument '--no-edit' cannot be used with '--edit'
 
-    Usage: jj describe --no-edit [REVSETS]...
+    Usage: jj describe [OPTIONS] [REVSETS]...
 
     For more information, try '--help'.
     [EOF]
@@ -959,6 +961,7 @@ fn test_add_trailer() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Warning: `jj describe --no-edit` is deprecated; use `jj metaedit` instead
     Working copy  (@) now at: qpvuntsm 2b2e302d (empty) Message from CLI
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
@@ -983,6 +986,7 @@ fn test_add_trailer() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Warning: `jj describe --no-edit` is deprecated; use `jj metaedit` instead
     Nothing changed.
     [EOF]
     ");
@@ -1006,6 +1010,7 @@ fn test_add_trailer() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Warning: `jj describe --no-edit` is deprecated; use `jj metaedit` instead
     Error: Invalid trailer line: this is an invalid trailer
     [EOF]
     [exit status: 1]
@@ -1027,6 +1032,7 @@ fn test_add_trailer() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Warning: `jj describe --no-edit` is deprecated; use `jj metaedit` instead
     Nothing changed.
     [EOF]
     ");
@@ -1068,6 +1074,7 @@ fn test_add_trailer_committer() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Warning: `jj describe --no-edit` is deprecated; use `jj metaedit` instead
     Working copy  (@) now at: qpvuntsm 05ddee5c (empty) Message from CLI
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]


### PR DESCRIPTION
previously discussed here: https://github.com/jj-vcs/jj/pull/7184#issuecomment-3189378788

# Checklist

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
