### PR TITLE
templates: add `hyperlink` alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * New config option `merge.hunk-level = "word"` to enable word-level merging.
 
+* A new builtin `hyperlink(url, text)` template alias creates clickable
+  hyperlinks using [OSC8 escape sequences](https://github.com/Alhadis/OSC8-Adoption) for terminals that support them.
+
 ### Fixed bugs
 
 ## [0.33.0] - 2025-09-03

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -97,6 +97,13 @@ if(
 '''
 
 [template-aliases]
+'hyperlink(url, text)' = '''
+concat(
+  raw_escape_sequence("\e]8;;" ++ url ++ "\e\\"),
+  text,
+  raw_escape_sequence("\e]8;;\e\\"),
+)
+'''
 
 'format_config_item(x)' = '''
 if(x.overridden(),

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -94,6 +94,12 @@ The following functions are defined.
   Surround **non-empty** content with texts such as parentheses.
 * `config(name: String) -> ConfigValue`: Look up configuration value by `name`.
 
+## Built-in Aliases
+
+* `hyperlink(url, text)`: Creates a clickable hyperlink using [OSC8 escape sequences](https://github.com/Alhadis/OSC8-Adoption).
+  The `text` will be displayed and clickable, linking to the given `url` in
+  terminals that support OSC8 hyperlinks.
+
 ## Types
 
 ### `AnnotationLine` type


### PR DESCRIPTION
I spotted this alias in @thoughtpolice's dotfiles and thought it was particularly useful, so copied it into my own, then figured it might actually be useful to include by default.

My use-case is: when PRs are merged via squash, GitHub automatically adds ` (#123)` to the end of the squashed commit message. I was planning on using this to generate clickable links back to the original PR.

Austin, I wasn't sure how to contact you to ask for your permission to raise this PR, so have simply set you as the author and myself as the committer. Also happy to close it if it's not useful to other people.