### PR TITLE
doc: fix broken links to the colocated repo documentation

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -93,7 +93,7 @@ Alternatively, you can use [jj-fzf](https://github.com/tim-janik/jj-fzf), where 
 
 The wiki lists additional TUIs and GUIs beyond the terminal: [GUI-and-TUI](https://github.com/jj-vcs/jj/wiki/GUI-and-TUI)
 
-### <a name="should-i-co-locate-my-repository"></a>Should I colocate my repository?
+### <a name="should-i-colocate-my-repository"></a>Should I colocate my repository?
 
 Colocating a Jujutsu repository allows you to use both Jujutsu and Git in the
 same working copy. The benefits of doing so are:

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -102,7 +102,7 @@ By default, the remote repository will be named `origin`. You can use
 a name of your choice by adding `--remote <remote name>` to the `jj
 git clone` command.
 
-## <a name="co-located-jujutsugit-repos"></a>Colocated Jujutsu/Git repos
+## <a name="colocated-jujutsugit-repos"></a>Colocated Jujutsu/Git repos
 
 A colocated Jujutsu repo is a hybrid Jujutsu/Git repo. This is the default
 for Git-backed repositories created with `jj git init` or `jj git clone`.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -79,7 +79,7 @@ long when using the Git backend. They are presented in regular hexadecimal
 format at the end of the line in `jj log`, using 12 hexadecimal digits by
 default. When using the Git backend, the commit ID is the Git commit ID.
 
-## <a name="co-located-repos"></a>Colocated repos
+## <a name="colocated-repos"></a>Colocated repos
 
 When using the Git [backend](#backend) and the backing Git repository's `.git/`
 directory is a sibling of `.jj/`, we call the repository colocated. Most


### PR DESCRIPTION
Also change the remaining HTML anchors that used co-locate instead of colocate.

Note that this last part of the change might cause some existing deep links to our docs to be broken. I think other similar links were changed previously so I hope that is OK?

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
