### PR TITLE
ci: ignore flaky test on windows arm

### DIFF
--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -4311,6 +4311,8 @@ fn test_concurrent_write_commit() {
 }
 
 #[test]
+// TODO: Fix flaky test on Windows
+#[cfg_attr(windows, ignore)]
 fn test_concurrent_read_write_commit() {
     let settings = user_settings_without_change_id();
     let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);


### PR DESCRIPTION
This test failing randomly has been pretty annoying in recent times.

# Checklist

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
