### PR TITLE
template: add string `replace` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rule for same-change conflicts.
   [#6369](https://github.com/jj-vcs/jj/issues/6369)
 
+* Templates now support a `replace()` method on strings for pattern-based
+  string replacement with optional limits. Supports all string patterns, including
+  regex with capture groups (e.g. `"hello world".replace(regex:'(\w+) (\w+)', "$2 $1")`).
+
 * A new builtin `hyperlink(url, text)` template alias creates clickable
   hyperlinks using [OSC8 escape sequences](https://github.com/Alhadis/OSC8-Adoption) for terminals that support them.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -436,6 +436,13 @@ defined.
   the first matching part of the string for the given pattern.
 
   An empty string is returned if there is no match.
+* `.replace(pattern: StringPattern, replacement: Stringify, [limit: Integer]) -> String`:
+  Replace occurrences of the given `pattern` with the `replacement` string.
+
+  By default, all occurrences are replaced. If `limit` is specified, at most
+  that many occurrences are replaced.
+
+  Supports capture groups in patterns using `$0` (entire match), `$1`, `$2` etc.
 * `.first_line() -> String`
 * `.lines() -> List<String>`: Split into lines excluding newline characters.
 * `.upper() -> String`


### PR DESCRIPTION
Implement the `replace(pattern, replacement, [limit])` method on strings with support for capture groups.