### PR TITLE
revset: parse '@_' as '@-' (typo tolerance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A new builtin `hyperlink(url, text)` template alias creates clickable
   hyperlinks using [OSC8 escape sequences](https://github.com/Alhadis/OSC8-Adoption) for terminals that support them.
 
+* Revset parser tolerates a common typo: `@_` is parsed as `@-` (parents of `@`).
+
 ### Fixed bugs
 
 ## [0.33.0] - 2025-09-03

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -91,6 +91,8 @@ only symbols.
 You can use parentheses to control evaluation order, such as `(x & y) | z` or
 `x & (y | z)`.
 
+Note: As a small typo tolerance, `@_` is interpreted the same as `@-` (parents of `@`).
+
 <!-- The following format will be understood by the web site generator, and will
  generate a folded section that can be unfolded at will. -->
 

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -54,6 +54,8 @@ parents_op = { "-" }
 children_op = { "+" }
 compat_parents_op = { "^" }
 
+typo_at_parents_op = { "@_" }
+
 dag_range_op = { "::" }
 dag_range_pre_op = { "::" }
 dag_range_post_op = { "::" }
@@ -97,6 +99,7 @@ primary = {
   "(" ~ whitespace* ~ expression ~ whitespace* ~ ")"
   | function
   | string_pattern
+  | typo_at_parents_op
   // "@" operator cannot be nested
   | symbol ~ at_op ~ symbol
   | symbol ~ at_op


### PR DESCRIPTION
Fixes #7473.

This was simpler (and hopefully, acceptable) than I expected, so sending a PR as well.

---

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
