### PR TITLE
local_working_copy: remove stale clippy exemption

### DIFF
--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![allow(missing_docs)]
-#![allow(clippy::let_unit_value)]
 
 use std::any::Any;
 use std::cmp::Ordering;


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
