### PR TITLE
metaedit: add `--committer-timestamp` and `--timestamp` arguments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added a new conditional configuration `--when.platforms` to include
   settings only on certain platforms.
 
+* `jj metaedit` has a new `--committer-timestamp` argument to set the committer
+  timestamp to a specific value
+
+* `jj metaedit` has a new `--timestamp` argument to set the both the committer
+  and author timestamps to the the same specific value
+
 ### Fixed bugs
 
 ## [0.33.0] - 2025-09-03

--- a/cli/src/commands/metaedit.rs
+++ b/cli/src/commands/metaedit.rs
@@ -89,17 +89,28 @@ pub(crate) struct MetaeditArgs {
     /// 2000-01-23T01:23:45+09:00)
     #[arg(
         long,
-        conflicts_with_all = ["update_author_timestamp"],
+        conflicts_with_all = ["update_author_timestamp", "timestamp"],
         value_parser = parse_datetime
     )]
     author_timestamp: Option<Timestamp>,
+
+    /// Set both author and committer timestamps to the given date
+    ///
+    /// This is equivalent to using both --author-timestamp and
+    /// --committer-timestamp with the same timestamp value.
+    #[arg(
+        long,
+        conflicts_with_all = ["author_timestamp", "update_author_timestamp", "committer_timestamp", "update_committer_timestamp"],
+        value_parser = parse_datetime
+    )]
+    timestamp: Option<Timestamp>,
 
     /// Set the committer date to the given date either human
     /// readable, eg Sun, 23 Jan 2000 01:23:45 JST) or as a time stamp, eg
     /// 2000-01-23T01:23:45+09:00)
     #[arg(
         long,
-        conflicts_with_all = ["update_committer_timestamp"],
+        conflicts_with_all = ["update_committer_timestamp", "timestamp"],
         value_parser = parse_datetime
     )]
     committer_timestamp: Option<Timestamp>,
@@ -179,6 +190,10 @@ pub(crate) fn cmd_metaedit(
                 if let Some(author_date) = args.author_timestamp {
                     new_author.timestamp = author_date;
                 }
+                // Handle --timestamp (sets both author and committer)
+                if let Some(timestamp_date) = args.timestamp {
+                    new_author.timestamp = timestamp_date;
+                }
                 // If the old commit had an unset author, the commit builder
                 // may already have the author updated from the current config.
                 // Thus, compare to the actual old_author to correctly detect
@@ -195,6 +210,13 @@ pub(crate) fn cmd_metaedit(
                 if let Some(committer_date) = args.committer_timestamp {
                     let mut new_committer = commit_builder.committer().clone();
                     new_committer.timestamp = committer_date;
+                    commit_builder = commit_builder.set_committer(new_committer);
+                    has_changes = true;
+                }
+                // Handle --timestamp (sets both author and committer)
+                if let Some(timestamp_date) = args.timestamp {
+                    let mut new_committer = commit_builder.committer().clone();
+                    new_committer.timestamp = timestamp_date;
                     commit_builder = commit_builder.set_committer(new_committer);
                     has_changes = true;
                 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1653,6 +1653,10 @@ Modify the metadata of a revision without changing its content
 
    This changes author name and email while retaining author timestamp for non-discardable commits.
 * `--author-timestamp <AUTHOR_TIMESTAMP>` — Set the author date to the given date either human readable, eg Sun, 23 Jan 2000 01:23:45 JST) or as a time stamp, eg 2000-01-23T01:23:45+09:00)
+* `--timestamp <TIMESTAMP>` — Set both author and committer timestamps to the given date
+
+   This is equivalent to using both --author-timestamp and --committer-timestamp with the same timestamp value.
+* `--committer-timestamp <COMMITTER_TIMESTAMP>` — Set the committer date to the given date either human readable, eg Sun, 23 Jan 2000 01:23:45 JST) or as a time stamp, eg 2000-01-23T01:23:45+09:00)
 * `--update-committer-timestamp` — Update the committer timestamp
 
    This updates the committer date to now, without modifying the committer.

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -366,12 +366,64 @@ fn test_metaedit() {
     [EOF]
     ");
 
+    // Set both author and committer timestamps with --timestamp
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    work_dir
+        .run_jj(["metaedit", "--timestamp", "1995-12-19T16:39:57-08:00"])
+        .success();
+    insta::assert_snapshot!(get_log(&work_dir), @r"
+    @  Commit ID: 23d7e7e09c4f3cc6b37bd9dd97340a3ecf2476ec
+    │  Change ID: mzvwutvlkqwtuzoztpszkqxkqmqyqyxo
+    │  Bookmarks: c
+    │  Author   : Test User <test.user@example.com> (1995-12-19 16:39:57.000 -08:00)
+    │  Committer: Test User <test.user@example.com> (1995-12-19 16:39:57.000 -08:00)
+    │
+    │      (no description set)
+    │
+    ○  Commit ID: 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  Change ID: kkmpptxzrspxrzommnulwmwkkqwworpl
+    │  Bookmarks: b
+    │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:11.000 +07:00)
+    │
+    │      (no description set)
+    │
+    ○  Commit ID: e6086990958c236d72030f0a2651806aa629f5dd
+    │  Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    │  Bookmarks: a
+    │  Author   : Test User <test.user@example.com> (2001-02-03 04:05:09.000 +07:00)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 04:05:09.000 +07:00)
+    │
+    │      (no description set)
+    │
+    ◆  Commit ID: 0000000000000000000000000000000000000000
+       Change ID: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+       Author   : (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+       Committer: (no name set) <(no email set)> (1970-01-01 00:00:00.000 +00:00)
+
+           (no description set)
+
+    [EOF]
+    ");
+
     // invalid committer timestamp gives an error
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     let output = work_dir.run_jj(["metaedit", "--committer-timestamp", "aaaaaa"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: invalid value 'aaaaaa' for '--committer-timestamp <COMMITTER_TIMESTAMP>': input contains invalid characters
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    // invalid timestamp gives an error
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+    let output = work_dir.run_jj(["metaedit", "--timestamp", "aaaaaa"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    error: invalid value 'aaaaaa' for '--timestamp <TIMESTAMP>': input contains invalid characters
 
     For more information, try '--help'.
     [EOF]
@@ -500,6 +552,76 @@ fn test_timestamp_option_conflicts() {
     let work_dir = test_env.work_dir("repo");
     work_dir.run_jj(["commit", "-m=a"]).success();
     work_dir.run_jj(["describe", "-m=b"]).success();
+
+    // --timestamp conflicts with --author-timestamp
+    insta::assert_snapshot!(work_dir.run_jj([
+        "metaedit",
+        "--timestamp",
+        "2020-01-01T10:00:00+00:00",
+        "--author-timestamp",
+        "2021-01-01T10:00:00+00:00",
+    ]), @r"
+    ------- stderr -------
+    error: the argument '--timestamp <TIMESTAMP>' cannot be used with '--author-timestamp <AUTHOR_TIMESTAMP>'
+
+    Usage: jj metaedit --timestamp <TIMESTAMP> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    // --timestamp conflicts with --committer-timestamp
+    insta::assert_snapshot!(work_dir.run_jj([
+        "metaedit",
+        "--timestamp",
+        "2020-01-01T10:00:00+00:00",
+        "--committer-timestamp",
+        "2021-01-01T10:00:00+00:00",
+    ]), @r"
+    ------- stderr -------
+    error: the argument '--timestamp <TIMESTAMP>' cannot be used with '--committer-timestamp <COMMITTER_TIMESTAMP>'
+
+    Usage: jj metaedit --timestamp <TIMESTAMP> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    // --timestamp conflicts with --update-author-timestamp
+    insta::assert_snapshot!(work_dir.run_jj([
+        "metaedit",
+        "--timestamp",
+        "2020-01-01T10:00:00+00:00",
+        "--update-author-timestamp",
+    ]), @r"
+    ------- stderr -------
+    error: the argument '--timestamp <TIMESTAMP>' cannot be used with '--update-author-timestamp'
+
+    Usage: jj metaedit --timestamp <TIMESTAMP> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
+
+    // --timestamp conflicts with --update-committer-timestamp
+    insta::assert_snapshot!(work_dir.run_jj([
+        "metaedit",
+        "--timestamp",
+        "2020-01-01T10:00:00+00:00",
+        "--update-committer-timestamp",
+    ]), @r"
+    ------- stderr -------
+    error: the argument '--timestamp <TIMESTAMP>' cannot be used with '--update-committer-timestamp'
+
+    Usage: jj metaedit --timestamp <TIMESTAMP> [REVSETS]...
+
+    For more information, try '--help'.
+    [EOF]
+    [exit status: 2]
+    ");
 
     // --committer-timestamp conflicts with --update-committer-timestamp
     insta::assert_snapshot!(work_dir.run_jj([


### PR DESCRIPTION
This makes it possible to set the committer timestamp to a specific value in the same way that it was already possible to do so for the author timestamp. This also makes it possible to set both the committer and the author timestamps to the same value in one go.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
