### PR TITLE
revsets: Remove hidden revisions from `mutable()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* The revset `mutable()` no longer includes hidden revisions.
+
 ## [0.33.0] - 2025-09-03
 
 ### Release highlights

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -33,4 +33,6 @@ latest(
 'builtin_immutable_heads()' = 'present(trunk()) | tags() | untracked_remote_bookmarks()'
 'immutable_heads()' = 'builtin_immutable_heads()'
 'immutable()' = '::(immutable_heads() | root())'
-'mutable()' = '~immutable()'
+# Use ..visible_heads() instead of ~immutable() to prevent mutable() from
+# including hidden revisions.
+'mutable()' = 'immutable()..visible_heads()'


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
