### PR TITLE
gerrit: rewrite change parents before children

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -235,7 +235,9 @@ pub fn cmd_gerrit_upload(
     }
 
     let mut old_to_new: HashMap<CommitId, Commit> = HashMap::new();
-    for original_commit in to_upload {
+    // to_upload is ordered with children first, parents last. The parent of a rewritten child
+    // needs to be the rewritten parent. Therefore we must rewrite in reverse, parents first.
+    for original_commit in to_upload.iter().rev() {
         let trailers = parse_description_trailers(original_commit.description());
 
         let change_id_trailers: Vec<&Trailer> = trailers
@@ -266,7 +268,7 @@ pub fn cmd_gerrit_upload(
             }
 
             // map the old commit to itself
-            old_to_new.insert(original_commit.id().clone(), original_commit);
+            old_to_new.insert(original_commit.id().clone(), original_commit.clone());
             continue;
         }
 


### PR DESCRIPTION
When rewriting changes to add a Change-Id line, child commits must have the rewritten parent as their parent.

The current implementation already attempts to achieve this by looking up the parent in old_to_new. Unfortunately, to_upload has children before parents, so when the child commit is rewritten, the parent is not yet in old_to_new.

Fixes #7544.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have added/updated tests to cover my changes
