### PR TITLE
doc: integrate Gerrit FAQ into Gerrit guide

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -554,33 +554,6 @@ Usually, the different commits associated with the conflicted bookmark should al
 appear in the log, but if they don't you can use `jj bookmark list`to show all the
 commits associated with it.
 
-### How do I integrate Jujutsu with Gerrit?
-
-Add this to your configuration to automatically add Change-Id trailers to commit messages:
-```toml
-[templates]
-commit_trailers = '''
-if(
-  !trailers.contains_key("Change-Id"),
-  format_gerrit_change_id_trailer(self)
-)
-'''
-```
-Note: If you don't check for the presence of the "Change-Id" trailer, you might
-occasionally get duplicate trailers.
-This happens when Jujutsu's change-id isn't in sync with the "Change-Id" trailer.
-Eg. after `jj split`, the "Change-Id" trailer generated for the new change would
-be different from the original one, it wouldn't be deduplicated.
-
-You'll have to manually invoke `git push` of `HEAD` on the underlying git repository
-into the remote Gerrit bookmark `refs/for/$BRANCH`, where `$BRANCH` is the base
-bookmark you want your changes to go to (e.g., `git push origin
-HEAD:refs/for/main`). Using a [colocated][colocated] repo
-will make the underlying git repo directly accessible from the working
-directory.
-
-We hope to integrate with Gerrit natively in the future.
-
 ### I'm experiencing `jj` command issues in a Vite/Vitest project, how do I fix this?
 
 When using Vite or Vitest in a Jujutsu repository, you may experience:

--- a/docs/gerrit.md
+++ b/docs/gerrit.md
@@ -108,3 +108,40 @@ $ jj edit xcv  # position on the stack to edit
  --- Apply needed edits ---
 $ jj gerrit upload -r xcv
 ```
+
+## `Change-Id` management
+
+When uploading, `jj gerrit upload` adds a `Change-Id` footer based on the JJ
+change id. That means that any changes made to a JJ change will become a new
+patch set on the Gerrit change during the next upload.
+
+Keep this association in mind when splitting or squashing changes. For example,
+when splitting a change, the portion that you want associated with the
+original Gerrit change should remain in the original JJ change (the first half
+of the split). Similarly, when squashing new changes, you typically want to
+squash into the change that was previously uploaded to Gerrit.
+
+If your JJ changes no longer align with the desired mapping to Gerrit changes,
+you can manually copy a Gerrit `Change-Id` footer into your JJ change
+description to directly assign a JJ change to an exist Gerrit change.
+
+As an alternative to `jj gerrit upload`'s automatic `Change-Id` mapping, you
+can configure JJ to automatically add `Change-Id` footers to all change
+descriptions:
+
+```toml
+[templates]
+commit_trailers = '''
+if(
+  !trailers.contains_key("Change-Id"),
+  format_gerrit_change_id_trailer(self)
+)
+'''
+```
+
+In this case, the Gerrit change mapping is defined entirely by the `Change-Id`
+footers. When splitting or squashing changes, be sure to keep the `Change-Id`
+footers associated with the desired changes. Be sure not to duplicate the same
+`Change-Id` across different changes. Gerrit will reject pushes that contain
+duplicate `Change-Id`s, but if the uploads are done separately, you may
+unintentionally overwrite an existing change.

--- a/docs/paid_contributors.md
+++ b/docs/paid_contributors.md
@@ -34,6 +34,7 @@ contribute or not.
 * matttproud
 * mlcui-corp
 * orthros
+* prattmic
 * qfel
 * Ralith
 * rdamazio


### PR DESCRIPTION
Provide a bit more detail about the JJ to Gerrit change mapping, advice on handling splits and squashes, as well as the existing FAQ configuration for adding Change-Id directly to change descriptions.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
