### PR TITLE
github: remove x86_64 macOS CI runners

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, macos-x86_64, macos-aarch64, win-x86_64]
+        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, macos-aarch64, win-x86_64]
         include:
         - build: linux-x86_64-musl
           os: ubuntu-24.04
@@ -27,9 +27,6 @@ jobs:
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-gnu
-        - build: macos-x86_64
-          os: macos-13
-          target: x86_64-apple-darwin
         - build: macos-aarch64
           os: macos-14
           target: aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        build: [linux-x86_64-gnu, linux-aarch64-gnu, macos-x86_64, macos-aarch64, windows-x86_64, windows-aarch64]
+        build: [linux-x86_64-gnu, linux-aarch64-gnu, macos-aarch64, windows-x86_64, windows-aarch64]
         include:
         - build: linux-x86_64-gnu
           os: ubuntu-24.04
@@ -27,9 +27,6 @@ jobs:
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           cargo_flags: "--all-features"
-        - build: macos-x86_64
-          os: macos-13
-          cargo_flags: ""
         - build: macos-aarch64
           os: macos-14
           cargo_flags: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux-x86_64-musl, linux-aarch64-musl, macos-x86_64, macos-aarch64, win-x86_64, win-aarch64]
+        build: [linux-x86_64-musl, linux-aarch64-musl, macos-aarch64, win-x86_64, win-aarch64]
         include:
         - build: linux-x86_64-musl
           os: ubuntu-24.04
@@ -25,9 +25,6 @@ jobs:
         - build: linux-aarch64-musl
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-musl
-        - build: macos-x86_64
-          os: macos-13
-          target: x86_64-apple-darwin
         - build: macos-aarch64
           os: macos-14
           target: aarch64-apple-darwin


### PR DESCRIPTION
Until we figure out the plan for macOS x86_64 support (or lack thereof), we have to do this before October 1st as the runners will be removed.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
