### PR TITLE
cli: improve `jj version` output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
     - name: Build release binary
       shell: bash
       run: cargo build --target ${{ matrix.target }} --verbose --release
+      env:
+        JJ_RELEASE_BUILD: "1"
     - name: Build archive
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The revset function `exactly(x, n)` will now evaluate `x` and error if it does
   not have exactly `n` elements.
 
+* `jj version` now has better output; the flags `--numeric-only` and `--details`
+  provide various levels of fidelity.
+
 ### Fixed bugs
+
+### Packaging changes
+
+* Packagers may set the environment variables `JJ_RELEASE_BUILD=1` and
+  `JJ_BUILD_SUFFIX=your-suffix-here` in their build scripts in order to get more
+  detailed output from `jj version`. We encourage all downstream distributions
+  to always provide `JJ_BUILD_SUFFIX` with an appropriate name.
 
 ## [0.33.0] - 2025-09-03
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
 use std::path::Path;
 use std::process::Command;
 use std::str;
@@ -32,10 +33,25 @@ fn main() {
     }
     println!("cargo:rerun-if-env-changed=NIX_JJ_GIT_HASH");
 
+    // build information
+    println!("cargo:rustc-env=JJ_VERSION={version}");
+    println!(
+        "cargo:rustc-env=JJ_CARGO_TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+
+    // if JJ_RELEASE_BUILD, propagate
+    if env::var("JJ_RELEASE_BUILD").is_ok() {
+        println!("cargo:rustc-env=JJ_RELEASE_BUILD=1");
+    }
+
+    // if the user/packager wants to provide some suffix, allow them to here
+    if let Ok(suffix) = env::var("JJ_BUILD_SUFFIX") {
+        println!("cargo:rustc-env=JJ_BUILD_SUFFIX={suffix}");
+    }
+
     if let Some(git_hash) = get_git_hash() {
-        println!("cargo:rustc-env=JJ_VERSION={version}-{git_hash}");
-    } else {
-        println!("cargo:rustc-env=JJ_VERSION={version}");
+        println!("cargo:rustc-env=JJ_GIT_COMMIT=g{git_hash}");
     }
 
     let docs_symlink_path = Path::new("docs");

--- a/cli/src/commands/version.rs
+++ b/cli/src/commands/version.rs
@@ -22,14 +22,71 @@ use crate::ui::Ui;
 
 /// Display version information
 #[derive(clap::Args, Clone, Debug)]
-pub(crate) struct VersionArgs {}
+pub(crate) struct VersionArgs {
+    /// Display only the version number and nothing else.
+    #[arg(long)]
+    pub(crate) numeric_only: bool,
+
+    /// Display build information.
+    #[arg(long, conflicts_with = "numeric_only")]
+    pub(crate) details: bool,
+}
 
 #[instrument(skip_all)]
 pub(crate) fn cmd_version(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &VersionArgs,
+    args: &VersionArgs,
 ) -> Result<(), CommandError> {
-    write!(ui.stdout(), "{}", command.app().render_version())?;
+    let base_version = command.app().get_version().unwrap();
+    let (version, git_commit) = if let Some(git_commit) = option_env!("JJ_GIT_COMMIT") {
+        // in a release build, don't include the commit hash in the
+        // `--numeric-version` or normal output. GH-3629
+        if option_env!("JJ_RELEASE_BUILD").is_some() {
+            (String::from(base_version), git_commit)
+        } else {
+            let short_commit = &git_commit[..12];
+            (format!("{base_version}-{short_commit}"), git_commit)
+        }
+    } else {
+        (String::from(base_version), "unknown")
+    };
+
+    let build_suffix = option_env!("JJ_BUILD_SUFFIX")
+        .map(|s| format!("-{s}"))
+        .unwrap_or_default();
+    let version = format!("{version}{build_suffix}");
+
+    if args.numeric_only {
+        writeln!(ui.stdout(), "{version}")?;
+        return Ok(());
+    }
+
+    writeln!(ui.stdout(), "Jujutsu version control system; jj {version}")?;
+
+    if !args.details {
+        writeln!(ui.stdout(), "For more details: run `jj version --details`",)?;
+        return Ok(());
+    }
+
+    write!(
+        ui.stdout(),
+        r#"Copyright (C) 2019-2025 The Jujutsu Authors
+
+License: Apache License, Version 2.0
+Homepage: <https://jj-vcs.github.io/jj>
+Report bugs: <https://github.com/jj-vcs/jj/issues>
+"#,
+    )?;
+
+    writeln!(ui.stdout())?;
+    writeln!(ui.stdout(), "Target: {}", env!("JJ_CARGO_TARGET"))?;
+    writeln!(ui.stdout(), "Commit: {git_commit}{build_suffix}")?;
+    writeln!(
+        ui.stdout(),
+        "Release: {}",
+        option_env!("JJ_RELEASE_BUILD").is_some()
+    )?;
+
     Ok(())
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2978,7 +2978,12 @@ Print the CLI help for all subcommands in Markdown
 
 Display version information
 
-**Usage:** `jj version`
+**Usage:** `jj version [OPTIONS]`
+
+###### **Options:**
+
+* `--numeric-only` — Display only the version number and nothing else
+* `--details` — Display build information
 
 
 


### PR DESCRIPTION
Refile of #3638 now that git2 is gone. Includes support for `JJ_BUILD_SUFFIX` so that downstreams can correctly identify themselves.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have added/updated tests to cover my changes
