### PR TITLE
nightly clippy: avoid false positive

### DIFF
--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -251,11 +251,10 @@ pub fn cmd_bookmark_list(
         commits = bookmark_list_items
             .iter()
             .filter_map(|item| item.primary.target().added_ids().next())
-            .cloned()
             .map(|commit_id| {
                 store
-                    .get_commit(&commit_id)
-                    .map(|commit| (commit_id, commit.store_commit().clone()))
+                    .get_commit(commit_id)
+                    .map(|commit| (commit_id.clone(), commit.store_commit().clone()))
             })
             .try_collect()?;
     }


### PR DESCRIPTION
After updating nightly rust, this code generates a false positive (below). AFAICT, the new code is only a little more consistent, but it avoids the warning.

The warning is:

```
warning: unneeded cloning of iterator items
   --> cli/src/commands/bookmark/list.rs:251:19
    |
251 |           commits = bookmark_list_items
    |  ___________________^
252 | |             .iter()
253 | |             .filter_map(|item| item.primary.target().added_ids().next())
254 | |             .cloned()
...   |
258 | |                     .map(|commit| (commit_id, commit.store_commit().clone()))
259 | |             })
    | |______________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_iter_cloned
    = note: `#[warn(clippy::redundant_iter_cloned)]` on by default
help: try
    |
253 ~             .filter_map(|item| item.primary.target().added_ids().next())
254 +             .map(|commit_id| {
255 +                 store
256 +                     .get_commit(&commit_id)
257 +                     .map(|commit| (commit_id, commit.store_commit().clone()))
258 +             })
    |

```

Rust version (nightly) that generates this clippy warning:

```console
$ rustc -Vv
rustc 1.92.0-nightly (0be8e1608 2025-09-19)
binary: rustc
commit-hash: 0be8e16088894483a7012c5026c3247c14a0c3c2
commit-date: 2025-09-19
host: aarch64-apple-darwin
release: 1.92.0-nightly
LLVM version: 21.1.1
```

Simply removing the `.cloned()` as suggested by Clippy results in this error:

```
error[E0277]: a value of type `std::collections::HashMap<jj_lib::backend::CommitId, std::sync::Arc<jj_lib::backend::Commit>>` cannot be built from an iterator over elements of type `(&jj_lib::backend::CommitId, std::sync::Arc<jj_lib::backend::Commit>)`
    --> cli/src/commands/bookmark/list.rs:259:14
     |
 259 |             .try_collect()?;
     |              ^^^^^^^^^^^ value of type `std::collections::HashMap<jj_lib::backend::CommitId, std::sync::Arc<jj_lib::backend::Commit>>` cannot be built from `std::iter::Iterator<Item=(&jj_lib::backend::CommitId, std::sync::Arc<jj_lib::backend::Commit>)>`
     |
     = help: the trait `FromIterator<(&jj_lib::backend::CommitId, std::sync::Arc<_>)>` is not implemented for `std::collections::HashMap<jj_lib::backend::CommitId, std::sync::Arc<jj_lib::backend::Commit>>`
             but trait `FromIterator<(jj_lib::backend::CommitId, std::sync::Arc<_>)>` is implemented for it
     = help: for that trait implementation, expected `jj_lib::backend::CommitId`, found `&jj_lib::backend::CommitId`
     = note: required for `Result<HashMap<CommitId, Arc<Commit>>, BackendError>` to implement `FromIterator<Result<(&CommitId, Arc<Commit>), BackendError>>`
note: required by a bound in `itertools::Itertools::try_collect`
    --> /Users/ilyagr/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/itertools-0.14.0/src/lib.rs:2381:23
     |
2378 |     fn try_collect<T, U, E>(self) -> Result<U, E>
     |        ----------- required by a bound in this associated function
...
2381 |         Result<U, E>: FromIterator<Result<T, E>>,
     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Itertools::try_collect`
     = note: the full name for the type has been written to '/Users/ilyagr/dev/jj/target/debug/deps/jj_cli-442101cf9493e967.long-type-2991360816845051416.txt'
     = note: consider using `--verbose` to print the full type name to the console
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
