### PR TITLE
op_store: remove stale TODO about renamed remote and view state

### DIFF
--- a/lib/src/protos/simple_op_store.proto
+++ b/lib/src/protos/simple_op_store.proto
@@ -54,10 +54,6 @@ message Bookmark {
   string name = 1;
   // Unset if the bookmark has been deleted locally.
   RefTarget local_target = 2;
-  // TODO: How would we support renaming remotes while having undo work? If
-  // the remote name is stored in config, it's going to become a mess if the
-  // remote is renamed but the configs are left unchanged. Should each remote
-  // be identified (here and in configs) by a UUID?
   repeated RemoteBookmark remote_bookmarks = 3;
 }
 

--- a/lib/src/protos/simple_op_store.rs
+++ b/lib/src/protos/simple_op_store.rs
@@ -59,10 +59,6 @@ pub struct Bookmark {
     /// Unset if the bookmark has been deleted locally.
     #[prost(message, optional, tag = "2")]
     pub local_target: ::core::option::Option<RefTarget>,
-    /// TODO: How would we support renaming remotes while having undo work? If
-    /// the remote name is stored in config, it's going to become a mess if the
-    /// remote is renamed but the configs are left unchanged. Should each remote
-    /// be identified (here and in configs) by a UUID?
     #[prost(message, repeated, tag = "3")]
     pub remote_bookmarks: ::prost::alloc::vec::Vec<RemoteBookmark>,
 }


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
