### PR TITLE
git_subprocess: make sure we do not try to fetch submodules regardless of .gitconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Fetching repositories that have submodules no longer errors even if
+`submodule.recurse=true`
+  is set in `.gitconfig` (but jj still isn't able to fetch the submodules
+  or to operate on them).
+
 ## [0.33.0] - 2025-09-03
 
 ### Release highlights

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -124,6 +124,10 @@ impl<'a> GitSubprocessContext<'a> {
             // In a colocated repo, the daemon will still get started the first time a `git`
             // command is run manually if the gitconfigs are set up that way.
             .args(["-c", "core.fsmonitor=false"])
+            // Avoids an error message when fetching repos with submodules if
+            // user has `submodule.recurse` configured to true in their Git
+            // config (#7565).
+            .args(["-c", "submodule.recurse=false"])
             .arg("--git-dir")
             .arg(&self.git_dir)
             // Disable translation and other locale-dependent behavior so we can


### PR DESCRIPTION
This fixes the following bug.

I have `submodule.recurse=true` set in my `.gitconfig`. When trying to fetch repos with submodules (e.g. https://github.com/git/git), I get errors like these:

```console
$ jj git fetch
remote: Enumerating objects: 853, done.
remote: Total 853 (delta 448), reused 439 (delta 413), pack-reused 315 (from 2)
Error: Git process failed: External git program failed:
Could not access submodule 'sha1collisiondetection'
```

This error occured when fetching only, *not* when cloning. It occured even when there wasn't anything to fetch.

I only tested repositories that never had submodules initialized or fetched (which would have to be done with Git).

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- (n/a) I have updated the documentation (`README.md`, `docs/`, `demos/`)
- (n/a) I have updated the config schema (`cli/src/config-schema.json`)
- (n/a ?) I have added/updated tests to cover my changes
