### PR TITLE
cli util: Support relative paths in jj util exec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj util exec` sets the environment variable `JJ_WORKSPACE_ROOT`
 
+* `jj util exec` supports running commands within the workspace by prefixing
+  the command with `$root/`
+
 ### Fixed bugs
 
 * Fetching repositories that have submodules no longer errors even if

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2891,7 +2891,10 @@ Print the JSON schema for the jj TOML config format
 
 Execute an external command via jj
 
-This command will have access to the environment variable JJ_WORKSPACE_ROOT.
+The command will be run in the directory this command was invoked from.
+It will have access to the environment variable JJ_WORKSPACE_ROOT.
+The command can be optionally prefixed with `$root/`, in which case it
+will be assumed to be relative to the workspace root instead of in $PATH.
 
 This is useful for arbitrary aliases.
 
@@ -2906,7 +2909,7 @@ when typing commands into the terminal!
 This feature may be removed or replaced by an embedded scripting language in
 the future.
 
-Let's assume you have a script called "my-jj-script" in you $PATH and you
+Let's assume you have a script called "my-jj-script" in your $PATH and you
 would like to execute it as "jj my-script". You would add the following line
 to your configuration file to achieve that:
 


### PR DESCRIPTION
There has been some pushback on this in #7373.

However, I believe this is a good idea. There were concerns about jj turning into a general purpose task runner. However, I believe that jj should be used to run only tasks directly related to version control.

For example, we have a command `jj sync` in chromium that is roughly equivalent to `git fetch origin main && jj rebase -d main@origin && <command to update git submodules>`. Having your simple version control operations within jj, but more complex ones outside of jj makes things more complex for users who have to remember whether to run `jj sync` or `jj-sync.py`, for example. It also means that if jj eventually comes to support submodules, for example, and we want to migrate directly to a `jj sync`, users would have to change their behavior.

Perhaps more importantly, It also allows for consistency between different repos. This way, I can alias `jj upload` to `upload.py` on a repo with presubmits, `jj gerrit upload` on a gerrit repo, and `jj git push` on a git repo. The same goes for `jj sync`

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
