### PR TITLE
cleanup: use method version of str::from_utf8()

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -14,7 +14,6 @@
 
 use std::path::Path;
 use std::process::Command;
-use std::str;
 
 const GIT_HEAD_PATH: &str = "../.git/HEAD";
 const JJ_OP_HEADS_PATH: &str = "../.jj/repo/op_heads/heads";

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -28,7 +28,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::slice;
-use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -17,7 +17,6 @@ use std::error::Error as _;
 use std::io;
 use std::io::Write as _;
 use std::iter;
-use std::str;
 use std::sync::Arc;
 
 use itertools::Itertools as _;

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -16,7 +16,6 @@ use std::io;
 use std::io::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
-use std::str;
 use std::sync::Arc;
 
 use indoc::writedoc;

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -745,7 +745,6 @@ fn write_sanitized(output: &mut impl Write, buf: &[u8]) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use std::error::Error as _;
-    use std::str;
 
     use bstr::BString;
     use indexmap::IndexMap;

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -109,8 +109,7 @@ fn pinentry_get_pw(url: &str) -> Option<String> {
                 continue;
             }
             i += 1;
-            let byte =
-                u8::from_str_radix(std::str::from_utf8(encoded.get(i..i + 2)?).ok()?, 16).ok()?;
+            let byte = u8::from_str_radix(str::from_utf8(encoded.get(i..i + 2)?).ok()?, 16).ok()?;
             decoded.push(byte);
             i += 2;
         }

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -223,11 +223,10 @@ fn make_diff_sections(
             DiffHunkKind::Matching => {
                 debug_assert!(hunk.contents.iter().all_equal());
                 let text = hunk.contents[0];
-                let text =
-                    std::str::from_utf8(text).map_err(|err| BuiltinToolError::DecodeUtf8 {
-                        source: err,
-                        item: "matching text in diff hunk",
-                    })?;
+                let text = str::from_utf8(text).map_err(|err| BuiltinToolError::DecodeUtf8 {
+                    source: err,
+                    item: "matching text in diff hunk",
+                })?;
                 sections.push(scm_record::Section::Unchanged {
                     lines: text
                         .split_inclusive('\n')
@@ -239,12 +238,12 @@ fn make_diff_sections(
                 let sides = &hunk.contents;
                 assert_eq!(sides.len(), 2, "only two inputs were provided to the diff");
                 let left_side =
-                    std::str::from_utf8(sides[0]).map_err(|err| BuiltinToolError::DecodeUtf8 {
+                    str::from_utf8(sides[0]).map_err(|err| BuiltinToolError::DecodeUtf8 {
                         source: err,
                         item: "left side of diff hunk",
                     })?;
                 let right_side =
-                    std::str::from_utf8(sides[1]).map_err(|err| BuiltinToolError::DecodeUtf8 {
+                    str::from_utf8(sides[1]).map_err(|err| BuiltinToolError::DecodeUtf8 {
                         source: err,
                         item: "right side of diff hunk",
                     })?;
@@ -597,7 +596,7 @@ fn make_merge_sections(
             for hunk in hunks {
                 let section = match hunk.into_resolved() {
                     Ok(contents) => {
-                        let contents = std::str::from_utf8(&contents).map_err(|err| {
+                        let contents = str::from_utf8(&contents).map_err(|err| {
                             BuiltinToolError::DecodeUtf8 {
                                 source: err,
                                 item: "unchanged hunk",
@@ -622,7 +621,7 @@ fn make_merge_sections(
                                 .cycle(),
                             )
                             .map(|(contents, change_type)| -> Result<_, BuiltinToolError> {
-                                let contents = std::str::from_utf8(contents).map_err(|err| {
+                                let contents = str::from_utf8(contents).map_err(|err| {
                                     BuiltinToolError::DecodeUtf8 {
                                         source: err,
                                         item: "conflicting hunk",

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -918,7 +918,7 @@ fn builtin_string_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
 
             let out_property = self_property.and_then(move |haystack| {
                 if let Some(m) = regex.find(haystack.as_bytes()) {
-                    Ok(std::str::from_utf8(m.as_bytes())?.to_owned())
+                    Ok(str::from_utf8(m.as_bytes())?.to_owned())
                 } else {
                     // We don't have optional strings, so empty string is the
                     // right null value.
@@ -1087,7 +1087,7 @@ fn builtin_string_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
                             let haystack_bytes = haystack.as_bytes();
                             let replace_bytes = replacement.as_bytes();
                             let result = regex.replacen(haystack_bytes, limit, replace_bytes);
-                            Ok(std::str::from_utf8(&result)?.to_owned())
+                            Ok(str::from_utf8(&result)?.to_owned())
                         }
                     },
                 );
@@ -1098,7 +1098,7 @@ fn builtin_string_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
                         let haystack_bytes = haystack.as_bytes();
                         let replace_bytes = replacement.as_bytes();
                         let result = regex.replace_all(haystack_bytes, replace_bytes);
-                        Ok(std::str::from_utf8(&result)?.to_owned())
+                        Ok(str::from_utf8(&result)?.to_owned())
                     },
                 );
                 Ok(out_property.into_dyn_wrapped())

--- a/lib/src/default_index/changed_path.rs
+++ b/lib/src/default_index/changed_path.rs
@@ -21,7 +21,6 @@ use std::fs::File;
 use std::io::Read;
 use std::io::Write as _;
 use std::path::Path;
-use std::str;
 use std::sync::Arc;
 
 use blake2::Blake2b512;

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -354,7 +354,6 @@ mod platform {
 #[cfg_attr(unix, expect(dead_code))]
 mod fallback {
     use std::ffi::OsStr;
-    use std::str;
 
     use thiserror::Error;
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -22,7 +22,6 @@ use std::default::Default;
 use std::fs::File;
 use std::num::NonZeroU32;
 use std::path::PathBuf;
-use std::str;
 use std::sync::Arc;
 
 use bstr::BStr;

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::process::Command;
 use std::process::ExitStatus;
-use std::str;
+use std::str::Utf8Error;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
@@ -923,7 +923,7 @@ fn to_read_object_err(
     }
 }
 
-fn to_invalid_utf8_err(source: str::Utf8Error, id: &impl ObjectId) -> BackendError {
+fn to_invalid_utf8_err(source: Utf8Error, id: &impl ObjectId) -> BackendError {
     BackendError::InvalidUtf8 {
         object_type: id.object_type(),
         hash: id.hex(),
@@ -1814,7 +1814,7 @@ mod tests {
 
         let mut commit_buf = Vec::new();
         commit.write_to(&mut commit_buf).unwrap();
-        let commit_str = std::str::from_utf8(&commit_buf).unwrap();
+        let commit_str = str::from_utf8(&commit_buf).unwrap();
 
         commit
             .extra_headers
@@ -1832,8 +1832,8 @@ mod tests {
         let sig = commit.secure_sig.expect("failed to read the signature");
 
         // converting to string for nicer assert diff
-        assert_eq!(std::str::from_utf8(&sig.sig).unwrap(), secure_sig);
-        assert_eq!(std::str::from_utf8(&sig.data).unwrap(), commit_str);
+        assert_eq!(str::from_utf8(&sig.sig).unwrap(), secure_sig);
+        assert_eq!(str::from_utf8(&sig.data).unwrap(), commit_str);
     }
 
     #[test]
@@ -2344,7 +2344,7 @@ mod tests {
         let obj = git_repo
             .find_object(gix::ObjectId::from_bytes_or_panic(id.as_bytes()))
             .unwrap();
-        insta::assert_snapshot!(std::str::from_utf8(&obj.data).unwrap(), @r"
+        insta::assert_snapshot!(str::from_utf8(&obj.data).unwrap(), @r"
         tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
         author Someone <someone@example.com> 0 +0000
         committer Someone <someone@example.com> 0 +0000
@@ -2362,11 +2362,11 @@ mod tests {
         let sig = commit.secure_sig.expect("failed to read the signature");
         assert_eq!(&sig, &returned_sig);
 
-        insta::assert_snapshot!(std::str::from_utf8(&sig.sig).unwrap(), @r"
+        insta::assert_snapshot!(str::from_utf8(&sig.sig).unwrap(), @r"
         test sig
         hash=03feb0caccbacce2e7b7bca67f4c82292dd487e669ed8a813120c9f82d3fd0801420a1f5d05e1393abfe4e9fc662399ec4a9a1898c5f1e547e0044a52bd4bd29
         ");
-        insta::assert_snapshot!(std::str::from_utf8(&sig.data).unwrap(), @r"
+        insta::assert_snapshot!(str::from_utf8(&sig.data).unwrap(), @r"
         tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
         author Someone <someone@example.com> 0 +0000
         committer Someone <someone@example.com> 0 +0000

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -69,13 +69,12 @@ impl GitIgnoreFile {
     ) -> Result<Arc<Self>, GitIgnoreError> {
         let mut builder = gitignore::GitignoreBuilder::new(prefix);
         for (i, input_line) in input.split(|b| *b == b'\n').enumerate() {
-            let line =
-                std::str::from_utf8(input_line).map_err(|err| GitIgnoreError::InvalidUtf8 {
-                    path: ignore_path.to_path_buf(),
-                    line_num_for_display: i + 1,
-                    line: String::from_utf8_lossy(input_line).to_string(),
-                    source: err,
-                })?;
+            let line = str::from_utf8(input_line).map_err(|err| GitIgnoreError::InvalidUtf8 {
+                path: ignore_path.to_path_buf(),
+                line_num_for_display: i + 1,
+                line: String::from_utf8_lossy(input_line).to_string(),
+                source: err,
+            })?;
             // The `from` argument doesn't provide any diagnostics or correctness, so it is
             // not required. It only allows retrieving the path from the `Glob` later, which
             // we never do.

--- a/lib/src/gpg_signing.rs
+++ b/lib/src/gpg_signing.rs
@@ -21,7 +21,6 @@ use std::io::Write as _;
 use std::process::Command;
 use std::process::ExitStatus;
 use std::process::Stdio;
-use std::str;
 
 use thiserror::Error;
 

--- a/lib/src/test_signing_backend.rs
+++ b/lib/src/test_signing_backend.rs
@@ -56,7 +56,7 @@ impl SigningBackend for TestSigningBackend {
         else {
             return Err(SignError::InvalidSignatureFormat);
         };
-        let key = (!key.is_empty()).then_some(std::str::from_utf8(key).unwrap().to_owned());
+        let key = (!key.is_empty()).then_some(str::from_utf8(key).unwrap().to_owned());
 
         let sig = self.sign(data, key.as_deref())?;
         if sig == signature {

--- a/lib/tests/test_fix.rs
+++ b/lib/tests/test_fix.rs
@@ -84,7 +84,7 @@ fn fix_file(store: &Store, file_to_fix: &FileToFix) -> Result<Option<FileId>, Fi
             .unwrap();
         Ok(Some(new_file_id))
     } else if let Some(rest) = old_content.strip_prefix(b"error:") {
-        Err(make_fix_content_error(std::str::from_utf8(rest).unwrap()))
+        Err(make_fix_content_error(str::from_utf8(rest).unwrap()))
     } else {
         Ok(None)
     }


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
