### PR TITLE
bisect: Make bisect able to search for first good/bad revision in the range

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -291,9 +291,11 @@ Uses binary search to find the first bad revision. Revisions are evaluated by ru
 
 It is assumed that if a given revision is bad, then all its descendants in the input range are also bad.
 
+The target of the bisection can be inverted to look for the first good revision by passing `--find-good`.
+
 Hint: You can pass your shell as evaluation command. You can then run manual tests in the shell and make sure to exit the shell with appropriate error code depending on the outcome (e.g. `exit 0` to mark the revision as good in Bash or Fish).
 
-**Usage:** `jj bisect run --range <REVSETS> --command <COMMAND>`
+**Usage:** `jj bisect run [OPTIONS] --range <REVSETS> --command <COMMAND>`
 
 ###### **Options:**
 
@@ -305,6 +307,11 @@ Hint: You can pass your shell as evaluation command. You can then run manual tes
    The command will be run from the workspace root. The exit status of the command will be used to mark revisions as good or bad: status 0 means good, 125 means to skip the revision, 127 (command not found) will abort the bisection, and any other non-zero exit status means the revision is bad.
 
    The target's commit ID is available to the command in the `$JJ_BISECT_TARGET` environment variable.
+* `--find-good` — Whether to find the first good revision instead
+
+   Inverts the interpretation of exit statuses (excluding special exit statuses).
+
+  Default value: `false`
 
 
 

--- a/lib/src/bisect.rs
+++ b/lib/src/bisect.rs
@@ -48,6 +48,20 @@ pub enum Evaluation {
     Skip,
 }
 
+impl Evaluation {
+    /// Maps the current evaluation to its inverse.
+    ///
+    /// Maps `Good`->`Bad`, `Bad`->`Good`, and keeps `Skip` as is.
+    pub fn invert(self) -> Self {
+        use Evaluation::*;
+        match self {
+            Good => Bad,
+            Bad => Good,
+            Skip => Skip,
+        }
+    }
+}
+
 /// Performs bisection to find the first bad commit in a range.
 pub struct Bisector<'repo> {
     repo: &'repo dyn Repo,


### PR DESCRIPTION
Inverting the condition for `jj bisect run` can be useful in cases where you might look for "when was this thing created" using `grep`/`ls` or similar. In such cases you are looking for when the check turned good.

The motivation for this is that inverting the exit code of a program is cumbersome, and even worse error-prone considering that `jj` places special consideration on some exit codes. So doing a naive thing that maps all >0 errors to 0 loses information that `jj` would have used.

I added very basic tests, not sure how much more valuable additional tests would be. If the existing bisect tests are at some point extended with more complicated cases a corresponding inverted test could be added.

# Checklist

If applicable:

- [ ] ~~I have updated `CHANGELOG.md`~~ The existing thing is fine.
      
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes