### PR TITLE
docs: Update code font to one that supports the log symbols

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,10 @@ theme:
     - content.tabs.link
     - navigation.instant
 
+  font:
+    # This has the relevant symbols used in the log.
+    code: Google Sans Code
+
   icon:
     repo: fontawesome/brands/github
     edit: material/pencil


### PR DESCRIPTION
One of the few fonts I found on Google Fonts that played well with the symbols, especially the diamond.

Here is how things look after the font change:

<img width="717" height="197" alt="image" src="https://github.com/user-attachments/assets/c7c75201-adc9-4fe5-beea-234f5863ff7e" />
<img width="601" height="282" alt="image" src="https://github.com/user-attachments/assets/c49435f2-1551-49ea-af7a-187cbcf5012b" />