### PR TITLE
docs: Update tutorial hint to better reflect current state

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,10 +1,11 @@
 # Tutorial
 
-> **Hint:** This tutorial has become somewhat out of date. Many people find
-> the alternative (not quite finished) [tutorial by Steve
-> Klabnik](https://steveklabnik.github.io/jujutsu-tutorial/) helpful.
-> If you're looking for a tutorial that doesn't require experience with Git,
-> take a look at [Jujutsu for everyone](https://jj-for-everyone.github.io).
+> **Hint:** This tutorial covers the basics accurately, but since it was
+> written Jujutsu has gained many new features. For a tutorial covering a wider
+> range of features, you may find the (not quite finished) [tutorial by Steve
+> Klabnik](https://steveklabnik.github.io/jujutsu-tutorial/) helpful. If you're
+> looking for a tutorial that doesn't require experience with Git, take a look
+> at [Jujutsu for everyone](https://jj-for-everyone.github.io).
 
 This text assumes that the reader is familiar with Git.
 


### PR DESCRIPTION
I had some people getting the feeling that the tutorials page is inaccurate because of the current hint, when the truth is that the content is accurate but some newer features aren't covered.