### PR TITLE
fixes #7602: calling `jj metaedit --author-timestamp` twice should not edit twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj metaedit --author-timestamp` twice with the same value no longer
+edits the change twice in some cases.
+
 ## [0.34.0] - 2025-10-01
 
 ### Release highlights

--- a/cli/src/commands/metaedit.rs
+++ b/cli/src/commands/metaedit.rs
@@ -175,7 +175,8 @@ pub(crate) fn cmd_metaedit(
                 // changes.
                 if new_author.name != old_author.name
                     || new_author.email != old_author.email
-                    || new_author.timestamp != commit_builder.author().timestamp
+                    || (new_author.timestamp != commit_builder.author().timestamp
+                        && new_author.timestamp != old_author.timestamp)
                 {
                     commit_builder = commit_builder.set_author(new_author);
                     has_changes = true;

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -485,6 +485,42 @@ fn test_update_empty_author() {
     ");
 }
 
+#[test]
+/// Test that setting the same timestamp twice does nothing (issue #7602)
+fn test_metaedit_set_same_timestamp_twice() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Set the author-timestamp to the same value twice
+    // and check that the second time it does nothing
+    let output = work_dir.run_jj([
+        "metaedit",
+        "--author-timestamp",
+        "2001-02-03 04:05:14.000+07:00",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Modified 1 commits:
+      qpvuntsm 51b97b23 (empty) (no description set)
+    Working copy  (@) now at: qpvuntsm 51b97b23 (empty) (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ");
+
+    // Running it again with the same date has no effect
+    let output = work_dir.run_jj([
+        "metaedit",
+        "--author-timestamp",
+        "2001-02-03 04:05:14.000+07:00",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+}
+
 #[must_use]
 fn get_log(work_dir: &TestWorkDir) -> CommandOutput {
     work_dir.run_jj([


### PR DESCRIPTION
I also added a test. I made a separate test case because that's how I was able to reproduce the issue.

# Checklist

If applicable:

- [x ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ x] I have added/updated tests to cover my changes
