### PR TITLE
templates: add remote and `*` to bookmarks in `builtin_log_redacted`

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1754,6 +1754,14 @@ fn builtin_commit_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
             Ok(out_property.into_dyn_wrapped())
         },
     );
+    map.insert(
+        "synced",
+        |_language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let out_property = self_property.map(|commit_ref| commit_ref.synced);
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
     map
 }
 

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -452,7 +452,13 @@ separate(" ",
   format_short_change_id_with_hidden_and_divergent_info(commit),
   label("author", format_user_redacted(commit.author())),
   format_timestamp(commit_timestamp(commit)),
-  commit.bookmarks().map(|bookmark| concat("bookmark-", hash(bookmark.name()).substr(0, 4))),
+  commit.bookmarks().map(|bookmark| concat(
+    "bookmark-", hash(bookmark.name()).substr(0, 4),
+    if(bookmark.remote(),
+      "@remote-" ++ hash(bookmark.remote()).substr(0, 4),
+      if(!bookmark.synced(), "*")
+    )
+  )),
   commit.tags().map(|tag| concat("tag-", hash(tag.name()).substr(0, 4))),
   commit.working_copies(),
   if(commit.git_head(), label("git_head", "git_head()")),

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1690,20 +1690,38 @@ fn test_log_full_description_template() {
 #[test]
 fn test_log_anonymize() {
     let test_env = TestEnvironment::default();
-    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let work_dir = test_env.work_dir("repo");
 
-    work_dir
+    test_env.run_jj_in(".", ["git", "init", "origin"]).success();
+    let origin_dir = test_env.work_dir("origin");
+    let origin_git_repo = origin_dir.root().join(".jj/repo/store/git");
+    let origin_git_repo = origin_git_repo.to_str().unwrap();
+    origin_dir
         .run_jj([
             "describe",
             "-m",
             "this is commit with a multiline description\n\n<full description>",
         ])
         .success();
+    origin_dir
+        .run_jj(["bookmark", "create", "-r@", "b1", "b2", "b3"])
+        .success();
+    origin_dir.run_jj(["git", "export"]).success();
 
-    let output = work_dir.run_jj(["log", "-Tbuiltin_log_redacted"]);
+    test_env
+        .run_jj_in(".", ["git", "clone", origin_git_repo, "local"])
+        .success();
+    let work_dir = test_env.work_dir("local");
+    work_dir
+        .run_jj(["bookmark", "track", "b1@origin", "b2@origin"])
+        .success();
+    work_dir.run_jj(["new", "b1"]).success();
+    work_dir.run_jj(["bookmark", "move", "b1", "-t@"]).success();
+
+    let output = work_dir.run_jj(["log", "-r::", "-Tbuiltin_log_redacted"]);
     insta::assert_snapshot!(output, @r"
-    @  qpvuntsm user-78cd 2001-02-03 08:05:08 37b69cda
+    @  yqosqzyt user-78cd 2001-02-03 08:05:13 bookmark-dc8b* de3c47af
+    │  (empty) (redacted)
+    ◆  qpvuntsm user-78cd 2001-02-03 08:05:08 bookmark-dc8b@remote-86e9 bookmark-56f1 bookmark-ff9e@remote-86e9 37b69cda
     │  (empty) (redacted)
     ◆  zzzzzzzz root() 00000000
     [EOF]

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -221,6 +221,9 @@ The following methods are defined.
   local ref.
 * `.tracking_behind_count() -> SizeHint`: Number of commits behind of the
   tracking local ref.
+* `.synced() -> Boolean`: For a local bookmark, true if synced with all tracked
+  remotes. For a remote bookmark, true if synced with the tracking local
+  bookmark.
 
 ### `ConfigValue` type
 


### PR DESCRIPTION
Remote names are potentially sensitive? Unsure, so better to redact them.

For getting the "*": This could have been done without modifying the Rust side, with e.g. `stringify(bookmark).ends_with("*")`. However, this feels brittle.

With adding `.synced()` to the template language, bookmark formatting _could_ be done entirely in templates now. I don't know if that's desired, so leaving for a potential future commmit.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
