### PR TITLE
docs: update default-description to be more concise

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -189,11 +189,7 @@ object](templates.md#commit-type).
 [templates]
 draft_commit_description = '''
 concat(
-  coalesce(description, default_commit_description, "\n"),
-  surround(
-    "\nJJ: This commit contains the following changes:\n", "",
-    indent("JJ:     ", diff.stat(72)),
-  ),
+  builtin_draft_commit_description,
   "\nJJ: ignore-rest\n",
   diff.git(),
 )


### PR DESCRIPTION
Update `draft_commit_description` since a) we can use `separate` instead of `concat` to handle joining newlines and b) `builtin_draft_commit_description` already coalesces the description and includes the diff stats.

# Checklist

If applicable:

- [ ] ~~I have updated `CHANGELOG.md`~~
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] ~~I have updated the config schema (`cli/src/config-schema.json`)~~
- [ ] ~~I have added/updated tests to cover my changes~~