### PR TITLE
cli: log `-G` is now the short form of `--no-graph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj log -G` is now available as a short form of `jj log --no-graph`.
+
 ### Fixed bugs
 
 ## [0.34.0] - 2025-10-01

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -94,7 +94,7 @@ pub(crate) struct LogArgs {
     #[arg(long)]
     reversed: bool,
     /// Don't show the graph, show a flat list of revisions
-    #[arg(long)]
+    #[arg(long, short = 'G')]
     no_graph: bool,
     /// Render each revision using the given template
     ///

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1649,7 +1649,7 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
    Applied after revisions are filtered and reordered topologically, but before being reversed.
 * `--reversed` — Show revisions in the opposite order (older revisions first)
-* `--no-graph` — Don't show the graph, show a flat list of revisions
+* `-G`, `--no-graph` — Don't show the graph, show a flat list of revisions
 * `-T`, `--template <TEMPLATE>` — Render each revision using the given template
 
    Run `jj log -T` to list the built-in templates.

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -113,6 +113,15 @@ fn test_log_with_or_without_diff() {
     [EOF]
     ");
 
+    // `-G` is the short name of --no-graph
+    let output = work_dir.run_jj(["log", "-T", r#"commit_id.short() ++ "\n""#, "-G"]);
+    insta::assert_snapshot!(output, @r"
+    58c940c45833
+    007859d3ad71
+    000000000000
+    [EOF]
+    ");
+
     // `-p` for default diff output, `-s` for summary
     let output = work_dir.run_jj(["log", "-T", "description", "-p", "-s"]);
     insta::assert_snapshot!(output, @r"


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes

Fixes #7638