### PR TITLE
template: add string `split` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Templates now support a `.split(separator, [limit])` method on strings to
+  split a string into a list of substrings.
+
 * `jj log -G` is now available as a short form of `jj log --no-graph`.
 
 * `jj metaedit` now accepts `-m`/`--message` option to non-interactively update

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -445,6 +445,10 @@ defined.
   Supports capture groups in patterns using `$0` (entire match), `$1`, `$2` etc.
 * `.first_line() -> String`
 * `.lines() -> List<String>`: Split into lines excluding newline characters.
+* `.split(separator: StringPattern, [limit: Integer]) -> List<String>`: Split into
+  substrings by the given `separator` pattern. If `limit` is specified, it
+  determines the maximum number of elements in the result, with the remainder
+  of the string returned as the final element. A `limit` of 0 returns an empty list.
 * `.upper() -> String`
 * `.lower() -> String`
 * `.starts_with(needle: Stringify) -> Boolean`


### PR DESCRIPTION
Motivated by `@joneshf`'s comment [here](https://github.com/jj-vcs/jj/discussions/6891#discussioncomment-14585371), I was trying to write a `slugify(text)` template alias and wanted to filter out words <3 characters in length, so tried to do something along the lines of...

> `"'aaa  b  ccc  d'.split(regex:'\s+').filter(|s| s.len() > 2).join('-')"`

...only to be surprised that `split` didn't exist.

---

One thing I wasn't sure about is what to do when `limit=0`. That is, should `"a b c".split(" ", limit=0)`:

* Error (i.e. require `limit > 0`)
* Return an empty list (i.e. `[]`)
* Return the original string (i.e. `["a b c"]`)
* Be unlimited, the same as if it wasn't specified at all (i.e. `["a", "b", "c"]`)

#### Go

```go
func main() {
  result := strings.SplitN("a b c", " ", 0)
  fmt.Printf("%#v", result)
}
```

```bash
$ go run main.go
[]string(nil)
```

#### JavaScript

```bash
$ node -p '"a b c".split(" ", 0)'
[]
```

#### Python

```python
$ python3 -c "print('a b c'.split(' ', 0))"
['a b c']
```

#### Ruby

```bash
$ ruby -e "p 'a b c'.split(' ', 0)"
["a", "b", "c"]
```

#### Rust

```rust
fn main() {
    let result: Vec<&str> = "a b c".splitn(0, ' ').collect();
    println!("{:?}", result);
}
```

```bash
$ rustc main.rs && ./main
[]
```