### PR TITLE
config: add workspace-level configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Workspaces may have an additional layered configuration, located at
+  `.jj/workspace-config.toml`. `jj config` subcommands which took layer options like
+  `--repo` now also support `--workspace`.
+
 ### Fixed bugs
 
 ## [0.34.0] - 2025-10-01

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3811,6 +3811,9 @@ impl<'a> CliRunner<'a> {
                 jj_lib::config::migrate(config, &self.config_migrations)?;
             Ok(())
         };
+
+        // Initial load: user, repo, and workspace-level configs for
+        // alias/default-command resolution
         // Use cwd-relative workspace configs to resolve default command and
         // aliases. WorkspaceLoader::init() won't do any heavy lifting other
         // than the path resolution.
@@ -3822,6 +3825,10 @@ impl<'a> CliRunner<'a> {
         if let Ok(loader) = &maybe_cwd_workspace_loader {
             config_env.reset_repo_path(loader.repo_path());
             config_env.reload_repo_config(&mut raw_config)?;
+            // register workspace config config: .jj/workspace-config.toml
+            let ws_conf_dir = loader.workspace_root().join(".jj");
+            config_env.reset_workspace_path(&ws_conf_dir);
+            config_env.reload_workspace_config(&mut raw_config)?;
         }
         let mut config = config_env.resolve_config(&raw_config)?;
         migrate_config(&mut config)?;
@@ -3866,6 +3873,10 @@ impl<'a> CliRunner<'a> {
                 .map_err(|err| map_workspace_load_error(err, Some(path)))?;
             config_env.reset_repo_path(loader.repo_path());
             config_env.reload_repo_config(&mut raw_config)?;
+            // update workspace path too
+            let ws_conf_dir = loader.workspace_root().join(".jj");
+            config_env.reset_workspace_path(&ws_conf_dir);
+            config_env.reload_workspace_config(&mut raw_config)?;
             Ok(loader)
         } else {
             maybe_cwd_workspace_loader
@@ -3883,6 +3894,7 @@ impl<'a> CliRunner<'a> {
                 ConfigSource::EnvBase | ConfigSource::EnvOverrides => "environment-provided",
                 ConfigSource::User => "user-level",
                 ConfigSource::Repo => "repo-level",
+                ConfigSource::Workspace => "workspace-level",
                 ConfigSource::CommandArg => "CLI-provided",
             };
             writeln!(

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -54,6 +54,10 @@ pub(crate) struct ConfigLevelArgs {
     /// Target the repo-level config
     #[arg(long)]
     repo: bool,
+
+    /// Target the workspace-level config
+    #[arg(long)]
+    workspace: bool,
 }
 
 impl ConfigLevelArgs {
@@ -62,6 +66,8 @@ impl ConfigLevelArgs {
             Some(ConfigSource::User)
         } else if self.repo {
             Some(ConfigSource::Repo)
+        } else if self.workspace {
+            Some(ConfigSource::Workspace)
         } else {
             None
         }
@@ -79,6 +85,11 @@ impl ConfigLevelArgs {
                 .repo_config_path()
                 .map(|p| vec![p])
                 .ok_or_else(|| user_error("No repo config path found"))
+        } else if self.workspace {
+            config_env
+                .workspace_config_path()
+                .map(|p| vec![p])
+                .ok_or_else(|| user_error("No workspace config path found"))
         } else {
             panic!("No config_level provided")
         }
@@ -115,6 +126,11 @@ impl ConfigLevelArgs {
             pick_one(
                 config_env.repo_config_files(config)?,
                 "No repo config path found to edit",
+            )
+        } else if self.workspace {
+            pick_one(
+                config_env.workspace_config_files(config)?,
+                "No workspace config path found to edit",
             )
         } else {
             panic!("No config_level provided")

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -373,8 +373,10 @@ impl UnresolvedConfigEnv {
 pub struct ConfigEnv {
     home_dir: Option<PathBuf>,
     repo_path: Option<PathBuf>,
+    workspace_path: Option<PathBuf>,
     user_config_paths: Vec<ConfigPath>,
     repo_config_path: Option<ConfigPath>,
+    workspace_config_path: Option<ConfigPath>,
     command: Option<String>,
 }
 
@@ -418,8 +420,10 @@ impl ConfigEnv {
         Self {
             home_dir,
             repo_path: None,
+            workspace_path: None,
             user_config_paths: env.resolve(ui),
             repo_config_path: None,
+            workspace_config_path: None,
             command: None,
         }
     }
@@ -538,6 +542,61 @@ impl ConfigEnv {
         Ok(())
     }
 
+    /// Sets the directory where workspace-specific config file is stored. The
+    /// path is usually `.jj/workspace/config.toml`.
+    pub fn reset_workspace_path(&mut self, path: &Path) {
+        self.workspace_path = Some(path.to_owned());
+        self.workspace_config_path = Some(ConfigPath::new(path.join("workspace-config.toml")));
+    }
+
+    /// Returns a path to the workspace-specific config file.
+    pub fn workspace_config_path(&self) -> Option<&Path> {
+        self.workspace_config_path.as_ref().map(|p| p.as_path())
+    }
+
+    /// Returns a path to the existing workspace-specific config file.
+    fn existing_workspace_config_path(&self) -> Option<&Path> {
+        match self.workspace_config_path {
+            Some(ref path) if path.exists() => Some(path.as_path()),
+            _ => None,
+        }
+    }
+
+    /// Returns workspace configuration files for modification. Instantiates one
+    /// if `config` has no workspace configuration layers.
+    ///
+    /// If the workspace path is unknown, this function returns an empty `Vec`.
+    /// Since the workspace config path cannot be a directory, the returned
+    /// `Vec` should have at most one config file.
+    pub fn workspace_config_files(
+        &self,
+        config: &RawConfig,
+    ) -> Result<Vec<ConfigFile>, ConfigLoadError> {
+        config_files_for(config, ConfigSource::Workspace, || {
+            self.new_workspace_config_file()
+        })
+    }
+
+    fn new_workspace_config_file(&self) -> Result<Option<ConfigFile>, ConfigLoadError> {
+        self.workspace_config_path()
+            .map(|path| {
+                // Load or create empty config file
+                ConfigFile::load_or_empty(ConfigSource::Workspace, path)
+            })
+            .transpose()
+    }
+
+    /// Loads workspace-specific config file into the given `config`. The old
+    /// workspace-config layer will be replaced if any.
+    #[instrument]
+    pub fn reload_workspace_config(&self, config: &mut RawConfig) -> Result<(), ConfigLoadError> {
+        config.as_mut().remove_layers(ConfigSource::Workspace);
+        if let Some(path) = self.existing_workspace_config_path() {
+            config.as_mut().load_file(ConfigSource::Workspace, path)?;
+        }
+        Ok(())
+    }
+
     /// Resolves conditional scopes within the current environment. Returns new
     /// resolved config.
     pub fn resolve_config(&self, config: &RawConfig) -> Result<StackedConfig, ConfigGetError> {
@@ -575,7 +634,7 @@ fn config_files_for(
 /// 2. Base environment variables
 /// 3. [User configs](https://jj-vcs.github.io/jj/latest/config/)
 /// 4. Repo config `.jj/repo/config.toml`
-/// 5. TODO: Workspace config `.jj/config.toml`
+/// 5. Workspace config `.jj/workspace-config.toml`
 /// 6. Override environment variables
 /// 7. Command-line arguments `--config` and `--config-file`
 ///
@@ -1812,8 +1871,10 @@ mod tests {
         ConfigEnv {
             home_dir,
             repo_path: None,
+            workspace_path: None,
             user_config_paths: env.resolve(&Ui::null()),
             repo_config_path: None,
+            workspace_config_path: None,
             command: None,
         }
     }

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -145,6 +145,7 @@ fn warn_user_redefined_builtin(
         ConfigSource::EnvBase
         | ConfigSource::User
         | ConfigSource::Repo
+        | ConfigSource::Workspace
         | ConfigSource::EnvOverrides
         | ConfigSource::CommandArg => {
             let checked_mutability_builtins =

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -637,7 +637,7 @@ Start an editor on a jj config file.
 
 Creates the file if it doesn't already exist regardless of what the editor does.
 
-**Usage:** `jj config edit <--user|--repo>`
+**Usage:** `jj config edit <--user|--repo|--workspace>`
 
 **Command Alias:** `e`
 
@@ -645,6 +645,7 @@ Creates the file if it doesn't already exist regardless of what the editor does.
 
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
+* `--workspace` — Target the workspace-level config
 
 
 
@@ -688,6 +689,7 @@ List variables set in config files, along with their values
 * `--include-overridden` — Allow printing overridden values
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
+* `--workspace` — Target the workspace-level config
 * `-T`, `--template <TEMPLATE>` — Render each variable using the given template
 
    The following keywords are available in the template expression:
@@ -717,7 +719,7 @@ A config file at that path may or may not exist.
 
 See `jj config edit` if you'd like to immediately edit a file.
 
-**Usage:** `jj config path <--user|--repo>`
+**Usage:** `jj config path <--user|--repo|--workspace>`
 
 **Command Alias:** `p`
 
@@ -725,6 +727,7 @@ See `jj config edit` if you'd like to immediately edit a file.
 
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
+* `--workspace` — Target the workspace-level config
 
 
 
@@ -732,7 +735,7 @@ See `jj config edit` if you'd like to immediately edit a file.
 
 Update a config file to set the given option to a given value
 
-**Usage:** `jj config set <--user|--repo> <NAME> <VALUE>`
+**Usage:** `jj config set <--user|--repo|--workspace> <NAME> <VALUE>`
 
 **Command Alias:** `s`
 
@@ -749,6 +752,7 @@ Update a config file to set the given option to a given value
 
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
+* `--workspace` — Target the workspace-level config
 
 
 
@@ -756,7 +760,7 @@ Update a config file to set the given option to a given value
 
 Update a config file to unset the given option
 
-**Usage:** `jj config unset <--user|--repo> <NAME>`
+**Usage:** `jj config unset <--user|--repo|--workspace> <NAME>`
 
 **Command Alias:** `u`
 
@@ -768,6 +772,7 @@ Update a config file to unset the given option
 
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
+* `--workspace` — Target the workspace-level config
 
 
 

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -260,6 +260,32 @@ fn test_config_list_layer() {
     test-layered-key = "test-layered-val"
     [EOF]
     "#);
+
+    // Workspace (new scope takes precedence over repo)
+    // Add a workspace-level setting
+    work_dir
+        .run_jj([
+            "config",
+            "set",
+            "--workspace",
+            "test-layered-wks-key",
+            "ws-val",
+        ])
+        .success();
+
+    // Listing user shouldn't include workspace
+    let output = work_dir.run_jj(["config", "list", "--user"]);
+    insta::assert_snapshot!(output, @r#"
+    test-key = "test-val"
+    [EOF]
+    "#);
+
+    // Workspace
+    let output = work_dir.run_jj(["config", "list", "--workspace"]);
+    insta::assert_snapshot!(output, @r#"
+    test-layered-wks-key = "ws-val"
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -554,11 +580,11 @@ fn test_config_set_bad_opts() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <--user|--repo>
+      <--user|--repo|--workspace>
       <NAME>
       <VALUE>
 
-    Usage: jj config set <--user|--repo> <NAME> <VALUE>
+    Usage: jj config set <--user|--repo|--workspace> <NAME> <VALUE>
 
     For more information, try '--help'.
     [EOF]
@@ -699,6 +725,31 @@ fn test_config_set_for_repo() {
 
     [test-table]
     foo = true
+    "#);
+}
+
+#[test]
+fn test_config_set_for_workspace() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["workspace", "add", "--name", "second", "../secondary"])
+        .success();
+    let work_dir = test_env.work_dir("secondary");
+
+    // set in workspace
+    work_dir
+        .run_jj(["config", "set", "--workspace", "test-key", "ws-val"])
+        .success();
+
+    // Read workspace config
+    let workspace_config = work_dir.read_file(".jj/workspace-config.toml");
+    insta::assert_snapshot!(workspace_config, @r#"
+    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+
+    test-key = "ws-val"
     "#);
 }
 
@@ -915,15 +966,39 @@ fn test_config_unset_for_repo() {
 }
 
 #[test]
+fn test_config_unset_for_workspace() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["workspace", "add", "--name", "second", "../secondary"])
+        .success();
+    let work_dir = test_env.work_dir("secondary");
+
+    // set then unset
+    work_dir
+        .run_jj(["config", "set", "--workspace", "foo", "bar"])
+        .success();
+    work_dir
+        .run_jj(["config", "unset", "--workspace", "foo"])
+        .success();
+
+    // Ensure workspace config has only schema
+    let workspace_config = work_dir.read_file(".jj/workspace-config.toml");
+    insta::assert_snapshot!(workspace_config, @"");
+}
+
+#[test]
 fn test_config_edit_missing_opt() {
     let test_env = TestEnvironment::default();
     let output = test_env.run_jj_in(".", ["config", "edit"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <--user|--repo>
+      <--user|--repo|--workspace>
 
-    Usage: jj config edit <--user|--repo>
+    Usage: jj config edit <--user|--repo|--workspace>
 
     For more information, try '--help'.
     [EOF]

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,10 @@ config path --user`.
 - The repo settings. These can be edited with `jj config edit --repo` and are
 located in `.jj/repo/config.toml`.
 
+- The workspace settings. These can be edited with `jj config edit --workspace`
+and are located in `.jj/workspace-config.toml` in the workspace root. The first working
+directory created in a fresh `jj` repo is itself a workspace.
+
 - Settings [specified in the command-line](#specifying-config-on-the-command-line).
 
 These are listed in the order they are loaded; the settings from earlier items

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -288,6 +288,8 @@ pub enum ConfigSource {
     User,
     /// Repo configuration files.
     Repo,
+    /// Workspace configuration files.
+    Workspace,
     /// Override environment variables.
     EnvOverrides,
     /// Command-line arguments (which has the highest precedence.)
@@ -301,6 +303,7 @@ impl Display for ConfigSource {
             Default => "default",
             User => "user",
             Repo => "repo",
+            Workspace => "workspace",
             CommandArg => "cli",
             EnvBase | EnvOverrides => "env",
         };


### PR DESCRIPTION
- Added support for workspace-specific configuration using `jj config` commands.
- Introduced `--workspace` option to `jj config edit`, `jj config set`, and `jj config unset`.
- Workspace configuration file is stored in `.jj/workspace-config.toml` per workspace.
- Simplified workspace path handling logic.
- Updated documentation and test snapshots to reflect new behavior.

This improves flexibility for users working across multiple workspaces.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
