### PR TITLE
changelog: Update links for v0.34.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4032,7 +4032,8 @@ No changes, only trying to get the automated build to work.
 Last release before this changelog started.
 
 
-[unreleased]: https://github.com/jj-vcs/jj/compare/v0.33.0...HEAD
+[unreleased]: https://github.com/jj-vcs/jj/compare/v0.34.0...HEAD
+[0.34.0]: https://github.com/jj-vcs/jj/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/jj-vcs/jj/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/jj-vcs/jj/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/jj-vcs/jj/compare/v0.30.0...v0.31.0


### PR DESCRIPTION
I was updating the changelog for another PR and noticed that the links were out of sync.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
