### PR TITLE
github: bump runners to `macos-15` across the board

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -28,10 +28,10 @@ jobs:
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-gnu
         - build: macos-x86_64
-          os: macos-13
+          os: macos-15
           target: x86_64-apple-darwin
         - build: macos-aarch64
-          os: macos-14
+          os: macos-15
           target: aarch64-apple-darwin
         - build: win-x86_64
           os: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
           os: ubuntu-24.04-arm
           cargo_flags: "--all-features"
         - build: macos-x86_64
-          os: macos-13
+          os: macos-15
           cargo_flags: ""
         - build: macos-aarch64
-          os: macos-14
+          os: macos-15
           cargo_flags: ""
         - build: windows-x86_64
           os: windows-2022

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-musl
         - build: macos-x86_64
-          os: macos-13
+          os: macos-15
           target: x86_64-apple-darwin
         - build: macos-aarch64
-          os: macos-14
+          os: macos-15
           target: aarch64-apple-darwin
         - build: win-x86_64
           os: windows-2022


### PR DESCRIPTION
We'll need to move off macos-13 soon anyway as those machines will get removed.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
