### PR TITLE
github: bump CI timer, again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,12 @@ jobs:
     # is a problem we should fix. in the mean time, this will make these flakes
     # less harmful, as it won't cause builds to spin for multiple hours, requiring
     # manual cancellation.
-    timeout-minutes: 20
+    #
+    # keep a log of updates (along with committed date) below:
+    #
+    # 2025-03-20 (aseipp): peak p99 builds seemed to be long, bump 15m -> 20m
+    # 2025-10-06 (aseipp): x86 macos runners consistently slower, bump 20m -> 25m
+    timeout-minutes: 25
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8


### PR DESCRIPTION
This also includes a note on the last time I did it, so anyone who has to regrettably trudge through the CI configuration can read it and see why.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
