### PR TITLE
cli: Split `jj squash` into `jj squash` and `jj amend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tags. These keywords may be useful in non-colocated Git repositories where
   local and exported `@git` tags can point to different revisions.
 
+* `jj amend` moves diffs between revisions, (similar to squash)
+
 ### Fixed bugs
 
 * `jj metaedit --author-timestamp` twice with the same value no longer

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -108,6 +108,7 @@ enum Command {
     Describe(describe::DescribeArgs),
     Diff(diff::DiffArgs),
     Diffedit(diffedit::DiffeditArgs),
+    Amend(squash::AmendArgs),
     Duplicate(duplicate::DuplicateArgs),
     Edit(edit::EditArgs),
     #[command(alias = "obslog", visible_alias = "evolution-log")]
@@ -180,6 +181,11 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Describe(args) => describe::cmd_describe(ui, command_helper, args),
         Command::Diff(args) => diff::cmd_diff(ui, command_helper, args),
         Command::Diffedit(args) => diffedit::cmd_diffedit(ui, command_helper, args),
+        Command::Amend(args) => squash::cmd_squash_or_amend(
+            ui,
+            command_helper,
+            squash::SquashOrAmendArgs::AmendArgs(args),
+        ),
         Command::Duplicate(args) => duplicate::cmd_duplicate(ui, command_helper, args),
         Command::Edit(args) => edit::cmd_edit(ui, command_helper, args),
         Command::Evolog(args) => evolog::cmd_evolog(ui, command_helper, args),
@@ -212,7 +218,11 @@ pub fn run_command(ui: &mut Ui, command_helper: &CommandHelper) -> Result<(), Co
         Command::Sign(args) => sign::cmd_sign(ui, command_helper, args),
         Command::Sparse(args) => sparse::cmd_sparse(ui, command_helper, args),
         Command::Split(args) => split::cmd_split(ui, command_helper, args),
-        Command::Squash(args) => squash::cmd_squash(ui, command_helper, args),
+        Command::Squash(args) => squash::cmd_squash_or_amend(
+            ui,
+            command_helper,
+            squash::SquashOrAmendArgs::SquashArgs(args),
+        ),
         Command::Status(args) => status::cmd_status(ui, command_helper, args),
         Command::Tag(args) => tag::cmd_tag(ui, command_helper, args),
         Command::Undo(args) => undo::cmd_undo(ui, command_helper, args),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -36,6 +36,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj describe`↴](#jj-describe)
 * [`jj diff`↴](#jj-diff)
 * [`jj diffedit`↴](#jj-diffedit)
+* [`jj amend`↴](#jj-amend)
 * [`jj duplicate`↴](#jj-duplicate)
 * [`jj edit`↴](#jj-edit)
 * [`jj evolog`↴](#jj-evolog)
@@ -141,6 +142,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
 * `describe` — Update the change description or other metadata [default alias: desc]
 * `diff` — Compare file contents between two revisions
 * `diffedit` — Touch up the content changes in a revision with a diff editor
+* `amend` — Move changes from a revision into another revision
 * `duplicate` — Create new changes with the same content as existing ones
 * `edit` — Sets the specified revision as the working-copy revision
 * `evolog` — Show how a change has evolved over time
@@ -168,7 +170,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
 * `simplify-parents` — Simplify parent edges for the specified revision(s)
 * `sparse` — Manage which paths from the working-copy commit are present in the working copy
 * `split` — Split a revision in two
-* `squash` — Move changes from a revision into another revision
+* `squash` — Combine revisions by moving changes from a revision into another revision
 * `status` — Show high-level repo status [default alias: st]
 * `tag` — Manage tags
 * `undo` — Undo the last operation
@@ -906,6 +908,35 @@ See `jj restore` if you want to move entire files from one revision to another. 
 * `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
 
    When rebasing a descendant on top of the rewritten revision, its diff compared to its parent(s) is normally preserved, i.e. the same way that descendants are always rebased. This flag makes it so the content/state is preserved instead of preserving the diff.
+
+
+
+## `jj amend`
+
+Move changes from a revision into another revision
+
+With the `-r` option, moves the changes from the specified revision to the parent revision. Fails if there are several parent revisions (i.e., the given revision is a merge).
+
+With the `--from` and/or `--into` options, moves changes from/to the given revisions. If either is left out, it defaults to the working-copy commit. For example, `jj squash --into @--` moves changes from the working-copy commit to the grandparent.
+
+EXPERIMENTAL FEATURES
+
+An alternative squashing UI is available via the `-d`, `-A`, and `-B` options. They can be used together with one or more `--from` options (if no `--from` is specified, `--from @` is assumed).
+
+**Usage:** `jj amend [OPTIONS] [FILESETS]...`
+
+###### **Arguments:**
+
+* `<FILESETS>` — Move only changes to these paths (instead of all paths)
+
+###### **Options:**
+
+* `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @). Incompatible with the experimental `-d`/`-A`/`-B` options
+* `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
+* `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
+* `-i`, `--interactive` — Interactively choose which parts to squash
+* `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
+* `-m`, `--message <MESSAGE>` — The description to overwrite for the destination revision
 
 
 
@@ -2715,13 +2746,15 @@ Splitting an empty commit is not supported because the same effect can be achiev
 
 ## `jj squash`
 
-Move changes from a revision into another revision
+Combine revisions by moving changes from a revision into another revision.
+
+Note: If you aren't trying to merge the revision metadata (eg. description, bookmarks), or if you want to do a partial squash, you probably want `jj amend`.
 
 With the `-r` option, moves the changes from the specified revision to the parent revision. Fails if there are several parent revisions (i.e., the given revision is a merge).
 
 With the `--from` and/or `--into` options, moves changes from/to the given revisions. If either is left out, it defaults to the working-copy commit. For example, `jj squash --into @--` moves changes from the working-copy commit to the grandparent.
 
-If, after moving changes out, the source revision is empty compared to its parent(s), and `--keep-emptied` is not set, it will be abandoned. Without `--interactive` or paths, the source revision will always be empty.
+If, after moving changes out, the source revision is empty compared to its parent(s), it will be abandoned. Without `--interactive` or paths, the source revision will always be empty.
 
 If the source was abandoned and both the source and destination had a non-empty description, you will be asked for the combined description. If either was empty, then the other one will be used.
 
@@ -2742,13 +2775,13 @@ An alternative squashing UI is available via the `-d`, `-A`, and `-B` options. T
 * `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @). Incompatible with the experimental `-d`/`-A`/`-B` options
 * `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
 * `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
+* `-i`, `--interactive` — Interactively choose which parts to squash
+* `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
+* `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
+* `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
 * `-d`, `--destination <REVSETS>` — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — (Experimental) The revision(s) to insert the new commit after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — (Experimental) The revision(s) to insert the new commit before (can be repeated to create a merge commit)
-* `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
-* `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
-* `-i`, `--interactive` — Interactively choose which parts to squash
-* `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-k`, `--keep-emptied` — The source revision will not be abandoned
 
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -362,7 +362,7 @@ fn test_squash_partial() {
 }
 
 #[test]
-fn test_squash_keep_emptied() {
+fn test_amend() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -391,22 +391,22 @@ fn test_squash_keep_emptied() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["squash", "-r", "b", "--keep-emptied"]);
-    insta::assert_snapshot!(output, @r"
+    let output = work_dir.run_jj(["amend", "-r", "b", "-m", "foo"]);
+    insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: mzvwutvl 093590e0 c | (no description set)
-    Parent commit (@-)      : kkmpptxz 357946cf b | (empty) (no description set)
+    Working copy  (@) now at: mzvwutvl b34c7e04 c | (no description set)
+    Parent commit (@-)      : kkmpptxz 4d5527a5 b | (empty) (no description set)
     [EOF]
-    ");
-    // With --keep-emptied, b remains even though it is now empty.
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @  093590e044bd c
-    ○  357946cf85df b (empty)
-    ○  2269fb3b12f5 a
+    "###);
+    // With amend b remains even though it is now empty.
+    insta::assert_snapshot!(get_log_output(&work_dir), @r###"
+    @  b34c7e040136 c
+    ○  4d5527a53208 b (empty)
+    ○  f2c844473038 a foo
     ◆  000000000000 (empty)
     [EOF]
-    ");
+    "###);
     let output = work_dir.run_jj(["file", "show", "file1", "-r", "a"]);
     insta::assert_snapshot!(output, @r"
     b


### PR DESCRIPTION
As has been discussed in several places, `jj squash` is a very complicated command that can do many things.

`jj movediff` is much simpler to explain ("moves diffs from one commit to another").

It is implemented in terms of squash because the difference between the two is more semantic than programatic.

In the future, we *may* consider removing the ability for squash to operate on individual files, but that is still hotly debated.

This works towards #7465

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
