### PR TITLE
templater: remove unneeded special case from string.split() method

### DIFF
--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1052,15 +1052,11 @@ fn builtin_string_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
                 let out_property =
                     (self_property, limit_property).and_then(move |(haystack, limit)| {
                         let haystack_bytes = haystack.as_bytes();
-                        if limit == 0 {
-                            Ok(vec![])
-                        } else {
-                            let parts: Vec<_> = regex
-                                .splitn(haystack_bytes, limit)
-                                .map(|part| str::from_utf8(part).map(|s| s.to_owned()))
-                                .try_collect()?;
-                            Ok(parts)
-                        }
+                        let parts: Vec<_> = regex
+                            .splitn(haystack_bytes, limit)
+                            .map(|part| str::from_utf8(part).map(|s| s.to_owned()))
+                            .try_collect()?;
+                        Ok(parts)
                     });
                 Ok(out_property.into_dyn_wrapped())
             } else {


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
