### PR TITLE
config: default time range template is now absolute localtime + duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   directly as positional arguments, such as
   `jj bisect --range=..main -- cargo check --all-targets`.
 
+* The default alias for formatting time ranges, used by `jj op log`,
+  now shows the absolute local end time and duration. 
+
 ### Fixed bugs
 
 * `jj metaedit --author-timestamp` twice with the same value no longer

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -332,7 +332,7 @@ commit_summary_separator = 'label("separator", " | ")'
 # the moment when the repo was actually modified due to this operation. TODO:
 # This macro might need a better name, e.g. `format_operation_time_range`.
 'format_time_range(time_range)' = '''
-  time_range.end().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
+  format_timestamp(time_range.end()) ++ label("time", ", lasted ") ++ time_range.duration()'''
 'format_timestamp(timestamp)' = 'timestamp.local().format("%Y-%m-%d %H:%M:%S")'
 
 'format_commit_summary_with_refs(commit, refs)' = '''

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -407,9 +407,9 @@ fn test_op_log_template() {
     [EOF]
     "#);
 
-    // Test the default template, i.e. with relative start time and duration. We
-    // don't generally use that template because it depends on the current time,
-    // so we need to reset the time range format here.
+    // Test a template with relative start time and duration, a previous default.
+    // We don't generally use this style of template because it depends on the
+    // current time, so we need to reset the time range format here.
     test_env.add_config(
         r#"
 [template-aliases]

--- a/docs/config.md
+++ b/docs/config.md
@@ -648,12 +648,12 @@ Can be customized by the `format_timestamp()` template alias.
 'format_timestamp(timestamp)' = 'timestamp.ago()'
 ```
 
-`jj op log` defaults to relative timestamps. To use absolute timestamps, you
-will need to modify the `format_time_range()` template alias.
+`jj op log` displays elapsed time with absolute local timestamps. To use relative
+timestamps, you will need to modify the `format_time_range()` template alias.
 
 ```toml
 [template-aliases]
-'format_time_range(time_range)' = 'time_range.start() ++ " - " ++ time_range.end()'
+'format_time_range(time_range)' = 'time_range.end().ago() ++ label("time", ", lasted ") ++ time_range.duration()'
 ```
 
 ### Author format

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -20,7 +20,7 @@ ui.merge-editor = "meld" # default
 # ui.merge-editor = "kdiff3"
 
 # Relative timestamp rendered as "x days/hours/seconds ago"
-template-aliases.'format_timestamp(timestamp)' = 'timestamp.ago()'
+# template-aliases.'format_timestamp(timestamp)' = 'timestamp.ago()'
 
 # The four merge tools listed above are pre-configured. For detailed information
 # about how to change the default configuration or how to configure another tool,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -393,16 +393,16 @@ commands to interact with it. To list the operations, use `jj op log`:
 
 ```shell
 $ jj op log
-@  d3b77addea49 martinvonz@vonz.svl.corp.google.com 3 minutes ago, lasted 3 milliseconds
+@  d3b77addea49 martinvonz@vonz.svl.corp.google.com 2025-05-12 00:27:27, lasted 3 milliseconds
 │  squash commits into f7fb5943a6b9460eb106dba2fac5cac1625c6f7a
 │  args: jj squash
-○  6fc1873c1180 martinvonz@vonz.svl.corp.google.com 3 minutes ago, lasted 1 milliseconds
+○  6fc1873c1180 martinvonz@vonz.svl.corp.google.com 2025-05-12 00:27:27, lasted 1 milliseconds
 │  snapshot working copy
 │  args: jj st
-○  ed91f7bcc1fb martinvonz@vonz.svl.corp.google.com 6 minutes ago, lasted 1 milliseconds
+○  ed91f7bcc1fb martinvonz@vonz.svl.corp.google.com 2025-05-12 00:24:21, lasted 1 milliseconds
 │  new empty commit
 │  args: jj new puqltutt
-○  367400773f87 martinvonz@vonz.svl.corp.google.com 12 minutes ago, lasted 3 milliseconds
+○  367400773f87 martinvonz@vonz.svl.corp.google.com 2025-05-12 00:18:08, lasted 3 milliseconds
 │  rebase commit daa6ffd5a09a8a7d09a65796194e69b7ed0a566d and descendants
 │  args: jj rebase -s puqltutt -d nuvyytnq
 [many more lines]


### PR DESCRIPTION
It bugged me that only the op log used .ago(), and then I found a situation where I wasn't sure whether "1 day ago" meant 1.1 days ago or 1.9 days ago.  IMHO, displaying absolute times should be the default for accuracy, unless the user wishes otherwise.

Grepping uncovered an SVG (and presumably corresponding PNG) that with op log content.  I am not sure whether this demo content needs updating, and if so, how.

This probably introduces inconsistencies with webpage content as well?

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
