### PR TITLE
cli: add -o as shorthand for --name-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `CryptographicSignature.key()` template method now also works for SSH
   signatures and returns the corresponding public key fingerprint.
 
+* `jj diff` now accepts `-o` as a shorthand for `--name-only`.
+
 ### Fixed bugs
 
 * `jj metaedit --author-timestamp` twice with the same value no longer

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -120,7 +120,7 @@ pub struct DiffFormatArgs {
     ///
     /// Typically useful for shell commands like:
     ///    `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
-    #[arg(long)]
+    #[arg(long, short = 'o')]
     pub name_only: bool,
     /// Show a Git-format diff
     #[arg(long)]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -840,7 +840,7 @@ If no option is specified, it defaults to `-r @`.
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff
@@ -969,7 +969,7 @@ Lists the previous commits which a change has pointed to. The current commit of 
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff
@@ -1604,7 +1604,7 @@ This excludes changes from other commits by temporarily rebasing `--from` onto `
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff
@@ -1667,7 +1667,7 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff
@@ -1915,7 +1915,7 @@ Compare changes to the repository between two operations
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff
@@ -1960,7 +1960,7 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff
@@ -2069,7 +2069,7 @@ Show changes to the repository in an operation
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff
@@ -2543,7 +2543,7 @@ Show commit description and changes in a revision
 * `--types` — For each path, show only its type before and after
 
    The diff is shown as two letters. The first letter indicates the type before and the second letter indicates the type after. '-' indicates that the path was not present, 'F' represents a regular file, `L' represents a symlink, 'C' represents a conflict, and 'G' represents a Git submodule.
-* `--name-only` — For each path, show only its path
+* `-o`, `--name-only` — For each path, show only its path
 
    Typically useful for shell commands like: `jj diff -r @- --name-only | xargs perl -pi -e's/OLD/NEW/g`
 * `--git` — Show a Git-format diff


### PR DESCRIPTION
Would be easier to type when using with other commands -- of course, one
could always use an alias too, especially if -o is too confusing.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
