### PR TITLE
prev/next: add an error when not using --edit and the working-copy has children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Unquoted `*` is now allowed in revsets. `bookmarks(glob:foo*)` no longer
   needs quoting.
 
+* `jj prev/next --no-edit` now generates an error if the working-copy has some
+  children.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/src/movement_util.rs
+++ b/cli/src/movement_util.rs
@@ -29,6 +29,7 @@ use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::short_commit_hash;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
+use crate::command_error::user_error_with_hint;
 use crate::ui::Ui;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -157,6 +158,21 @@ fn get_target_commit(
     args: &MovementArgsInternal,
 ) -> Result<Commit, CommandError> {
     let wc_revset = RevsetExpression::commit(working_commit_id.clone());
+
+    // If we're not editing, the working-copy shouldn't have any children
+    if !args.should_edit
+        && !workspace_command
+            .repo()
+            .view()
+            .heads()
+            .contains(working_commit_id)
+    {
+        return Err(user_error_with_hint(
+            "The working copy must not have any children",
+            "Create a new commit on top of this one or use `--edit`",
+        ));
+    }
+
     // If we're editing, start at the working-copy commit. Otherwise, start from
     // its direct parent(s).
     let start_revset = if args.should_edit {


### PR DESCRIPTION
We shouldn't be in that case, and it can lead to confusing situations with next completely switching branch.

fix: #7046

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
