### PR TITLE
docs: Add date pattern link in `Timestamp` type

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -540,8 +540,14 @@ The following methods are defined.
   format string](https://docs.rs/chrono/latest/chrono/format/strftime/).
 * `.utc() -> Timestamp`: Convert timestamp into UTC timezone.
 * `.local() -> Timestamp`: Convert timestamp into local timezone.
-* `.after(date: String) -> Boolean`: True if the timestamp is exactly at or after the given date.
-* `.before(date: String) -> Boolean`: True if the timestamp is before, but not including, the given date.
+* `.after(date: String) -> Boolean`: True if the timestamp is exactly at or
+  after the given date. Supported date formats are the same as the revset
+  [Date pattern type].
+* `.before(date: String) -> Boolean`: True if the timestamp is before, but
+  not including, the given date. Supported date formats are the same as the
+  revset [Date pattern type].
+
+[Date pattern type]: revsets.md#date-patterns
 
 ### `TimestampRange` type
 


### PR DESCRIPTION
Functionality remains the same; this only affects the docs. This change points users to supported formats for the `Timestamp.after()` and `Timestamp.before()` methods, which can already be found in the revset "Date pattern" type.

Note that "date pattern" is already sort of exposed to the user in this context:
```bash
$ jj log -r @ -T 'committer.timestamp().before("asdf")'
Error: Failed to parse template: Invalid date pattern
Caused by:
1:  --> 1:30
  |
1 | committer.timestamp().before("asdf")
  |                              ^----^
  |
  = Invalid date pattern
2: expected unsupported identifier as position 0..4
```

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
