### PR TITLE
docs: update link to vim dirdiff instructions

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1080,7 +1080,7 @@ Using `ui.diff-editor = "vimdiff"` is possible but not recommended. For a better
 experience, you can follow [instructions from the Wiki] to configure the
 [DirDiff Vim plugin] and/or the [vimtabdiff Python script].
 
-[instructions from the Wiki]: https://github.com/jj-vcs/jj/wiki/Vim#using-vim-as-a-diff-tool
+[instructions from the Wiki]: https://github.com/jj-vcs/jj/wiki/Vim,-Neovim#using-vim-as-a-diff-tool
 
 [DirDiff Vim plugin]: https://github.com/will133/vim-dirdiff
 [vimtabdiff Python script]: https://github.com/balki/vimtabdiff


### PR DESCRIPTION
Updated the broken link.

# Checklist

If applicable:

- [ ] ~I have updated `CHANGELOG.md`~
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] ~I have updated the config schema (`cli/src/config-schema.json`)~
- [ ] ~I have added/updated tests to cover my changes~
