### PR TITLE
cli undo: warn about undoing push operations

### DIFF
--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -49,6 +49,7 @@ use self::init::GitInitArgs;
 use self::init::cmd_git_init;
 use self::push::GitPushArgs;
 use self::push::cmd_git_push;
+pub use self::push::is_push_operation;
 use self::remote::RemoteCommand;
 use self::remote::cmd_git_remote;
 use self::root::GitRootArgs;

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -33,6 +33,7 @@ use jj_lib::git::GitBranchPushTargets;
 use jj_lib::git::GitPushStats;
 use jj_lib::index::IndexResult;
 use jj_lib::op_store::RefTarget;
+use jj_lib::operation::Operation;
 use jj_lib::ref_name::RefName;
 use jj_lib::ref_name::RefNameBuf;
 use jj_lib::ref_name::RemoteName;
@@ -205,6 +206,8 @@ fn make_bookmark_term(bookmark_names: &[impl fmt::Display]) -> String {
 
 const DEFAULT_REMOTE: &RemoteName = RemoteName::new("origin");
 
+const TX_DESC_PUSH: &str = "push ";
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BookmarkMoveDirection {
     Forward,
@@ -246,7 +249,7 @@ pub fn cmd_git_push(
             }
         }
         tx_description = format!(
-            "push all bookmarks to git remote {remote}",
+            "{TX_DESC_PUSH}all bookmarks to git remote {remote}",
             remote = remote.as_symbol()
         );
     } else if args.tracked {
@@ -267,7 +270,7 @@ pub fn cmd_git_push(
             }
         }
         tx_description = format!(
-            "push all tracked bookmarks to git remote {remote}",
+            "{TX_DESC_PUSH}all tracked bookmarks to git remote {remote}",
             remote = remote.as_symbol()
         );
     } else if args.deleted {
@@ -289,7 +292,7 @@ pub fn cmd_git_push(
             }
         }
         tx_description = format!(
-            "push all deleted bookmarks to git remote {remote}",
+            "{TX_DESC_PUSH}all deleted bookmarks to git remote {remote}",
             remote = remote.as_symbol()
         );
     } else {
@@ -381,7 +384,7 @@ pub fn cmd_git_push(
         }
 
         tx_description = format!(
-            "push {names} to git remote {remote}",
+            "{TX_DESC_PUSH}{names} to git remote {remote}",
             names = make_bookmark_term(
                 &bookmark_updates
                     .iter()
@@ -1021,4 +1024,8 @@ fn find_bookmarks_targeted_by_revisions<'a>(
         })
         .collect_vec();
     Ok(bookmarks_targeted)
+}
+
+pub fn is_push_operation(op: &Operation) -> bool {
+    op.metadata().description.starts_with(TX_DESC_PUSH)
 }

--- a/cli/tests/test_undo_redo_commands.rs
+++ b/cli/tests/test_undo_redo_commands.rs
@@ -56,6 +56,31 @@ fn test_undo_merge_operation() {
 }
 
 #[test]
+fn test_undo_push_operation() {
+    let test_env = TestEnvironment::default();
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "origin"])
+        .success();
+    test_env
+        .run_jj_in(".", ["git", "clone", "origin", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("foo", "foo");
+    work_dir.run_jj(["commit", "-mfoo"]).success();
+    work_dir.run_jj(["git", "push", "-c@-"]).success();
+    let output = work_dir.run_jj(["undo"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Warning: Undoing a push operation often leads to conflicted bookmarks.
+    Hint: To avoid this, run `jj redo` now.
+    Restored to operation: f9fd582ef03c (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_undo_jump_old_undo_stack() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Motivated by a discussed on discord: https://discord.com/channels/968932220549103686/1427215834950008973

I'm not 100% convinced we need this, but it's a reasonable idea to consider.

# Checklist

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
