### PR TITLE
cli bookmark move: deprecate multiple name arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   bookmarks if the specified `pattern` matches `git`. The default is
   `remote=~exact:"git"` as before.
 
+* Specifying multiple bookmark arguments for `jj bookmark move` is deprecated.
+  Moving multiple bookmarks at once can still be done with a string pattern.
+
 ### Deprecations
 
  * `jj bisect run --command <cmd>` is deprecated in favor of

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -347,7 +347,7 @@ See [`jj help -k bookmarks`] for more information.
 * `delete` — Delete an existing bookmark and propagate the deletion to remotes on the next push
 * `forget` — Forget a bookmark without marking it as a deletion to be pushed
 * `list` — List bookmarks and their targets
-* `move` — Move existing bookmarks to target revision
+* `move` — Move an existing bookmark to a target revision
 * `rename` — Rename `old` bookmark name to `new` bookmark name
 * `set` — Create or update a bookmark to point to a certain commit
 * `track` — Start tracking given remote bookmarks
@@ -480,27 +480,28 @@ See [`jj help -k bookmarks`] for more information.
 
 ## `jj bookmark move`
 
-Move existing bookmarks to target revision
+Move an existing bookmark to a target revision
 
-If bookmark names are given, the specified bookmarks will be updated to point to the target revision.
+If a bookmark name is given, the specified bookmark will be updated to point to the target revision.
 
-If `--from` options are given, bookmarks currently pointing to the specified revisions will be updated. The bookmarks can also be filtered by names.
+If `--from` options are given, bookmarks currently pointing to the specified revisions will be updated. The bookmarks can also be filtered by name.
 
 Example: pull up the nearest bookmarks to the working-copy parent
 
 $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 
-**Usage:** `jj bookmark move [OPTIONS] <NAMES|--from <REVSETS>>`
+**Usage:** `jj bookmark move [OPTIONS] <NAME|--from <REVSETS>>`
 
 **Command Alias:** `m`
 
 ###### **Arguments:**
 
-* `<NAMES>` — Move bookmarks matching the given name patterns
+* `<NAME>` — Move bookmark matching the given name pattern
 
-   By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
+   By default, the specified name matches exactly. Use the `glob:` or `regex:` prefix to select multiple bookmarks by [string pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [string pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+* `<ADDITIONAL_NAMES>`
 
 ###### **Options:**
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -418,9 +418,9 @@ fn test_bookmark_move_matching() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <NAMES|--from <REVSETS>>
+      <NAME|--from <REVSETS>>
 
-    Usage: jj bookmark move <NAMES|--from <REVSETS>>
+    Usage: jj bookmark move <NAME|--from <REVSETS>>
 
     For more information, try '--help'.
     [EOF]


### PR DESCRIPTION
This is split off from #7330. There, my suggestion was to make the target revision of `jj bookmark move` a positional argument. We decided against that. But as part of the proposal, having multiple positional bookmark arguments would have to be deprecated. My thoughts kept coming back to that even after closing the original proposal.

I think that moving multiple bookmarks to the same revision is fundamentally a weird thing to do. Having that be the central way the CLI function makes the documentation confusing to me. E.g. reading this:

> Move existing bookmarks to target revision
>
> If bookmark names are given, the specified bookmarks will be updated to
> point to the target revision.

My brain immediately goes "Why would I want to move multiple bookmarks to the same revision?" So I confuses me about how bookmarks are supposed to be used. So, I propose to deprecate that purely as a documentation improvement. When the functionality is actually needed in rare cases, a string pattern or shell loop can do the job just fine.

I realize this is a breaking change taking away functionality for relatively little gain (slightly better documentation). The conclusion here may well be "No, let's not do that." I'd be okay with that and close the PR. I just wanted to get the proposal out there, because it keeps coming up in my mind.

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
