### PR TITLE
config: add remotes.<name>.auto-track-bookmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj prev/next --no-edit` now generates an error if the working-copy has some
   children.
 
+* A new config option `remotes.<name>.auto-track-bookmarks` can be set to a
+  pattern. New bookmarks matching it will automatically track that remote.
+  See <https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks>.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/src/commands/bookmark/create.rs
+++ b/cli/src/commands/bookmark/create.rs
@@ -81,9 +81,27 @@ pub fn cmd_bookmark_create(
     }
 
     let mut tx = workspace_command.start_transaction();
+    let remote_settings = tx.settings().remote_settings()?;
+    let readonly_repo = tx.base_repo().clone();
     for name in bookmark_names {
         tx.repo_mut()
             .set_local_bookmark_target(name, RefTarget::normal(target_commit.id().clone()));
+        for (remote_name, settings) in &remote_settings {
+            if !settings.auto_track_bookmarks.is_match(name.as_str()) {
+                continue;
+            }
+            let Some(view) = readonly_repo.view().get_remote_view(remote_name) else {
+                continue;
+            };
+            let symbol = name.to_remote_symbol(remote_name);
+            if view.bookmarks.contains_key(name) {
+                writeln!(
+                    ui.warning_default(),
+                    "Auto-tracking bookmark that exists on the remote: {symbol}"
+                )?;
+            }
+            tx.repo_mut().track_remote_bookmark(symbol)?;
+        }
     }
 
     if let Some(mut formatter) = ui.status_formatter() {

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -243,8 +243,9 @@ fn init_git_refs(
         return Ok(repo);
     }
     if colocated {
-        // If git.auto-local-bookmark = true, local bookmarks could be created for
-        // the imported remote branches.
+        // If git.auto-local-bookmark = true or
+        // remotes.<name>.auto-track-bookmarks is set, local bookmarks could be
+        // created for the imported remote branches.
         let stats = git::export_refs(tx.repo_mut())?;
         print_git_export_stats(ui, &stats)?;
     }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -491,6 +491,20 @@
                 }
             }
         },
+        "remotes": {
+            "type": "object",
+            "description": "Settings related to specific remotes",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "auto-track-bookmarks": {
+                        "type": "string",
+                        "description": "A string pattern describing the bookmarks to automatically track with this remote. It will be applied to any new bookmark, created or fetched. See https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks",
+                        "default": ""
+                    }
+                }
+            }
+        },
         "gerrit": {
             "type": "object",
             "description": "Settings for interacting with Gerrit",

--- a/docs/config.md
+++ b/docs/config.md
@@ -1528,6 +1528,60 @@ jj bookmark delete gh-pages
 jj bookmark untrack gh-pages@upstream
 ```
 
+### Automatic tracking of bookmarks
+
+You can configure which bookmarks to track automatically per remote, using the
+key `auto-track-bookmarks` under a section `[remotes.<name>]`. The value is a
+[string pattern](./revsets.md#string-patterns) for the bookmarks to track. This
+setting is applied to all new bookmarks, including ones created locally and ones
+fetched from the remote. For example:
+
+```toml
+[remote.origin]
+auto-track-bookmarks = "glob:*"
+```
+
+This will simply track all bookmarks for the remote "origin". There are various
+reasons to restrict which bookmarks to track:
+
+When collaborating with other people via the same remote, you may not want to
+track all the bookmarks of your collaborators. Similarly, you may not want to
+push some of your bookmarks to the remote at all. Some may only be intended
+for local use. Many people use a "personal prefix" in their bookmark names.
+This marks a bookmark as belonging to one person, making it possible to track
+and push only bookmarks with that prefix. For example, Alice may set her
+configuration like so:
+
+```toml
+[remote.origin]
+auto-track-bookmarks = "glob:alice/*"
+```
+
+That way, bookmarks pushed by other people (who probably use a different prefix
+or none at all) are not tracked automatically. At the same time, Alice can
+create bookmarks without the prefix for local-only use. You can also configure
+Jujutsu to use your prefix for generated bookmark names, see the section
+["Generated bookmark names on push"](#generated-bookmark-names-on-push).
+
+Another reason to restrict the bookmarks to track may be that you're not
+collaborating with people using the same remote, but a different one. For
+example, if you make a fork on GitHub, your fork will usually be called
+"origin", while the repository you forked from is usually called "upstream".
+In that case, you may want to track all bookmarks from your fork, but only the
+"main" bookmark from upstream. Here's an example how to achieve that:
+
+```toml
+[remote.origin]
+auto-track-bookmarks = "glob:*"
+[remote.upstream]
+auto-track-bookmarks = "main"
+```
+
+Lastly, you may be working on various projects with different conventions for
+bookmark names. In that case, it can be handy to apply different configuration
+to different (groups of) repositories. Read about how to do that in the section
+["Conditional variables"](conditional-variables).
+
 ### Automatic local bookmark creation on `jj git clone`
 
 When cloning a new Git repository, `jj` by default creates a local bookmark

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -755,7 +755,17 @@ fn default_remote_ref_state_for(
 ) -> RemoteRefState {
     match kind {
         GitRefKind::Bookmark => {
-            if symbol.remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO || git_settings.auto_local_bookmark {
+            if symbol.remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
+                || git_settings.auto_local_bookmark
+                || git_settings
+                    .remotes
+                    .get(symbol.remote)
+                    .is_some_and(|remote_settings| {
+                        remote_settings
+                            .auto_track_bookmarks
+                            .is_match(symbol.name.as_str())
+                    })
+            {
                 RemoteRefState::Tracked
             } else {
                 RemoteRefState::New

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -328,6 +328,11 @@ impl View {
             .map(|(name, view)| (name.as_ref(), view))
     }
 
+    /// Returns the remote view for `name`.
+    pub fn get_remote_view(&self, name: &RemoteName) -> Option<&RemoteView> {
+        self.data.remote_views.get(name)
+    }
+
     /// Adds remote view if it doesn't exist.
     pub fn ensure_remote(&mut self, remote_name: &RemoteName) {
         if self.data.remote_views.contains_key(remote_name) {


### PR DESCRIPTION
I intend to follow this up with deprecations for `--allow-new`, `git.push-new-bookmarks` and `git.auto-local-bookmark`.

closes #7072
closes #4856

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes