### PR TITLE
op_store: convert OpStore trait to be async

### DIFF
--- a/cli/src/commands/debug/object.rs
+++ b/cli/src/commands/debug/object.rs
@@ -117,7 +117,7 @@ pub fn cmd_debug_object(
         DebugObjectArgs::Operation(args) => {
             let id = OperationId::try_from_hex(&args.id)
                 .ok_or_else(|| user_error("Invalid hex operation id"))?;
-            let operation = repo_loader.op_store().read_operation(&id)?;
+            let operation = repo_loader.op_store().read_operation(&id).block_on()?;
             writeln!(ui.stdout(), "{operation:#?}")?;
         }
         DebugObjectArgs::Symlink(args) => {
@@ -154,7 +154,7 @@ pub fn cmd_debug_object(
                 ViewId::try_from_hex(args.id.as_ref().unwrap())
                     .ok_or_else(|| user_error("Invalid hex view id"))?
             };
-            let view = repo_loader.op_store().read_view(&id)?;
+            let view = repo_loader.op_store().read_view(&id).block_on()?;
             writeln!(ui.stdout(), "{view:#?}")?;
         }
     }

--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 use thiserror::Error;
 
 use crate::dag_walk;
@@ -97,7 +98,7 @@ where
 
     if op_heads.len() == 1 {
         let operation_id = op_heads.pop().unwrap();
-        let operation = op_store.read_operation(&operation_id)?;
+        let operation = op_store.read_operation(&operation_id).block_on()?;
         return Ok(Operation::new(op_store.clone(), operation_id, operation));
     }
 
@@ -118,14 +119,14 @@ where
 
     if op_head_ids.len() == 1 {
         let op_head_id = op_head_ids[0].clone();
-        let op_head = op_store.read_operation(&op_head_id)?;
+        let op_head = op_store.read_operation(&op_head_id).block_on()?;
         return Ok(Operation::new(op_store.clone(), op_head_id, op_head));
     }
 
     let op_heads: Vec<_> = op_head_ids
         .iter()
         .map(|op_id: &OperationId| -> Result<Operation, OpStoreError> {
-            let data = op_store.read_operation(op_id)?;
+            let data = op_store.read_operation(op_id).block_on()?;
             Ok(Operation::new(op_store.clone(), op_id.clone(), data))
         })
         .try_collect()?;

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -23,6 +23,7 @@ use std::iter;
 use std::sync::LazyLock;
 use std::time::SystemTime;
 
+use async_trait::async_trait;
 use itertools::Itertools as _;
 use thiserror::Error;
 
@@ -457,21 +458,22 @@ pub enum OpStoreError {
 
 pub type OpStoreResult<T> = Result<T, OpStoreError>;
 
+#[async_trait]
 pub trait OpStore: Any + Send + Sync + Debug {
     fn name(&self) -> &str;
 
     fn root_operation_id(&self) -> &OperationId;
 
-    fn read_view(&self, id: &ViewId) -> OpStoreResult<View>;
+    async fn read_view(&self, id: &ViewId) -> OpStoreResult<View>;
 
-    fn write_view(&self, contents: &View) -> OpStoreResult<ViewId>;
+    async fn write_view(&self, contents: &View) -> OpStoreResult<ViewId>;
 
-    fn read_operation(&self, id: &OperationId) -> OpStoreResult<Operation>;
+    async fn read_operation(&self, id: &OperationId) -> OpStoreResult<Operation>;
 
-    fn write_operation(&self, contents: &Operation) -> OpStoreResult<OperationId>;
+    async fn write_operation(&self, contents: &Operation) -> OpStoreResult<OperationId>;
 
     /// Resolves an unambiguous operation ID prefix.
-    fn resolve_operation_id_prefix(
+    async fn resolve_operation_id_prefix(
         &self,
         prefix: &HexPrefix,
     ) -> OpStoreResult<PrefixResolution<OperationId>>;

--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -23,6 +23,8 @@ use std::hash::Hasher;
 use std::iter;
 use std::sync::Arc;
 
+use pollster::FutureExt as _;
+
 use crate::backend::CommitId;
 use crate::op_store;
 use crate::op_store::OpStore;
@@ -107,13 +109,13 @@ impl Operation {
     pub fn parents(&self) -> impl ExactSizeIterator<Item = OpStoreResult<Self>> + use<'_> {
         let op_store = &self.op_store;
         self.data.parents.iter().map(|parent_id| {
-            let data = op_store.read_operation(parent_id)?;
+            let data = op_store.read_operation(parent_id).block_on()?;
             Ok(Self::new(op_store.clone(), parent_id.clone(), data))
         })
     }
 
     pub fn view(&self) -> OpStoreResult<View> {
-        let data = self.op_store.read_view(&self.data.view_id)?;
+        let data = self.op_store.read_view(&self.data.view_id).block_on()?;
         Ok(View::new(data))
     }
 

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -777,7 +777,7 @@ impl RepoLoader {
 
     /// Loads the specified operation from the operation store.
     pub fn load_operation(&self, id: &OperationId) -> OpStoreResult<Operation> {
-        let data = self.op_store.read_operation(id)?;
+        let data = self.op_store.read_operation(id).block_on()?;
         Ok(Operation::new(self.op_store.clone(), id.clone(), data))
     }
 

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 use thiserror::Error;
 
 use crate::backend::Timestamp;
@@ -140,7 +141,10 @@ impl Transaction {
         let (mut_index, view, predecessors) = mut_repo.consume();
 
         let operation = {
-            let view_id = base_repo.op_store().write_view(view.store_view())?;
+            let view_id = base_repo
+                .op_store()
+                .write_view(view.store_view())
+                .block_on()?;
             self.op_metadata.description = description.into();
             self.op_metadata.time.end = self.end_time.unwrap_or_else(Timestamp::now);
             let parents = self.parent_ops.iter().map(|op| op.id().clone()).collect();
@@ -150,7 +154,10 @@ impl Transaction {
                 metadata: self.op_metadata,
                 commit_predecessors: Some(predecessors),
             };
-            let new_op_id = base_repo.op_store().write_operation(&store_operation)?;
+            let new_op_id = base_repo
+                .op_store()
+                .write_operation(&store_operation)
+                .block_on()?;
             Operation::new(base_repo.op_store().clone(), new_op_id, store_operation)
         };
 

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -19,6 +19,7 @@ use jj_lib::repo::Repo as _;
 use jj_lib::repo::StoreFactories;
 use jj_lib::workspace::Workspace;
 use jj_lib::workspace::default_working_copy_factories;
+use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
@@ -159,7 +160,11 @@ fn test_bad_locking_children(backend: TestRepoBackend) {
     assert!(merged_repo.view().heads().contains(child1.id()));
     assert!(merged_repo.view().heads().contains(child2.id()));
     let op_id = merged_repo.op_id().clone();
-    let op = merged_repo.op_store().read_operation(&op_id).unwrap();
+    let op = merged_repo
+        .op_store()
+        .read_operation(&op_id)
+        .block_on()
+        .unwrap();
     assert_eq!(op.parents.len(), 2);
 }
 

--- a/lib/tests/test_evolution_predecessors.rs
+++ b/lib/tests/test_evolution_predecessors.rs
@@ -29,6 +29,7 @@ use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
 use jj_lib::settings::UserSettings;
 use maplit::btreemap;
+use pollster::FutureExt as _;
 use testutils::TestRepo;
 use testutils::commit_transactions;
 use testutils::write_random_commit;
@@ -109,7 +110,7 @@ fn test_walk_predecessors_basic_legacy_op() {
     let repo2 = {
         let mut data = repo2.operation().store_operation().clone();
         data.commit_predecessors = None;
-        let op_id = loader.op_store().write_operation(&data).unwrap();
+        let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
         let op = loader.load_operation(&op_id).unwrap();
         loader.load_at(&op).unwrap()
     };
@@ -450,7 +451,7 @@ fn test_walk_predecessors_direct_cycle_within_op() {
         data.commit_predecessors = Some(btreemap! {
             commit1.id().clone() => vec![commit1.id().clone()],
         });
-        let op_id = loader.op_store().write_operation(&data).unwrap();
+        let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
         let op = loader.load_operation(&op_id).unwrap();
         loader.load_at(&op).unwrap()
     };
@@ -479,7 +480,7 @@ fn test_walk_predecessors_indirect_cycle_within_op() {
             commit2.id().clone() => vec![commit1.id().clone()],
             commit3.id().clone() => vec![commit2.id().clone()],
         });
-        let op_id = loader.op_store().write_operation(&data).unwrap();
+        let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
         let op = loader.load_operation(&op_id).unwrap();
         loader.load_at(&op).unwrap()
     };

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -32,6 +32,7 @@ use jj_lib::operation::Operation;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
 use jj_lib::settings::UserSettings;
+use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::TestRepo;
 use testutils::write_random_commit;
@@ -247,7 +248,7 @@ fn test_stored_commit_predecessors() {
     // Save operation without the predecessors as old jj would do.
     let mut data = op.store_operation().clone();
     data.commit_predecessors = None;
-    let op_id = loader.op_store().write_operation(&data).unwrap();
+    let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
     assert_ne!(&op_id, op.id());
     let op = loader.load_operation(&op_id).unwrap();
     assert!(!op.stores_commit_predecessors());
@@ -526,7 +527,7 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
         // fall back to the legacy code path immediately.
         let mut data = repo_4.operation().store_operation().clone();
         data.commit_predecessors = None;
-        let op_id = op_store.write_operation(&data).unwrap();
+        let op_id = op_store.write_operation(&data).block_on().unwrap();
         repo_at(&op_id)
     };
 


### PR DESCRIPTION
like #7768 , makes the OpStore support async backends similar to the backend storage.


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
