### PR TITLE
op_heads_store: convert OpHeadsStore trait to be async

### DIFF
--- a/cli/src/commands/operation/abandon.rs
+++ b/cli/src/commands/operation/abandon.rs
@@ -19,6 +19,7 @@ use std::slice;
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
 use jj_lib::op_walk;
+use pollster::FutureExt as _;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::short_operation_hash;
@@ -128,7 +129,9 @@ pub fn cmd_op_abandon(
         stats.rewritten_count,
     )?;
     for (old, new_id) in reparented_head_ops().filter(|&(old, new_id)| old.id() != new_id) {
-        op_heads_store.update_op_heads(slice::from_ref(old.id()), new_id)?;
+        op_heads_store
+            .update_op_heads(slice::from_ref(old.id()), new_id)
+            .block_on()?;
     }
     // Remap the operation id of the current workspace. If there were any
     // divergent operations, user will need to re-abandon their ancestors.

--- a/lib/src/op_heads_store.rs
+++ b/lib/src/op_heads_store.rs
@@ -19,7 +19,9 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 use thiserror::Error;
 
 use crate::dag_walk;
@@ -50,25 +52,26 @@ pub enum OpHeadResolutionError {
 pub trait OpHeadsStoreLock {}
 
 /// Manages the set of current heads of the operation log.
+#[async_trait]
 pub trait OpHeadsStore: Any + Send + Sync + Debug {
     fn name(&self) -> &str;
 
     /// Remove the old op heads and add the new one.
     ///
     /// The old op heads must not contain the new one.
-    fn update_op_heads(
+    async fn update_op_heads(
         &self,
         old_ids: &[OperationId],
         new_id: &OperationId,
     ) -> Result<(), OpHeadsStoreError>;
 
-    fn get_op_heads(&self) -> Result<Vec<OperationId>, OpHeadsStoreError>;
+    async fn get_op_heads(&self) -> Result<Vec<OperationId>, OpHeadsStoreError>;
 
     /// Optionally takes a lock on the op heads store. The purpose of the lock
     /// is to prevent concurrent processes from resolving the same divergent
     /// operations. It is not needed for correctness; implementations are free
     /// to return a type that doesn't hold a lock.
-    fn lock(&self) -> Result<Box<dyn OpHeadsStoreLock + '_>, OpHeadsStoreError>;
+    async fn lock(&self) -> Result<Box<dyn OpHeadsStoreLock + '_>, OpHeadsStoreError>;
 }
 
 impl dyn OpHeadsStore {
@@ -93,7 +96,7 @@ where
     // This can be empty if the OpHeadsStore doesn't support atomic updates.
     // For example, all entries ahead of a readdir() pointer could be deleted by
     // another concurrent process.
-    let mut op_heads = op_heads_store.get_op_heads()?;
+    let mut op_heads = op_heads_store.get_op_heads().block_on()?;
 
     if op_heads.len() == 1 {
         let operation_id = op_heads.pop().unwrap();
@@ -109,8 +112,8 @@ where
     // Note that the locking isn't necessary for correctness of merge; we take
     // the lock only to prevent other concurrent processes from doing the same
     // work (and producing another set of divergent heads).
-    let _lock = op_heads_store.lock()?;
-    let op_head_ids = op_heads_store.get_op_heads()?;
+    let _lock = op_heads_store.lock().block_on()?;
+    let op_head_ids = op_heads_store.get_op_heads().block_on()?;
 
     if op_head_ids.is_empty() {
         return Err(OpHeadResolutionError::NoHeads.into());
@@ -147,7 +150,9 @@ where
 
     // Return without creating a merge operation
     if let [op_head] = &*op_heads {
-        op_heads_store.update_op_heads(&ancestor_op_heads, op_head.id())?;
+        op_heads_store
+            .update_op_heads(&ancestor_op_heads, op_head.id())
+            .block_on()?;
         return Ok(op_head.clone());
     }
 
@@ -155,6 +160,8 @@ where
     let new_op = resolver(op_heads)?;
     let mut old_op_heads = ancestor_op_heads;
     old_op_heads.extend_from_slice(new_op.parent_ids());
-    op_heads_store.update_op_heads(&old_op_heads, new_op.id())?;
+    op_heads_store
+        .update_op_heads(&old_op_heads, new_op.id())
+        .block_on()?;
     Ok(new_op)
 }

--- a/lib/src/op_walk.rs
+++ b/lib/src/op_walk.rs
@@ -21,6 +21,7 @@ use std::slice;
 use std::sync::Arc;
 
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 use thiserror::Error;
 
 use crate::dag_walk;
@@ -206,7 +207,8 @@ pub fn get_current_head_ops(
     op_heads_store: &dyn OpHeadsStore,
 ) -> Result<Vec<Operation>, OpsetEvaluationError> {
     let mut head_ops: Vec<_> = op_heads_store
-        .get_op_heads()?
+        .get_op_heads()
+        .block_on()?
         .into_iter()
         .map(|id| -> OpStoreResult<Operation> {
             let data = op_store.read_operation(&id)?;

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -223,7 +223,9 @@ impl ReadonlyRepo {
         let op_heads_store = op_heads_store_initializer(settings, &op_heads_path)?;
         let op_heads_type_path = op_heads_path.join("type");
         fs::write(&op_heads_type_path, op_heads_store.name()).context(&op_heads_type_path)?;
-        op_heads_store.update_op_heads(&[], op_store.root_operation_id())?;
+        op_heads_store
+            .update_op_heads(&[], op_store.root_operation_id())
+            .block_on()?;
         let op_heads_store: Arc<dyn OpHeadsStore> = Arc::from(op_heads_store);
 
         let index_path = repo_path.join("index");

--- a/lib/src/transaction.rs
+++ b/lib/src/transaction.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use itertools::Itertools as _;
+use pollster::FutureExt as _;
 use thiserror::Error;
 
 use crate::backend::Timestamp;
@@ -215,9 +216,10 @@ impl UnpublishedOperation {
     }
 
     pub fn publish(self) -> Result<Arc<ReadonlyRepo>, TransactionCommitError> {
-        let _lock = self.op_heads_store.lock()?;
+        let _lock = self.op_heads_store.lock().block_on()?;
         self.op_heads_store
-            .update_op_heads(self.operation().parent_ids(), self.operation().id())?;
+            .update_op_heads(self.operation().parent_ids(), self.operation().id())
+            .block_on()?;
         Ok(self.repo)
     }
 


### PR DESCRIPTION
like #7767, makes the OpHeadsStore support async backends similar to the backend storage.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
