### PR TITLE
tests: prevent cli tests from failing when generating code coverage

### DIFF
--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -130,6 +130,10 @@ impl TestEnvironment {
         cmd.env("JJ_OP_HOSTNAME", "host.example.com");
         cmd.env("JJ_OP_USERNAME", "test-username");
         cmd.env("JJ_TZ_OFFSET_MINS", "660");
+        // Coverage files should not pollute the working directory
+        if let Some(cov_var) = std::env::var_os("LLVM_PROFILE_FILE") {
+            cmd.env("LLVM_PROFILE_FILE", cov_var);
+        }
         for (key, value) in &self.env_vars {
             cmd.env(key, value);
         }


### PR DESCRIPTION
I tried generating some llvm-cov reports but quickly found that the cli tests don't expect profiling files to appear in their cwd. Pass along the LLVM_PROFILE_FILE environment variable so that doesn't happen.  Passed a full nextest run on my box.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes