### PR TITLE
fake-formatter: remove unused clap::arg import

### DIFF
--- a/cli/testing/fake-formatter.rs
+++ b/cli/testing/fake-formatter.rs
@@ -18,7 +18,6 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::Parser;
-use clap::arg;
 use itertools::Itertools as _;
 
 /// A fake code formatter, useful for testing


### PR DESCRIPTION
Looks like it was added during a refactor, probably by autocomplete. Shouldn't need to import `arg` for the `clap::Parser`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
