### PR TITLE
github: make validation script check to not fail on non-dismissable PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,7 @@ jobs:
             }
             else {
               // All commits are formatted correctly, dismiss any change requests.
-              if (latestReview) {
+              if (latestReview && latestReview.state === 'CHANGES_REQUESTED') {
                 await github.rest.pulls.dismissReview({
                   message: 'All commits are now correctly formatted. Thank you for your contribution!',
                   review_id: latestReview.id,


### PR DESCRIPTION
This change prevents the PR workflow (Validate Pull Request) from failing with:

> Error: Unhandled error: HttpError: Validation Failed: "Can not dismiss a dismissed pull request review"

For example, this happens in my other PR: https://github.com/jj-vcs/jj/pull/7704

Here's the workflow that fails:

https://github.com/jj-vcs/jj/actions/runs/18632398780/job/53118936287?pr=7704

In this commit it's fixed by first checking if the PR is in a dismissable state, ie: `latestReview.state === 'CHANGES_REQUESTED'`

However, I'm not 100% sure this works. I'm not sure what's the best way to test it. Open to ideas :)