### PR TITLE
rebase: Make `--skip-emptied` the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `core.watchman.register_snapshot_trigger`
   - `diff.format`
 
+* `jj rebase --skip-emptied` is now the default. Use `--keep-emptied` instead
+  to disable this.
+
 ### Deprecations
 
  * `jj bisect run --command <cmd>` is deprecated in favor of

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2213,6 +2213,10 @@ rebased to:
   parents and to rebase the targets and their descendants onto the rebased
   revisions
 
+If a non-merge commit is made empty by the rebase, it is skipped and
+abandoned. This usually happens when you attempt to rebase a commit that has
+since been submitted onto trunk.
+
 See the sections below for details about the different ways of specifying
 which revisions to rebase where.
 
@@ -2429,7 +2433,7 @@ J           J
 * `-d`, `--destination <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
-* `--skip-emptied` — If true, when rebasing would produce an empty commit, the commit is abandoned. It will not be abandoned if it was already empty before the rebase. Will never skip merge commits with multiple non-empty parents
+* `--keep-emptied` — If true, when rebasing would produce an empty commit, the commit is not abandoned
 * `--keep-divergent` — Keep divergent commits while rebasing
 
    Without this flag, divergent commits are abandoned while rebasing if another commit with the same change ID is already present in the destination with identical changes.

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -2728,7 +2728,7 @@ fn test_rebase_skip_emptied() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-d=b", "--skip-emptied"]);
+    let output = work_dir.run_jj(["rebase", "-d=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 commits to destination
@@ -2762,12 +2762,7 @@ fn test_rebase_skip_emptied() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj([
-        "rebase",
-        "-r=description('will become empty')",
-        "-d=b",
-        "--skip-emptied",
-    ]);
+    let output = work_dir.run_jj(["rebase", "-r=description('will become empty')", "-d=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 descendant commits
@@ -2823,7 +2818,7 @@ fn test_rebase_skip_emptied_descendants() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-r", "b", "--before", "c", "--skip-emptied"]);
+    let output = work_dir.run_jj(["rebase", "-r", "b", "--before", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 1 commits that were already in place
@@ -3042,7 +3037,7 @@ fn test_rebase_skip_duplicate_divergent() {
 
     // Rebase with "--keep-divergent" shouldn't skip any duplicates
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "c", "-d", "d", "--keep-divergent"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "c", "-d", "d", "--keep-divergent", "--keep-emptied"]), @r"
     ------- stderr -------
     Rebased 2 commits to destination
     [EOF]


### PR DESCRIPTION
After fetching and rebasing, it's very easy to have empty commits. `--skip-emptied` was designed to solve this.  However, I can't think of a reason why someone wouldn't want this feature. I've added `--keep-emptied` in case they for some reason want to keep it, but I'd honestly be happier if we just removed the flag entirely and added it back if people complain.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
