### PR TITLE
packaging: automated COPR builds on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,38 @@ jobs:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"
+
+  copr-build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        with:
+          python-version: 3.11
+      - name: Install uv
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+        with:
+          version: "0.5.1"
+      - name: Write version to copr.spec
+        run: |
+          VERSION=${RELEASE_TAG_NAME#v}
+          # needs the tag to be 'v<jj version>'
+          sed -i "s/{{version}}/$VERSION/" copr.spec
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+      - name: Start COPR build
+        run: |
+          # setup copr-cli auth
+          echo "[copr-cli]" > ~/.config/copr
+          echo "login = ${{ secrets.COPR_LOGIN }}" >> ~/.config/copr
+          echo "username = jj-vcs" >> ~/.config/copr
+          echo "token = ${{ secrets.COPR_TOKEN }}" >> ~/.config/copr
+          echo "copr_url = https://copr.fedorainfracloud.org" >> ~/.config/copr
+          chmod 600 ~/.config/copr
+
+          uvx copr-cli build jj-vcs/jj copr.spec --enable-net=on --nowait

--- a/copr.spec
+++ b/copr.spec
@@ -1,0 +1,58 @@
+Name:           jj-cli
+Version:        {{version}}
+Release:        %{autorelease}
+Summary:        A Git-compatible VCS that is both simple and powerful
+
+License:        Apache-2.0
+URL:            https://github.com/jj-vcs/jj
+Source0:        https://github.com/jj-vcs/jj/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:  rust >= 1.88
+BuildRequires:  cargo >= 1.88
+
+Requires:       git
+
+%description
+Jujutsu is a powerful version control system for software projects. You use it to get a copy of your code, track changes to the code, and finally publish those changes for others to see and use. It is designed from the ground up to be easy to use—whether you're new or experienced, working on brand new projects alone, or large scale software projects with large histories and teams.
+
+Jujutsu is unlike most other systems, because internally it abstracts the user interface and version control algorithms from the storage systems used to serve your content. This allows it to serve as a VCS with many possible physical backends, that may have their own data or networking models—like Mercurial or Breezy, or hybrid systems like Google's cloud-based design, Piper/CitC.
+
+%prep
+%autosetup -C
+cargo fetch --locked
+
+%build
+cargo build --release --frozen --bin jj
+
+OLD_PATH="$PATH"
+export PATH="$PWD/target/release:$PATH"
+COMPLETE=bash jj > jj.bash
+COMPLETE=fish jj > jj.fish
+COMPLETE=zsh  jj > jj.zsh
+export PATH="$OLD_PATH"
+
+./target/release/jj util install-man-pages .
+
+%install
+install -Dm755 %{_builddir}/%{buildsubdir}/target/release/jj %{buildroot}%{_bindir}/jj
+
+install -Dm644 %{_builddir}/%{buildsubdir}/jj.bash %{buildroot}%{bash_completions_dir}/jj
+install -Dm644 %{_builddir}/%{buildsubdir}/jj.fish %{buildroot}%{fish_completions_dir}/jj.fish
+install -Dm644 %{_builddir}/%{buildsubdir}/jj.zsh  %{buildroot}%{zsh_completions_dir}/_jj
+
+install -dm755 %{buildroot}%{_mandir}
+cp -a %{_builddir}/%{buildsubdir}/man1 %{buildroot}%{_mandir}
+
+%files
+%license LICENSE
+%{_bindir}/jj
+
+%{bash_completions_dir}/jj
+%{fish_completions_dir}/jj.fish
+%{zsh_completions_dir}/_jj
+
+%{_mandir}/man1/jj.1*
+%{_mandir}/man1/jj-*.1*
+
+%changelog
+%autochangelog

--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -112,6 +112,15 @@ emerge -av dev-vcs/jj
 zypper install jujutsu
 ```
 
+#### Fedora
+
+`jj-cli` can be installed from the Jujutsu [Fedora COPR](https://copr.fedorainfracloud.org/coprs/jj-vcs/jj) repository:
+
+```shell
+sudo dnf copr enable jj-vcs/jj
+sudo dnf install jj-cli
+```
+
 ### Mac
 
 #### From Source


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->
Fixes #6469

This is a possible way of setting up COPR builds for jj, but it would need setting up an official jj account on https://copr.fedorainfracloud.org first.

On each release this would write the version (from the tag name) to the `copr.spec` file and schedule the build on COPR from it. It does not create packages for every dependency, instead it does an online build. No sources are bundled, the SRPM is created from the release tarball by the COPR infrastructure. This is how I set up my own COPR (https://github.com/AldanTanneo/copr-jj), but the Github action there has to check for new releases every day, whereas this action can just react to new releases.

Needed for working builds:
- [ ] a COPR account named `jj-vcs` (tbd)
- [ ] a project in this account named `jj` (tbd)
- [ ] credentials for this account added to Github actions secrets: `COPR_LOGIN`, `COPR_TOKEN`.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
