### PR TITLE
cli: restore: provide modified file completion for --changes-in/-c

### DIFF
--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -50,7 +50,7 @@ pub(crate) struct RestoreArgs {
     #[arg(
         value_name = "FILESETS",
         value_hint = clap::ValueHint::AnyPath,
-        add = ArgValueCompleter::new(complete::modified_range_files),
+        add = ArgValueCompleter::new(complete::modified_changes_in_or_range_files),
     )]
     paths: Vec<String>,
     /// Revision to restore from (source)

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1456,6 +1456,35 @@ fn test_files() {
     [EOF]
     ");
 
+    let output = work_dir.complete_fish(["restore", "-c", "@-", "f_"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    f_added	Added
+    f_another_renamed_2	Renamed
+    f_copied	Copied
+    f_deleted	Deleted
+    f_dir/
+    f_modified	Modified
+    f_not_yet_copied	Modified
+    f_not_yet_renamed	Renamed
+    f_not_yet_renamed_2	Renamed
+    f_not_yet_renamed_3	Renamed
+    f_renamed	Renamed
+    [EOF]
+    ");
+
+    let output = work_dir.complete_fish(["restore", "--from", "root()", "--to", "@-", "f_"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    f_added	Added
+    f_another_renamed_2	Added
+    f_copied	Added
+    f_dir/
+    f_modified	Added
+    f_not_yet_copied	Added
+    f_renamed	Added
+    f_unchanged	Added
+    [EOF]
+    ");
+
     // interdiff has a different behavior with --from and --to flags
     let output = work_dir.complete_fish([
         "interdiff",


### PR DESCRIPTION
Just noticed that `jj restore -c` wasn't properly suggesting file paths.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
