### PR TITLE
hooks: Add support for running `jj fix` as a pre-upload hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   colocation state (`status`) and to convert a non-colocated git repo into
   a colocated repo (`enable`) and vice-versa `disable`.
 
+* Added pre-upload hooks to jj. For now, this is limited in scope to a hook
+  named fix, and only works for `jj gerrit upload`. 
+  Toggled via the config flag `hooks.pre-upload.fix.enabled`.
+
 ### Fixed bugs
 
 * `jj metaedit --author-timestamp` twice with the same value no longer

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -28,7 +28,7 @@ mod duplicate;
 mod edit;
 mod evolog;
 mod file;
-mod fix;
+pub(crate) mod fix;
 #[cfg(feature = "git")]
 mod gerrit;
 #[cfg(feature = "git")]

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -939,6 +939,32 @@
                 }
             }
         },
+        "hooks": {
+            "type": "object",
+            "description": "Settings for jj hooks",
+            "properties": {
+               "pre-upload": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "description": "Each pre-upload tool will run once, and be passed all commits to be uploaded in reverse jj log order (topological)",
+                        "properties": {
+                           "enabled": {
+                                "type": "boolean",
+                                "description": "Disables this tool if set to false",
+                                "default": true
+                            },
+                            "order": {
+                                "type": "integer",
+                                "description": "Hooks are run in ascending order on (order, name)",
+                                "default": 0
+                            }
+                        }
+                    },
+                    "description": "Settings for pre-upload hooks"
+                }
+            }
+        },
         "--when": {
             "type": "object",
             "description": "Conditions restriction the application of the configuration",

--- a/cli/src/hooks.rs
+++ b/cli/src/hooks.rs
@@ -1,0 +1,139 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use itertools::Itertools as _;
+use jj_lib::backend::CommitId;
+use jj_lib::fileset::FilesetExpression;
+use jj_lib::settings::UserSettings;
+
+use crate::cli_util::CommandHelper;
+use crate::cli_util::WorkspaceCommandHelper;
+use crate::command_error::CommandError;
+use crate::command_error::user_error;
+use crate::commands::fix::fix_revisions;
+use crate::ui::Ui;
+
+/// A hook in the `hooks.pre-upload` config table.
+enum PreUploadToolConfig {
+    FixTool,
+}
+
+/// Parses the `hooks.pre-upload` config table.
+fn pre_upload_tools(settings: &UserSettings) -> Result<Vec<PreUploadToolConfig>, CommandError> {
+    // Simplifies deserialization of the config values while building a ToolConfig.
+    #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    struct RawPreUploadToolConfig {
+        enabled: bool,
+    }
+
+    let mut tools: Vec<_> = vec![];
+    for name in settings
+        .table_keys("hooks.pre-upload")
+        // Sort keys so errors are deterministic.
+        .sorted()
+    {
+        let tool: RawPreUploadToolConfig = settings.get(["hooks", "pre-upload", name])?;
+        if tool.enabled {
+            tools.push(if name == "fix" {
+                PreUploadToolConfig::FixTool
+            } else {
+                return Err(user_error(
+                    "Generic pre-upload hooks are currently unsupported. Only fix is supported \
+                     for now",
+                ));
+            });
+        }
+    }
+    Ok(tools)
+}
+
+/// Triggered every time a user runs something that semantically approximates
+/// an "upload".
+///
+/// Currently, this triggers on `jj gerrit upload`. Other forges which
+/// implement custom upload scripts should also call this.
+///
+/// This should ideally work for `jj git push` too, but doing so has
+/// consequences. `git push` can be used to upload to code review, but it can
+/// do many other things as well. We need to ensure the UX works well before
+/// adding it to `git push`.
+///
+/// This function may create transactions that rewrite commits, so is not
+/// allowed to be called while a transaction is ongoing.
+/// It returns a mapping of rewrites, and users are expected to update any
+/// references to point at the new revision.
+pub(crate) fn run_pre_upload_hooks(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    workspace_command: &mut WorkspaceCommandHelper,
+    commit_ids: &[CommitId],
+) -> Result<HashMap<CommitId, Vec<CommitId>>, CommandError> {
+    // Rewrites are a many-to-many relationship.
+    let mut rewrites = HashMap::<CommitId, Vec<CommitId>>::new();
+    let mut current_commits = commit_ids.to_vec();
+    for tool in pre_upload_tools(command.settings())? {
+        let next_rewrites: HashMap<CommitId, Vec<CommitId>> = match tool {
+            PreUploadToolConfig::FixTool => {
+                let mut tx = workspace_command.start_transaction();
+                let summary = fix_revisions(
+                    ui,
+                    &mut tx,
+                    &current_commits,
+                    &FilesetExpression::all().to_matcher(),
+                    false,
+                )?;
+                tx.finish(ui, format!("fixed {} commits", summary.num_fixed_commits))?;
+                summary
+                    .rewrites
+                    .into_iter()
+                    .map(|(k, v)| (k, vec![v]))
+                    .collect()
+            }
+        };
+
+        current_commits = apply_rewrites(&next_rewrites, current_commits);
+
+        // Apply transitive rewrites.
+        for v in rewrites.values_mut() {
+            *v = apply_rewrites(&next_rewrites, v.clone());
+        }
+
+        for (from, to) in next_rewrites {
+            rewrites.insert(from, to);
+        }
+    }
+    Ok(rewrites)
+}
+
+pub(crate) fn apply_rewrites(
+    rewrites: &HashMap<CommitId, Vec<CommitId>>,
+    commits: Vec<CommitId>,
+) -> Vec<CommitId> {
+    let rewritten: Vec<_> = commits
+        .into_iter()
+        .flat_map(|c| rewrites.get(&c).cloned().unwrap_or(vec![c]))
+        .collect();
+    let mut filtered = vec![];
+    let mut seen = HashSet::new();
+    for commit in &rewritten {
+        if seen.insert(commit) {
+            filtered.push(commit.clone());
+        }
+    }
+    filtered
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -39,6 +39,7 @@ pub mod git_util {
     }
 }
 pub mod graphlog;
+pub mod hooks;
 pub mod merge_tools;
 pub mod movement_util;
 pub mod operation_templater;

--- a/docs/config.md
+++ b/docs/config.md
@@ -1747,6 +1747,24 @@ eol-conversion = "input-output"
       [`gitoxide`][gitoxide-is-binary] or [`git`][git-is-binary]. Jujutsu
       doesn't plan to align the binary detection logic with git.
 
+## Hook settings
+
+### Pre-upload hooks
+Pre-upload hooks are triggered when you upload your code for code review. This
+hook is only run during `jj gerrit upload`.
+
+Hooks are configured via the `hooks.pre-upload.<name>` table, similar to fix
+tools. Relevant options are:
+* `enabled`: Defaults to `true`. If disabled, the hook will not run.
+
+#### Predefined pre-upload hooks
+These hooks support the `enabled` flag. They are disabled by default.
+
+* `hooks.pre-upload.fix`: Runs `jj fix` before uploading.
+
+#### Generic pre-upload hooks
+These are not yet supported.
+
 ## Ways to specify `jj` config: details
 
 ### User config files


### PR DESCRIPTION
We will support arbitrary hooks in the future, but for a few reasons we will special-case `jj fix`:
* Performance (jj fix is hyper-optimized for running on stacks of commits at the same time)
* Common (This will probably be the most common requested pre-upload check)
* Simplicity (this was much easier to implement, so is a good first hook)

Bug: #3577

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
