### PR TITLE
cli: ignore `$PAGER` in environment by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * In [filesets or path patterns](docs/filesets.md#file-patterns), glob matching
   is enabled by default. You can use `cwd:"path"` to match literal paths.
 
+* `jj` now ignores `$PAGER` set in the environment and uses `less -FRX` on most
+  platforms (`:builtin` on Windows). See [the docs](docs/config.md#pager) for
+  more information, and [#3502](https://github.com/jj-vcs/jj/issues/3502) for
+  motivation.
+
 ### Deprecations
 
 * The `--destination`/`-d` arguments for `jj rebase`, `jj split`, `jj revert`,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -673,14 +673,13 @@ fn env_base_layer() -> ConfigLayer {
         // should override $NO_COLOR." https://no-color.org/
         layer.set_value("ui.color", "never").unwrap();
     }
-    if let Ok(value) = env::var("PAGER") {
-        layer.set_value("ui.pager", value).unwrap();
-    }
     if let Ok(value) = env::var("VISUAL") {
         layer.set_value("ui.editor", value).unwrap();
     } else if let Ok(value) = env::var("EDITOR") {
         layer.set_value("ui.editor", value).unwrap();
     }
+    // Intentionally NOT respecting $PAGER here as it often creates a bad
+    // out-of-the-box experience for users, see http://github.com/jj-vcs/jj/issues/3502.
     layer
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -711,27 +711,23 @@ show-cryptographic-signatures = true
 
 ## Pager
 
-The default pager is can be set via `ui.pager` or the `PAGER` environment
-variable. The priority is as follows (environment variables are marked with
-a `$`):
+By default, jj will paginate output that would scroll off the screen. It does
+this by passing output through `less -FRX` on most platforms (on Windows it uses
+[the pager](#builtin-pager) that is built-in to jj).
 
-`ui.pager` > `$PAGER`
+Which pager to use can be customized by setting `ui.pager`. When choosing a
+pager, ensure that it either supports color codes or that you disable color (see
+[Colorizing output](#colorizing-output)).
 
-`less -FRX` is the default pager in the absence of any other setting, except
-on Windows where it is `:builtin`.
-
-The special value `:builtin` enables usage of the [integrated
-pager](#builtin-pager).
-
-If you are using a standard Linux distro, your system likely already has
-`$PAGER` set and that will be preferred over the built-in. To use the built-in:
+Examples:
 
 ```shell
-jj config set --user ui.pager :builtin
-```
+# Pipe output through `less -FRX` (default on non-Windows platforms)
+$ jj config set --user ui.pager "less -FRX"
 
-It is possible the default will change to `:builtin` for all platforms in the
-future.
+# Use the built-in pager (default on Windows)
+$ jj config set --user ui.pager :builtin
+```
 
 Additionally, paging behavior can be toggled via `ui.paginate` like so:
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -68,9 +68,8 @@ especially IDEs, preserve LF line endings.
 ## Pagination
 
 On Windows, `jj` will use its integrated pager called `streampager` by default,
-unless the environment variable `%PAGER%` or the config `ui.pager` is explicitly
-set. See the [pager section of the config docs](config.md#pager) for more
-details.
+unless the config `ui.pager` is explicitly set. See the [pager section of the
+config docs](config.md#pager) for more details.
 
 If the built-in pager doesn't meet your needs and you have Git installed, you
 can switch to using Git's pager as follows:


### PR DESCRIPTION
When `$PAGER` is set in the environment, jj uses that instead of the default (`:builtin` on Windows, `less -FRX` everywhere else). Commonly, users will have `PAGER=less` in their environment for various reasons, and this is respected by jj. This means that every jj command, even one that only outputs one or two lines, will still invoke a full screen pager. It also means that every jj command which uses escape sequences for color, which is most of them, will be output through a pager that doesn't handle that well, so users see output that looks like this, which isn't very readable:

```
ESC[1mESC[38;5;2m@ESC[0m  ESC[1mESC[38;5;13mspmESC[38;5;8mwzlkq...
```

To fix this issue that new users stumble upon, ignore `$PAGER` from the environment, and always use our per-platform default. Users can override this and select whatever pager they want by setting ui.pager in their jj config.

This seems like the least bad option for resolving #3502. The cases I considered were:

1. User doesn't have `PAGER` set. No change.
2. User has `PAGER=less` in their environment. We'll still run `less`, just with `-FRX`, so this seems fine. This case is surprisingly common.
3. User has `PAGER` set because they prefer another pager. We'll ignore that preference and run `less -FRX`.
4. User has `PAGER` set because `less` isn't available on their platform. This is uncommon except for Windows, where we'll run `:builtin` instead of `less -FRX` by default anyway.

This may cause some users who have intentionally set and configured `PAGER` to be frustrated that we aren't respecting that value, but it's generally not possible to respect that value in all cases _and_ have a consistent and usable experience out of the box for the majority of users.

#### Alternatives considered

1. Disable color and OSC8 hyperlinks if `PAGER` is set, since we can't be sure the pager supports the color codes.
2. Don't paginate by default if `PAGER` is set. This seems counterintuitive, but would at least resolve the problem. Users would assume that the `jj` CLI doesn't support paginating, and either wrap it in a pager themselves (this is a bad outcome) or find `ui.pager` and change the setting.
3. Set `LESS` (iff it's not set already), then invoke `PAGER`. This means that users setting things like `LESS=i` breaks our output as well, and cases where `PAGER` isn't 'less' aren't fixed.

Fixes #3502

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
