### PR TITLE
index: convert `ReadonlyIndex` and `MutableIndex` methods to be fallible

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -35,6 +35,7 @@ use jj_lib::fileset::FilesetParseError;
 use jj_lib::fileset::FilesetParseErrorKind;
 use jj_lib::fix::FixError;
 use jj_lib::gitignore::GitIgnoreError;
+use jj_lib::index::IndexError;
 use jj_lib::op_heads_store::OpHeadResolutionError;
 use jj_lib::op_heads_store::OpHeadsStoreError;
 use jj_lib::op_store::OpStoreError;
@@ -325,6 +326,12 @@ impl From<BackendError> for CommandError {
             BackendError::Unsupported(_) => user_error(err),
             _ => internal_error_with_message("Unexpected error from backend", err),
         }
+    }
+}
+
+impl From<IndexError> for CommandError {
+    fn from(err: IndexError) -> Self {
+        internal_error_with_message("Unexpected error from index", err)
     }
 }
 

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -117,7 +117,7 @@ pub fn cmd_op_diff(
     let mut tx = to_repo.start_transaction();
     // Merge index from `from_repo` to `to_repo`, so commits in `from_repo` are
     // accessible.
-    tx.repo_mut().merge_index(&from_repo);
+    tx.repo_mut().merge_index(&from_repo)?;
     let merged_repo = tx.repo();
 
     let diff_renderer = {

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -607,11 +607,12 @@ impl MutableIndex for DefaultMutableIndex {
             .map_err(|err| IndexError::Other(err.into()))
     }
 
-    fn merge_in(&mut self, other: &dyn ReadonlyIndex) {
+    fn merge_in(&mut self, other: &dyn ReadonlyIndex) -> IndexResult<()> {
         let other: &DefaultReadonlyIndex = other
             .downcast_ref()
             .expect("index to merge in must be a DefaultReadonlyIndex");
         Self::merge_in(self, other);
+        Ok(())
     }
 }
 

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -178,7 +178,7 @@ pub trait MutableIndex: Any {
 
     fn add_commit(&mut self, commit: &Commit) -> IndexResult<()>;
 
-    fn merge_in(&mut self, other: &dyn ReadonlyIndex);
+    fn merge_in(&mut self, other: &dyn ReadonlyIndex) -> IndexResult<()>;
 }
 
 impl dyn MutableIndex {

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2480,7 +2480,8 @@ fn reload_repo_at_operation(
         .map_err(|err| RevsetResolutionError::Other(err.into()))?;
     base_repo.reload_at(&operation).map_err(|err| match err {
         RepoLoaderError::Backend(err) => RevsetResolutionError::Backend(err),
-        RepoLoaderError::IndexStore(_)
+        RepoLoaderError::Index(_)
+        | RepoLoaderError::IndexStore(_)
         | RepoLoaderError::OpHeadResolution(_)
         | RepoLoaderError::OpHeadsStoreError(_)
         | RepoLoaderError::OpStore(_)


### PR DESCRIPTION
# Context

This is part of a series of changes to make most methods on index traits (i.e. `ChangeIdIndex`, `MutableIndex`, `ReadonlyIndex`, `Index`) fallible. The changes will enable networked implementations of these traits, which can produce I/O errors during operation. See #7825 for more information.

This is a follow-up to #7799 and #7823.

# Changes

These two changes convert the necessary methods on `ReadonlyIndex` and `MutableIndex` to be fallible:
- ~~`ReadonlyIndex::change_id_index`~~
- ~~`MutableIndex::change_id_index`~~
- `MutableIndex::merge_in`

Two things to note:
- I did not also convert `ReadonlyIndex::start_modification` to return a `Result` for the reasons described in #7825.
- I changed `MutableRepo::merge` to return a `RepoLoaderError` instead of a `BackendError`, but we should verify that we think this makes sense. My line of thinking was as follows:
    - Without a larger change to error organization, the only other error type that seems to make sense in this context would be to smuggle the new `IndexError` from `merge_in` into `BackendError::Other`.
    - `MutableRepo::merge` is only used in two contexts (`cmd_op_revert` and `Transaction::merge_operation`). In both situations we are _loading_ two repos and then merging them, and `Transaction::merge_operation` is a caller that already returns a `RepoLoaderError`.
    - `ReadonlyRepo` has a few methods that are already returning `RepoLoaderError`.

**EDIT**: ended up dropping conversion of `change_id_index` -- for any implementers looking to perform effects in this method, we can recommend they use interior mutation like they'll have to with `start_modification`.

Thanks!
Brian

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
