### PR TITLE
describe: ensure --stdin messages get trailing newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ edits the change twice in some cases.
 * Fixed parsing of `files(expr)` revset expression including parentheses.
   [#7747](https://github.com/jj-vcs/jj/issues/7747)
 
+* Fixed `jj describe --stdin` to append a final newline character.
+
 ## [0.34.0] - 2025-10-01
 
 ### Release highlights

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -37,6 +37,7 @@ use crate::description_util::edit_description;
 use crate::description_util::edit_multiple_descriptions;
 use crate::description_util::join_message_paragraphs;
 use crate::description_util::parse_trailers_template;
+use crate::text_util::complete_newline;
 use crate::text_util::parse_author;
 use crate::ui::Ui;
 
@@ -174,7 +175,7 @@ pub(crate) fn cmd_describe(
     let shared_description = if args.stdin {
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer)?;
-        Some(buffer)
+        Some(complete_newline(buffer))
     } else if !args.message_paragraphs.is_empty() {
         Some(join_message_paragraphs(&args.message_paragraphs))
     } else {


### PR DESCRIPTION
As noted by @yuja in #7808, --stdin tests should probably get newlines automatically.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
