### PR TITLE
cleanup: remove redundant + use<'_> after migrating to 2024 edition

### DIFF
--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -1116,10 +1116,10 @@ impl JjBuilder {
 /// multiple times, the parsing will pick any of the available ones, while the
 /// actual execution of the command would fail.
 mod parse {
-    pub(super) fn parse_flag<'a, I: Iterator<Item = String>>(
-        candidates: &'a [&str],
-        mut args: I,
-    ) -> impl Iterator<Item = String> + use<'a, I> {
+    pub(super) fn parse_flag(
+        candidates: &[&str],
+        mut args: impl Iterator<Item = String>,
+    ) -> impl Iterator<Item = String> {
         std::iter::from_fn(move || {
             for arg in args.by_ref() {
                 // -r REV syntax

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -762,7 +762,7 @@ fn duplicate_child_stdin(stdin: &ChildStdin) -> io::Result<std::os::windows::io:
     stdin.as_handle().try_clone_to_owned()
 }
 
-fn format_error_with_sources(err: &dyn error::Error) -> impl fmt::Display + use<'_> {
+fn format_error_with_sources(err: &dyn error::Error) -> impl fmt::Display {
     iter::successors(Some(err), |&err| err.source()).format(": ")
 }
 

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -100,7 +100,7 @@ impl Commit {
         &self.data.parents
     }
 
-    pub fn parents(&self) -> impl Iterator<Item = BackendResult<Self>> + use<'_> {
+    pub fn parents(&self) -> impl Iterator<Item = BackendResult<Self>> {
         self.data.parents.iter().map(|id| self.store.get_commit(id))
     }
 

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -687,10 +687,10 @@ pub struct MaterializedTreeDiffEntry {
     pub values: BackendResult<(MaterializedTreeValue, MaterializedTreeValue)>,
 }
 
-pub fn materialized_diff_stream<'a>(
-    store: &'a Store,
-    tree_diff: BoxStream<'a, CopiesTreeDiffEntry>,
-) -> impl Stream<Item = MaterializedTreeDiffEntry> + use<'a> {
+pub fn materialized_diff_stream(
+    store: &Store,
+    tree_diff: BoxStream<'_, CopiesTreeDiffEntry>,
+) -> impl Stream<Item = MaterializedTreeDiffEntry> {
     tree_diff
         .map(async |CopiesTreeDiffEntry { path, values }| match values {
             Err(err) => MaterializedTreeDiffEntry {

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -367,7 +367,7 @@ impl CompositeCommitIndex {
         self.heads_pos(result)
     }
 
-    pub(super) fn all_heads(&self) -> impl Iterator<Item = CommitId> + use<'_> {
+    pub(super) fn all_heads(&self) -> impl Iterator<Item = CommitId> {
         self.all_heads_pos()
             .map(move |pos| self.entry_by_pos(pos).commit_id())
     }

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -457,7 +457,7 @@ impl ReadonlyCommitIndexSegment {
     fn overflow_changes_from(
         &self,
         overflow_pos: u32,
-    ) -> impl Iterator<Item = LocalCommitPosition> + use<'_> {
+    ) -> impl Iterator<Item = LocalCommitPosition> {
         let table = &self.data[self.change_overflow_base..];
         let offset = (overflow_pos as usize) * 4;
         let (chunks, _remainder) = table[offset..].as_chunks();

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -121,8 +121,7 @@ impl<I: AsCompositeIndex + Clone> RevsetImpl<I> {
 
     fn positions(
         &self,
-    ) -> impl Iterator<Item = Result<GlobalCommitPosition, RevsetEvaluationError>> + use<'_, I>
-    {
+    ) -> impl Iterator<Item = Result<GlobalCommitPosition, RevsetEvaluationError>> {
         self.inner.positions().attach(self.index.as_composite())
     }
 
@@ -1420,10 +1419,7 @@ fn diff_match_lines(
     }
 }
 
-fn match_lines<'a, 'b>(
-    text: &'a [u8],
-    pattern: &'b StringPattern,
-) -> impl Iterator<Item = &'a [u8]> + use<'a, 'b> {
+fn match_lines<'a>(text: &'a [u8], pattern: &StringPattern) -> impl Iterator<Item = &'a [u8]> {
     // The pattern is matched line by line so that it can be anchored to line
     // start/end. For example, exact:"" will match blank lines.
     text.split_inclusive(|b| *b == b'\n').filter(|line| {

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -76,11 +76,11 @@ pub fn find_nonword_ranges(text: &[u8]) -> Vec<Range<usize>> {
         .collect()
 }
 
-fn bytes_ignore_all_whitespace(text: &[u8]) -> impl Iterator<Item = u8> + use<'_> {
+fn bytes_ignore_all_whitespace(text: &[u8]) -> impl Iterator<Item = u8> {
     text.iter().copied().filter(|b| !b.is_ascii_whitespace())
 }
 
-fn bytes_ignore_whitespace_amount(text: &[u8]) -> impl Iterator<Item = u8> + use<'_> {
+fn bytes_ignore_whitespace_amount(text: &[u8]) -> impl Iterator<Item = u8> {
     let mut prev_was_space = false;
     text.iter().filter_map(move |&b| {
         let was_space = prev_was_space;
@@ -295,8 +295,7 @@ impl<'input> LocalDiffSource<'input, '_> {
 
     fn hashed_words(
         &self,
-    ) -> impl DoubleEndedIterator<Item = HashedWord<'input>> + ExactSizeIterator + use<'_, 'input>
-    {
+    ) -> impl DoubleEndedIterator<Item = HashedWord<'input>> + ExactSizeIterator {
         iter::zip(self.ranges, self.hashes).map(|(range, &hash)| {
             let text = &self.text[range.clone()];
             HashedWord { hash, text }
@@ -780,10 +779,7 @@ impl<'input> ContentDiff<'input> {
     }
 
     /// Returns contents at the unchanged `range`.
-    fn hunk_at<'a, 'b>(
-        &'a self,
-        range: &'b UnchangedRange,
-    ) -> impl Iterator<Item = &'input BStr> + use<'a, 'b, 'input> {
+    fn hunk_at(&self, range: &UnchangedRange) -> impl Iterator<Item = &'input BStr> {
         itertools::chain(
             iter::once(&self.base_input[range.base.clone()]),
             iter::zip(&self.other_inputs, &range.others).map(|(input, r)| &input[r.clone()]),
@@ -791,11 +787,11 @@ impl<'input> ContentDiff<'input> {
     }
 
     /// Returns contents between the `previous` ends and the `current` starts.
-    fn hunk_between<'a, 'b>(
-        &'a self,
-        previous: &'b UnchangedRange,
-        current: &'b UnchangedRange,
-    ) -> impl Iterator<Item = &'input BStr> + use<'a, 'b, 'input> {
+    fn hunk_between(
+        &self,
+        previous: &UnchangedRange,
+        current: &UnchangedRange,
+    ) -> impl Iterator<Item = &'input BStr> {
         itertools::chain(
             iter::once(&self.base_input[previous.base.end..current.base.start]),
             itertools::izip!(&self.other_inputs, &previous.others, &current.others)

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -604,10 +604,7 @@ struct AliasFunctionOverloads<'a, V> {
 }
 
 impl<'a, V> AliasFunctionOverloads<'a, V> {
-    // TODO: Perhaps, V doesn't have to be captured, but "currently, all type
-    // parameters are required to be mentioned in the precise captures list" as
-    // of rustc 1.85.0.
-    fn arities(&self) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator + use<'a, V> {
+    fn arities(&self) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator {
         self.overloads.iter().map(|(params, _)| params.len())
     }
 

--- a/lib/src/evolution.rs
+++ b/lib/src/evolution.rs
@@ -58,7 +58,7 @@ impl CommitEvolutionEntry {
     }
 
     /// Predecessor commit objects of this commit.
-    pub fn predecessors(&self) -> impl ExactSizeIterator<Item = BackendResult<Commit>> + use<'_> {
+    pub fn predecessors(&self) -> impl ExactSizeIterator<Item = BackendResult<Commit>> {
         let store = self.commit.store();
         self.predecessor_ids().iter().map(|id| store.get_commit(id))
     }

--- a/lib/src/files.rs
+++ b/lib/src/files.rs
@@ -464,11 +464,11 @@ fn collect_resolved<'input>(hunks: impl IntoIterator<Item = MergeHunk<'input>>) 
 }
 
 /// Iterator that attempts to resolve trivial merge conflict for each hunk.
-fn resolve_diff_hunks<'a, 'input>(
-    diff: &'a ContentDiff<'input>,
+fn resolve_diff_hunks<'input>(
+    diff: &ContentDiff<'input>,
     num_diffs: usize,
     same_change: SameChange,
-) -> impl Iterator<Item = Merge<&'input BStr>> + use<'a, 'input> {
+) -> impl Iterator<Item = Merge<&'input BStr>> {
     diff.hunks().map(move |diff_hunk| match diff_hunk.kind {
         DiffHunkKind::Matching => {
             debug_assert!(diff_hunk.contents.iter().all_equal());

--- a/lib/src/matchers.rs
+++ b/lib/src/matchers.rs
@@ -484,10 +484,7 @@ impl<V> RepoPathTree<V> {
     fn walk_to<'a, 'b>(
         &'a self,
         dir: &'b RepoPath,
-        // TODO: V doesn't have to be captured, but "currently, all type
-        // parameters are required to be mentioned in the precise captures list"
-        // as of rustc 1.85.0.
-    ) -> impl Iterator<Item = (&'a Self, &'b RepoPath)> + use<'a, 'b, V> {
+    ) -> impl Iterator<Item = (&'a Self, &'b RepoPath)> {
         iter::successors(Some((self, dir)), |(sub, dir)| {
             let mut components = dir.components();
             let name = components.next()?;

--- a/lib/src/operation.rs
+++ b/lib/src/operation.rs
@@ -106,7 +106,7 @@ impl Operation {
         &self.data.parents
     }
 
-    pub fn parents(&self) -> impl ExactSizeIterator<Item = OpStoreResult<Self>> + use<'_> {
+    pub fn parents(&self) -> impl ExactSizeIterator<Item = OpStoreResult<Self>> {
         let op_store = &self.op_store;
         self.data.parents.iter().map(|parent_id| {
             let data = op_store.read_operation(parent_id).block_on()?;

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -2517,7 +2517,7 @@ fn to_resolved_ref(
 fn all_formatted_bookmark_symbols(
     repo: &dyn Repo,
     include_synced_remotes: bool,
-) -> impl Iterator<Item = String> + use<'_> {
+) -> impl Iterator<Item = String> {
     let view = repo.view();
     view.bookmarks().flat_map(move |(name, bookmark_target)| {
         let local_target = bookmark_target.local_target;

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -146,20 +146,20 @@ impl View {
 
     /// Iterates local bookmarks `(name, target)` in lexicographical order where
     /// the target adds `commit_id`.
-    pub fn local_bookmarks_for_commit<'a, 'b>(
-        &'a self,
-        commit_id: &'b CommitId,
-    ) -> impl Iterator<Item = (&'a RefName, &'a RefTarget)> + use<'a, 'b> {
+    pub fn local_bookmarks_for_commit(
+        &self,
+        commit_id: &CommitId,
+    ) -> impl Iterator<Item = (&RefName, &RefTarget)> {
         self.local_bookmarks()
             .filter(|(_, target)| target.added_ids().contains(commit_id))
     }
 
     /// Iterates local bookmark `(name, target)`s matching the given pattern.
     /// Entries are sorted by `name`.
-    pub fn local_bookmarks_matching<'a, 'b>(
-        &'a self,
-        pattern: &'b StringPattern,
-    ) -> impl Iterator<Item = (&'a RefName, &'a RefTarget)> + use<'a, 'b> {
+    pub fn local_bookmarks_matching(
+        &self,
+        pattern: &StringPattern,
+    ) -> impl Iterator<Item = (&RefName, &RefTarget)> {
         pattern
             .filter_btree_map_as_deref(&self.data.local_bookmarks)
             .map(|(name, target)| (name.as_ref(), target))
@@ -215,11 +215,11 @@ impl View {
     /// specified remote that match the given pattern.
     ///
     /// Entries are sorted by `symbol`, which is `(name, remote)`.
-    pub fn remote_bookmarks_matching<'a, 'b>(
-        &'a self,
-        bookmark_pattern: &'b StringPattern,
-        remote_pattern: &'b StringPattern,
-    ) -> impl Iterator<Item = (RemoteRefSymbol<'a>, &'a RemoteRef)> + use<'a, 'b> {
+    pub fn remote_bookmarks_matching(
+        &self,
+        bookmark_pattern: &StringPattern,
+        remote_pattern: &StringPattern,
+    ) -> impl Iterator<Item = (RemoteRefSymbol<'_>, &RemoteRef)> {
         // Use kmerge instead of flat_map for consistency with all_remote_bookmarks().
         remote_pattern
             .filter_btree_map_as_deref(&self.data.remote_views)
@@ -362,10 +362,10 @@ impl View {
 
     /// Iterates local tag `(name, target)`s matching the given pattern. Entries
     /// are sorted by `name`.
-    pub fn local_tags_matching<'a, 'b>(
-        &'a self,
-        pattern: &'b StringPattern,
-    ) -> impl Iterator<Item = (&'a RefName, &'a RefTarget)> + use<'a, 'b> {
+    pub fn local_tags_matching(
+        &self,
+        pattern: &StringPattern,
+    ) -> impl Iterator<Item = (&RefName, &RefTarget)> {
         pattern
             .filter_btree_map_as_deref(&self.data.local_tags)
             .map(|(name, target)| (name.as_ref(), target))
@@ -416,11 +416,11 @@ impl View {
     /// specified remote that match the given pattern.
     ///
     /// Entries are sorted by `symbol`, which is `(name, remote)`.
-    pub fn remote_tags_matching<'a, 'b>(
-        &'a self,
-        tag_pattern: &'b StringPattern,
-        remote_pattern: &'b StringPattern,
-    ) -> impl Iterator<Item = (RemoteRefSymbol<'a>, &'a RemoteRef)> + use<'a, 'b> {
+    pub fn remote_tags_matching(
+        &self,
+        tag_pattern: &StringPattern,
+        remote_pattern: &StringPattern,
+    ) -> impl Iterator<Item = (RemoteRefSymbol<'_>, &RemoteRef)> {
         // Use kmerge instead of flat_map for consistency with all_remote_tags().
         remote_pattern
             .filter_btree_map_as_deref(&self.data.remote_views)

--- a/lib/tests/test_annotate.rs
+++ b/lib/tests/test_annotate.rs
@@ -37,7 +37,7 @@ use testutils::repo_path;
 
 fn create_commit_fn(
     mut_repo: &mut MutableRepo,
-) -> impl FnMut(&str, &[&CommitId], MergedTreeId) -> Commit + use<'_> {
+) -> impl FnMut(&str, &[&CommitId], MergedTreeId) -> Commit {
     // stabilize commit IDs for ease of debugging
     let signature = Signature {
         name: "Some One".to_owned(),


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
