### PR TITLE
metaedit: replace `--update-committer-timestamp` with `--force-rewrite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * `jj bisect run --command <cmd>` is deprecated in favor of
    `jj bisect run -- <cmd>`.
 
+ * `jj metaedit --update-committer-timestamp` was renamed to
+   `jj metaedit --force-rewrite` since the old name (and help text)
+   incorrectly suggested that the committer name and email would _not_
+   be updated.
+
 ### New features
 
 * Templates now support a `.split(separator, [limit])` method on strings to

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1754,6 +1754,8 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
 Modify the metadata of a revision without changing its content
 
+Whenever any metadata is updated, the committer name, email, and timestamp are also updated for all rebased commits. The name and email may come from the `JJ_USER` and `JJ_EMAIL` environment variables, as well as by passing `--config user.name` and `--config user.email`.
+
 **Usage:** `jj metaedit [OPTIONS] [REVSETS]...`
 
 ###### **Arguments:**
@@ -1772,7 +1774,7 @@ Modify the metadata of a revision without changing its content
    Use `jj describe` if you want to use an editor.
 * `--update-author-timestamp` — Update the author timestamp
 
-   This updates the author date to now, without modifying the author.
+   This updates the author date to the current time, without modifying the author.
 * `--update-author` — Update the author to the configured user
 
    This updates the author name and email. The author timestamp is not modified – use --update-author-timestamp to update the author timestamp.
@@ -1784,11 +1786,15 @@ Modify the metadata of a revision without changing its content
 
    This changes author name and email while retaining author timestamp for non-discardable commits.
 * `--author-timestamp <AUTHOR_TIMESTAMP>` — Set the author date to the given date either human readable, eg Sun, 23 Jan 2000 01:23:45 JST) or as a time stamp, eg 2000-01-23T01:23:45+09:00)
-* `--update-committer-timestamp` — Update the committer timestamp
+* `--force-rewrite` — Rewrite the commit, even if no other metadata changed
 
-   This updates the committer date to now, without modifying the committer.
+   This updates the committer timestamp to the current time, as well as the committer name and email.
 
-   Even if this option is not passed, the committer timestamp will be updated if other metadata is updated. This option effectively just forces every commit to be rewritten whether or not there are other changes.
+   Even if this option is not passed, the committer name, email, and timestamp will be updated if other metadata is updated. This option just forces every commit to be rewritten whether or not there are other changes.
+
+   You can use it in combination with the `JJ_USER` and `JJ_EMAIL` environment variables to set a different committer:
+
+   $ JJ_USER='Foo Bar' JJ_EMAIL=foo@bar.com jj metaedit --force-rewrite
 
 
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Just moments ago, I ran into a case where I wanted to change both the
author and committer of a change. I knew about the new `jj metaedit`
command, but until now that only gave me the ability to update the
author of my change, so the committer would remain the same. My only
other option was to reach for `jj desc ... --reset-author`, which has
a deprecation warning:

    Warning: `jj describe --reset-author` is deprecated; use `jj metaedit --update-author` instead

In spite of that warning, this had the desired effect: both the author
and committer were updated.

So I figured I'd help `metaedit` grow these flags so it can be a _true_
replacement for `jj desc --reset-author`.

---

The above all happened before I was kindly informed in Discord
(https://discord.com/channels/968932220549103686/1431315533164314674)
that `jj metaedit --update-committer-timestamp` should do what I was
hoping for, which I had initially disregarded and never tried because
the help text originally said:

    This updates the committer date to now, without modifying the committer.

However, after trying it out, I noticed it actually _did_ modify the
committer.

So, I set out to improve the situation by renaming the flag (so it's
not partially-wrong: it does update the committer timestamp, as well as
everything else about the committer) and improving the help text in the
various flags.

---

In no particular order, thanks to:

* obtuse, for informing me that the `--update-committer-timestamp`
flag does what I wanted in the first place
* gaetan, for pointing out that my way of thinking was not quite meshing
with how jj does things (every modification will update the committer)
* Martin, for the new flag name



# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
