### PR TITLE
docs: suggest adding remote_bookmarks() to immutable_heads()

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -443,6 +443,13 @@ To prevent rewriting commits authored by other users:
 "immutable_heads()" = "builtin_immutable_heads() | (trunk().. & ~mine())"
 ```
 
+To prevent rewriting any commits that have been pushed and seen by other users:
+
+```toml
+[revset-aliases]
+"immutable_heads()" = "builtin_immutable_heads() | remote_bookmarks()"
+```
+
 Ancestors of the configured set are also immutable. The root commit is always
 immutable even if the set is empty.
 


### PR DESCRIPTION
One issue that comes up (on Discord) time and again is unintended editing of commits that have been pushed to a remote. This commit suggests an adjustment to immutable_heads() to protedt those commits.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
