### PR TITLE
index: make `Index::has_id` fallible

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -429,6 +429,7 @@ impl From<WalkPredecessorsError> for CommandError {
     fn from(err: WalkPredecessorsError) -> Self {
         match err {
             WalkPredecessorsError::Backend(err) => err.into(),
+            WalkPredecessorsError::Index(err) => err.into(),
             WalkPredecessorsError::OpStore(err) => err.into(),
             WalkPredecessorsError::CycleDetected(_) => internal_error(err),
         }
@@ -551,6 +552,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
                         .to_string(),
                 ),
                 GitImportError::Backend(_) => None,
+                GitImportError::Index(_) => None,
                 GitImportError::Git(_) => None,
                 GitImportError::UnexpectedBackend(_) => None,
             };

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -368,7 +368,13 @@ impl DetachedCommitBuilder {
         let predecessors = self.commit.predecessors.clone();
         let commit = write_to_store(&self.store, self.commit, &self.sign_settings)?;
         // FIXME: Google's index.has_id() always returns true.
-        if mut_repo.is_backed_by_default_index() && mut_repo.index().has_id(commit.id()) {
+        if mut_repo.is_backed_by_default_index()
+            && mut_repo
+                .index()
+                .has_id(commit.id())
+                // TODO: indexing error shouldn't be a "BackendError"
+                .map_err(|err| BackendError::Other(err.into()))?
+        {
             // Recording existing commit as new would create cycle in
             // predecessors/parent mappings within the current transaction, and
             // in predecessors graph globally.

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -581,8 +581,8 @@ impl Index for CompositeIndex {
         Ok(self.commits().resolve_commit_id_prefix(prefix))
     }
 
-    fn has_id(&self, commit_id: &CommitId) -> bool {
-        self.commits().has_id(commit_id)
+    fn has_id(&self, commit_id: &CommitId) -> IndexResult<bool> {
+        Ok(self.commits().has_id(commit_id))
     }
 
     fn is_ancestor(&self, ancestor_id: &CommitId, descendant_id: &CommitId) -> bool {

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -556,7 +556,7 @@ impl Index for DefaultMutableIndex {
         self.0.resolve_commit_id_prefix(prefix)
     }
 
-    fn has_id(&self, commit_id: &CommitId) -> bool {
+    fn has_id(&self, commit_id: &CommitId) -> IndexResult<bool> {
         self.0.has_id(commit_id)
     }
 

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -628,6 +628,10 @@ impl DefaultReadonlyIndex {
         self.0.changed_paths()
     }
 
+    pub(super) fn has_id_impl(&self, commit_id: &CommitId) -> bool {
+        self.0.commits().has_id(commit_id)
+    }
+
     /// Returns the number of all indexed commits.
     pub fn num_commits(&self) -> u32 {
         self.0.commits().num_commits()
@@ -723,8 +727,8 @@ impl Index for DefaultReadonlyIndex {
         self.0.resolve_commit_id_prefix(prefix)
     }
 
-    fn has_id(&self, commit_id: &CommitId) -> bool {
-        self.0.has_id(commit_id)
+    fn has_id(&self, commit_id: &CommitId) -> IndexResult<bool> {
+        Ok(self.has_id_impl(commit_id))
     }
 
     fn is_ancestor(&self, ancestor_id: &CommitId, descendant_id: &CommitId) -> bool {

--- a/lib/src/default_index/store.rs
+++ b/lib/src/default_index/store.rs
@@ -50,7 +50,6 @@ use crate::file_util;
 use crate::file_util::IoResultExt as _;
 use crate::file_util::PathError;
 use crate::file_util::persist_temp_file;
-use crate::index::Index as _;
 use crate::index::IndexStore;
 use crate::index::IndexStoreError;
 use crate::index::IndexStoreResult;
@@ -319,7 +318,7 @@ impl DefaultIndexStore {
         let parent_index_has_id = |id: &CommitId| {
             maybe_parent_index
                 .as_ref()
-                .is_some_and(|index| index.has_id(id))
+                .is_some_and(|index| index.has_id_impl(id))
         };
         let get_commit_with_op = |commit_id: &CommitId, op_id: &OperationId| {
             let op_id = op_id.clone();

--- a/lib/src/id_prefix.rs
+++ b/lib/src/id_prefix.rs
@@ -172,7 +172,7 @@ impl IdPrefixIndex<'_> {
                 PrefixResolution::SingleMatch(id) => {
                     // The disambiguation set may be loaded from a different repo,
                     // and contain a commit that doesn't exist in the current repo.
-                    if repo.index().has_id(&id) {
+                    if repo.index().has_id(&id)? {
                         return Ok(PrefixResolution::SingleMatch(id));
                     } else {
                         return Ok(PrefixResolution::NoMatch);

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -112,7 +112,7 @@ pub trait Index: Send + Sync {
     ) -> IndexResult<PrefixResolution<CommitId>>;
 
     /// Returns true if `commit_id` is present in the index.
-    fn has_id(&self, commit_id: &CommitId) -> bool;
+    fn has_id(&self, commit_id: &CommitId) -> IndexResult<bool>;
 
     /// Returns true if `ancestor_id` commit is an ancestor of the
     /// `descendant_id` commit, or if `ancestor_id` equals `descendant_id`.

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -4625,7 +4625,7 @@ fn test_concurrent_write_commit() {
 
     // The index should be consistent with the store.
     for commit_id in commit_change_ids.keys() {
-        assert!(repo.index().has_id(commit_id));
+        assert!(repo.index().has_id(commit_id).unwrap());
         let commit = repo.store().get_commit(commit_id).unwrap();
         assert_eq!(
             repo.resolve_change_id(commit.change_id()).unwrap(),
@@ -4751,7 +4751,7 @@ fn test_concurrent_read_write_commit() {
     // The index should be consistent with the store.
     let repo = repo.reload_at_head().unwrap();
     for commit_id in &commit_ids {
-        assert!(repo.index().has_id(commit_id));
+        assert!(repo.index().has_id(commit_id).unwrap());
         let commit = repo.store().get_commit(commit_id).unwrap();
         assert_eq!(
             repo.resolve_change_id(commit.change_id()).unwrap(),
@@ -4873,7 +4873,7 @@ fn test_shallow_commits_lack_parents() {
         "unshallowed commits have correct parents"
     );
     // FIXME: new ancestors should be indexed
-    assert!(!repo.index().has_id(&jj_id(a)));
+    assert!(!repo.index().has_id(&jj_id(a)).unwrap());
 }
 
 #[test]

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use jj_lib::backend::CommitId;
+use jj_lib::index::Index;
 use jj_lib::op_store::RefTarget;
 use jj_lib::op_store::RemoteRef;
 use jj_lib::op_store::RemoteRefState;
@@ -42,6 +43,10 @@ where
         name: name.as_ref(),
         remote: remote.as_ref(),
     }
+}
+
+fn index_has_id(index: &dyn Index, commit_id: &CommitId) -> bool {
+    index.has_id(commit_id).unwrap()
 }
 
 #[test]
@@ -354,14 +359,15 @@ fn test_add_head_success() {
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
+
     assert!(!mut_repo.view().heads().contains(new_commit.id()));
-    assert!(!mut_repo.index().has_id(new_commit.id()));
+    assert!(!index_has_id(mut_repo.index(), new_commit.id()));
     mut_repo.add_head(&new_commit).unwrap();
     assert!(mut_repo.view().heads().contains(new_commit.id()));
-    assert!(mut_repo.index().has_id(new_commit.id()));
+    assert!(index_has_id(mut_repo.index(), new_commit.id()));
     let repo = tx.commit("test").unwrap();
     assert!(repo.view().heads().contains(new_commit.id()));
-    assert!(repo.index().has_id(new_commit.id()));
+    assert!(index_has_id(repo.index(), new_commit.id()));
 }
 
 #[test]
@@ -414,9 +420,9 @@ fn test_add_head_not_immediate_child() {
         mut_repo.view().heads(),
         &hashset! {initial.id().clone(), child.id().clone()}
     );
-    assert!(mut_repo.index().has_id(initial.id()));
-    assert!(mut_repo.index().has_id(rewritten.id()));
-    assert!(mut_repo.index().has_id(child.id()));
+    assert!(index_has_id(mut_repo.index(), initial.id()));
+    assert!(index_has_id(mut_repo.index(), rewritten.id()));
+    assert!(index_has_id(mut_repo.index(), child.id()));
 }
 
 #[test]
@@ -441,17 +447,17 @@ fn test_remove_head() {
     assert!(!heads.contains(commit3.id()));
     assert!(!heads.contains(commit2.id()));
     assert!(!heads.contains(commit1.id()));
-    assert!(mut_repo.index().has_id(commit1.id()));
-    assert!(mut_repo.index().has_id(commit2.id()));
-    assert!(mut_repo.index().has_id(commit3.id()));
+    assert!(index_has_id(mut_repo.index(), commit1.id()));
+    assert!(index_has_id(mut_repo.index(), commit2.id()));
+    assert!(index_has_id(mut_repo.index(), commit3.id()));
     let repo = tx.commit("test").unwrap();
     let heads = repo.view().heads().clone();
     assert!(!heads.contains(commit3.id()));
     assert!(!heads.contains(commit2.id()));
     assert!(!heads.contains(commit1.id()));
-    assert!(repo.index().has_id(commit1.id()));
-    assert!(repo.index().has_id(commit2.id()));
-    assert!(repo.index().has_id(commit3.id()));
+    assert!(index_has_id(repo.index(), commit1.id()));
+    assert!(index_has_id(repo.index(), commit2.id()));
+    assert!(index_has_id(repo.index(), commit3.id()));
 }
 
 #[test]

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -23,6 +23,7 @@ use jj_lib::backend::CommitId;
 use jj_lib::config::ConfigLayer;
 use jj_lib::config::ConfigSource;
 use jj_lib::evolution::walk_predecessors;
+use jj_lib::index::Index;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::OperationId;
 use jj_lib::op_walk;
@@ -54,6 +55,10 @@ fn list_dir(dir: &Path) -> Vec<String> {
         .map(|entry| entry.unwrap().file_name().to_str().unwrap().to_owned())
         .sorted()
         .collect()
+}
+
+fn index_has_id(index: &dyn Index, commit_id: &CommitId) -> bool {
+    index.has_id(commit_id).unwrap()
 }
 
 #[test]
@@ -567,8 +572,8 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
     assert_eq!(stats.unreachable_count, 1);
     let repo = repo_at(&stats.new_head_ids[0]);
     // A0 - B0 are still reachable
-    assert!(repo.index().has_id(commit_a0.id()));
-    assert!(repo.index().has_id(commit_b0.id()));
+    assert!(index_has_id(repo.index(), commit_a0.id()));
+    assert!(index_has_id(repo.index(), commit_b0.id()));
     assert_eq!(
         get_predecessors(&repo, commit_a1.id()),
         [commit_a0.id().clone()]
@@ -593,17 +598,17 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
     assert_eq!(stats.unreachable_count, 2);
     let repo = repo_at(&stats.new_head_ids[0]);
     // A0 is still reachable
-    assert!(repo.index().has_id(commit_a0.id()));
+    assert!(index_has_id(repo.index(), commit_a0.id()));
     if op_stores_commit_predecessors {
         // B0 is no longer reachable
-        assert!(!repo.index().has_id(commit_b0.id()));
+        assert!(!index_has_id(repo.index(), commit_b0.id()));
         // the predecessor record `A1: A0` no longer exists
         assert_eq!(get_predecessors(&repo, commit_a1.id()), []);
         // Unreachable predecessors should be excluded
         assert_eq!(get_predecessors(&repo, commit_b1.id()), []);
     } else {
         // B0 is retained because it is immediate predecessor of B1
-        assert!(repo.index().has_id(commit_b0.id()));
+        assert!(index_has_id(repo.index(), commit_b0.id()));
         assert_eq!(
             get_predecessors(&repo, commit_a1.id()),
             [commit_a0.id().clone()]
@@ -627,9 +632,9 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
     assert_eq!(stats.unreachable_count, 3);
     let repo = repo_at(&stats.new_head_ids[0]);
     // A0 is no longer reachable
-    assert!(!repo.index().has_id(commit_a0.id()));
+    assert!(!index_has_id(repo.index(), commit_a0.id()));
     // A1 is still reachable through A2
-    assert!(repo.index().has_id(commit_a1.id()));
+    assert!(index_has_id(repo.index(), commit_a1.id()));
     assert_eq!(
         get_predecessors(&repo, commit_a2.id()),
         [commit_a1.id().clone()]


### PR DESCRIPTION
This is part of a series of changes to make most methods on index traits (i.e. `ChangeIdIndex`, `MutableIndex`, `ReadonlyIndex`, `Index`) fallible. This will enable networked implementations of these traits, which may produce I/O errors during operation. See #7825 for more information.

Previous PRs in this line of work: #7799, #7823, #7830, #7832.

Note that I added ~~one~~ two new instances of the existing anti-pattern, `TODO: indexing error shouldn't be a "BackendError"`, to `DetachedCommitBuilder::write` and `MutableRepo::add_heads`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
