### PR TITLE
docs: clarify simliarity between abandon and restore

### DIFF
--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -35,9 +35,12 @@ use crate::ui::Ui;
 
 /// Abandon a revision
 ///
-/// Abandon a revision, rebasing descendants onto its parent(s). The behavior is
-/// similar to `jj restore --changes-in`; the difference is that `jj abandon`
-/// gives you a new change, while `jj restore` updates the existing change.
+/// Abandon a revision, rebasing descendants onto its parent(s).
+///
+/// `jj abandon` and `jj restore --changes-in` are similar; the difference is
+/// that `jj abandon` removes the change (and gives you a new one if it was the
+/// working copy), whereas `jj restore` updates the existing change and makes it
+/// empty.
 ///
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -229,7 +229,9 @@ To get started, see the tutorial [`jj help -k tutorial`].
 
 Abandon a revision
 
-Abandon a revision, rebasing descendants onto its parent(s). The behavior is similar to `jj restore --changes-in`; the difference is that `jj abandon` gives you a new change, while `jj restore` updates the existing change.
+Abandon a revision, rebasing descendants onto its parent(s).
+
+`jj abandon` and `jj restore --changes-in` are similar; the difference is that `jj abandon` removes the change (and gives you a new one if it was the working copy), whereas `jj restore` updates the existing change and makes it empty.
 
 If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
 


### PR DESCRIPTION
The note about how `jj abandon` "gives you a new change" only really applies to when you use it on the working copy.