### PR TITLE
github: pin actions/github-script version by hash

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Check if PR author is a contributor
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const { pull_request, review } = context.payload;


### PR DESCRIPTION
The hash here is for v8, so it's only a no-op once #7868 has been merged, but I'll have to wait for that anyway.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
