### PR TITLE
conflicts: prefer emitting snapshot for first side

### DIFF
--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -1633,22 +1633,22 @@ mod tests {
                             SectionChangedLine {
                                 is_checked: false,
                                 change_type: Removed,
-                                line: "%%%%%%% Changes from base to side #1\n",
+                                line: "+++++++ Contents of side #1\n",
                             },
                             SectionChangedLine {
                                 is_checked: false,
                                 change_type: Removed,
-                                line: "+1\n",
+                                line: "1\n",
                             },
                             SectionChangedLine {
                                 is_checked: false,
                                 change_type: Removed,
-                                line: "+++++++ Contents of side #2\n",
+                                line: "%%%%%%% Changes from base to side #2\n",
                             },
                             SectionChangedLine {
                                 is_checked: false,
                                 change_type: Removed,
-                                line: "2\n",
+                                line: "+2\n",
                             },
                             SectionChangedLine {
                                 is_checked: false,

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -198,33 +198,34 @@ fn test_absorb_replace_single_line_hunk() {
     │  index 0000000000..2f87e8e465 100644
     │  --- a/file1
     │  +++ b/file1
-    │  @@ -1,10 +1,3 @@
+    │  @@ -1,9 +1,3 @@
     │  -<<<<<<< Conflict 1 of 1
-    │  -%%%%%%% Changes from base to side #1
-    │  --2a
-    │  - 1a
-    │  --2b
-    │  -+++++++ Contents of side #2
-    │   2a
-    │   1A
-    │   2b
+    │  -+++++++ Contents of side #1
+    │  -1a
+    │  -%%%%%%% Changes from base to side #2
+    │  - 2a
+    │  --1a
+    │  -+1A
+    │  - 2b
     │  ->>>>>>> Conflict 1 of 1 ends
+    │  +2a
+    │  +1A
+    │  +2b
     ×  qpvuntsm 5bdb5ca1 (conflict) 1
     │  diff --git a/file1 b/file1
     ~  new file mode 100644
        index 0000000000..0000000000
        --- /dev/null
        +++ b/file1
-       @@ -0,0 +1,10 @@
+       @@ -0,0 +1,9 @@
        +<<<<<<< Conflict 1 of 1
-       +%%%%%%% Changes from base to side #1
-       +-2a
-       + 1a
-       +-2b
-       ++++++++ Contents of side #2
-       +2a
-       +1A
-       +2b
+       ++++++++ Contents of side #1
+       +1a
+       +%%%%%%% Changes from base to side #2
+       + 2a
+       +-1a
+       ++1A
+       + 2b
        +>>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");
@@ -443,12 +444,12 @@ fn test_absorb_conflict() {
     let conflict_content = work_dir.read_file("file1");
     insta::assert_snapshot!(conflict_content, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
-    +1a
-    +1b
-    +++++++ Contents of side #2
-    2a
-    2b
+    +++++++ Contents of side #1
+    1a
+    1b
+    %%%%%%% Changes from base to side #2
+    +2a
+    +2b
     >>>>>>> Conflict 1 of 1 ends
     ");
 
@@ -578,11 +579,11 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     │  +++ /dev/null
     │  @@ -1,7 +0,0 @@
     │  -<<<<<<< Conflict 1 of 1
-    │  -%%%%%%% Changes from base to side #1
-    │  --1a
-    │  - 1b
-    │  -+++++++ Contents of side #2
-    │  -1a
+    │  -+++++++ Contents of side #1
+    │  -1b
+    │  -%%%%%%% Changes from base to side #2
+    │  - 1a
+    │  --1b
     │  ->>>>>>> Conflict 1 of 1 ends
     ×  kkmpptxz 8407ab95 (conflict) 2
     │  diff --git a/file1 b/file1
@@ -590,26 +591,27 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     │  index 0000000000..0000000000
     │  --- a/file1
     │  +++ /dev/null
-    │  @@ -1,6 +0,0 @@
+    │  @@ -1,7 +0,0 @@
     │  -<<<<<<< Conflict 1 of 1
-    │  -%%%%%%% Changes from base to side #1
-    │  - 1a
-    │  -+1b
-    │  -+++++++ Contents of side #2
+    │  -+++++++ Contents of side #1
+    │  -1a
+    │  -1b
+    │  -%%%%%%% Changes from base to side #2
+    │  --1a
     │  ->>>>>>> Conflict 1 of 1 ends
     │  diff --git a/file2 b/file2
     │  --- a/file2
     │  +++ b/file2
     │  @@ -1,7 +1,7 @@
     │   <<<<<<< Conflict 1 of 1
-    │   %%%%%%% Changes from base to side #1
-    │  - 1a
-    │  --1b
-    │  +-1a
-    │  + 1b
-    │   +++++++ Contents of side #2
-    │  -1b
-    │  +1a
+    │   +++++++ Contents of side #1
+    │  -1a
+    │  +1b
+    │   %%%%%%% Changes from base to side #2
+    │  --1a
+    │  - 1b
+    │  + 1a
+    │  +-1b
     │   >>>>>>> Conflict 1 of 1 ends
     ×  qpvuntsm f1473264 (conflict) 1
     │  diff --git a/file1 b/file1
@@ -617,12 +619,13 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
        index 0000000000..0000000000
        --- /dev/null
        +++ b/file1
-       @@ -0,0 +1,6 @@
+       @@ -0,0 +1,7 @@
        +<<<<<<< Conflict 1 of 1
-       +%%%%%%% Changes from base to side #1
-       + 1a
-       ++1b
-       ++++++++ Contents of side #2
+       ++++++++ Contents of side #1
+       +1a
+       +1b
+       +%%%%%%% Changes from base to side #2
+       +-1a
        +>>>>>>> Conflict 1 of 1 ends
        diff --git a/file2 b/file2
        new file mode 100644
@@ -631,11 +634,11 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
        +++ b/file2
        @@ -0,0 +1,7 @@
        +<<<<<<< Conflict 1 of 1
-       +%%%%%%% Changes from base to side #1
-       + 1a
-       +-1b
-       ++++++++ Contents of side #2
-       +1b
+       ++++++++ Contents of side #1
+       +1a
+       +%%%%%%% Changes from base to side #2
+       +-1a
+       + 1b
        +>>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -2971,13 +2971,13 @@ fn test_diff_conflict_three_sides() {
     diff --git a/file b/file
     --- a/file
     +++ b/file
-    @@ -2,3 +2,3 @@
-     <<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
-    +%%%%%%% Changes from base #1 to side #1
+    @@ -6,3 +6,3 @@
+     line 4 base
+    -%%%%%%% Changes from base to side #2
+    +%%%%%%% Changes from base #1 to side #2
      -line 2 base
     @@ -12,2 +12,5 @@
-     line 4 b.2
+     +line 4 b.2
     +%%%%%%% Changes from base #2 to side #3
     + line 2 base
     ++line 3 c.2
@@ -2986,12 +2986,12 @@ fn test_diff_conflict_three_sides() {
     ");
     insta::assert_snapshot!(diff_color_words_materialized("side1+side2", "side1+side2+side3"), @r"
     [38;5;3mModified conflict in file:[39m
-    [38;5;1m   1[39m [38;5;2m   1[39m: line 1
-    [38;5;1m   2[39m [38;5;2m   2[39m: <<<<<<< Conflict 1 of 1
-    [38;5;1m   3[39m [38;5;2m   3[39m: %%%%%%% Changes from base [4m[38;5;2m#1 [24m[39mto side #1
-    [38;5;1m   4[39m [38;5;2m   4[39m: -line 2 base
         ...
-    [38;5;1m  12[39m [38;5;2m  12[39m: line 4 b.2
+    [38;5;1m   6[39m [38;5;2m   6[39m: line 4 base
+    [38;5;1m   7[39m [38;5;2m   7[39m: %%%%%%% Changes from base [4m[38;5;2m#1 [24m[39mto side #2
+    [38;5;1m   8[39m [38;5;2m   8[39m: -line 2 base
+        ...
+    [38;5;1m  12[39m [38;5;2m  12[39m: +line 4 b.2
          [38;5;2m  13[39m: [4m[38;5;2m%%%%%%% Changes from base #2 to side #3[24m[39m
          [38;5;2m  14[39m: [4m[38;5;2m line 2 base[24m[39m
          [38;5;2m  15[39m: [4m[38;5;2m+line 3 c.2[24m[39m

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -650,11 +650,11 @@ fn test_diffedit_merge() {
     let output = work_dir.run_jj(["file", "show", "file2"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    c
+    %%%%%%% Changes from base to side #2
     -a
-    +c
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -74,12 +74,11 @@ fn test_evolog_with_or_without_diff() {
     │  -- operation 3499115d3831 snapshot working copy
     │  Resolved conflict in file1:
     │     1     : <<<<<<< Conflict 1 of 1
-    │     2     : %%%%%%% Changes from base to side #1
-    │     3     : -foo
-    │     4     : +++++++ Contents of side #2
-    │     5     : foo
-    │     6     : bar
-    │     7    1: >>>>>>> Conflict 1 of 1 endsresolved
+    │     2     : +++++++ Contents of side #1
+    │     3     : %%%%%%% Changes from base to side #2
+    │     4     :  foo
+    │     5     : +bar
+    │     6    1: >>>>>>> Conflict 1 of 1 endsresolved
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     │  my description
     │  -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
@@ -163,13 +162,12 @@ fn test_evolog_with_or_without_diff() {
     index 0000000000..2ab19ae607 100644
     --- a/file1
     +++ b/file1
-    @@ -1,7 +1,1 @@
+    @@ -1,6 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
-    --foo
-    -+++++++ Contents of side #2
-    -foo
-    -bar
+    -+++++++ Contents of side #1
+    -%%%%%%% Changes from base to side #2
+    - foo
+    -+bar
     ->>>>>>> Conflict 1 of 1 ends
     +resolved
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -139,10 +139,10 @@ fn test_annotate_conflicted() {
     insta::assert_snapshot!(output, @r"
     qpvuntsm test.use 2001-02-03 08:05:08    1: line1
     yostqsxw test.use 2001-02-03 08:05:15    2: <<<<<<< Conflict 1 of 1
-    yostqsxw test.use 2001-02-03 08:05:15    3: %%%%%%% Changes from base to side #1
-    yostqsxw test.use 2001-02-03 08:05:15    4: +new text from new commit 1
-    yostqsxw test.use 2001-02-03 08:05:15    5: +++++++ Contents of side #2
-    royxmykx test.use 2001-02-03 08:05:13    6: new text from new commit 2
+    yostqsxw test.use 2001-02-03 08:05:15    3: +++++++ Contents of side #1
+    zsuskuln test.use 2001-02-03 08:05:11    4: new text from new commit 1
+    yostqsxw test.use 2001-02-03 08:05:15    5: %%%%%%% Changes from base to side #2
+    yostqsxw test.use 2001-02-03 08:05:15    6: +new text from new commit 2
     yostqsxw test.use 2001-02-03 08:05:15    7: >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -56,11 +56,11 @@ fn test_chmod_regular_conflict() {
     let output = work_dir.run_jj(["file", "show", "file"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    x
+    %%%%%%% Changes from base to side #2
     -base
-    +x
-    +++++++ Contents of side #2
-    n
+    +n
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");
@@ -75,11 +75,11 @@ fn test_chmod_regular_conflict() {
     let output = work_dir.run_jj(["file", "show", "file"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    x
+    %%%%%%% Changes from base to side #2
     -base
-    +x
-    +++++++ Contents of side #2
-    n
+    +n
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");
@@ -92,11 +92,11 @@ fn test_chmod_regular_conflict() {
     let output = work_dir.run_jj(["file", "show", "file"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    x
+    %%%%%%% Changes from base to side #2
     -base
-    +x
-    +++++++ Contents of side #2
-    n
+    +n
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");

--- a/cli/tests/test_file_show_command.rs
+++ b/cli/tests/test_file_show_command.rs
@@ -106,11 +106,11 @@ fn test_show() {
     let output = work_dir.run_jj(["file", "show", "file1"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -b
-    +a
-    +++++++ Contents of side #2
-    c
+    +c
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -1358,10 +1358,10 @@ fn test_fix_both_sides_of_conflict() {
     let output = work_dir.run_jj(["file", "show", "file", "-r", "@"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
-    +CONTENT A
-    +++++++ Contents of side #2
-    CONTENT B
+    +++++++ Contents of side #1
+    CONTENT A
+    %%%%%%% Changes from base to side #2
+    +CONTENT B
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -165,11 +165,11 @@ fn test_interdiff_conflicting() {
     +++ b/file
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -abc
+    -%%%%%%% Changes from base to side #2
     --foo
-    -+abc
-    -+++++++ Contents of side #2
-    -bar
+    -+bar
     ->>>>>>> Conflict 1 of 1 ends
     +def
     [EOF]

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -190,11 +190,11 @@ fn test_new_merge_conflicts() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    3a 1a
+    %%%%%%% Changes from base to side #2
     -1a
-    +3a 1a
-    +++++++ Contents of side #2
-    1a 2a
+    +1a 2a
     >>>>>>> Conflict 1 of 1 ends
     1b
     2c
@@ -262,10 +262,10 @@ fn test_new_merge_same_change() {
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     a
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
-    +b
-    +++++++ Contents of side #2
+    +++++++ Contents of side #1
     b
+    %%%%%%% Changes from base to side #2
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
 }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -54,11 +54,11 @@ fn test_resolution() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
     let setup_opid = work_dir.current_operation_id();
@@ -88,11 +88,11 @@ fn test_resolution() {
     +++ b/file
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a
+    -%%%%%%% Changes from base to side #2
     --base
-    -+a
-    -+++++++ Contents of side #2
-    -b
+    -+b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
     [EOF]
@@ -128,11 +128,11 @@ fn test_resolution() {
     +++ b/file
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a
+    -%%%%%%% Changes from base to side #2
     --base
-    -+a
-    -+++++++ Contents of side #2
-    -b
+    -+b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
     [EOF]
@@ -162,11 +162,11 @@ fn test_resolution() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor1")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
@@ -176,11 +176,11 @@ fn test_resolution() {
     +++ b/file
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a
+    -%%%%%%% Changes from base to side #2
     --base
-    -+a
-    -+++++++ Contents of side #2
-    -b
+    -+b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution
     [EOF]
@@ -234,11 +234,11 @@ fn test_resolution() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
     // Note the "Modified" below
@@ -248,13 +248,15 @@ fn test_resolution() {
     +++ b/file
     @@ -1,7 +1,7 @@
      <<<<<<< Conflict 1 of 1
-     %%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a
+    -%%%%%%% Changes from base to side #2
     --base
-    -+a
+    -+b
+    +%%%%%%% Changes from base to side #1
     +-some
     ++fake
-     +++++++ Contents of side #2
-    -b
+    ++++++++ Contents of side #2
     +conflict
      >>>>>>> Conflict 1 of 1 ends
     [EOF]
@@ -307,11 +309,11 @@ fn test_resolution() {
     +++ b/file
     @@ -1,7 +1,7 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a
+    -%%%%%%% Changes from base to side #2
     --base
-    -+a
-    -+++++++ Contents of side #2
-    -b
+    -+b
     ->>>>>>> Conflict 1 of 1 ends
     +<<<<<<<
     +%%%%%%%
@@ -391,13 +393,15 @@ fn test_resolution() {
     +++ b/file
     @@ -1,7 +1,7 @@
      <<<<<<< Conflict 1 of 1
-     %%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a
+    -%%%%%%% Changes from base to side #2
     --base
-    -+a
+    -+b
+    +%%%%%%% Changes from base to side #1
     +-fake
     ++some
-     +++++++ Contents of side #2
-    -b
+    ++++++++ Contents of side #2
     +conflict
      >>>>>>> Conflict 1 of 1 ends
     [EOF]
@@ -462,13 +466,15 @@ fn test_resolution() {
     +++ b/file
     @@ -1,7 +1,7 @@
      <<<<<<< Conflict 1 of 1
-     %%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a
+    -%%%%%%% Changes from base to side #2
     --base
-    -+a
+    -+b
+    +%%%%%%% Changes from base to side #1
     +-fake
     ++some
-     +++++++ Contents of side #2
-    -b
+    ++++++++ Contents of side #2
     +conflict
      >>>>>>> Conflict 1 of 1 ends
     [EOF]
@@ -570,11 +576,11 @@ fn test_normal_conflict_input_files() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
 
@@ -610,10 +616,10 @@ fn test_baseless_conflict_input_files() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
-    +a
-    +++++++ Contents of side #2
-    b
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
 
@@ -692,20 +698,20 @@ fn test_simplify_conflict_sides() {
     ");
     insta::assert_snapshot!(work_dir.read_file("fileA"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    1
+    %%%%%%% Changes from base to side #2
     -base
-    +1
-    +++++++ Contents of side #2
-    2
+    +2
     >>>>>>> Conflict 1 of 1 ends
     ");
     insta::assert_snapshot!(work_dir.read_file("fileB"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    1
+    %%%%%%% Changes from base to side #2
     -base
-    +1
-    +++++++ Contents of side #2
-    2
+    +2
     >>>>>>> Conflict 1 of 1 ends
     ");
 
@@ -762,11 +768,11 @@ fn test_simplify_conflict_sides() {
     "###);
     insta::assert_snapshot!(work_dir.read_file("fileB"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    1_edited
+    %%%%%%% Changes from base to side #2
     -base_edited
-    +1_edited
-    +++++++ Contents of side #2
-    2_edited
+    +2_edited
     >>>>>>> Conflict 1 of 1 ends
     ");
     insta::assert_snapshot!(work_dir.run_jj(["resolve", "--list"]), @r"
@@ -951,21 +957,21 @@ fn test_resolve_conflicts_with_executable() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file1"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a1
+    %%%%%%% Changes from base to side #2
     -base1
-    +a1
-    +++++++ Contents of side #2
-    b1
+    +b1
     >>>>>>> Conflict 1 of 1 ends
     "
     );
     insta::assert_snapshot!(work_dir.read_file("file2"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a2
+    %%%%%%% Changes from base to side #2
     -base2
-    +a2
-    +++++++ Contents of side #2
-    b2
+    +b2
     >>>>>>> Conflict 1 of 1 ends
     "
     );
@@ -1000,11 +1006,11 @@ fn test_resolve_conflicts_with_executable() {
     +++ b/file1
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a1
+    -%%%%%%% Changes from base to side #2
     --base1
-    -+a1
-    -+++++++ Contents of side #2
-    -b1
+    -+b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
     [EOF]
@@ -1044,11 +1050,11 @@ fn test_resolve_conflicts_with_executable() {
     +++ b/file2
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a2
+    -%%%%%%% Changes from base to side #2
     --base2
-    -+a2
-    -+++++++ Contents of side #2
-    -b2
+    -+b2
     ->>>>>>> Conflict 1 of 1 ends
     +resolution2
     [EOF]
@@ -1076,26 +1082,24 @@ fn test_resolve_conflicts_with_executable() {
     +++ b/file1
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+     a1
+    -%%%%%%% Changes from base to side #2
     --base1
-    -+a1
-    -+++++++ Contents of side #2
-    -b1
+    -+b1
     ->>>>>>> Conflict 1 of 1 ends
-    +a1
     diff --git a/file2 b/file2
     index 0000000000..c1827f07e1 100755
     --- a/file2
     +++ b/file2
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+     a2
+    -%%%%%%% Changes from base to side #2
     --base2
-    -+a2
-    -+++++++ Contents of side #2
-    -b2
+    -+b2
     ->>>>>>> Conflict 1 of 1 ends
-    +a2
     [EOF]
     ");
 
@@ -1117,24 +1121,26 @@ fn test_resolve_conflicts_with_executable() {
     +++ b/file1
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a1
+    -%%%%%%% Changes from base to side #2
     --base1
-    -+a1
-    -+++++++ Contents of side #2
-     b1
+    -+b1
     ->>>>>>> Conflict 1 of 1 ends
+    +b1
     diff --git a/file2 b/file2
     index 0000000000..e6bfff5c1d 100755
     --- a/file2
     +++ b/file2
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a2
+    -%%%%%%% Changes from base to side #2
     --base2
-    -+a2
-    -+++++++ Contents of side #2
-     b2
+    -+b2
     ->>>>>>> Conflict 1 of 1 ends
+    +b2
     [EOF]
     ");
 }
@@ -1740,20 +1746,20 @@ fn test_multiple_conflicts() {
     insta::assert_snapshot!(
         work_dir.read_file("this_file_has_a_very_long_name_to_test_padding"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    first a
+    %%%%%%% Changes from base to side #2
     -first base
-    +first a
-    +++++++ Contents of side #2
-    first b
+    +first b
     >>>>>>> Conflict 1 of 1 ends
     ");
     insta::assert_snapshot!(work_dir.read_file("another_file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    second a
+    %%%%%%% Changes from base to side #2
     -second base
-    +second a
-    +++++++ Contents of side #2
-    second b
+    +second b
     >>>>>>> Conflict 1 of 1 ends
     ");
     let setup_opid = work_dir.current_operation_id();
@@ -1798,11 +1804,11 @@ fn test_multiple_conflicts() {
     +++ b/another_file
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -second a
+    -%%%%%%% Changes from base to side #2
     --second base
-    -+second a
-    -+++++++ Contents of side #2
-    -second b
+    -+second b
     ->>>>>>> Conflict 1 of 1 ends
     +resolution another_file
     [EOF]
@@ -1841,11 +1847,11 @@ fn test_multiple_conflicts() {
     +++ b/another_file
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -second a
+    -%%%%%%% Changes from base to side #2
     --second base
-    -+second a
-    -+++++++ Contents of side #2
-    -second b
+    -+second b
     ->>>>>>> Conflict 1 of 1 ends
     +first resolution for auto-chosen file
     diff --git a/this_file_has_a_very_long_name_to_test_padding b/this_file_has_a_very_long_name_to_test_padding
@@ -1854,11 +1860,11 @@ fn test_multiple_conflicts() {
     +++ b/this_file_has_a_very_long_name_to_test_padding
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -first a
+    -%%%%%%% Changes from base to side #2
     --first base
-    -+first a
-    -+++++++ Contents of side #2
-    -first b
+    -+first b
     ->>>>>>> Conflict 1 of 1 ends
     +second resolution for auto-chosen file
     [EOF]
@@ -1916,21 +1922,21 @@ fn test_multiple_conflicts_with_error() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file1"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a1
+    %%%%%%% Changes from base to side #2
     -base1
-    +a1
-    +++++++ Contents of side #2
-    b1
+    +b1
     >>>>>>> Conflict 1 of 1 ends
     "
     );
     insta::assert_snapshot!(work_dir.read_file("file2"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a2
+    %%%%%%% Changes from base to side #2
     -base2
-    +a2
-    +++++++ Contents of side #2
-    b2
+    +b2
     >>>>>>> Conflict 1 of 1 ends
     "
     );
@@ -1973,11 +1979,11 @@ fn test_multiple_conflicts_with_error() {
     +++ b/file1
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a1
+    -%%%%%%% Changes from base to side #2
     --base1
-    -+a1
-    -+++++++ Contents of side #2
-    -b1
+    -+b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
     [EOF]
@@ -2025,11 +2031,11 @@ fn test_multiple_conflicts_with_error() {
     +++ b/file1
     @@ -1,7 +1,1 @@
     -<<<<<<< Conflict 1 of 1
-    -%%%%%%% Changes from base to side #1
+    -+++++++ Contents of side #1
+    -a1
+    -%%%%%%% Changes from base to side #2
     --base1
-    -+a1
-    -+++++++ Contents of side #2
-    -b1
+    -+b1
     ->>>>>>> Conflict 1 of 1 ends
     +resolution1
     [EOF]
@@ -2110,20 +2116,20 @@ fn test_resolve_with_contents_of_side() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
     insta::assert_snapshot!(work_dir.read_file("other"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    left
+    %%%%%%% Changes from base to side #2
     -base
-    +left
-    +++++++ Contents of side #2
-    right
+    +right
     >>>>>>> Conflict 1 of 1 ends
     ");
     let setup_opid = work_dir.current_operation_id();

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -182,11 +182,11 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
 
@@ -195,11 +195,11 @@ fn test_restore_conflicted_merge() {
     insta::assert_snapshot!(work_dir.run_jj(["diff"]), @r"
     Resolved conflict in file:
        1     : <<<<<<< Conflict 1 of 1
-       2     : %%%%%%% Changes from base to side #1
-       3     : -base
-       4     : +a
-       5     : +++++++ Contents of side #2
-       6     : b
+       2     : +++++++ Contents of side #1
+       3     : a
+       4     : %%%%%%% Changes from base to side #2
+       5     : -base
+       6     : +b
        7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
     [EOF]
@@ -219,11 +219,11 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
     let output = work_dir.run_jj(["diff"]);
@@ -234,11 +234,11 @@ fn test_restore_conflicted_merge() {
     insta::assert_snapshot!(work_dir.run_jj(["diff"]), @r"
     Resolved conflict in file:
        1     : <<<<<<< Conflict 1 of 1
-       2     : %%%%%%% Changes from base to side #1
-       3     : -base
-       4     : +a
-       5     : +++++++ Contents of side #2
-       6     : b
+       2     : +++++++ Contents of side #1
+       3     : a
+       4     : %%%%%%% Changes from base to side #2
+       5     : -base
+       6     : +b
        7     : >>>>>>> Conflict 1 of 1 ends
             1: resolution
     [EOF]
@@ -258,11 +258,11 @@ fn test_restore_conflicted_merge() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -base
-    +a
-    +++++++ Contents of side #2
-    b
+    +b
     >>>>>>> Conflict 1 of 1 ends
     ");
 }

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -898,14 +898,14 @@ fn test_squash_from_multiple() {
     let output = work_dir.run_jj(["file", "show", "-r=d", "file"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base #1 to side #1
-    -a
-    +d
-    %%%%%%% Changes from base #2 to side #2
+    +++++++ Contents of side #1
+    d
+    %%%%%%% Changes from base #1 to side #2
     -a
     +b
-    +++++++ Contents of side #3
-    c
+    %%%%%%% Changes from base #2 to side #3
+    -a
+    +c
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");
@@ -1056,14 +1056,14 @@ fn test_squash_from_multiple_partial() {
     let output = work_dir.run_jj(["file", "show", "-r=d", "file1"]);
     insta::assert_snapshot!(output, @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base #1 to side #1
-    -a
-    +d
-    %%%%%%% Changes from base #2 to side #2
+    +++++++ Contents of side #1
+    d
+    %%%%%%% Changes from base #1 to side #2
     -a
     +b
-    +++++++ Contents of side #3
-    c
+    %%%%%%% Changes from base #2 to side #3
+    -a
+    +c
     >>>>>>> Conflict 1 of 1 ends
     [EOF]
     ");

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -244,16 +244,16 @@ fn test_materialize_conflict_three_sides() {
         @r"
     line 1
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base #1 to side #1
+    +++++++ Contents of side #1
+    line 2 a.1
+    line 3 a.2
+    line 4 base
+    %%%%%%% Changes from base #1 to side #2
     -line 2 base
-    -line 3 base
-    +line 2 a.1
-    +line 3 a.2
-     line 4 base
-    +++++++ Contents of side #2
-    line 2 b.1
-    line 3 base
-    line 4 b.2
+    +line 2 b.1
+     line 3 base
+    -line 4 base
+    +line 4 b.2
     %%%%%%% Changes from base #2 to side #3
      line 2 base
     +line 3 c.2
@@ -1758,19 +1758,19 @@ fn test_update_conflict_from_content_simplified_conflict() {
         materialized,
         @r"
     <<<<<<< Conflict 1 of 2
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    left 1
+    %%%%%%% Changes from base to side #2
     -line 1
-    +left 1
-    +++++++ Contents of side #2
-    right 1
+    +right 1
     >>>>>>> Conflict 1 of 2 ends
     line 2
     <<<<<<< Conflict 2 of 2
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    left 3
+    %%%%%%% Changes from base to side #2
     -line 3
-    +left 3
-    +++++++ Contents of side #2
-    right 3
+    +right 3
     >>>>>>> Conflict 2 of 2 ends
     "
     );
@@ -2003,11 +2003,11 @@ fn test_update_conflict_from_content_no_eol() {
         @r"
     line 1
     <<<<<<< Conflict 1 of 2
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    line 2 left
+    %%%%%%% Changes from base to side #2
     -line 2
-    +line 2 left
-    +++++++ Contents of side #2
-    line 2 right
+    +line 2 right
     >>>>>>> Conflict 1 of 2 ends
     line 3
     <<<<<<< Conflict 2 of 2
@@ -2280,19 +2280,19 @@ fn test_update_from_content_malformed_conflict() {
     insta::assert_snapshot!(materialized, @r"
     line 1
     <<<<<<< Conflict 1 of 2
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    line 2 left
+    %%%%%%% Changes from base to side #2
     -line 2
-    +line 2 left
-    +++++++ Contents of side #2
-    line 2 right
+    +line 2 right
     >>>>>>> Conflict 1 of 2 ends
     line 3
     <<<<<<< Conflict 2 of 2
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    line 4 left
+    %%%%%%% Changes from base to side #2
     -line 4
-    +line 4 left
-    +++++++ Contents of side #2
-    line 4 right
+    +line 4 right
     >>>>>>> Conflict 2 of 2 ends
     line 5
     "

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -885,22 +885,22 @@ fn test_materialize_snapshot_conflicted_files() {
         std::fs::read_to_string(file1_path.to_fs_path_unchecked(&workspace_root)).ok().unwrap(),
         @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    a
+    %%%%%%% Changes from base to side #2
     -b
-    +a
-    +++++++ Contents of side #2
-    c
+    +c
     >>>>>>> Conflict 1 of 1 ends
     ");
     insta::assert_snapshot!(
         std::fs::read_to_string(file2_path.to_fs_path_unchecked(&workspace_root)).ok().unwrap(),
         @r"
     <<<<<<< Conflict 1 of 1
-    %%%%%%% Changes from base to side #1
+    +++++++ Contents of side #1
+    1
+    %%%%%%% Changes from base to side #2
     -2
-    +1
-    +++++++ Contents of side #2
-    4
+    +4
     >>>>>>> Conflict 1 of 1 ends
     ");
 


### PR DESCRIPTION
Often, the diffs for the first side and second side are approximately the same size, so we have the choice of whether we want to emit a snapshot for the first side or for the second side. Currently, we prefer to emit a diff for the first side when possible.

I think it would make more sense to prefer emitting snapshots instead for the first side since the first side of the merge usually makes more sense semantically as the snapshot. For instance, in merges, the first side is the first parent, and in rebases, the first side is the destination to which the diff is being applied. Therefore, I think we should prefer to emit a snapshot for the first term unless it would create a diff that's more than 10% larger.

Stacked on #7872

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
