### PR TITLE
cli: add `jj file track --include-ignored` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Revsets now support logical operators in string patterns.
 
+* `jj file track` now accepts an `--include-ignored` flag to track files that
+  are ignored by `.gitignore` or exceed the `snapshot.max-new-file-size` limit.
+  [#2837](https://github.com/jj-vcs/jj/issues/2837)
+
 ### Fixed bugs
 
 * `jj metaedit --author-timestamp` twice with the same value no longer

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -70,6 +70,7 @@ use jj_lib::gitignore::GitIgnoreError;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::matchers::Matcher;
+use jj_lib::matchers::NothingMatcher;
 use jj_lib::merge::Diff;
 use jj_lib::merge::MergedTreeValue;
 use jj_lib::merged_tree::MergedTree;
@@ -1387,6 +1388,7 @@ to the current parents may contain changes from multiple commits.
             base_ignores,
             progress: None,
             start_tracking_matcher,
+            force_tracking_matcher: &NothingMatcher,
             max_new_file_size,
         })
     }

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -16,6 +16,7 @@ use jj_lib::local_working_copy::TreeStateError;
 use jj_lib::local_working_copy::TreeStateSettings;
 use jj_lib::matchers::EverythingMatcher;
 use jj_lib::matchers::Matcher;
+use jj_lib::matchers::NothingMatcher;
 use jj_lib::merge::Diff;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree::TreeDiffEntry;
@@ -283,6 +284,7 @@ diff editing in mind and be a little inaccurate.
             base_ignores,
             progress: None,
             start_tracking_matcher: &EverythingMatcher,
+            force_tracking_matcher: &NothingMatcher,
             max_new_file_size: u64::MAX,
         })?;
         Ok(output_tree_state.current_tree().clone())

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1141,11 +1141,17 @@ Without arguments, all paths that are not ignored will be tracked.
 
 By default, new files in the working copy are automatically tracked, so this command has no effect. You can configure which paths to automatically track by setting `snapshot.auto-track` (e.g. to `"none()"` or `"glob:**/*.rs"`). Files that don't match the pattern can be manually tracked using this command. The default pattern is `all()`.
 
-**Usage:** `jj file track <FILESETS>...`
+**Usage:** `jj file track [OPTIONS] <FILESETS>...`
 
 ###### **Arguments:**
 
 * `<FILESETS>` — Paths to track
+
+###### **Options:**
+
+* `--include-ignored` — Track paths even if they're ignored or too large
+
+   By default, `jj file track` will not track files that are ignored by .gitignore or exceed the maximum file size. This flag overrides those restrictions, explicitly tracking the specified paths.
 
 
 

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -84,6 +84,8 @@ fn test_snapshot_large_file() {
         This will increase the maximum file size allowed for new files, in this repository only.
       - Run `jj --config snapshot.max-new-file-size=11264 file track large large2`
         This will increase the maximum file size allowed for new files, for this command only.
+      - Run `jj file track --include-ignored large large2`
+        This will track the files even though they exceed the size limit.
     [EOF]
     ");
 

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1082,6 +1082,7 @@ impl TreeState {
             ref base_ignores,
             progress,
             start_tracking_matcher,
+            force_tracking_matcher,
             max_new_file_size,
         } = options;
 
@@ -1116,6 +1117,7 @@ impl TreeState {
                 current_tree: &self.tree,
                 matcher: &matcher,
                 start_tracking_matcher,
+                force_tracking_matcher,
                 // Move tx sides so they'll be dropped at the end of the scope.
                 tree_entries_tx,
                 file_states_tx,
@@ -1264,6 +1266,7 @@ struct FileSnapshotter<'a> {
     current_tree: &'a MergedTree,
     matcher: &'a dyn Matcher,
     start_tracking_matcher: &'a dyn Matcher,
+    force_tracking_matcher: &'a dyn Matcher,
     tree_entries_tx: Sender<(RepoPathBuf, MergedTreeValue)>,
     file_states_tx: Sender<(RepoPathBuf, FileState)>,
     untracked_paths_tx: Sender<(RepoPathBuf, UntrackedReason)>,
@@ -1368,7 +1371,9 @@ impl FileSnapshotter<'_> {
 
         if file_type.is_dir() {
             let file_states = file_states.prefixed_at(dir, name);
-            if git_ignore.matches(&path.to_internal_dir_string()) {
+            if git_ignore.matches(&path.to_internal_dir_string())
+                && self.force_tracking_matcher.visit(&path).is_nothing()
+            {
                 // If the whole directory is ignored by .gitignore, visit only
                 // paths we're already tracking. This is because .gitignore in
                 // ignored directory must be ignored. It's also more efficient.
@@ -1394,7 +1399,8 @@ impl FileSnapshotter<'_> {
                 progress(&path);
             }
             if maybe_current_file_state.is_none()
-                && git_ignore.matches(path.as_internal_file_string())
+                && (git_ignore.matches(path.as_internal_file_string())
+                    && !self.force_tracking_matcher.matches(&path))
             {
                 // If it wasn't already tracked and it matches
                 // the ignored paths, then ignore it.
@@ -1412,7 +1418,10 @@ impl FileSnapshotter<'_> {
                     message: format!("Failed to stat file {}", entry.path().display()),
                     err: err.into(),
                 })?;
-                if maybe_current_file_state.is_none() && metadata.len() > self.max_new_file_size {
+                if maybe_current_file_state.is_none()
+                    && (metadata.len() > self.max_new_file_size
+                        && !self.force_tracking_matcher.matches(&path))
+                {
                     // Leave the large file untracked
                     let reason = UntrackedReason::FileTooLarge {
                         size: metadata.len(),

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -221,6 +221,9 @@ pub struct SnapshotOptions<'a> {
     /// For new files that are not already tracked, start tracking them if they
     /// match this.
     pub start_tracking_matcher: &'a dyn Matcher,
+    /// For files that match the ignore patterns or are too large, start
+    /// tracking them anyway if they match this.
+    pub force_tracking_matcher: &'a dyn Matcher,
     /// The size of the largest file that should be allowed to become tracked
     /// (already tracked files are always snapshotted). If there are larger
     /// files in the working copy, then `LockedWorkingCopy::snapshot()` may

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -45,6 +45,7 @@ use jj_lib::config::StackedConfig;
 use jj_lib::git_backend::GitBackend;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::matchers::EverythingMatcher;
+use jj_lib::matchers::NothingMatcher;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::MutableRepo;
@@ -132,6 +133,7 @@ pub fn empty_snapshot_options() -> SnapshotOptions<'static> {
         base_ignores: GitIgnoreFile::empty(),
         progress: None,
         start_tracking_matcher: &EverythingMatcher,
+        force_tracking_matcher: &NothingMatcher,
         max_new_file_size: u64::MAX,
     }
 }


### PR DESCRIPTION
This adds support for tracking ignored and oversized files with `jj file track`.

Previously, `jj file track` would silently fail to track files that were ignored by
`.gitignore` or larger than `snapshot.max-new-file-size`. This commit introduces an
`--include-ignored` flag that allows users to explicitly track these files.

## Implementation

Added a `force_tracking_matcher` field to `SnapshotOptions` that overrides ignore rules
and size limits. When `--include-ignored` is specified, the file pattern matcher is
passed as `force_tracking_matcher`, allowing three checks in `FileSnapshotter` to bypass
their usual restrictions for directory ignores, file ignores, and file size limits.

## Tests

- `test_track_ignored_with_flag`: Verifies `.gitignore`d files can be tracked
- `test_track_large_file_with_flag`: Verifies oversized files can be tracked
- `test_track_ignored_directory`: Verifies ignored directories can be tracked recursively

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes