### PR TITLE
docs: use long-form flag names in command documentation

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -68,8 +68,8 @@ pub(crate) struct NewArgs {
     _edit: bool,
     /// Insert the new change after the given commit(s)
     ///
-    /// Example: `jj new --after A` creates a new change between `A` and its
-    /// children:
+    /// Example: `jj new --insert-after A` creates a new change between `A` and
+    /// its children:
     ///
     /// ```text
     ///                 B   C
@@ -79,11 +79,12 @@ pub(crate) struct NewArgs {
     ///       A           A
     /// ```
     ///
-    /// Specifying `--after` multiple times will relocate all children of the
-    /// given commits.
+    /// Specifying `--insert-after` multiple times will relocate all children of
+    /// the given commits.
     ///
-    /// Example: `jj new --after A --after X` creates a change with `A` and `X`
-    /// as parents, and rebases all children on top of the new change:
+    /// Example: `jj new --insert-after A --insert-after X` creates a change
+    /// with `A` and `X` as parents, and rebases all children on top of the new
+    /// change:
     ///
     /// ```text
     ///                 B   Y
@@ -104,8 +105,8 @@ pub(crate) struct NewArgs {
     insert_after: Option<Vec<RevisionArg>>,
     /// Insert the new change before the given commit(s)
     ///
-    /// Example: `jj new --before C` creates a new change between `C` and its
-    /// parents:
+    /// Example: `jj new --insert-before C` creates a new change between `C` and
+    /// its parents:
     ///
     /// ```text
     ///                    C
@@ -115,9 +116,9 @@ pub(crate) struct NewArgs {
     ///     A   B        A   B
     /// ```
     ///
-    /// `--after` and `--before` can be combined.
+    /// `--insert-after` and `--insert-before` can be combined.
     ///
-    /// Example: `jj new --after A --before D`:
+    /// Example: `jj new --insert-after A --insert-before D`:
     ///
     /// ```text
     /// 
@@ -130,7 +131,8 @@ pub(crate) struct NewArgs {
     ///     A            A
     /// ```
     ///
-    /// Similar to `--after`, you can specify `--before` multiple times.
+    /// Similar to `--insert-after`, you can specify `--insert-before` multiple
+    /// times.
     #[arg(
         long,
         short = 'B',

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -30,16 +30,16 @@ use crate::ui::Ui;
 
 /// Restore paths from another revision
 ///
-/// That means that the paths get the same content in the destination (`--to`)
+/// That means that the paths get the same content in the destination (`--into`)
 /// as they had in the source (`--from`). This is typically used for undoing
 /// changes to some paths in the working copy (`jj restore <paths>`).
 ///
-/// If only one of `--from` or `--to` is specified, the other one defaults to
+/// If only one of `--from` or `--into` is specified, the other one defaults to
 /// the working copy.
 ///
-/// When neither `--from` nor `--to` is specified, the command restores into the
-/// working copy from its parent(s). `jj restore` without arguments is similar
-/// to `jj abandon`, except that it leaves an empty revision with its
+/// When neither `--from` nor `--into` is specified, the command restores into
+/// the working copy from its parent(s). `jj restore` without arguments is
+/// similar to `jj abandon`, except that it leaves an empty revision with its
 /// description and other metadata preserved.
 ///
 /// See `jj diffedit` if you'd like to restore portions of files rather than

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1846,8 +1846,8 @@ Note that you can create a merge commit by specifying multiple revisions as argu
 * `--no-edit` — Do not edit the newly created change
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — Insert the new change after the given commit(s)
 
-   Example: `jj new --after A` creates a new change between `A` and its
-   children:
+   Example: `jj new --insert-after A` creates a new change between `A` and
+   its children:
 
    ```text
                    B   C
@@ -1857,11 +1857,12 @@ Note that you can create a merge commit by specifying multiple revisions as argu
          A           A
    ```
 
-   Specifying `--after` multiple times will relocate all children of the
-   given commits.
+   Specifying `--insert-after` multiple times will relocate all children of
+   the given commits.
 
-   Example: `jj new --after A --after X` creates a change with `A` and `X`
-   as parents, and rebases all children on top of the new change:
+   Example: `jj new --insert-after A --insert-after X` creates a change
+   with `A` and `X` as parents, and rebases all children on top of the new
+   change:
 
    ```text
                    B   Y
@@ -1872,8 +1873,8 @@ Note that you can create a merge commit by specifying multiple revisions as argu
    ```
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — Insert the new change before the given commit(s)
 
-   Example: `jj new --before C` creates a new change between `C` and its
-   parents:
+   Example: `jj new --insert-before C` creates a new change between `C` and
+   its parents:
 
    ```text
                       C
@@ -1883,9 +1884,9 @@ Note that you can create a merge commit by specifying multiple revisions as argu
        A   B        A   B
    ```
 
-   `--after` and `--before` can be combined.
+   `--insert-after` and `--insert-before` can be combined.
 
-   Example: `jj new --after A --before D`:
+   Example: `jj new --insert-after A --insert-before D`:
 
    ```text
 
@@ -1898,7 +1899,8 @@ Note that you can create a merge commit by specifying multiple revisions as argu
        A            A
    ```
 
-   Similar to `--after`, you can specify `--before` multiple times.
+   Similar to `--insert-after`, you can specify `--insert-before` multiple
+   times.
 
 
 
@@ -2560,11 +2562,11 @@ Note that conflicts can also be resolved without using this command. You may edi
 
 Restore paths from another revision
 
-That means that the paths get the same content in the destination (`--to`) as they had in the source (`--from`). This is typically used for undoing changes to some paths in the working copy (`jj restore <paths>`).
+That means that the paths get the same content in the destination (`--into`) as they had in the source (`--from`). This is typically used for undoing changes to some paths in the working copy (`jj restore <paths>`).
 
-If only one of `--from` or `--to` is specified, the other one defaults to the working copy.
+If only one of `--from` or `--into` is specified, the other one defaults to the working copy.
 
-When neither `--from` nor `--to` is specified, the command restores into the working copy from its parent(s). `jj restore` without arguments is similar to `jj abandon`, except that it leaves an empty revision with its description and other metadata preserved.
+When neither `--from` nor `--into` is specified, the command restores into the working copy from its parent(s). `jj restore` without arguments is similar to `jj abandon`, except that it leaves an empty revision with its description and other metadata preserved.
 
 See `jj diffedit` if you'd like to restore portions of files rather than entire files.
 


### PR DESCRIPTION
in clap, the visible_aliases, e.g. '[aliases: --after]' are shown at  the very end, which makes it confusing if you're reading from top to bottom.

aliases are currently omitted entirely from the man pages, making it confusing to see undocumented aliases being used.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
