### PR TITLE
cli: document that `jj git import/export` are not needed when colocated

### DIFF
--- a/cli/src/commands/git/export.rs
+++ b/cli/src/commands/git/export.rs
@@ -20,6 +20,9 @@ use crate::git_util::print_git_export_stats;
 use crate::ui::Ui;
 
 /// Update the underlying Git repo with changes made in the repo
+///
+/// There is no need to run this command if you're in colocated repo because the
+/// export happens automatically there.
 #[derive(clap::Args, Clone, Debug)]
 pub struct GitExportArgs {}
 

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -23,6 +23,9 @@ use crate::ui::Ui;
 ///
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
+///
+/// There is no need to run this command if you're in colocated repo because the
+/// import happens automatically there.
 #[derive(clap::Args, Clone, Debug)]
 pub struct GitImportArgs {}
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1401,6 +1401,8 @@ Show the current colocation status
 
 Update the underlying Git repo with changes made in the repo
 
+There is no need to run this command if you're in colocated repo because the export happens automatically there.
+
 **Usage:** `jj git export`
 
 
@@ -1437,6 +1439,8 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 Update repo with changes made in the underlying Git repo
 
 If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
+
+There is no need to run this command if you're in colocated repo because the import happens automatically there.
 
 **Usage:** `jj git import`
 


### PR DESCRIPTION
Closes #7910

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
