### PR TITLE
log: add `--count` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,9 @@ should not be broken.
 * Added `join()` template function. This is different from `separate()` in that
   it adds a separator between all arguments, even if empty.
 
+* `jj log` now supports a `--count` flag to print the number of commits instead
+  of displaying them.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1763,6 +1763,7 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
    [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `-p`, `--patch` — Show patch
+* `--count` — Print the number of commits instead of showing them
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
 * `--types` — For each path, show only its type before and after

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1757,3 +1757,34 @@ fn test_log_anonymize() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_log_count() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1", "foo\n");
+    work_dir.run_jj(["describe", "-m", "first"]).success();
+    work_dir.run_jj(["new", "-m", "second"]).success();
+    work_dir.write_file("file2", "bar\n");
+    work_dir.run_jj(["new", "-m", "third"]).success();
+
+    let output = work_dir.run_jj(["log", "--count"]);
+    insta::assert_snapshot!(output, @r"
+    4
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["log", "--count", "-r", "all() ~ root()"]);
+    insta::assert_snapshot!(output, @r"
+    3
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["log", "--count", "--limit", "2"]);
+    insta::assert_snapshot!(output, @r"
+    2
+    [EOF]
+    ");
+}


### PR DESCRIPTION
Inspired by @indirect's talk at JJ Con and associated [discussion](https://github.com/jj-vcs/jj/discussions/6683), introduce `--count` to avoid gnarly one-liners like:

> `jj log --no-graph -r "main..@ & (~empty() | merges())" -T '"n"' 2> /dev/null | wc -c | tr -d ' '`