### PR TITLE
tests: exercise more bisect behaviors

### DIFF
--- a/cli/testing/fake-bisector.rs
+++ b/cli/testing/fake-bisector.rs
@@ -41,6 +41,8 @@ fn main() {
         let parts = command.split(' ').collect_vec();
         match parts.as_slice() {
             [""] => {}
+            ["abort"] => exit(127),
+            ["skip"] => exit(125),
             ["fail"] => exit(1),
             ["fail-if-target-is", bad_target_commit] => {
                 if commit_to_test == *bad_target_commit {


### PR DESCRIPTION
More of the same; I found a number of cases in the `jj bisect run` code that weren't being hit with the bisect code itself:
- Bisecting over an empty range
- Bisection process aborts early
- Bisect command skips (all) revisions
- Bisection finds multiple results

Feedback and bikeshedding welcome.  In particular, should I teach the fake bisection script how to skip/abort rather than using `sh`, or is this acceptable?

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
