### PR TITLE
config: add hostname-based conditional config scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Add support for `--when.workspaces` config scopes.
 
+* Add support for `--when.hostnames` config scopes. This allows configuration to
+  be conditionally applied based on the hostname set in `operation.hostname`.
+
 * `jj bisect run` accepts the command and arguments to pass to the command
   directly as positional arguments, such as
   `jj bisect --range=..main -- cargo check --all-targets`.

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -950,6 +950,13 @@
                         "type": "string"
                     }
                 },
+                "hostnames": {
+                    "type": "array",
+                    "description": "List of hostnames to match the hostname",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "workspaces": {
                     "type": "array",
                     "description": "List of paths to match the workspace path prefix",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -376,6 +376,7 @@ pub struct ConfigEnv {
     repo_config_path: Option<ConfigPath>,
     workspace_config_path: Option<ConfigPath>,
     command: Option<String>,
+    hostname: Option<String>,
 }
 
 impl ConfigEnv {
@@ -423,6 +424,7 @@ impl ConfigEnv {
             repo_config_path: None,
             workspace_config_path: None,
             command: None,
+            hostname: whoami::fallible::hostname().ok(),
         }
     }
 
@@ -602,6 +604,7 @@ impl ConfigEnv {
             repo_path: self.repo_path.as_deref(),
             workspace_path: self.workspace_path.as_deref(),
             command: self.command.as_deref(),
+            hostname: self.hostname.as_deref().unwrap_or(""),
         };
         jj_lib::config::resolve(config.as_ref(), &context)
     }
@@ -1852,6 +1855,7 @@ mod tests {
             repo_config_path: None,
             workspace_config_path: None,
             command: None,
+            hostname: None,
         }
     }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1883,6 +1883,12 @@ email = "YOUR_DEFAULT_EMAIL@example.com"
 [--scope.user]
 email = "YOUR_OSS_EMAIL@example.org"
 
+# override ui.pager on specific machines
+[[--scope]]
+--when.hostnames = ["work-laptop", "work-desktop"]
+[--scope.ui]
+pager = "delta"
+
 # disable pagination for `jj status`, use `delta` for `jj diff` and `jj show`
 [[--scope]]
 --when.commands = ["status"]
@@ -1939,6 +1945,16 @@ wip = ["log", "-r", "work"]
   The same concerns about the path as for `--when.repositories` applies.
 
   Use `jj root` to see the workspace root directory.
+
+* `--when.hostnames`: List of hostnames to match against the `operation.hostname`
+  config setting.
+
+  Hostnames are compared case-sensitively and must match exactly.
+
+  ```toml
+  --when.hostnames = ["work-laptop"]               # matches only "work-laptop"
+  --when.hostnames = ["home-desktop", "laptop"]    # matches "home-desktop" OR "laptop"
+  ```
 
 * `--when.commands`: List of subcommands to match.
 


### PR DESCRIPTION
This enables configuration to be conditionally applied based on the hostname set in `operation.hostname`. Users can now use `--when.hostnames = ["host-a", "host-b"]` in their config files to apply settings only on specific machines. I think this would be a great addition as e.g. I have the same folder structure on my work and personal machine, so I can't use `--when.repositories` to distinguish config scopes.

This is my first contribution to jj, so if I did something wrong let me know!
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
