### PR TITLE
cli: help: add support for aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Revsets now support logical operators in string patterns.
 
+* `jj help` now supports aliases.
+
 ### Fixed bugs
 
 * `jj metaedit --author-timestamp` twice with the same value no longer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,7 @@ dependencies = [
  "scm-record",
  "serde",
  "serde_json",
+ "shlex",
  "slab",
  "strsim",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ sapling-streampager = "0.11.0"
 scm-record = "0.8.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0.145"
+shlex = "1.3.0"
 slab = "0.4.11"
 smallvec = { version = "1.15.1", features = [
     "const_generics",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -90,6 +90,7 @@ sapling-streampager = { workspace = true }
 scm-record = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shlex = { workspace = true }
 slab = { workspace = true }
 strsim = { workspace = true }
 tempfile = { workspace = true }

--- a/cli/src/commands/help.rs
+++ b/cli/src/commands/help.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::fmt::Write as _;
 use std::io::Write as _;
 
@@ -20,11 +21,12 @@ use clap::builder::StyledStr;
 use clap::error::ContextKind;
 use crossterm::style::Stylize as _;
 use itertools::Itertools as _;
+use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
-use crate::command_error::cli_error;
+use crate::command_error::user_error;
 use crate::ui::Ui;
 
 /// Print this message or the help of the given subcommand(s)
@@ -63,8 +65,27 @@ pub(crate) fn cmd_help(
         .string_args()
         .first()
         .map_or(command.app().get_name(), |name| name.as_ref());
+
+    // Check if the first command argument is an alias
+    let mut resolved_alias_definition: Option<Vec<String>> = None;
+    let command_path = if let Some(first_arg) = args.command.first()
+        && let Some((original_definition, resolved_definition)) =
+            resolve_alias(command.settings(), first_arg)?
+    {
+        if args.command.len() > 1 {
+            return Err(user_error(format!(
+                "Invalid arguments following alias '{first_arg}'"
+            )));
+        }
+
+        resolved_alias_definition = Some(original_definition);
+        resolved_definition
+    } else {
+        args.command.clone()
+    };
+
     let mut args_to_get_command = vec![bin_name];
-    args_to_get_command.extend(args.command.iter().map(|s| s.as_str()));
+    args_to_get_command.extend(command_path.iter().map(|s| s.as_str()));
 
     let mut app = command.app().clone();
     // This propagates global arguments to subcommand, and generates error if
@@ -76,20 +97,85 @@ pub(crate) fn cmd_help(
             // `help log -- -r`, etc. shouldn't generate an argument error.
         }
     }
-    let command = args
-        .command
+    // Use command_path (which may be resolved) instead of args.command
+    // Walk the subcommand tree, stopping when we hit something that isn't a
+    // subcommand First, figure out how many elements are actual subcommands
+    let mut subcommand_depth = 0;
+    let mut current_cmd = &app;
+    for name in &command_path {
+        if let Some(subcmd) = current_cmd.find_subcommand(name) {
+            current_cmd = subcmd;
+            subcommand_depth += 1;
+        } else {
+            // Not a subcommand (probably an argument like "-r"), stop here
+            break;
+        }
+    }
+
+    // Now walk the mutable path for the actual depth we found
+    let subcommand = command_path
         .iter()
+        .take(subcommand_depth)
         .try_fold(&mut app, |cmd, name| cmd.find_subcommand_mut(name))
-        .ok_or_else(|| cli_error(format!("Unknown command: {}", args.command.join(" "))))?;
+        .unwrap(); // Safe because we already validated the path exists
 
     ui.request_pager();
-    let help_text = command.render_long_help();
+
+    // If this was an alias, print the alias info first
+    if let Some(alias_definition) = resolved_alias_definition {
+        let alias_display = format_alias_definition(&alias_definition);
+        writeln!(ui.stdout(), "{alias_display}")?;
+        writeln!(ui.stdout())?; // Blank line separator
+    }
+
+    // Render the help for the resolved command
+    let help_text = subcommand.render_long_help();
     if ui.color() {
         write!(ui.stdout(), "{}", help_text.ansi())?;
     } else {
         write!(ui.stdout(), "{help_text}")?;
     }
     Ok(())
+}
+
+type ResolvedAlias = Option<(Vec<String>, Vec<String>)>;
+
+/// Resolves an alias to its definition, recursively expanding nested aliases.
+///
+/// Returns `Some((original_definition, resolved_definition))` if the name is an
+/// alias, or `None` if it's not an alias.
+///
+/// The original definition is what the user configured (e.g., `["b",
+/// "--no-graph"]`). The resolved definition has all nested aliases expanded
+/// (e.g., `["log", "-r", "@", "-T", "bookmarks", "--no-graph"]`).
+fn resolve_alias(settings: &UserSettings, alias_name: &str) -> Result<ResolvedAlias, CommandError> {
+    let config = settings.config();
+
+    let alias_keys: HashSet<_> = config.table_keys("aliases").collect();
+    if !alias_keys.contains(alias_name) {
+        return Ok(None);
+    }
+
+    let alias_definition: Vec<String> = config.get(["aliases", alias_name])?;
+
+    let mut seen_aliases = HashSet::new();
+    let resolved_definition = crate::cli_util::expand_alias_recursively(
+        config,
+        alias_name,
+        &alias_keys,
+        &mut seen_aliases,
+    )?;
+
+    Ok(Some((alias_definition, resolved_definition)))
+}
+
+/// Formats an alias definition for display in help output.
+fn format_alias_definition(alias_definition: &[String]) -> String {
+    // Use shlex to properly quote the definition if needed
+    match shlex::try_join(alias_definition.iter().map(|s| &**s)) {
+        Ok(joined) => format!("Alias for \"{joined}\""),
+        Err(_) => format!("Alias for {alias_definition:?}"),
+    }
 }
 
 #[derive(Clone)]

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use itertools::Itertools as _;
+
 use crate::common::TestEnvironment;
 
 #[test]
@@ -462,4 +464,96 @@ fn test_aliases_overriding_friendly_errors() {
     Test User
     [EOF]
     ");
+}
+
+#[test]
+fn test_alias_help() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let repo_path = test_env.env_root().join("repo");
+
+    test_env.add_config(r#"aliases.b = ["log", "-r", "@", "-T", "bookmarks"]"#);
+    test_env.add_config(r#"aliases.s = ["status"]"#);
+    test_env.add_config(r#"aliases.f = ["git", "fetch"]"#); // test nested subcommand
+    test_env.add_config(r#"aliases.b2 = ["b", "--no-graph"]"#); // test recursive subcommand
+    test_env.add_config(r#"aliases.empty = []"#);
+    test_env.add_config(r#"aliases.option-only = ["--no-pager"]"#);
+    test_env.add_config(r#"aliases.bad = ["this-command-does-not-exist"]"#);
+
+    let output = test_env.run_jj_in(&repo_path, ["help", "b"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().take(3).join("\n"), @r#"
+    Alias for "log -r @ -T bookmarks"
+
+    Show revision history
+    "#);
+    let output = test_env.run_jj_in(&repo_path, ["b", "-h"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().next().unwrap(), @"Show revision history");
+
+    let output = test_env.run_jj_in(&repo_path, ["help", "s"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().take(3).join("\n"), @r#"
+    Alias for "status"
+
+    Show high-level repo status [default alias: st]
+    "#);
+    let output = test_env.run_jj_in(&repo_path, ["s", "-h"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().next().unwrap(), @"Show high-level repo status [default alias: st]");
+
+    let output = test_env.run_jj_in(&repo_path, ["help", "f"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().take(3).join("\n"), @r###"
+    Alias for "git fetch"
+
+    Fetch from a Git remote
+    "###);
+    let output = test_env.run_jj_in(&repo_path, ["f", "-h"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().next().unwrap(), @"Fetch from a Git remote");
+
+    let output = test_env.run_jj_in(&repo_path, ["help", "b2"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().take(3).join("\n"), @r###"
+    Alias for "b --no-graph"
+
+    Show revision history
+    "###);
+    let output = test_env.run_jj_in(&repo_path, ["b2", "-h"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().next().unwrap(), @"Show revision history");
+
+    let output = test_env.run_jj_in(&repo_path, ["help", "empty"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().take(3).join("\n"), @r#"
+    Alias for ""
+
+    Jujutsu (An experimental VCS)
+    "#);
+    let output = test_env.run_jj_in(&repo_path, ["empty", "-h"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().next().unwrap(), @"Jujutsu (An experimental VCS)");
+
+    let output = test_env.run_jj_in(&repo_path, ["help", "option-only"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout.lines().take(3).join("\n"), @r#"
+    Alias for "--no-pager"
+
+    Jujutsu (An experimental VCS)
+    "#);
+
+    let output = test_env.run_jj_in(&repo_path, ["help", "bad"]);
+    let stdout = output.stdout.normalized();
+    insta::assert_snapshot!(stdout, @"");
+
+    let output = test_env.run_jj_in(&repo_path, ["bad", "-h"]);
+    let stderr = output.stderr.normalized();
+    insta::assert_snapshot!(stderr, @r###"
+    error: unrecognized subcommand 'this-command-does-not-exist'
+
+    Usage: jj [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    "###);
 }


### PR DESCRIPTION
As suggested in #7408 this now handles alias resolution in the help command. The code is now much simpler but also has slightly different behaviour; most notably that it doesn't list defined aliases when we print help for the original command. Based on the discussion in the aforementioned PR this seems like it might even be preferable.

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have added/updated tests to cover my changes

---

I've written very little Rust before so although I've tried to write idiomatic code it's likely I've gotten some things wrong.