### PR TITLE
mise: rename "live" tasks to "watch"

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -98,14 +98,13 @@ tools.uv = "{{vars.uv_version}}"
 run = "uv run mkdocs serve"
 
 
-# not sure how to name these
-[tasks."clippy:live"]
+[tasks."clippy:watch"]
 description = "Lint the code with Clippy when the code changes"
 tools.rust = "{{vars.rust_version}}"
 tools."cargo:bacon" = "{{vars.bacon_version}}"
 run = "bacon clippy -- --workspace --all-targets"
 
-[tasks."test:live"]
+[tasks."test:watch"]
 description = "Run tests when the code changes"
 tools.rust = "{{vars.rust_version}}"
 tools."cargo:bacon" = "{{vars.bacon_version}}"


### PR DESCRIPTION
Just a small patch. Especially for test, I find the term "live" unintuitive. Does it mean testing whether something is "alive"? Is it testing "live in production"?

cc @glehmann 
