### PR TITLE
cli: squash: add --editor flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj squash` now accepts `--editor` / `-E` to edit the squashed commit message.
+
 ### Fixed bugs
 
 ## [0.35.0] - 2025-11-05

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2835,6 +2835,7 @@ An alternative squashing UI is available via the `-d`, `-A`, and `-B` options. T
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — (Experimental) The revision(s) to insert the new commit before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
 * `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
+* `-E`, `--editor` — Open an editor to edit the squashed commit's description
 * `-i`, `--interactive` — Interactively choose which parts to squash
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-k`, `--keep-emptied` — The source revision will not be abandoned


### PR DESCRIPTION
Closes #7684. I've tried to follow patterns established by `jj describe --edit` where the edit happens after any other flags that would affect the description.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
