### PR TITLE
cargo: upgrade assert_cmd to 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,13 +116,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.17"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",
@@ -771,12 +770,6 @@ dependencies = [
  "quote",
  "syn 2.0.108",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "document-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["version-control", "development-tools"]
 keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
 
 [workspace.dependencies]
-assert_cmd = "2.0.8"
+assert_cmd = "2.1.1"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
 blake2 = "0.10.6"

--- a/cli/tests/common/mod.rs
+++ b/cli/tests/common/mod.rs
@@ -22,21 +22,21 @@ pub use self::test_environment::TestEnvironment;
 pub use self::test_environment::TestWorkDir;
 
 pub fn fake_bisector_path() -> String {
-    let path = assert_cmd::cargo::cargo_bin("fake-bisector");
+    let path = assert_cmd::cargo::cargo_bin!("fake-bisector");
     assert!(path.is_file());
-    path.into_os_string().into_string().unwrap()
+    path.as_os_str().to_str().unwrap().to_owned()
 }
 
 pub fn fake_editor_path() -> String {
-    let path = assert_cmd::cargo::cargo_bin("fake-editor");
+    let path = assert_cmd::cargo::cargo_bin!("fake-editor");
     assert!(path.is_file());
-    path.into_os_string().into_string().unwrap()
+    path.as_os_str().to_str().unwrap().to_owned()
 }
 
 pub fn fake_diff_editor_path() -> String {
-    let path = assert_cmd::cargo::cargo_bin("fake-diff-editor");
+    let path = assert_cmd::cargo::cargo_bin!("fake-diff-editor");
     assert!(path.is_file());
-    path.into_os_string().into_string().unwrap()
+    path.as_os_str().to_str().unwrap().to_owned()
 }
 
 /// Forcibly enable interactive prompt.

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -113,7 +113,8 @@ impl TestEnvironment {
     /// Use `run_jj_with()` to run command within customized environment.
     #[must_use]
     pub fn new_jj_cmd(&self) -> assert_cmd::Command {
-        let mut cmd = assert_cmd::Command::cargo_bin("jj").unwrap();
+        let jj_path = assert_cmd::cargo::cargo_bin!("jj");
+        let mut cmd = assert_cmd::Command::new(jj_path);
         cmd.current_dir(&self.env_root);
         cmd.env_clear();
         cmd.env("COLUMNS", "100");

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -24,7 +24,7 @@ use crate::common::TestEnvironment;
 use crate::common::to_toml_value;
 
 fn set_up_fake_formatter(test_env: &TestEnvironment, args: &[&str]) {
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     test_env.add_config(formatdoc! {"
         [fix.tools.fake-formatter]
@@ -68,7 +68,7 @@ fn test_config_multiple_tools() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
     test_env.add_config(format!(
@@ -111,7 +111,7 @@ fn test_config_multiple_tools_with_same_name() {
     let mut test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
 
@@ -167,7 +167,7 @@ fn test_config_disabled_tools() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
     test_env.add_config(format!(
@@ -217,7 +217,7 @@ fn test_config_disabled_tools_warning_when_all_tools_are_disabled() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
     test_env.add_config(format!(
@@ -246,7 +246,7 @@ fn test_config_tables_overlapping_patterns() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
 
@@ -327,7 +327,7 @@ fn test_config_tables_some_commands_missing() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
     test_env.add_config(format!(
@@ -367,7 +367,7 @@ fn test_config_tables_empty_patterns_list() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
     test_env.add_config(format!(
@@ -400,7 +400,7 @@ fn test_config_filesets() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
     test_env.add_config(format!(
@@ -447,7 +447,7 @@ fn test_relative_paths() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
     test_env.add_config(format!(
@@ -519,11 +519,11 @@ fn test_relative_tool_path_from_subdirectory() {
     let work_dir = test_env.work_dir("repo");
 
     // Copy the fake-formatter into the workspace as a relative tool
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     let formatter_name = formatter_path.file_name().unwrap().to_str().unwrap();
     let tool_dir = work_dir.create_dir("tools");
     let workspace_formatter_path = tool_dir.root().join(formatter_name);
-    std::fs::copy(&formatter_path, &workspace_formatter_path).unwrap();
+    std::fs::copy(formatter_path, &workspace_formatter_path).unwrap();
     work_dir.write_file(".gitignore", "tools/\n");
     let formatter_relative_path = PathBuf::from_iter(["$root", "tools", formatter_name]);
     test_env.add_config(format!(
@@ -1410,7 +1410,7 @@ fn test_all_files() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     assert!(formatter_path.is_file());
     let formatter = to_toml_value(formatter_path.to_str().unwrap());
 

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -128,7 +128,7 @@ fn test_shell_completions() {
 #[test]
 fn test_util_exec() {
     let test_env = TestEnvironment::default();
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     let output = test_env.run_jj_in(
         ".",
         [
@@ -147,7 +147,7 @@ fn test_util_exec() {
 #[test]
 fn test_util_exec_fail() {
     let test_env = TestEnvironment::default();
-    let formatter_path = assert_cmd::cargo::cargo_bin("fake-formatter");
+    let formatter_path = assert_cmd::cargo::cargo_bin!("fake-formatter");
     let output = test_env.run_jj_in(
         ".",
         [


### PR DESCRIPTION
Dependabot couldn't do this because some methods became deprecated.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
