### PR TITLE
cli: squash: add --no-editor flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj squash` now accepts `--editor` / `-E` to edit the squashed commit message.
 
+* `jj squash` now accepts `--no-editor` to ensure squash is non-interactive
+  when two or more squashed commits have a non-empty description.
+
 ### Fixed bugs
 
 ## [0.35.0] - 2025-11-05

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2835,6 +2835,7 @@ An alternative squashing UI is available via the `-d`, `-A`, and `-B` options. T
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — (Experimental) The revision(s) to insert the new commit before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)
 * `-u`, `--use-destination-message` — Use the description of the destination revision and discard the description(s) of the source revision(s)
+* `--no-editor` — Don't open an editor when squashing multiple commits with non-empty descriptions. The destination commit will get the concatenated descriptions of all squashed commits. In all other cases this flag has no effect
 * `-E`, `--editor` — Open an editor to edit the squashed commit's description
 * `-i`, `--interactive` — Interactively choose which parts to squash
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)


### PR DESCRIPTION
Closes #7515.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
