### PR TITLE
docs: fix incorrect reference to `git log` command

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -642,7 +642,7 @@ Show the initial commits in the repo (the ones Git calls "root commits"):
 jj log -r 'root()+'
 ```
 
-Show some important commits (like `git --simplify-by-decoration`):
+Show some important commits (like `git log --simplify-by-decoration`):
 
 ```shell
 jj log -r 'tags() | bookmarks()'


### PR DESCRIPTION
# Checklist

If applicable:

- n/a I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- n/a I have updated the config schema (`cli/src/config-schema.json`)
- n/a I have added/updated tests to cover my changes
