### PR TITLE
cli: describe: deprecate --edit in favour of --editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* `jj describe --edit` is deprecated in favor of `--editor` / `-E`.
+
 ### New features
 
 * `jj squash` now accepts `--editor` / `-E` to edit the squashed commit message.

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -81,13 +81,20 @@ pub(crate) struct DescribeArgs {
     /// Don't open an editor
     ///
     /// This is mainly useful in combination with e.g. `--reset-author`.
-    #[arg(long, hide = true, conflicts_with = "edit")]
+    #[arg(long, hide = true, conflicts_with_all = ["edit", "editor"])]
     no_edit: bool,
+    /// Open an editor to edit the change description
+    ///
+    /// Forces an editor to open when using `--stdin` or `--message` to
+    /// allow the message to be edited afterwards.
+    #[arg(long, short = 'E')]
+    editor: bool,
+    // TODO: Delete in jj 0.42.0+
     /// Open an editor
     ///
     /// Forces an editor to open when using `--stdin` or `--message` to
     /// allow the message to be edited afterwards.
-    #[arg(long)]
+    #[arg(long, hide = true, conflicts_with = "editor")]
     edit: bool,
     // TODO: Delete in jj 0.40.0+
     /// Reset the author name, email, and timestamp
@@ -125,6 +132,12 @@ pub(crate) fn cmd_describe(
         writeln!(
             ui.warning_default(),
             "`jj describe --no-edit` is deprecated; use `jj metaedit` instead"
+        )?;
+    }
+    if args.edit {
+        writeln!(
+            ui.warning_default(),
+            "`jj describe --edit` is deprecated; use `jj describe --editor` (or `-E`) instead"
         )?;
     }
     if args.reset_author {
@@ -205,7 +218,7 @@ pub(crate) fn cmd_describe(
         })
         .collect_vec();
 
-    let use_editor = args.edit || (shared_description.is_none() && !args.no_edit);
+    let use_editor = args.editor || args.edit || (shared_description.is_none() && !args.no_edit);
 
     if let Some(trailer_template) = parse_trailers_template(ui, &tx)? {
         for commit_builder in &mut commit_builders {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -812,7 +812,7 @@ Starts an editor to let you edit the description of changes. The editor will be 
 * `--stdin` — Read the change description from stdin
 
    If multiple revisions are specified, the same description will be used for all of them.
-* `--edit` — Open an editor
+* `-E`, `--editor` — Open an editor to edit the change description
 
    Forces an editor to open when using `--stdin` or `--message` to allow the message to be edited afterwards.
 

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -889,14 +889,14 @@ fn test_describe_avoids_unc() {
 }
 
 #[test]
-fn test_describe_with_edit_and_message_args_opens_editor() {
+fn test_describe_with_editor_and_message_args_opens_editor() {
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_editor();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
-    let output = work_dir.run_jj(["describe", "-m", "message from command line", "--edit"]);
+    let output = work_dir.run_jj(["describe", "-m", "message from command line", "--editor"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: qpvuntsm f9bee6de (empty) message from command line
@@ -914,7 +914,7 @@ fn test_describe_with_edit_and_message_args_opens_editor() {
 }
 
 #[test]
-fn test_describe_change_with_existing_message_with_edit_and_message_args_opens_editor() {
+fn test_describe_change_with_existing_message_with_editor_and_message_args_opens_editor() {
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_editor();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
@@ -925,7 +925,7 @@ fn test_describe_change_with_existing_message_with_edit_and_message_args_opens_e
         .success();
 
     std::fs::write(edit_script, ["dump editor"].join("\0")).unwrap();
-    let output = work_dir.run_jj(["describe", "-m", "new message", "--edit"]);
+    let output = work_dir.run_jj(["describe", "-m", "new message", "--editor"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: qpvuntsm f8f14f7c (empty) new message
@@ -943,21 +943,39 @@ fn test_describe_change_with_existing_message_with_edit_and_message_args_opens_e
 }
 
 #[test]
-fn test_edit_cannot_be_used_with_no_edit() {
+fn test_editor_cannot_be_used_with_no_edit() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
-    let output = work_dir.run_jj(["describe", "--no-edit", "--edit"]);
+    let output = work_dir.run_jj(["describe", "--no-edit", "--editor"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: the argument '--no-edit' cannot be used with '--edit'
+    error: the argument '--no-edit' cannot be used with '--editor'
 
     Usage: jj describe [OPTIONS] [REVSETS]...
 
     For more information, try '--help'.
     [EOF]
     [exit status: 2]
+    ");
+}
+
+#[test]
+fn test_describe_deprecated_edit_flag() {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    std::fs::write(edit_script, ["write\nfinal message"].join("\0")).unwrap();
+    let output = work_dir.run_jj(["describe", "-m", "initial message", "--edit"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Warning: `jj describe --edit` is deprecated; use `jj describe --editor` (or `-E`) instead
+    Working copy  (@) now at: qpvuntsm 46842128 (empty) final message
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
     ");
 }
 


### PR DESCRIPTION
Following on from #7929 this updates the flag to match its usage elsewhere. The benefit of --editor is it allows us to use it for commands that already have a `--edit` flag. Likewise, the `-E` was chosen to not clash with `--edit`'s short form.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have added/updated tests to cover my changes
