### PR TITLE
cli: deprecate --destination/-d in favor of --onto/-o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* The `--destination`/`-d` arguments for `jj rebase`, `jj split`, `jj revert`,
+  etc. were renamed to `--onto`/`-o`. The old names will be removed at some
+  point in the future, but we realize that they are deep in muscle memory, so
+  you can expect an unusually long deprecation period.
+
 ### New features
 
 * `jj squash` now accepts `--editor` / `-E` to edit the squashed commit message.

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -37,17 +37,16 @@ use crate::ui::Ui;
 
 /// Create new changes with the same content as existing ones
 ///
-/// When none of the `--destination`, `--insert-after`, or `--insert-before`
-/// arguments are provided, commits will be duplicated onto their existing
-/// parents or onto other newly duplicated commits.
+/// When none of the `--onto`, `--insert-after`, or `--insert-before` arguments
+/// are provided, commits will be duplicated onto their existing parents or onto
+/// other newly duplicated commits.
 ///
-/// When any of the `--destination`, `--insert-after`, or `--insert-before`
-/// arguments are provided, the roots of the specified commits will be
-/// duplicated onto the destination indicated by the arguments. Other specified
-/// commits will be duplicated onto these newly duplicated commits. If the
-/// `--insert-after` or `--insert-before` arguments are provided, the new
-/// children indicated by the arguments will be rebased onto the heads of the
-/// specified commits.
+/// When any of the `--onto`, `--insert-after`, or `--insert-before` arguments
+/// are provided, the roots of the specified commits will be duplicated onto the
+/// destination indicated by the arguments. Other specified commits will be
+/// duplicated onto these newly duplicated commits. If the `--insert-after` or
+/// `--insert-before` arguments are provided, the new children indicated by the
+/// arguments will be rebased onto the heads of the specified commits.
 ///
 /// By default, the duplicated commits retain the descriptions of the originals.
 /// This can be customized with the `templates.duplicate_description` setting.
@@ -70,18 +69,20 @@ pub(crate) struct DuplicateArgs {
     /// commit)
     #[arg(
         long,
+        alias = "destination",
         short,
+        short_alias = 'd',
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert after (can be repeated to create a merge
     /// commit)
     #[arg(
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
@@ -92,7 +93,7 @@ pub(crate) struct DuplicateArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
@@ -123,21 +124,19 @@ pub(crate) fn cmd_duplicate(
         return Err(user_error("Cannot duplicate the root commit"));
     }
 
-    let location = if args.destination.is_none()
-        && args.insert_after.is_none()
-        && args.insert_before.is_none()
-    {
-        None
-    } else {
-        Some(compute_commit_location(
-            ui,
-            &workspace_command,
-            args.destination.as_deref(),
-            args.insert_after.as_deref(),
-            args.insert_before.as_deref(),
-            "duplicated commits",
-        )?)
-    };
+    let location =
+        if args.onto.is_none() && args.insert_after.is_none() && args.insert_before.is_none() {
+            None
+        } else {
+            Some(compute_commit_location(
+                ui,
+                &workspace_command,
+                args.onto.as_deref(),
+                args.insert_after.as_deref(),
+                args.insert_before.as_deref(),
+                "duplicated commits",
+            )?)
+        };
 
     let mut tx = workspace_command.start_transaction();
 

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -53,10 +53,10 @@ pub(crate) struct NewArgs {
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
     revisions: Option<Vec<RevisionArg>>,
-    /// Ignored (but lets you pass `-d`/`-r` for consistency with other
+    /// Ignored (but lets you pass `-o/-d`/`-r` for consistency with other
     /// commands)
-    #[arg(short = 'd', hide = true, short_alias = 'r',  action = clap::ArgAction::Count)]
-    unused_destination: u8,
+    #[arg(short = 'o', hide = true, short_aliases = ['d', 'r'],  action = clap::ArgAction::Count)]
+    unused_onto: u8,
     /// The change description to use
     #[arg(long = "message", short, value_name = "MESSAGE")]
     message_paragraphs: Vec<String>,

--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -42,7 +42,7 @@ use crate::ui::Ui;
 /// The description of the new revisions can be customized with the
 /// `templates.revert_description` config variable.
 #[derive(clap::Args, Clone, Debug)]
-#[command(group(ArgGroup::new("location").args(&["destination", "insert_after", "insert_before"]).required(true).multiple(true)))]
+#[command(group(ArgGroup::new("location").args(&["onto", "insert_after", "insert_before"]).required(true).multiple(true)))]
 pub(crate) struct RevertArgs {
     /// The revision(s) to apply the reverse of
     #[arg(
@@ -53,18 +53,21 @@ pub(crate) struct RevertArgs {
     revisions: Vec<RevisionArg>,
     /// The revision(s) to apply the reverse changes on top of
     #[arg(
-        long, short,
+        long,
+        alias = "destination",
+        short,
+        short_alias = 'd',
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert the reverse changes after (can be repeated to
     /// create a merge commit)
     #[arg(
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
@@ -75,7 +78,7 @@ pub(crate) struct RevertArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
     )]
@@ -100,7 +103,7 @@ pub(crate) fn cmd_revert(
     let (new_parent_ids, new_child_ids) = compute_commit_location(
         ui,
         &workspace_command,
-        args.destination.as_deref(),
+        args.onto.as_deref(),
         args.insert_after.as_deref(),
         args.insert_before.as_deref(),
         "reverted commits",

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -90,19 +90,21 @@ pub(crate) struct SplitArgs {
     /// a merge commit)
     #[arg(
         long,
+        alias = "destination",
         short,
+        short_alias = 'd',
         conflicts_with = "parallel",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
     /// The revision(s) to insert after (can be repeated to create a merge
     /// commit)
     #[arg(
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         conflicts_with = "parallel",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
@@ -114,7 +116,7 @@ pub(crate) struct SplitArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         conflicts_with = "parallel",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),
@@ -166,14 +168,13 @@ impl SplitArgs {
             self.tool.as_deref(),
             self.interactive || self.paths.is_empty(),
         )?;
-        let use_move_flags = self.destination.is_some()
-            || self.insert_after.is_some()
-            || self.insert_before.is_some();
+        let use_move_flags =
+            self.onto.is_some() || self.insert_after.is_some() || self.insert_before.is_some();
         let (new_parent_ids, new_child_ids) = if use_move_flags {
             compute_commit_location(
                 ui,
                 workspace_command,
-                self.destination.as_deref(),
+                self.onto.as_deref(),
                 self.insert_after.as_deref(),
                 self.insert_before.as_deref(),
                 "split-out commit",

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -71,13 +71,13 @@ use crate::ui::Ui;
 ///
 /// EXPERIMENTAL FEATURES
 ///
-/// An alternative squashing UI is available via the `-d`, `-A`, and `-B`
+/// An alternative squashing UI is available via the `-o`, `-A`, and `-B`
 /// options. They can be used together with one or more `--from` options
 /// (if no `--from` is specified, `--from @` is assumed).
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct SquashArgs {
     /// Revision to squash into its parent (default: @). Incompatible with the
-    /// experimental `-d`/`-A`/`-B` options.
+    /// experimental `-o`/`-A`/`-B` options.
     #[arg(
         long,
         short,
@@ -109,13 +109,15 @@ pub(crate) struct SquashArgs {
     /// be repeated to create a merge commit)
     #[arg(
         long,
+        alias = "destination",
         short,
+        short_alias = 'd',
         conflicts_with = "into",
         conflicts_with = "revision",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]
-    destination: Option<Vec<RevisionArg>>,
+    onto: Option<Vec<RevisionArg>>,
 
     /// (Experimental) The revision(s) to insert the new commit after (can be
     /// repeated to create a merge commit)
@@ -123,7 +125,7 @@ pub(crate) struct SquashArgs {
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         conflicts_with = "into",
         conflicts_with = "revision",
         value_name = "REVSETS",
@@ -137,7 +139,7 @@ pub(crate) struct SquashArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "destination",
+        conflicts_with = "onto",
         conflicts_with = "into",
         conflicts_with = "revision",
         value_name = "REVSETS",
@@ -190,7 +192,7 @@ pub(crate) fn cmd_squash(
     args: &SquashArgs,
 ) -> Result<(), CommandError> {
     let insert_destination_commit =
-        args.destination.is_some() || args.insert_after.is_some() || args.insert_before.is_some();
+        args.onto.is_some() || args.insert_after.is_some() || args.insert_before.is_some();
 
     let mut workspace_command = command.workspace_helper(ui)?;
 
@@ -257,7 +259,7 @@ pub(crate) fn cmd_squash(
         let (parent_ids, child_ids) = compute_commit_location(
             ui,
             tx.base_workspace_helper(),
-            args.destination.as_deref(),
+            args.onto.as_deref(),
             args.insert_after.as_deref(),
             args.insert_before.as_deref(),
             "squashed commit",

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -917,9 +917,9 @@ See `jj restore` if you want to move entire files from one revision to another. 
 
 Create new changes with the same content as existing ones
 
-When none of the `--destination`, `--insert-after`, or `--insert-before` arguments are provided, commits will be duplicated onto their existing parents or onto other newly duplicated commits.
+When none of the `--onto`, `--insert-after`, or `--insert-before` arguments are provided, commits will be duplicated onto their existing parents or onto other newly duplicated commits.
 
-When any of the `--destination`, `--insert-after`, or `--insert-before` arguments are provided, the roots of the specified commits will be duplicated onto the destination indicated by the arguments. Other specified commits will be duplicated onto these newly duplicated commits. If the `--insert-after` or `--insert-before` arguments are provided, the new children indicated by the arguments will be rebased onto the heads of the specified commits.
+When any of the `--onto`, `--insert-after`, or `--insert-before` arguments are provided, the roots of the specified commits will be duplicated onto the destination indicated by the arguments. Other specified commits will be duplicated onto these newly duplicated commits. If the `--insert-after` or `--insert-before` arguments are provided, the new children indicated by the arguments will be rebased onto the heads of the specified commits.
 
 By default, the duplicated commits retain the descriptions of the originals. This can be customized with the `templates.duplicate_description` setting.
 
@@ -931,7 +931,7 @@ By default, the duplicated commits retain the descriptions of the originals. Thi
 
 ###### **Options:**
 
-* `-d`, `--destination <REVSETS>` — The revision(s) to duplicate onto (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` — The revision(s) to duplicate onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 
@@ -2294,7 +2294,7 @@ If no option is specified, it defaults to `-b @`.
 There are three different ways of specifying where the revisions should be
 rebased to:
 
-* `--destination/-d` to rebase the revisions onto the specified targets
+* `--onto/-o` to rebase the revisions onto the specified targets
 * `--insert-after/-A` to rebase the revisions onto the specified targets and
   to rebase the targets' descendants onto the rebased revisions
 * `--insert-before/-B` to rebase the revisions onto the specified targets'
@@ -2310,7 +2310,7 @@ revision. This is true in general; it is not specific to this command.
 ### Specifying which revisions to rebase
 
 With `--source/-s`, the command rebases the specified revision and its
-descendants to the destination. For example, `jj rebase -s M -d O` would
+descendants to the destination. For example, `jj rebase -s M -o O` would
 transform your history like this (letters followed by an apostrophe are
 post-rebase versions):
 
@@ -2329,7 +2329,7 @@ J           J
 ```
 
 Each revision passed to `-s` will become a direct child of the destination,
-so if you instead run `jj rebase -s M -s N -d O` (or `jj rebase -s 'M|N' -d
+so if you instead run `jj rebase -s M -s N -o O` (or `jj rebase -s 'M|N' -o
 O`) in the example above, then N' would instead be a direct child of O.
 
 With `--branch/-b`, the command rebases the whole "branch" containing the
@@ -2339,10 +2339,10 @@ specified revision. A "branch" is the set of revisions that includes:
   destination
 * all descendants of those revisions
 
-In other words, `jj rebase -b X -d Y` rebases revisions in the revset
-`(Y..X)::` (which is equivalent to `jj rebase -s 'roots(Y..X)' -d Y` for a
-single root). For example, either `jj rebase -b L -d O` or `jj rebase -b M
--d O` would transform your history like this (because `L` and `M` are on the
+In other words, `jj rebase -b X -o Y` rebases revisions in the revset
+`(Y..X)::` (which is equivalent to `jj rebase -s 'roots(Y..X)' -o Y` for a
+single root). For example, either `jj rebase -b L -o O` or `jj rebase -b M
+-o O` would transform your history like this (because `L` and `M` are on the
 same "branch", relative to the destination):
 
 ```text
@@ -2362,7 +2362,7 @@ J           J
 With `--revisions/-r`, the command rebases only the specified revisions to
 the destination. Any "hole" left behind will be filled by rebasing
 descendants onto the specified revisions' parent(s). For example,
-`jj rebase -r K -d M` would transform your history like this:
+`jj rebase -r K -o M` would transform your history like this:
 
 ```text
 M          K'
@@ -2375,7 +2375,7 @@ J          J
 ```
 
 Multiple revisions can be specified, and any dependencies (graph edges)
-within the set will be preserved. For example, `jj rebase -r 'K|N' -d O`
+within the set will be preserved. For example, `jj rebase -r 'K|N' -o O`
 would transform your history like this:
 
 ```text
@@ -2398,10 +2398,10 @@ or if you passed multiple `-s` arguments, then `jj rebase -s` will make each
 of the specified revisions an immediate child of the destination, while
 `jj rebase -r` will preserve dependencies within the set.
 
-Note that you can create a merge revision by repeating the `-d` argument.
+Note that you can create a merge revision by repeating the `-o` argument.
 For example, if you realize that revision L actually depends on revision M
 in order to work (in addition to its current parent K), you can run `jj
-rebase -s L -d K -d M`:
+rebase -s L -o K -o M`:
 
 ```text
 M          L'
@@ -2415,12 +2415,12 @@ J          J
 
 ### Specifying where to rebase the revisions
 
-With `--destination/-d`, the command rebases the selected revisions onto
-the targets. Existing descendants of the targets will not be affected. See
+With `--onto/-o`, the command rebases the selected revisions onto the
+targets. Existing descendants of the targets will not be affected. See
 the section above for examples.
 
 With `--insert-after/-A`, the selected revisions will be inserted after the
-targets. This is similar to `-d`, but if the targets have any existing
+targets. This is similar to `-o`, but if the targets have any existing
 descendants, then those will be rebased onto the rebased selected revisions.
 
 For example, `jj rebase -r K -A L` will rewrite history like this:
@@ -2468,7 +2468,7 @@ J           J
 
 The `-A` and `-B` arguments can also be combined, which can be useful around
 merges. For example, you can use `jj rebase -r K -A J -B M` to create a new
-merge (but `jj rebase -r M -d L -d K` might be simpler in this particular
+merge (but `jj rebase -r M -o L -o K` might be simpler in this particular
 case):
 ```text
 M           M'
@@ -2495,13 +2495,13 @@ K |         K |
 J           J
 ```
 
-**Usage:** `jj rebase [OPTIONS] <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
+**Usage:** `jj rebase [OPTIONS] <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
 
 ###### **Options:**
 
 * `-b`, `--branch <REVSETS>` — Rebase the whole branch relative to destination's ancestors (can be repeated)
 
-   `jj rebase -b=br -d=dst` is equivalent to `jj rebase '-s=roots(dst..br)' -d=dst`.
+   `jj rebase -b=br -o=dst` is equivalent to `jj rebase '-s=roots(dst..br)' -o=dst`.
 
    If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
 * `-s`, `--source <REVSETS>` — Rebase specified revision(s) together with their trees of descendants (can be repeated)
@@ -2514,7 +2514,7 @@ J           J
    Unlike `-s` or `-b`, you may `jj rebase -r` a revision `A` onto a descendant of `A`.
 
    If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
-* `-d`, `--destination <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` — The revision(s) to rebase onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `--skip-emptied` — If true, when rebasing would produce an empty commit, the commit is abandoned. It will not be abandoned if it was already empty before the rebase. Will never skip merge commits with multiple non-empty parents
@@ -2603,12 +2603,12 @@ The reverse of each of the given revisions is applied sequentially in reverse to
 
 The description of the new revisions can be customized with the `templates.revert_description` config variable.
 
-**Usage:** `jj revert [OPTIONS] <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
+**Usage:** `jj revert [OPTIONS] <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
 
 ###### **Options:**
 
 * `-r`, `--revisions <REVSETS>` — The revision(s) to apply the reverse of
-* `-d`, `--destination <REVSETS>` — The revision(s) to apply the reverse changes on top of
+* `-o`, `--onto <REVSETS>` — The revision(s) to apply the reverse changes on top of
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert the reverse changes after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert the reverse changes before (can be repeated to create a merge commit)
 
@@ -2791,7 +2791,7 @@ Splitting an empty commit is not supported because the same effect can be achiev
 * `-r`, `--revision <REVSET>` — The revision to split
 
   Default value: `@`
-* `-d`, `--destination <REVSETS>` — The revision(s) to base the new revision onto (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` — The revision(s) to base the new revision onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
@@ -2817,7 +2817,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 EXPERIMENTAL FEATURES
 
-An alternative squashing UI is available via the `-d`, `-A`, and `-B` options. They can be used together with one or more `--from` options (if no `--from` is specified, `--from @` is assumed).
+An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. They can be used together with one or more `--from` options (if no `--from` is specified, `--from @` is assumed).
 
 **Usage:** `jj squash [OPTIONS] [FILESETS]...`
 
@@ -2827,10 +2827,10 @@ An alternative squashing UI is available via the `-d`, `-A`, and `-B` options. T
 
 ###### **Options:**
 
-* `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @). Incompatible with the experimental `-d`/`-A`/`-B` options
+* `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @). Incompatible with the experimental `-o`/`-A`/`-B` options
 * `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
 * `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
-* `-d`, `--destination <REVSETS>` — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — (Experimental) The revision(s) to insert the new commit after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — (Experimental) The revision(s) to insert the new commit before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -295,7 +295,7 @@ fn test_duplicate_destination() {
     ");
 
     // Duplicate a single commit onto a single destination.
-    let output = work_dir.run_jj(["duplicate", "a1", "-d", "c"]);
+    let output = work_dir.run_jj(["duplicate", "a1", "-o", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Duplicated 5d93a4b8f4bd as kxryzmor 08f0f980 a1
@@ -318,7 +318,7 @@ fn test_duplicate_destination() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // Duplicate a single commit onto multiple destinations.
-    let output = work_dir.run_jj(["duplicate", "a1", "-d", "c", "-d", "d"]);
+    let output = work_dir.run_jj(["duplicate", "a1", "-o", "c", "-o", "d"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Duplicated 5d93a4b8f4bd as xznxytkn 0bad88fb a1
@@ -342,7 +342,7 @@ fn test_duplicate_destination() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // Duplicate a single commit onto its descendant.
-    let output = work_dir.run_jj(["duplicate", "a1", "-d", "a3"]);
+    let output = work_dir.run_jj(["duplicate", "a1", "-o", "a3"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: Duplicating commit 5d93a4b8f4bd as a descendant of itself
@@ -367,7 +367,7 @@ fn test_duplicate_destination() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     // Duplicate multiple commits without a direct ancestry relationship onto a
     // single destination.
-    let output = work_dir.run_jj(["duplicate", "-r=a1", "-r=b", "-d", "c"]);
+    let output = work_dir.run_jj(["duplicate", "-r=a1", "-r=b", "-o", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Duplicated 5d93a4b8f4bd as pzsxstzt 663f101c a1
@@ -394,7 +394,7 @@ fn test_duplicate_destination() {
 
     // Duplicate multiple commits without a direct ancestry relationship onto
     // multiple destinations.
-    let output = work_dir.run_jj(["duplicate", "-r=a1", "b", "-d", "c", "-d", "d"]);
+    let output = work_dir.run_jj(["duplicate", "-r=a1", "b", "-o", "c", "-o", "d"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Duplicated 5d93a4b8f4bd as qmkrwlvp b0f531b0 a1
@@ -422,7 +422,7 @@ fn test_duplicate_destination() {
 
     // Duplicate multiple commits with an ancestry relationship onto a
     // single destination.
-    let output = work_dir.run_jj(["duplicate", "a1", "a3", "-d", "c"]);
+    let output = work_dir.run_jj(["duplicate", "a1", "a3", "-o", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Duplicated 5d93a4b8f4bd as qwyusntz 5f1c245f a1
@@ -448,7 +448,7 @@ fn test_duplicate_destination() {
 
     // Duplicate multiple commits with an ancestry relationship onto
     // multiple destinations.
-    let output = work_dir.run_jj(["duplicate", "a1", "a3", "-d", "c", "-d", "d"]);
+    let output = work_dir.run_jj(["duplicate", "a1", "a3", "-o", "c", "-o", "d"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Duplicated 5d93a4b8f4bd as soqnvnyz bc6678fd a1
@@ -2400,7 +2400,7 @@ fn test_rebase_duplicates() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-s", "b", "-d", "root()"]);
+    let output = work_dir.run_jj(["rebase", "-s", "b", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 4 commits to destination
@@ -2467,7 +2467,7 @@ fn test_duplicate_description_template() {
 
     // Test empty template
     test_env.add_config("templates.duplicate_description = ''");
-    let output = work_dir.run_jj(["duplicate", "b", "-d", "root()"]);
+    let output = work_dir.run_jj(["duplicate", "b", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Duplicated 6960bbcfd5b1 as kpqxywon 33044659 (no description set)
@@ -2479,7 +2479,7 @@ fn test_duplicate_description_template() {
     let output = work_dir.run_jj([
         "duplicate",
         "c",
-        "-d",
+        "-o",
         "root()",
         // Use an argument here so we can actually see the log in the last test
         // (We don't have a way to remove a config in TestEnvironment)

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -26,7 +26,7 @@ fn test_evolog_with_or_without_diff() {
     work_dir.write_file("file1", "foo\nbar\n");
     work_dir.write_file("file2", "foo\n");
     work_dir
-        .run_jj(["rebase", "-r", "@", "-d", "root()"])
+        .run_jj(["rebase", "-r", "@", "-o", "root()"])
         .success();
     work_dir.write_file("file1", "resolved\n");
 
@@ -34,13 +34,13 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 3499115d3831 snapshot working copy
+    │  -- operation 62777a103786 snapshot working copy
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     │  my description
-    │  -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
-    │  -- operation 18a971ce330a snapshot working copy
+    │  -- operation 826347115e2d snapshot working copy
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
        (empty) my description
        -- operation e0f8e58b3800 new empty commit
@@ -52,13 +52,13 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
     │  [1mmy description[0m
-    │  [38;5;8m--[39m operation [38;5;4m3499115d3831[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m62777a103786[39m snapshot working copy
     [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m7[0m[38;5;8mf56b2a0[39m [38;5;1mconflict[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4meb87ec366530[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  [38;5;8m--[39m operation [38;5;4mad81b0a6af14[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m18a971ce330a[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m826347115e2d[39m snapshot working copy
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m
        [38;5;2m(empty)[39m my description
        [38;5;8m--[39m operation [38;5;4me0f8e58b3800[39m new empty commit
@@ -71,7 +71,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 3499115d3831 snapshot working copy
+    │  -- operation 62777a103786 snapshot working copy
     │  Resolved conflict in file1:
     │     1     : <<<<<<< Conflict 1 of 1
     │     2     : %%%%%%% Changes from base to side #1
@@ -82,10 +82,10 @@ fn test_evolog_with_or_without_diff() {
     │     7    1: >>>>>>> Conflict 1 of 1 endsresolved
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     │  my description
-    │  -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
-    │  -- operation 18a971ce330a snapshot working copy
+    │  -- operation 826347115e2d snapshot working copy
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
@@ -104,13 +104,13 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 3499115d3831 snapshot working copy
+    │  -- operation 62777a103786 snapshot working copy
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     │  my description
-    │  -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
-    │  -- operation 18a971ce330a snapshot working copy
+    │  -- operation 826347115e2d snapshot working copy
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
        (empty) my description
        -- operation e0f8e58b3800 new empty commit
@@ -128,10 +128,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 3499115d3831 snapshot working copy
+    │  -- operation 62777a103786 snapshot working copy
     ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     │  my description
-    │  -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     [EOF]
     ");
 
@@ -140,13 +140,13 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 3499115d3831 snapshot working copy
+    -- operation 62777a103786 snapshot working copy
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     my description
-    -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     my description
-    -- operation 18a971ce330a snapshot working copy
+    -- operation 826347115e2d snapshot working copy
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
     (empty) my description
     -- operation e0f8e58b3800 new empty commit
@@ -158,7 +158,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 3499115d3831 snapshot working copy
+    -- operation 62777a103786 snapshot working copy
     diff --git a/file1 b/file1
     index 0000000000..2ab19ae607 100644
     --- a/file1
@@ -174,10 +174,10 @@ fn test_evolog_with_or_without_diff() {
     +resolved
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     my description
-    -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     my description
-    -- operation 18a971ce330a snapshot working copy
+    -- operation 826347115e2d snapshot working copy
     diff --git a/file1 b/file1
     index 257cc5642c..3bd1f0e297 100644
     --- a/file1
@@ -283,7 +283,7 @@ fn test_evolog_with_custom_symbols() {
     work_dir.write_file("file1", "foo\nbar\n");
     work_dir.write_file("file2", "foo\n");
     work_dir
-        .run_jj(["rebase", "-r", "@", "-d", "root()"])
+        .run_jj(["rebase", "-r", "@", "-o", "root()"])
         .success();
     work_dir.write_file("file1", "resolved\n");
 
@@ -293,13 +293,13 @@ fn test_evolog_with_custom_symbols() {
     insta::assert_snapshot!(output, @r"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 3622beb20303 snapshot working copy
+    │  -- operation 2ea9565d2b85 snapshot working copy
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
     │  my description
-    │  -- operation eb87ec366530 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
-    │  -- operation 18a971ce330a snapshot working copy
+    │  -- operation 826347115e2d snapshot working copy
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
        (empty) my description
        -- operation e0f8e58b3800 new empty commit

--- a/cli/tests/test_file_show_command.rs
+++ b/cli/tests/test_file_show_command.rs
@@ -101,7 +101,7 @@ fn test_show() {
     work_dir.run_jj(["new"]).success();
     work_dir.write_file("file1", "c\n");
     work_dir
-        .run_jj(["rebase", "-r", "@", "-d", "@--"])
+        .run_jj(["rebase", "-r", "@", "-o", "@--"])
         .success();
     let output = work_dir.run_jj(["file", "show", "file1"]);
     insta::assert_snapshot!(output, @r"

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1241,7 +1241,7 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     // Create rebase conflict
     work_dir
-        .run_jj(["rebase", "-r", "left", "-d", "right"])
+        .run_jj(["rebase", "-r", "left", "-o", "right"])
         .success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @r"

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -687,7 +687,7 @@ fn create_trunk2_and_rebase_bookmarks(work_dir: &TestWorkDir) -> String {
     create_commit(work_dir, "trunk2", &["trunk1"]);
     for br in ["a1", "a2", "b"] {
         work_dir
-            .run_jj(["rebase", "-b", br, "-d", "trunk2"])
+            .run_jj(["rebase", "-b", br, "-o", "trunk2"])
             .success();
     }
     format!(

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -1415,7 +1415,7 @@ fn test_git_push_conflict() {
     work_dir.run_jj(["commit", "-m", "second"]).success();
     work_dir.write_file("file", "third");
     work_dir
-        .run_jj(["rebase", "-r", "@", "-d", "@--"])
+        .run_jj(["rebase", "-r", "@", "-o", "@--"])
         .success();
     work_dir
         .run_jj(["bookmark", "create", "-r@", "my-bookmark"])

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -32,9 +32,9 @@ fn test_rebase_invalid() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+      <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
-    Usage: jj rebase <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -42,12 +42,12 @@ fn test_rebase_invalid() {
     ");
 
     // Both -r and -s
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-s", "a", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-s", "a", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the argument '--revisions <REVSETS>' cannot be used with '--source <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -55,38 +55,38 @@ fn test_rebase_invalid() {
     ");
 
     // Both -b and -s
-    let output = work_dir.run_jj(["rebase", "-b", "a", "-s", "a", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-b", "a", "-s", "a", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the argument '--branch <REVSETS>' cannot be used with '--source <REVSETS>'
 
-    Usage: jj rebase --branch <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --branch <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
     [exit status: 2]
     ");
 
-    // Both -d and --after
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b", "--after", "b"]);
+    // Both -o and --after
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "b", "--after", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: the argument '--destination <REVSETS>' cannot be used with '--insert-after <REVSETS>'
+    error: the argument '--onto <REVSETS>' cannot be used with '--insert-after <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
     [exit status: 2]
     ");
 
-    // Both -d and --before
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b", "--before", "b"]);
+    // Both -o and --before
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "b", "--before", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: the argument '--destination <REVSETS>' cannot be used with '--insert-before <REVSETS>'
+    error: the argument '--onto <REVSETS>' cannot be used with '--insert-before <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -94,7 +94,7 @@ fn test_rebase_invalid() {
     ");
 
     // Rebase onto self with -r
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Cannot rebase 7d980be7a1d4 onto itself
@@ -103,7 +103,7 @@ fn test_rebase_invalid() {
     ");
 
     // Rebase root with -r
-    let output = work_dir.run_jj(["rebase", "-r", "root()", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "root()", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The root commit 000000000000 is immutable
@@ -112,7 +112,7 @@ fn test_rebase_invalid() {
     ");
 
     // Rebase onto descendant with -s
-    let output = work_dir.run_jj(["rebase", "-s", "a", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-s", "a", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Cannot rebase 7d980be7a1d4 onto descendant 123b4d91f6e5
@@ -121,7 +121,7 @@ fn test_rebase_invalid() {
     ");
 
     // Rebase onto itself with -s
-    let output = work_dir.run_jj(["rebase", "-s", "a", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-s", "a", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Cannot rebase 7d980be7a1d4 onto itself
@@ -194,7 +194,7 @@ fn test_rebase_bookmark() {
     ");
     let setup_opid = work_dir.current_operation_id();
 
-    let output = work_dir.run_jj(["rebase", "-b", "c", "-d", "e"]);
+    let output = work_dir.run_jj(["rebase", "-b", "c", "-o", "e"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
@@ -286,7 +286,7 @@ fn test_rebase_bookmark_with_merge() {
     ");
     let setup_opid = work_dir.current_operation_id();
 
-    let output = work_dir.run_jj(["rebase", "-b", "d", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-b", "d", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
@@ -309,7 +309,7 @@ fn test_rebase_bookmark_with_merge() {
     ");
 
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
@@ -359,7 +359,7 @@ fn test_rebase_single_revision() {
 
     // Descendants of the rebased commit "c" should be rebased onto parents. First
     // we test with a non-merge commit.
-    let output = work_dir.run_jj(["rebase", "-r", "c", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-r", "c", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -385,7 +385,7 @@ fn test_rebase_single_revision() {
 
     // Now, let's try moving the merge commit. After, both parents of "d" ("b" and
     // "c") should become parents of "e".
-    let output = work_dir.run_jj(["rebase", "-r", "d", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "d", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -434,7 +434,7 @@ fn test_rebase_single_revision_merge_parent() {
 
     // Descendants of the rebased commit should be rebased onto parents, and if
     // the descendant is a merge commit, it shouldn't forget its other parents.
-    let output = work_dir.run_jj(["rebase", "-r", "c", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "c", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -493,7 +493,7 @@ fn test_rebase_multiple_revisions() {
     let setup_opid = work_dir.current_operation_id();
 
     // Test with two non-related non-merge commits.
-    let output = work_dir.run_jj(["rebase", "-r", "c", "-r", "e", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "c", "-r", "e", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 commits to destination
@@ -526,7 +526,7 @@ fn test_rebase_multiple_revisions() {
     // Test with two related non-merge commits. Since "b" is a parent of "c", when
     // rebasing commits "b" and "c", their ancestry relationship should be
     // preserved.
-    let output = work_dir.run_jj(["rebase", "-r", "b", "-r", "c", "-d", "e"]);
+    let output = work_dir.run_jj(["rebase", "-r", "b", "-r", "c", "-o", "e"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 commits to destination
@@ -560,7 +560,7 @@ fn test_rebase_multiple_revisions() {
     // inherit its descendants which are not in the subtree ("c" and "d").
     // "f" will retain its parent "c" since "c" is outside the target set, and not
     // a descendant of any new children.
-    let output = work_dir.run_jj(["rebase", "-r", "e::g", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "e::g", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
@@ -596,7 +596,7 @@ fn test_rebase_multiple_revisions() {
     // rebased commits. "d" should be a new parent of "f", and "f" should be a
     // new parent of "h". "f" will retain its parent "c" since "c" is outside the
     // target set, and not a descendant of any new children.
-    let output = work_dir.run_jj(["rebase", "-r", "d", "-r", "f", "-r", "h", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-r", "d", "-r", "f", "-r", "h", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
@@ -628,7 +628,7 @@ fn test_rebase_multiple_revisions() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // Test rebasing a subgraph onto its descendants.
-    let output = work_dir.run_jj(["rebase", "-r", "d::e", "-d", "i"]);
+    let output = work_dir.run_jj(["rebase", "-r", "d::e", "-o", "i"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 commits to destination
@@ -680,7 +680,7 @@ fn test_rebase_revision_onto_descendant() {
     let setup_opid = work_dir.current_operation_id();
 
     // Simpler example
-    let output = work_dir.run_jj(["rebase", "-r", "base", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "base", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -714,7 +714,7 @@ fn test_rebase_revision_onto_descendant() {
     Added 1 files, modified 0 files, removed 0 files
     [EOF]
     ");
-    let output = work_dir.run_jj(["rebase", "-r", "base", "-d", "merge"]);
+    let output = work_dir.run_jj(["rebase", "-r", "base", "-o", "merge"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -760,7 +760,7 @@ fn test_rebase_multiple_destinations() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b", "-d", "c"]);
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "b", "-o", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -782,7 +782,7 @@ fn test_rebase_multiple_destinations() {
         "--config=ui.always-allow-large-revsets=false",
         "-r",
         "a",
-        "-d",
+        "-o",
         "b|c",
     ]);
     insta::assert_snapshot!(output, @r"
@@ -801,7 +801,7 @@ fn test_rebase_multiple_destinations() {
         "--config=ui.always-allow-large-revsets=false",
         "-r",
         "a",
-        "-d",
+        "-o",
         "all:b|c",
     ]);
     insta::assert_snapshot!(output, @r"
@@ -839,21 +839,21 @@ fn test_rebase_multiple_destinations() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "b", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b|c", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "b|c", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "b", "-d", "root()"]);
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "b", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The Git backend does not support creating merge commits with the root commit as one of the parents.
@@ -885,7 +885,7 @@ fn test_rebase_with_descendants() {
     ");
     let setup_opid = work_dir.current_operation_id();
 
-    let output = work_dir.run_jj(["rebase", "-s", "b", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-s", "b", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
@@ -996,7 +996,7 @@ fn test_rebase_error_revision_does_not_exist() {
         .success();
     work_dir.run_jj(["new", "-r", "@-", "-m", "two"]).success();
 
-    let output = work_dir.run_jj(["rebase", "-b", "b-one", "-d", "this"]);
+    let output = work_dir.run_jj(["rebase", "-b", "b-one", "-o", "this"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Revision `this` doesn't exist
@@ -1004,7 +1004,7 @@ fn test_rebase_error_revision_does_not_exist() {
     [exit status: 1]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-b", "this", "-d", "b-one"]);
+    let output = work_dir.run_jj(["rebase", "-b", "this", "-o", "b-one"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: Revision `this` doesn't exist
@@ -1042,7 +1042,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
 
     // ===================== rebase -s tests =================
     // This should be a no-op
-    let output = work_dir.run_jj(["rebase", "-s", "base", "-d", "notroot"]);
+    let output = work_dir.run_jj(["rebase", "-s", "base", "-o", "notroot"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 4 commits that were already in place
@@ -1063,7 +1063,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
 
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     // This should be a no-op
-    let output = work_dir.run_jj(["rebase", "-s", "a", "-d", "base"]);
+    let output = work_dir.run_jj(["rebase", "-s", "a", "-o", "base"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 3 commits that were already in place
@@ -1083,7 +1083,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ");
 
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-s", "a", "-d", "root()"]);
+    let output = work_dir.run_jj(["rebase", "-s", "a", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
@@ -1122,7 +1122,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
 
     // The commits in roots(base..c), i.e. commit "a" should be rebased onto "base",
     // which is a no-op
-    let output = work_dir.run_jj(["rebase", "-b", "c", "-d", "base"]);
+    let output = work_dir.run_jj(["rebase", "-b", "c", "-o", "base"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 3 commits that were already in place
@@ -1142,7 +1142,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ");
 
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-b", "c", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-b", "c", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 commits to destination
@@ -1164,7 +1164,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
 
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     // This should be a no-op
-    let output = work_dir.run_jj(["rebase", "-b", "a", "-d", "root()"]);
+    let output = work_dir.run_jj(["rebase", "-b", "a", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 5 commits that were already in place
@@ -1198,7 +1198,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-r", "base", "-d", "root()"]);
+    let output = work_dir.run_jj(["rebase", "-r", "base", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -1225,7 +1225,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-r", "base", "-d", "b"]);
+    let output = work_dir.run_jj(["rebase", "-r", "base", "-o", "b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -1251,7 +1251,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-r", "base", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "base", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -1288,7 +1288,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["rebase", "-r", "a", "-d", "root()"]);
+    let output = work_dir.run_jj(["rebase", "-r", "a", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -1312,7 +1312,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     ");
 
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-r", "b", "-d", "root()"]);
+    let output = work_dir.run_jj(["rebase", "-r", "b", "-o", "root()"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -1340,7 +1340,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // This tests the algorithm for rebasing onto descendants. The result should
     // have unsimplified ancestry.
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-r", "b", "-d", "c"]);
+    let output = work_dir.run_jj(["rebase", "-r", "b", "-o", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -1366,7 +1366,7 @@ fn test_rebase_with_child_and_descendant_bug_2600() {
     // In this test, the commit with weird ancestry is not rebased (neither directly
     // nor indirectly).
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    let output = work_dir.run_jj(["rebase", "-r", "c", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-r", "c", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
@@ -2876,7 +2876,7 @@ fn test_rebase_skip_if_on_destination() {
     ");
 
     // Skip rebase with -b
-    let output = work_dir.run_jj(["rebase", "-b", "d", "-d", "a"]);
+    let output = work_dir.run_jj(["rebase", "-b", "d", "-o", "a"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 6 commits that were already in place
@@ -2899,7 +2899,7 @@ fn test_rebase_skip_if_on_destination() {
     ");
 
     // Skip rebase with -s
-    let output = work_dir.run_jj(["rebase", "-s", "c", "-d", "b1", "-d", "b2"]);
+    let output = work_dir.run_jj(["rebase", "-s", "c", "-o", "b1", "-o", "b2"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 4 commits that were already in place
@@ -2922,7 +2922,7 @@ fn test_rebase_skip_if_on_destination() {
     ");
 
     // Skip rebase with -r since commit has no children
-    let output = work_dir.run_jj(["rebase", "-r", "d", "-d", "c"]);
+    let output = work_dir.run_jj(["rebase", "-r", "d", "-o", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 1 commits that were already in place
@@ -2945,7 +2945,7 @@ fn test_rebase_skip_if_on_destination() {
     ");
 
     // Skip rebase of commit, but rebases children onto destination with -r
-    let output = work_dir.run_jj(["rebase", "-r", "e", "-d", "c"]);
+    let output = work_dir.run_jj(["rebase", "-r", "e", "-o", "c"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Skipped rebase of 1 commits that were already in place
@@ -2982,7 +2982,7 @@ fn test_rebase_skip_duplicate_divergent() {
     create_commit_with_files(&work_dir, "a", &[], &[("file1", "initial\n")]);
     create_commit_with_files(&work_dir, "b2", &["a"], &[("file1", "initial\nb\n")]);
     create_commit_with_files(&work_dir, "c", &["a"], &[("file2", "c\n")]);
-    work_dir.run_jj(["rebase", "-r", "b2", "-d", "c"]).success();
+    work_dir.run_jj(["rebase", "-r", "b2", "-o", "c"]).success();
     work_dir
         .run_jj(["bookmark", "create", "b1", "-r", "at_operation(@-, b2)"])
         .success();
@@ -3002,7 +3002,7 @@ fn test_rebase_skip_duplicate_divergent() {
     let setup_opid = work_dir.current_operation_id();
 
     // By default, rebase should skip the duplicate of commit B
-    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-r", "c::", "-d", "d"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-r", "c::", "-o", "d"]), @r"
     ------- stderr -------
     Abandoned 1 divergent commits that were already present in the destination:
       zsuskuln?? 3f194323 b2 | b2
@@ -3020,7 +3020,7 @@ fn test_rebase_skip_duplicate_divergent() {
 
     // Rebasing should work even if the root of the target set is abandoned
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "b1", "-d", "b2"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "b1", "-o", "b2"]), @r"
     ------- stderr -------
     Abandoned 1 divergent commits that were already present in the destination:
       zsuskuln?? 48bf33ab b1 | b2
@@ -3042,7 +3042,7 @@ fn test_rebase_skip_duplicate_divergent() {
 
     // Rebase with "--keep-divergent" shouldn't skip any duplicates
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "c", "-d", "d", "--keep-divergent"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "c", "-o", "d", "--keep-divergent"]), @r"
     ------- stderr -------
     Rebased 2 commits to destination
     [EOF]

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -48,16 +48,16 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     error: the following required arguments were not provided:
-      <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+      <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
-    Usage: jj revert --revisions <REVSETS> <--destination <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj revert --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
     [exit status: 2]
     ");
 
-    // Revert the commit with `--destination`
+    // Revert the commit with `--onto`
     let output = work_dir.run_jj(["revert", "-ra", "-d@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -1291,7 +1291,7 @@ fn test_split_move_first_commit() {
         "file1",
         "-r",
         "qpvuntsmwlqt",
-        "--destination",
+        "--onto",
         "rlvkpnrzqnoo",
         "file1",
     ]);

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -1644,10 +1644,10 @@ fn test_squash_option_exclusion() {
     insta::assert_snapshot!(work_dir.run_jj([
         "squash",
         "-r@",
-        "--destination=@-"
+        "--onto=@-"
     ]), @r"
     ------- stderr -------
-    error: the argument '--revision <REVSET>' cannot be used with '--destination <REVSETS>'
+    error: the argument '--revision <REVSET>' cannot be used with '--onto <REVSETS>'
 
     Usage: jj squash --revision <REVSET> [FILESETS]...
 
@@ -1688,13 +1688,13 @@ fn test_squash_option_exclusion() {
 
     insta::assert_snapshot!(work_dir.run_jj([
         "squash",
-        "--destination=@",
+        "--onto=@",
         "--into=@-"
     ]), @r"
     ------- stderr -------
-    error: the argument '--destination <REVSETS>' cannot be used with '--into <REVSET>'
+    error: the argument '--onto <REVSETS>' cannot be used with '--into <REVSET>'
 
-    Usage: jj squash --destination <REVSETS> [FILESETS]...
+    Usage: jj squash --onto <REVSETS> [FILESETS]...
 
     For more information, try '--help'.
     [EOF]
@@ -1836,7 +1836,7 @@ fn test_squash_to_new_commit() {
         "file 3&4",
         "-f",
         "kkmpptxzrspx::",
-        "--destination",
+        "--onto",
         "qpvuntsmwlqt",
     ]);
     insta::assert_snapshot!(output, @r"
@@ -1935,9 +1935,9 @@ fn test_squash_to_new_commit() {
         "file 3&4",
         "-f",
         "kkmpptxzrspx::",
-        "--destination",
+        "--onto",
         "rlvkpnrzqnoo",
-        "--destination",
+        "--onto",
         "kkmpptxzrspx",
     ]);
     insta::assert_snapshot!(output, @r"
@@ -2016,10 +2016,10 @@ fn test_squash_to_new_commit() {
     insta::assert_snapshot!(output, @r"
     ○    xlzxqlsl test.user@example.com 2001-02-03 08:05:31 8ceb6c68
     ├─╮  file 3&4
-    │ │  -- operation dc662694ff45 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 05266483f4c2 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln hidden test.user@example.com 2001-02-03 08:05:31 c7946a56
     │ │  file4
-    │ │  -- operation dc662694ff45 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 05266483f4c2 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln hidden test.user@example.com 2001-02-03 08:05:11 38778966
     │ │  file4
     │ │  -- operation 83489d186f66 commit 89a30a7539466ed176c1ef122a020fd9cb15848e
@@ -2031,7 +2031,7 @@ fn test_squash_to_new_commit() {
     │    -- operation 19d57874b952 commit c23c424826221bc4fdee9487926595324e50ee95
     ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:31 3ab8a4a5
     │  file3
-    │  -- operation dc662694ff45 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │  -- operation 05266483f4c2 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     ○  kkmpptxz hidden test.user@example.com 2001-02-03 08:05:10 0d254956
     │  file3
     │  -- operation 19d57874b952 commit c23c424826221bc4fdee9487926595324e50ee95
@@ -2115,7 +2115,7 @@ fn test_squash_to_new_commit() {
     insta::assert_snapshot!(output, @r"
     ○  zowrlwsv test.user@example.com 2001-02-03 08:05:38 5feda7c2
        (empty) (no description set)
-       -- operation 8dc838fe4842 squash 0 commits
+       -- operation bfcdfe8808b3 squash 0 commits
     [EOF]
     ");
 
@@ -2158,7 +2158,7 @@ fn test_squash_to_new_commit() {
     insta::assert_snapshot!(output, @r"
     ○  nsrwusvy test.user@example.com 2001-02-03 08:05:42 c2183685
        (empty) (no description set)
-       -- operation 2b93f729fd60 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+       -- operation 68089102e2bb squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     [EOF]
     ");
 
@@ -2175,7 +2175,7 @@ fn test_squash_to_new_commit() {
         "squash",
         "-f",
         "wtlqussy",
-        "--destination",
+        "--onto",
         "root()",
         "--use-destination-message",
     ]);
@@ -2205,10 +2205,10 @@ fn test_squash_to_new_commit() {
     insta::assert_snapshot!(output, @r"
     ○  ukwxllxp test.user@example.com 2001-02-03 08:05:46 43a4b8e0
     │  (empty) (no description set)
-    │  -- operation ff0dd67ed609 squash commit 7eff41c8d17b8b4d2e7110402719e9d245dba975
+    │  -- operation 05a5eef8665f squash commit 7eff41c8d17b8b4d2e7110402719e9d245dba975
     ○  wtlqussy hidden test.user@example.com 2001-02-03 08:05:46 7eff41c8
        (empty) (no description set)
-       -- operation a8bb9104802c new empty commit
+       -- operation 9f39ca40bedf new empty commit
     [EOF]
     ");
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -544,7 +544,7 @@ To revert the merge in `C`, create a new commit with `jj new C`,
 then `jj restore --from B`, and then describe the message
 with something like `jj desc -m "Revert the merge of D into B`. Now, commit `@`
 undoes the merge of `D` into  `B`. If necessary, you can now rebase it
-elsewhere, e.g. `jj rebase -r @ -d main`.
+elsewhere, e.g. `jj rebase -r @ -o main`.
 
 ### How do I deal with divergent changes ('??' after the [change ID])?
 

--- a/docs/design/copy-tracking.md
+++ b/docs/design/copy-tracking.md
@@ -71,8 +71,8 @@ B rename foo->bar
 |
 A add foo
 
-$ jj rebase -r C -d A
-$ jj rebase -r C -d B # Takes us back to the state above
+$ jj rebase -r C -o A
+$ jj rebase -r C -o B # Takes us back to the state above
 ```
 
 
@@ -88,7 +88,7 @@ B rename foo->bar
 |
 A add foo
 
-$ jj revert -r B -d B
+$ jj revert -r B -o B
 $ jj diff --from B- --to B+ # Should be empty
 ```
 
@@ -528,7 +528,7 @@ B rename foo->bar
 |
 A add foo
 
-$ jj rebase -r C -d A
+$ jj rebase -r C -o A
 ```
 
 
@@ -540,7 +540,7 @@ C rename foo->baz
 |/
 A add foo
 
-$ jj rebase -r C -d B
+$ jj rebase -r C -o B
 ```
 
 #### Example: Rename added file
@@ -637,7 +637,7 @@ C | rename bar->baz
 |/
 A add foo="foo" and bar="bar"
 
-$ jj rebase -r E -d C
+$ jj rebase -r E -o C
 $ jj new D E -m F
 ```
 

--- a/docs/git-command-table.yml
+++ b/docs/git-command-table.yml
@@ -251,7 +251,7 @@
     `git rebase B A`
     (may need to rebase other descendant branches separately)
   Jujutsu command: >
-    `jj rebase -b A -d B`
+    `jj rebase -b A -o B`
   Notes: ''
 
 - Use case: Move change A and its descendants onto change B
@@ -259,7 +259,7 @@
     `git rebase --onto B A^ <some descendant bookmark>`
     (may need to rebase other descendant bookmarks separately)
   Jujutsu command: >
-    `jj rebase -s A -d B`
+    `jj rebase -s A -o B`
   Notes: ''
 
 - Use case: Reorder changes from A-B-C-D to A-C-B-D
@@ -333,7 +333,7 @@
   Git command: >
     `git co <destination>; git cherry-pick <source>`
   Jujutsu command: >
-    `jj duplicate <source> -d <destination>`
+    `jj duplicate <source> -o <destination>`
   Notes: ''
 
 - Use case: Find the root of the working copy (or check if in a repo)

--- a/docs/github.md
+++ b/docs/github.md
@@ -52,7 +52,7 @@ a new commits. Unlike Git, Jujutsu will not do it automatically.
 
 As of October 2023, Jujutsu has no equivalent to a `git pull` command (see
 [issue #1039][sync-issue]). Until such a command is added, you need to use
-`jj git fetch` followed by a `jj rebase -d $main_bookmark` to update your
+`jj git fetch` followed by a `jj rebase -o $main_bookmark` to update your
 changes.
 
 [sync-issue]: https://github.com/jj-vcs/jj/issues/1039

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -593,21 +593,21 @@ meaning. Strictly speaking, it is not part of the revset language. The notation
 is similar to the modifiers like `glob:` allowed before [string
 patterns](#string-patterns).
 
-For example, `jj rebase -r w -d xyz+` will rebase `w` on top of the child of
+For example, `jj rebase -r w -o xyz+` will rebase `w` on top of the child of
 `xyz` as long as `xyz` has exactly one child.
 
 If `xyz` has more than one child, the `all:` modifier is *not* specified, and
-`ui.always-allow-large-revsets` is `false`, `jj rebase -r w -d xyz+` will return
+`ui.always-allow-large-revsets` is `false`, `jj rebase -r w -o xyz+` will return
 an error.
 
 If `ui.always-allow-large-revsets` was `true` (the default), the above command
 would act as if `all:` was set (see the next paragraph).
 
-With the `all:` modifier, `jj rebase -r w -d all:xyz+` will make `w` into a merge
+With the `all:` modifier, `jj rebase -r w -o all:xyz+` will make `w` into a merge
 commit if `xyz` has more than one child. The `all:` modifier confirms that the
 user expected `xyz` to have more than one child.
 
-A more useful example: if `w` is a merge commit, `jj rebase -s w -d all:w- -d
+A more useful example: if `w` is a merge commit, `jj rebase -s w -o all:w- -d
 xyz` will add `xyz` to the list of `w`'s parents.
 
 ## Examples

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -266,11 +266,10 @@ $ jj log
 
 We now have a few commits, where A, B1, and B2 modify the same file, while C
 modifies a different file. Let's now rebase B2 directly onto A. We use the
-`--source`/`-s` option on the change ID of B2, and `--destination`/`-d` option
-on A.
+`--source`/`-s` option on the change ID of B2, and `--onto`/`-o` option on A.
 
 ```shell
-$ jj rebase -s puqltutt -d nuvyytnq  # Replace the IDs by what you have for B2 and A
+$ jj rebase -s puqltutt -o nuvyytnq  # Replace the IDs by what you have for B2 and A
 Rebased 2 commits to destination
 Working copy  (@) now at: qzvqqupx 1978b534 (conflict) C
 Parent commit (@-)      : puqltutt f7fb5943 (conflict) B2
@@ -404,7 +403,7 @@ $ jj op log
 │  args: jj new puqltutt
 ○  367400773f87 martinvonz@vonz.svl.corp.google.com 12 minutes ago, lasted 3 milliseconds
 │  rebase commit daa6ffd5a09a8a7d09a65796194e69b7ed0a566d and descendants
-│  args: jj rebase -s puqltutt -d nuvyytnq
+│  args: jj rebase -s puqltutt -o nuvyytnq
 [many more lines]
 ```
 


### PR DESCRIPTION


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
