### PR TITLE
testutils: dump_tree: print contents of conflicted trees

### DIFF
--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -2004,16 +2004,18 @@ fn test_fsmonitor() {
 
     let tree_state = snapshot(&[foo_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
-    tree 2a5341b103917cfdb48a
-      file "foo" (e99c2057c15160add351): "foo\n"
+    merged tree (sides: 1)
+      tree 2a5341b103917cfdb48a
+        file "foo" (e99c2057c15160add351): "foo\n"
     "#);
 
     let mut tree_state = snapshot(&[foo_path, bar_path, nested_path, ignored_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
-    tree 1c5c336421714b1df7bb
-      file "bar" (94cc973e7e1aefb7eff6): "bar\n"
-      file "foo" (e99c2057c15160add351): "foo\n"
-      file "path/to/nested" (6209060941cd770c8d46): "nested\n"
+    merged tree (sides: 1)
+      tree 1c5c336421714b1df7bb
+        file "bar" (94cc973e7e1aefb7eff6): "bar\n"
+        file "foo" (e99c2057c15160add351): "foo\n"
+        file "path/to/nested" (6209060941cd770c8d46): "nested\n"
     "#);
     tree_state.save().unwrap();
 
@@ -2021,18 +2023,20 @@ fn test_fsmonitor() {
     testutils::write_working_copy_file(&workspace_root, bar_path, "updated bar\n");
     let tree_state = snapshot(&[foo_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
-    tree f653dfa18d0b025bdb9e
-      file "bar" (94cc973e7e1aefb7eff6): "bar\n"
-      file "foo" (e0fbd106147cc04ccd05): "updated foo\n"
-      file "path/to/nested" (6209060941cd770c8d46): "nested\n"
+    merged tree (sides: 1)
+      tree f653dfa18d0b025bdb9e
+        file "bar" (94cc973e7e1aefb7eff6): "bar\n"
+        file "foo" (e0fbd106147cc04ccd05): "updated foo\n"
+        file "path/to/nested" (6209060941cd770c8d46): "nested\n"
     "#);
 
     std::fs::remove_file(foo_path.to_fs_path_unchecked(&workspace_root)).unwrap();
     let mut tree_state = snapshot(&[foo_path]);
     insta::assert_snapshot!(testutils::dump_tree(tree_state.current_tree()), @r#"
-    tree b7416fc248a038b920c3
-      file "bar" (94cc973e7e1aefb7eff6): "bar\n"
-      file "path/to/nested" (6209060941cd770c8d46): "nested\n"
+    merged tree (sides: 1)
+      tree b7416fc248a038b920c3
+        file "bar" (94cc973e7e1aefb7eff6): "bar\n"
+        file "path/to/nested" (6209060941cd770c8d46): "nested\n"
     "#);
     tree_state.save().unwrap();
 }

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -291,13 +291,7 @@ fn test_resolve_success() {
     );
     let resolved_tree = tree.resolve().block_on().unwrap();
     assert!(resolved_tree.tree_ids().is_resolved());
-    assert_tree_eq!(
-        resolved_tree,
-        expected,
-        "actual entries: {:#?}, expected entries {:#?}",
-        resolved_tree.entries().collect_vec(),
-        expected.entries().collect_vec()
-    );
+    assert_tree_eq!(resolved_tree, expected);
 }
 
 #[test]


### PR DESCRIPTION
Previously, `assert_tree_eq!` would give a confusing panic message if one of the trees had a conflict.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
