### PR TITLE
diff_util: replace `[T; 2]` with `Diff<T>`

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -16,6 +16,7 @@ use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
 use indoc::writedoc;
 use jj_lib::backend::Signature;
+use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
 use tracing::instrument;
@@ -141,7 +142,7 @@ new working-copy commit.
         )
     };
     let tree = diff_selector.select(
-        [&base_tree, &commit.tree()],
+        Diff::new(&base_tree, &commit.tree()),
         matcher.as_ref(),
         format_instructions,
     )?;

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -17,6 +17,7 @@ use clap_complete::ArgValueCompleter;
 use indexmap::IndexSet;
 use itertools::Itertools as _;
 use jj_lib::copies::CopyRecords;
+use jj_lib::merge::Diff;
 use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::merge_commit_trees;
 use pollster::FutureExt as _;
@@ -222,7 +223,7 @@ pub(crate) fn cmd_diff(
         .show_diff(
             ui,
             ui.stdout_formatter().as_mut(),
-            [&from_tree, &to_tree],
+            Diff::new(&from_tree, &to_tree),
             &matcher,
             &copy_records,
             ui.term_width(),

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -17,6 +17,7 @@ use std::io::Write as _;
 use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
 use itertools::Itertools as _;
+use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::rewrite::merge_commit_trees;
 use pollster::FutureExt as _;
@@ -148,7 +149,8 @@ don't make any changes, then the operation will be aborted.",
     };
     let base_tree = merge_commit_trees(tx.repo(), base_commits.as_slice()).block_on()?;
     let tree = target_commit.tree();
-    let edited_tree = diff_editor.edit([&base_tree, &tree], &matcher, format_instructions)?;
+    let edited_tree =
+        diff_editor.edit(Diff::new(&base_tree, &tree), &matcher, format_instructions)?;
     if edited_tree.tree_ids() == target_commit.tree_ids() {
         writeln!(ui.status(), "Nothing changed.")?;
     } else {

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -18,6 +18,7 @@ use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
 use indoc::formatdoc;
 use itertools::Itertools as _;
+use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
 use tracing::instrument;
 
@@ -162,7 +163,11 @@ pub(crate) fn cmd_restore(
             to_commit = workspace_command.format_commit_summary(&to_commit),
         }
     };
-    let new_tree = diff_selector.select([&to_tree, &from_tree], &matcher, format_instructions)?;
+    let new_tree = diff_selector.select(
+        Diff::new(&to_tree, &from_tree),
+        &matcher,
+        format_instructions,
+    )?;
     if new_tree.tree_ids() == to_commit.tree_ids() {
         writeln!(ui.status(), "Nothing changed.")?;
     } else {

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -19,6 +19,7 @@ use clap_complete::ArgValueCompleter;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
 use jj_lib::matchers::Matcher;
+use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::rewrite::CommitWithSelection;
 use jj_lib::rewrite::EmptyBehavior;
@@ -462,7 +463,7 @@ The changes that are not selected will replace the original commit.
     };
     let parent_tree = target_commit.parent_tree(tx.repo())?;
     let selected_tree = diff_selector.select(
-        [&parent_tree, &target_commit.tree()],
+        Diff::new(&parent_tree, &target_commit.tree()),
         matcher,
         format_instructions,
     )?;

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -22,6 +22,7 @@ use itertools::Itertools as _;
 use jj_lib::commit::Commit;
 use jj_lib::commit::CommitIteratorExt as _;
 use jj_lib::matchers::Matcher;
+use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
 use jj_lib::rewrite;
@@ -481,8 +482,11 @@ fn select_diff(
                 destination = tx.format_commit_summary(destination),
             }
         };
-        let selected_tree =
-            diff_selector.select([&parent_tree, &source_tree], matcher, format_instructions)?;
+        let selected_tree = diff_selector.select(
+            Diff::new(&parent_tree, &source_tree),
+            matcher,
+            format_instructions,
+        )?;
         source_commits.push(CommitWithSelection {
             commit: source.clone(),
             selected_tree,

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -14,6 +14,7 @@
 
 use itertools::Itertools as _;
 use jj_lib::copies::CopyRecords;
+use jj_lib::merge::Diff;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::repo::Repo as _;
 use jj_lib::repo_path::RepoPath;
@@ -98,7 +99,7 @@ pub(crate) fn cmd_status(
                     .show_diff(
                         ui,
                         formatter,
-                        [&parent_tree, &tree],
+                        Diff::new(&parent_tree, &tree),
                         &matcher,
                         &copy_records,
                         width,

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -19,6 +19,7 @@ use jj_lib::conflicts::choose_materialized_conflict_marker_len;
 use jj_lib::conflicts::materialize_merge_result_to_bytes;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::matchers::Matcher;
+use jj_lib::merge::Diff;
 use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree::MergedTreeBuilder;
@@ -376,7 +377,7 @@ pub fn run_mergetool_external(
 
 pub fn edit_diff_external(
     editor: &ExternalMergeTool,
-    trees: [&MergedTree; 2],
+    trees: Diff<&MergedTree>,
     matcher: &dyn Matcher,
     instructions: Option<&str>,
     base_ignores: Arc<GitIgnoreFile>,
@@ -423,7 +424,7 @@ pub fn edit_diff_external(
 pub fn generate_diff(
     ui: &Ui,
     writer: &mut dyn Write,
-    trees: [&MergedTree; 2],
+    trees: Diff<&MergedTree>,
     matcher: &dyn Matcher,
     tool: &ExternalMergeTool,
     default_conflict_marker_style: ConflictMarkerStyle,

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -30,6 +30,7 @@ use jj_lib::conflicts::MaterializedFileConflictValue;
 use jj_lib::conflicts::try_materialize_file_conflict_value;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::matchers::Matcher;
+use jj_lib::merge::Diff;
 use jj_lib::merge::Merge;
 use jj_lib::merge::MergedTreeValue;
 use jj_lib::merged_tree::MergedTree;
@@ -294,7 +295,7 @@ impl DiffEditor {
     /// Starts a diff editor on the two directories.
     pub fn edit(
         &self,
-        trees: [&MergedTree; 2],
+        trees: Diff<&MergedTree>,
         matcher: &dyn Matcher,
         format_instructions: impl FnOnce() -> String,
     ) -> Result<MergedTree, DiffEditError> {

--- a/lib/src/diff_presentation/mod.rs
+++ b/lib/src/diff_presentation/mod.rs
@@ -32,6 +32,7 @@ use crate::diff::ContentDiff;
 use crate::diff::DiffHunk;
 use crate::diff::DiffHunkKind;
 use crate::diff::find_line_ranges;
+use crate::merge::Diff;
 use crate::merge::Merge;
 use crate::repo_path::RepoPath;
 
@@ -113,7 +114,7 @@ pub fn diff_by_line<'input, T: AsRef<[u8]> + ?Sized + 'input>(
 }
 
 /// Splits `[left, right]` hunk pairs into `[left_lines, right_lines]`.
-pub fn unzip_diff_hunks_to_lines<'content, I>(diff_hunks: I) -> [Vec<DiffTokenVec<'content>>; 2]
+pub fn unzip_diff_hunks_to_lines<'content, I>(diff_hunks: I) -> Diff<Vec<DiffTokenVec<'content>>>
 where
     I: IntoIterator,
     I::Item: Borrow<DiffHunk<'content>>,
@@ -164,5 +165,5 @@ where
     if !right_tokens.is_empty() {
         right_lines.push(right_tokens);
     }
-    [left_lines, right_lines]
+    Diff::new(left_lines, right_lines)
 }

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -46,7 +46,7 @@ use crate::tree::Tree;
 ///
 /// This is not a diff in the `patch(1)` sense. See `diff::ContentDiff` for
 /// that.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Diff<T> {
     /// The state before
     pub before: T,
@@ -66,6 +66,19 @@ impl<T> Diff<T> {
             before: f(self.before),
             after: f(self.after),
         }
+    }
+
+    /// Convert a `&Diff<T>` into a `Diff<&T>`.
+    pub fn as_ref(&self) -> Diff<&T> {
+        Diff {
+            before: &self.before,
+            after: &self.after,
+        }
+    }
+
+    /// Convert a diff into an array `[before, after]`.
+    pub fn into_array(self) -> [T; 2] {
+        [self.before, self.after]
     }
 }
 


### PR DESCRIPTION
I think using `Diff<T>` for these makes the code more readable, since using 2-element arrays gives a less clear meaning to the arguments.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
