### PR TITLE
cli bookmark rename: simplify warning logic

### DIFF
--- a/cli/src/commands/bookmark/rename.rs
+++ b/cli/src/commands/bookmark/rename.rs
@@ -94,14 +94,14 @@ pub fn cmd_bookmark_rename(
         })
         .map(|(symbol, _)| symbol.remote.to_owned())
         .collect_vec();
-    let mut tracked_present_remote_bookmarks_exist_for_new_bookmark = false;
+    let mut tracked_remote_bookmarks_exist_for_new_bookmark = false;
     let existing_untracked_remotes = tx
         .base_repo()
         .view()
         .remote_bookmarks_matching(&StringMatcher::exact(new_bookmark), &remote_matcher)
         .filter(|(_, remote_ref)| {
-            if remote_ref.is_tracked() && remote_ref.is_present() {
-                tracked_present_remote_bookmarks_exist_for_new_bookmark = true;
+            if remote_ref.is_tracked() {
+                tracked_remote_bookmarks_exist_for_new_bookmark = true;
             }
             !remote_ref.is_tracked()
         })
@@ -151,7 +151,7 @@ pub fn cmd_bookmark_rename(
             new_bookmark = new_bookmark.as_symbol()
         )?;
     }
-    if tracked_present_remote_bookmarks_exist_for_new_bookmark {
+    if tracked_remote_bookmarks_exist_for_new_bookmark {
         // This isn't an error because bookmark renaming can't be propagated to
         // the remote immediately. "rename old new && rename new old" should be
         // allowed even if the original old bookmark had tracked remotes.


### PR DESCRIPTION
I was made aware of this on Discord:
https://discord.com/channels/968932220549103686/969291218347524238/1436916237866242268

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
