### PR TITLE
template: Add `RepoPath.absolute()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--editor`, which ensures an editor will be opened with the commit
   description even if one was provided via `--message`/`-m`.
 
-* All `jj` commands show a warning when the provided `fileset` expression 
+* All `jj` commands show a warning when the provided `fileset` expression
   doesn't match any files.
+
+* `RepoPath` template type now has a `absolute() -> String` method that returns
+  the absolute path as a string.
 
 ### Fixed bugs
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -391,6 +391,8 @@ _Conversion: `Boolean`: no, `Serialize`: yes, `Template`: yes_
 A slash-separated path relative to the repository root. The following methods
 are defined.
 
+* `.absolute() -> String`: Format as absolute path using platform-native
+  separator.
 * `.display() -> String`: Format path for display. The formatted path uses
   platform-native separator, and is relative to the current working directory.
 * `.parent() -> Option<RepoPath>`: Parent directory path.


### PR DESCRIPTION
My first time writing actual Rust code, so please call out anything that could be improved!

Also for some reason `jj fix` and `cargo +nightly fmt` weren't doing anything to `commit_templater.rs`, so I formatted it by hand.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
