### PR TITLE
docs: add missing `run` in bisect command line example

### DIFF
--- a/cli/src/commands/bisect/run.rs
+++ b/cli/src/commands/bisect/run.rs
@@ -52,8 +52,8 @@ use crate::ui::Ui;
 ///
 /// Example: To run `cargo test` with the changes from revision `xyz` applied:
 ///
-/// `jj bisect --range v1.0..main -- bash -c "jj duplicate -r xyz -B @ && cargo
-/// test"`
+/// `jj bisect run --range v1.0..main -- bash -c "jj duplicate -r xyz -B @ &&
+/// cargo test"`
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct BisectRunArgs {
     /// Range of revisions to bisect

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -303,7 +303,7 @@ Hint: You can pass your shell as evaluation command. You can then run manual tes
 
 Example: To run `cargo test` with the changes from revision `xyz` applied:
 
-`jj bisect --range v1.0..main -- bash -c "jj duplicate -r xyz -B @ && cargo test"`
+`jj bisect run --range v1.0..main -- bash -c "jj duplicate -r xyz -B @ && cargo test"`
 
 **Usage:** `jj bisect run [OPTIONS] --range <REVSETS> [COMMAND] [ARGS]...`
 


### PR DESCRIPTION
I based a bisect execution on that example command line and noticed the `run` command was missing.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
