### PR TITLE
Trivial formatting fix for `jj debug watchman status`

### DIFF
--- a/cli/src/commands/debug/watchman.rs
+++ b/cli/src/commands/debug/watchman.rs
@@ -61,8 +61,8 @@ pub fn cmd_debug_watchman(
                     writeln!(ui.stdout(), "Watchman is enabled via `fsmonitor.backend`.")?;
                     writeln!(
                         ui.stdout(),
-                        r"Background snapshotting is {}. Use \
-                          `fsmonitor.watchman.register-snapshot-trigger` to control it.",
+                        "Background snapshotting is {}. Use \
+                         `fsmonitor.watchman.register-snapshot-trigger` to control it.",
                         if config.register_trigger {
                             "enabled"
                         } else {


### PR DESCRIPTION
# Before Patch

```
Watchman is enabled via `fsmonitor.backend`.
Background snapshotting is disabled. Use \
                          `fsmonitor.watchman.register-snapshot-trigger` to control it.
The watchman server seems to be installed and working correctly.
Background snapshotting is currently inactive.
```

# After Patch

```
Watchman is enabled via `fsmonitor.backend`.
Background snapshotting is disabled. Use
  `fsmonitor.watchman.register-snapshot-trigger` to control it.
The watchman server seems to be installed and working correctly.
Background snapshotting is currently inactive.
```
