### PR TITLE
rust: update MSRV to Rust 1.89

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -7,7 +7,7 @@
 bacon_version = "3.16.0"
 cargo_insta_version = "1.43.1"
 cargo_nextest_version = "0.9.103"
-rust_version = "1.88"
+rust_version = "1.89"
 uv_version = "0.8.13"
 
 [settings]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
       with:
-        toolchain: 1.88
+        toolchain: 1.89
     - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
       with:
         tool: nextest
@@ -107,7 +107,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
       with:
-        toolchain: 1.88
+        toolchain: 1.89
     - name: Build
       run: cargo build -p jj-cli --no-default-features --verbose
 
@@ -222,7 +222,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
-          toolchain: 1.88
+          toolchain: 1.89
       # NOTE: We need to run `cargo test --doc` separately from normal tests:
       # - `cargo build --all-targets` specifies: "Build all targets"
       # - `cargo test --all-targets` specifies: "Test all targets (does not include doctests)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   more information, and [#3502](https://github.com/jj-vcs/jj/issues/3502) for
   motivation.
 
+* The minimum supported Rust version (MSRV) is now 1.89.
+
 ### Deprecations
 
 * The `--destination`/`-d` arguments for `jj rebase`, `jj split`, `jj revert`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["cli", "lib", "lib/gen-protos", "lib/proc-macros", "lib/testutils"]
 [workspace.package]
 version = "0.35.0"
 license = "Apache-2.0"
-rust-version = "1.88" # NOTE: remember to update CI, mise.toml, contributing.md, changelog.md, and install-and-setup.md
+rust-version = "1.89" # NOTE: remember to update CI, mise.toml, contributing.md, changelog.md, and install-and-setup.md
 edition = "2024"
 readme = "README.md"
 homepage = "https://github.com/jj-vcs/jj"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -150,7 +150,7 @@ recommended steps.
 One-time setup:
 
     rustup toolchain add nightly  # wanted for 'rustfmt'
-    rustup toolchain add 1.88     # also specified in Cargo.toml
+    rustup toolchain add 1.89     # also specified in Cargo.toml
     cargo install --locked bacon
     cargo install --locked cargo-insta
     cargo install --locked cargo-nextest
@@ -188,7 +188,7 @@ These are listed roughly in order of decreasing importance.
 3. Your code will be rejected if it cannot be compiled with the minimal
    supported version of Rust ("MSRV"). Currently, `jj` follows a rather
    casual MSRV policy: "The current `rustc` stable version, minus one."
-   As of this writing, that version is **1.88.0**.
+   As of this writing, that version is **1.89.0**.
 
 4. Your code needs to pass `cargo clippy`. You can also
    use `cargo +nightly clippy` if you wish to see more warnings.


### PR DESCRIPTION
updates MSRV to Rust 1.89, providing for use of std file locking. separate PR on the way for that.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
