### PR TITLE
template: Fail on unexpected keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Windows. This renders completion results viable when using jj in Git Bash.
   [#7024](https://github.com/jj-vcs/jj/issues/7024)
 
+* Unexpected keyword arguments now return a parse failure for the `coalesce()`
+  and `concat()` templating functions.
+
 ## [0.35.0] - 2025-11-05
 
 ### Release highlights

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -148,6 +148,14 @@ impl<'i, T> FunctionCallNode<'i, T> {
     }
 
     /// Extracts N required arguments and remainders.
+    ///
+    /// This can be used to get all the positional arguments without requiring
+    /// any (N = 0):
+    /// ```ignore
+    /// let ([], content_nodes) = function.expect_some_arguments()?;
+    /// ```
+    /// Avoid accessing `function.args` directly, as that may allow keyword
+    /// arguments to be silently ignored.
     #[expect(clippy::type_complexity)]
     pub fn expect_some_arguments<const N: usize>(
         &self,


### PR DESCRIPTION
Any keyword arguments given to the `coalesce()` and `concat()` functions were being silently ignored because `FunctionCallNode.args` was being accessed directly without checking `keyword_args` at all.

Also added new test case for `separate()`, which is the only other function that accepts a variable number of arguments.

Before:
```bash
$ jj log -T 'concat("test", arg="ignored!")'
@  test
│ ○  test
├─┘
◆  test
│
~
$ jj log -T '"output: " ++ coalesce("", arg="ignored!") ++ "."'
@  output: .
│ ○  output: .
├─┘
◆  output: .
│
~
```

After:
```bash
$ jj log -T 'concat("test", arg="ignored!")'
Error: Failed to parse template: Function `concat`: Unexpected keyword arguments
Caused by:  --> 1:16
  |
1 | concat("test", arg="ignored!")
  |                ^------------^
  |
  = Function `concat`: Unexpected keyword arguments
$ jj log -T '"output: " ++ coalesce("", arg1="ignored!") ++ "."'
Error: Failed to parse template: Function `coalesce`: Unexpected keyword arguments
Caused by:  --> 1:28
  |
1 | "output: " ++ coalesce("", arg1="ignored!") ++ "."
  |                            ^-------------^
  |
  = Function `coalesce`: Unexpected keyword arguments
```

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
