### PR TITLE
template: add a format_path(...) template to allow path customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `RepoPath` template type now has a `absolute() -> String` method that returns
   the absolute path as a string.
 
+* Added `format_path(path)` template that controls how file paths are printed
+  with `jj file list`.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -34,7 +34,7 @@ commit_trailers = ''
 evolog = 'builtin_evolog_compact'
 
 file_list = '''
-path.display() ++ "\n"
+format_path(path) ++ "\n"
 '''
 file_show = ''
 
@@ -310,6 +310,7 @@ commit_summary_separator = 'label("separator", " | ")'
 'format_short_change_id(id)' = 'format_short_id(id)'
 'format_short_commit_id(id)' = 'format_short_id(id)'
 'format_short_operation_id(id)' = 'id.short()'
+'format_path(path)' = 'path.display()'
 'format_short_signature(signature)' = '''
   coalesce(signature.email(), email_placeholder)'''
 'format_short_signature_oneline(signature)' = '''


### PR DESCRIPTION
this adds a format_path hook to allow people the customize the output of file paths in templates. originally motivated by having file paths rendered as hyperlinks, this came from a suggestion out of that: https://github.com/jj-vcs/jj/discussions/7920#discussioncomment-14842620

as it stands, it'll only be used in the `jj file list` output. but eventually if other templates print file paths (e.g. [jj status](https://github.com/jj-vcs/jj/issues/8021)) then this could be used there as well. 

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
