### PR TITLE
cli: warn when `jj file untrack` fileset doesn't match

### DIFF
--- a/cli/tests/test_file_track_untrack_commands.rs
+++ b/cli/tests/test_file_track_untrack_commands.rs
@@ -82,6 +82,14 @@ fn test_track_untrack() {
     assert!(work_dir.root().join("file1.bak").exists());
     assert!(work_dir.root().join("file2.bak").exists());
 
+    // Warns if path doesn't exist
+    let output = work_dir.run_jj(["file", "untrack", "nonexistent"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    ------- stderr -------
+    Warning: No matching entries for paths: nonexistent
+    [EOF]
+    ");
+
     // Errors out when multiple specified files are not ignored
     let output = work_dir.run_jj(["file", "untrack", "target"]);
     insta::assert_snapshot!(output.normalize_backslash(), @r"


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
