### PR TITLE
docs: remove description of deprecated `all:` revset prefix

### DIFF
--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -216,8 +216,8 @@ updated both locally and on a remote.
 
 To resolve a conflicted state in a local bookmark (e.g. `main`), you can move the
 bookmark to the desired target with `jj bookmark move`. You may want to first either
-merge the conflicted targets with `jj new` (e.g. `jj new 'all:main'`), or you may
-want to rebase one side on top of the other with `jj rebase`.
+merge the conflicted targets with `jj new` (e.g. `jj new main`), or you may want to
+rebase one side on top of the other with `jj rebase`.
 
 To resolve a conflicted state in a remote bookmark (e.g. `main@origin`), simply
 pull from the remote (e.g. `jj git fetch`). The conflict resolution will also

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -578,39 +578,6 @@ for a comprehensive list.
   Note that modifying this will *not* change whether a commit is immutable.
   To do that, edit `immutable_heads()`.
 
-
-## The `all:` modifier
-
-Certain commands (such as `jj rebase`) can take multiple revset arguments, and
-each of these may resolve to one-or-many revisions.
-
-If you set the `ui.always-allow-large-revsets` option to `false`, `jj` will not
-allow revsets that resolve to more than one revision &mdash; a so-called "large
-revset" &mdash; and will ask you to confirm that you want to proceed by
-prefixing it with the `all:` modifier. *This option is planned to be removed.*
-
-An `all:` modifier before a revset expression does not otherwise change its
-meaning. Strictly speaking, it is not part of the revset language. The notation
-is similar to the modifiers like `glob:` allowed before [string
-patterns](#string-patterns).
-
-For example, `jj rebase -r w -o xyz+` will rebase `w` on top of the child of
-`xyz` as long as `xyz` has exactly one child.
-
-If `xyz` has more than one child, the `all:` modifier is *not* specified, and
-`ui.always-allow-large-revsets` is `false`, `jj rebase -r w -o xyz+` will return
-an error.
-
-If `ui.always-allow-large-revsets` was `true` (the default), the above command
-would act as if `all:` was set (see the next paragraph).
-
-With the `all:` modifier, `jj rebase -r w -o all:xyz+` will make `w` into a merge
-commit if `xyz` has more than one child. The `all:` modifier confirms that the
-user expected `xyz` to have more than one child.
-
-A more useful example: if `w` is a merge commit, `jj rebase -s w -o all:w- -d
-xyz` will add `xyz` to the list of `w`'s parents.
-
 ## Examples
 
 Show the parent(s) of the working-copy commit (like `git log -1 HEAD`):


### PR DESCRIPTION
Since the prefix is no longer needed, I don't think there is much reason to document. It just seems confusing to describe it if it's not needed.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
