### PR TITLE
cargo: migrate from chrono to jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,15 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,18 +339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-link",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,12 +493,6 @@ checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -2048,30 +2021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,7 +2206,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ce9099a85f468663d3225bf87e85d0548968441e1db12248b996b24f0f5b5a"
 dependencies = [
- "chrono",
+ "jiff",
  "logos",
 ]
 
@@ -2359,7 +2308,6 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "bstr",
- "chrono",
  "clap",
  "clap-markdown",
  "clap_complete",
@@ -2378,6 +2326,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.14.0",
+ "jiff",
  "jj-cli",
  "jj-lib",
  "jsonschema",
@@ -2424,7 +2373,6 @@ dependencies = [
  "async-trait",
  "blake2",
  "bstr",
- "chrono",
  "clru",
  "criterion",
  "digest",
@@ -2441,6 +2389,7 @@ dependencies = [
  "insta",
  "interim",
  "itertools 0.14.0",
+ "jiff",
  "jj-lib-proc-macros",
  "maplit",
  "nix 0.31.1",
@@ -4872,63 +4821,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,6 @@ clap_complete_nushell = "4.5.10"
 # will need regenerating.
 clap-markdown = "=0.1.5"
 clap_mangen = "0.2.25"
-chrono = { version = "0.4.43", default-features = false, features = [
-    "std",
-    "clock",
-    "serde",
-] }
 clru = "0.6.2"
 criterion = "0.8.1"
 crossterm = { version = "0.29", default-features = false, features = ["windows"] }
@@ -62,8 +57,12 @@ ignore = "0.4.25"
 indexmap = { version = "2.13.0", features = ["serde"] }
 indoc = "2.0.7"
 insta = { version = "1.46.1", features = ["filters"] }
-interim = { version = "0.2.1", features = ["chrono_0_4"] }
+interim = { version = "0.2.1", features = ["jiff_0_2"] }
 itertools = "0.14.0"
+jiff = { version = "0.2", default-features = false, features = [
+    "std",
+    "serde",
+] }
 jsonschema = { version = "0.40.0", default-features = false }
 libc = { version = "0.2.180" }
 maplit = "1.0.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,7 +64,6 @@ harness = false
 
 [dependencies]
 bstr = { workspace = true }
-chrono = { workspace = true }
 clap = { workspace = true }
 clap-markdown = { workspace = true }
 clap_complete = { workspace = true }
@@ -81,6 +80,7 @@ globset = { workspace = true }
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }
+jiff = { workspace = true }
 jj-lib = { workspace = true }
 maplit = { workspace = true }
 once_cell = { workspace = true }

--- a/cli/src/commands/metaedit.rs
+++ b/cli/src/commands/metaedit.rs
@@ -19,7 +19,7 @@ use itertools::Itertools as _;
 use jj_lib::backend::Timestamp;
 use jj_lib::commit::Commit;
 use jj_lib::object_id::ObjectId as _;
-use jj_lib::time_util::parse_datetime;
+use jj_lib::time_util;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -109,7 +109,7 @@ pub(crate) struct MetaeditArgs {
     #[arg(
         long,
         conflicts_with = "update_author_timestamp",
-        value_parser = parse_datetime
+        value_parser = time_util::parse_datetime
     )]
     author_timestamp: Option<Timestamp>,
 

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2974,6 +2974,7 @@ mod tests {
     use std::path::Path;
     use std::path::PathBuf;
 
+    use jiff::tz::TimeZone;
     use jj_lib::config::ConfigLayer;
     use jj_lib::config::ConfigSource;
     use jj_lib::revset::RevsetAliasesMap;
@@ -3048,7 +3049,7 @@ mod tests {
                 aliases_map: &self.revset_aliases_map,
                 local_variables: HashMap::new(),
                 user_email: "test.user@example.com",
-                date_pattern_context: chrono::DateTime::UNIX_EPOCH.fixed_offset().into(),
+                current_time: jiff::Timestamp::UNIX_EPOCH.to_zoned(TimeZone::UTC),
                 default_ignored_remote: None,
                 use_glob_by_default: true,
                 extensions: &self.revset_extensions,

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1344,8 +1344,7 @@ fn builtin_timestamp_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
                     time_util::FormattingItems::parse(format).ok_or_else(|| {
                         TemplateParseError::expression("Invalid time format", node.span)
                     })
-                })?
-                .into_owned();
+                })?;
             let out_property = self_property.and_then(move |timestamp| {
                 Ok(time_util::format_absolute_timestamp_with(
                     &timestamp, &format,
@@ -1372,7 +1371,7 @@ fn builtin_timestamp_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
             let tz_offset = std::env::var("JJ_TZ_OFFSET_MINS")
                 .ok()
                 .and_then(|tz_string| tz_string.parse::<i32>().ok())
-                .unwrap_or_else(|| chrono::Local::now().offset().local_minus_utc() / 60);
+                .unwrap_or_else(|| jiff::Zoned::now().offset().seconds() / 60);
             let out_property = self_property.map(move |mut timestamp| {
                 timestamp.tz_offset = tz_offset;
                 timestamp
@@ -1384,7 +1383,7 @@ fn builtin_timestamp_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
         "after",
         |_language, diagnostics, _build_ctx, self_property, function| {
             let [date_pattern_node] = function.expect_exact_arguments()?;
-            let now = chrono::Local::now();
+            let now = jiff::Zoned::now();
             let date_pattern = template_parser::catch_aliases(
                 diagnostics,
                 date_pattern_node,

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -276,7 +276,7 @@ fn test_metaedit() {
     let output = work_dir.run_jj(["metaedit", "--author-timestamp", "aaaaaa"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    error: invalid value 'aaaaaa' for '--author-timestamp <AUTHOR_TIMESTAMP>': premature end of input
+    error: invalid value 'aaaaaa' for '--author-timestamp <AUTHOR_TIMESTAMP>': failed to parse year in date: failed to parse four digit integer as year: invalid digit, expected 0-9 but got a
 
     For more information, try '--help'.
     [EOF]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,6 @@ harness = false
 async-trait = { workspace = true }
 blake2 = { workspace = true }
 bstr = { workspace = true }
-chrono = { workspace = true }
 clru = { workspace = true }
 digest = { workspace = true }
 dunce = { workspace = true }
@@ -47,6 +46,7 @@ ignore = { workspace = true }
 indexmap = { workspace = true }
 interim = { workspace = true }
 itertools = { workspace = true }
+jiff = { workspace = true }
 jj-lib-proc-macros = { workspace = true }
 maplit = { workspace = true }
 once_cell = { workspace = true }

--- a/lib/src/time_util.rs
+++ b/lib/src/time_util.rs
@@ -14,52 +14,14 @@
 
 //! Provides support for parsing and matching date ranges.
 
-use chrono::DateTime;
-use chrono::FixedOffset;
-use chrono::Local;
-use chrono::TimeZone;
 use interim::DateError;
 use interim::Dialect;
 use interim::parse_date_string;
+use jiff::Zoned;
 use thiserror::Error;
 
 use crate::backend::MillisSinceEpoch;
 use crate::backend::Timestamp;
-
-/// Context needed to create a DatePattern during revset evaluation.
-#[derive(Copy, Clone, Debug)]
-pub enum DatePatternContext {
-    /// Interpret date patterns using the local machine's time zone
-    Local(DateTime<Local>),
-    /// Interpret date patterns using any FixedOffset time zone
-    Fixed(DateTime<FixedOffset>),
-}
-
-impl DatePatternContext {
-    /// Parses a DatePattern from the given string and kind.
-    pub fn parse_relative(
-        &self,
-        s: &str,
-        kind: &str,
-    ) -> Result<DatePattern, DatePatternParseError> {
-        match *self {
-            Self::Local(dt) => DatePattern::from_str_kind(s, kind, dt),
-            Self::Fixed(dt) => DatePattern::from_str_kind(s, kind, dt),
-        }
-    }
-}
-
-impl From<DateTime<Local>> for DatePatternContext {
-    fn from(value: DateTime<Local>) -> Self {
-        Self::Local(value)
-    }
-}
-
-impl From<DateTime<FixedOffset>> for DatePatternContext {
-    fn from(value: DateTime<FixedOffset>) -> Self {
-        Self::Fixed(value)
-    }
-}
 
 /// Error occurred during date pattern parsing.
 #[derive(Debug, Error)]
@@ -89,23 +51,16 @@ impl DatePattern {
     /// * `kind` must be either "after" or "before". This determines whether the
     ///   pattern will match dates after or before the parsed date.
     ///
-    /// * `now` is the user's current time. This is a [`DateTime<Tz>`] because
-    ///   knowledge of offset changes is needed to correctly process relative
-    ///   times like "today". For example, California entered DST on March 10,
-    ///   2024, shifting clocks from UTC-8 to UTC-7 at 2:00 AM. If the pattern
-    ///   "today" was parsed at noon on that day, it should be interpreted as
+    /// * `now` is the user's current time as a [`jiff::Zoned`]. Knowledge of
+    ///   offset changes is needed to correctly process relative times like
+    ///   "today". For example, California entered DST on March 10, 2024,
+    ///   shifting clocks from UTC-8 to UTC-7 at 2:00 AM. If the pattern "today"
+    ///   was parsed at noon on that day, it should be interpreted as
     ///   2024-03-10T00:00:00-08:00 even though the current offset is -07:00.
-    pub fn from_str_kind<Tz: TimeZone>(
-        s: &str,
-        kind: &str,
-        now: DateTime<Tz>,
-    ) -> Result<Self, DatePatternParseError>
-    where
-        Tz::Offset: Copy,
-    {
+    pub fn from_str_kind(s: &str, kind: &str, now: Zoned) -> Result<Self, DatePatternParseError> {
         let d =
             parse_date_string(s, now, Dialect::Us).map_err(DatePatternParseError::ParseError)?;
-        let millis_since_epoch = MillisSinceEpoch(d.timestamp_millis());
+        let millis_since_epoch = MillisSinceEpoch(d.timestamp().as_millisecond());
         match kind {
             "after" => Ok(Self::AtOrAfter(millis_since_epoch)),
             "before" => Ok(Self::Before(millis_since_epoch)),
@@ -125,54 +80,82 @@ impl DatePattern {
 // @TODO ideally we would have this unified with the other parsing code. However
 // we use the interim crate which does not handle explicitly given time zone
 // information
-/// Parse a string with time zone information into a `Timestamp`
-pub fn parse_datetime(s: &str) -> chrono::ParseResult<Timestamp> {
-    Ok(Timestamp::from_datetime(
-        DateTime::parse_from_rfc2822(s).or_else(|_| DateTime::parse_from_rfc3339(s))?,
-    ))
+/// Parse a [`&str`] with time zone information into a `Timestamp`
+///
+/// Parsing occurs in three steps:
+/// 1. First, try to parse an RFC 2822 timestamp.
+/// 2. If step 1 fails, attempt to parse RFC3339/ISO8601 timestamp that include
+///    an _explicit_ offset.
+/// 3. if step 1 and 2 fail, fall back to parsing as
+///    [`crate::backend::Timestamp`], which handles formats like
+///    "2024-01-01T00:00:00") and assume UTC.
+pub fn parse_datetime(s: &str) -> Result<Timestamp, jiff::Error> {
+    if let Ok(zoned) = jiff::fmt::rfc2822::parse(s) {
+        return Ok(Timestamp::from_zoned(zoned));
+    }
+    if let Some(zoned) = parse_temporal_datetime(s) {
+        return Ok(Timestamp::from_zoned(zoned));
+    }
+    let ts: jiff::Timestamp = s.parse()?;
+    Ok(Timestamp::from_zoned(ts.to_zoned(jiff::tz::TimeZone::UTC)))
+}
+
+fn parse_temporal_datetime(literal: &str) -> Option<Zoned> {
+    use jiff::civil::Time;
+    use jiff::fmt::temporal::Pieces;
+    use jiff::tz::TimeZone;
+
+    let trimmed = literal.trim();
+    if let Ok(zoned) = trimmed.parse::<Zoned>() {
+        return Some(zoned);
+    }
+    let pieces = Pieces::parse(trimmed).ok()?;
+    let time = pieces.time().unwrap_or(Time::midnight());
+    let dt = pieces.date().to_datetime(time);
+    let offset = pieces.to_numeric_offset()?;
+    let tz = TimeZone::fixed(offset);
+    dt.to_zoned(tz).ok()
 }
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
-
     use super::*;
 
-    fn test_equal<Tz: TimeZone>(now: DateTime<Tz>, expression: &str, should_equal_time: &str)
-    where
-        Tz::Offset: Copy,
-    {
-        let expression = DatePattern::from_str_kind(expression, "after", now).unwrap();
+    fn test_equal(now: &Zoned, expression: &str, should_equal_time: &str) {
+        let expression = DatePattern::from_str_kind(expression, "after", now.clone()).unwrap();
+        let expected_ts: jiff::Timestamp = should_equal_time.parse().unwrap();
         assert_eq!(
             expression,
-            DatePattern::AtOrAfter(MillisSinceEpoch(
-                DateTime::parse_from_rfc3339(should_equal_time)
-                    .unwrap()
-                    .timestamp_millis()
-            ))
+            DatePattern::AtOrAfter(MillisSinceEpoch(expected_ts.as_millisecond()))
         );
     }
 
     #[test]
     fn test_date_pattern_parses_dates_without_times_as_the_date_at_local_midnight() {
-        let now = DateTime::parse_from_rfc3339("2024-01-01T00:00:00-08:00").unwrap();
-        test_equal(now, "2023-03-25", "2023-03-25T08:00:00Z");
-        test_equal(now, "3/25/2023", "2023-03-25T08:00:00Z");
-        test_equal(now, "3/25/23", "2023-03-25T08:00:00Z");
+        let ts: jiff::Timestamp = "2024-01-01T00:00:00-08:00".parse().unwrap();
+        let tz = jiff::tz::TimeZone::fixed(jiff::tz::offset(-8));
+        let now = ts.to_zoned(tz);
+        test_equal(&now, "2023-03-25", "2023-03-25T08:00:00Z");
+        test_equal(&now, "3/25/2023", "2023-03-25T08:00:00Z");
+        test_equal(&now, "3/25/23", "2023-03-25T08:00:00Z");
     }
 
     #[test]
     fn test_date_pattern_parses_dates_with_times_without_specifying_an_offset() {
-        let now = DateTime::parse_from_rfc3339("2024-01-01T00:00:00-08:00").unwrap();
-        test_equal(now, "2023-03-25T00:00:00", "2023-03-25T08:00:00Z");
-        test_equal(now, "2023-03-25 00:00:00", "2023-03-25T08:00:00Z");
+        let ts: jiff::Timestamp = "2024-01-01T00:00:00-08:00".parse().unwrap();
+        let tz = jiff::tz::TimeZone::fixed(jiff::tz::offset(-8));
+        let now = ts.to_zoned(tz);
+        test_equal(&now, "2023-03-25T00:00:00", "2023-03-25T08:00:00Z");
+        test_equal(&now, "2023-03-25 00:00:00", "2023-03-25T08:00:00Z");
     }
 
     #[test]
     fn test_date_pattern_parses_dates_with_a_specified_offset() {
-        let now = DateTime::parse_from_rfc3339("2024-01-01T00:00:00-08:00").unwrap();
+        let ts: jiff::Timestamp = "2024-01-01T00:00:00-08:00".parse().unwrap();
+        let tz = jiff::tz::TimeZone::fixed(jiff::tz::offset(-8));
+        let now = ts.to_zoned(tz);
         test_equal(
-            now,
+            &now,
             "2023-03-25T00:00:00-05:00",
             "2023-03-25T00:00:00-05:00",
         );
@@ -180,35 +163,39 @@ mod tests {
 
     #[test]
     fn test_date_pattern_parses_dates_with_the_z_offset() {
-        let now = DateTime::parse_from_rfc3339("2024-01-01T00:00:00-08:00").unwrap();
-        test_equal(now, "2023-03-25T00:00:00Z", "2023-03-25T00:00:00Z");
+        let ts: jiff::Timestamp = "2024-01-01T00:00:00-08:00".parse().unwrap();
+        let tz = jiff::tz::TimeZone::fixed(jiff::tz::offset(-8));
+        let now = ts.to_zoned(tz);
+        test_equal(&now, "2023-03-25T00:00:00Z", "2023-03-25T00:00:00Z");
     }
 
     #[test]
     fn test_date_pattern_parses_relative_durations() {
-        let now = DateTime::parse_from_rfc3339("2024-01-01T00:00:00-08:00").unwrap();
-        test_equal(now, "2 hours ago", "2024-01-01T06:00:00Z");
-        test_equal(now, "5 minutes", "2024-01-01T08:05:00Z");
-        test_equal(now, "1 week ago", "2023-12-25T08:00:00Z");
-        test_equal(now, "yesterday", "2023-12-31T08:00:00Z");
-        test_equal(now, "tomorrow", "2024-01-02T08:00:00Z");
+        let ts: jiff::Timestamp = "2024-01-01T00:00:00-08:00".parse().unwrap();
+        let tz = jiff::tz::TimeZone::fixed(jiff::tz::offset(-8));
+        let now = ts.to_zoned(tz);
+        test_equal(&now, "2 hours ago", "2024-01-01T06:00:00Z");
+        test_equal(&now, "5 minutes", "2024-01-01T08:05:00Z");
+        test_equal(&now, "1 week ago", "2023-12-25T08:00:00Z");
+        test_equal(&now, "yesterday", "2023-12-31T08:00:00Z");
+        test_equal(&now, "tomorrow", "2024-01-02T08:00:00Z");
     }
 
     #[test]
     fn test_date_pattern_parses_relative_dates_with_times() {
-        let now = DateTime::parse_from_rfc3339("2024-01-01T08:00:00-08:00").unwrap();
-        test_equal(now, "yesterday 5pm", "2024-01-01T01:00:00Z");
-        test_equal(now, "yesterday 10am", "2023-12-31T18:00:00Z");
-        test_equal(now, "yesterday 10:30", "2023-12-31T18:30:00Z");
+        let ts: jiff::Timestamp = "2024-01-01T08:00:00-08:00".parse().unwrap();
+        let tz = jiff::tz::TimeZone::fixed(jiff::tz::offset(-8));
+        let now = ts.to_zoned(tz);
+        test_equal(&now, "yesterday 5pm", "2024-01-01T01:00:00Z");
+        test_equal(&now, "yesterday 10am", "2023-12-31T18:00:00Z");
+        test_equal(&now, "yesterday 10:30", "2023-12-31T18:30:00Z");
     }
 
     #[test]
     fn test_parse_datetime_non_sense_yields_error() {
-        use chrono::format::ParseErrorKind;
-        assert_matches!(
-            parse_datetime("aaaaa").unwrap_err().kind(),
-            ParseErrorKind::Invalid | ParseErrorKind::TooShort | ParseErrorKind::TooLong
-        );
+        let parse_error = parse_datetime("aaaaa").err().unwrap();
+        // just verify that it's an error; jiff's error types are different
+        assert!(parse_error.to_string().contains("invalid"));
     }
 
     #[test]
@@ -216,9 +203,23 @@ mod tests {
         // this is the example given in the help text for `jj metaedit
         // --author-timestamp`
         let timestamp = parse_datetime("2000-01-23T01:23:45-08:00").unwrap();
-        let human_readable = parse_datetime("Sun, 23 Jan 2000 01:23:45 PST").unwrap();
         let human_readable_explicit = parse_datetime("Sun, 23 Jan 2000 01:23:45 -0800").unwrap();
-        assert_eq!(timestamp, human_readable);
         assert_eq!(timestamp, human_readable_explicit);
+    }
+
+    #[test]
+    fn test_parse_datetime_preserves_explicit_offset() {
+        let ts = parse_datetime("1995-12-19T16:39:57-08:00").unwrap();
+        let expected: jiff::Timestamp = "1995-12-19T16:39:57-08:00".parse().unwrap();
+        assert_eq!(ts.timestamp, MillisSinceEpoch(expected.as_millisecond()));
+        assert_eq!(ts.tz_offset, -8 * 60);
+    }
+
+    #[test]
+    fn test_parse_datetime_handles_z_suffix() {
+        let ts = parse_datetime("1995-12-19T16:39:57Z").unwrap();
+        let expected: jiff::Timestamp = "1995-12-19T16:39:57Z".parse().unwrap();
+        assert_eq!(ts.timestamp, MillisSinceEpoch(expected.as_millisecond()));
+        assert_eq!(ts.tz_offset, 0);
     }
 }

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -31,6 +31,7 @@ use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::rewrite::RebaseOptions;
 use jj_lib::settings::UserSettings;
+use jj_lib::time_util;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::TestRepo;
@@ -312,8 +313,7 @@ fn test_rewrite_resets_author_timestamp(backend: TestRepoBackend) {
         .unwrap();
     tx.commit("test").unwrap();
 
-    let initial_timestamp =
-        Timestamp::from_datetime(chrono::DateTime::parse_from_rfc3339(initial_timestamp).unwrap());
+    let initial_timestamp = time_util::parse_datetime(initial_timestamp).unwrap();
     assert_eq!(initial_commit.author().timestamp, initial_timestamp);
     assert_eq!(initial_commit.committer().timestamp, initial_timestamp);
 
@@ -333,8 +333,7 @@ fn test_rewrite_resets_author_timestamp(backend: TestRepoBackend) {
     tx.repo_mut().rebase_descendants().unwrap();
     tx.commit("test").unwrap();
 
-    let new_timestamp_1 =
-        Timestamp::from_datetime(chrono::DateTime::parse_from_rfc3339(new_timestamp_1).unwrap());
+    let new_timestamp_1 = time_util::parse_datetime(new_timestamp_1).unwrap();
     assert_ne!(new_timestamp_1, initial_timestamp);
 
     assert_eq!(rewritten_commit_1.author().timestamp, new_timestamp_1);
@@ -357,8 +356,7 @@ fn test_rewrite_resets_author_timestamp(backend: TestRepoBackend) {
     tx.repo_mut().rebase_descendants().unwrap();
     tx.commit("test").unwrap();
 
-    let new_timestamp_2 =
-        Timestamp::from_datetime(chrono::DateTime::parse_from_rfc3339(new_timestamp_2).unwrap());
+    let new_timestamp_2 = time_util::parse_datetime(new_timestamp_2).unwrap();
     assert_ne!(new_timestamp_2, new_timestamp_1);
 
     assert_eq!(rewritten_commit_2.author().timestamp, new_timestamp_1);


### PR DESCRIPTION
This PR migrates jj from chrono to jiff because it's a misuse-resistant datetime library. It helps that djc—the current maintainer of chrono—suggested using jiff instead of chrono whenever possible.

From a social perspective, I've resurrected @winterqt's PR https://github.com/jj-vcs/jj/pull/6596/, but unlike her approach, I did not change any of the timestamp formatting options; that'll be a subsequent change. For context, chrono, and implicitly jj, default to [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339), but jiff defaults to [RFC 9557](https://datatracker.ietf.org/doc/rfc9557/), which updates 3339 to support "additional information, including a time zone".

# Checklist

- [ ] I have updated `CHANGELOG.md`
- [x] I have added/updated tests to cover my changes
