### PR TITLE
cli: add `visible()` and `hidden()` aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added `format_path(path)` template that controls how file paths are printed
   with `jj file list`.
 
+* New built-in revset aliases `visible()` and `hidden()`.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -34,3 +34,6 @@ latest(
 'immutable_heads()' = 'builtin_immutable_heads()'
 'immutable()' = '::(immutable_heads() | root())'
 'mutable()' = '~immutable()'
+
+'visible()' = '::visible_heads()'
+'hidden()' = '~visible()'

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -578,6 +578,15 @@ for a comprehensive list.
   Note that modifying this will *not* change whether a commit is immutable.
   To do that, edit `immutable_heads()`.
 
+* `visible()`: The set of visible commits. Resolves to `::visible_heads()`.
+  This is equal to `all()` unless your revset includes
+  [hidden revisions](#hidden-revisions).
+
+* `hidden()`: The set of hidden commits. Resolves to `~visible()`. This is empty
+  unless your revset includes [hidden revisions](#hidden-revisions). Note that
+  this is *not* [the set of all previously visible
+  commits](https://github.com/jj-vcs/jj/issues/2623).
+
 ## Examples
 
 Show the parent(s) of the working-copy commit (like `git log -1 HEAD`):


### PR DESCRIPTION
When looking for a revset for visible commits, it seems natural to reach for `visible()`. It's less obvious to find
`visible_heads()`.

Similarly, we don't have a revset for `hidden()` commits, so I added that too. I defined it as the obvious `~visible()`. That doesn't include all hidden commits reachable from the operation log (or from the index). Maybe we'll want a revset for that eventually. Hopefully we can come up with a decent name for it then. It's probably better to define that as all of the historical commits including the current ones in that case, so `hidden()` would not be a good name.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
