### PR TITLE
docs: document snapshot.auto-update-stale configuration

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1711,6 +1711,24 @@ Files that already exist in the working copy are not subject to this limit.
 
 Setting this value to zero will disable the limit entirely.
 
+### Automatic update of stale working copies
+
+When a working copy becomes stale (meaning the working copy's recorded commit is
+no longer the current commit for that workspace), `jj` will normally prompt you
+to update it with `jj workspace update-stale`. You can configure `jj` to
+automatically update stale working copies by setting:
+
+```toml
+[snapshot]
+auto-update-stale = true
+```
+
+This is particularly useful if you have [multiple workspaces](working-copy.md#workspaces)
+and want to avoid manually updating each one.
+
+For more information on stale working copies, see the [working copy
+documentation](working-copy.md#stale-working-copy).
+
 ## Working copy settings
 
 ### EOL conversion settings


### PR DESCRIPTION
## Summary
Add documentation for the `snapshot.auto-update-stale` configuration option that enables automatic updating of stale working copies.

## Changes
- Added new subsection "Automatic update of stale working copies" in the Snapshot settings section
- Documented the configuration option with example usage
- Included links to related documentation about stale working copies and workspaces

## Background
The `snapshot.auto-update-stale` option was added in commit 49890fa2d (#3820) but was not documented in the configuration reference. This PR adds the missing documentation as requested in #8033.

This option is particularly useful for users working with multiple workspaces who want to avoid manually running `jj workspace update-stale` for each workspace.

Fixes #8033