### PR TITLE
fix(gerrit): make `--help` match config option

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -74,7 +74,7 @@ pub struct UploadArgs {
     /// The location where your changes are intended to land
     ///
     /// This should be a branch on the remote. Can be configured with the
-    /// `gerrit.default-branch` repository option.
+    /// `gerrit.default-remote-branch` repository option.
     #[arg(long = "remote-branch", short = 'b')]
     remote_branch: Option<String>,
 


### PR DESCRIPTION
In the documentation the option is called
`gerrit.default-remote-branch`, but when you do `jj gerrit upload --help`, it says the option is called `gerrit.default-branch`. This commit fix the situation and make the `--help` output match the real config option.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
