### PR TITLE
templates: ensure empty description in compact_full_description is terminated

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -234,13 +234,13 @@ if(commit.root(),
       separate(" ",
         if(commit.empty(), empty_commit_marker),
         if(commit.description(),
-          commit.description().trim_end() ++ "\n",
+          commit.description().trim_end(),
           label(if(commit.empty(), "empty"), description_placeholder),
         ),
       ) ++ "\n",
     ),
   )
-)
+) ++ "\n"
 '''
 
 builtin_log_comfortable = 'builtin_log_compact ++ "\n"'

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1711,7 +1711,7 @@ fn test_log_full_description_template() {
 
     work_dir
         .run_jj([
-            "describe",
+            "commit",
             "-m",
             "this is commit with a multiline description\n\n<full description>",
         ])
@@ -1719,12 +1719,16 @@ fn test_log_full_description_template() {
 
     let output = work_dir.run_jj(["log", "-T", "builtin_log_compact_full_description"]);
     insta::assert_snapshot!(output, @r"
-    @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 37b69cda
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 3a70504b
+    │  (empty) (no description set)
+    │
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 37b69cda
     │  (empty) this is commit with a multiline description
     │
     │  <full description>
     │
     ◆  zzzzzzzz root() 00000000
+
     [EOF]
     ");
 }


### PR DESCRIPTION
Fixes #8073

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
