### PR TITLE
cli: don't error out when `trunk()` is undefined

### DIFF
--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -132,8 +132,11 @@ fn write_repository_level_trunk_alias(
     symbol: RemoteRefSymbol<'_>,
 ) -> Result<(), CommandError> {
     let mut file = ConfigFile::load_or_empty(ConfigSource::Repo, repo_path.join("config.toml"))?;
-    file.set_value(["revset-aliases", "trunk()"], symbol.to_string())
-        .expect("initial repo config shouldn't have invalid values");
+    file.set_value(
+        ["revset-aliases", "trunk()"],
+        format!("present({})", symbol.to_string()),
+    )
+    .expect("initial repo config shouldn't have invalid values");
     file.save()?;
     writeln!(
         ui.status(),

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -622,7 +622,7 @@
                 "log": {
                     "type": "string",
                     "description": "Default set of revisions to show when no explicit revset is given for jj log and similar commands",
-                    "default": "present(@) | ancestors(immutable_heads().., 2) | present(trunk())"
+                    "default": "present(@) | ancestors(immutable_heads().., 2) | trunk()"
                 },
                 "short-prefixes": {
                     "type": "string",
@@ -656,7 +656,7 @@
                 "immutable_heads()": {
                     "type": "string",
                     "description": "Revisions to consider immutable. Ancestors of these are also considered immutable. The root commit is always considered immutable.",
-                    "default": "present(trunk()) | tags() | untracked_remote_bookmarks()"
+                    "default": "trunk() | tags() | untracked_remote_bookmarks()"
                 }
             },
             "additionalProperties": {

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -7,15 +7,15 @@ simplify-parents = "reachable(@, mutable())"
 # log revset is also used as the default short-prefixes. If it failed to
 # evaluate, lengthy warning messages would be printed. Use present(expr) to
 # suppress symbol resolution error.
-log = "present(@) | ancestors(immutable_heads().., 2) | present(trunk())"
+log = "present(@) | ancestors(immutable_heads().., 2) | trunk()"
 # Emit the working-copy branch first, which is usually most interesting.
 # This also helps stabilize output order.
 log-graph-prioritize = "present(@)"
 sign = "reachable(@, mutable())"
 
 [revset-aliases]
-# trunk() can be overridden as '<bookmark>@<remote>'. Use present(trunk()) if
-# symbol resolution error should be suppressed.
+# trunk() can be overridden as '<bookmark>@<remote>', but may print lengthy
+# errors
 'trunk()' = '''
 latest(
   remote_bookmarks(exact:"main", exact:"origin") |
@@ -24,13 +24,14 @@ latest(
   remote_bookmarks(exact:"main", exact:"upstream") |
   remote_bookmarks(exact:"master", exact:"upstream") |
   remote_bookmarks(exact:"trunk", exact:"upstream") |
-  root()
+  none()
 )
 '''
 
-# If immutable_heads() failed to evaluate, many jj commands wouldn't work. Use
-# present(expr) to suppress symbol resolution error.
-'builtin_immutable_heads()' = 'present(trunk()) | tags() | untracked_remote_bookmarks()'
+# If immutable_heads() failed to evaluate, many jj commands wouldn't work.
+# Things here must either always return none() instead of erroring, or
+# be wrapped in present() to handle that case.
+'builtin_immutable_heads()' = 'trunk() | tags() | untracked_remote_bookmarks()'
 'immutable_heads()' = 'builtin_immutable_heads()'
 'immutable()' = '::(immutable_heads() | root())'
 'mutable()' = '~immutable()'

--- a/cli/tests/test_builtin_aliases.rs
+++ b/cli/tests/test_builtin_aliases.rs
@@ -141,10 +141,7 @@ fn test_builtin_alias_trunk_no_match() {
     let work_dir = test_env.work_dir("local");
 
     let output = work_dir.run_jj(["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(output, @r"
-    ◆  zzzzzzzz root() 00000000
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 }
 
 #[test]
@@ -153,10 +150,7 @@ fn test_builtin_alias_trunk_no_match_only_exact() {
     let work_dir = test_env.work_dir("local");
 
     let output = work_dir.run_jj(["log", "-r", "trunk()"]);
-    insta::assert_snapshot!(output, @r"
-    ◆  zzzzzzzz root() 00000000
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 }
 
 #[test]

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -587,7 +587,7 @@ fn test_git_clone_remote_default_bookmark() {
     // "trunk()" alias should be set to default bookmark "main"
     let output = clone_dir1.run_jj(["config", "list", "--repo", "revset-aliases.'trunk()'"]);
     insta::assert_snapshot!(output, @r#"
-    revset-aliases.'trunk()' = "main@origin"
+    revset-aliases.'trunk()' = "present(main@origin)"
     [EOF]
     "#);
 
@@ -638,7 +638,7 @@ fn test_git_clone_remote_default_bookmark() {
     // "trunk()" alias should be set to new default bookmark "feature1"
     let output = clone_dir3.run_jj(["config", "list", "--repo", "revset-aliases.'trunk()'"]);
     insta::assert_snapshot!(output, @r#"
-    revset-aliases.'trunk()' = "feature1@origin"
+    revset-aliases.'trunk()' = "present(feature1@origin)"
     [EOF]
     "#);
 
@@ -737,7 +737,7 @@ fn test_git_clone_remote_default_bookmark_with_escape() {
     let clone_dir = test_env.work_dir("clone");
     let output = clone_dir.run_jj(["config", "list", "--repo", "revset-aliases.'trunk()'"]);
     insta::assert_snapshot!(output, @r#"
-    revset-aliases.'trunk()' = '"\""@origin'
+    revset-aliases.'trunk()' = 'present("\""@origin)'
     [EOF]
     "#);
 }
@@ -879,8 +879,6 @@ fn test_git_clone_trunk_deleted() {
     ------- stderr -------
     Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
-    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
-    Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     [EOF]
     ");
 
@@ -891,10 +889,6 @@ fn test_git_clone_trunk_deleted() {
     ○  qomsplrm someone@example.org 1970-01-01 11:00:00 ebeb70d8
     │  message
     ◆  zzzzzzzz root() 00000000
-    [EOF]
-    ------- stderr -------
-    Warning: Failed to resolve `revset-aliases.trunk()`: Revision `main@origin` doesn't exist
-    Hint: Use `jj config edit --repo` to adjust the `trunk()` alias.
     [EOF]
     ");
 }

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -228,7 +228,7 @@ fn test_git_init_external_import_trunk(bare: bool) {
     let output = work_dir.run_jj(["config", "list", "--repo", "revset-aliases.\"trunk()\""]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(output, @r#"
-        revset-aliases."trunk()" = "trunk@origin"
+        revset-aliases."trunk()" = "present(trunk@origin)"
         [EOF]
         "#);
     }
@@ -306,7 +306,7 @@ fn test_git_init_external_import_trunk_upstream_takes_precedence() {
     let output = work_dir.run_jj(["config", "list", "--repo", "revset-aliases.\"trunk()\""]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(output, @r#"
-        revset-aliases."trunk()" = "develop@upstream"
+        revset-aliases."trunk()" = "present(develop@upstream)"
         [EOF]
         "#);
     }

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -212,7 +212,6 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace() {
     (empty) (no description set)
     kkmpptxz test.user@example.com 2001-02-03 08:05:09 main e1cb4cf3
     (empty) a
-    zzzzzzzz root() 00000000
     [EOF]
     ");
 }
@@ -625,7 +624,7 @@ fn test_immutable_log() {
     │  (empty) (no description set)
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
-    ◆  zzzzzzzz root() 00000000
+    ~
     [EOF]
     ");
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -426,7 +426,7 @@ page](conflicts.md#conflict-markers).
 You can configure the set of immutable commits via
 `revset-aliases."immutable_heads()"`. The default set of immutable heads is
 `builtin_immutable_heads()`, which in turn is defined as
-`present(trunk()) | tags() | untracked_remote_bookmarks()`. For example, to
+`trunk() | tags() | untracked_remote_bookmarks()`. For example, to
 also consider the `release@origin` bookmark immutable:
 
 ```toml
@@ -507,7 +507,7 @@ log = "main@origin.."
 ```
 
 The default value for `revsets.log` is
-`'present(@) | ancestors(immutable_heads().., 2) | present(trunk())'`.
+`'present(@) | ancestors(immutable_heads().., 2) | trunk()'`.
 
 ### Prioritize Revsets in the Log over @
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -559,12 +559,12 @@ for a comprehensive list.
   ```
 
 * `builtin_immutable_heads()`: Resolves to
-  `present(trunk()) | tags() | untracked_remote_bookmarks()`. It is used as the
+  `trunk() | tags() | untracked_remote_bookmarks()`. It is used as the
    default definition for `immutable_heads()` below. It is not recommended to
    redefine this alias. Prefer to redefine `immutable_heads()` instead.
 
 * `immutable_heads()`: Resolves to
-  `present(trunk()) | tags() | untracked_remote_bookmarks()` by default. It is
+  `trunk() | tags() | untracked_remote_bookmarks()` by default. It is
   actually defined as `builtin_immutable_heads()`, and can be overridden as
   required. See [here](config.md#set-of-immutable-commits) for details.
 


### PR DESCRIPTION
Isaac found a case on Discord where he got into a bad situation by accidentally forgetting the bookmark `main@origin`, which caused `trunk()` to start failing, causing cascading stale working copies. It's fixable but not intuitive.

It's probably better if `trunk() = none()` in the event of an error anyway for the sake of keeping things sane. Alternatively, we could make this a warning.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
