### PR TITLE
config: deprecate git.push-new-bookmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj describe --edit` is deprecated in favor of `--editor`.
 
-* The config option `git.auto-local-bookmark` is deprecated
-  in favor of `remotes.<name>.auto-track-bookmarks`. See
-  <https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks>.
+* The config options `git.auto-local-bookmark` and `git.push-new-bookmarks` are
+  deprecated in favor of `remotes.<name>.auto-track-bookmarks`. For example:
+  ```toml
+  [remote.origin]
+  auto-track-bookmarks = "glob:*"
+  ```
+  For more details, refer to [the docs](
+  docs/config/#automatic-tracking-of-bookmarks).
 
 ### New features
 

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -140,9 +140,6 @@ pub struct GitPushArgs {
     /// Allow pushing new bookmarks
     ///
     /// Newly-created remote bookmarks will be tracked automatically.
-    ///
-    /// This can also be turned on by the `git.push-new-bookmarks` setting. If
-    /// it's set to `true`, `--allow-new` is no-op.
     #[arg(long, short = 'N', conflicts_with = "what")]
     allow_new: bool,
     /// Allow pushing commits with empty descriptions

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -429,11 +429,6 @@
                     "description": "Whether jj should abandon commits that became unreachable in Git.",
                     "default": true
                 },
-                "push-new-bookmarks": {
-                    "type": "boolean",
-                    "description": "Allow pushing new bookmarks without --allow-new",
-                    "default": false
-                },
                 "fetch": {
                     "description": "The remote(s) from which commits are fetched",
                     "default": "origin",

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -775,7 +775,25 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
             },
             |_| {
                 Ok("`git.auto-local-bookmark` is deprecated; use \
-                    `remotes.<name>.auto-track-bookmarks` instead."
+                    `remotes.<name>.auto-track-bookmarks` instead.
+Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
+For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks"
+                    .into())
+            },
+        ),
+        // TODO: Delete in jj 0.42.0+
+        ConfigMigrationRule::custom(
+            |layer| {
+                let Ok(Some(val)) = layer.look_up_item("git.push-new-bookmarks") else {
+                    return false;
+                };
+                val.as_bool().is_some_and(|b| b)
+            },
+            |_| {
+                Ok("`git.push-new-bookmarks` is deprecated; use \
+                    `remotes.<name>.auto-track-bookmarks` instead.
+Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
+For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks"
                     .into())
             },
         ),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1535,8 +1535,6 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 * `-N`, `--allow-new` — Allow pushing new bookmarks
 
    Newly-created remote bookmarks will be tracked automatically.
-
-   This can also be turned on by the `git.push-new-bookmarks` setting. If it's set to `true`, `--allow-new` is no-op.
 * `--allow-empty-description` — Allow pushing commits with empty descriptions
 * `--allow-private` — Allow pushing commits that are private
 

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -681,6 +681,8 @@ fn test_git_clone_remote_default_bookmark() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Warning: Deprecated CLI-provided config: `git.auto-local-bookmark` is deprecated; use `remotes.<name>.auto-track-bookmarks` instead.
+    Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
+    For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks
     Fetching into new repo in "$TEST_ENV/clone5"
     bookmark: feature1@origin [new] tracked
     bookmark: main@origin     [new] tracked

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -606,6 +606,9 @@ fn test_git_push_locally_created_and_rewritten() {
     ]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Warning: Deprecated CLI-provided config: `git.push-new-bookmarks` is deprecated; use `remotes.<name>.auto-track-bookmarks` instead.
+    Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
+    For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks
     Changes to push to origin:
       Add bookmark my to e0cba5e497ee
     Dry-run requested, not pushing.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1582,17 +1582,6 @@ abandon-unreachable-commits = false
 
 [reachable]: https://git-scm.com/docs/gitglossary/#Documentation/gitglossary.txt-aiddefreachableareachable
 
-### Allow pushing new bookmarks
-
-`jj git push` does not push newly-created bookmarks by default.
-If you do not want to specify `--allow-new` every time you have created a new
-bookmark, you may want to allow new bookmarks to be pushed by default:
-
-```toml
-[git]
-push-new-bookmarks = true
-```
-
 ### Generated bookmark names on push
 
 `jj git push --change` generates bookmark names with a prefix of "push-" by


### PR DESCRIPTION
follow up to #7745 and #8066

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
