### PR TITLE
untrack: Succeed even if some paths are not ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pattern. New bookmarks matching it will automatically track that remote.
   See <https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks>.
 
+* `jj file untrack` now succeeds even if not all paths matching the fileset are
+  ignored. Files that match the fileset but aren't ignored will not be untracked.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1163,7 +1163,7 @@ Stop tracking specified paths in the working copy
 
 ###### **Arguments:**
 
-* `<FILESETS>` — Paths to untrack. They must already be ignored.
+* `<FILESETS>` — Paths to untrack. They must be ignored to be untracked; any paths that are not ignored will remain tracked.
 
    The paths could be ignored via a .gitignore or .git/info/exclude (in colocated workspaces).
 


### PR DESCRIPTION
After adding a tracked file to `.gitignore`, it is nice to be able to execute `jj file untrack .` to untrack anything that matches the new `.gitignore` patterns.

If any files matching the fileset don't match, they remain tracked and a warning is printed. Specifying a fileset that doesn't untrack any files is a noop.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
