### PR TITLE
Add Netlify deployment for documentation

### DIFF
--- a/.github/workflows/netlify-docs.yml
+++ b/.github/workflows/netlify-docs.yml
@@ -1,0 +1,50 @@
+name: netlify-website
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  prerelease-docs-netlify-deploy:
+    # Mirrors the GitHub Pages deployment but deploys to Netlify instead
+    permissions:
+      contents: read
+    if: github.repository_owner == 'jj-vcs' # Stops this job from running on forks
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+      - run: "git fetch origin gh-pages --depth=1"
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        with:
+          python-version: 3.11
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3
+        with:
+          version: "0.5.1"
+      - name: Install dependencies and compile docs
+        run: |
+          export MKDOCS_SITE_NAME="Jujutsu docs (prerelease)"
+          export MKDOCS_PRIMARY_COLOR="blue grey"
+          # Build docs without pushing to gh-pages
+          .github/scripts/docs-build-deploy prerelease
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654
+        with:
+          publish-dir: './rendered-docs'
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          enable-commit-status: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,40 @@ jobs:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: "Show `git diff --stat`"
         run: git diff --stat gh-pages^ gh-pages || echo "(No diffs)"
+
+  docs-deploy-netlify-latest-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+      - run:  "git fetch origin gh-pages --depth=1"
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        with:
+          python-version: 3.11
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3
+        with:
+          version: "0.5.1"
+      - name: Install dependencies and compile docs for latest release
+        run: |
+          # Using the 'latest' tag below makes the website default
+          # to this version.
+          .github/scripts/docs-build-deploy "${RELEASE_TAG_NAME}" latest --update-aliases
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654
+        with:
+          publish-dir: './rendered-docs'
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          enable-commit-status: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
This adds Netlify deployment alongside the existing GitHub Pages deployment.

This lets us kick the tires on Netlify without actually moving to it just yet. We'd want to do that slowly and deliberately, we have several steps we can take before doing that. We also may want to consider taking those steps after 0.36, which would happen in just over two weeks. That way we can ensure that the release workflow works as well.

This will not work until `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` secrets are added; I have those values, but cannot set them in the repository myself. Happy to DM them to someone who can.

This is one strategy; another one would be to install the Netlify GitHub app. This could then trigger on any push to the gh-pages branch, which would require no code changes in the repository. This one is much nicer from a setup perspective, but I am not completely sure if I have permissions to set this up or not. I believe I could request permission and then someone would have to approve. But I figured that since that requires no code changes, I'd at least throw this up there so we could discuss it, even if the end result is closing this PR and doing that. (which, I think is the route I'd prefer.)

# Checklist

None applicable, I believe.