### PR TITLE
template: Add `join()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pattern. New bookmarks matching it will automatically track that remote.
   See <https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks>.
 
+* Added `join()` template function. This is different from `separate()` in that
+  it adds a separator between all arguments, even if empty.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -89,8 +89,10 @@ The following functions are defined.
   content.
 * `concat(content: Template...) -> Template`:
   Same as `content_1 ++ ... ++ content_n`.
-* `separate(separator: Template, content: Template...) -> Template`:
-  Insert separator between **non-empty** contents.
+* `join(separator: Template, content: Template...) -> Template`: Insert
+  `separator` between `content`s.
+* `separate(separator: Template, content: Template...) -> Template`: Insert
+  `separator` between **non-empty** `content`s.
 * `surround(prefix: Template, suffix: Template, content: Template) -> Template`:
   Surround **non-empty** content with texts such as parentheses.
 * `config(name: String) -> ConfigValue`: Look up configuration value by `name`.


### PR DESCRIPTION
Sometimes it's useful to add a separator between everything, even if it's empty.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
