### PR TITLE
cli: simplify `jj fix` child process handling

### DIFF
--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -303,14 +303,15 @@ fn run_tool(
             return Err(());
         }
     };
-    let mut stdin = child.stdin.take().unwrap();
-    let output = std::thread::scope(|s| {
-        s.spawn(move || {
-            stdin.write_all(old_content).ok();
-        });
-        Some(child.wait_with_output().or(Err(())))
-    })
-    .unwrap()?;
+    child
+        .stdin
+        .take()
+        .expect(
+            "The child process is created with piped stdin, and it's our first access to stdin.",
+        )
+        .write_all(old_content)
+        .or(Err(()))?;
+    let output = child.wait_with_output().or(Err(()))?;
     tracing::debug!(?command, ?output.status, "fix tool exited:");
     if !output.stderr.is_empty() {
         let mut stderr = ui.stderr();

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -965,6 +965,32 @@ fn test_fix_empty_file() {
 }
 
 #[test]
+fn test_fix_large_file() {
+    let mut test_env = TestEnvironment::default();
+    set_up_fake_formatter(&mut test_env, &["--lowercase"]);
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let mut large_contents = (0..0x1_000_000).map(|_| b'A').collect::<Vec<_>>();
+    large_contents.push(b'\n');
+    work_dir.write_file("file", &large_contents);
+
+    work_dir.run_jj(["config", "set", "--repo", "snapshot.max-new-file-size", "16777217"]).success();
+    let output = work_dir.run_jj(["fix", "-s", "@"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Fixed 1 commits of 1 checked.
+    Working copy  (@) now at: qpvuntsm cc4f0abd (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["file", "show", "file", "-r", "@"]);
+    let stdout_bytes = output.stdout.raw().as_bytes();
+    assert_eq!(stdout_bytes.len(), large_contents.len());
+    assert!(stdout_bytes == &large_contents.to_ascii_lowercase());
+}
+
+#[test]
 fn test_fix_some_paths() {
     let mut test_env = TestEnvironment::default();
     set_up_fake_formatter(&mut test_env, &["--uppercase"]);


### PR DESCRIPTION
* `Some(x).unwrap` is not necessary.
* Add a test to ensure that we handle the child process IO correctly per https://doc.rust-lang.org/std/process/index.html#handling-io. The old implementation is correct to spawn another thread. This test makes sure we don't refactor the code incorrectly into using a single thread.

I am drafting the `gitattributes` `filter` design, and I want to make sure that we handle child process in the same way in the repo, so I come up with this PR.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
