### PR TITLE
Move gh pages -> jj-vcs.dev

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.jj-vcs.dev


### PR DESCRIPTION
This will configure github pages to have a custom domain of jj-vcs.dev.

I have confirmed through my own experiments that doing this will result in an HTTP 301 redirect, even for sub-pages (names changed for privacy):

```text
> GET /project/pages/services.html HTTP/2
> Host: steveklabnik.github.io
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/2 301 
< server: GitHub.com
< content-type: text/html
< location: http://www.stevestest.com/pages/services.html
```

This allows us to use the new domain while preserving any existing links to jj-vcs.github.io/jj/

After this is accepted and working, I'll send in a PR to update documentation, the mkdocs config, and anything else we should update.
