### PR TITLE
config: Clean up `templates.toml`

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -2,13 +2,23 @@
 bookmark_list = '''
 if(remote,
   if(tracked,
-    "  " ++ separate(" ",
-      label("bookmark", "@" ++ remote),
-      if(present, format_tracked_remote_ref_distances(self)),
-    ) ++ if(present, format_ref_targets(self), " (not created yet)"),
-    label("bookmark", name ++ "@" ++ remote) ++ format_ref_targets(self),
+    concat(
+      "  ",
+      separate(" ",
+        label("bookmark", "@" ++ remote),
+        if(present, format_tracked_remote_ref_distances(self)),
+      ),
+      if(present, format_ref_targets(self), " (not created yet)"),
+    ),
+    concat(
+      label("bookmark", name ++ "@" ++ remote),
+      format_ref_targets(self),
+    ),
   ),
-  label("bookmark", name) ++ if(present, format_ref_targets(self), " (deleted)"),
+  concat(
+    label("bookmark", name),
+    if(present, format_ref_targets(self), " (deleted)"),
+  ),
 ) ++ "\n"
 '''
 
@@ -18,7 +28,7 @@ file_annotate = '''
 separate(" ",
   commit.change_id().shortest(8),
   pad_end(8, truncate_end(8, commit.author().email().local())),
-  commit_timestamp(commit).local().format('%Y-%m-%d %H:%M:%S'),
+  commit_timestamp(commit).local().format("%Y-%m-%d %H:%M:%S"),
   pad_start(4, line_number),
 ) ++ ": " ++ content
 '''
@@ -33,9 +43,7 @@ commit_trailers = ''
 
 evolog = 'builtin_evolog_compact'
 
-file_list = '''
-format_path(path) ++ "\n"
-'''
+file_list = 'format_path(path) ++ "\n"'
 file_show = ''
 
 git_push_bookmark = '"push-" ++ change_id.short()'
@@ -58,7 +66,12 @@ label("tag", name) ++ format_ref_targets(self) ++ "\n"
 '''
 
 workspace_list = '''
-name ++ ": " ++ format_commit_summary_with_refs(target, target.bookmarks()) ++ "\n"
+concat(
+  name,
+  ": ",
+  format_commit_summary_with_refs(target, target.bookmarks()),
+  "\n",
+)
 '''
 
 op_summary = '''
@@ -106,19 +119,22 @@ if(x.overridden(),
 
 builtin_config_list = '''
 label(if(overridden, "overridden"),
-  format_config_item(self) ++ "\n")
+  format_config_item(self) ++ "\n"
+)
 '''
 
 builtin_config_list_detailed = '''
 label(if(overridden, "overridden"),
-  format_config_item(self) ++ " # " ++ separate(" ", source, path) ++ "\n")
+  format_config_item(self) ++ " # " ++ separate(" ", source, path) ++ "\n"
+)
 '''
 
 builtin_draft_commit_description = '''
 concat(
   coalesce(description, default_commit_description, "\n"),
   "\n",
-  "JJ: Change ID: " ++ format_short_change_id(change_id) ++ "\n",
+  "JJ: Change ID: " ++ format_short_change_id(change_id),
+  "\n",
   surround(
     "JJ: This commit contains the following changes:\n", "",
     indent("JJ:     ", diff.summary()),
@@ -150,26 +166,25 @@ if(commit.root(),
       if(commit.immutable(), "immutable", "mutable"),
       if(commit.conflict(), "conflicted"),
     ),
-    concat(
-      separate(" ",
-        format_short_change_id_with_hidden_and_divergent_info(commit),
-        format_short_signature_oneline(commit.author()),
-        format_timestamp(commit_timestamp(commit)),
-        commit.bookmarks(),
-        commit.tags(),
-        commit.working_copies(),
-        if(commit.git_head(), label("git_head", "git_head()")),
-        format_short_commit_id(commit.commit_id()),
-        if(commit.conflict(), label("conflict", "conflict")),
-        if(config("ui.show-cryptographic-signatures").as_boolean(),
-          format_short_cryptographic_signature(commit.signature())),
-        if(commit.empty(), empty_commit_marker),
-        if(commit.description(),
-          commit.description().first_line(),
-          label(if(commit.empty(), "empty"), description_placeholder),
-        ),
-      ) ++ "\n",
-    ),
+    separate(" ",
+      format_short_change_id_with_hidden_and_divergent_info(commit),
+      format_short_signature_oneline(commit.author()),
+      format_timestamp(commit_timestamp(commit)),
+      commit.bookmarks(),
+      commit.tags(),
+      commit.working_copies(),
+      if(commit.git_head(), label("git_head", "git_head()")),
+      format_short_commit_id(commit.commit_id()),
+      if(commit.conflict(), label("conflict", "conflict")),
+      if(config("ui.show-cryptographic-signatures").as_boolean(),
+        format_short_cryptographic_signature(commit.signature())
+      ),
+      if(commit.empty(), empty_commit_marker),
+      if(commit.description(),
+        commit.description().first_line(),
+        label(if(commit.empty(), "empty"), description_placeholder),
+      ),
+    ) ++ "\n",
   )
 )
 '''
@@ -219,7 +234,9 @@ if(commit.root(),
 )
 '''
 
-builtin_log_compact_full_description = 'builtin_log_compact_full_description(self)'
+builtin_log_compact_full_description = '''
+builtin_log_compact_full_description(self)
+'''
 'builtin_log_compact_full_description(commit)' = '''
 if(commit.root(),
   format_root_commit(commit),
@@ -249,17 +266,27 @@ builtin_log_detailed = 'builtin_log_detailed(self)'
 concat(
   "Commit ID: " ++ commit.commit_id() ++ "\n",
   "Change ID: " ++ commit.change_id() ++ "\n",
-  surround("Bookmarks: ", "\n", separate(" ", commit.local_bookmarks(), commit.remote_bookmarks())),
+  surround("Bookmarks: ", "\n", separate(" ",
+    commit.local_bookmarks(),
+    commit.remote_bookmarks(),
+  )),
   surround("Tags     : ", "\n", commit.tags()),
   "Author   : " ++ format_detailed_signature(commit.author()) ++ "\n",
   "Committer: " ++ format_detailed_signature(commit.committer())  ++ "\n",
   if(config("ui.show-cryptographic-signatures").as_boolean(),
-    "Signature: " ++ format_detailed_cryptographic_signature(commit.signature()) ++ "\n"),
+    concat(
+      "Signature: ",
+      format_detailed_cryptographic_signature(commit.signature()),
+      "\n",
+    )
+  ),
   "\n",
   indent("    ",
     if(commit.description(),
       commit.description().trim_end(),
-      label(if(commit.empty(), "empty"), description_placeholder)) ++ "\n"),
+      label(if(commit.empty(), "empty"), description_placeholder)
+    ) ++ "\n"
+  ),
   "\n",
 )
 '''
@@ -299,7 +326,9 @@ label(if(op.current_operation(), "current_operation"),
 
 default_commit_description = '""'
 empty_commit_marker = 'label("empty", "(empty)")'
-description_placeholder = 'label("description placeholder", "(no description set)")'
+description_placeholder = '''
+label("description placeholder", "(no description set)")
+'''
 email_placeholder = 'label("email placeholder", "(no email set)")'
 name_placeholder = 'label("name placeholder", "(no name set)")'
 commit_summary_separator = 'label("separator", " | ")'
@@ -312,20 +341,26 @@ commit_summary_separator = 'label("separator", " | ")'
 'format_short_operation_id(id)' = 'id.short()'
 'format_path(path)' = 'path.display()'
 'format_short_signature(signature)' = '''
-  coalesce(signature.email(), email_placeholder)'''
+coalesce(signature.email(), email_placeholder)
+'''
 'format_short_signature_oneline(signature)' = '''
-  coalesce(signature.email().local(), email_placeholder)'''
+coalesce(signature.email().local(), email_placeholder)
+'''
 
 'format_detailed_signature(signature)' = '''
-  coalesce(signature.name(), name_placeholder)
-  ++ " <" ++ coalesce(signature.email(), email_placeholder) ++ ">"
-  ++ " (" ++ format_timestamp(signature.timestamp()) ++ ")"'''
+separate(" ",
+  coalesce(signature.name(), name_placeholder),
+  "<" ++ coalesce(signature.email(), email_placeholder) ++ ">",
+  "(" ++ format_timestamp(signature.timestamp()) ++ ")",
+)
+'''
 # For operations, when it makes a difference whether to use the start time or
 # the end time, the latter is more meaningful. For mutating operations, this is
 # the moment when the repo was actually modified due to this operation. TODO:
 # This macro might need a better name, e.g. `format_operation_time_range`.
 'format_time_range(time_range)' = '''
-  time_range.end().ago() ++ label("time", ", lasted ") ++ time_range.duration()'''
+time_range.end().ago() ++ label("time", ", lasted ") ++ time_range.duration()
+'''
 'format_timestamp(timestamp)' = 'timestamp.local().format("%Y-%m-%d %H:%M:%S")'
 
 'format_commit_summary_with_refs(commit, refs)' = '''
@@ -363,8 +398,12 @@ label("immutable",
 if(ref.conflict(),
   separate("\n",
     " " ++ label("conflict", "(conflicted)") ++ ":",
-    ref.removed_targets().map(|c| "  - " ++ format_commit_summary_with_refs(c, "")).join("\n"),
-    ref.added_targets().map(|c| "  + " ++ format_commit_summary_with_refs(c, "")).join("\n"),
+    ref.removed_targets().map(|c|
+      "  - " ++ format_commit_summary_with_refs(c, "")
+    ).join("\n"),
+    ref.added_targets().map(|c|
+      "  + " ++ format_commit_summary_with_refs(c, "")
+    ).join("\n"),
   ),
   ": " ++ format_commit_summary_with_refs(ref.normal_target(), ""),
 )
@@ -375,38 +414,51 @@ if(ref.tracking_present(), surround("(", ")", separate(", ",
   if(!ref.tracking_ahead_count().zero(),
     if(ref.tracking_ahead_count().exact(),
       "ahead by " ++ ref.tracking_ahead_count().exact() ++ " commits",
-      "ahead by at least " ++ ref.tracking_ahead_count().lower() ++ " commits")),
+      "ahead by at least " ++ ref.tracking_ahead_count().lower() ++ " commits"
+    )
+  ),
   if(!ref.tracking_behind_count().zero(),
     if(ref.tracking_behind_count().exact(),
       "behind by " ++ ref.tracking_behind_count().exact() ++ " commits",
-      "behind by at least " ++ ref.tracking_behind_count().lower() ++ " commits")),
+      "behind by at least " ++ ref.tracking_behind_count().lower() ++ " commits"
+    )
+  ),
 )))
 '''
 
 'format_operation(op)' = '''
 concat(
-  separate(" ", format_short_operation_id(op.id()), op.user(), format_time_range(op.time())), "\n",
+  separate(" ",
+    format_short_operation_id(op.id()),
+    op.user(),
+    format_time_range(op.time()),
+  ), "\n",
   op.description().first_line(), "\n",
-  if(op.tags(), op.tags() ++ "\n"),
+  surround("", "\n", op.tags()),
 )
 '''
 'format_operation_redacted(op)' = '''
 concat(
-  separate(" ", format_short_operation_id(op.id()), format_user_redacted(op.user()), format_time_range(op.time())), "\n",
+  separate(" ",
+    format_short_operation_id(op.id()),
+    format_user_redacted(op.user()),
+    format_time_range(op.time()),
+  ), "\n",
   op.description().first_line(), "\n",
-  "(redacted)",
+  if(op.tags(), "(redacted)\n"),
 )
 '''
 'format_snapshot_operation(op)' = 'format_operation(op)'
 'format_snapshot_operation_redacted(op)' = 'format_operation_redacted(op)'
-'format_root_operation(root)' = 'separate(" ", root.id().short(), label("root", "root()")) ++ "\n"'
-
+'format_root_operation(root)' = '''
+separate(" ", root.id().short(), label("root", "root()")) ++ "\n"
+'''
 
 'format_operation_oneline(op)' = '''
 separate(" ",
   format_short_operation_id(op.id()), op.user(), format_time_range(op.time()),
   op.description().first_line(),
-  if(op.tags(), op.tags()),
+  op.tags(),
 ) ++ "\n"
 '''
 'format_snapshot_operation_oneline(op)' = 'format_operation_oneline(op)'
@@ -437,10 +489,14 @@ separate(" ",
   format_short_commit_id(commit.commit_id()),
   if(commit.conflict(), label("conflict", "conflict")),
   if(config("ui.show-cryptographic-signatures").as_boolean(),
-    format_short_cryptographic_signature(commit.signature())),
+    format_short_cryptographic_signature(commit.signature())
+  ),
 )
 '''
 
+# TODO: Possibly add some kind of repo-unique salt to the hash methods, if it
+# makes users feel more secure (right now, `main` will always be `branch-c8c7a`
+# for every repo)
 'format_short_commit_header_redacted(commit)' = '''
 separate(" ",
   format_short_change_id_with_hidden_and_divergent_info(commit),
@@ -459,9 +515,10 @@ separate(" ",
   format_short_commit_id(commit.commit_id()),
   if(commit.conflict(), label("conflict", "conflict")),
   if(config("ui.show-cryptographic-signatures").as_boolean(),
-    format_short_cryptographic_signature(commit.signature())),
+    format_short_cryptographic_signature(commit.signature())
+  ),
 )
-''' # TODO: Possibly add some kind of repo-unique salt to the hash methods, if it makes users feel more secure (right now, `main` will always be `branch-c8c7a` for every repo)
+'''
 
 'format_detailed_cryptographic_signature(signature)' = '''
 if(signature,
@@ -476,19 +533,20 @@ if(signature,
 '''
 'format_short_cryptographic_signature(signature)' = '''
 if(signature,
-  label("signature status", concat(
-    "[",
+  label("signature status", surround(
+    "[", "]",
     label(signature.status(), coalesce(
       if(signature.status() == "good", "✓︎"),
       if(signature.status() == "unknown", "?"),
       "x",
-    )),
-    "]",
+    ))
   ))
 )
 '''
 
-'format_user_redacted(user)' = '''label("user", concat('user-', hash(user).substr(0, 4)))'''
+'format_user_redacted(user)' = '''
+label("user", concat("user-", hash(user).substr(0, 4)))
+'''
 
 builtin_log_node = '''
 coalesce(
@@ -547,21 +605,25 @@ coalesce(
 # 'git format-patch'.
 # See https://git-scm.com/docs/git-format-patch#_description
 git_format_patch_email_headers = '''
-  concat(
-    "From " ++ commit_id ++ " Mon Sep 17 00:00:00 2001\n",
-    "From: " ++ author ++ "\n",
-    "Date: " ++ author.timestamp().format("%a, %-e %b %Y %T %z") ++ "\n",
-    "Subject: [PATCH] " ++ description.first_line() ++ "\n",
-    "\n",
-    description.remove_prefix(description.first_line()).trim_start(),
-    "---\n",
-    indent(" ", diff.stat()),
-    "\n"
-  )
+concat(
+  "From " ++ commit_id ++ " Mon Sep 17 00:00:00 2001\n",
+  "From: " ++ author ++ "\n",
+  "Date: " ++ author.timestamp().format("%a, %-e %b %Y %T %z") ++ "\n",
+  "Subject: [PATCH] " ++ description.first_line() ++ "\n",
+  "\n",
+  description.remove_prefix(description.first_line()).trim_start(),
+  "---\n",
+  indent(" ", diff.stat()),
+  "\n",
+)
 '''
 
-"format_signed_off_by_trailer(commit)" = '"Signed-off-by: " ++ commit.committer() ++ "\n"'
+"format_signed_off_by_trailer(commit)" = '''
+"Signed-off-by: " ++ commit.committer() ++ "\n"
+'''
 
 # Gerrit change id is 40 chars, jj change id is 32, so we need some padding.
 # `6a6a6964` is the hexadecimal of `jjid` in ASCII, just to not pad with zeros.
-"format_gerrit_change_id_trailer(commit)" = '"Change-Id: I" ++ commit.change_id().normal_hex() ++ "6a6a6964\n"'
+"format_gerrit_change_id_trailer(commit)" = '''
+"Change-Id: I" ++ commit.change_id().normal_hex() ++ "6a6a6964\n"
+'''

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -2913,7 +2913,6 @@ fn test_op_log_anonymize() {
     │  (redacted)
     ○  8f47435a3990 user-5910 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    │  (redacted)
     ○  000000000000 root()
     [EOF]
     ");


### PR DESCRIPTION
- Wrapped all lines to 80 columns (using `concat()` where able).
- Dedented all TOML values.
- Put all close parentheses on their own line (looks more balanced).
- Added trailing commas for variadic functions such as `concat()` and
  `separate()`.
- Fixed "(redacted)" bug for `format_operation_redacted(op)`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
