### PR TITLE
deps: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.43.2"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+checksum = "e8732d3774162a0851e3f2b150eb98f31a9885dd75985099421d393385a01dfd"
 dependencies = [
  "console",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ hashbrown = { version = "0.16.1", default-features = false, features = ["inline-
 ignore = "0.4.25"
 indexmap = { version = "2.12.1", features = ["serde"] }
 indoc = "2.0.7"
-insta = { version = "1.43.2", features = ["filters"] }
+insta = { version = "1.44.1", features = ["filters"] }
 interim = { version = "0.2.1", features = ["chrono_0_4"] }
 itertools = "0.14.0"
 jsonschema = { version = "0.37.1", default-features = false }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -138,9 +138,7 @@ fn test_git_colocated_intent_to_add() {
     // If we remove the added file, it's removed from the index
     work_dir.remove_file("file2.txt");
     work_dir.run_jj(["status"]).success();
-    insta::assert_snapshot!(get_index_state(work_dir.root()), @r"
-    Unconflicted Mode(FILE) 0839b2e9412b ctime=0:0 mtime=0:0 size=0 flags=0 file1.txt
-    ");
+    insta::assert_snapshot!(get_index_state(work_dir.root()), @"Unconflicted Mode(FILE) 0839b2e9412b ctime=0:0 mtime=0:0 size=0 flags=0 file1.txt");
 
     // If we untrack the file, it's removed from the index
     work_dir
@@ -1606,9 +1604,7 @@ fn test_git_colocated_operation_cleanup() {
         .output()
         .unwrap();
     assert!(output.status.success());
-    insta::assert_snapshot!(String::from_utf8(output.stdout).unwrap(), @r#"
-    UU file
-    "#);
+    insta::assert_snapshot!(String::from_utf8(output.stdout).unwrap(), @"UU file");
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
     @  588c505e689d116180684778b29c540fe7180268
     ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main git_head() 2


### PR DESCRIPTION
This is https://github.com/jj-vcs/jj/pull/8108 without the update to jsonschema or gix, and with test fixups for the `insta` update.

~~I do *not* understand where the change to the `git_clone` test came from. I tried
holding `gix` and `clap` (separately) back, it didn't seem to change much. But it doesn't seem
to be any worse, I guess.~~

**Update:** Or perhaps it does make a difference? I may or may not keep investigating, but holding them both back did seem to prevent the test change.

**Update 2:** I now think it was the update to gix, now split out into a separate PR.