### PR TITLE
testutils: add check for strict UTF-8 filesystems

### DIFF
--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -172,7 +172,6 @@ fn test_init_checkout(backend: TestRepoBackend) {
 }
 
 #[cfg(unix)]
-#[cfg_attr(target_os = "macos", ignore = "APFS/HFS+ don't like non-UTF-8 paths")]
 #[test]
 fn test_init_load_non_utf8_path() {
     use std::ffi::OsStr;
@@ -183,6 +182,15 @@ fn test_init_load_non_utf8_path() {
 
     let settings = testutils::user_settings();
     let test_env = TestEnvironment::init();
+
+    if testutils::check_strict_utf8_fs(test_env.root()) {
+        eprintln!(
+            "Skipping test \"test_init_load_non_utf8_path\" due to strict UTF-8 filesystem for \
+             path {:?}",
+            test_env.root()
+        );
+        return;
+    }
 
     let git_repo_path = test_env.root().join(OsStr::from_bytes(b"git\xe0"));
     assert!(git_repo_path.to_str().is_none());

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -93,7 +93,6 @@ fn test_init_additional_workspace() {
 }
 
 #[cfg(unix)]
-#[cfg_attr(target_os = "macos", ignore = "APFS/HFS+ don't like non-UTF-8 paths")]
 #[test]
 fn test_init_additional_workspace_non_utf8_path() {
     use std::ffi::OsStr;
@@ -101,6 +100,15 @@ fn test_init_additional_workspace_non_utf8_path() {
 
     let settings = testutils::user_settings();
     let test_env = TestEnvironment::init();
+
+    if testutils::check_strict_utf8_fs(test_env.root()) {
+        eprintln!(
+            "Skipping test \"test_init_additional_workspace_non_utf8_path\" due to strict UTF-8 \
+             filesystem for path {:?}",
+            test_env.root()
+        );
+        return;
+    }
 
     let ws1_root = test_env.root().join(OsStr::from_bytes(b"ws1_root\xe0"));
     std::fs::create_dir(&ws1_root).unwrap();

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -768,3 +768,21 @@ pub fn assert_no_forgotten_test_files(test_dir: &Path) {
             .join(", "),
     );
 }
+
+/// Returns true if the directory appears to be on a filesystem with strict
+/// UTF-8 validation, as on ZFS with the `utf8only=on` property set.
+#[cfg(unix)]
+pub fn check_strict_utf8_fs(dir: &Path) -> bool {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let test_file_normal = tempfile::Builder::new()
+        .prefix(OsStr::from_bytes(b"strict-utf8-normal-"))
+        .tempfile_in(dir);
+    assert!(test_file_normal.is_ok());
+
+    let test_file_invalid = tempfile::Builder::new()
+        .prefix(OsStr::from_bytes(b"strict-utf8-\xe0-"))
+        .tempfile_in(dir);
+    test_file_invalid.is_err()
+}


### PR DESCRIPTION
`test_init_load_non_utf8_path` and
`test_init_additional_workspace_non_utf8_path` now early-return on strict UTF-8 filesystems because there's no way to report a test as "skipped" at runtime.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
