### PR TITLE
nextest: default to only printing suspicious tests to terminal scrollback

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,9 @@
 [profile.default]
 slow-timeout = { period = "10s" }
+# Rely on the new nextest feature that shows all the currently running
+# tests instead of taking over the terminal scrollback with every
+# passed test
+status-level = "leak"
 
 [profile.ci]
 slow-timeout = { period = "10s", terminate-after = 10 }


### PR DESCRIPTION
Recent versions of nextest show all the currently running tests, removing the need for printing successful tests in interactive use.

TODO: mise tasks already do this with env vars, I should probably unset those env vars to not do the same thing in two different ways.
