### PR TITLE
cli: simplify `jj fix` child process handling

### DIFF
--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -303,14 +303,15 @@ fn run_tool(
             return Err(());
         }
     };
-    let mut stdin = child.stdin.take().unwrap();
+    let mut stdin = child.stdin.take().expect(
+        "The child process is created with piped stdin, and it's our first access to stdin.",
+    );
     let output = std::thread::scope(|s| {
         s.spawn(move || {
             stdin.write_all(old_content).ok();
         });
-        Some(child.wait_with_output().or(Err(())))
-    })
-    .unwrap()?;
+        child.wait_with_output().or(Err(()))
+    })?;
     tracing::debug!(?command, ?output.status, "fix tool exited:");
     if !output.stderr.is_empty() {
         let mut stderr = ui.stderr();


### PR DESCRIPTION
* `Some(x).unwrap()` is not necessary.
* Add a new test to ensure that we handle the fix child process IO without deadlock. The new test introduces byte mode to fake-formatter which pipe the stdin contents to stdout byte by byte in a streaming fashion. The test contents are 512KB, which is larger than page size, can trigger the blocking read behavior, and doesn't make the test the slowest. This test ensures that we handle the child process IO correctly per https://doc.rust-lang.org/std/process/index.html#handling-io. The old implementation is correct to spawn another thread. This test makes sure we don't refactor the code incorrectly into using a single thread.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
