### PR TITLE
docs: jj-vcs.github.io -> jj-vcs.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+The documentation has moved from <https://jj-vcs.github.io/jj/> to
+<https://docs.jj-vcs.dev/>.
+
+301 redirects are being issued towards the new domain, so any existing links
+should not be broken.
+
 ### Breaking changes
 
 * In [filesets or path patterns](docs/filesets.md#file-patterns), glob matching

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ license = "Apache-2.0"
 rust-version = "1.89" # NOTE: remember to update CI, mise.toml, contributing.md, changelog.md, and install-and-setup.md
 edition = "2024"
 readme = "README.md"
-homepage = "https://github.com/jj-vcs/jj"
+homepage = "https://www.jj-vcs.dev/"
 repository = "https://github.com/jj-vcs/jj"
-documentation = "https://jj-vcs.github.io/jj/"
+documentation = "https://docs.jj-vcs.dev/"
 categories = ["version-control", "development-tools"]
 keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 **[Development Roadmap] &nbsp;&nbsp;&bull;&nbsp;&nbsp;**
 **[Contributing](#contributing)**
 
-[Homepage]: https://jj-vcs.github.io/jj
-[Installation]: https://jj-vcs.github.io/jj/latest/install-and-setup
-[Getting Started]: https://jj-vcs.github.io/jj/latest/tutorial
-[Development Roadmap]: https://jj-vcs.github.io/jj/latest/roadmap
+[Homepage]: https://www.jj-vcs.dev
+[Installation]: https://docs.jj-vcs.dev/latest/install-and-setup
+[Getting Started]: https://docs.jj-vcs.dev/latest/tutorial
+[Development Roadmap]: https://docs.jj-vcs.dev/latest/roadmap
 
 </div>
 
@@ -71,9 +71,9 @@ systems into a single tool. Some of those sources of inspiration include:
   conflict resolution can be performed and propagated automatically.
 
 [perf]: https://github.com/jj-vcs/jj/discussions/49
-[revset]: https://jj-vcs.github.io/jj/latest/revsets/
-[no-index]: https://jj-vcs.github.io/jj/latest/git-comparison/#the-index
-[conflicts]: https://jj-vcs.github.io/jj/latest/conflicts/
+[revset]: https://docs.jj-vcs.dev/latest/revsets/
+[no-index]: https://docs.jj-vcs.dev/latest/git-comparison/#the-index
+[conflicts]: https://docs.jj-vcs.dev/latest/conflicts/
 
 And it adds several innovative, useful features of its own:
 
@@ -118,9 +118,9 @@ And it adds several innovative, useful features of its own:
   _should_ happen is that it will expose conflicts between the local and remote
   state, leaving you to resolve them.
 
-[wcc]: https://jj-vcs.github.io/jj/latest/working-copy/
+[wcc]: https://docs.jj-vcs.dev/latest/working-copy/
 [undo-history]: https://en.wikipedia.org/wiki/Undo#History
-[conc-safety]: https://jj-vcs.github.io/jj/latest/technical/concurrency/
+[conc-safety]: https://docs.jj-vcs.dev/latest/technical/concurrency/
 
 The command-line tool is called `jj` for now because it's easy to type and easy
 to replace (rare in English). The project is called "Jujutsu" because it matches
@@ -185,25 +185,25 @@ The wiki also contains a more extensive list of [media references][wiki-media].
 > it unusable for your particular use.
 
 Follow the [installation
-instructions](https://jj-vcs.github.io/jj/latest/install-and-setup) to
+instructions](https://docs.jj-vcs.dev/latest/install-and-setup) to
 obtain and configure `jj`.
 
 The best way to get started is probably to go through [the
-tutorial](https://jj-vcs.github.io/jj/latest/tutorial). Also see the [Git
-comparison](https://jj-vcs.github.io/jj/latest/git-comparison), which
+tutorial](https://docs.jj-vcs.dev/latest/tutorial). Also see the [Git
+comparison](https://docs.jj-vcs.dev/latest/git-comparison), which
 includes a table of `jj` vs. `git` commands.
 
 As you become more familiar with Jujutsu, the following resources may be helpful:
 
-- The [FAQ](https://jj-vcs.github.io/jj/latest/FAQ).
-- The [Glossary](https://jj-vcs.github.io/jj/latest/glossary).
+- The [FAQ](https://docs.jj-vcs.dev/latest/FAQ).
+- The [Glossary](https://docs.jj-vcs.dev/latest/glossary).
 - The `jj help` command (e.g. `jj help rebase`).
 - The `jj help -k <keyword>` command (e.g. `jj help -k config`). Use `jj help --help`
   to see what keywords are available.
 
 If you are using a **prerelease** version of `jj`, you would want to consult
 [the docs for the prerelease (main branch)
-version](https://jj-vcs.github.io/jj/prerelease/). You can also get there
+version](https://docs.jj-vcs.dev/prerelease/). You can also get there
 from the docs for the latest release by using the website's version switcher. The version switcher is visible in
 the header of the website when you scroll to the top of any page.
 
@@ -215,7 +215,7 @@ Jujutsu is designed so that the underlying data and storage model is abstract.
 Today, only the Git backend is production-ready. The Git backend uses the
 [gitoxide](https://github.com/Byron/gitoxide) Rust library.
 
-[backends]: https://jj-vcs.github.io/jj/latest/glossary#backend
+[backends]: https://docs.jj-vcs.dev/latest/glossary#backend
 
 The Git backend is fully featured and maintained, and allows you to use Jujutsu
 with any Git remote. The commits you create will look like regular Git commits.
@@ -227,7 +227,7 @@ Here is how you can explore a GitHub repository with `jj`.
 <img src="demos/git_compat.png" />
 
 You can even have a [colocated local
-workspace](https://jj-vcs.github.io/jj/latest/git-compatibility#colocated-jujutsugit-repos)
+workspace](https://docs.jj-vcs.dev/latest/git-compatibility#colocated-jujutsugit-repos)
 where you can use both `jj` and `git` commands interchangeably.
 
 ### The working copy is automatically committed
@@ -268,7 +268,7 @@ particular operation which does not have to be the most recent one.
 ### Conflicts can be recorded in commits
 
 If an operation results in
-[conflicts](https://jj-vcs.github.io/jj/latest/glossary#conflict),
+[conflicts](https://docs.jj-vcs.dev/latest/glossary#conflict),
 information about those conflicts will be recorded in the commit(s). The
 operation will succeed. You can then resolve the conflicts later. One
 consequence of this design is that there's no need to continue interrupted
@@ -320,7 +320,7 @@ upgrade commands or scripts if requested.
 ## Related work
 
 There are several tools trying to solve similar problems as Jujutsu. See
-[related work](https://jj-vcs.github.io/jj/latest/related-work) for details.
+[related work](https://docs.jj-vcs.dev/latest/related-work) for details.
 
 ## Contributing
 
@@ -329,7 +329,7 @@ don't be shy. Please ask if you want a pointer on something you can help with,
 and hopefully we can all figure something out.
 
 We do have [a few policies and
-suggestions](https://jj-vcs.github.io/jj/prerelease/contributing/)
+suggestions](https://docs.jj-vcs.dev/prerelease/contributing/)
 for contributors. The broad TL;DR:
 
 - Bug reports are very welcome!

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1864,7 +1864,7 @@ to the current parents may contain changes from multiple commits.
             error.add_hint("Immutable commits are used to protect shared history.");
             error.add_hint(indoc::indoc! {"
                 For more information, see:
-                      - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+                      - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
                       - `jj help -k config`, \"Set of immutable commits\""});
 
             // Not using self.id_prefix_context() for consistency with
@@ -1948,7 +1948,7 @@ to the current parents may contain changes from multiple commits.
                                 short_operation_hash(&old_op_id)
                             ),
                             "Run `jj workspace update-stale` to update it.
-See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
+See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy \
                              for more information.",
                         ),
                     ));
@@ -1968,7 +1968,7 @@ See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
                         user_error_with_hint(
                             "Could not read working copy's operation.",
                             "Run `jj workspace update-stale` to recover.
-See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy \
+See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy \
                              for more information.",
                         ),
                     ));
@@ -3261,7 +3261,7 @@ fn ensure_no_commit_loop(
 /// To get started, see the tutorial [`jj help -k tutorial`].
 ///
 /// [`jj help -k tutorial`]:
-///     https://jj-vcs.github.io/jj/latest/tutorial/
+///     https://docs.jj-vcs.dev/latest/tutorial/
 #[derive(clap::Parser, Clone, Debug)]
 #[command(name = "jj")]
 pub struct Args {

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -800,8 +800,8 @@ fn find_source_parse_error_hint(err: &dyn error::Error) -> Option<String> {
     }
 }
 
-const REVSET_SYMBOL_HINT: &str = "See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help \
-                                  -k revsets` for how to quote symbols.";
+const REVSET_SYMBOL_HINT: &str = "See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k \
+                                  revsets` for how to quote symbols.";
 
 fn bookmark_name_parse_error_hint(err: &BookmarkNameParseError) -> Option<String> {
     use revset::ExpressionKind;
@@ -825,8 +825,8 @@ fn config_get_error_hint(err: &ConfigGetError) -> Option<String> {
 fn file_pattern_parse_error_hint(err: &FilePatternParseError) -> Option<String> {
     match err {
         FilePatternParseError::InvalidKind(_) => Some(String::from(
-            "See https://jj-vcs.github.io/jj/latest/filesets/#file-patterns or `jj help -k \
-             filesets` for valid prefixes.",
+            "See https://docs.jj-vcs.dev/latest/filesets/#file-patterns or `jj help -k filesets` \
+             for valid prefixes.",
         )),
         // Suggest root:"<path>" if input can be parsed as repo-relative path
         FilePatternParseError::UiPath(UiPathParseError::Fs(e)) => {
@@ -842,7 +842,7 @@ fn file_pattern_parse_error_hint(err: &FilePatternParseError) -> Option<String> 
 fn fileset_parse_error_hint(err: &FilesetParseError) -> Option<String> {
     match err.kind() {
         FilesetParseErrorKind::SyntaxError => Some(String::from(
-            "See https://jj-vcs.github.io/jj/latest/filesets/ or use `jj help -k filesets` for \
+            "See https://docs.jj-vcs.dev/latest/filesets/ or use `jj help -k filesets` for \
              filesets syntax and how to match file paths.",
         )),
         FilesetParseErrorKind::NoSuchFunction {
@@ -876,8 +876,8 @@ pub(crate) fn revset_parse_error_hint(err: &RevsetParseError) -> Option<String> 
     let bottom_err = iter::successors(Some(err), |e| e.origin()).last().unwrap();
     match bottom_err.kind() {
         RevsetParseErrorKind::SyntaxError => Some(
-            "See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for \
-             revsets syntax and how to quote symbols."
+            "See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets \
+             syntax and how to quote symbols."
                 .into(),
         ),
         RevsetParseErrorKind::NotPrefixOperator {
@@ -1000,8 +1000,7 @@ fn try_handle_command_result(ui: &mut Ui, result: Result<(), CommandError>) -> i
             print_error(ui, "Config error: ", err, hints)?;
             writeln!(
                 ui.stderr_formatter().labeled("hint"),
-                "For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k \
-                 config`."
+                "For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`."
             )?;
             Ok(1)
         }

--- a/cli/src/commands/bookmark/delete.rs
+++ b/cli/src/commands/bookmark/delete.rs
@@ -41,7 +41,7 @@ pub struct BookmarkDeleteArgs {
     /// select bookmarks by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(
         required = true,
         value_parser = StringPattern::parse,

--- a/cli/src/commands/bookmark/forget.rs
+++ b/cli/src/commands/bookmark/forget.rs
@@ -51,7 +51,7 @@ pub struct BookmarkForgetArgs {
     /// select bookmarks by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(
         required = true,
         value_parser = StringPattern::parse,

--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -49,7 +49,7 @@ use crate::ui::Ui;
 /// See [`jj help -k bookmarks`] for more information.
 ///
 /// [`jj help -k bookmarks`]:
-///     https://jj-vcs.github.io/jj/latest/bookmarks
+///     https://docs.jj-vcs.dev/latest/bookmarks
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkListArgs {
     /// Show all tracking and non-tracking remote bookmarks including the ones
@@ -67,7 +67,7 @@ pub struct BookmarkListArgs {
     /// prefix to select remotes by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(
         long = "remote",
         value_name = "REMOTE",
@@ -91,7 +91,7 @@ pub struct BookmarkListArgs {
     /// select bookmarks by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(add = ArgValueCandidates::new(complete::bookmarks))]
     names: Option<Vec<String>>,
 
@@ -109,10 +109,10 @@ pub struct BookmarkListArgs {
     /// for more information.
     ///
     /// [`CommitRef` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#commitref-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#commitref-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -66,7 +66,7 @@ use crate::ui::Ui;
 /// See [`jj help -k bookmarks`] for more information.
 ///
 /// [`jj help -k bookmarks`]:
-///     https://jj-vcs.github.io/jj/latest/bookmarks
+///     https://docs.jj-vcs.dev/latest/bookmarks
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum BookmarkCommand {
     #[command(visible_alias("c"))]

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -51,7 +51,7 @@ pub struct BookmarkMoveArgs {
     /// select bookmarks by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(
         group = "source",
         value_parser = StringPattern::parse,

--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -42,7 +42,7 @@ pub struct BookmarkTrackArgs {
     /// Examples: bookmark@remote, glob:main@*, glob:jjfan-*@upstream
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(
         required = true,
         value_name = "BOOKMARK@REMOTE",

--- a/cli/src/commands/bookmark/untrack.rs
+++ b/cli/src/commands/bookmark/untrack.rs
@@ -41,7 +41,7 @@ pub struct BookmarkUntrackArgs {
     /// Examples: bookmark@remote, glob:main@*, glob:jjfan-*@upstream
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(
         required = true,
         value_name = "BOOKMARK@REMOTE",

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -62,7 +62,7 @@ pub struct ConfigListArgs {
     /// See [`jj help -k templates`] for more information.
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(
         long, short = 'T',
         verbatim_doc_comment,

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -147,7 +147,7 @@ impl ConfigLevelArgs {
 /// config options, and other details about `jj config`.
 ///
 /// [`jj help -k config`]:
-///     https://jj-vcs.github.io/jj/latest/config/
+///     https://docs.jj-vcs.dev/latest/config/
 #[derive(clap::Subcommand, Clone, Debug)]
 pub(crate) enum ConfigCommand {
     #[command(visible_alias("e"))]

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -109,10 +109,10 @@ pub(crate) struct DiffArgs {
     /// more information.
     ///
     /// [`TreeDiffEntry` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#treediffentry-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#treediffentry-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(
         long,
         short = 'T',

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -38,7 +38,7 @@ use crate::ui::Ui;
 /// the "from" revision to the "to" revision.
 ///
 /// [diff editor]:
-///     https://jj-vcs.github.io/jj/latest/config/#editing-diffs
+///     https://docs.jj-vcs.dev/latest/config/#editing-diffs
 ///
 /// Edit the right side of the diff until it looks the way you want. Once you
 /// close the editor, the revision specified with `-r` or `--to` will be

--- a/cli/src/commands/edit.rs
+++ b/cli/src/commands/edit.rs
@@ -30,7 +30,7 @@ use crate::ui::Ui;
 /// squash`.
 ///
 /// [generally recommended]:
-///     https://jj-vcs.github.io/jj/latest/FAQ#how-do-i-resume-working-on-an-existing-change
+///     https://docs.jj-vcs.dev/latest/FAQ#how-do-i-resume-working-on-an-existing-change
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct EditArgs {
     /// The commit to edit

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -73,10 +73,10 @@ pub(crate) struct EvologArgs {
     /// If not specified, this defaults to the `templates.evolog` setting.
     ///
     /// [`CommitEvolutionEntry` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#commitevolutionentry-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#commitevolutionentry-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show patch compared to the previous version of this change

--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -60,10 +60,10 @@ pub(crate) struct FileAnnotateArgs {
     /// setting.
     ///
     /// [`AnnotationLine` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#annotationline-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#annotationline-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }

--- a/cli/src/commands/file/list.rs
+++ b/cli/src/commands/file/list.rs
@@ -44,10 +44,10 @@ pub(crate) struct FileListArgs {
     /// more information.
     ///
     /// [`TreeEntry` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#treeentry-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#treeentry-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -65,10 +65,10 @@ pub(crate) struct FileShowArgs {
     /// If not specified, this defaults to the `templates.file_show` setting.
     ///
     /// [`TreeEntry` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#treeentry-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#treeentry-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -73,7 +73,7 @@ pub struct GitCloneArgs {
     /// [git.colocate config] is set to `false`.
     ///
     /// [git.colocate config]:
-    ///     https://jj-vcs.github.io/jj/latest/config/#default-colocation
+    ///     https://docs.jj-vcs.dev/latest/config/#default-colocation
     #[arg(long)]
     colocate: bool,
     /// Disable colocation of the Jujutsu repo with the git repo
@@ -86,7 +86,7 @@ pub struct GitCloneArgs {
     /// workspaces.
     ///
     /// [colocation docs]:
-    ///     https://jj-vcs.github.io/jj/latest/git-compatibility/#colocated-jujutsugit-repos
+    ///     https://docs.jj-vcs.dev/latest/git-compatibility/#colocated-jujutsugit-repos
     #[arg(long, conflicts_with = "colocate")]
     no_colocate: bool,
     /// Create a shallow clone of the given depth

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -78,7 +78,7 @@ pub struct GitFetchArgs {
     /// patterns.
     ///
     /// [string pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets#string-patterns
     #[arg(
         long = "remote",
         value_name = "REMOTE",

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -71,7 +71,7 @@ pub struct GitInitArgs {
     /// This option is mutually exclusive with `--git-repo`.
     ///
     /// [git.colocate config]:
-    ///     https://jj-vcs.github.io/jj/latest/config/#default-colocation
+    ///     https://docs.jj-vcs.dev/latest/config/#default-colocation
     #[arg(long, conflicts_with = "git_repo")]
     colocate: bool,
 
@@ -85,7 +85,7 @@ pub struct GitInitArgs {
     /// workspaces.
     ///
     /// [colocation docs]:
-    ///     https://jj-vcs.github.io/jj/latest/git-compatibility/#colocated-jujutsugit-repos
+    ///     https://docs.jj-vcs.dev/latest/git-compatibility/#colocated-jujutsugit-repos
     #[arg(long, conflicts_with = "colocate")]
     no_colocate: bool,
 

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -65,10 +65,10 @@ use crate::ui::Ui;
 /// See this [comparison], including a [table of commands].
 ///
 /// [comparison]:
-///     https://jj-vcs.github.io/jj/latest/git-comparison/.
+///     https://docs.jj-vcs.dev/latest/git-comparison/.
 ///
 /// [table of commands]:
-///     https://jj-vcs.github.io/jj/latest/git-command-table
+///     https://docs.jj-vcs.dev/latest/git-command-table
 #[derive(Subcommand, Clone, Debug)]
 pub enum GitCommand {
     Clone(GitCloneArgs),

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -89,10 +89,10 @@ use crate::ui::Ui;
 /// conflicts].
 ///
 /// [safety checks]:
-///     https://jj-vcs.github.io/jj/latest/bookmarks/#pushing-bookmarks-safety-checks
+///     https://docs.jj-vcs.dev/latest/bookmarks/#pushing-bookmarks-safety-checks
 ///
 /// [bookmark conflicts]:
-///     https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
+///     https://docs.jj-vcs.dev/latest/bookmarks/#conflicts
 
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(ArgGroup::new("specific").args(&["bookmark", "change", "revisions", "named"]).multiple(true)))]
@@ -111,7 +111,7 @@ pub struct GitPushArgs {
     /// select bookmarks by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets#string-patterns
     #[arg(
         long, short,
         alias = "branch",
@@ -128,7 +128,7 @@ pub struct GitPushArgs {
     /// from the [relevant remote].
     ///
     /// [relevant remote]:
-    ///     https://jj-vcs.github.io/jj/latest/bookmarks#remotes-and-tracked-bookmarks
+    ///     https://docs.jj-vcs.dev/latest/bookmarks#remotes-and-tracked-bookmarks
     #[arg(long)]
     tracked: bool,
     /// Push all deleted bookmarks

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -50,7 +50,7 @@ use crate::ui::Ui;
 /// all revisions. See [`jj help -k revsets`] for information about the syntax.
 ///
 /// [`jj help -k revsets`]:
-///     https://jj-vcs.github.io/jj/latest/revsets/
+///     https://docs.jj-vcs.dev/latest/revsets/
 ///
 /// Spans of revisions that are not included in the graph per `--revisions` are
 /// rendered as a synthetic node labeled "(elided revisions)".
@@ -60,10 +60,10 @@ use crate::ui::Ui;
 /// All of these symbols can be [customized].
 ///
 /// [Immutable revisions]:
-///     https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+///     https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
 ///
 /// [customized]:
-///     https://jj-vcs.github.io/jj/latest/config/#node-style
+///     https://docs.jj-vcs.dev/latest/config/#node-style
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct LogArgs {
     /// Which revisions to show
@@ -107,10 +107,10 @@ pub(crate) struct LogArgs {
     /// If not specified, this defaults to the `templates.log` setting.
     ///
     /// [built-in keywords]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+    ///     https://docs.jj-vcs.dev/latest/templates/#commit-keywords
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show patch

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -43,7 +43,7 @@ use crate::ui::Ui;
 /// working copy and the `main` bookmark as parents.
 ///
 /// [working copy]:
-///     https://jj-vcs.github.io/jj/latest/working-copy/
+///     https://docs.jj-vcs.dev/latest/working-copy/
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct NewArgs {
     /// Parent(s) of the new change

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -66,10 +66,10 @@ pub struct OperationLogArgs {
     /// information.
     ///
     /// [built-in keywords]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
+    ///     https://docs.jj-vcs.dev/latest/templates/#operation-keywords
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show changes to the repository at each operation

--- a/cli/src/commands/operation/mod.rs
+++ b/cli/src/commands/operation/mod.rs
@@ -43,7 +43,7 @@ use crate::ui::Ui;
 /// See the [operation log documentation] for more information.
 ///
 /// [operation log documentation]:
-///     https://jj-vcs.github.io/jj/latest/operation-log/
+///     https://docs.jj-vcs.dev/latest/operation-log/
 #[derive(Subcommand, Clone, Debug)]
 pub enum OperationCommand {
     Abandon(OperationAbandonArgs),

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -44,10 +44,10 @@ pub struct OperationShowArgs {
     /// information.
     ///
     /// [built-in keywords]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
+    ///     https://docs.jj-vcs.dev/latest/templates/#operation-keywords
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     /// Show patch of modifications to changes

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -46,10 +46,10 @@ pub(crate) struct ShowArgs {
     /// [built-in keywords]. See [`jj help -k templates`] for more information.
     ///
     /// [built-in keywords]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+    ///     https://docs.jj-vcs.dev/latest/templates/#commit-keywords
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
     #[command(flatten)]

--- a/cli/src/commands/sign.rs
+++ b/cli/src/commands/sign.rs
@@ -34,7 +34,7 @@ use crate::ui::Ui;
 /// This command requires configuring a [commit signing] backend.
 ///
 /// [commit signing]:
-///     https://jj-vcs.github.io/jj/latest/config/#commit-signing
+///     https://docs.jj-vcs.dev/latest/config/#commit-signing
 #[derive(clap::Args, Clone, Debug)]
 pub struct SignArgs {
     /// What revision(s) to sign
@@ -68,7 +68,7 @@ pub fn cmd_sign(ui: &mut Ui, command: &CommandHelper, args: &SignArgs) -> Result
     if !workspace_command.repo().store().signer().can_sign() {
         return Err(user_error_with_hint(
             "No signing backend configured",
-            "For configuring a signing backend, see https://jj-vcs.github.io/jj/latest/config/#commit-signing",
+            "For configuring a signing backend, see https://docs.jj-vcs.dev/latest/config/#commit-signing",
         ));
     }
 

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -56,7 +56,7 @@ use crate::ui::Ui;
 /// revision. The remaining changes will be put in a new revision on top.
 ///
 /// [diff editor]:
-///     https://jj-vcs.github.io/jj/latest/config/#editing-diffs
+///     https://docs.jj-vcs.dev/latest/config/#editing-diffs
 ///
 /// If the change you split had a description, you will be asked to enter a
 /// change description for each commit. If the change did not have a

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -46,7 +46,7 @@ use crate::ui::Ui;
 /// * [Conflicted bookmarks]
 ///
 /// [Conflicted bookmarks]:
-///     https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
+///     https://docs.jj-vcs.dev/latest/bookmarks/#conflicts
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct StatusArgs {
     /// Restrict the status display to these paths

--- a/cli/src/commands/tag/delete.rs
+++ b/cli/src/commands/tag/delete.rs
@@ -34,7 +34,7 @@ pub struct TagDeleteArgs {
     /// select tags by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(
         required = true,
         value_parser = StringPattern::parse,

--- a/cli/src/commands/tag/list.rs
+++ b/cli/src/commands/tag/list.rs
@@ -34,7 +34,7 @@ pub struct TagListArgs {
     /// select tags by [wildcard pattern].
     ///
     /// [wildcard pattern]:
-    ///     https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     pub names: Option<Vec<String>>,
     /// Render each tag using the given template
     ///
@@ -43,10 +43,10 @@ pub struct TagListArgs {
     /// for more information.
     ///
     /// [`CommitRef` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#commitref-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#commitref-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }

--- a/cli/src/commands/unsign.rs
+++ b/cli/src/commands/unsign.rs
@@ -33,7 +33,7 @@ use crate::ui::Ui;
 /// See also [commit signing] docs.
 ///
 /// [commit signing]:
-///     https://jj-vcs.github.io/jj/latest/config/#commit-signing
+///     https://docs.jj-vcs.dev/latest/config/#commit-signing
 #[derive(clap::Args, Clone, Debug)]
 pub struct UnsignArgs {
     /// What revision(s) to unsign

--- a/cli/src/commands/util/completion.rs
+++ b/cli/src/commands/util/completion.rs
@@ -43,7 +43,7 @@ Apply it by running one of these:
 See the docs on [command-line completion] for more details.
 
 [command-line completion]:
-    https://jj-vcs.github.io/jj/latest/install-and-setup/#command-line-completion
+    https://docs.jj-vcs.dev/latest/install-and-setup/#command-line-completion
 "#]
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]

--- a/cli/src/commands/workspace/list.rs
+++ b/cli/src/commands/workspace/list.rs
@@ -33,10 +33,10 @@ pub struct WorkspaceListArgs {
     /// more information.
     ///
     /// [`WorkspaceRef` type]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/#workspaceref-type
+    ///     https://docs.jj-vcs.dev/latest/templates/#workspaceref-type
     ///
     /// [`jj help -k templates`]:
-    ///     https://jj-vcs.github.io/jj/latest/templates/
+    ///     https://docs.jj-vcs.dev/latest/templates/
     #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
     template: Option<String>,
 }

--- a/cli/src/commands/workspace/update_stale.rs
+++ b/cli/src/commands/workspace/update_stale.rs
@@ -24,7 +24,7 @@ use crate::ui::Ui;
 /// See the [stale working copy documentation] for more information.
 ///
 /// [stale working copy documentation]:
-///     https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy
+///     https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy
 #[derive(clap::Args, Clone, Debug)]
 pub struct WorkspaceUpdateStaleArgs {}
 

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -3,7 +3,7 @@
     "$comment": "`taplo` and the corresponding VS Code plugins only support version draft-04 of JSON Schema, see <https://taplo.tamasfe.dev/configuration/developing-schemas.html>. draft-07 is mostly compatible with it, newer versions may not be.",
     "title": "Jujutsu config",
     "type": "object",
-    "description": "User configuration for Jujutsu VCS. See https://jj-vcs.github.io/jj/latest/config/ for details",
+    "description": "User configuration for Jujutsu VCS. See https://docs.jj-vcs.dev/latest/config/ for details",
     "properties": {
         "user": {
             "type": "object",
@@ -166,7 +166,7 @@
                     "description": "Options for rendering revision graphs from jj log etc",
                     "properties": {
                         "style": {
-                            "description": "Style of connectors/markings used to render the graph. See https://jj-vcs.github.io/jj/latest/config/#graph-style",
+                            "description": "Style of connectors/markings used to render the graph. See https://docs.jj-vcs.dev/latest/config/#graph-style",
                             "enum": [
                                 "curved",
                                 "square",
@@ -494,7 +494,7 @@
                 "properties": {
                     "auto-track-bookmarks": {
                         "type": "string",
-                        "description": "A string pattern describing the bookmarks to automatically track with this remote. It will be applied to any new bookmark, created or fetched. See https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks",
+                        "description": "A string pattern describing the bookmarks to automatically track with this remote. It will be applied to any new bookmark, created or fetched. See https://docs.jj-vcs.dev/latest/config/#automatic-tracking-of-bookmarks",
                         "default": ""
                     }
                 }
@@ -591,12 +591,12 @@
                         "items": {
                             "type": "number"
                         },
-                        "description": "Array of exit codes to indicate that the conflict was only partially resolved. See https://jj-vcs.github.io/jj/latest/config/#editing-conflict-markers-with-a-tool-or-a-text-editor",
+                        "description": "Array of exit codes to indicate that the conflict was only partially resolved. See https://docs.jj-vcs.dev/latest/config/#editing-conflict-markers-with-a-tool-or-a-text-editor",
                         "default": []
                     },
                     "merge-tool-edits-conflict-markers": {
                         "type": "boolean",
-                        "description": "Whether to populate the output file with conflict markers before starting the merge tool. See https://jj-vcs.github.io/jj/latest/config/#editing-conflict-markers-with-a-tool-or-a-text-editor",
+                        "description": "Whether to populate the output file with conflict markers before starting the merge tool. See https://docs.jj-vcs.dev/latest/config/#editing-conflict-markers-with-a-tool-or-a-text-editor",
                         "default": false
                     },
                     "conflict-marker-style": {
@@ -686,7 +686,7 @@
                 },
                 "auto-update-stale": {
                     "type": "boolean",
-                    "description": "Whether to automatically update the working copy if it is stale. See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy",
+                    "description": "Whether to automatically update the working copy if it is stale. See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy",
                     "default": false
                 },
                 "max-new-file-size": {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -564,7 +564,7 @@ fn config_files_for(
 /// Sources from the lowest precedence:
 /// 1. Default
 /// 2. Base environment variables
-/// 3. [User configs](https://jj-vcs.github.io/jj/latest/config/)
+/// 3. [User configs](https://docs.jj-vcs.dev/latest/config/)
 /// 4. Repo config `.jj/repo/config.toml`
 /// 5. Workspace config `.jj/workspace-config.toml`
 /// 6. Override environment variables
@@ -777,7 +777,7 @@ pub fn default_config_migrations() -> Vec<ConfigMigrationRule> {
                 Ok("`git.auto-local-bookmark` is deprecated; use \
                     `remotes.<name>.auto-track-bookmarks` instead.
 Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
-For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks"
+For details, see: https://docs.jj-vcs.dev/latest/config/#automatic-tracking-of-bookmarks"
                     .into())
             },
         ),
@@ -793,7 +793,7 @@ For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-
                 Ok("`git.push-new-bookmarks` is deprecated; use \
                     `remotes.<name>.auto-track-bookmarks` instead.
 Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
-For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks"
+For details, see: https://docs.jj-vcs.dev/latest/config/#automatic-tracking-of-bookmarks"
                     .into())
             },
         ),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -127,7 +127,7 @@ Jujutsu (An experimental VCS)
 
 To get started, see the tutorial [`jj help -k tutorial`].
 
-[`jj help -k tutorial`]: https://jj-vcs.github.io/jj/latest/tutorial/
+[`jj help -k tutorial`]: https://docs.jj-vcs.dev/latest/tutorial/
 
 **Usage:** `jj [OPTIONS] [COMMAND]`
 
@@ -337,7 +337,7 @@ Manage bookmarks [default alias: b]
 
 See [`jj help -k bookmarks`] for more information.
 
-[`jj help -k bookmarks`]: https://jj-vcs.github.io/jj/latest/bookmarks
+[`jj help -k bookmarks`]: https://docs.jj-vcs.dev/latest/bookmarks
 
 **Usage:** `jj bookmark <COMMAND>`
 
@@ -393,7 +393,7 @@ If you don't want the deletion of the local bookmark to propagate to any tracked
 
    By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 
 
@@ -413,7 +413,7 @@ If a local bookmark is forgotten, any corresponding remote bookmarks will become
 
    By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 ###### **Options:**
 
@@ -431,7 +431,7 @@ By default, a tracking remote bookmark will be included only if its target is di
 
 See [`jj help -k bookmarks`] for more information.
 
-[`jj help -k bookmarks`]: https://jj-vcs.github.io/jj/latest/bookmarks
+[`jj help -k bookmarks`]: https://docs.jj-vcs.dev/latest/bookmarks
 
 **Usage:** `jj bookmark list [OPTIONS] [NAMES]...`
 
@@ -443,7 +443,7 @@ See [`jj help -k bookmarks`] for more information.
 
    By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 ###### **Options:**
 
@@ -454,7 +454,7 @@ See [`jj help -k bookmarks`] for more information.
 
    By default, the specified remote name matches exactly. Use `glob:` prefix to select remotes by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 * `-t`, `--tracked` — Show remote tracked bookmarks only. Omits local Git-tracking bookmarks by default
 * `-c`, `--conflicted` — Show conflicted bookmarks only
 * `-r`, `--revisions <REVSETS>` — Show bookmarks whose local targets are in the given revisions
@@ -464,9 +464,9 @@ See [`jj help -k bookmarks`] for more information.
 
    All 0-argument methods of the [`CommitRef` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
-   [`CommitRef` type]: https://jj-vcs.github.io/jj/latest/templates/#commitref-type
+   [`CommitRef` type]: https://docs.jj-vcs.dev/latest/templates/#commitref-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `--sort <SORT_KEY>` — Sort bookmarks based on the given key (or multiple keys)
 
    Suffix the key with `-` to sort in descending order of the value (e.g. `--sort name-`). Note that when using multiple keys, the first key is the most significant.
@@ -500,7 +500,7 @@ $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 
    By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 ###### **Options:**
 
@@ -568,7 +568,7 @@ A tracking remote bookmark will be imported as a local bookmark of the same name
 
    Examples: bookmark@remote, glob:main@*, glob:jjfan-*@upstream
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 
 
@@ -590,7 +590,7 @@ If you want to forget a local bookmark while also untracking the corresponding r
 
    Examples: bookmark@remote, glob:main@*, glob:jjfan-*@upstream
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 
 
@@ -635,7 +635,7 @@ Operates on jj configuration, which comes from the config file and environment v
 
 See [`jj help -k config`] to know more about file locations, supported config options, and other details about `jj config`.
 
-[`jj help -k config`]: https://jj-vcs.github.io/jj/latest/config/
+[`jj help -k config`]: https://docs.jj-vcs.dev/latest/config/
 
 **Usage:** `jj config <COMMAND>`
 
@@ -726,7 +726,7 @@ List variables set in config files, along with their values
    See [`jj help -k templates`] for more information.
 
    [`jj help -k templates`]:
-       https://jj-vcs.github.io/jj/latest/templates/
+       https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -856,9 +856,9 @@ If no option is specified, it defaults to `-r @`.
 
    All 0-argument methods of the [`TreeDiffEntry` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
-   [`TreeDiffEntry` type]: https://jj-vcs.github.io/jj/latest/templates/#treediffentry-type
+   [`TreeDiffEntry` type]: https://docs.jj-vcs.dev/latest/templates/#treediffentry-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
 * `--types` — For each path, show only its type before and after
@@ -886,7 +886,7 @@ With the `-r` option, starts a [diff editor] on the changes in the revision.
 
 With the `--from` and/or `--to` options, starts a [diff editor] comparing the "from" revision to the "to" revision.
 
-[diff editor]: https://jj-vcs.github.io/jj/latest/config/#editing-diffs
+[diff editor]: https://docs.jj-vcs.dev/latest/config/#editing-diffs
 
 Edit the right side of the diff until it looks the way you want. Once you close the editor, the revision specified with `-r` or `--to` will be updated. Unless `--restore-descendants` is used, descendants will be rebased on top as usual, which may result in conflicts.
 
@@ -946,7 +946,7 @@ Sets the specified revision as the working-copy revision
 
 Note: it is [generally recommended] to instead use `jj new` and `jj squash`.
 
-[generally recommended]: https://jj-vcs.github.io/jj/latest/FAQ#how-do-i-resume-working-on-an-existing-change
+[generally recommended]: https://docs.jj-vcs.dev/latest/FAQ#how-do-i-resume-working-on-an-existing-change
 
 **Usage:** `jj edit <REVSET>`
 
@@ -982,9 +982,9 @@ Lists the previous commits which a change has pointed to. The current commit of 
 
    If not specified, this defaults to the `templates.evolog` setting.
 
-   [`CommitEvolutionEntry` type]: https://jj-vcs.github.io/jj/latest/templates/#commitevolutionentry-type
+   [`CommitEvolutionEntry` type]: https://docs.jj-vcs.dev/latest/templates/#commitevolutionentry-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `-p`, `--patch` — Show patch compared to the previous version of this change
 
    If the previous version has different parents, it will be temporarily rebased to the parents of the new version, so the diff is not contaminated by unrelated changes.
@@ -1045,9 +1045,9 @@ Annotates a revision line by line. Each line includes the source change that int
 
    If not specified, this defaults to the `templates.file_annotate` setting.
 
-   [`AnnotationLine` type]: https://jj-vcs.github.io/jj/latest/templates/#annotationline-type
+   [`AnnotationLine` type]: https://docs.jj-vcs.dev/latest/templates/#annotationline-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -1098,9 +1098,9 @@ List files in a revision
 
    All 0-argument methods of the [`TreeEntry` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
-   [`TreeEntry` type]: https://jj-vcs.github.io/jj/latest/templates/#treeentry-type
+   [`TreeEntry` type]: https://docs.jj-vcs.dev/latest/templates/#treeentry-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -1127,9 +1127,9 @@ If the given path is a directory, files in the directory will be visited recursi
 
    If not specified, this defaults to the `templates.file_show` setting.
 
-   [`TreeEntry` type]: https://jj-vcs.github.io/jj/latest/templates/#treeentry-type
+   [`TreeEntry` type]: https://docs.jj-vcs.dev/latest/templates/#treeentry-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -1289,9 +1289,9 @@ Commands for working with Git remotes and the underlying Git repo
 
 See this [comparison], including a [table of commands].
 
-[comparison]: https://jj-vcs.github.io/jj/latest/git-comparison/.
+[comparison]: https://docs.jj-vcs.dev/latest/git-comparison/.
 
-[table of commands]: https://jj-vcs.github.io/jj/latest/git-command-table
+[table of commands]: https://docs.jj-vcs.dev/latest/git-command-table
 
 **Usage:** `jj git <COMMAND>`
 
@@ -1335,14 +1335,14 @@ Create a new repo backed by a clone of a Git repo
 
    **This is the default**, and this option has no effect, unless the [git.colocate config] is set to `false`.
 
-   [git.colocate config]: https://jj-vcs.github.io/jj/latest/config/#default-colocation
+   [git.colocate config]: https://docs.jj-vcs.dev/latest/config/#default-colocation
 * `--no-colocate` — Disable colocation of the Jujutsu repo with the git repo
 
    Prevent Git tools that are unaware of `jj` and regular Git commands from operating on the repo. The Git repository that stores most of the repo data will be hidden inside a sub-directory of the `.jj` directory.
 
    See [colocation docs] for some minor advantages of non-colocated workspaces.
 
-   [colocation docs]: https://jj-vcs.github.io/jj/latest/git-compatibility/#colocated-jujutsugit-repos
+   [colocation docs]: https://docs.jj-vcs.dev/latest/git-compatibility/#colocated-jujutsugit-repos
 * `--depth <DEPTH>` — Create a shallow clone of the given depth
 * `--fetch-tags <FETCH_TAGS>` — Configure when to fetch tags
 
@@ -1438,7 +1438,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
    By default, the specified remote names matches exactly. Use a [string pattern], e.g. `--remote 'glob:*'`, to select remotes using patterns.
 
-   [string pattern]: https://jj-vcs.github.io/jj/latest/revsets#string-patterns
+   [string pattern]: https://docs.jj-vcs.dev/latest/revsets#string-patterns
 * `--all-remotes` — Fetch from all remotes
 
 
@@ -1481,14 +1481,14 @@ Create a new Git backed repo
 
    This option is mutually exclusive with `--git-repo`.
 
-   [git.colocate config]: https://jj-vcs.github.io/jj/latest/config/#default-colocation
+   [git.colocate config]: https://docs.jj-vcs.dev/latest/config/#default-colocation
 * `--no-colocate` — Disable colocation of the Jujutsu repo with the git repo
 
    Prevent Git tools that are unaware of `jj` and regular Git commands from operating on the repo. The Git repository that stores most of the repo data will be hidden inside a sub-directory of the `.jj` directory.
 
    See [colocation docs] for some minor advantages of non-colocated workspaces.
 
-   [colocation docs]: https://jj-vcs.github.io/jj/latest/git-compatibility/#colocated-jujutsugit-repos
+   [colocation docs]: https://docs.jj-vcs.dev/latest/git-compatibility/#colocated-jujutsugit-repos
 * `--git-repo <GIT_REPO>` — Specifies a path to an **existing** git repository to be used as the backing git repo for the newly created `jj` repo.
 
    If the specified `--git-repo` path happens to be the same as the `jj` repo path (both .jj and .git directories are in the same working directory), then both `jj` and `git` commands will work on the same repo. This is called a colocated workspace.
@@ -1507,9 +1507,9 @@ Unlike in Git, the remote to push to is not derived from the tracked remote book
 
 Before the command actually moves, creates, or deletes a remote bookmark, it makes several [safety checks]. If there is a problem, you may need to run `jj git fetch --remote <remote name>` and/or resolve some [bookmark conflicts].
 
-[safety checks]: https://jj-vcs.github.io/jj/latest/bookmarks/#pushing-bookmarks-safety-checks
+[safety checks]: https://docs.jj-vcs.dev/latest/bookmarks/#pushing-bookmarks-safety-checks
 
-[bookmark conflicts]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
+[bookmark conflicts]: https://docs.jj-vcs.dev/latest/bookmarks/#conflicts
 
 **Usage:** `jj git push [OPTIONS]`
 
@@ -1522,13 +1522,13 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 
    By default, the specified name matches exactly. Use `glob:` prefix to select bookmarks by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets#string-patterns
 * `--all` — Push all bookmarks (including new bookmarks)
 * `--tracked` — Push all tracked bookmarks
 
    This usually means that the bookmark was already pushed to or fetched from the [relevant remote].
 
-   [relevant remote]: https://jj-vcs.github.io/jj/latest/bookmarks#remotes-and-tracked-bookmarks
+   [relevant remote]: https://docs.jj-vcs.dev/latest/bookmarks#remotes-and-tracked-bookmarks
 * `--deleted` — Push all deleted bookmarks
 
    Only tracked bookmarks can be successfully deleted on the remote. A warning will be printed if any untracked bookmarks on the remote correspond to missing local bookmarks.
@@ -1725,15 +1725,15 @@ Show revision history
 
 Renders a graphical view of the project's history, ordered with children before parents. By default, the output only includes mutable revisions, along with some additional revisions for context. Use `jj log -r ::` to see all revisions. See [`jj help -k revsets`] for information about the syntax.
 
-[`jj help -k revsets`]: https://jj-vcs.github.io/jj/latest/revsets/
+[`jj help -k revsets`]: https://docs.jj-vcs.dev/latest/revsets/
 
 Spans of revisions that are not included in the graph per `--revisions` are rendered as a synthetic node labeled "(elided revisions)".
 
 The working-copy commit is indicated by a `@` symbol in the graph. [Immutable revisions] have a `◆` symbol. Other commits have a `○` symbol. All of these symbols can be [customized].
 
-[Immutable revisions]: https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+[Immutable revisions]: https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
 
-[customized]: https://jj-vcs.github.io/jj/latest/config/#node-style
+[customized]: https://docs.jj-vcs.dev/latest/config/#node-style
 
 **Usage:** `jj log [OPTIONS] [FILESETS]...`
 
@@ -1759,9 +1759,9 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
    If not specified, this defaults to the `templates.log` setting.
 
-   [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#commit-keywords
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `-p`, `--patch` — Show patch
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
@@ -1838,7 +1838,7 @@ By default, `jj` will edit the new change, making the [working copy] represent t
 
 Note that you can create a merge commit by specifying multiple revisions as argument. For example, `jj new @ main` will create a new commit with the working copy and the `main` bookmark as parents.
 
-[working copy]: https://jj-vcs.github.io/jj/latest/working-copy/
+[working copy]: https://docs.jj-vcs.dev/latest/working-copy/
 
 **Usage:** `jj new [OPTIONS] [REVSETS]...`
 
@@ -1969,7 +1969,7 @@ Commands for working with the operation log
 
 See the [operation log documentation] for more information.
 
-[operation log documentation]: https://jj-vcs.github.io/jj/latest/operation-log/
+[operation log documentation]: https://docs.jj-vcs.dev/latest/operation-log/
 
 **Usage:** `jj operation <COMMAND>`
 
@@ -2057,9 +2057,9 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
 
    You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
-   [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#operation-keywords
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `-d`, `--op-diff` — Show changes to the repository at each operation
 * `-p`, `--patch` — Show patch of modifications to changes (implies --op-diff)
 
@@ -2166,9 +2166,9 @@ Show changes to the repository in an operation
 
    You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
-   [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#operation-keywords
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#operation-keywords
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `-p`, `--patch` — Show patch of modifications to changes
 
    If the previous version has different parents, it will be temporarily rebased to the parents of the new version, so the diff is not contaminated by unrelated changes.
@@ -2644,9 +2644,9 @@ Show commit description and changes in a revision
 
    You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
-   [built-in keywords]: https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#commit-keywords
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 * `-s`, `--summary` — For each path, show only whether it was modified, added, or deleted
 * `--stat` — Show a histogram of the changes
 * `--types` — For each path, show only its type before and after
@@ -2673,7 +2673,7 @@ Cryptographically sign a revision
 
 This command requires configuring a [commit signing] backend.
 
-[commit signing]: https://jj-vcs.github.io/jj/latest/config/#commit-signing
+[commit signing]: https://docs.jj-vcs.dev/latest/config/#commit-signing
 
 **Usage:** `jj sign [OPTIONS]`
 
@@ -2774,7 +2774,7 @@ Split a revision in two
 
 Starts a [diff editor] on the changes in the revision. Edit the right side of the diff until it has the content you want in the new revision. Once you close the editor, your edited content will replace the previous revision. The remaining changes will be put in a new revision on top.
 
-[diff editor]: https://jj-vcs.github.io/jj/latest/config/#editing-diffs
+[diff editor]: https://docs.jj-vcs.dev/latest/config/#editing-diffs
 
 If the change you split had a description, you will be asked to enter a change description for each commit. If the change did not have a description, the remaining changes will not get a description, and you will be asked for a description only for the selected changes.
 
@@ -2863,7 +2863,7 @@ This includes:
 
 * [Conflicted bookmarks]
 
-[Conflicted bookmarks]: https://jj-vcs.github.io/jj/latest/bookmarks/#conflicts
+[Conflicted bookmarks]: https://docs.jj-vcs.dev/latest/bookmarks/#conflicts
 
 **Usage:** `jj status [FILESETS]...`
 
@@ -2903,7 +2903,7 @@ Revisions referred to by the deleted tags are not abandoned.
 
    By default, the specified name matches exactly. Use `glob:` prefix to select tags by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 
 
@@ -2921,7 +2921,7 @@ List tags
 
    By default, the specified name matches exactly. Use `glob:` prefix to select tags by [wildcard pattern].
 
-   [wildcard pattern]: https://jj-vcs.github.io/jj/latest/revsets/#string-patterns
+   [wildcard pattern]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 ###### **Options:**
 
@@ -2929,9 +2929,9 @@ List tags
 
    All 0-argument methods of the [`CommitRef` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
-   [`CommitRef` type]: https://jj-vcs.github.io/jj/latest/templates/#commitref-type
+   [`CommitRef` type]: https://docs.jj-vcs.dev/latest/templates/#commitref-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -2986,7 +2986,7 @@ Drop a cryptographic signature
 
 See also [commit signing] docs.
 
-[commit signing]: https://jj-vcs.github.io/jj/latest/config/#commit-signing
+[commit signing]: https://docs.jj-vcs.dev/latest/config/#commit-signing
 
 **Usage:** `jj unsign [OPTIONS]`
 
@@ -3036,7 +3036,7 @@ Apply it by running one of these:
 See the docs on [command-line completion] for more details.
 
 [command-line completion]:
-   https://jj-vcs.github.io/jj/latest/install-and-setup/#command-line-completion
+   https://docs.jj-vcs.dev/latest/install-and-setup/#command-line-completion
 
 **Usage:** `jj util completion <SHELL>`
 
@@ -3246,9 +3246,9 @@ List workspaces
 
    All 0-argument methods of the [`WorkspaceRef` type] are available as keywords in the template expression. See [`jj help -k templates`] for more information.
 
-   [`WorkspaceRef` type]: https://jj-vcs.github.io/jj/latest/templates/#workspaceref-type
+   [`WorkspaceRef` type]: https://docs.jj-vcs.dev/latest/templates/#workspaceref-type
 
-   [`jj help -k templates`]: https://jj-vcs.github.io/jj/latest/templates/
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -3278,7 +3278,7 @@ Update a workspace that has become stale
 
 See the [stale working copy documentation] for more information.
 
-[stale working copy documentation]: https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy
+[stale working copy documentation]: https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy
 
 **Usage:** `jj workspace update-stale`
 

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -176,12 +176,12 @@ fn test_absorb_replace_single_line_hunk() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      qpvuntsm 5bdb5ca1 (conflict) 1
+      qpvuntsm 19034586 (conflict) 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: mzvwutvl 804fe9d9 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 6068e8fc 2
+    Working copy  (@) now at: mzvwutvl f9c426f2 (empty) (no description set)
+    Parent commit (@-)      : kkmpptxz a5f84679 2
     New conflicts appeared in 1 commits:
-      qpvuntsm 5bdb5ca1 (conflict) 1
+      qpvuntsm 19034586 (conflict) 1
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new qpvuntsm
@@ -192,8 +192,8 @@ fn test_absorb_replace_single_line_hunk() {
     "###);
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
-    @  mzvwutvl 804fe9d9 (empty) (no description set)
-    ○  kkmpptxz 6068e8fc 2
+    @  mzvwutvl f9c426f2 (empty) (no description set)
+    ○  kkmpptxz a5f84679 2
     │  diff --git a/file1 b/file1
     │  index 0000000000..2f87e8e465 100644
     │  --- a/file1
@@ -209,7 +209,7 @@ fn test_absorb_replace_single_line_hunk() {
     │   1A
     │   2b
     │  ->>>>>>> Conflict 1 of 1 ends
-    ×  qpvuntsm 5bdb5ca1 (conflict) 1
+    ×  qpvuntsm 19034586 (conflict) 1
     │  diff --git a/file1 b/file1
     ~  new file mode 100644
        index 0000000000..0000000000
@@ -424,13 +424,13 @@ fn test_absorb_conflict() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: kkmpptxz 66d44b8c (conflict) (no description set)
+    Working copy  (@) now at: kkmpptxz 01e6cd99 (conflict) (no description set)
     Parent commit (@-)      : qpvuntsm e35bcaff 1
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file1    2-sided conflict
     New conflicts appeared in 1 commits:
-      kkmpptxz 66d44b8c (conflict) (no description set)
+      kkmpptxz 01e6cd99 (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new kkmpptxz
@@ -550,14 +550,14 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Absorbed changes into 2 revisions:
-      kkmpptxz 8407ab95 (conflict) 2
-      qpvuntsm f1473264 (conflict) 1
+      kkmpptxz 9210e16d (conflict) 2
+      qpvuntsm a52f61f7 (conflict) 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: zsuskuln b56f0c39 (no description set)
-    Parent commit (@-)      : kkmpptxz 8407ab95 (conflict) 2
+    Working copy  (@) now at: zsuskuln f8744d38 (no description set)
+    Parent commit (@-)      : kkmpptxz 9210e16d (conflict) 2
     New conflicts appeared in 2 commits:
-      kkmpptxz 8407ab95 (conflict) 2
-      qpvuntsm f1473264 (conflict) 1
+      kkmpptxz 9210e16d (conflict) 2
+      qpvuntsm a52f61f7 (conflict) 1
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
       jj new qpvuntsm
@@ -570,7 +570,7 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     "###);
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
-    @  zsuskuln b56f0c39 (no description set)
+    @  zsuskuln f8744d38 (no description set)
     │  diff --git a/file2 b/file2
     │  deleted file mode 100644
     │  index 0000000000..0000000000
@@ -584,7 +584,7 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     │  -+++++++ Contents of side #2
     │  -1a
     │  ->>>>>>> Conflict 1 of 1 ends
-    ×  kkmpptxz 8407ab95 (conflict) 2
+    ×  kkmpptxz 9210e16d (conflict) 2
     │  diff --git a/file1 b/file1
     │  deleted file mode 100644
     │  index 0000000000..0000000000
@@ -611,7 +611,7 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     │  -1b
     │  +1a
     │   >>>>>>> Conflict 1 of 1 ends
-    ×  qpvuntsm f1473264 (conflict) 1
+    ×  qpvuntsm a52f61f7 (conflict) 1
     │  diff --git a/file1 b/file1
     ~  new file mode 100644
        index 0000000000..0000000000
@@ -900,7 +900,7 @@ fn test_absorb_immutable() {
     Hint: Could not modify commit: qpvuntsm e35bcaff main | 1
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -150,7 +150,7 @@ fn test_alias_calls_help() {
 
     To get started, see the tutorial [`jj help -k tutorial`].
 
-    [`jj help -k tutorial`]: https://jj-vcs.github.io/jj/latest/tutorial/
+    [`jj help -k tutorial`]: https://docs.jj-vcs.dev/latest/tutorial/
 
     Usage: jj [OPTIONS] <COMMAND>
     [EOF]
@@ -280,7 +280,7 @@ fn test_alias_invalid_definition() {
     Caused by: invalid type: integer `5`, expected a sequence
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -291,7 +291,7 @@ fn test_alias_invalid_definition() {
     Caused by: invalid type: integer `0`, expected a string
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -158,7 +158,7 @@ fn test_bookmark_bad_name() {
       | ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -175,7 +175,7 @@ fn test_bookmark_bad_name() {
       | ^^
       |
       = Expected non-empty string
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -192,7 +192,7 @@ fn test_bookmark_bad_name() {
       | ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -210,7 +210,7 @@ fn test_bookmark_bad_name() {
       | ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -2111,7 +2111,7 @@ fn test_bookmark_list_filtered() {
       |      ^---
       |
       = expected `::`, `..`, `~`, or <primary>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -890,7 +890,7 @@ fn test_log_immutable() {
       | ^--------^
       |
       = Function `unknown_fn` doesn't exist
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1357,7 +1357,7 @@ fn test_files() {
     │  M f_modified
     │  M f_not_yet_copied
     │  R {f_not_yet_renamed => f_renamed}
-    │ ×  royxmykx test.user@example.com 2001-02-03 08:05:14 conflicted cf10549a conflict
+    │ ×  royxmykx test.user@example.com 2001-02-03 08:05:14 conflicted a24d7569 conflict
     ├─╯  conflicted
     │    A f_added_2
     │    A f_dir/dir_file_1

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -645,7 +645,7 @@ fn test_config_set_for_user() {
     let user_config_toml = std::fs::read_to_string(&user_config_path)
         .unwrap_or_else(|_| panic!("Failed to read file {}", user_config_path.display()));
     insta::assert_snapshot!(user_config_toml, @r#"
-    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+    #:schema https://docs.jj-vcs.dev/latest/config-schema.json
 
     test-key = "test-val"
 
@@ -719,7 +719,7 @@ fn test_config_set_for_repo() {
     // Ensure test-key successfully written to user config.
     let repo_config_toml = work_dir.read_file(".jj/repo/config.toml");
     insta::assert_snapshot!(repo_config_toml, @r#"
-    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+    #:schema https://docs.jj-vcs.dev/latest/config-schema.json
 
     test-key = "test-val"
 
@@ -747,7 +747,7 @@ fn test_config_set_for_workspace() {
     // Read workspace config
     let workspace_config = work_dir.read_file(".jj/workspace-config.toml");
     insta::assert_snapshot!(workspace_config, @r#"
-    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+    #:schema https://docs.jj-vcs.dev/latest/config-schema.json
 
     test-key = "ws-val"
     "#);
@@ -774,7 +774,7 @@ fn test_config_set_toml_types() {
     set_value("test-table.string", r#""foo""#);
     set_value("test-table.invalid", r"a + b");
     insta::assert_snapshot!(std::fs::read_to_string(&user_config_path).unwrap(), @r#"
-    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+    #:schema https://docs.jj-vcs.dev/latest/config-schema.json
 
     [test-table]
     integer = 42
@@ -870,7 +870,7 @@ fn test_config_unset_inline_table_key() {
         .success();
     let user_config_toml = std::fs::read_to_string(&user_config_path).unwrap();
     insta::assert_snapshot!(user_config_toml, @r"
-    #:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+    #:schema https://docs.jj-vcs.dev/latest/config-schema.json
 
     inline-table = {}
     ");
@@ -1237,7 +1237,7 @@ fn test_config_get() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: Value not found for nonexistent
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1412,7 +1412,7 @@ fn test_config_path_syntax() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: Value not found for a.'b()'.x
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1717,7 +1717,7 @@ fn test_config_show_paths() {
     Caused by: unknown variant `:builtin`, expected `never` or `auto`
 
     Hint: Check the config file: $TEST_ENV/config/config0001.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -362,7 +362,7 @@ fn test_diff_basic() {
     ------- stderr -------
     Config error: Invalid type or value for ui.diff-formatter
     Caused by: Invalid builtin diff format: unknown
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -2461,13 +2461,13 @@ fn test_diff_conflict_sides_differ() {
     // left1+right1.
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @r"
-    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left2+right2 530ede8c conflict
+    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left2+right2 3d17e6d8 conflict
     ├─╮  (empty) left2+right2
     │ ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 right2 e57450eb
     │ │  right2
     ○ │  royxmykx test.user@example.com 2001-02-03 08:05:13 left2 b50b218b
     │ │  left2
-    │ │ ×  kmkuslsw test.user@example.com 2001-02-03 08:05:18 left1+right1 83cdbdb5 conflict
+    │ │ ×  kmkuslsw test.user@example.com 2001-02-03 08:05:18 left1+right1 98363e39 conflict
     ╭─┬─╯  (empty) left1+right1
     │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 right1 3fe2e860
     │ │  right1
@@ -2755,7 +2755,7 @@ fn test_diff_conflict_bases_differ() {
     // left1+right1.
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @r"
-    ×    nkmrtpmo test.user@example.com 2001-02-03 08:05:22 left2+right2 22cb40d9 conflict
+    ×    nkmrtpmo test.user@example.com 2001-02-03 08:05:22 left2+right2 2b31acda conflict
     ├─╮  (empty) left2+right2
     │ ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 right2 656695c3
     │ │  right2
@@ -2763,7 +2763,7 @@ fn test_diff_conflict_bases_differ() {
     ├─╯  left2
     ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 base2 3c4d67e6
     │  base2
-    │ ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left1+right1 1711cb65 conflict
+    │ ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left1+right1 602dfc5f conflict
     │ ├─╮  (empty) left1+right1
     │ │ ○  royxmykx test.user@example.com 2001-02-03 08:05:13 right1 3087be1f
     ├───╯  right1
@@ -2911,11 +2911,11 @@ fn test_diff_conflict_three_sides() {
     // Test the setup
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @r"
-    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 side1+side2+side3 ac1efd43 conflict
+    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 side1+side2+side3 8c9bc04f conflict
     ├─╮  (empty) side1+side2+side3
     │ ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 side3 f73063c9
     │ │  side3
-    × │    kmkuslsw test.user@example.com 2001-02-03 08:05:18 side1+side2 a1f24e10 conflict
+    × │    kmkuslsw test.user@example.com 2001-02-03 08:05:18 side1+side2 1fc4b03f conflict
     ├───╮  (empty) side1+side2
     │ │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 side2 bc176227
     │ │ │  side2

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -392,7 +392,7 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     let output = work_dir.run_jj(["diffedit"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: mzvwutvl 268f208f (conflict) (empty) (no description set)
+    Working copy  (@) now at: mzvwutvl b9458f20 (conflict) (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 74e448a1 side-a
     Parent commit (@-)      : zsuskuln 6982bce7 side-b
     Added 0 files, modified 1 files, removed 0 files
@@ -471,7 +471,7 @@ fn test_diffedit_external_tool_conflict_marker_style() {
     let output = work_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @r"
     The working copy has no changes.
-    Working copy  (@) : mzvwutvl 268f208f (conflict) (empty) (no description set)
+    Working copy  (@) : mzvwutvl b9458f20 (conflict) (empty) (no description set)
     Parent commit (@-): rlvkpnrz 74e448a1 side-a
     Parent commit (@-): zsuskuln 6982bce7 side-b
     Warning: There are unresolved conflicts at these paths:
@@ -633,8 +633,8 @@ fn test_diffedit_merge() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: yqosqzyt ce686d54 (conflict) (empty) (no description set)
-    Parent commit (@-)      : royxmykx 47cae64e (conflict) merge
+    Working copy  (@) now at: yqosqzyt 5e33630e (conflict) (empty) (no description set)
+    Parent commit (@-)      : royxmykx 501edbda (conflict) merge
     Added 0 files, modified 0 files, removed 1 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -34,10 +34,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 62777a103786 snapshot working copy
-    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    │  -- operation ae9fa2e2ea1c snapshot working copy
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 1d598134 conflict
     │  my description
-    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b5bfb716eb6f rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
     │  -- operation 826347115e2d snapshot working copy
@@ -52,10 +52,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
     │  [1mmy description[0m
-    │  [38;5;8m--[39m operation [38;5;4m62777a103786[39m snapshot working copy
-    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m7[0m[38;5;8mf56b2a0[39m [38;5;1mconflict[39m
+    │  [38;5;8m--[39m operation [38;5;4mae9fa2e2ea1c[39m snapshot working copy
+    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m1[0m[38;5;8md598134[39m [38;5;1mconflict[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4mad81b0a6af14[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  [38;5;8m--[39m operation [38;5;4mb5bfb716eb6f[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[39m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m
     │  my description
     │  [38;5;8m--[39m operation [38;5;4m826347115e2d[39m snapshot working copy
@@ -71,7 +71,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 62777a103786 snapshot working copy
+    │  -- operation ae9fa2e2ea1c snapshot working copy
     │  Resolved conflict in file1:
     │     1     : <<<<<<< Conflict 1 of 1
     │     2     : %%%%%%% Changes from base to side #1
@@ -80,9 +80,9 @@ fn test_evolog_with_or_without_diff() {
     │     5     : foo
     │     6     : bar
     │     7    1: >>>>>>> Conflict 1 of 1 endsresolved
-    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 1d598134 conflict
     │  my description
-    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b5bfb716eb6f rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
     │  -- operation 826347115e2d snapshot working copy
@@ -104,10 +104,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 62777a103786 snapshot working copy
-    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    │  -- operation ae9fa2e2ea1c snapshot working copy
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 1d598134 conflict
     │  my description
-    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b5bfb716eb6f rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
     │  -- operation 826347115e2d snapshot working copy
@@ -128,10 +128,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 62777a103786 snapshot working copy
-    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    │  -- operation ae9fa2e2ea1c snapshot working copy
+    ×  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 1d598134 conflict
     │  my description
-    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b5bfb716eb6f rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     [EOF]
     ");
 
@@ -140,10 +140,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 62777a103786 snapshot working copy
-    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    -- operation ae9fa2e2ea1c snapshot working copy
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 1d598134 conflict
     my description
-    -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation b5bfb716eb6f rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     my description
     -- operation 826347115e2d snapshot working copy
@@ -158,7 +158,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 62777a103786 snapshot working copy
+    -- operation ae9fa2e2ea1c snapshot working copy
     diff --git a/file1 b/file1
     index 0000000000..2ab19ae607 100644
     --- a/file1
@@ -172,9 +172,9 @@ fn test_evolog_with_or_without_diff() {
     -bar
     ->>>>>>> Conflict 1 of 1 ends
     +resolved
-    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 1d598134 conflict
     my description
-    -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation b5bfb716eb6f rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     my description
     -- operation 826347115e2d snapshot working copy
@@ -293,10 +293,10 @@ fn test_evolog_with_custom_symbols() {
     insta::assert_snapshot!(output, @r"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2ea9565d2b85 snapshot working copy
-    ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 7f56b2a0 conflict
+    │  -- operation a51c9c093002 snapshot working copy
+    ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 1d598134 conflict
     │  my description
-    │  -- operation ad81b0a6af14 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation b5bfb716eb6f rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ┝  rlvkpnrz hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
     │  my description
     │  -- operation 826347115e2d snapshot working copy

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -106,7 +106,7 @@ fn test_chmod_regular_conflict() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No matching entries for paths: nonexistent
-    Working copy  (@) now at: yostqsxw df2619be conflict | (conflict) conflict
+    Working copy  (@) now at: yostqsxw e5b18f6d conflict | (conflict) conflict
     Parent commit (@-)      : royxmykx 02247291 x | x
     Parent commit (@-)      : zsuskuln eb0ba805 n | n
     Added 0 files, modified 1 files, removed 0 files
@@ -196,14 +196,14 @@ fn test_chmod_file_dir_deletion_conflicts() {
     let output = work_dir.run_jj(["file", "chmod", "x", "file", "-r=file_deletion"]);
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw dc89f9e7 file_deletion | (conflict) file_deletion
+    Working copy  (@) now at: kmkuslsw 849406ce file_deletion | (conflict) file_deletion
     Parent commit (@-)      : zsuskuln bc9cdea1 file | file
     Parent commit (@-)      : royxmykx d7d39332 deletion | deletion
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion and an executable
     New conflicts appeared in 1 commits:
-      kmkuslsw dc89f9e7 file_deletion | (conflict) file_deletion
+      kmkuslsw 849406ce file_deletion | (conflict) file_deletion
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new kmkuslsw

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -52,7 +52,7 @@ fn test_config_no_tools() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: No `fix.tools` are configured
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -169,7 +169,7 @@ fn test_config_multiple_tools_with_same_name() {
     duplicate key
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -261,7 +261,7 @@ fn test_config_disabled_tools_warning_when_all_tools_are_disabled() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: At least one entry of `fix.tools` must be enabled.
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -335,7 +335,7 @@ fn test_config_tables_all_commands_missing() {
     Caused by: missing field `command`
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -375,7 +375,7 @@ fn test_config_tables_some_commands_missing() {
     Caused by: missing field `command`
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -894,7 +894,7 @@ fn test_fix_immutable_commit() {
     Hint: Could not modify commit: qpvuntsm a86b2ecc immutable | (no description set)
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -1395,7 +1395,7 @@ fn test_fix_both_sides_of_conflict() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Fixed 3 commits of 3 checked.
-    Working copy  (@) now at: mzvwutvl d4d02bf0 (conflict) (empty) (no description set)
+    Working copy  (@) now at: mzvwutvl e1acdc6e (conflict) (empty) (no description set)
     Parent commit (@-)      : qpvuntsm 0eae0dae a | (no description set)
     Parent commit (@-)      : kkmpptxz eb61ba8d b | (no description set)
     Added 0 files, modified 1 files, removed 0 files

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -682,7 +682,7 @@ fn test_git_clone_remote_default_bookmark() {
     ------- stderr -------
     Warning: Deprecated CLI-provided config: `git.auto-local-bookmark` is deprecated; use `remotes.<name>.auto-track-bookmarks` instead.
     Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
-    For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks
+    For details, see: https://docs.jj-vcs.dev/latest/config/#automatic-tracking-of-bookmarks
     Fetching into new repo in "$TEST_ENV/clone5"
     bookmark: feature1@origin [new] tracked
     bookmark: main@origin     [new] tracked
@@ -778,7 +778,7 @@ fn test_git_clone_ignore_working_copy() {
     ------- stderr -------
     Error: The working copy is stale (not updated since operation 8f47435a3990).
     Hint: Run `jj workspace update-stale` to update it.
-    See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
+    See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
     [exit status: 1]
     ");
@@ -1039,7 +1039,7 @@ fn test_git_clone_invalid_immutable_heads() {
     ------- stderr -------
     Config error: Invalid `revset-aliases.immutable_heads()`
     Caused by: Revision `unknown` doesn't exist
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1074,7 +1074,7 @@ fn test_git_clone_malformed() {
     ------- stderr -------
     Error: The working copy is stale (not updated since operation 353078ed182b).
     Hint: Run `jj workspace update-stale` to update it.
-    See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
+    See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1138,7 +1138,7 @@ fn test_git_colocated_update_index_merge_conflict() {
     work_dir.run_jj(["new", "left", "right"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @    8b05232ad2cda6f6d06b290486e07251f53c0958
+    @    985fe3b46a6caecb44b6a12d22fc2b1fc33c219d
     ├─╮
     │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
     ○ │  d0f55ffafa1e0e72980202c349af23d093f825be left git_head()
@@ -1162,8 +1162,8 @@ fn test_git_colocated_update_index_merge_conflict() {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @  7c98aa1e17acd7829c9ccb9eaae705df9b255bd1
-    ×    8b05232ad2cda6f6d06b290486e07251f53c0958 git_head()
+    @  4e86bd16fa83ac6276701bfa361c683e258a653b
+    ×    985fe3b46a6caecb44b6a12d22fc2b1fc33c219d git_head()
     ├─╮
     │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
     ○ │  d0f55ffafa1e0e72980202c349af23d093f825be left
@@ -1245,7 +1245,7 @@ fn test_git_colocated_update_index_rebase_conflict() {
         .success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @  535388c5aab1b3a33fdc04a4bf8033de0d1b86ec left
+    @  b641af6d56002585b3152e84d4bd92f8181d7909 left
     ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right git_head()
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
@@ -1264,8 +1264,8 @@ fn test_git_colocated_update_index_rebase_conflict() {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @  04ebd7523ac6107ccdd5bc34600a073b94e43299
-    ×  535388c5aab1b3a33fdc04a4bf8033de0d1b86ec left git_head()
+    @  3118c1f8fb0a6279d411eb484906e7274ab5c8f7
+    ×  b641af6d56002585b3152e84d4bd92f8181d7909 left git_head()
     ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
@@ -1341,7 +1341,7 @@ fn test_git_colocated_update_index_3_sided_conflict() {
         .success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @      3105daa0d68e3cdc22b2533d7d1b231cd41c76ec
+    @      3b8792248f224ce8e3f6652681e518a4f3cb3a0f
     ├─┬─╮
     │ │ ○  5008c8807feaa955d02e96cb1b0dcf51536fefb8 side-3
     │ ○ │  da6e0a03f8b72f6868a9ea33836123fe965c0cb4 side-2
@@ -1367,8 +1367,8 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     work_dir.run_jj(["new"]).success();
 
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @  5b4266a02e8fe9febc6294c7d0a02fc8463221e8
-    ×      3105daa0d68e3cdc22b2533d7d1b231cd41c76ec git_head()
+    @  b16ae318909e9bf70fc312217988f2ca0abccb62
+    ×      3b8792248f224ce8e3f6652681e518a4f3cb3a0f git_head()
     ├─┬─╮
     │ │ ○  5008c8807feaa955d02e96cb1b0dcf51536fefb8 side-3
     │ ○ │  da6e0a03f8b72f6868a9ea33836123fe965c0cb4 side-2

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -616,7 +616,7 @@ fn test_git_push_locally_created_and_rewritten() {
     ------- stderr -------
     Warning: Deprecated CLI-provided config: `git.push-new-bookmarks` is deprecated; use `remotes.<name>.auto-track-bookmarks` instead.
     Example: jj config set --user remotes.origin.auto-track-bookmarks 'glob:*'
-    For details, see: https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks
+    For details, see: https://docs.jj-vcs.dev/latest/config/#automatic-tracking-of-bookmarks
     Changes to push to origin:
       Add bookmark my to e0cba5e497ee
     Dry-run requested, not pushing.
@@ -1431,8 +1431,8 @@ fn test_git_push_conflict() {
     let output = work_dir.run_jj(["git", "push", "--all"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Won't push commit 654e715becca since it has conflicts
-    Hint: Rejected commit: yostqsxw 654e715b my-bookmark | (conflict) third
+    Error: Won't push commit d1b152bb0916 since it has conflicts
+    Hint: Rejected commit: yostqsxw d1b152bb my-bookmark | (conflict) third
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -350,7 +350,7 @@ fn test_invalid_filesets_looking_like_filepaths() {
       |     ^---
       |
       = expected `~` or <primary>
-    Hint: See https://jj-vcs.github.io/jj/latest/filesets/ or use `jj help -k filesets` for filesets syntax and how to match file paths.
+    Hint: See https://docs.jj-vcs.dev/latest/filesets/ or use `jj help -k filesets` for filesets syntax and how to match file paths.
     [EOF]
     [exit status: 1]
     ");
@@ -518,7 +518,7 @@ fn test_color_config() {
     Config error: Invalid type or value for ui.color
     Caused by: wanted string or table
 
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -745,7 +745,7 @@ fn test_config_args() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Config error: --config must be specified as NAME=VALUE
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -760,7 +760,7 @@ fn test_config_args() {
         Caused by:
         1: Cannot access unknown.toml
         2: <redacted>
-        For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+        For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
         [EOF]
         [exit status: 1]
         ");
@@ -784,7 +784,7 @@ fn test_invalid_config() {
     unexpected key or value, expected newline, `#`
 
     Hint: Check the config file: $TEST_ENV/config/config0002.toml
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -803,7 +803,7 @@ fn test_invalid_config_value() {
     Config error: Invalid type or value for snapshot.auto-track
     Caused by: invalid type: sequence, expected a string
 
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -49,7 +49,7 @@ fn test_rewrite_immutable_generic() {
     Hint: Could not modify commit: kkmpptxz 9d190342 main | b
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -63,7 +63,7 @@ fn test_rewrite_immutable_generic() {
     Hint: Could not modify commit: qpvuntsm c8c8515a a
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 2 immutable commits.
     [EOF]
@@ -89,7 +89,7 @@ fn test_rewrite_immutable_generic() {
     ------- stderr -------
     Config error: Invalid `revset-aliases.immutable_heads()`
     Caused by: Revision `bookmark_that_does_not_exist` doesn't exist
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -247,7 +247,7 @@ fn test_rewrite_immutable_commands() {
     insta::assert_snapshot!(output, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:14 55c97dc7
     │  (no description set)
-    │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 4397373a conflict
+    │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main e4459202 conflict
     ╭─┤  merge
     │ │
     │ ~
@@ -262,11 +262,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["abandon", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -280,7 +280,7 @@ fn test_rewrite_immutable_commands() {
     Hint: Could not modify commit: kkmpptxz 9d190342 b
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 2 immutable commits.
     [EOF]
@@ -290,11 +290,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["file", "chmod", "-r=main", "x", "file"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -304,11 +304,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["describe", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -318,11 +318,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["diffedit", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -332,11 +332,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["edit", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -346,11 +346,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["metaedit", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -360,11 +360,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["new", "--insert-before", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -374,11 +374,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["new", "--insert-after", "subject(glob:b)"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -388,11 +388,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["parallelize", "subject(glob:b)", "main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -402,11 +402,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["rebase", "-s=main", "-d=@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -420,7 +420,7 @@ fn test_rewrite_immutable_commands() {
     Hint: Could not modify commit: zsuskuln dfa21421 c
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 2 immutable commits.
     [EOF]
@@ -430,11 +430,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["rebase", "-r=main", "-d=@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -444,11 +444,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["resolve", "-r=subject(glob:merge)", "file"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -458,11 +458,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["restore", "-c=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -472,11 +472,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["restore", "--into=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -486,11 +486,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["split", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -500,11 +500,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["split", "-B=main", "-m", "will fail", "file"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -518,7 +518,7 @@ fn test_rewrite_immutable_commands() {
     Hint: Could not modify commit: kkmpptxz 9d190342 b
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 4 immutable commits.
     [EOF]
@@ -528,11 +528,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--from=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -542,11 +542,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--into=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -556,11 +556,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--after=main-"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -570,11 +570,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["squash", "--before=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -584,11 +584,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["sign", "-r=main", "--config=signing.backend=test"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]
@@ -598,11 +598,11 @@ fn test_rewrite_immutable_commands() {
     let output = work_dir.run_jj(["unsign", "-r=main"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Error: Commit 4397373a0991 is immutable
-    Hint: Could not modify commit: mzvwutvl 4397373a main | (conflict) merge
+    Error: Commit e44592029478 is immutable
+    Hint: Could not modify commit: mzvwutvl e4459202 main | (conflict) merge
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -530,7 +530,7 @@ fn test_log_bad_short_prefixes() {
       | ^---
       |
       = expected <strict_identifier> or <expression>
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -1365,7 +1365,7 @@ fn test_graph_styles() {
     Config error: Invalid type or value for ui.graph.style
     Caused by: unknown variant `unknown`, expected one of `ascii`, `ascii-large`, `curved`, `square`
 
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_new_command.rs
+++ b/cli/tests/test_new_command.rs
@@ -180,7 +180,7 @@ fn test_new_merge_conflicts() {
     let output = work_dir.run_jj(["new", "2|3"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 5234fbf2 (conflict) (empty) (no description set)
+    Working copy  (@) now at: vruxwmqv 0361ec6a (conflict) (empty) (no description set)
     Parent commit (@-)      : royxmykx 1b282e07 3 | 3
     Parent commit (@-)      : zsuskuln 7ac709e5 2 | 2
     Added 0 files, modified 1 files, removed 0 files
@@ -251,7 +251,7 @@ fn test_new_merge_same_change() {
     let output = work_dir.run_jj(["new", "2|3", "--config=merge.same-change=keep"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: znkkpsqq 0d655a01 (conflict) (empty) (no description set)
+    Working copy  (@) now at: znkkpsqq 453a144b (conflict) (empty) (no description set)
     Parent commit (@-)      : royxmykx 1b9fe696 3 | 3
     Parent commit (@-)      : zsuskuln 829e1e90 2 | 2
     Added 1 files, modified 0 files, removed 0 files

--- a/cli/tests/test_next_prev_commands.rs
+++ b/cli/tests/test_next_prev_commands.rs
@@ -929,7 +929,7 @@ fn test_next_conflict_head() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The working copy has no descendants with conflicts
-    Hint: Working copy: rlvkpnrz 5f088cac (conflict) (no description set)
+    Hint: Working copy: rlvkpnrz 09d24b1f (conflict) (no description set)
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -789,7 +789,7 @@ fn test_parallelize_no_immutable_non_base_commits() {
     Hint: Could not modify commit: kkmpptxz 6d01ab1f (empty) x1
     Hint: Immutable commits are used to protect shared history.
     Hint: For more information, see:
-          - https://jj-vcs.github.io/jj/latest/config/#set-of-immutable-commits
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
           - `jj help -k config`, "Set of immutable commits"
     Hint: This operation would rewrite 1 immutable commits.
     [EOF]

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -31,14 +31,14 @@ fn test_report_conflicts() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: zsuskuln dd37d4a5 (conflict) (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz c7f5d6e5 (conflict) C
+    Working copy  (@) now at: zsuskuln 1f0443b9 (conflict) (empty) (no description set)
+    Parent commit (@-)      : kkmpptxz 94037e0e (conflict) C
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 2 commits:
-      kkmpptxz c7f5d6e5 (conflict) C
-      rlvkpnrz 032a8668 (conflict) B
+      kkmpptxz 94037e0e (conflict) C
+      rlvkpnrz 871ac2e2 (conflict) B
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
       jj new rlvkpnrz
@@ -65,14 +65,14 @@ fn test_report_conflicts() {
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 2 descendant commits
-    Working copy  (@) now at: zsuskuln 5b511768 (conflict) (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz 0252a7f0 (conflict) C
+    Working copy  (@) now at: zsuskuln f525f3b5 (conflict) (empty) (no description set)
+    Parent commit (@-)      : kkmpptxz 2aa6a481 (conflict) C
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 2 commits:
-      kkmpptxz 0252a7f0 (conflict) C
-      rlvkpnrz fcfd7304 (conflict) B
+      kkmpptxz 2aa6a481 (conflict) C
+      rlvkpnrz 50a742b3 (conflict) B
     Hint: To resolve the conflicts, start by creating a commit on top of
     one of the first conflicted commits:
       jj new kkmpptxz
@@ -87,8 +87,8 @@ fn test_report_conflicts() {
     let output = work_dir.run_jj(["new", "rlvkpnrzqnoo"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 55514f4e (conflict) (empty) (no description set)
-    Parent commit (@-)      : rlvkpnrz fcfd7304 (conflict) B
+    Working copy  (@) now at: vruxwmqv 36e37773 (conflict) (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 50a742b3 (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
@@ -127,15 +127,15 @@ fn test_report_conflicts_with_divergent_commits() {
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits to destination
-    Working copy  (@) now at: zsuskuln?? 08a31f4f (conflict) C2
-    Parent commit (@-)      : kkmpptxz 099d6624 (conflict) B
+    Working copy  (@) now at: zsuskuln?? e91a430b (conflict) C2
+    Parent commit (@-)      : kkmpptxz fcd54aca (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 3 commits:
-      zsuskuln?? df34134a (conflict) C3
-      zsuskuln?? 08a31f4f (conflict) C2
-      kkmpptxz 099d6624 (conflict) B
+      zsuskuln?? 33d16252 (conflict) C3
+      zsuskuln?? e91a430b (conflict) C2
+      kkmpptxz fcd54aca (conflict) B
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
       jj new kkmpptxz
@@ -161,13 +161,13 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: zsuskuln?? dfe73891 (conflict) C2
+    Working copy  (@) now at: zsuskuln?? 151c23fc (conflict) C2
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 1 commits:
-      zsuskuln?? dfe73891 (conflict) C2
+      zsuskuln?? 151c23fc (conflict) C2
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new zsuskuln
@@ -182,7 +182,7 @@ fn test_report_conflicts_with_divergent_commits() {
     ------- stderr -------
     Rebased 1 commits to destination
     New conflicts appeared in 1 commits:
-      zsuskuln?? 02834578 (conflict) C3
+      zsuskuln?? d59fa233 (conflict) C3
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new zsuskuln
@@ -234,14 +234,14 @@ fn test_report_conflicts_with_resolving_conflicts_hint_disabled() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: zsuskuln dd37d4a5 (conflict) (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz c7f5d6e5 (conflict) C
+    Working copy  (@) now at: zsuskuln 1f0443b9 (conflict) (empty) (no description set)
+    Parent commit (@-)      : kkmpptxz 94037e0e (conflict) C
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 2 commits:
-      kkmpptxz c7f5d6e5 (conflict) C
-      rlvkpnrz 032a8668 (conflict) B
+      kkmpptxz 94037e0e (conflict) C
+      rlvkpnrz 871ac2e2 (conflict) B
     [EOF]
     ");
 }

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -215,14 +215,14 @@ fn test_resolution() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 0d40d2b8 conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv e4a8cd2d conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 45537d53 a | a
     Parent commit (@-)      : royxmykx 89d1b299 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 0d40d2b8 conflict | (conflict) conflict
+      vruxwmqv e4a8cd2d conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -359,14 +359,14 @@ fn test_resolution() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv d5f058ec conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv fe2a966d conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 45537d53 a | a
     Parent commit (@-)      : royxmykx 89d1b299 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv d5f058ec conflict | (conflict) conflict
+      vruxwmqv fe2a966d conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -438,14 +438,14 @@ fn test_resolution() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 6c205356 conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv 16d4ec9a conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 45537d53 a | a
     Parent commit (@-)      : royxmykx 89d1b299 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 6c205356 conflict | (conflict) conflict
+      vruxwmqv 16d4ec9a conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -743,15 +743,15 @@ fn test_simplify_conflict_sides() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: fileB
-    Working copy  (@) now at: nkmrtpmo 25c5dd0b conflict | (conflict) conflict
-    Parent commit (@-)      : kmkuslsw ccb05364 conflictA | (conflict) (empty) conflictA
-    Parent commit (@-)      : lylxulpl d9bc60cb conflictB | (conflict) (empty) conflictB
+    Working copy  (@) now at: nkmrtpmo e2260d62 conflict | (conflict) conflict
+    Parent commit (@-)      : kmkuslsw 73b61e6e conflictA | (conflict) (empty) conflictA
+    Parent commit (@-)      : lylxulpl 563db74e conflictB | (conflict) (empty) conflictB
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     fileA    2-sided conflict
     fileB    2-sided conflict
     New conflicts appeared in 1 commits:
-      nkmrtpmo 25c5dd0b conflict | (conflict) conflict
+      nkmrtpmo e2260d62 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new nkmrtpmo
@@ -977,14 +977,14 @@ fn test_resolve_conflicts_with_executable() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file1
-    Working copy  (@) now at: znkkpsqq 8ab9c54e conflict | (conflict) conflict
+    Working copy  (@) now at: znkkpsqq dd280a2f conflict | (conflict) conflict
     Parent commit (@-)      : mzvwutvl 86f7f0e3 a | a
     Parent commit (@-)      : yqosqzyt 36361412 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict including an executable
     New conflicts appeared in 1 commits:
-      znkkpsqq 8ab9c54e conflict | (conflict) conflict
+      znkkpsqq dd280a2f conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new znkkpsqq
@@ -1021,14 +1021,14 @@ fn test_resolve_conflicts_with_executable() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file2
-    Working copy  (@) now at: znkkpsqq d47830a6 conflict | (conflict) conflict
+    Working copy  (@) now at: znkkpsqq 6a536f34 conflict | (conflict) conflict
     Parent commit (@-)      : mzvwutvl 86f7f0e3 a | a
     Parent commit (@-)      : yqosqzyt 36361412 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file1    2-sided conflict including an executable
     New conflicts appeared in 1 commits:
-      znkkpsqq d47830a6 conflict | (conflict) conflict
+      znkkpsqq 6a536f34 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new znkkpsqq
@@ -1204,7 +1204,7 @@ fn test_resolve_change_delete_executable() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["log", "--git"]), @r"
-    @    kmkuslsw test.user@example.com 2001-02-03 08:05:18 conflict 7a7ac759 conflict
+    @    kmkuslsw test.user@example.com 2001-02-03 08:05:18 conflict 861671a0 conflict
     ├─╮  (empty) conflict
     │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:17 b 888b6cc3
     │ │  b
@@ -1305,7 +1305,7 @@ fn test_resolve_change_delete_executable() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file2
-    Working copy  (@) now at: kmkuslsw 1323520e conflict | (conflict) conflict
+    Working copy  (@) now at: kmkuslsw 50de8ae5 conflict | (conflict) conflict
     Parent commit (@-)      : mzvwutvl e2d3924b a | a
     Parent commit (@-)      : vruxwmqv 888b6cc3 b | b
     Added 0 files, modified 1 files, removed 0 files
@@ -1336,7 +1336,7 @@ fn test_resolve_change_delete_executable() {
     let output = work_dir.run_jj(["resolve", "file4", "--tool=:ours"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: kmkuslsw 630e8689 conflict | (conflict) conflict
+    Working copy  (@) now at: kmkuslsw 94218b9e conflict | (conflict) conflict
     Parent commit (@-)      : mzvwutvl e2d3924b a | a
     Parent commit (@-)      : vruxwmqv 888b6cc3 b | b
     Added 0 files, modified 1 files, removed 0 files
@@ -1511,14 +1511,14 @@ fn test_resolve_long_conflict_markers() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 1e254ee3 conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv c0d761e3 conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 10d994ef a | a
     Parent commit (@-)      : royxmykx 7f215575 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 1e254ee3 conflict | (conflict) conflict
+      vruxwmqv c0d761e3 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -1581,14 +1581,14 @@ fn test_resolve_long_conflict_markers() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 2481a401 conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv eab21a40 conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 10d994ef a | a
     Parent commit (@-)      : royxmykx 7f215575 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 2481a401 conflict | (conflict) conflict
+      vruxwmqv eab21a40 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -1657,14 +1657,14 @@ fn test_resolve_long_conflict_markers() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: file
-    Working copy  (@) now at: vruxwmqv 2cf0bfd3 conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv cd9cf2ca conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 10d994ef a | a
     Parent commit (@-)      : royxmykx 7f215575 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 2cf0bfd3 conflict | (conflict) conflict
+      vruxwmqv cd9cf2ca conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -1790,14 +1790,14 @@ fn test_multiple_conflicts() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Resolving conflicts in: another_file
-    Working copy  (@) now at: vruxwmqv d3584f6e conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv 57b85650 conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 2c821f70 a | a
     Parent commit (@-)      : royxmykx 4c2029de b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     this_file_has_a_very_long_name_to_test_padding 2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv d3584f6e conflict | (conflict) conflict
+      vruxwmqv 57b85650 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -1962,14 +1962,14 @@ fn test_multiple_conflicts_with_error() {
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
-    Working copy  (@) now at: vruxwmqv 98296abe conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv 7fb57d04 conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 6c31698c a | a
     Parent commit (@-)      : royxmykx ba0a5538 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 98296abe conflict | (conflict) conflict
+      vruxwmqv 7fb57d04 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv
@@ -2014,14 +2014,14 @@ fn test_multiple_conflicts_with_error() {
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
-    Working copy  (@) now at: vruxwmqv 7daa6406 conflict | (conflict) conflict
+    Working copy  (@) now at: vruxwmqv 0a5265e6 conflict | (conflict) conflict
     Parent commit (@-)      : zsuskuln 6c31698c a | a
     Parent commit (@-)      : royxmykx ba0a5538 b | b
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict
     New conflicts appeared in 1 commits:
-      vruxwmqv 7daa6406 conflict | (conflict) conflict
+      vruxwmqv 0a5265e6 conflict | (conflict) conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new vruxwmqv

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -67,13 +67,13 @@ fn test_restore() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 descendant commits
-    Working copy  (@) now at: kkmpptxz 4f7af0b0 (conflict) (no description set)
+    Working copy  (@) now at: kkmpptxz 315c9388 (conflict) (no description set)
     Parent commit (@-)      : rlvkpnrz 67841e01 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file2    2-sided conflict including 1 deletion
     New conflicts appeared in 1 commits:
-      kkmpptxz 4f7af0b0 (conflict) (no description set)
+      kkmpptxz 315c9388 (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new kkmpptxz
@@ -218,7 +218,7 @@ fn test_restore_conflicted_merge() {
     let output = work_dir.run_jj(["restore", "file"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv f587c5e5 conflict | (conflict) (empty) conflict
+    Working copy  (@) now at: vruxwmqv 45d86d72 conflict | (conflict) (empty) conflict
     Parent commit (@-)      : zsuskuln 45537d53 a | a
     Parent commit (@-)      : royxmykx 89d1b299 b | b
     Added 0 files, modified 1 files, removed 0 files
@@ -257,7 +257,7 @@ fn test_restore_conflicted_merge() {
     let output = work_dir.run_jj(["restore"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Working copy  (@) now at: vruxwmqv 846bb35c conflict | (conflict) (empty) conflict
+    Working copy  (@) now at: vruxwmqv e46a78b9 conflict | (conflict) (empty) conflict
     Parent commit (@-)      : zsuskuln 45537d53 a | a
     Parent commit (@-)      : royxmykx 89d1b299 b | b
     Added 0 files, modified 1 files, removed 0 files

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -45,7 +45,7 @@ fn test_syntax_error() {
       |    ^---
       |
       = expected `::`, `..`, `~`, or <primary>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -217,7 +217,7 @@ fn test_bad_function_call() {
       |     ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-    Hint: See https://jj-vcs.github.io/jj/latest/filesets/ or use `jj help -k filesets` for filesets syntax and how to match file paths.
+    Hint: See https://docs.jj-vcs.dev/latest/filesets/ or use `jj help -k filesets` for filesets syntax and how to match file paths.
     [EOF]
     [exit status: 1]
     ");
@@ -240,7 +240,7 @@ fn test_bad_function_call() {
       |
       = Invalid file pattern
     3: Invalid file pattern kind `foo:`
-    Hint: See https://jj-vcs.github.io/jj/latest/filesets/#file-patterns or `jj help -k filesets` for valid prefixes.
+    Hint: See https://docs.jj-vcs.dev/latest/filesets/#file-patterns or `jj help -k filesets` for valid prefixes.
     [EOF]
     [exit status: 1]
     "#);
@@ -356,7 +356,7 @@ fn test_bad_function_call() {
       |                  ^---
       |
       = expected <strict_identifier> or <expression>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -371,7 +371,7 @@ fn test_bad_function_call() {
       |                         ^---
       |
       = expected <expression>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -597,7 +597,7 @@ fn test_alias() {
       |           ^---
       |
       = expected `::`, `..`, `~`, or <primary>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
     [EOF]
     [exit status: 1]
     ");
@@ -926,7 +926,7 @@ fn test_all_modifier() {
       |    ^
       |
       = `:` is not an infix operator
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_sign_unsign_commands.rs
+++ b/cli/tests/test_sign_unsign_commands.rs
@@ -298,7 +298,7 @@ backend = "none"
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: No signing backend configured
-    Hint: For configuring a signing backend, see https://jj-vcs.github.io/jj/latest/config/#commit-signing
+    Hint: For configuring a signing backend, see https://docs.jj-vcs.dev/latest/config/#commit-signing
     [EOF]
     [exit status: 1]
     ");

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -875,10 +875,10 @@ fn test_squash_from_multiple() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: kpqxywon 703c6f0c f | (no description set)
-    Parent commit (@-)      : yostqsxw 3d6a1899 e | (no description set)
+    Working copy  (@) now at: kpqxywon 0b695306 f | (no description set)
+    Parent commit (@-)      : yostqsxw ff064d52 e | (no description set)
     New conflicts appeared in 1 commits:
-      yqosqzyt a3221d7a d | (conflict) (no description set)
+      yqosqzyt 61130da4 d | (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new yqosqzyt
@@ -888,10 +888,10 @@ fn test_squash_from_multiple() {
     [EOF]
     "###);
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @  703c6f0cae6f f
-    ○    3d6a18995cae e
+    @  0b6953066ee0 f
+    ○    ff064d529578 e
     ├─╮
-    × │  a3221d7ae02a d
+    × │  61130da4e714 d
     ├─╯
     ○  e88768e65e67 a b c
     ◆  000000000000 (empty)
@@ -1019,10 +1019,10 @@ fn test_squash_from_multiple_partial() {
     insta::assert_snapshot!(output, @r###"
     ------- stderr -------
     Rebased 2 descendant commits
-    Working copy  (@) now at: kpqxywon f3ae0274 f | (no description set)
-    Parent commit (@-)      : yostqsxw 45ad30bd e | (no description set)
+    Working copy  (@) now at: kpqxywon a724910c f | (no description set)
+    Parent commit (@-)      : yostqsxw 1bc405e1 e | (no description set)
     New conflicts appeared in 1 commits:
-      yqosqzyt 15efa8c0 d | (conflict) (no description set)
+      yqosqzyt 7ddfe685 d | (conflict) (no description set)
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new yqosqzyt
@@ -1032,13 +1032,13 @@ fn test_squash_from_multiple_partial() {
     [EOF]
     "###);
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
-    @  f3ae0274fb6c f
-    ○      45ad30bdccc6 e
+    @  a724910cd361 f
+    ○      1bc405e12b68 e
     ├─┬─╮
     │ │ ○  e9db15b956c4 b
     │ ○ │  83cbe51db94d c
     │ ├─╯
-    × │  15efa8c069e0 d
+    × │  7ddfe6857387 d
     ├─╯
     ○  64ea60be8d77 a
     ◆  000000000000 (empty)

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -242,11 +242,11 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @r"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 7e0bc4cf conflict
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 6e3ffaa1 conflict
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 681c71af conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 7f9e90e6 conflict
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 30558616 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 f024cc11 conflict
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change
@@ -261,8 +261,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @r###"
     The working copy has no changes.
-    Working copy  (@) : yqosqzyt 7e0bc4cf (conflict) (empty) boom-cont-2
-    Parent commit (@-): royxmykx 681c71af (conflict) (empty) boom-cont
+    Working copy  (@) : yqosqzyt 6e3ffaa1 (conflict) (empty) boom-cont-2
+    Parent commit (@-): royxmykx 7f9e90e6 (conflict) (empty) boom-cont
     Warning: There are unresolved conflicts at these paths:
     conflicted.txt    2-sided conflict
     Hint: To resolve the conflicts, start by creating a commit on top of
@@ -277,8 +277,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status", "--color=always"]);
     insta::assert_snapshot!(output, @r###"
     The working copy has no changes.
-    Working copy  (@) : [1m[38;5;13my[38;5;8mqosqzyt[39m [38;5;12m7[38;5;8me0bc4cf[39m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
-    Parent commit (@-): [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m6[0m[38;5;8m81c71af[39m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
+    Working copy  (@) : [1m[38;5;13my[38;5;8mqosqzyt[39m [38;5;12m6[38;5;8me3ffaa1[39m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
+    Parent commit (@-): [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m7[0m[38;5;8mf9e90e6[39m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
     [1m[38;5;3mWarning: [39mThere are unresolved conflicts at these paths:[0m
     conflicted.txt    [38;5;3m2-sided conflict[39m
     [1m[38;5;6mHint: [0m[39mTo resolve the conflicts, start by creating a commit on top of[39m
@@ -293,8 +293,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status", "--config=hints.resolving-conflicts=false"]);
     insta::assert_snapshot!(output, @r"
     The working copy has no changes.
-    Working copy  (@) : yqosqzyt 7e0bc4cf (conflict) (empty) boom-cont-2
-    Parent commit (@-): royxmykx 681c71af (conflict) (empty) boom-cont
+    Working copy  (@) : yqosqzyt 6e3ffaa1 (conflict) (empty) boom-cont-2
+    Parent commit (@-): royxmykx 7f9e90e6 (conflict) (empty) boom-cont
     Warning: There are unresolved conflicts at these paths:
     conflicted.txt    2-sided conflict
     [EOF]
@@ -312,15 +312,15 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @r"
-    @  wqnwkozp test.user@example.com 2001-02-03 08:05:20 cc7d68f7
+    @  wqnwkozp test.user@example.com 2001-02-03 08:05:20 1ad2785d
     │  fixed 2
-    ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 812e2163
+    ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 aeb3b829
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 7e0bc4cf conflict
+    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 6e3ffaa1 conflict
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 681c71af conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 7f9e90e6 conflict
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 30558616 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 f024cc11 conflict
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change
@@ -337,8 +337,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     insta::assert_snapshot!(output, @r"
     Working copy changes:
     M conflicted.txt
-    Working copy  (@) : wqnwkozp cc7d68f7 fixed 2
-    Parent commit (@-): kmkuslsw 812e2163 fixed 1
+    Working copy  (@) : wqnwkozp 1ad2785d fixed 2
+    Parent commit (@-): kmkuslsw aeb3b829 fixed 1
     [EOF]
     ");
 
@@ -348,15 +348,15 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @r"
-    ○  wqnwkozp test.user@example.com 2001-02-03 08:05:20 cc7d68f7
+    ○  wqnwkozp test.user@example.com 2001-02-03 08:05:20 1ad2785d
     │  fixed 2
-    @  kmkuslsw test.user@example.com 2001-02-03 08:05:19 812e2163
+    @  kmkuslsw test.user@example.com 2001-02-03 08:05:19 aeb3b829
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 7e0bc4cf conflict
+    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 6e3ffaa1 conflict
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 681c71af conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 7f9e90e6 conflict
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 30558616 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 f024cc11 conflict
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change
@@ -373,8 +373,8 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     insta::assert_snapshot!(output, @r"
     Working copy changes:
     M conflicted.txt
-    Working copy  (@) : kmkuslsw 812e2163 fixed 1
-    Parent commit (@-): yqosqzyt 7e0bc4cf (conflict) (empty) boom-cont-2
+    Working copy  (@) : kmkuslsw aeb3b829 fixed 1
+    Parent commit (@-): yqosqzyt 6e3ffaa1 (conflict) (empty) boom-cont-2
     Hint: Conflict in parent commit has been resolved in working copy
     [EOF]
     ");
@@ -386,15 +386,15 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @r"
-    ○  wqnwkozp test.user@example.com 2001-02-03 08:05:20 cc7d68f7
+    ○  wqnwkozp test.user@example.com 2001-02-03 08:05:20 1ad2785d
     │  fixed 2
-    ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 812e2163
+    ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 aeb3b829
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 7e0bc4cf conflict
+    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 6e3ffaa1 conflict
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 681c71af conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 7f9e90e6 conflict
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 30558616 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 f024cc11 conflict
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change
@@ -443,9 +443,9 @@ fn test_status_simplify_conflict_sides() {
     insta::assert_snapshot!(work_dir.run_jj(["status"]),
     @r###"
     The working copy has no changes.
-    Working copy  (@) : nkmrtpmo a5a545ce conflict | (conflict) (empty) conflict
-    Parent commit (@-): kmkuslsw ccb05364 conflictA | (conflict) (empty) conflictA
-    Parent commit (@-): lylxulpl d9bc60cb conflictB | (conflict) (empty) conflictB
+    Working copy  (@) : nkmrtpmo 14a0b4b7 conflict | (conflict) (empty) conflict
+    Parent commit (@-): kmkuslsw 73b61e6e conflictA | (conflict) (empty) conflictA
+    Parent commit (@-): lylxulpl 563db74e conflictB | (conflict) (empty) conflictB
     Warning: There are unresolved conflicts at these paths:
     fileA    2-sided conflict
     fileB    2-sided conflict

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -142,7 +142,7 @@ fn test_tag_bad_name() {
       | ^---
       |
       = expected <identifier>, <string_literal>, or <raw_string_literal>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -159,7 +159,7 @@ fn test_tag_bad_name() {
       | ^^
       |
       = Expected non-empty string
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");
@@ -176,7 +176,7 @@ fn test_tag_bad_name() {
       |    ^---
       |
       = expected <EOI>
-    Hint: See https://jj-vcs.github.io/jj/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for how to quote symbols.
     [EOF]
     [exit status: 2]
     ");

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -28,7 +28,7 @@ fn test_util_config_schema() {
             "$comment": "`taplo` and the corresponding VS Code plugins only support version draft-04 of JSON Schema, see <https://taplo.tamasfe.dev/configuration/developing-schemas.html>. draft-07 is mostly compatible with it, newer versions may not be.",
             "title": "Jujutsu config",
             "type": "object",
-            "description": "User configuration for Jujutsu VCS. See https://jj-vcs.github.io/jj/latest/config/ for details",
+            "description": "User configuration for Jujutsu VCS. See https://docs.jj-vcs.dev/latest/config/ for details",
             "properties": {
                 [...]
             }

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -95,7 +95,7 @@ fn test_snapshot_large_file() {
     ------- stderr -------
     Config error: Invalid type or value for snapshot.max-new-file-size
     Caused by: Expected a positive integer or a string in '<number><unit>' form
-    For help, see https://jj-vcs.github.io/jj/latest/config/ or use `jj help -k config`.
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
     [EOF]
     [exit status: 1]
     ");
@@ -365,7 +365,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // Working copy should contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("24e92a40dcc49af78b9a96b9c9ee4e50416fb020e1f2a6e3d6c79cb9f602c18363ad61dac496199068a811e55edb406aeb6dcc3382162e2e632de52d01d0208b")
+    Current operation: OperationId("53f0bb27f3ac96896abd48a5fb0fdfcf4e61389a70290468a2e1ec1db5389661fc6e4aec6c1d03f1bd7db07cafa9f6a802dc5e78c936c09e7dbd9aea1b4ea2fa")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]), .. }
     Normal { <executable> }           249 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -399,7 +399,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     insta::assert_snapshot!(output, @r"
     Working copy changes:
     M file
-    Working copy  (@) : mzvwutvl b6b012dc (conflict) (no description set)
+    Working copy  (@) : mzvwutvl 0cb93a38 (conflict) (no description set)
     Parent commit (@-): rlvkpnrz ccf9527c side-a
     Parent commit (@-): zsuskuln d7acaf48 side-b
     Warning: There are unresolved conflicts at these paths:
@@ -428,7 +428,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // Working copy should still contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("fec98cc5f0ab48ff5cc57fc13f82ad50270a26226426b2849c4e14decfc9c588617344f6a250594df652a25259335651662e1896c96684944b810505fb90907b")
+    Current operation: OperationId("d9ace267ba6a972d19d345fadcfa2177f42e4ea6c11ff4a44e70c034322c233372edfe6169e14292f0cc5d43d43c42329a7a0fa8231b524a43a73fba96b8f114")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]), .. }
     Normal { <executable> }           289 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -463,7 +463,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // working copy
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("52a48bfa7fe015cd99a2e7172c78da044f04ca92dee7e7d9dfb4024cf1ec236cecfacbff78db4e9844e39368f95776f61dbfe9d613d41d683d7d9a3ae351e267")
+    Current operation: OperationId("77a5650168d075d4b3171483acafab04e2822ae3ff1d30d2cdb1ae4bcb6d7739439847891752cc9408a356438e0762a8acc4ae9473c0a9c06619ea71d60984a0")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")), .. }
     Normal { <executable> }           130 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -530,7 +530,7 @@ fn test_workspaces_conflicting_edits() {
     ------- stderr -------
     Error: The working copy is stale (not updated since operation bd4f780d0422).
     Hint: Run `jj workspace update-stale` to update it.
-    See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
+    See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
     [exit status: 1]
     ");
@@ -540,7 +540,7 @@ fn test_workspaces_conflicting_edits() {
     ------- stderr -------
     Error: The working copy is stale (not updated since operation bd4f780d0422).
     Hint: Run `jj workspace update-stale` to update it.
-    See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
+    See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
     [exit status: 1]
     ");
@@ -561,7 +561,7 @@ fn test_workspaces_conflicting_edits() {
     insta::assert_snapshot!(get_log_output(&secondary_dir),
     @r"
     @  90f3d42e0bff secondary@ (divergent)
-    │ ×  de7155dbea42 (divergent)
+    │ ×  3ef90f18334b (divergent)
     ├─╯
     │ ○  3a9b690d6e67 default@
     ├─╯
@@ -572,7 +572,7 @@ fn test_workspaces_conflicting_edits() {
     // The stale working copy should have been resolved by the previous command
     insta::assert_snapshot!(get_log_output(&secondary_dir), @r"
     @  90f3d42e0bff secondary@ (divergent)
-    │ ×  de7155dbea42 (divergent)
+    │ ×  3ef90f18334b (divergent)
     ├─╯
     │ ○  3a9b690d6e67 default@
     ├─╯
@@ -631,7 +631,7 @@ fn test_workspaces_updated_by_other() {
     ------- stderr -------
     Error: The working copy is stale (not updated since operation bd4f780d0422).
     Hint: Run `jj workspace update-stale` to update it.
-    See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
+    See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
     [exit status: 1]
     ");
@@ -831,7 +831,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ------- stderr -------
         Error: Could not read working copy's operation.
         Hint: Run `jj workspace update-stale` to recover.
-        See https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy for more information.
+        See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
         [EOF]
         [exit status: 1]
         ");

--- a/docs/config.md
+++ b/docs/config.md
@@ -1828,7 +1828,7 @@ enable schema validation in your editor, add this line at the top of your TOML
 config files:
 
 ```toml
-#:schema https://jj-vcs.github.io/jj/latest/config-schema.json
+#:schema https://docs.jj-vcs.dev/latest/config-schema.json
 ```
 
 This enables features like:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,7 +101,7 @@ stakeholders, which we do with [Design Docs](design_docs.md), see the
 We appreciate [bug
 reports](https://github.com/jj-vcs/jj/issues/new?template=bug_report.md)
 about any problems, however small, lurking in [our documentation
-website](https://jj-vcs.github.io/jj/prerelease) or in the `jj help
+website](https://docs.jj-vcs.dev/prerelease) or in the `jj help
 <command>` docs. If a part of the bug report template does not apply, you can
 just delete it.
 
@@ -390,7 +390,7 @@ You can customize this configuration using
 ## Previewing the HTML documentation
 
 The documentation for `jj` is automatically published online at
-<https://jj-vcs.github.io/jj/>.
+<https://docs.jj-vcs.dev/>.
 
 When editing documentation, you should check your changes locally — especially
 if you are adding a new page, or doing a major rewrite.
@@ -480,8 +480,8 @@ MKDOCS_OFFLINE=true uv run mkdocs build
 
 The full `jj` website includes the documentation for several `jj` versions
 (`prerelease`, latest release, and the older releases). The top-level
-URL <https://jj-vcs.github.io/jj> redirects to
-<https://jj-vcs.github.io/jj/latest>, which in turn redirects to
+URL <https://docs.jj-vcs.dev> redirects to
+<https://docs.jj-vcs.dev/latest>, which in turn redirects to
 the docs for the last stable version.
 
 The different versions of documentation are managed and deployed with
@@ -550,12 +550,12 @@ If you need to do something more complicated, you can use `uv run mike
 ...` commands. You can also edit the `gh-pages` bookmark directly, but take care
 to avoid files that will be overwritten by future invocations of `mike`. Then,
 you can submit a PR based on the `gh-pages` bookmark of
-<https://jj-vcs.github.com/jj> (instead of the usual `main` bookmark).
+<https://docs.jj-vcs.dev/> (instead of the usual `main` bookmark).
 
 Previously, the version switcher would not work unless the value of the
 `site_url` config in `mkdocs.yml` matched the actual URL the site is being
 served from. This bug should now be fixed, but if you are not serving the site
-from <https://jj-vcs.github.com/jj> and something fails weirdly, you might want
+from <https://docs.jj-vcs.dev/> and something fails weirdly, you might want
 to adjust the `site_url` to something like `https://jjfan.github.io/jj`.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ Additional help is available using the `jj help` command if you have
 
 You may want to jump to:
 
-- Documentation for the [latest released version of `jj`](https://jj-vcs.github.io/jj/latest).
-- Documentation for the [unreleased version of `jj`](https://jj-vcs.github.io/jj/prerelease). This version of the docs corresponds to the `main` branch of the `jj` repo.
+- Documentation for the [latest released version of `jj`](https://docs.jj-vcs.dev/latest).
+- Documentation for the [unreleased version of `jj`](https://docs.jj-vcs.dev/prerelease). This version of the docs corresponds to the `main` branch of the `jj` repo.
 
 ## Some useful links
 

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -564,9 +564,8 @@ impl ConfigFile {
                 source: error,
             })) if error.kind() == io::ErrorKind::NotFound => {
                 let mut data = DocumentMut::new();
-                data.decor_mut().set_prefix(
-                    "#:schema https://jj-vcs.github.io/jj/latest/config-schema.json\n\n",
-                );
+                data.decor_mut()
+                    .set_prefix("#:schema https://docs.jj-vcs.dev/latest/config-schema.json\n\n");
                 let layer = ConfigLayer {
                     source,
                     path: Some(path),

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1468,13 +1468,13 @@ fn write_tree_conflict(
     .collect_vec();
     let readme_id = repo
         .write_blob(
-            r#"This commit was made by jj, https://github.com/jj-vcs/jj.
+            r#"This commit was made by jj, https://jj-vcs.dev/.
 The commit contains file conflicts, and therefore looks wrong when used with plain
 Git or other tools that are unfamiliar with jj.
 
 The .jjconflict-* directories represent the different inputs to the conflict.
 For details, see
-https://jj-vcs.github.io/jj/prerelease/git-compatibility/#format-mapping-details
+https://docs.jj-vcs.dev/prerelease/git-compatibility/#format-mapping-details
 
 If you see this file in your working copy, it probably means that you used a
 regular `git` command to check out a conflicted commit. Use `jj abandon` to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: !ENV [MKDOCS_SITE_NAME, 'Jujutsu docs']
 site_dir: 'rendered-docs'
 # Not having this (or viewing the site locally, or from any place other than the
 # site_url) leads to version switching failing to preserve the current path.
-site_url: 'https://jj-vcs.github.io/jj/'
+site_url: 'https://docs.jj-vcs.dev/'
 repo_url: https://github.com/jj-vcs/jj
 repo_name: jj-vcs/jj
 edit_uri: edit/main/docs/


### PR DESCRIPTION
As a follow-up to #8115, this moves all references in the codebase to use the new website.

I didn't update the older CHANGELOG entries because I figured they're intended to be immutable.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
