### PR TITLE
snapshots: Add a global flag `--snapshot-name`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,9 @@ should not be broken.
 * Added `join()` template function. This is different from `separate()` in that
   it adds a separator between all arguments, even if empty.
 
+* Added a global option `--snapshot-name`. This overrides the default name of
+  the snapshot in the op log, allowing you to easily find it later.
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -191,6 +191,9 @@ To get started, see the tutorial [`jj help -k tutorial`].
    By default, Jujutsu snapshots the working copy at the beginning of every command. The working copy is also updated at the end of the command, if the command modified the working-copy commit (`@`). If you want to avoid snapshotting the working copy and instead see a possibly stale working-copy commit, you can use `--ignore-working-copy`. This may be useful e.g. in a command prompt, especially if you have another process that commits the working copy.
 
    Loading the repository at a specific operation with `--at-operation` implies `--ignore-working-copy`.
+* `--snapshot-name <SNAPSHOT_NAME>` — When taking the snapshot of the working copy, sets the name of the transaction in the operation log.
+
+   Note: When this flag is provided, jj will create operations even if no files have been changed.
 * `--ignore-immutable` — Allow rewriting immutable commits
 
    By default, Jujutsu prevents rewriting commits in the configured set of immutable commits. This option disables that check and lets you rewrite any commit but the root commit.

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -199,13 +199,14 @@ fn test_bookmark_names() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.complete_fish(["bookmark", "rename", ""]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     aaa-local	x
     aaa-tracked	x
     bbb-local	x
     bbb-tracked	x
     --repository	Path to repository to operate on
     --ignore-working-copy	Don't snapshot the working copy, and don't update it
+    --snapshot-name	When taking the snapshot of the working copy, sets the name of the transaction in the operation log
     --ignore-immutable	Allow rewriting immutable commits
     --at-operation	Operation to load the repo at
     --debug	Enable debug logging
@@ -216,7 +217,7 @@ fn test_bookmark_names() {
     --config-file	Additional configuration files (can be repeated)
     --help	Print help (see more with '--help')
     [EOF]
-    ");
+    "###);
 
     let output = work_dir.complete_fish(["bookmark", "rename", "a"]);
     insta::assert_snapshot!(output, @r"

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -1039,7 +1039,7 @@ fn test_help() {
     let test_env = TestEnvironment::default();
 
     let output = test_env.run_jj_in(".", ["diffedit", "-h"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r###"
     Touch up the content changes in a revision with a diff editor
 
     Usage: jj diffedit [OPTIONS] [FILESETS]...
@@ -1056,19 +1056,21 @@ fn test_help() {
       -h, --help                 Print help (see more with '--help')
 
     Global Options:
-      -R, --repository <REPOSITORY>      Path to repository to operate on
-          --ignore-working-copy          Don't snapshot the working copy, and don't update it
-          --ignore-immutable             Allow rewriting immutable commits
-          --at-operation <AT_OPERATION>  Operation to load the repo at [aliases: --at-op]
-          --debug                        Enable debug logging
-          --color <WHEN>                 When to colorize output [possible values: always, never, debug,
-                                         auto]
-          --quiet                        Silence non-primary command output
-          --no-pager                     Disable the pager
-          --config <NAME=VALUE>          Additional configuration options (can be repeated)
-          --config-file <PATH>           Additional configuration files (can be repeated)
+      -R, --repository <REPOSITORY>        Path to repository to operate on
+          --ignore-working-copy            Don't snapshot the working copy, and don't update it
+          --snapshot-name <SNAPSHOT_NAME>  When taking the snapshot of the working copy, sets the name
+                                           of the transaction in the operation log
+          --ignore-immutable               Allow rewriting immutable commits
+          --at-operation <AT_OPERATION>    Operation to load the repo at [aliases: --at-op]
+          --debug                          Enable debug logging
+          --color <WHEN>                   When to colorize output [possible values: always, never,
+                                           debug, auto]
+          --quiet                          Silence non-primary command output
+          --no-pager                       Disable the pager
+          --config <NAME=VALUE>            Additional configuration options (can be repeated)
+          --config-file <PATH>             Additional configuration files (can be repeated)
     [EOF]
-    ");
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
This overrides the default name of the snapshot in the op log, allowing you to easily find it later. This helps with several workflows.
* Manually naming a snapshot before taking a risky change so I can come back to it later
* AI agents can take a snapshot before editing your repo so you can easily revert bad changes that it made.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes

Fixes #3428