### PR TITLE
working-copy: Ensure sub-repos are not tracked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ should not be broken.
   is not read anymore. Use `$XDG_CONFIG_HOME/jj` instead (defaults to
   `~/.config/jj`).
 
+* Sub-repos are no longer tracked. Any directory containing `.jj` or `.git`
+  is ignored. Note that git submodules are unaffected by this.
+
 ### Deprecations
 
 * The `--destination`/`-d` arguments for `jj rebase`, `jj split`, `jj revert`,
@@ -124,6 +127,9 @@ should not be broken.
 * Nushell completion script documentation add `-f` option, to keep it up to
   date.
   [#8007](https://github.com/jj-vcs/jj/issues/8007)
+
+* Ensured that with git submodules, remnants of your submodules do not show up
+  in the working copy after running `jj new`
 
 ## [0.35.0] - 2025-11-05
 

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -440,11 +440,11 @@ fn test_workspaces_add_workspace_in_current_workspace() {
 
     // Workspace created despite warning
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @r"
-    default: rlvkpnrz af2d0cd5 (no description set)
+    insta::assert_snapshot!(output, @r###"
+    default: rlvkpnrz 504e3d8c (empty) (no description set)
     secondary: pmmvwywv 058f604d (empty) (no description set)
     [EOF]
-    ");
+    "###);
 
     // Use explicit path instead (no warning)
     let output = main_dir.run_jj(["workspace", "add", "./third"]);
@@ -459,22 +459,18 @@ fn test_workspaces_add_workspace_in_current_workspace() {
 
     // Both workspaces created
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @r"
-    default: rlvkpnrz b2288847 (no description set)
+    insta::assert_snapshot!(output, @r###"
+    default: rlvkpnrz 504e3d8c (empty) (no description set)
     secondary: pmmvwywv 058f604d (empty) (no description set)
     third: zxsnswpr 1c1effec (empty) (no description set)
     [EOF]
-    ");
+    "###);
 
-    // Can see files from the other workspaces in main workspace, since they are
-    // child directories and will therefore be snapshotted
     let output = main_dir.run_jj(["file", "list"]);
-    insta::assert_snapshot!(output.normalize_backslash(), @r"
+    insta::assert_snapshot!(output.normalize_backslash(), @r###"
     file
-    secondary/file
-    third/file
     [EOF]
-    ");
+    "###);
 }
 
 /// Test making changes to the working copy in a workspace as it gets rewritten

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -1350,6 +1350,16 @@ fn test_dotgit_ignored() {
     testutils::write_working_copy_file(&workspace_root, repo_path(".git"), "contents");
     let new_tree = test_workspace.snapshot().unwrap();
     assert_tree_eq!(new_tree, empty_tree);
+    std::fs::remove_file(workspace_root.join(".git")).unwrap();
+
+    // Test a nested repository foo/ containing .git and f.
+    let foo_path = workspace_root.join("foo");
+    std::fs::create_dir(&foo_path).unwrap();
+    testutils::write_working_copy_file(&workspace_root, repo_path("foo/.git"), "");
+    testutils::write_working_copy_file(&workspace_root, repo_path("foo/f"), "contents");
+    let new_tree = test_workspace.snapshot().unwrap();
+    assert_tree_eq!(new_tree, empty_tree);
+    std::fs::remove_dir_all(&foo_path).unwrap();
 }
 
 #[test_case(""; "ignore nothing")]


### PR DESCRIPTION
If a submodule was created in a commit C on a remote repo, switching from any commit after C to any commit before C (eg. `jj new C-`) will result in jj starting to track the files introduced in the submodule.

This issue has popped up very frequently for chromium developers, who get issues when attempting to check out an older version of chromium.

Fixes #4349

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [X] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
