### PR TITLE
git remote: only check for an existing remote in local config when adding/renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@ should not be broken.
   date.
   [#8007](https://github.com/jj-vcs/jj/issues/8007)
 
+* `jj git clone` now succeeds if configuration for the current remote exists
+  in a global config file.
+  [#7820](https://github.com/jj-vcs/jj/issues/7820)
+
 ## [0.35.0] - 2025-11-05
 
 ### Release highlights

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -553,41 +553,23 @@ fn test_git_remote_with_global_git_remote_config() {
     // Complete remotes from the global configuration are listed.
     //
     // `git remote -v` lists all remotes from the global configuration,
-    // even incomplete ones like `origin`. This is inconsistent with
-    // the other `git remote` commands, which ignore the global
-    // configuration (even `git remote get-url`).
+    // even incomplete ones like `origin`. Confusingly, these remotes
+    // are ignored by other `git remote` commands (even `git remote get-url`).
+    //
+    // This behavior is replicated by `jj git remote`. `jj git remote list`
+    // will list remotes from both global and local configuration, but other
+    // commands like `rename` will ignore the global configuration.
     insta::assert_snapshot!(output, @r"
     foo htps://example.com/repo/foo
     [EOF]
     ");
 
     let output = work_dir.run_jj(["git", "remote", "rename", "foo", "bar"]);
-    // Divergence from Git: we read the remote from the global
-    // configuration and write it back out. Git will use the global
-    // configuration for commands like `git remote -v`, `git fetch`,
-    // and `git push`, but `git remote rename`, `git remote remove`,
-    // `git remote set-url`, etc., will ignore it.
-    //
-    // This behavior applies to `jj git remote remove` and
-    // `jj git remote set-url` as well. It would be hard to change due
-    // to gitoxide’s model, but hopefully it’s relatively harmless.
-    insta::assert_snapshot!(output, @"");
-    insta::assert_snapshot!(read_git_config(work_dir.root()), @r#"
-    [core]
-    	repositoryformatversion = 0
-    	bare = true
-    	logallrefupdates = false
-    [remote "bar"]
-    	url = htps://example.com/repo/foo
-    	fetch = +refs/heads/*:refs/remotes/bar/*
-    "#);
-    // This has the unfortunate consequence that the original remote
-    // still exists after renaming.
-    let output = work_dir.run_jj(["git", "remote", "list"]);
     insta::assert_snapshot!(output, @r"
-    bar htps://example.com/repo/foo
-    foo htps://example.com/repo/foo
+    ------- stderr -------
+    Error: No git remote named 'foo'
     [EOF]
+    [exit status: 1]
     ");
 
     let output = work_dir.run_jj([
@@ -610,7 +592,6 @@ fn test_git_remote_with_global_git_remote_config() {
 
     let output = work_dir.run_jj(["git", "remote", "list"]);
     insta::assert_snapshot!(output, @r"
-    bar htps://example.com/repo/foo
     foo htps://example.com/repo/foo
     origin https://example.com/repo/origin/2
     [EOF]
@@ -620,9 +601,6 @@ fn test_git_remote_with_global_git_remote_config() {
     	repositoryformatversion = 0
     	bare = true
     	logallrefupdates = false
-    [remote "bar"]
-    	url = htps://example.com/repo/foo
-    	fetch = +refs/heads/*:refs/remotes/bar/*
     [remote "origin"]
     	url = https://example.com/repo/origin/2
     	fetch = +refs/heads/*:refs/remotes/origin/*


### PR DESCRIPTION
reopening #7860

cloning currently fails with `Error: Git remote named '$remote' already exists` if the user has some config somewhere that applies to `$remote`, e.g. in ~/.gitconfig. this error makes sense if you are trying to add a remote that already exists in the local config, but doesn't make sense while cloning since there must not be a local config

this PR fixes the bug by only looking for configuration that originated from the local `.git/config` file

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] ~I have updated the documentation (`README.md`, `docs/`, `demos/`)~
- [ ] ~I have updated the config schema (`cli/src/config-schema.json`)~
- [x] I have added/updated tests to cover my changes
