### PR TITLE
working_copy: correctly ignore added and removed submodules

### DIFF
--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -374,7 +374,7 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
             }
             Kind::GitSubmodule => {
                 // Not supported for now
-                assert!(maybe_metadata.is_err(), "{path:?} should not exist");
+                // assert!(maybe_metadata.is_err(), "{path:?} should not exist");
             }
         };
     }
@@ -1409,7 +1409,7 @@ fn test_git_submodule(gitignore_content: &str) {
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1).unwrap();
 
-    std::fs::create_dir(submodule_path.to_fs_path_unchecked(&workspace_root)).unwrap();
+    // std::fs::create_dir(submodule_path.to_fs_path_unchecked(&workspace_root)).unwrap();
 
     testutils::write_working_copy_file(
         &workspace_root,
@@ -1455,7 +1455,7 @@ fn test_git_submodule(gitignore_content: &str) {
     let stats = ws
         .check_out(repo.op_id().clone(), None, &store.root_commit())
         .unwrap();
-    assert_eq!(stats.skipped_files, 1);
+    assert_eq!(stats.skipped_files, 0);
 }
 
 #[test]


### PR DESCRIPTION
This is my first PR to jj! Tests and changelog needs to be updated, but I wanted to get some feedback on my chosen solution idea before updating the tests.

I also think that maybe the parent directory deletion done for Absent files should possibly be added to the submodule removed handling. What do you think?
Alternatively, I think the code block starting with [1] could be modified or skipped for submodules instead of my `if` blocks. I do however like the printed info that I have added.

---

Completely rewritten 2025-12-02.

---

Fixes #8065.

This commit fixes the problem of jj marking a git submodule as a deleted file,
after the user moves (edit/new) to a commit where the submodule did not exist
and then back to a commit where it existed. The submodule would not only appear
as a deleted file when the user edited the last commit, but also any other
commit the user navigated to afterwards, essentially putting the following
non-clearable line in `jj status`:

    D <submodule path>


The above problem is created in two steps:

First, when moving to a commit where the submodule no longer existed, jj would
try to remove its directory, as if it were a file, and fail. jj would then mark
the type of the path to be a "placeholder" instead of a "submodule" in the
commit. jj would also indicate that the commit was in conflict, but with no way
to resolve it (restore showed empty data).

Secondly, when moving back to a commit where the submodule existed, jj would
once again see a conflict between the not-removed submodule directory on disk
and the "placeholder":

    D <submodule path (as placeholder type)>

Also with no way to restore.


The code is updated to remove the submodule _directory_ when leaving a submodule
behind, but only if the directory is empty. If the directory is not empty, the
deletion of the "submodule file" will still be successful in jj, to record a
correct state. This is in
line with Git behavior and makes sure that no modified files in the submodule
get thrown away.

Note: If the user has forgotten to mark the submodule directory as ignored/
excluded, the directory contents will be picked up as new files (status: `A
<file>`). This behavior already existed before the change. There is no way for
jj to know of "files that might at some point belong to a submodule but
currently doesn't". The solution for the user is to ignore the submodule
directory.

The code is also updated to not indicate a conflict if the target path, upon a
submodule checkout, is already an existing directory. The directory is assumed
to be the submodule's directory, possibly left over when moving from a commit
where the submodule existed. This is also in line with Git behavior.

The submodule directory is created when the user checks out a commit with a
submodule, to mimic Git behavior.

If the target path for the checkout is empty but jj finds that it cannot write
to disk, the "file" in the change is now kept as a "submodule", instead of a
"placeholder". This avoids file "modifications" that the user cannot restore
from and is also in line with jj "ignoring" submodules.

The code change also addresses the user moving from a commit where the path was
a submodule, to a commit where the path is a file. Since the submodule directory
cannot be safely removed, the user is instead told to run `git reset --hard` to
explicitly replace the submodule with the file.


The script [1] was used to test the new functionality. The output of a run is
shown in [2].


[1]
```
#!/bin/bash

# Have the correct jj in PATH

set -ex

TOPDIR=submodtest_run
ABSTOPDIR=$(realpath $TOPDIR)
rm -rf -- $TOPDIR

mkdir $TOPDIR
cd $TOPDIR

set +x; echo -e '\033[31;1m +++++ PREPARE: CREATE CHILD REPO +++++\033[0m'; set -x

git init child
pushd child
echo "child file" > childfile.txt
git add  childfile.txt
git commit -m "Add childfile.txt"
popd

set +x; echo -e '\033[31;1m +++++ PREPARE: CREATE PARENT REPO +++++\033[0m'; set -x

git init parent
pushd parent
echo "parent file" > parentfile.txt
git add parentfile.txt
git commit -m "Add parentfile.txt"

set +x; echo -e '\033[31;1m +++++ PREPARE: ADD SUBMODULE +++++\033[0m'; set -x

# File system submodules are not allowed, so using SSH instead
git submodule add localhost:$ABSTOPDIR/child
git commit -m "Add child submodule"
git submodule
ls child

echo "modified parent file" >> parentfile.txt
git commit -am "Modify parentfile.txt"

set +x; echo -e '\033[31;1m +++++ TEST JJ BEHAVIOR +++++\033[0m'; set -x

set +x; echo -e '\033[31;1m +++++ INIT JJ +++++\033[0m'; set -x
jj git init
jj st
jj show

set +x; echo -e '\033[31;1m +++++ GO BACK BEFORE SUBMODULE +++++\033[0m'; set -x
jj new @---
jj st
git submodule
git status
ls child

echo The user forgot to ignore the sumodule directory and JJ snatched the child. Fix that.
echo "/child" >> .git/info/exclude
jj file untrack child
jj st

set +x; echo -e '\033[31;1m +++++ GO FORWARD AFTER SUBMODULE +++++\033[0m'; set -x
jj new @-++
jj st
git submodule
git status
ls child

set +x; echo -e '\033[31;1m +++++ ADD NEW SUBMODULE +++++\033[0m'; set -x
git submodule add localhost:$ABSTOPDIR/child newmod
# Important to commit the new submodule before running jj to avoid it finding the contents
git commit -m "Add newmod submodule"
git submodule
ls newmod
jj st

set +x; echo -e '\033[31;1m +++++ REMOVE SUBMODULE +++++\033[0m'; set -x
git rm newmod
git commit -m "Remove newmod submodule"
git status
git submodule
jj st

set +x; echo -e '\033[31;1m +++++ SUBMODULE -> FILE +++++\033[0m'; set -x
git rm child
# Don't ignore the path anymore
rm .git/info/exclude
echo "child is now a file" > child
git add child
git commit -m "Change child submodule to a file"
git status
git submodule
jj st
file child

set +x; echo -e '\033[31;1m +++++ GO BACK TO WHERE THE SUBMODULE EXISTED +++++\033[0m'; set -x
jj new @--
jj st
git submodule
file child

set +x; echo -e '\033[31;1m +++++ INITIALIZE THE SUBMODULE +++++\033[0m'; set -x
# This will hit the case where a non-empty submodule directory cannot be removed
git submodule update --init --recursive
set +x; echo -e '\033[31;1m +++++ GO FORWARD TO WHERE THE SUBMODULE IS A FILE +++++\033[0m'; set -x

jj new "@-+ ~ @"
jj st
file child

set +x; echo -e '\033[31;1m +++++ RECOVER USING GIT +++++\033[0m'; set -x
git reset --hard
jj st

popd
```

[2]
```
+ TOPDIR=submodtest_run
++ realpath submodtest_run
+ ABSTOPDIR=/home/thomas/src/jj/tmp/submodtest_run
+ rm -rf -- submodtest_run
+ mkdir submodtest_run
+ cd submodtest_run
+ set +x
 +++++ PREPARE: CREATE CHILD REPO +++++
+ git init child
Initialized empty Git repository in /home/thomas/src/jj/tmp/submodtest_run/child/.git/
+ pushd child
~/src/jj/tmp/submodtest_run/child ~/src/jj/tmp/submodtest_run
+ echo 'child file'
+ git add childfile.txt
+ git commit -m 'Add childfile.txt'
[main (root-commit) a75c66c] Add childfile.txt
 1 file changed, 1 insertion(+)
 create mode 100644 childfile.txt
+ popd
~/src/jj/tmp/submodtest_run
+ set +x
 +++++ PREPARE: CREATE PARENT REPO +++++
+ git init parent
Initialized empty Git repository in /home/thomas/src/jj/tmp/submodtest_run/parent/.git/
+ pushd parent
~/src/jj/tmp/submodtest_run/parent ~/src/jj/tmp/submodtest_run
+ echo 'parent file'
+ git add parentfile.txt
+ git commit -m 'Add parentfile.txt'
[main (root-commit) 1867644] Add parentfile.txt
 1 file changed, 1 insertion(+)
 create mode 100644 parentfile.txt
+ set +x
 +++++ PREPARE: ADD SUBMODULE +++++
+ git submodule add localhost:/home/thomas/src/jj/tmp/submodtest_run/child
Cloning into '/home/thomas/src/jj/tmp/submodtest_run/parent/child'...
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (3/3), done.
+ git commit -m 'Add child submodule'
[main b99ed6c] Add child submodule
 2 files changed, 4 insertions(+)
 create mode 100644 .gitmodules
 create mode 160000 child
+ git submodule
 a75c66c87b87a4e54494e879b86afb687a291572 child (heads/main)
+ ls child
childfile.txt
+ echo 'modified parent file'
+ git commit -am 'Modify parentfile.txt'
[main 2a14627] Modify parentfile.txt
 1 file changed, 1 insertion(+)
+ set +x
 +++++ TEST JJ BEHAVIOR +++++
+ set +x
 +++++ INIT JJ +++++
+ jj git init
Done importing changes from the underlying Git repo.
ignoring git submodule at "child"
Initialized repo in "."
Hint: Running `git clean -xdf` will remove `.jj/`!
+ jj st
The working copy has no changes.
Working copy  (@) : mploqxqn 858b8be6 (empty) (no description set)
Parent commit (@-): tlrlqqns 2a146272 main | Modify parentfile.txt
+ jj show
Commit ID: 858b8be61409cb2313f72ce77d073d5ab034c965
Change ID: mploqxqnomtllkmlkntwymmmnkxpxmry
Author   : Thomas Axelsson <thomasa88@gmail.com> (2025-12-02 06:55:59)
Committer: Thomas Axelsson <thomasa88@gmail.com> (2025-12-02 06:55:59)

    (no description set)

+ set +x
 +++++ GO BACK BEFORE SUBMODULE +++++
+ jj new @---
warning: failed to remove submodule directory /home/thomas/src/jj/tmp/submodtest_run/parent/child: directory not empty
Files from the submodule will appear as added. Add the submodule to `.git/info/exclude` and run `jj file untrack` to ignore the directory contents.
Working copy  (@) now at: mnvxtovw f4772938 (empty) (no description set)
Parent commit (@-)      : olvuopxt 1867644e Add parentfile.txt
Added 0 files, modified 1 files, removed 2 files
+ jj st
Working copy changes:
A child/childfile.txt
Working copy  (@) : mnvxtovw 8ebdc64d (no description set)
Parent commit (@-): olvuopxt 1867644e Add parentfile.txt
+ git submodule
+ git status
Not currently on any branch.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	new file:   child/childfile.txt

no changes added to commit (use "git add" and/or "git commit -a")
+ ls child
childfile.txt
+ echo The user forgot to ignore the sumodule directory and JJ snatched the child. Fix that.
The user forgot to ignore the sumodule directory and JJ snatched the child. Fix that.
+ echo /child
+ jj file untrack child
+ jj st
The working copy has no changes.
Working copy  (@) : mnvxtovw 355ff742 (empty) (no description set)
Parent commit (@-): olvuopxt 1867644e Add parentfile.txt
+ set +x
 +++++ GO FORWARD AFTER SUBMODULE +++++
+ jj new @-++
Working copy  (@) now at: lnuvntuo c78c321b (empty) (no description set)
Parent commit (@-)      : tlrlqqns 2a146272 main | Modify parentfile.txt
Added 2 files, modified 1 files, removed 0 files
+ jj st
The working copy has no changes.
Working copy  (@) : lnuvntuo c78c321b (empty) (no description set)
Parent commit (@-): tlrlqqns 2a146272 main | Modify parentfile.txt
+ git submodule
 a75c66c87b87a4e54494e879b86afb687a291572 child (heads/main)
+ git status
Not currently on any branch.
nothing to commit, working tree clean
+ ls child
childfile.txt
+ set +x
 +++++ ADD NEW SUBMODULE +++++
+ git submodule add localhost:/home/thomas/src/jj/tmp/submodtest_run/child newmod
Cloning into '/home/thomas/src/jj/tmp/submodtest_run/parent/newmod'...
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (3/3), done.
+ git commit -m 'Add newmod submodule'
[detached HEAD 98d6301] Add newmod submodule
 2 files changed, 4 insertions(+)
 create mode 160000 newmod
+ git submodule
 a75c66c87b87a4e54494e879b86afb687a291572 child (heads/main)
 a75c66c87b87a4e54494e879b86afb687a291572 newmod (heads/main)
+ ls newmod
childfile.txt
+ jj st
ignoring git submodule at "newmod"
Reset the working copy parent to the new Git HEAD.
The working copy has no changes.
Working copy  (@) : orooqqmm 57c055c6 (empty) (no description set)
Parent commit (@-): lnnnxzqm 98d63019 Add newmod submodule
+ set +x
 +++++ REMOVE SUBMODULE +++++
+ git rm newmod
rm 'newmod'
+ git commit -m 'Remove newmod submodule'
[detached HEAD 61dc947] Remove newmod submodule
 2 files changed, 4 deletions(-)
 delete mode 160000 newmod
+ git status
Not currently on any branch.
nothing to commit, working tree clean
+ git submodule
 a75c66c87b87a4e54494e879b86afb687a291572 child (heads/main)
+ jj st
Reset the working copy parent to the new Git HEAD.
The working copy has no changes.
Working copy  (@) : tkowyunq c63c5df3 (empty) (no description set)
Parent commit (@-): lqtvyyyp 61dc9472 Remove newmod submodule
+ set +x
 +++++ SUBMODULE -> FILE +++++
+ git rm child
rm 'child'
+ rm .git/info/exclude
+ echo 'child is now a file'
+ git add child
+ git commit -m 'Change child submodule to a file'
[detached HEAD e8da460] Change child submodule to a file
 2 files changed, 1 insertion(+), 4 deletions(-)
 mode change 160000 => 100644 child
+ git status
Not currently on any branch.
nothing to commit, working tree clean
+ git submodule
+ jj st
Reset the working copy parent to the new Git HEAD.
The working copy has no changes.
Working copy  (@) : xoonwtzz 6d447acd (empty) (no description set)
Parent commit (@-): yloywlvr e8da460b Change child submodule to a file
+ file child
child: ASCII text
+ set +x
 +++++ GO BACK TO WHERE THE SUBMODULE EXISTED +++++
+ jj new @--
Working copy  (@) now at: pspyrulq 8853ffe7 (empty) (no description set)
Parent commit (@-)      : lqtvyyyp 61dc9472 Remove newmod submodule
Added 0 files, modified 2 files, removed 0 files
+ jj st
The working copy has no changes.
Working copy  (@) : pspyrulq 8853ffe7 (empty) (no description set)
Parent commit (@-): lqtvyyyp 61dc9472 Remove newmod submodule
+ git submodule
-a75c66c87b87a4e54494e879b86afb687a291572 child
+ file child
child: directory
+ set +x
 +++++ INITIALIZE THE SUBMODULE +++++
+ git submodule update --init --recursive
Submodule path 'child': checked out 'a75c66c87b87a4e54494e879b86afb687a291572'
+ set +x
 +++++ GO FORWARD TO WHERE THE SUBMODULE IS A FILE +++++
+ jj new '@-+ ~ @'
warning: failed to remove submodule directory /home/thomas/src/jj/tmp/submodtest_run/parent/child: directory not empty
Submodule child is replaced by a file in the commit. Run `git reset --hard` to remove the left-over submodule directory and replace it with the file.
Working copy  (@) now at: nylolxxx 9b5496f7 (empty) (no description set)
Parent commit (@-)      : yloywlvr e8da460b Change child submodule to a file
Added 0 files, modified 2 files, removed 0 files
+ jj st
Working copy changes:
D child
A child/childfile.txt
Working copy  (@) : nylolxxx f4b016a6 (no description set)
Parent commit (@-): yloywlvr e8da460b Change child submodule to a file
+ file child
child: directory
+ set +x
 +++++ RECOVER USING GIT +++++
+ git reset --hard
HEAD is now at e8da460 Change child submodule to a file
+ jj st
The working copy has no changes.
Working copy  (@) : nylolxxx d471c54a (empty) (no description set)
Parent commit (@-): yloywlvr e8da460b Change child submodule to a file
+ popd
~/src/jj/tmp/submodtest_run
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- (N/A) I have updated the documentation (`README.md`, `docs/`, `demos/`)
  -  `* **Submodules: No.** They will not show up in the working copy, but they will
  not be lost either.` in docs/git-compatibility.md is even more true.
- (N/A) I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
