### PR TITLE
templates: Expose conflicted files in the template language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj log` now supports a `--count` flag to print the number of commits instead
   of displaying them.
 
+* `Commit` type now has a `conflicted_files()` method that returns a list of
+  files with merge conflicts.
+
+* `TreeEntry` type now has a `conflict_side_count()` method that returns the number
+  of sides in a merge conflict (1 for non-conflicted files, 2 or more for
+  conflicts).
+
 ### Fixed bugs
 
 * `jj fix` now prints a warning if a tool failed to run on a file.

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1294,6 +1294,22 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
         },
     );
     map.insert(
+        "conflicted_files",
+        |_language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let out_property = self_property.and_then(|commit| {
+                let tree = commit.tree();
+                let entries: Vec<_> = tree
+                    .conflicts()
+                    .map(|(path, value)| value.map(|value| (path, value)))
+                    .map_ok(|(path, value)| TreeEntry { path, value })
+                    .try_collect()?;
+                Ok(entries)
+            });
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
+    map.insert(
         "root",
         |language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
@@ -2482,6 +2498,15 @@ fn builtin_tree_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|entry| !entry.value.is_resolved());
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
+    map.insert(
+        "conflict_side_count",
+        |_language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let out_property = self_property
+                .and_then(|entry| Ok(i64::try_from(entry.value.simplify().num_sides())?));
             Ok(out_property.into_dyn_wrapped())
         },
     );

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1506,6 +1506,90 @@ fn test_file_list_entries() {
     ");
 }
 
+#[test]
+fn test_conflicted_files() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Base commit with files.
+    work_dir.write_file("normal-file", "base content");
+    work_dir.write_file("conflict-file1", "base content");
+    work_dir.write_file("conflict-file2", "base content");
+    work_dir.run_jj(["commit", "-m", "base"]).success();
+
+    // Sibling branches with conflicting changes.
+    work_dir.write_file("conflict-file1", "left content");
+    work_dir.write_file("conflict-file2", "left content");
+    work_dir.run_jj(["commit", "-m", "left"]).success();
+
+    work_dir.run_jj(["new", "subject(glob:base)"]).success();
+    work_dir.write_file("conflict-file1", "right content");
+    work_dir.write_file("conflict-file2", "right content");
+    work_dir.run_jj(["commit", "-m", "right"]).success();
+
+    // Merge with conflicts.
+    work_dir
+        .run_jj(["new", "subject(glob:left)", "subject(glob:right)"])
+        .success();
+
+    // Test basic conflicted_files() listing.
+    let template = r#"self.conflicted_files().map(|e| e.path()) ++ "\n""#;
+    let output = work_dir.run_jj(["log", "-r", "@", "-T", template, "--no-graph"]);
+    insta::assert_snapshot!(output, @r"
+    conflict-file1 conflict-file2
+    [EOF]
+    ");
+
+    // Test that non-conflicted commit returns empty list.
+    let template = r#"self.conflicted_files().len() ++ "\n""#;
+    let output = work_dir.run_jj([
+        "log",
+        "-r",
+        "subject(glob:left)",
+        "-T",
+        template,
+        "--no-graph",
+    ]);
+    insta::assert_snapshot!(output, @r"
+    0
+    [EOF]
+    ");
+
+    // Metadata for conflicted_files.
+    let template = indoc! {r#"
+        self.conflicted_files().map(|e| separate(" ",
+          e.path(),
+          "conflict=" ++ e.conflict(),
+          "type=" ++ e.file_type(),
+          "sides=" ++ e.conflict_side_count(),
+        )).join("\n") ++ "\n"
+    "#};
+    let output = work_dir.run_jj(["log", "-r", "@", "-T", template, "--no-graph"]);
+    insta::assert_snapshot!(output, @r"
+    conflict-file1 conflict=true type=conflict sides=2
+    conflict-file2 conflict=true type=conflict sides=2
+    [EOF]
+    ");
+
+    // Metadata for all files.
+    let template = indoc! {r#"
+        self.files().map(|e| separate(" ",
+          e.path(),
+          "conflict=" ++ e.conflict(),
+          "type=" ++ e.file_type(),
+          "sides=" ++ e.conflict_side_count(),
+        )).join("\n") ++ "\n"
+    "#};
+    let output = work_dir.run_jj(["log", "-r", "@", "-T", template, "--no-graph"]);
+    insta::assert_snapshot!(output, @r"
+    conflict-file1 conflict=true type=conflict sides=2
+    conflict-file2 conflict=true type=conflict sides=2
+    normal-file conflict=false type=file sides=1
+    [EOF]
+    ");
+}
+
 #[cfg(unix)]
 #[test]
 fn test_file_list_symlink() {

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -42,7 +42,7 @@ fn test_templater_parse_error() {
       | ^-------^
       |
       = Keyword `conflicts` doesn't exist
-    Hint: Did you mean `conflict`, `conflicting`?
+    Hint: Did you mean `conflict`, `conflicted_files`, `conflicting`?
     [EOF]
     [exit status: 1]
     ");

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -178,6 +178,7 @@ This type cannot be printed. The following methods are defined.
 * `.files([files: String]) -> List<TreeEntry>`: Files that exist in this commit,
   matching [the `files` expression](filesets.md). Use `.diff().files()` to list
   changed files.
+* `.conflicted_files() -> List<TreeEntry>`: Conflicted files in this commit.
 * `.root() -> Boolean`: True if the commit is the root commit.
 
 ### `CommitEvolutionEntry` type
@@ -630,6 +631,8 @@ This type cannot be printed. The following methods are defined.
 
 * `.path() -> RepoPath`: Path to the entry.
 * `.conflict() -> Boolean`: True if the entry is a merge conflict.
+* `.conflict_side_count() -> Integer`: Number of sides in the merge conflict (1 if not
+  conflicted, 2 or more for multi-way merges).
 * `.file_type() -> String`: One of `"file"`, `"symlink"`, `"tree"`,
   `"git-submodule"`, or `"conflict"`.
 * `.executable() -> Boolean`: True if the entry is an executable file.


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Will allow things like showing info about conflicted files in the log.

Should synergize well with https://github.com/jj-vcs/jj/pull/8184

Fixes: https://github.com/jj-vcs/jj/issues/7377

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
