### PR TITLE
file_util: fix broken symlink on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* On Windows, symlinks that point to a path with `/` won't be supported. This
+  path is [invalid on Windows].
+
+[invalid on Windows]: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+
 ### Deprecations
 
 ### New features
@@ -20,6 +25,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `working-copy.exec-bit-change = "respect" | "ignore"`.
 
 ### Fixed bugs
+
+* Broken symlink on Windows. [#6934](https://github.com/jj-vcs/jj/issues/6934).
 
 ## [0.36.0] - 2025-12-03
 


### PR DESCRIPTION
... due to using incorrect separators.

Fix #8185.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
