### PR TITLE
Support for fileset operators in shell completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ should not be broken.
 
 * Dynamic command-line completion of path parameters now supports fileset operators,
   so for example typing `jj log ~RE` and pressing Tab could complete to `~README.md`.
+  Workspace-relative patterns (e.g. `root:foo`) will also autocomplete correctly
+  from subdirectories.
 
 ### Fixed bugs
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1476,6 +1476,23 @@ fn test_files() {
     [EOF]
     ");
 
+    let output = subdir.complete_fish(["file", "show", "root:dir_"]);
+    insta::assert_snapshot!(output, @"");
+
+    let output = subdir.complete_fish(["file", "show", "root:"]);
+    insta::assert_snapshot!(output, @r"
+    root:f_added
+    root:f_added_2
+    root:f_another_renamed_2
+    root:f_copied
+    root:f_dir/
+    root:f_modified
+    root:f_not_yet_copied
+    root:f_renamed
+    root:f_unchanged
+    [EOF]
+    ");
+
     let output = subdir.complete_fish(["file", "show", "./"]);
     insta::assert_snapshot!(output, @r"
     ./dir_file_1
@@ -1547,6 +1564,32 @@ fn test_files() {
     f_dir/../f_not_yet_renamed_2	Renamed
     f_dir/../f_not_yet_renamed_3	Renamed
     f_dir/../f_renamed	Renamed
+    [EOF]
+    ");
+
+    let output = subdir.complete_fish(["diff", "-r", "@-", "./"]);
+    insta::assert_snapshot!(output, @r"
+    ./../
+    ./dir_file_1	Added
+    ./dir_file_2	Added
+    ./dir_file_3	Added
+    ./f_renamed_3	Renamed
+    [EOF]
+    ");
+
+    let output = subdir.complete_fish(["diff", "-r", "@-", "~root-glob-i:"]);
+    insta::assert_snapshot!(output, @r"
+    ~root-glob-i:f_added	Added
+    ~root-glob-i:f_another_renamed_2	Renamed
+    ~root-glob-i:f_copied	Copied
+    ~root-glob-i:f_deleted	Deleted
+    ~root-glob-i:f_dir/
+    ~root-glob-i:f_modified	Modified
+    ~root-glob-i:f_not_yet_copied	Modified
+    ~root-glob-i:f_not_yet_renamed	Renamed
+    ~root-glob-i:f_not_yet_renamed_2	Renamed
+    ~root-glob-i:f_not_yet_renamed_3	Renamed
+    ~root-glob-i:f_renamed	Renamed
     [EOF]
     ");
 


### PR DESCRIPTION
Allows one to type shell lines like `jj log ~cli/ex⇥`. Workspace-relative patterns (`root*:`) are also handled, so they can be completed from any subdirectory (e.g. `jj diff root:lib/⇥`).

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
