### PR TITLE
working_copy: determine staleness by comparing op id instead of tree id

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1920,6 +1920,7 @@ to the current parents may contain changes from multiple commits.
             // committing the working copy.
             return Ok(SnapshotStats::default());
         };
+
         self.user_repo = ReadonlyUserRepo::new(repo);
         let (new_tree, stats) = {
             let mut options = options;

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -957,19 +957,21 @@ fn test_workspaces_unpublished_operation_same_tree() {
     main_dir
         .run_jj(["new", "-m=C", "--ignore-working-copy"])
         .success();
-    // TODO: The working copy should be stale and should require a `jj workspace
+    // The working copy should be stale and should require a `jj workspace
     // update-stale`
     let output = main_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @r"
-    The working copy has no changes.
-    Working copy  (@) : zsuskuln 36a15ac4 (empty) C
-    Parent commit (@-): qpvuntsm 8777db25 (empty) A
+    ------- stderr -------
+    Internal error: The repo was loaded at operation 502db81004ba, which seems to be a sibling of the working copy's operation 48631817a82e
     [EOF]
+    [exit status: 255]
     ");
     let output = main_dir.run_jj(["workspace", "update-stale"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Attempted recovery, but the working copy is not stale
+    Working copy  (@) now at: zsuskuln 36a15ac4 (empty) C
+    Parent commit (@-)      : qpvuntsm 8777db25 (empty) A
+    Updated working copy to fresh commit 36a15ac414e8
     [EOF]
     ");
 }

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -365,9 +365,8 @@ impl WorkingCopyFreshness {
         wc_commit: &Commit,
         repo: &ReadonlyRepo,
     ) -> Result<Self, OpStoreError> {
-        // Check if the working copy's tree matches the repo's view
-        let wc_tree = locked_wc.old_tree();
-        if wc_commit.tree_ids() == wc_tree.tree_ids() {
+        // Check if the working copy's operation matches the repo's operation
+        if locked_wc.old_operation_id() == repo.op_id() {
             // The working copy isn't stale, and no need to reload the repo.
             Ok(Self::Fresh)
         } else {
@@ -387,7 +386,12 @@ impl WorkingCopyFreshness {
             } else if ancestor_op.id() == wc_operation.id() {
                 // The working copy was not updated when some repo operation committed,
                 // meaning that it's stale compared to the repo view.
-                Ok(Self::WorkingCopyStale)
+                if locked_wc.old_tree().tree_ids() == wc_commit.tree_ids() {
+                    // The working copy doesn't require any changes
+                    Ok(Self::Fresh)
+                } else {
+                    Ok(Self::WorkingCopyStale)
+                }
             } else {
                 Ok(Self::SiblingOperation)
             }


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
