### PR TITLE
ci: Update CI to use macos15-intel instead of macos-x86_64

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, macos-x86_64, macos-aarch64, win-x86_64]
+        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, macos15-intel, macos-aarch64, win-x86_64]
         include:
         - build: linux-x86_64-musl
           os: ubuntu-24.04
@@ -27,7 +27,7 @@ jobs:
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-gnu
-        - build: macos-x86_64
+        - build: macos15-intel
           os: macos-15
           target: x86_64-apple-darwin
         - build: macos-aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        build: [linux-x86_64-gnu, linux-aarch64-gnu, macos-x86_64, macos-aarch64, windows-x86_64, windows-aarch64]
+        build: [linux-x86_64-gnu, linux-aarch64-gnu, macos15-intel, macos-aarch64, windows-x86_64, windows-aarch64]
         include:
         - build: linux-x86_64-gnu
           os: ubuntu-24.04
@@ -27,7 +27,7 @@ jobs:
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           cargo_flags: "--all-features"
-        - build: macos-x86_64
+        - build: macos15-intel
           os: macos-15
           cargo_flags: ""
         - build: macos-aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux-x86_64-musl, linux-aarch64-musl, macos-x86_64, macos-aarch64, win-x86_64, win-aarch64]
+        build: [linux-x86_64-musl, linux-aarch64-musl, macos15-intel, macos-aarch64, win-x86_64, win-aarch64]
         include:
         - build: linux-x86_64-musl
           os: ubuntu-24.04
@@ -25,7 +25,7 @@ jobs:
         - build: linux-aarch64-musl
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-musl
-        - build: macos-x86_64
+        - build: macos15-intel
           os: macos-15
           target: x86_64-apple-darwin
         - build: macos-aarch64


### PR DESCRIPTION
As part of #7550, the macos-x86_64 runners are going away soon, macos15-intel is the replacement.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
