### PR TITLE
cli: default Gerrit --remote-branch is gerrit.default-remote-branch

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -75,7 +75,7 @@ pub struct UploadArgs {
     /// The location where your changes are intended to land
     ///
     /// This should be a branch on the remote. Can be configured with the
-    /// `gerrit.default-branch` repository option.
+    /// `gerrit.default-remote-branch` repository option.
     #[arg(long = "remote-branch", short = 'b')]
     remote_branch: Option<String>,
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1313,7 +1313,7 @@ Note: this command takes 1-or-more revsets arguments, each of which can resolve 
    This can be any arbitrary set of commits. Note that when you push a commit at the head of a stack, all ancestors are pushed too. This means that `jj gerrit upload -r foo` is equivalent to `jj gerrit upload -r 'mutable()::foo`.
 * `-b`, `--remote-branch <REMOTE_BRANCH>` — The location where your changes are intended to land
 
-   This should be a branch on the remote. Can be configured with the `gerrit.default-branch` repository option.
+   This should be a branch on the remote. Can be configured with the `gerrit.default-remote-branch` repository option.
 * `--remote <REMOTE>` — The Gerrit remote to push to
 
    Can be configured with the `gerrit.default-remote` repository option as well. This is typically a full SSH URL for your Gerrit instance.


### PR DESCRIPTION
`gerrit.default-branch` does not seem to be a real option.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
