### PR TITLE
WIP: guides: Add "Configuring `revsets.log`"

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -34,7 +34,8 @@ with `jj rebase`, `jj describe`, etc). In that case, `jj log -r commit_id`
 should show the revision as "hidden". `jj new commit_id` should make the
 revision visible again.
 
-See [revsets] and [templates] for further guidance.
+See [revsets] and [templates] for further guidance. For a good introduction to
+[revsets], see [configuring `revsets.log`]
 
 ### What are elided revisions in the output of `jj log`? How can I display them?
 
@@ -643,6 +644,7 @@ revsets. This seemed unlikely to be accepted by the Git project.
 [change]: glossary.md#change
 [change ID]: glossary.md#change-id
 [colocated]: glossary.md#colocated-workspaces
+[configuring `revsets.log`]: guides/configuring-revsets-log.md
 [commit ID]: glossary.md#commit-id
 [commits]: glossary.md#commit
 [config]: config.md

--- a/docs/guides/configuring-revsets-log.md
+++ b/docs/guides/configuring-revsets-log.md
@@ -1,0 +1,30 @@
+# Configuring `revsets.log`
+
+## Explaining the default log revset
+
+The default log revset of `present(@) | ancestors(immutable_heads().., 2) | trunk()`
+where the builtin definition of `immutable_heads()` is `trunk() | `
+can be explained as show me all revisions which are an ancestor of the current
+revision, mutable and intersected with _any_ currently tracked bookmarks and
+tags in the repository. This is an extremely lengthy way to spell
+"show me all current mutable revisions".
+
+In many situations this doesn't align with the equivalent in Gits log. Out of
+this reason we wrote this Guide.
+
+## Large repositories
+
+For large repositories with many contributors the default log revset is very
+noisy, to improve upon that many people from the community define a `stack()`
+revset. They often differ in minor detail but all have a common base, the
+`reachable(ancestors(@), x)` expression.
+
+
+```text
+
+```
+
+
+
+[revset]: ../revsets.md
+TODO: everything

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav: # This lists all the files that become part of the documentation
 
   - Guides:
       - CLI options for specifying revisions: 'guides/cli-revision-options.md'
+      - Configuring revsets.log: 'guides/configuring-revsets-log.md'
       - Divergent changes: 'guides/divergence.md'
       - Multiple remotes: 'guides/multiple-remotes.md'
 


### PR DESCRIPTION
The goal of this guide is to introduce revsets to users. It also introduces a bunch of variations of the `stack(...)` revset which is useful for large repositories such as chromium or llvm with many concurrent branches at the same time.

cc @jennings @steveklabnik for suggestion and improvements. 

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
