### PR TITLE
ci: macos-x86_64 should actually build for x86_64-apple-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,21 +24,27 @@ jobs:
         - build: linux-x86_64-gnu
           os: ubuntu-24.04
           cargo_flags: "--all-features"
+          extra_targets: ""
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           cargo_flags: "--all-features"
+          extra_targets: ""
         - build: macos-x86_64
           os: macos-15
-          cargo_flags: ""
+          cargo_flags: "--target x86_64-apple-darwin"
+          extra_targets: "x86_64-apple-darwin"
         - build: macos-aarch64
           os: macos-15
           cargo_flags: ""
+          extra_targets: ""
         - build: windows-x86_64
           os: windows-2022
           cargo_flags: ""
+          extra_targets: ""
         - build: windows-aarch64
           os: windows-11-arm
           cargo_flags: ""
+          extra_targets: ""
     runs-on: ${{ matrix.os }}
 
     # TODO FIXME (aseipp): keep the timeout limit to ~20 minutes. this is long
@@ -69,6 +75,8 @@ jobs:
       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
       with:
         toolchain: 1.89
+        # comma-separated list of extra targets to install
+        targets: ${{ matrix.extra_targets }}
     - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d
       with:
         tool: nextest


### PR DESCRIPTION
The `macos-15` runner is actually an ARM64 machine -- see https://github.com/actions/runner-images for current runner image meanings, but as of this commit, macos-15 was listed as this:

    Image 	YAML Label 	Included Software
    macOS 15 Arm64 	macos-latest, macos-15, or macos-15-xlarge 	macOS-15-arm64

This fixes things such that there is an _actual_ CI build of x86_64-apple-darwin.

The release.yml and binaries.yml workflows are not affected, as they manually specify targets, rather than taking the "autodetected" host target (which is what was happening here and is wrong for building x86_64 binaries on aarch64 hardware via Rosetta).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes

---

ref: https://github.com/jj-vcs/jj/issues/7550 (specifically, this takes the approach in checkbox 2 of the original ticket's body)
ref: https://github.com/jj-vcs/jj/pull/8201#issuecomment-3604069227