### PR TITLE
docs: Fix `remotes.<remote>` config documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,22 +62,22 @@ should not be broken.
 * The config options `git.auto-local-bookmark` and `git.push-new-bookmarks` are
   deprecated in favor of `remotes.<name>.auto-track-bookmarks`. For example:
   ```toml
-  [remote.origin]
+  [remotes.origin]
   auto-track-bookmarks = "glob:*"
   ```
-  For more details, refer to [the docs](
-  docs/config/#automatic-tracking-of-bookmarks).
+  For more details, refer to
+  [the docs](docs/config.md#automatic-tracking-of-bookmarks).
 
 * The flag `--allow-new` on `jj git push` is deprecated. In order to push new
   bookmarks, please track them with `jj bookmark track`. Alternatively, consider
   setting up an auto-tracking configuration to avoid the chore of tracking
   bookmarks manually. For example:
   ```toml
-  [remote.origin]
+  [remotes.origin]
   auto-track-bookmarks = "glob:*"
   ```
-  For more details, refer to [the docs](
-  docs/config/#automatic-tracking-of-bookmarks).
+  For more details, refer to
+  [the docs](docs/config.md#automatic-tracking-of-bookmarks).
 
 ### New features
 
@@ -103,8 +103,9 @@ should not be broken.
   children.
 
 * A new config option `remotes.<name>.auto-track-bookmarks` can be set to a
-  pattern. New bookmarks matching it will automatically track that remote.
-  See <https://jj-vcs.github.io/jj/latest/config/#automatic-tracking-of-bookmarks>.
+  string pattern. New bookmarks matching it will be automatically tracked for
+  the specified remote. See
+  [the docs](docs/config.md#automatic-tracking-of-bookmarks).
 
 * Added `join()` template function. This is different from `separate()` in that
   it adds a separator between all arguments, even if empty.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1535,56 +1535,57 @@ demand.
 ### Automatic tracking of bookmarks
 
 You can configure which bookmarks to track automatically per remote, using the
-key `auto-track-bookmarks` under a section `[remotes.<name>]`. The value is a
-[string pattern](./revsets.md#string-patterns) for the bookmarks to track. This
-setting is applied to all new bookmarks, including ones created locally and ones
-fetched from the remote. For example:
+`remotes.<name>.auto-track-bookmarks` config. The value is a
+[string pattern](./revsets.md#string-patterns) that matches the names of the
+bookmarks to track. This setting is applied to all new bookmarks, including ones
+created locally and ones fetched from the remote. For example:
 
 ```toml
-[remote.origin]
+[remotes.origin]
 auto-track-bookmarks = "glob:*"
 ```
 
 This will simply track all bookmarks for the remote "origin". There are various
 reasons to restrict which bookmarks to track:
 
-When collaborating with other people via the same remote, you may not want to
-track all the bookmarks of your collaborators. Similarly, you may not want to
-push some of your bookmarks to the remote at all. Some may only be intended
-for local use. Many people use a "personal prefix" in their bookmark names.
-This marks a bookmark as belonging to one person, making it possible to track
-and push only bookmarks with that prefix. For example, Alice may set her
-configuration like so:
+- When collaborating with other people via the same remote, you may not want to
+  track all the bookmarks of your collaborators. Similarly, you may not want to
+  push some of your bookmarks to the remote at all; these may only be intended
+  for local use. Many people use a "personal prefix" in their bookmark names.
+  This marks a bookmark as belonging to one person, making it possible to track
+  and push only bookmarks with that prefix. For example, Alice may set her
+  configuration like so:
 
-```toml
-[remote.origin]
-auto-track-bookmarks = "glob:alice/*"
-```
+  ```toml
+  [remotes.origin]
+  auto-track-bookmarks = "glob:alice/*"
+  ```
 
-That way, bookmarks pushed by other people (who probably use a different prefix
-or none at all) are not tracked automatically. At the same time, Alice can
-create bookmarks without the prefix for local-only use. You can also configure
-Jujutsu to use your prefix for generated bookmark names, see the section
-["Generated bookmark names on push"](#generated-bookmark-names-on-push).
+  That way, bookmarks pushed by other people (who probably use a different
+  prefix or none at all) are not tracked automatically. At the same time, Alice
+  can create bookmarks without the prefix for local-only use. You can also
+  configure Jujutsu to use your prefix for generated bookmark names; see the
+  section
+  ["Generated bookmark names on push"](#generated-bookmark-names-on-push).
 
-Another reason to restrict the bookmarks to track may be that you're not
-collaborating with people using the same remote, but a different one. For
-example, if you make a fork on GitHub, your fork will usually be called
-"origin", while the repository you forked from is usually called "upstream".
-In that case, you may want to track all bookmarks from your fork, but only the
-"main" bookmark from upstream. Here's an example how to achieve that:
+- Another reason to restrict the bookmarks to track may be that you're not
+  collaborating with people using the same remote, but a different one. For
+  example, if you make a fork on GitHub, your fork will usually be called
+  "origin", while the repository you forked from is usually called "upstream".
+  In that case, you may want to track all bookmarks from your fork, but only the
+  "main" bookmark from upstream. Here's an example how to achieve that:
 
-```toml
-[remote.origin]
-auto-track-bookmarks = "glob:*"
-[remote.upstream]
-auto-track-bookmarks = "main"
-```
+  ```toml
+  [remotes.origin]
+  auto-track-bookmarks = "glob:*"
+  [remotes.upstream]
+  auto-track-bookmarks = "main"
+  ```
 
-Lastly, you may be working on various projects with different conventions for
-bookmark names. In that case, it can be handy to apply different configuration
-to different (groups of) repositories. Read about how to do that in the section
-["Conditional variables"](conditional-variables).
+- Lastly, you may be working on various projects with different conventions for
+  bookmark names. In that case, it can be handy to apply different configuration
+  to different (groups of) repositories. Read about how to do that in the
+  section ["Conditional variables"](#conditional-variables).
 
 ### Automatic local bookmark creation on `jj git clone`
 


### PR DESCRIPTION
Fixed typos in the examples (`remote.<remote>` vs. `remotes.<remote>`), and fixed some broken links.

I was looking at the changelog and noticed that there was a typo in the example. Then I got a little carried away and also updated the documentation to be a little clearer (IMO).

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
