### PR TITLE
lib: derive Debug on a few more types

### DIFF
--- a/lib/src/copies.rs
+++ b/lib/src/copies.rs
@@ -101,6 +101,7 @@ pub enum CopyOperation {
 }
 
 /// A `TreeDiffEntry` with copy information.
+#[derive(Debug)]
 pub struct CopiesTreeDiffEntry {
     /// The path.
     pub path: CopiesTreeDiffEntryPath,

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -267,6 +267,7 @@ impl MergedTree {
 }
 
 /// A single entry in a tree diff.
+#[derive(Debug)]
 pub struct TreeDiffEntry {
     /// The path.
     pub path: RepoPathBuf,
@@ -891,6 +892,7 @@ impl Stream for DiffStreamForFileSystem<'_> {
 /// You start by creating an instance of this type with one or more
 /// base trees. You then add overrides on top. The overrides may be
 /// conflicts. Then you can write the result as a merge of trees.
+#[derive(Debug)]
 pub struct MergedTreeBuilder {
     base_tree: MergedTree,
     overrides: BTreeMap<RepoPathBuf, MergedTreeValue>,

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -327,6 +327,7 @@ impl<'repo> CommitRewriter<'repo> {
     }
 }
 
+#[derive(Debug)]
 pub enum RebasedCommit {
     Rewritten(Commit),
     Abandoned { parent_id: CommitId },
@@ -426,6 +427,7 @@ pub struct RewriteRefsOptions {
     pub delete_abandoned_bookmarks: bool,
 }
 
+#[derive(Debug)]
 pub struct MoveCommitsStats {
     /// The number of commits in the target set which were rebased.
     pub num_rebased_targets: u32,
@@ -861,7 +863,7 @@ fn apply_move_commits(
     })
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct DuplicateCommitsStats {
     /// Map of original commit ID to newly duplicated commit.
     pub duplicated_commits: IndexMap<CommitId, Commit>,
@@ -1123,6 +1125,7 @@ fn compute_commits_heads(
         .collect_vec()
 }
 
+#[derive(Debug)]
 pub struct CommitWithSelection {
     pub commit: Commit,
     pub selected_tree: MergedTree,


### PR DESCRIPTION
I wanted to do print a `TreeDiffEntry` and noticed that it didn't implement `Debug`. This patch adds it for that type and for some others I found.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
