### PR TITLE
working_copy: existing submodule directory is ok. Fixes submodule history traversion issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Improved performance for snapshotting, visibly improving `jj status`
   speed for large repositories.
 
+* Pre-existing Git submodule directories are no longer considered conflicts in
+  checkouts. [#8065](https://github.com/jj-vcs/jj/issues/8065).
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -2288,9 +2288,25 @@ impl TreeState {
 
             // If not, create temporary file to test the path validity.
             if !present_file_deleted && !can_create_new_file(&disk_path)? {
-                changed_file_states.push((path, FileState::placeholder()));
-                stats.skipped_files += 1;
-                return Ok(());
+                if matches!(after, MaterializedTreeValue::GitSubmodule(_)) && disk_path.is_dir() {
+                    // Failing to materialize submodule, over a directory which
+                    // is presumably the submodule before it was added in a
+                    // commit, is not an error.
+                    // Falling through to the "after" state code, to set the
+                    // correct file state.
+                } else if matches!(before.as_normal(), Some(TreeValue::GitSubmodule(_)))
+                    && after.is_absent()
+                {
+                    // Failing to delete un-tracked submodule directory is not
+                    // an error, as the, possibly untracked, contents would
+                    // otherwise be lost.
+                    // Falling through to the "after" state code in case there
+                    // are parents to be deleted.
+                } else {
+                    changed_file_states.push((path, FileState::placeholder()));
+                    stats.skipped_files += 1;
+                    return Ok(());
+                }
             }
 
             // We get the previous executable bit from the file states and not

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -1836,6 +1836,23 @@ fn test_git_submodule(gitignore_content: &str) -> TestResult {
     let tree_id2 = tree_builder.write_tree().block_on()?;
     let commit2 = commit_with_tree(repo.store(), tree_id2.clone());
 
+    // A commit with a file instead of the submodule at the same path
+    let mut tree_builder = MergedTreeBuilder::new(store.empty_merged_tree());
+    tree_builder.set_or_remove(
+        submodule_path.to_owned(),
+        Merge::normal(TreeValue::File {
+            id: testutils::write_file(
+                repo.store(),
+                submodule_path,
+                "file with same path as submodule\n",
+            ),
+            executable: false,
+            copy_id: CopyId::new(vec![]),
+        }),
+    );
+    let tree_id3 = tree_builder.write_tree().block_on()?;
+    let commit3_file_clash = commit_with_tree(repo.store(), tree_id3.clone());
+
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
         .block_on()?;
@@ -1881,7 +1898,7 @@ fn test_git_submodule(gitignore_content: &str) -> TestResult {
     let stats = ws
         .check_out(repo.op_id().clone(), None, &store.root_commit())
         .block_on()?;
-    assert_eq!(stats.skipped_files, 1);
+    assert_eq!(stats.skipped_files, 0, "Empty tree should checkout cleanly");
 
     // Start with an empty submodule directory and check out a commit without
     // the submodule
@@ -1910,6 +1927,56 @@ fn test_git_submodule(gitignore_content: &str) -> TestResult {
     assert!(
         submodule_dir.metadata().is_ok(),
         "{submodule_dir:?} should exist"
+    );
+    assert_eq!(stats.skipped_files, 0);
+
+    // Restore submodule contents (pretend that the user did `git submodule update`)
+    testutils::write_working_copy_file(
+        &workspace_root,
+        added_submodule_path,
+        "i am a file in a submodule\n",
+    );
+
+    // Check that the files in the submodule are not deleted after checking out
+    // a commit without the submodule
+    let ws = &mut test_workspace.workspace;
+    let stats = ws
+        .check_out(repo.op_id().clone(), None, &store.root_commit())
+        .block_on()?;
+    let file_in_submodule_path = added_submodule_path.to_fs_path_unchecked(&workspace_root);
+    assert!(
+        file_in_submodule_path.metadata().is_ok(),
+        "{file_in_submodule_path:?} should exist"
+    );
+
+    // Check that checking out a submodule over an existing directory with the
+    // same path does not result in a conflict and that the submodule is still
+    // recorded as a submodule in the commit
+    let ws = &mut test_workspace.workspace;
+    ws.check_out(repo.op_id().clone(), None, &commit2)
+        .block_on()?;
+    assert_eq!(stats.skipped_files, 0);
+    let (new_tree, _stats) = test_workspace.snapshot_with_options(&snapshot_options)?;
+    assert_tree_eq!(new_tree, tree_id2);
+
+    // Restore submodule contents (pretend that the user did `git submodule update`)
+    testutils::write_working_copy_file(
+        &workspace_root,
+        added_submodule_path,
+        "i am a file in a submodule\n",
+    );
+
+    // Check out a commit which tries to place a file at the same path
+    let ws = &mut test_workspace.workspace;
+    ws.check_out(repo.op_id().clone(), None, &commit3_file_clash)
+        .block_on()?;
+
+    // Check that the submodule is not replaced by the file, preserving the
+    // user's existing submodule files
+    let file_in_submodule_path = added_submodule_path.to_fs_path_unchecked(&workspace_root);
+    assert!(
+        file_in_submodule_path.metadata().is_ok(),
+        "{file_in_submodule_path:?} should exist"
     );
     Ok(())
 }


### PR DESCRIPTION
Replaces https://github.com/jj-vcs/jj/pull/8176

Fixes #8065.

This commit fixes the problem of jj marking a git submodule as a deleted path,
after the user moves (edit/new) to a commit where the submodule did not exist
and then back to a commit where it existed. Failure to remove a
submodule's directory is no longer considered a conflict - if it was not going
to be replaced by another file.


<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- N/A I have updated the documentation (`README.md`, `docs/`, `demos/`)
- N/A I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
