### PR TITLE
Improve squash command description

### DIFF
--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -74,6 +74,9 @@ use crate::ui::Ui;
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
 ///
+/// The name "squash" comes from the idea of combining (squashing) the changes
+/// from multiple revisions together.
+///
 /// EXPERIMENTAL FEATURES
 ///
 /// An alternative squashing UI is available via the `-o`, `-A`, and `-B`

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2869,6 +2869,8 @@ If the source was abandoned and both the source and destination had a non-empty 
 
 If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
 
+The name "squash" comes from the idea of combining (squashing) the changes from multiple revisions together.
+
 EXPERIMENTAL FEATURES
 
 An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. Using any of these options creates a new commit. They can be used together with one or more `--from` options (if no `--from` is specified, `--from @` is assumed).


### PR DESCRIPTION
Update the one-line description to be clearer about what the command does, and add an explanation for why it's called "squash".

Fixes #7661

I'm fine with painting the bikeshed a different way, but here's my crack at it. After some consideration, I think trying to motivate "squash" while also describing what it does is too much, and so doing it this way might be best.

