### PR TITLE
docs: mention ?? means 'divergence'

### DIFF
--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -61,11 +61,16 @@ use crate::ui::Ui;
 /// [Immutable revisions] have a `◆` symbol. Other commits have a `○` symbol.
 /// All of these symbols can be [customized].
 ///
+/// Changes with a ?? after their ID are [divergent].
+///
 /// [Immutable revisions]:
 ///     https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
 ///
 /// [customized]:
 ///     https://docs.jj-vcs.dev/latest/config/#node-style
+///
+/// [divergent]:
+///     https://docs.jj-vcs.dev/latest/guides/divergence/
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct LogArgs {
     /// Which revisions to show

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1769,9 +1769,13 @@ Spans of revisions that are not included in the graph per `--revisions` are rend
 
 The working-copy commit is indicated by a `@` symbol in the graph. [Immutable revisions] have a `◆` symbol. Other commits have a `○` symbol. All of these symbols can be [customized].
 
+Changes with a ?? after their ID are [divergent].
+
 [Immutable revisions]: https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
 
 [customized]: https://docs.jj-vcs.dev/latest/config/#node-style
+
+[divergent]: https://docs.jj-vcs.dev/latest/guides/divergence/
 
 **Usage:** `jj log [OPTIONS] [FILESETS]...`
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -107,7 +107,8 @@ call that a [divergent change](#divergent-change).
 ## Divergent change
 
 A divergent change is a [change](#change) that has more than one
-[visible commit](#visible-commits).
+[visible commit](#visible-commits). These changes are displayed with a `??`
+after their change ID.
 
 ## Head
 

--- a/docs/guides/divergence.md
+++ b/docs/guides/divergence.md
@@ -5,6 +5,14 @@
 A [divergent change] occurs when multiple [visible commits] have the same change
 ID.
 
+These changes are displayed with a `??` after their change ID:
+
+```shell
+$ jj log
+@  mzvwutvl?? test.user@example.com 2001-02-03 08:05:12 29d07a2d
+│  a divergent change
+```
+
 Normally, when commits are rewritten, the original version (the "predecessor")
 becomes hidden and the new commit (the "successor") is visible. Thus, only one
 commit with a given change ID is visible at a time.


### PR DESCRIPTION
While divergence is talked about in the documentation, few places actually mention how divergent changes are displayed. I've added such notes to the help out put of `jj log`, the glossary, and added an example to the guide we have on divergence.

Fixes #6365

