### PR TITLE
cli git push: allow pushing explicitly named bookmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj git push --bookmark <name>` will now automatically track the bookmark if
+  it isn't tracked with any remote already.
+
 ### Fixed bugs
 
 * `jj git push` now ensures that tracked remote bookmarks are updated even if

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -119,6 +119,9 @@ pub struct GitPushArgs {
     /// Push only this bookmark, or bookmarks matching a pattern (can be
     /// repeated)
     ///
+    /// If a bookmark isn't tracking anything yet, the remote bookmark will be
+    /// tracked automatically.
+    ///
     /// By default, the specified pattern matches bookmark names with glob
     /// syntax. You can also use other [string pattern syntax].
     ///
@@ -356,6 +359,10 @@ pub fn cmd_git_push(
                 continue;
             }
             let remote_symbol = name.to_remote_symbol(remote);
+            // Override allow_new if the bookmark is not tracked with any remote
+            // already. The user has specified --bookmark, so their intent which
+            // bookmarks to push is clear.
+            let allow_new = allow_new || !has_tracked_remote_bookmarks(tx.repo(), name);
             let allow_delete = true; // named explicitly, allow delete without --delete
             match classify_bookmark_update(remote_symbol, targets, allow_new, allow_delete) {
                 Ok(Some(update)) => bookmark_updates.push((name.to_owned(), update)),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1618,6 +1618,8 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
    This defaults to the `git.push` setting. If that is not configured, and if there are multiple remotes, the remote named "origin" will be used.
 * `-b`, `--bookmark <BOOKMARK>` — Push only this bookmark, or bookmarks matching a pattern (can be repeated)
 
+   If a bookmark isn't tracking anything yet, the remote bookmark will be tracked automatically.
+
    By default, the specified pattern matches bookmark names with glob syntax. You can also use other [string pattern syntax].
 
    [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns


### PR DESCRIPTION
This idea was recently [mentioned again](https://github.com/jj-vcs/jj/pull/8082#issuecomment-3618859440). There was a [feature request](https://github.com/jj-vcs/jj/issues/7138) about it, but it was closed as a duplicate of the discussion about [auto-tracking bookmarks](https://github.com/jj-vcs/jj/issues/7072). In the [preceeding discussion](https://github.com/jj-vcs/jj/pull/4871) I brought up the idea that `jj git push --bookmark` should work for yet-untracked bookmarks. I think it was overlooked a bit because other, more important topics were being discussed in the same thread. I still think this has merit on its own, now that auto-tracking bookmarks has landed.

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
