### PR TITLE
add error for committing an empty file set without a message

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -159,6 +159,18 @@ new working-copy commit.
             "The given paths do not match any file: {}",
             args.paths.join(" ")
         )?;
+
+        if args.message_paragraphs.is_empty() {
+            let error = format!(
+                "Did you mean `commit --message \"{}\"` ?",
+                args.paths.join(" ")
+            );
+
+            return Err(CommandError::new(
+                crate::command_error::CommandErrorKind::User,
+                error,
+            ));
+        }
     }
 
     let mut commit_builder = tx.repo_mut().rewrite_commit(&commit).detach();


### PR DESCRIPTION
hit this a few times unintentionally doing AoC, where the warning shown is hidden by the new editor opening, doing something like `jj commit d5p1`.

I have not done items in the checklist below because I am not sure if this is even the best approach. 

Edit: On a personal level I'd rather the file set *become* the message in this case but that's probably not something `jj` wants to do.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
