### PR TITLE
docs: fix MD031 markdown lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * The config options `git.auto-local-bookmark` and `git.push-new-bookmarks` are
   deprecated in favor of `remotes.<name>.auto-track-bookmarks`. For example:
+
   ```toml
   [remotes.origin]
   auto-track-bookmarks = "glob:*"
   ```
+
   For more details, refer to
   [the docs](docs/config.md#automatic-tracking-of-bookmarks).
 
@@ -105,10 +107,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   bookmarks, please track them with `jj bookmark track`. Alternatively, consider
   setting up an auto-tracking configuration to avoid the chore of tracking
   bookmarks manually. For example:
+
   ```toml
   [remotes.origin]
   auto-track-bookmarks = "glob:*"
   ```
+
   For more details, refer to
   [the docs](docs/config.md#automatic-tracking-of-bookmarks).
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -531,6 +531,7 @@ empty commit. To revert the changes merged in from the second parent, instead
 use `jj restore --from <first parent>` .
 
 Example:
+
 ```text
 @
 |
@@ -540,6 +541,7 @@ B D
 |/
 A
 ```
+
 To revert the merge in `C`, create a new commit with `jj new C`,
 then `jj restore --from B`, and then describe the message
 with something like `jj desc -m "Revert the merge of D into B`. Now, commit `@`
@@ -575,6 +577,7 @@ which can slow down both tools and occasionally cause file access conflicts.
 
 **Solution**: Configure Vite to ignore the `.jj` directory by adding it to the
 `server.watch.ignored` array inside your Vite configuration, for example:
+
 ```js
 // vite.config.js
 export default defineConfig({

--- a/docs/config.md
+++ b/docs/config.md
@@ -200,6 +200,7 @@ concat(
 ```
 
 You can override only the `default_commit_description` value if you like, e.g.:
+
 ```toml
 [template-aliases]
 default_commit_description = '''
@@ -572,6 +573,7 @@ templates.
 - `templates.op_log_node` for operations (with `Operation` keywords)
 
 For example:
+
 ```toml
 [templates]
 log_node = '''

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -595,16 +595,20 @@ turns on `debug` log level for `jj-lib` and `jj-cli` only.
 
 One easy-to-use sampling profiler
 is [samply](https://github.com/mstange/samply). For example:
+
 ```shell
 cargo install samply
 samply record jj diff
 ```
+
 Then just open the link it prints.
 
 Another option is to use the instrumentation we've added manually (using
 `tracing::instrument`) in various places. For example:
+
 ```shell
 JJ_TRACE=/tmp/trace.json jj diff
 ```
+
 Then go to `https://ui.perfetto.dev/` in Chrome and load `/tmp/trace.json` from
 there.

--- a/docs/design/copy-tracking.md
+++ b/docs/design/copy-tracking.md
@@ -63,6 +63,7 @@ lossy; rebasing a commit and then rebasing it back yields the same content. We
 should ideally preserve this property when possible.
 
 For example:
+
 ```console
 $ jj log
 C rename bar->baz
@@ -82,6 +83,7 @@ Patches should be reversible so you can make a change and then revert it, and
 end up with an empty diff across both commits.
 
 For example:
+
 ```console
 $ jj log
 B rename foo->bar
@@ -95,6 +97,7 @@ $ jj diff --from B- --to B+ # Should be empty
 #### Parallelize/serialize
 
 This is a special case of the lossless rebase.
+
 ```console
 $ jj log
 E edit qux
@@ -118,6 +121,7 @@ $ jj rebase -r D -A C
 #### Copies inside merge commit
 
 We should be able to resolve a naming conflict:
+
 ```console
 $ jj log
 D  resolve naming conflict by choosing `foo` as the source
@@ -135,6 +139,7 @@ We should also be able to back out that resolution and get back into the
 name-conflicted state.
 
 We should be able to rename files that exist on only one side:
+
 ```console
 $ jj log
 D  rename foo2->foo3 and bar2->bar3
@@ -198,6 +203,7 @@ existing file involved. That makes logical sense, but I'm not sure how useful
 it will be.
 
 The data structure might look like this:
+
 ```rust
 // Current `TreeValue::File` variant:
 File { id: FileId, executable: bool },
@@ -248,6 +254,7 @@ Notation:
 * The `2:bar->1:foo` means that copy ID 2 (i.e. hash of the `CopyHistory`
   struct) has file `bar`, which was copied from copy ID `1`, where it was
   called `foo`.
+
 ```console
 Commit K:
 name: foo, id: K, copy_id: 1:foo
@@ -264,6 +271,7 @@ name: baz, id: M, copy_id: 5:baz->1:foo
 
 This graph also shows the relationship between the copy IDs and which commits
 they appear in:
+
 ```mermaid
 graph LR
 
@@ -389,6 +397,7 @@ when materialized. It will therefore not show up in the working copy until the
 user has resolved the conflict.
 
 For example:
+
 ```console
 M set foo="bye"
 |
@@ -484,6 +493,7 @@ then all apply to `foo`, which means we get a 4-sided conflict.
 #### Example: Convergent renames
 
 Consider this "convergent copy/rename" scenario:
+
 ```console
 $ jj log
 C rename bar->baz
@@ -497,6 +507,7 @@ $ jj new B C
 
 It seems clear that `baz`'s copy graph should inherit from both `foo` and `bar`,
 producing a merge in copy graph. The trees would look like this:
+
 ```
 Commit A:
 name: foo, id: aaa111, copy_id: 1:foo
@@ -567,6 +578,7 @@ propagated to `bar`.
 #### Example: Divergent renames
 
 Consider this "divergent rename" scenario:
+
 ```console
 $ jj log
 C rename foo->baz

--- a/docs/design/secure-config.md
+++ b/docs/design/secure-config.md
@@ -158,6 +158,7 @@ message Metadata {
 ```
 
 The function to load repository configuration, will roughly speaking, look like:
+
 ```rust
 enum ConfigLoadError { NoRepoId, NoConfig, PathMismatch, }
 


### PR DESCRIPTION
[MD031/blanks-around-fences](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md031.md) : Fenced code blocks should be surrounded by blank lines
