### PR TITLE
rustc_lint: enable redundant-imports lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,9 @@ unused_trait_names = "warn"
 use_self = "warn"
 useless_conversion = "warn"
 
+[workspace.lints.rust]
+redundant_imports = "warn"
+
 [profile.dev.package]
 # Insta suggests compiling these packages in opt mode for faster testing.
 # See https://docs.rs/insta/latest/insta/#optional-faster-runs.

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -2822,7 +2822,6 @@ mod tests {
     use std::path::Component;
     use std::path::Path;
     use std::path::PathBuf;
-    use std::sync::Arc;
 
     use jj_lib::config::ConfigLayer;
     use jj_lib::config::ConfigSource;

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -751,7 +751,6 @@ mod tests {
     use indoc::indoc;
     use jj_lib::config::ConfigLayer;
     use jj_lib::config::ConfigSource;
-    use jj_lib::config::StackedConfig;
 
     use super::*;
 

--- a/lib/src/config_resolver.rs
+++ b/lib/src/config_resolver.rs
@@ -433,7 +433,6 @@ mod tests {
     use indoc::indoc;
 
     use super::*;
-    use crate::config::ConfigSource;
 
     #[test]
     fn test_expand_home() {

--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -20,7 +20,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Write as _;
-use std::future::Future;
 use std::hash::Hash;
 use std::iter::zip;
 use std::slice;

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -773,7 +773,6 @@ pub fn assert_no_forgotten_test_files(test_dir: &Path) {
 /// UTF-8 validation, as on ZFS with the `utf8only=on` property set.
 #[cfg(unix)]
 pub fn check_strict_utf8_fs(dir: &Path) -> bool {
-    use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt as _;
 
     let test_file_normal = tempfile::Builder::new()


### PR DESCRIPTION
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#redundant-imports
