### PR TITLE
rustc_lint: enable let_underscore_drop lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ use_self = "warn"
 useless_conversion = "warn"
 
 [workspace.lints.rust]
+let_underscore_drop = "warn"
 redundant_imports = "warn"
 
 [profile.dev.package]

--- a/cli/src/commands/debug/watchman.rs
+++ b/cli/src/commands/debug/watchman.rs
@@ -89,7 +89,7 @@ pub fn cmd_debug_watchman(
                 }
             };
             let wc = check_local_disk_wc(workspace_command.working_copy())?;
-            let _ = wc.query_watchman(&config)?;
+            wc.query_watchman(&config)?;
             writeln!(
                 ui.stdout(),
                 "The watchman server seems to be installed and working correctly."

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -1061,12 +1061,12 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
     // No config migration for completion. Simply ignore deprecated variables.
     let mut config_env = ConfigEnv::from_environment();
     let maybe_cwd_workspace_loader = DefaultWorkspaceLoaderFactory.create(find_workspace_dir(&cwd));
-    let _ = config_env.reload_user_config(&mut raw_config);
+    config_env.reload_user_config(&mut raw_config).ok();
     if let Ok(loader) = &maybe_cwd_workspace_loader {
         config_env.reset_repo_path(loader.repo_path());
-        let _ = config_env.reload_repo_config(&mut raw_config);
+        config_env.reload_repo_config(&mut raw_config).ok();
         config_env.reset_workspace_path(loader.workspace_root());
-        let _ = config_env.reload_workspace_config(&mut raw_config);
+        config_env.reload_workspace_config(&mut raw_config).ok();
     }
     let mut config = config_env.resolve_config(&raw_config)?;
     // skip 2 because of the clap_complete prelude: jj -- jj <actual args...>
@@ -1084,9 +1084,9 @@ fn get_jj_command() -> Result<(JjBuilder, UserSettings), CommandError> {
         // Try to update repo-specific config on a best-effort basis.
         if let Ok(loader) = DefaultWorkspaceLoaderFactory.create(&cwd.join(&repository)) {
             config_env.reset_repo_path(loader.repo_path());
-            let _ = config_env.reload_repo_config(&mut raw_config);
+            config_env.reload_repo_config(&mut raw_config).ok();
             config_env.reset_workspace_path(loader.workspace_root());
-            let _ = config_env.reload_workspace_config(&mut raw_config);
+            config_env.reload_workspace_config(&mut raw_config).ok();
             if let Ok(new_config) = config_env.resolve_config(&raw_config) {
                 config = new_config;
             }
@@ -1340,7 +1340,7 @@ mod tests {
     #[test]
     fn test_config_keys() {
         // Just make sure the schema is parsed without failure.
-        let _ = config_keys();
+        config_keys();
     }
 
     #[test]

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -135,7 +135,7 @@ fn pinentry_get_pw(url: &str) -> Option<String> {
         Ok(out)
     };
     let maybe_out = interact();
-    _ = pinentry.wait();
+    pinentry.wait().ok();
     for line in maybe_out.ok()?.split('\n') {
         if !line.starts_with("D ") {
             continue;
@@ -255,14 +255,14 @@ pub fn with_remote_git_callbacks<T>(ui: &Ui, f: impl FnOnce(git::RemoteCallbacks
     if let Some(mut output) = ui.progress_output() {
         let mut progress = Progress::new(Instant::now());
         progress_callback = move |x: &git::Progress| {
-            _ = progress.update(Instant::now(), x, &mut output);
+            progress.update(Instant::now(), x, &mut output).ok();
         };
         callbacks.progress = Some(&mut progress_callback);
     }
 
     let mut sideband_progress_writer = GitSidebandProgressMessageWriter::new(ui);
     let mut sideband_progress_callback = |progress_message: &[u8]| {
-        _ = sideband_progress_writer.write(ui, progress_message);
+        sideband_progress_writer.write(ui, progress_message).ok();
     };
     callbacks.sideband_progress = Some(&mut sideband_progress_callback);
 
@@ -276,7 +276,7 @@ pub fn with_remote_git_callbacks<T>(ui: &Ui, f: impl FnOnce(git::RemoteCallbacks
     callbacks.get_username_password = Some(&mut get_user_pw);
 
     let result = f(callbacks);
-    _ = sideband_progress_writer.flush(ui);
+    sideband_progress_writer.flush(ui).ok();
     result
 }
 
@@ -387,7 +387,7 @@ impl Progress {
             let guard = CleanupGuard::new(move || {
                 drop(guard);
             });
-            _ = write!(output, "{}", crossterm::cursor::Hide);
+            write!(output, "{}", crossterm::cursor::Hide).ok();
             self.guard = Some(guard);
         }
 

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -56,11 +56,12 @@ pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + use<>> {
         let (display_path, _) =
             text_util::elide_start(fs_path.to_str().unwrap(), "...", max_path_width);
 
-        _ = write!(
+        write!(
             state.output,
             "\r{}Snapshotting {display_path}",
             Clear(ClearType::CurrentLine),
-        );
-        _ = state.output.flush();
+        )
+        .ok();
+        state.output.flush().ok();
     })
 }

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -745,8 +745,8 @@ pub struct OutputGuard {
 impl Drop for OutputGuard {
     #[instrument(skip_all)]
     fn drop(&mut self) {
-        _ = self.output.write_all(self.text.as_bytes());
-        _ = self.output.flush();
+        self.output.write_all(self.text.as_bytes()).ok();
+        self.output.flush().ok();
     }
 }
 

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -773,7 +773,7 @@ fn can_create_new_file(disk_path: &Path) -> Result<bool, CheckoutError> {
     if let Some(new_file) = new_file {
         reject_reserved_existing_file(new_file, disk_path).inspect_err(|_| {
             // We keep the error from `reject_reserved_existing_file`
-            let _ = fs::remove_file(disk_path);
+            fs::remove_file(disk_path).ok();
         })?;
 
         fs::remove_file(disk_path).map_err(|err| CheckoutError::Other {

--- a/lib/src/lock/unix.rs
+++ b/lib/src/lock/unix.rs
@@ -81,7 +81,7 @@ impl Drop for FileLock {
     #[instrument(skip_all)]
     fn drop(&mut self) {
         // Removing the file isn't strictly necessary, but reduces confusion.
-        _ = std::fs::remove_file(&self.path);
+        std::fs::remove_file(&self.path).ok();
         // Unblock any processes that tried to acquire the lock while we held it.
         // They're responsible for creating and locking a new lockfile, since we
         // just deleted this one.

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -763,7 +763,7 @@ impl<'matcher> TreeDiffStreamImpl<'matcher> {
             }
 
             for (dir, tree_diff) in tree_diffs {
-                let _ = self.pending_trees.remove_entry(&dir).unwrap();
+                drop(self.pending_trees.remove_entry(&dir).unwrap());
                 match tree_diff {
                     Ok((trees1, trees2)) => {
                         self.add_dir_diff_items(&dir, &trees1, &trees2);

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -324,7 +324,7 @@ impl Workspace {
             Ok((workspace, repo))
         })()
         .inspect_err(|_err| {
-            let _ = std::fs::remove_dir_all(jj_dir);
+            std::fs::remove_dir_all(jj_dir).ok();
         })
     }
 

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -57,7 +57,7 @@ fn diff_paths(from_tree: &MergedTree, to_tree: &MergedTree) -> Vec<RepoPathBuf> 
     from_tree
         .diff_stream(to_tree, &EverythingMatcher)
         .map(|diff| {
-            let _ = diff.values.unwrap();
+            diff.values.unwrap();
             diff.path
         })
         .collect()

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -766,7 +766,7 @@ fn test_rebase_descendants_multiple_swap() {
         .set_rewritten_commit(commit_b.id().clone(), commit_d.id().clone());
     tx.repo_mut()
         .set_rewritten_commit(commit_d.id().clone(), commit_b.id().clone());
-    let _ = tx.repo_mut().rebase_descendants(); // Panics because of the cycle
+    tx.repo_mut().rebase_descendants().ok(); // Panics because of the cycle
 }
 
 #[test]


### PR DESCRIPTION
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#let-underscore-drop
