### PR TITLE
tests: update cargo insta snapshots

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -714,7 +714,7 @@ mod tests {
         assert_snapshot!(update(Duration::from_millis(10), 0.12), @"");
         assert_snapshot!(update(Duration::from_millis(10), 0.13), @"");
         // We get an update now that we go over the threshold
-        assert_snapshot!(update(Duration::from_millis(100), 0.30), @" 30% [█████▍            ][K");
+        assert_snapshot!(update(Duration::from_millis(100), 0.30), @"\r 30% [█████▍            ]\u{1b}[K");
         // Even though we went over by quite a bit, the new threshold is relative to the
         // previous output, so we don't get an update here
         assert_snapshot!(update(Duration::from_millis(30), 0.40), @"");

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -962,7 +962,7 @@ mod tests {
             "executable_file",
         ]
         "#);
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -987,7 +987,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree = apply_diff(store, &left_tree, &right_tree, &changed_files, &files);
         assert_tree_eq!(left_tree, no_changes_tree, "no-changes tree was different");
 
@@ -1316,7 +1316,7 @@ mod tests {
             "file_with_content",
         ]
         "#);
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -1341,7 +1341,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree = apply_diff(store, &left_tree, &right_tree, &changed_files, &files);
         assert_tree_eq!(left_tree, no_changes_tree, "no-changes tree was different");
 
@@ -1472,7 +1472,7 @@ mod tests {
             "file_with_content",
         ]
         "#);
-        insta::assert_debug_snapshot!(files, @r###"
+        insta::assert_debug_snapshot!(files, @r#"
         [
             File {
                 old_path: None,
@@ -1493,7 +1493,7 @@ mod tests {
                 ],
             },
         ]
-        "###);
+        "#);
         let no_changes_tree = apply_diff(store, &left_tree, &right_tree, &changed_files, &files);
         assert_tree_eq!(left_tree, no_changes_tree, "no-changes tree was different");
 

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -3839,14 +3839,14 @@ mod tests {
             @"1----true--test--");
 
         // Separator is required.
-        insta::assert_snapshot!(env.parse_err(r#"join()"#), @r#"
+        insta::assert_snapshot!(env.parse_err(r#"join()"#), @r"
          --> 1:6
           |
         1 | join()
           |      ^
           |
           = Function `join`: Expected at least 1 arguments
-        "#);
+        ");
 
         // Labeled.
         insta::assert_snapshot!(

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -173,7 +173,7 @@ fn test_absorb_replace_single_line_hunk() {
     work_dir.run_jj(["new"]).success();
     work_dir.write_file("file1", "2a\n1A\n2b\n");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
       qpvuntsm 19034586 (conflict) 1
@@ -189,7 +189,7 @@ fn test_absorb_replace_single_line_hunk() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
     @  mzvwutvl f9c426f2 (empty) (no description set)
@@ -421,7 +421,7 @@ fn test_absorb_conflict() {
     work_dir.run_jj(["new", "root()"]).success();
     work_dir.write_file("file1", "2a\n2b\n");
     let output = work_dir.run_jj(["rebase", "-r@", "-dsubject(glob:1)"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     Working copy  (@) now at: kkmpptxz 01e6cd99 (conflict) (no description set)
@@ -438,7 +438,7 @@ fn test_absorb_conflict() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     let conflict_content = work_dir.read_file("file1");
     insta::assert_snapshot!(conflict_content, @r"
@@ -547,7 +547,7 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     work_dir.remove_file("file1");
     work_dir.remove_file("file2");
     let output = work_dir.run_jj(["absorb"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 2 revisions:
       kkmpptxz 9210e16d (conflict) 2
@@ -567,7 +567,7 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     Remaining changes:
     D file2
     [EOF]
-    "###);
+    ");
 
     insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
     @  zsuskuln f8744d38 (no description set)

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -138,6 +138,8 @@ fn test_commit_with_empty_description_from_editor() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(),
         @r#"
+
+
     JJ: Change ID: qpvuntsm
     JJ:
     JJ: Lines starting with "JJ:" (like this one) will be removed.
@@ -313,6 +315,8 @@ fn test_commit_with_default_description() {
     "#);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
+
+
     TESTED=TODO
 
     JJ: Change ID: qpvuntsm
@@ -361,6 +365,7 @@ fn test_commit_with_description_template() {
     work_dir.run_jj(["commit", "file1"]).success();
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
+
     JJ: Author: Test User <test.user@example.com> (2001-02-03 08:05:08)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
 
@@ -381,6 +386,7 @@ fn test_commit_with_description_template() {
         .success();
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
+
     JJ: Author: Another User <another.user@example.com> (2001-02-03 08:05:08)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -394,6 +400,7 @@ fn test_commit_with_description_template() {
     work_dir.run_jj(["commit", "--reset-author"]).success();
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
+
     JJ: Author: Test User <test.user@example.com> (2001-02-03 08:05:10)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:10)
 
@@ -647,6 +654,7 @@ fn test_commit_with_editor_and_empty_message() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
 
+
     Trailer: value
 
     JJ: Change ID: qpvuntsm
@@ -673,6 +681,8 @@ fn test_commit_with_editor_without_message() {
     // Verify editor was opened
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
+
+
     JJ: Change ID: qpvuntsm
     JJ: This commit contains the following changes:
     JJ:     A file1

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1543,12 +1543,12 @@ fn test_files() {
     insta::assert_snapshot!(
         output.normalize_stdout_with(|s| s.replace(std::path::MAIN_SEPARATOR, "→")),
         @r"
-        f_dir→dir_file_1	Added
-        f_dir→dir_file_2	Added
-        f_dir→dir_file_3	Added
-        f_dir→f_renamed_3	Renamed
-        [EOF]
-        ");
+    f_dir→dir_file_1	Added
+    f_dir→dir_file_2	Added
+    f_dir→dir_file_3	Added
+    f_dir→f_renamed_3	Renamed
+    [EOF]
+    ");
 
     let output = work_dir.complete_fish(["diff", "--from", "root()", "--to", "@-", "f_"]);
     insta::assert_snapshot!(output, @r"

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -205,12 +205,12 @@ fn test_concurrent_snapshot_wc_reloadable() {
     .unwrap();
     work_dir.write_file("child2", "");
     let output = work_dir.run_jj(["describe", "-m", "new child2"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: kkmpptxz 493da83e new child2
     Parent commit (@-)      : rlvkpnrz 15bd889d new child1
     [EOF]
-    "###);
+    ");
 
     // Since the repo can be reloaded before snapshotting, "child2" should be
     // a child of "child1", not of "initial".

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -447,12 +447,12 @@ fn test_config_layer_override_default() {
         "--config",
         &format!("{config_key}={value}", value = to_toml_value("command-arg")),
     ]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     # merge-tools.vimdiff.program = "user"
     # merge-tools.vimdiff.program = "repo"
     merge-tools.vimdiff.program = "command-arg"
     [EOF]
-    "##);
+    "#);
 
     let output = work_dir.run_jj([
         "config",
@@ -536,14 +536,14 @@ fn test_config_layer_override_env() {
         "--config",
         &format!("{config_key}={value}", value = to_toml_value("command-arg")),
     ]);
-    insta::assert_snapshot!(output, @r##"
+    insta::assert_snapshot!(output, @r#"
     # ui.editor = "env-base"
     # ui.editor = "user"
     # ui.editor = "repo"
     # ui.editor = "env-override"
     ui.editor = "command-arg"
     [EOF]
-    "##);
+    "#);
 }
 
 #[test]
@@ -1106,7 +1106,8 @@ fn test_config_edit_invalid_config() {
     let output = work_dir.run_jj(["config", "get", "test"]);
     insta::assert_snapshot!(output, @r"
     success
-    [EOF]"
+    [EOF]
+    "
     );
 
     // Test the restore previous config
@@ -1135,7 +1136,8 @@ fn test_config_edit_invalid_config() {
     let output = work_dir.run_jj(["config", "get", "test"]);
     insta::assert_snapshot!(output, @r"
     success
-    [EOF]"
+    [EOF]
+    "
     );
 }
 

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -634,12 +634,12 @@ fn test_describe_stdin_description() {
             .args(["describe", "--stdin"])
             .write_stdin("first stdin\nsecond stdin")
     });
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: qpvuntsm b9990801 (empty) first stdin
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]
-    "#);
+    ");
     let output = work_dir.run_jj(["log", "--no-graph", "-r@", "-Tdescription"]);
     insta::assert_snapshot!(output, @r"
     first stdin
@@ -669,6 +669,8 @@ fn test_describe_default_description() {
     "#);
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
+
+
     TESTED=TODO
 
     JJ: Change ID: qpvuntsm
@@ -767,6 +769,7 @@ fn test_describe_author() {
     ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
+
     JJ: Author: Super Seeder <super.seeder@example.com> (2001-02-03 08:05:12)
     JJ: Committer: Test User <test.user@example.com> (2001-02-03 08:05:12)
 

--- a/cli/tests/test_diffedit_command.rs
+++ b/cli/tests/test_diffedit_command.rs
@@ -335,7 +335,7 @@ fn test_diffedit_existing_instructions() {
     ");
     // Test that we didn't delete or overwrite the "JJ-INSTRUCTIONS" file.
     let content = work_dir.read_file("JJ-INSTRUCTIONS");
-    insta::assert_snapshot!(content, @r"modified");
+    insta::assert_snapshot!(content, @"modified");
 }
 
 #[test]

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -246,6 +246,7 @@ fn test_annotate_with_template() {
 
     let output = work_dir.run_jj(["file", "annotate", "file.txt", "-T", template]);
     insta::assert_snapshot!(output, @r"
+
     qpvuntsm initial
     2001-02-03 08:05:08 Test User <test.user@example.com>
        2 ->   1: initial 2

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -222,7 +222,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "chmod", "x", "file", "-r=file_deletion"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: kmkuslsw 849406ce file_deletion | (conflict) file_deletion
     Parent commit (@-)      : zsuskuln bc9cdea1 file | file
@@ -239,7 +239,7 @@ fn test_chmod_file_dir_deletion_conflicts() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     let output = work_dir.run_jj(["debug", "tree", "-r=file_deletion"]);
     insta::assert_snapshot!(output, @r#"
     file: Ok(Conflicted([Some(File { id: FileId("78981922613b2afb6025042ff6bd878ac1994e85"), executable: true, copy_id: CopyId("") }), Some(File { id: FileId("df967b96a579e45a18b8251732d16804b2e56a55"), executable: true, copy_id: CopyId("") }), None]))
@@ -418,13 +418,13 @@ fn test_chmod_exec_bit_ignore_then_respect() {
 
     // Set the in-repo executable bit to true.
     let output = work_dir.run_jj(["file", "chmod", "x", "file"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Working copy  (@) now at: rlvkpnrz cb3f99cb base | base
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
-    "#);
+    ");
     assert_file_executable(path, false);
 
     test_env.add_config(r#"working-copy.exec-bit-change = "respect""#);

--- a/cli/tests/test_file_track_untrack_commands.rs
+++ b/cli/tests/test_file_track_untrack_commands.rs
@@ -72,7 +72,7 @@ fn test_track_untrack() {
     // Can untrack a single file
     assert!(files_before.stdout.raw().contains("file1.bak\n"));
     let output = work_dir.run_jj(["file", "untrack", "file1.bak"]);
-    insta::assert_snapshot!(output, @r"");
+    insta::assert_snapshot!(output, @"");
     let files_after = work_dir.run_jj(["file", "list"]).success();
     // The file is no longer tracked
     assert!(!files_after.stdout.raw().contains("file1.bak"));

--- a/cli/tests/test_fix_command.rs
+++ b/cli/tests/test_fix_command.rs
@@ -456,9 +456,15 @@ fn test_config_filesets() {
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "show", "b1", "-r", "@"]);
-    insta::assert_snapshot!(output, @"1b[EOF]");
+    insta::assert_snapshot!(output, @r"
+
+    1b[EOF]
+    ");
     let output = work_dir.run_jj(["file", "show", "b2", "-r", "@"]);
-    insta::assert_snapshot!(output, @"2b[EOF]");
+    insta::assert_snapshot!(output, @r"
+
+    2b[EOF]
+    ");
 }
 
 #[test]
@@ -583,15 +589,15 @@ fn test_relative_tool_path_from_subdirectory() {
     ");
 
     let output = work_dir.run_jj(["file", "show", "test.txt", "-r", "@"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     HELLO WORLD
     [EOF]
-    "###);
+    ");
     let output = work_dir.run_jj(["file", "show", "subdir/nested.txt", "-r", "@"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     NESTED CONTENT
     [EOF]
-    "###);
+    ");
 
     // Reset so the fix tools should have an effect again
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -608,15 +614,15 @@ fn test_relative_tool_path_from_subdirectory() {
     ");
 
     let output = work_dir.run_jj(["file", "show", "test.txt", "-r", "@"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     HELLO WORLD
     [EOF]
-    "###);
+    ");
     let output = work_dir.run_jj(["file", "show", "subdir/nested.txt", "-r", "@"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     NESTED CONTENT
     [EOF]
-    "###);
+    ");
 }
 
 #[test]
@@ -1006,7 +1012,10 @@ fn test_fix_cyclic() {
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(output, @"tnetnoc[EOF]");
+    insta::assert_snapshot!(output, @r"
+
+    tnetnoc[EOF]
+    ");
 
     let output = work_dir.run_jj(["fix"]);
     insta::assert_snapshot!(output, @r"
@@ -1018,7 +1027,10 @@ fn test_fix_cyclic() {
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(output, @"content[EOF]");
+    insta::assert_snapshot!(output, @r"
+
+    content[EOF]
+    ");
 }
 
 #[test]
@@ -1286,7 +1298,7 @@ fn test_fix_executable() {
     [EOF]
     ");
     let output = work_dir.run_jj(["file", "show", "file", "-r", "@"]);
-    insta::assert_snapshot!(output, @r"CONTENT[EOF]");
+    insta::assert_snapshot!(output, @"CONTENT[EOF]");
     let executable = std::fs::metadata(&path).unwrap().permissions().mode() & 0o111;
     assert_eq!(executable, 0o111);
 }

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -25,30 +25,30 @@ fn test_gerrit_upload_dryrun() {
     create_commit(&work_dir, "b", &["a"]);
     create_commit(&work_dir, "c", &["a"]);
     let output = work_dir.run_jj(["gerrit", "upload", "-r", "b"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: No remote specified, and no 'gerrit' remote was found
     [EOF]
     [exit status: 1]
-    "###);
+    ");
 
     // With remote specified but.
     test_env.add_config(r#"gerrit.default-remote="origin""#);
     let output = work_dir.run_jj(["gerrit", "upload", "-r", "b"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The remote 'origin' (configured via `gerrit.default-remote`) does not exist
     [EOF]
     [exit status: 1]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["gerrit", "upload", "-r", "b", "--remote=origin"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The remote 'origin' (specified via `--remote`) does not exist
     [EOF]
     [exit status: 1]
-    "###);
+    ");
 
     let output = work_dir.run_jj([
         "git",
@@ -59,33 +59,33 @@ fn test_gerrit_upload_dryrun() {
     ]);
     insta::assert_snapshot!(output, @"");
     let output = work_dir.run_jj(["gerrit", "upload", "-r", "b", "--remote=origin"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: No target branch specified via --remote-branch, and no 'gerrit.default-remote-branch' was found
     [EOF]
     [exit status: 1]
-    "###);
+    ");
 
     test_env.add_config(r#"gerrit.default-remote-branch="main""#);
     let output = work_dir.run_jj(["gerrit", "upload", "-r", "b", "--dry-run"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
 
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
 
     Dry-run: Would push zsuskuln 123b4d91 b | b
     [EOF]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["gerrit", "upload", "-r", "b", "--dry-run", "-b", "other"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
 
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'other'
 
     Dry-run: Would push zsuskuln 123b4d91 b | b
     [EOF]
-    "###);
+    ");
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn test_gerrit_upload_local() {
     // The output should only mentioned commit IDs from the log output above (no
     // temporary commits)
     let output = local_dir.run_jj(["log", "-r", "all()"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:14 c 9590bf26
     │  c
     ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
@@ -116,22 +116,22 @@ fn test_gerrit_upload_local() {
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
-    "###);
+    ");
 
     let output = local_dir.run_jj(["gerrit", "upload", "-r", "c", "--remote-branch=main"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
 
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
 
     Pushing yqosqzyt 9590bf26 c | c
     [EOF]
-    "###);
+    ");
 
     // The output should be unchanged because we only add Change-Id trailers
     // transiently
     let output = local_dir.run_jj(["log", "-r", "all()"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:14 c 9590bf26
     │  c
     ○  mzvwutvl test.user@example.com 2001-02-03 08:05:12 b 3bcb28c4
@@ -140,12 +140,12 @@ fn test_gerrit_upload_local() {
     │  a
     ◆  zzzzzzzz root() 00000000
     [EOF]
-    "###);
+    ");
 
     // There's no particular reason to run this with jj util exec, it's just that
     // the infra makes it easier to run this way.
     let output = remote_dir.run_jj(["util", "exec", "--", "git", "log", "refs/for/main"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     commit ab6776c073b82fbbd2cd0858482a9646afd56f85
     Author: Test User <test.user@example.com>
     Date:   Sat Feb 3 04:05:13 2001 +0700
@@ -168,5 +168,5 @@ fn test_gerrit_upload_local() {
 
         a
     [EOF]
-    "###);
+    ");
 }

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -49,7 +49,8 @@ fn test_git_colocation_enable_success() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
-    [EOF]");
+    [EOF]
+    ");
 
     // Run colocate command
     let output = work_dir.run_jj(["git", "colocation", "enable"]);
@@ -84,7 +85,8 @@ fn test_git_colocation_enable_success() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 git_head() e8849ae1
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
-    [EOF]");
+    [EOF]
+    ");
 }
 
 #[test]
@@ -130,7 +132,8 @@ fn test_git_colocation_enable_with_existing_git_dir() {
     ------- stderr -------
     Error: A .git directory already exists in the workspace root. Cannot colocate.
     [EOF]
-    [exit status: 1]");
+    [exit status: 1]
+    ");
 }
 
 #[test]
@@ -155,7 +158,8 @@ fn test_git_colocation_disable_success() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 git_head() e8849ae1
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
-    [EOF]");
+    [EOF]
+    ");
 
     // Verify it's colocated
     assert!(workspace_root.join(".git").exists());
@@ -190,7 +194,8 @@ fn test_git_colocation_disable_success() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
     ◆  zzzzzzzz root() 00000000
-    [EOF]");
+    [EOF]
+    ");
 }
 
 #[test]

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1940,13 +1940,13 @@ fn test_git_fetch_tracked() {
         .success();
 
     // Both should be tracked
-    insta::assert_snapshot!(get_bookmark_output(&work_dir), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     feature1: txqvqkwm fc8f3f42 message
       @origin: txqvqkwm fc8f3f42 message
     main: kmpysrkw 0130f303 message
       @origin: kmpysrkw 0130f303 message
     [EOF]
-    "###);
+    ");
 
     // Now untrack feature1
     work_dir
@@ -1954,13 +1954,13 @@ fn test_git_fetch_tracked() {
         .success();
 
     // Verify feature1 is untracked
-    insta::assert_snapshot!(get_bookmark_output(&work_dir), @r###"
+    insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     feature1: txqvqkwm fc8f3f42 message
     feature1@origin: txqvqkwm fc8f3f42 message
     main: kmpysrkw 0130f303 message
       @origin: kmpysrkw 0130f303 message
     [EOF]
-    "###);
+    ");
 
     // Add new commits to all bookmarks on the remote
     add_commit_to_branch(&remote_repo, "main", "message");
@@ -2029,11 +2029,11 @@ fn test_git_fetch_tracked_no_tracked_bookmarks() {
 
     // Fetch with --tracked should indicate nothing changed
     let output = work_dir.run_jj(["git", "fetch", "--tracked"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -402,12 +402,12 @@ fn test_git_remote_named_git() {
     insta::assert_snapshot!(output, @"");
     let output = work_dir.run_jj(["git", "remote", "list"]);
     insta::assert_snapshot!(output, @"");
-    insta::assert_snapshot!(read_git_config(work_dir.root()), @r#"
+    insta::assert_snapshot!(read_git_config(work_dir.root()), @r"
     [core]
     	repositoryformatversion = 0
     	bare = false
     	logallrefupdates = true
-    "#);
+    ");
     // @git bookmark shouldn't be removed.
     let output = work_dir.run_jj(["log", "-rmain@git", "-Tbookmarks"]);
     insta::assert_snapshot!(output, @r"

--- a/cli/tests/test_git_root.rs
+++ b/cli/tests/test_git_root.rs
@@ -23,10 +23,10 @@ fn test_git_root_git_backend_noncolocated() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["git", "root"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     $TEST_ENV/repo/.jj/repo/store/git
     [EOF]
-    "#);
+    ");
 }
 
 #[test]
@@ -38,10 +38,10 @@ fn test_git_root_git_backend_colocated() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["git", "root"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     $TEST_ENV/repo/.git
     [EOF]
-    "#);
+    ");
 }
 
 #[test]
@@ -78,10 +78,10 @@ fn test_git_root_git_backend_external_git_dir() {
         .success();
 
     let output = work_dir.run_jj(["git", "root"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     $TEST_ENV/git-repo/.git
     [EOF]
-    "#);
+    ");
 }
 
 #[test]
@@ -93,10 +93,10 @@ fn test_git_root_simple_backend() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["git", "root"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Error: The repo is not backed by a Git repo
     [EOF]
     [exit status: 1]
-    "#);
+    ");
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -919,11 +919,11 @@ fn test_log_filtered_by_path() {
 
     // The output filtered to a non-existent file should display a warning.
     let output = work_dir.run_jj(["log", "-r", "@-", "-T", "description", "nonexistent"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No matching entries for paths: nonexistent
     [EOF]
-    "#);
+    ");
 
     // The output filtered to a non-existent file should display a warning.
     // The warning should be displayed at the beginning of the output.
@@ -1134,7 +1134,7 @@ fn test_log_warn_path_might_be_revset() {
     // been added to the working copy, yet.
     let sub_dir = work_dir.create_dir_all("dir");
     let output = sub_dir.run_jj(["log", "."]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No matching entries for paths: .
     [EOF]
@@ -1160,7 +1160,7 @@ fn test_log_warn_path_might_be_revset() {
 
     // If an explicit revision is provided, then suppress the warning.
     let output = work_dir.run_jj(["log", "@", "-r", "@", "-T", "description"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No matching entries for paths: @
     [EOF]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -2879,7 +2879,7 @@ fn test_op_log_parents() {
         .success();
     let template = r#"id.short() ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|o| o.id().short()) ++ "\n""#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     @    ea1c99c7c4a9
     ├─╮  P: 2 12f7cbba4278 dd1534c4b064
     ○ │  12f7cbba4278
@@ -2894,7 +2894,7 @@ fn test_op_log_parents() {
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     [EOF]
-    "###);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -28,7 +28,7 @@ fn test_report_conflicts() {
     work_dir.run_jj(["commit", "-m=C"]).success();
 
     let output = work_dir.run_jj(["rebase", "-s=subject(glob:B)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
     Working copy  (@) now at: zsuskuln 1f0443b9 (conflict) (empty) (no description set)
@@ -46,7 +46,7 @@ fn test_report_conflicts() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["rebase", "-d=subject(glob:A)"]);
     insta::assert_snapshot!(output, @r"
@@ -61,7 +61,7 @@ fn test_report_conflicts() {
 
     // Can get hint about multiple root commits
     let output = work_dir.run_jj(["rebase", "-r=subject(glob:B)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     Rebased 2 descendant commits
@@ -81,7 +81,7 @@ fn test_report_conflicts() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     // Resolve one of the conflicts by (mostly) following the instructions
     let output = work_dir.run_jj(["new", "rlvkpnrzqnoo"]);
@@ -123,7 +123,7 @@ fn test_report_conflicts_with_divergent_commits() {
         .success();
 
     let output = work_dir.run_jj(["rebase", "-s=subject(glob:B)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits to destination
@@ -143,7 +143,7 @@ fn test_report_conflicts_with_divergent_commits() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["rebase", "-d=subject(glob:A)"]);
     insta::assert_snapshot!(output, @r"
@@ -158,7 +158,7 @@ fn test_report_conflicts_with_divergent_commits() {
 
     // Same thing when rebasing the divergent commits one at a time
     let output = work_dir.run_jj(["rebase", "-s=subject(glob:C2)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     Working copy  (@) now at: zsuskuln?? 151c23fc (conflict) C2
@@ -175,10 +175,10 @@ fn test_report_conflicts_with_divergent_commits() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["rebase", "-s=subject(glob:C3)", "-d=root()"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     New conflicts appeared in 1 commits:
@@ -190,7 +190,7 @@ fn test_report_conflicts_with_divergent_commits() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["rebase", "-s=subject(glob:C2)", "-d=subject(glob:B)"]);
     insta::assert_snapshot!(output, @r"

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -212,7 +212,7 @@ fn test_resolution() {
         "resolve",
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv e4a8cd2d conflict | (conflict) conflict
@@ -230,7 +230,7 @@ fn test_resolution() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor2")).unwrap(), @r"
     <<<<<<< Conflict 1 of 1
@@ -356,7 +356,7 @@ fn test_resolution() {
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
         "--config=merge-tools.fake-editor.conflict-marker-style=git",
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv fe2a966d conflict | (conflict) conflict
@@ -374,7 +374,7 @@ fn test_resolution() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor4")).unwrap(), @r"
     <<<<<<< Side #1 (Conflict 1 of 1)
@@ -435,7 +435,7 @@ fn test_resolution() {
         "resolve",
         "--config=merge-tools.fake-editor.merge-conflict-exit-codes=[1]",
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv 16d4ec9a conflict | (conflict) conflict
@@ -453,7 +453,7 @@ fn test_resolution() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor5")).unwrap(), @"");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
@@ -830,7 +830,7 @@ fn test_simplify_conflict_sides() {
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
         "fileB",
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: fileB
     Working copy  (@) now at: nkmrtpmo e2260d62 conflict | (conflict) conflict
@@ -849,7 +849,7 @@ fn test_simplify_conflict_sides() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.read_file("fileB"), @r"
     <<<<<<< Conflict 1 of 1
     %%%%%%% Changes from base to side #1
@@ -1064,7 +1064,7 @@ fn test_resolve_conflicts_with_executable() {
     // Test resolving the conflict in "file1", which should produce an executable
     std::fs::write(&editor_script, b"write\nresolution1\n").unwrap();
     let output = work_dir.run_jj(["resolve", "file1"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file1
     Working copy  (@) now at: znkkpsqq dd280a2f conflict | (conflict) conflict
@@ -1082,7 +1082,7 @@ fn test_resolve_conflicts_with_executable() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100755
@@ -1108,7 +1108,7 @@ fn test_resolve_conflicts_with_executable() {
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
     std::fs::write(&editor_script, b"write\nresolution2\n").unwrap();
     let output = work_dir.run_jj(["resolve", "file2"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file2
     Working copy  (@) now at: znkkpsqq 6a536f34 conflict | (conflict) conflict
@@ -1126,7 +1126,7 @@ fn test_resolve_conflicts_with_executable() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file2 b/file2
     index 0000000000..775f078581 100755
@@ -1502,7 +1502,7 @@ fn test_pass_path_argument() {
         "file",
         r#"--config=merge-tools.fake-editor.merge-args=["$output", "$path"]"#,
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv 682816de conflict | conflict
@@ -1510,7 +1510,7 @@ fn test_pass_path_argument() {
     Parent commit (@-)      : royxmykx 89d1b299 b | b
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file b/file
     index 0000000000..88425ec521 100644
@@ -1598,7 +1598,7 @@ fn test_resolve_long_conflict_markers() {
     )
     .unwrap();
     let output = work_dir.run_jj(["resolve"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv c0d761e3 conflict | (conflict) conflict
@@ -1616,7 +1616,7 @@ fn test_resolve_long_conflict_markers() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
@@ -1668,7 +1668,7 @@ fn test_resolve_long_conflict_markers() {
         "resolve",
         "--config=merge-tools.fake-editor.merge-tool-edits-conflict-markers=true",
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv eab21a40 conflict | (conflict) conflict
@@ -1686,7 +1686,7 @@ fn test_resolve_long_conflict_markers() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r"
     <<<<<<<<<<< Conflict 1 of 1
@@ -1744,7 +1744,7 @@ fn test_resolve_long_conflict_markers() {
         "resolve",
         r#"--config=merge-tools.fake-editor.merge-args=["$output", "$marker_length"]"#,
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: file
     Working copy  (@) now at: vruxwmqv cd9cf2ca conflict | (conflict) conflict
@@ -1762,7 +1762,7 @@ fn test_resolve_long_conflict_markers() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file b/file
     --- a/file
@@ -1877,7 +1877,7 @@ fn test_multiple_conflicts() {
     // Check that we can manually pick which of the conflicts to resolve first
     std::fs::write(&editor_script, "expect\n\0write\nresolution another_file\n").unwrap();
     let output = work_dir.run_jj(["resolve", "another_file"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Resolving conflicts in: another_file
     Working copy  (@) now at: vruxwmqv 57b85650 conflict | (conflict) conflict
@@ -1895,7 +1895,7 @@ fn test_multiple_conflicts() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/another_file b/another_file
     index 0000000000..a9fcc7d486 100644
@@ -2048,7 +2048,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let output = work_dir.run_jj(["resolve"]);
-    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r###"
+    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r"
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
@@ -2070,7 +2070,7 @@ fn test_multiple_conflicts_with_error() {
     Caused by: The output file is either unchanged or empty after the editor quit (run with --debug to see the exact invocation).
     [EOF]
     [exit status: 1]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644
@@ -2100,7 +2100,7 @@ fn test_multiple_conflicts_with_error() {
     )
     .unwrap();
     let output = work_dir.run_jj(["resolve"]);
-    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r###"
+    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @r"
     ------- stderr -------
     Resolving conflicts in: file1
     Resolving conflicts in: file2
@@ -2122,7 +2122,7 @@ fn test_multiple_conflicts_with_error() {
     Caused by: Tool exited with exit status: 1 (run with --debug to see the exact invocation)
     [EOF]
     [exit status: 1]
-    "###);
+    ");
     insta::assert_snapshot!(work_dir.run_jj(["diff", "--git"]), @r"
     diff --git a/file1 b/file1
     index 0000000000..95cc18629d 100644
@@ -2247,12 +2247,12 @@ fn test_resolve_with_contents_of_side() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @"a");
     insta::assert_snapshot!(work_dir.read_file("other"), @"left");
-    insta::assert_snapshot!(work_dir.run_jj(["resolve", "--list"]), @r#"
+    insta::assert_snapshot!(work_dir.run_jj(["resolve", "--list"]), @r"
     ------- stderr -------
     Error: No conflicts found at this revision
     [EOF]
     [exit status: 2]
-    "#);
+    ");
 
     // Check that ":theirs" merge tool works correctly
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
@@ -2269,10 +2269,10 @@ fn test_resolve_with_contents_of_side() {
     ");
     insta::assert_snapshot!(work_dir.read_file("file"), @"b");
     insta::assert_snapshot!(work_dir.read_file("other"), @"right");
-    insta::assert_snapshot!(work_dir.run_jj(["resolve", "--list"]), @r#"
+    insta::assert_snapshot!(work_dir.run_jj(["resolve", "--list"]), @r"
     ------- stderr -------
     Error: No conflicts found at this revision
     [EOF]
     [exit status: 2]
-    "#);
+    ");
 }

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -206,11 +206,11 @@ fn test_revert() {
 
     // Revert nothing
     let output = work_dir.run_jj(["revert", "-r", "none()", "-d", "@"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     No revisions to revert.
     [EOF]
-    "#);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_revset_output.rs
+++ b/cli/tests/test_revset_output.rs
@@ -519,7 +519,7 @@ fn test_default_string_pattern() {
 
     // substring match by default as of jj 0.35
     let output = work_dir.run_jj(["log", "-rauthor('test.user')"]);
-    insta::assert_snapshot!(output.normalize_backslash(), @r###"
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
     │  (empty) (no description set)
     ~
@@ -533,7 +533,7 @@ fn test_default_string_pattern() {
       |
       = Default pattern syntax will be changed to `glob:` / `exact:` (depending on whether it looks like a glob) in a future release; use `substring:` prefix or set ui.revsets-use-glob-by-default=true to suppress this warning
     [EOF]
-    "###);
+    ");
 
     // with default flipped
     let output = work_dir.run_jj([

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -340,13 +340,13 @@ fn test_split_with_descendants() {
     // Third commit.
     work_dir.write_file("file4", "foobarbaz\n");
     work_dir.run_jj(["describe", "-m", "Add file4"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r###"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r"
     @  kkmpptxzrspx false Add file4
     ○  rlvkpnrzqnoo false Add file3
     ○  qpvuntsmwlqt false Add file1 & file2
     ◆  zzzzzzzzzzzz true
     [EOF]
-    "###);
+    ");
 
     // Set up the editor and do the split.
     std::fs::write(

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -334,12 +334,12 @@ fn test_squash_partial() {
     // No warning if we pass a positional argument does not parse as a revset
     work_dir.run_jj(["op", "restore", &start_op_id]).success();
     let output = work_dir.run_jj(["squash", ".tmp"]);
-    insta::assert_snapshot!(output, @r#"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Warning: No matching entries for paths: .tmp
     Nothing changed.
     [EOF]
-    "#);
+    ");
 
     // we can use --interactive and fileset together
     work_dir.run_jj(["op", "restore", &start_op_id]).success();
@@ -900,7 +900,7 @@ fn test_squash_from_multiple() {
 
     // Squash a few commits sideways
     let output = work_dir.run_jj(["squash", "--from=b", "--from=c", "--into=d"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 descendant commits
     Working copy  (@) now at: kpqxywon 0b695306 f | (no description set)
@@ -914,7 +914,7 @@ fn test_squash_from_multiple() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
     @  0b6953066ee0 f
     ○    ff064d529578 e
@@ -1044,7 +1044,7 @@ fn test_squash_from_multiple_partial() {
 
     // Partially squash a few commits sideways
     let output = work_dir.run_jj(["squash", "--from=b|c", "--into=d", "file1"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 2 descendant commits
     Working copy  (@) now at: kpqxywon a724910c f | (no description set)
@@ -1058,7 +1058,7 @@ fn test_squash_from_multiple_partial() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
     @  a724910cd361 f
     ○      1bc405e12b68 e
@@ -2435,6 +2435,7 @@ fn test_squash_with_editor_and_empty_message() {
     insta::assert_snapshot!(
         std::fs::read_to_string(test_env.env_root().join("editor")).unwrap(), @r#"
 
+
     Trailer: value
 
     JJ: Change ID: qpvuntsm
@@ -2444,7 +2445,6 @@ fn test_squash_with_editor_and_empty_message() {
     JJ: Lines starting with "JJ:" (like this one) will be removed.
     "#);
     insta::assert_snapshot!(get_description(&work_dir, "@-"), @r"
-
     Trailer: value
     [EOF]
     ");

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -259,7 +259,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     ");
 
     let output = work_dir.run_jj(["status"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     The working copy has no changes.
     Working copy  (@) : yqosqzyt 6e3ffaa1 (conflict) (empty) boom-cont-2
     Parent commit (@-): royxmykx 7f9e90e6 (conflict) (empty) boom-cont
@@ -272,10 +272,10 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["status", "--color=always"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     The working copy has no changes.
     Working copy  (@) : [1m[38;5;13my[38;5;8mqosqzyt[39m [38;5;12m6[38;5;8me3ffaa1[39m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
     Parent commit (@-): [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m7[0m[38;5;8mf9e90e6[39m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
@@ -288,7 +288,7 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     [39mOnce the conflicts are resolved, you can inspect the result with `jj diff`.[39m
     [39mThen run `jj squash` to move the resolution into the conflicted commit.[39m
     [EOF]
-    "###);
+    ");
 
     let output = work_dir.run_jj(["status", "--config=hints.resolving-conflicts=false"]);
     insta::assert_snapshot!(output, @r"
@@ -441,7 +441,7 @@ fn test_status_simplify_conflict_sides() {
     create_commit_with_files(&work_dir, "conflict", &["conflictA", "conflictB"], &[]);
 
     insta::assert_snapshot!(work_dir.run_jj(["status"]),
-    @r###"
+    @r"
     The working copy has no changes.
     Working copy  (@) : nkmrtpmo 14a0b4b7 conflict | (conflict) (empty) conflict
     Parent commit (@-): kmkuslsw 73b61e6e conflictA | (conflict) (empty) conflictA
@@ -457,7 +457,7 @@ fn test_status_simplify_conflict_sides() {
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
     [EOF]
-    "###);
+    ");
 }
 
 #[test]

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -159,7 +159,7 @@ fn test_util_exec_fail() {
         ],
     );
     // Ensures only stdout contains text
-    insta::assert_snapshot!(output.normalize_stderr_with(|s| s.replace(".exe", "")), @r###"
+    insta::assert_snapshot!(output.normalize_stderr_with(|s| s.replace(".exe", "")), @r"
     ------- stderr -------
     error: unexpected argument '--badopt' found
 
@@ -168,7 +168,7 @@ fn test_util_exec_fail() {
     For more information, try '--help'.
     [EOF]
     [exit status: 2]
-    "###);
+    ");
 }
 
 #[test]
@@ -201,8 +201,8 @@ fn test_util_exec_sets_env() {
             r#"echo "$JJ_WORKSPACE_ROOT""#,
         ],
     );
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     $TEST_ENV/repo
     [EOF]
-    "###);
+    ");
 }

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -498,12 +498,12 @@ fn test_submodule_ignored() {
         &format!("{}/submodule", test_env.env_root().display()),
         "sub",
     ]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Cloning into '$TEST_ENV/repo/sub'...
     done.
     [EOF]
-    "###);
+    ");
     // Use git to commit since jj won't play nice with the submodule.
     work_dir
         .run_jj([
@@ -523,12 +523,12 @@ fn test_submodule_ignored() {
 
     // This should be empty. We shouldn't track the submodule itself.
     let output = work_dir.run_jj(["diff", "--summary"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     ignoring git submodule at "sub"
     Done importing changes from the underlying Git repo.
     [EOF]
-    "###);
+    "#);
 
     // Switch to a historical commit before the submodule was checked in.
     work_dir.run_jj(["prev"]).success();

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -453,11 +453,11 @@ fn test_workspaces_add_workspace_in_current_workspace() {
 
     // Workspace created despite warning
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     default: rlvkpnrz 504e3d8c (empty) (no description set)
     secondary: pmmvwywv 058f604d (empty) (no description set)
     [EOF]
-    "###);
+    ");
 
     // Use explicit path instead (no warning)
     let output = main_dir.run_jj(["workspace", "add", "./third"]);
@@ -472,18 +472,18 @@ fn test_workspaces_add_workspace_in_current_workspace() {
 
     // Both workspaces created
     let output = main_dir.run_jj(["workspace", "list"]);
-    insta::assert_snapshot!(output, @r###"
+    insta::assert_snapshot!(output, @r"
     default: rlvkpnrz 504e3d8c (empty) (no description set)
     secondary: pmmvwywv 058f604d (empty) (no description set)
     third: zxsnswpr 1c1effec (empty) (no description set)
     [EOF]
-    "###);
+    ");
 
     let output = main_dir.run_jj(["file", "list"]);
-    insta::assert_snapshot!(output.normalize_backslash(), @r###"
+    insta::assert_snapshot!(output.normalize_backslash(), @r"
     file
     [EOF]
-    "###);
+    ");
 }
 
 /// Test making changes to the working copy in a workspace as it gets rewritten

--- a/lib/src/config_resolver.rs
+++ b/lib/src/config_resolver.rs
@@ -1005,10 +1005,10 @@ mod tests {
             hostname: "",
         };
         let resolved_config = resolve(&source_config, &context).unwrap();
-        insta::assert_snapshot!(resolved_config.layers()[0].data, @r#"
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @r"
         a = 'a none'
         b = 'b none'
-        "#);
+        ");
         if cfg!(target_os = "linux") {
             assert_eq!(resolved_config.layers().len(), 3);
             insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a linux'");

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3948,7 +3948,7 @@ mod tests {
         }
         "#);
         // Parse the nullary "range" operator
-        insta::assert_debug_snapshot!(parse("..").unwrap(), @r#"NotIn(Root)"#);
+        insta::assert_debug_snapshot!(parse("..").unwrap(), @"NotIn(Root)");
         // Parse the "negate" operator
         insta::assert_debug_snapshot!(
             parse("~ foo").unwrap(),


### PR DESCRIPTION
Running "cargo insta test --workspace", results in numerous warnings:

Snapshot test passes but the existing value is in a legacy format. Please run `cargo insta test --force-update-snapshots` to update to a newer format.

This commit is the result of running the suggested command.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
