### PR TITLE
Fix stray whitespace in doc comment block

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -135,7 +135,6 @@ pub(crate) struct NewArgs {
     /// Example: `jj new --insert-after A --insert-before D`:
     ///
     /// ```text
-    /// 
     ///     D            D
     ///     |           / \
     ///     C          |   C

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2207,7 +2207,6 @@ Note that you can create a merge commit by specifying multiple revisions as argu
    Example: `jj new --insert-after A --insert-before D`:
 
    ```text
-
        D            D
        |           / \
        C          |   C


### PR DESCRIPTION
Remove an unnecessary whitespace character in a doc comment. While minor, this nit consistently shows up when running:

```sh
cargo fmt --all -- --emit files
```