### PR TITLE
colocation: use gix for toggling `core.bare` config

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1828,7 +1828,7 @@ fn remove_ref(reference: gix::Reference) -> gix::refs::transaction::RefEdit {
 /// Note that the resulting configuration changes are *not* persisted to the
 /// originating [`gix::Repository`]! The repository must be reloaded with the
 /// new configuration if necessary.
-fn save_git_config(config: &gix::config::File) -> std::io::Result<()> {
+pub fn save_git_config(config: &gix::config::File) -> std::io::Result<()> {
     let mut config_file = File::create(
         config
             .meta()


### PR DESCRIPTION
Instead of forking a git process, use `gix` to toggle `core.bare` config.

The original `git -C <repo_root>/.jj/repo/store/git config repo.bare <true|false>` fails when the user has `safe.bareRepository` config set to 'explicit'. A typical failure looks like this:

	% jj git colocation disable
	Error: Failed to set core.bare to true in Git config.
	Caused by: Git config failed: fatal: not in a git directory

.git is moved to .jj/repo/store/git as a bare repo, and if we run git directly:
	
	% git -C .jj/repo/store/git config repo.bare true
	fatal: not in a git directory

	% git -C .jj/repo/store/git status
	fatal: cannot use bare repository
	<repo_root>/.jj/repo/store/git (safe.bareRepository is 'explicit')

Use `gix` to avoid forking git and being interferred by git's configs.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
