### PR TITLE
docs: clarify that `jj bookmark track` works for new bookmarks

### DIFF
--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -29,6 +29,9 @@ use crate::ui::Ui;
 
 /// Start tracking given remote bookmarks
 ///
+/// This command can be used to track remote bookmarks that already exist on the
+/// remote, or to set up tracking for local bookmarks before pushing them.
+///
 /// A tracking remote bookmark will be imported as a local bookmark of the same
 /// name. Changes to it will propagate to the existing local bookmark on future
 /// pulls.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -555,6 +555,8 @@ Create or update a bookmark to point to a certain commit
 
 Start tracking given remote bookmarks
 
+This command can be used to track remote bookmarks that already exist on the remote, or to set up tracking for local bookmarks before pushing them.
+
 A tracking remote bookmark will be imported as a local bookmark of the same name. Changes to it will propagate to the existing local bookmark on future pulls.
 
 **Usage:** `jj bookmark track <BOOKMARK@REMOTE>...`


### PR DESCRIPTION
Update the help text for `jj bookmark track` to explicitly state that it can be used proactively for local bookmarks before pushing them, not just for importing existing remote bookmarks.

Fixes #8302

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
