### PR TITLE
docs: clarify what happens to unselected changes in `jj commit`

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -37,7 +37,10 @@ use crate::ui::Ui;
 /// When called without path arguments or `--interactive`, `jj commit` is
 /// equivalent to `jj describe` followed by `jj new`.
 ///
-/// Otherwise, this command is very similar to `jj split`. Differences include:
+/// When using `--interactive` or path arguments, the selected changes stay in
+/// the current commit while the remaining changes are moved to a new
+/// working-copy commit on top. This is very similar to `jj split`. Differences
+/// include:
 ///
 /// * `jj commit` is not interactive by default (it selects all changes).
 ///
@@ -51,7 +54,7 @@ use crate::ui::Ui;
 ///   destination with `-d/-A/-B`.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct CommitArgs {
-    /// Interactively choose which changes to include in the first commit
+    /// Interactively choose which changes to include in the current commit
     #[arg(short, long)]
     interactive: bool,
     /// Specify diff editor to be used (implies --interactive)
@@ -70,7 +73,7 @@ pub(crate) struct CommitArgs {
     /// message to be edited afterwards.
     #[arg(long)]
     editor: bool,
-    /// Put these paths in the first commit
+    /// Put these paths in the current commit
     #[arg(
         value_name = "FILESETS",
         value_hint = clap::ValueHint::AnyPath,

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -601,7 +601,7 @@ Update the description and create a new change on top [default alias: ci]
 
 When called without path arguments or `--interactive`, `jj commit` is equivalent to `jj describe` followed by `jj new`.
 
-Otherwise, this command is very similar to `jj split`. Differences include:
+When using `--interactive` or path arguments, the selected changes stay in the current commit while the remaining changes are moved to a new working-copy commit on top. This is very similar to `jj split`. Differences include:
 
 * `jj commit` is not interactive by default (it selects all changes).
 
@@ -615,11 +615,11 @@ Otherwise, this command is very similar to `jj split`. Differences include:
 
 ###### **Arguments:**
 
-* `<FILESETS>` — Put these paths in the first commit
+* `<FILESETS>` — Put these paths in the current commit
 
 ###### **Options:**
 
-* `-i`, `--interactive` — Interactively choose which changes to include in the first commit
+* `-i`, `--interactive` — Interactively choose which changes to include in the current commit
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
 * `--editor` — Open an editor to edit the change description


### PR DESCRIPTION
When using `--interactive` or path arguments, it wasn't clear from the help text what happens to the changes that aren't selected. This adds an explanation to the main command documentation and updates the flag and argument descriptions to use "current commit" instead.

Fixes #6666

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
