### PR TITLE
docs: remove misleading "See also List type" from ListTemplate

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -353,9 +353,10 @@ The following methods are defined. See also the `List` type.
 
 _Conversion: `Boolean`: no, `Serialize`: no, `Template`: yes_
 
-The following methods are defined. See also the `List` type.
+The following methods are defined.
 
-* `.join(separator: Template) -> Template`
+* `.join(separator: Template) -> Template`: Concatenate elements with
+  the given `separator`.
 
 ### `Operation` type
 


### PR DESCRIPTION
This cross-reference was added in 998727266cea (March 2023) when ListTemplate was first documented. At that time, List only had two methods: .join() and .map(). The reference made some sense since ListTemplate was the result type of .map() and shared the .join() method.

However, List has since grown significantly with .len(), .filter(), .any(), .all(), and Boolean conversion - none of which ListTemplate supports. ListTemplate still only has .join(). This makes the cross-reference misleading, as it implies a compatibility that doesn't exist (unlike List<Trailer> which truly extends List).

Fixes #7951

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
