### PR TITLE
WIP: rebase: auto-abandon commits with existing same patch

### DIFF
--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -31,6 +31,7 @@ use jj_lib::rewrite::MoveCommitsTarget;
 use jj_lib::rewrite::RebaseOptions;
 use jj_lib::rewrite::RewriteRefsOptions;
 use jj_lib::rewrite::compute_move_commits;
+use jj_lib::rewrite::find_different_changeid_commits;
 use jj_lib::rewrite::find_duplicate_divergent_commits;
 use tracing::instrument;
 
@@ -328,6 +329,14 @@ pub(crate) struct RebaseArgs {
     /// destination with identical changes.
     #[arg(long)]
     keep_divergent: bool,
+
+    /// Keep commits with same changes, but different change IDs while rebasing
+    ///
+    /// Without this flag, commits with the same changeset are abandoned while
+    /// rebasing if another commit with the same changeset is already
+    /// present in the destination with identical changes.
+    #[arg(long)]
+    keep_changed_changeid: bool,
 }
 
 #[derive(clap::Args, Clone, Debug)]
@@ -395,6 +404,26 @@ pub(crate) fn cmd_rebase(
 
     let mut tx = workspace_command.start_transaction();
     let mut computed_move = compute_move_commits(tx.repo(), &loc)?;
+    if !args.keep_changed_changeid {
+        let abandoned_changed =
+            find_different_changeid_commits(tx.repo(), &loc.new_parent_ids, &loc.target)?;
+        computed_move.record_to_abandon(abandoned_changed.iter().map(Commit::id).cloned());
+        if !abandoned_changed.is_empty()
+            && let Some(mut formatter) = ui.status_formatter()
+        {
+            writeln!(
+                formatter,
+                "Abandoned {} commits with identical changes that were already present in the \
+                 destination:",
+                abandoned_changed.len(),
+            )?;
+            print_updated_commits(
+                formatter.as_mut(),
+                &tx.base_workspace_helper().commit_summary_template(),
+                &abandoned_changed,
+            )?;
+        }
+    };
     if !args.keep_divergent {
         let abandoned_divergent =
             find_duplicate_divergent_commits(tx.repo(), &loc.new_parent_ids, &loc.target)?;


### PR DESCRIPTION
When a commit was rebased by a different VCS and the change id was lost, jj does not detect that in the rebase and either will empty the commit, or run into unnecessary merge conflicts (see #2979)

This PR is very much WIP to check if the rebased commits contain the same patch and automatically abandon them.

Right now I am a bit stuck on getting the patches of a `Commit` in the lib crate. Hints welcome!

## Still to do

- [ ] get the patches of commits:
  - in the range of "new commits added before the rebase destination" => HashSet to check against
  - commits to be rebased
- [ ] do not drop empty patches by this logic
- [ ] come up with better name for the command line flag
- [ ] check which way around the default of the flag should be
- [ ] try avoiding code duplication with keep_divergent
- [ ] write test cases
- [ ] write documentation


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
