### PR TITLE
default_index: sort `resolve_change_id_prefix()` by descending position

### DIFF
--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -752,15 +752,15 @@ mod tests {
         );
         assert_eq!(
             index.resolve_change_id_prefix(&HexPrefix::from_id(&id_1)),
-            PrefixResolution::SingleMatch((id_1.clone(), index_positions_vec(&[1, 3, 9])))
+            PrefixResolution::SingleMatch((id_1.clone(), index_positions_vec(&[9, 3, 1])))
         );
         assert_eq!(
             index.resolve_change_id_prefix(&HexPrefix::from_id(&id_2)),
-            PrefixResolution::SingleMatch((id_2.clone(), index_positions_vec(&[2, 4, 5])))
+            PrefixResolution::SingleMatch((id_2.clone(), index_positions_vec(&[5, 4, 2])))
         );
         assert_eq!(
             index.resolve_change_id_prefix(&HexPrefix::from_id(&id_3)),
-            PrefixResolution::SingleMatch((id_3.clone(), index_positions_vec(&[6, 7])))
+            PrefixResolution::SingleMatch((id_3.clone(), index_positions_vec(&[7, 6])))
         );
         assert_eq!(
             index.resolve_change_id_prefix(&HexPrefix::from_id(&id_4)),
@@ -794,7 +794,7 @@ mod tests {
         // Global lookup with globally unique prefix stored in both parts
         assert_eq!(
             index.resolve_change_id_prefix(&HexPrefix::try_from_hex("009").unwrap()),
-            PrefixResolution::SingleMatch((id_1.clone(), index_positions_vec(&[1, 3, 9])))
+            PrefixResolution::SingleMatch((id_1.clone(), index_positions_vec(&[9, 3, 1])))
         );
 
         // Global lookup with locally ambiguous prefix


### PR DESCRIPTION
Suggested in https://github.com/jj-vcs/jj/pull/7194#discussion_r2595960596

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
