### PR TITLE
complete: include offset in completions for divergent changes

### DIFF
--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -390,7 +390,16 @@ fn revisions(match_prefix: &str, revset_filter: Option<&str>) -> Vec<CompletionC
             .arg("--revisions")
             .arg(revisions)
             .arg("--template")
-            .arg(r#"change_id.shortest() ++ " " ++ if(description, description.first_line(), "(no description set)") ++ "\n""#)
+            .arg(
+                r#"
+                join(" ",
+                    separate("/",
+                        change_id.shortest(),
+                        if(hidden || divergent, change_offset),
+                    ),
+                    if(description, description.first_line(), "(no description set)"),
+                ) ++ "\n""#,
+            )
             .output()
             .map_err(user_error)?;
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -809,14 +809,16 @@ fn test_revisions() {
     );
 
     work_dir.write_file("file", "A");
-    work_dir
-        .run_jj(["b", "c", "-r@", "mutable_bookmark"])
-        .success();
     work_dir.run_jj(["describe", "-m", "mutable 1"]).success();
+    work_dir.run_jj(["describe", "-m", "mutable 2"]).success();
+    // Create divergent change
+    work_dir
+        .run_jj(["b", "c", "-r=at_operation(@-, @)", "mutable_bookmark"])
+        .success();
 
     work_dir.run_jj(["new", "immutable_bookmark"]).success();
     work_dir.write_file("file", "B");
-    work_dir.run_jj(["describe", "-m", "mutable 2"]).success();
+    work_dir.run_jj(["describe", "-m", "mutable 3"]).success();
     work_dir.run_jj(["new", "@", "mutable_bookmark"]).success();
     work_dir
         .run_jj(["b", "c", "-r@", "conflicted_bookmark"])
@@ -840,10 +842,11 @@ fn test_revisions() {
     conflicted_bookmark	conflicted
     immutable_bookmark	immutable
     mutable_bookmark	mutable 1
-    u	working_copy
-    l	conflicted
-    k	mutable 2
-    y	mutable 1
+    x	working_copy
+    k	conflicted
+    w	mutable 3
+    y/0	mutable 2
+    y/1	mutable 1
     q	immutable
     r	remote_commit
     z	(no description set)
@@ -859,10 +862,11 @@ fn test_revisions() {
     ..conflicted_bookmark	conflicted
     ..immutable_bookmark	immutable
     ..mutable_bookmark	mutable 1
-    ..u	working_copy
-    ..l	conflicted
-    ..k	mutable 2
-    ..y	mutable 1
+    ..x	working_copy
+    ..k	conflicted
+    ..w	mutable 3
+    ..y/0	mutable 2
+    ..y/1	mutable 1
     ..q	immutable
     ..r	remote_commit
     ..z	(no description set)
@@ -877,10 +881,11 @@ fn test_revisions() {
     insta::assert_snapshot!(output, @r"
     conflicted_bookmark	conflicted
     mutable_bookmark	mutable 1
-    u	working_copy
-    l	conflicted
-    k	mutable 2
-    y	mutable 1
+    x	working_copy
+    k	conflicted
+    w	mutable 3
+    y/0	mutable 2
+    y/1	mutable 1
     r	remote_commit
     alias_with_newline	    roots(
     siblings	@-+ ~@
@@ -892,10 +897,11 @@ fn test_revisions() {
     insta::assert_snapshot!(output, @r"
     y::conflicted_bookmark	conflicted
     y::mutable_bookmark	mutable 1
-    y::u	working_copy
-    y::l	conflicted
-    y::k	mutable 2
-    y::y	mutable 1
+    y::x	working_copy
+    y::k	conflicted
+    y::w	mutable 3
+    y::y/0	mutable 2
+    y::y/1	mutable 1
     y::r	remote_commit
     y::alias_with_newline	    roots(
     y::siblings	@-+ ~@
@@ -913,7 +919,7 @@ fn test_revisions() {
     let output = work_dir.complete_fish(["resolve", "-r", ""]);
     insta::assert_snapshot!(output, @r"
     conflicted_bookmark	conflicted
-    l	conflicted
+    k	conflicted
     alias_with_newline	    roots(
     siblings	@-+ ~@
     [EOF]
@@ -926,10 +932,11 @@ fn test_revisions() {
     conflicted_bookmark	conflicted
     immutable_bookmark	immutable
     mutable_bookmark	mutable 1
-    u	working_copy
-    l	conflicted
-    k	mutable 2
-    y	mutable 1
+    x	working_copy
+    k	conflicted
+    w	mutable 3
+    y/0	mutable 2
+    y/1	mutable 1
     q	immutable
     r	remote_commit
     z	(no description set)
@@ -953,10 +960,11 @@ fn test_revisions() {
     a=conflicted_bookmark	conflicted
     a=immutable_bookmark	immutable
     a=mutable_bookmark	mutable 1
-    a=u	working_copy
-    a=l	conflicted
-    a=k	mutable 2
-    a=y	mutable 1
+    a=x	working_copy
+    a=k	conflicted
+    a=w	mutable 3
+    a=y/0	mutable 2
+    a=y/1	mutable 1
     a=q	immutable
     a=r	remote_commit
     a=z	(no description set)


### PR DESCRIPTION
Follow up to #7194.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
