### PR TITLE
templates: add "divergent" label to log for divergent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * On Windows, symlinks that point to a path with `/` won't be supported. This
   path is [invalid on Windows].
 
+* The template alias `format_short_change_id_with_hidden_and_divergent_info(commit)`
+  has been replaced by `format_short_change_id_with_change_offset(commit)`.
+
 [invalid on Windows]: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
 
 * The following deprecated config options have been removed:

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -61,19 +61,11 @@ use crate::ui::Ui;
 /// [Immutable revisions] have a `◆` symbol. Other commits have a `○` symbol.
 /// All of these symbols can be [customized].
 ///
-/// Visible changes with a [change offset] after their ID are [divergent].
-///
 /// [Immutable revisions]:
 ///     https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
 ///
 /// [customized]:
 ///     https://docs.jj-vcs.dev/latest/config/#node-style
-///
-/// [change offset]:
-///     https://docs.jj-vcs.dev/latest/glossary/#change-offset
-///
-/// [divergent]:
-///     https://docs.jj-vcs.dev/latest/guides/divergence/
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct LogArgs {
     /// Which revisions to show

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -167,14 +167,14 @@ if(commit.root(),
       if(commit.conflict(), "conflicted"),
     ),
     separate(" ",
-      format_short_change_id_with_hidden_and_divergent_info(commit),
+      format_short_change_id_with_change_offset(commit),
       format_short_signature_oneline(commit.author()),
       format_timestamp(commit_timestamp(commit)),
       commit.bookmarks(),
       commit.tags(),
       commit.working_copies(),
       format_short_commit_id(commit.commit_id()),
-      if(commit.conflict(), label("conflict", "conflict")),
+      format_commit_labels(commit),
       if(config("ui.show-cryptographic-signatures").as_boolean(),
         format_short_cryptographic_signature(commit.signature())
       ),
@@ -365,12 +365,12 @@ time_range.end().ago() ++ label("time", ", lasted ") ++ time_range.duration()
 'format_commit_summary_with_refs(commit, refs)' = '''
 label(if(commit.current_working_copy(), "working_copy"),
   separate(" ",
-    format_short_change_id_with_hidden_and_divergent_info(commit),
+    format_short_change_id_with_change_offset(commit),
     format_short_commit_id(commit.commit_id()),
     separate(commit_summary_separator,
       refs,
       separate(" ",
-        if(commit.conflict(), label("conflict", "(conflict)")),
+        format_commit_labels(commit),
         if(commit.empty(), empty_commit_marker),
         if(commit.description(),
           commit.description().first_line(),
@@ -462,38 +462,46 @@ separate(" ",
 '''
 'format_snapshot_operation_oneline(op)' = 'format_operation_oneline(op)'
 
-# We have "hidden" override "divergent", since a hidden revision does not cause
-# change id conflicts and is not affected by such conflicts; you have to use the
-# commit id to refer to a hidden revision regardless.
-'format_short_change_id_with_hidden_and_divergent_info(commit)' = '''
-if(commit.hidden(),
-  label("hidden",
-    join(" ",
+'format_short_change_id_with_change_offset(commit)' = '''
+coalesce(
+  if(commit.hidden(),
+    label("hidden",
       format_short_change_id(commit.change_id()) ++ format_change_offset(commit),
-      "hidden",
     ),
   ),
   if(commit.divergent(),
     label("divergent",
       format_short_change_id(commit.change_id()) ++ format_change_offset(commit),
     ),
-    format_short_change_id(commit.change_id()),
   ),
+  format_short_change_id(commit.change_id()),
 )
 '''
+
 'format_change_offset(commit)' = 'surround(label("change_offset", "/"), "", commit.change_offset())'
 
+# We have "hidden" override "divergent", since a hidden revision does not cause
+# divergence and is not affected by divergence.
+'format_commit_labels(commit)' = '''
+separate(" ",
+  coalesce(
+    if(commit.hidden(), label("hidden", "(hidden)")),
+    if(commit.divergent(), label("divergent", "(divergent)")),
+  ),
+  if(commit.conflict(), label("conflict", "(conflict)")),
+)
+'''
 
 'format_short_commit_header(commit)' = '''
 separate(" ",
-  format_short_change_id_with_hidden_and_divergent_info(commit),
+  format_short_change_id_with_change_offset(commit),
   format_short_signature(commit.author()),
   format_timestamp(commit_timestamp(commit)),
   commit.bookmarks(),
   commit.tags(),
   commit.working_copies(),
   format_short_commit_id(commit.commit_id()),
-  if(commit.conflict(), label("conflict", "conflict")),
+  format_commit_labels(commit),
   if(config("ui.show-cryptographic-signatures").as_boolean(),
     format_short_cryptographic_signature(commit.signature())
   ),
@@ -505,7 +513,7 @@ separate(" ",
 # for every repo)
 'format_short_commit_header_redacted(commit)' = '''
 separate(" ",
-  format_short_change_id_with_hidden_and_divergent_info(commit),
+  format_short_change_id_with_change_offset(commit),
   label("author", format_user_redacted(commit.author())),
   format_timestamp(commit_timestamp(commit)),
   commit.bookmarks().map(|bookmark| concat(
@@ -518,7 +526,7 @@ separate(" ",
   commit.tags().map(|tag| concat("tag-", hash(tag.name()).substr(0, 4))),
   commit.working_copies(),
   format_short_commit_id(commit.commit_id()),
-  if(commit.conflict(), label("conflict", "conflict")),
+  format_commit_labels(commit),
   if(config("ui.show-cryptographic-signatures").as_boolean(),
     format_short_cryptographic_signature(commit.signature())
   ),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1852,15 +1852,9 @@ Spans of revisions that are not included in the graph per `--revisions` are rend
 
 The working-copy commit is indicated by a `@` symbol in the graph. [Immutable revisions] have a `◆` symbol. Other commits have a `○` symbol. All of these symbols can be [customized].
 
-Visible changes with a [change offset] after their ID are [divergent].
-
 [Immutable revisions]: https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
 
 [customized]: https://docs.jj-vcs.dev/latest/config/#node-style
-
-[change offset]: https://docs.jj-vcs.dev/latest/glossary/#change-offset
-
-[divergent]: https://docs.jj-vcs.dev/latest/guides/divergence/
 
 **Usage:** `jj log [OPTIONS] [FILESETS]...`
 

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -129,28 +129,28 @@ fn test_absorb_simple() {
     insta::assert_snapshot!(get_evolog(&work_dir, "subject(1)"), @r"
     ○    kkmpptxz 5810eb0f 1
     ├─╮
-    │ ○  yqosqzyt/0 hidden 39b42898 (no description set)
-    │ ○  yqosqzyt/1 hidden 977269ac (empty) (no description set)
-    ○    kkmpptxz/1 hidden bd7d4016 1
+    │ ○  yqosqzyt/0 39b42898 (hidden) (no description set)
+    │ ○  yqosqzyt/1 977269ac (hidden) (empty) (no description set)
+    ○    kkmpptxz/1 bd7d4016 (hidden) 1
     ├─╮
-    │ ○  mzvwutvl/0 hidden 0b307741 (no description set)
-    │ ○  mzvwutvl/1 hidden f2709b4e (empty) (no description set)
-    ○  kkmpptxz/2 hidden 1553c5e8 1
-    ○  kkmpptxz/3 hidden eb943711 (empty) 1
+    │ ○  mzvwutvl/0 0b307741 (hidden) (no description set)
+    │ ○  mzvwutvl/1 f2709b4e (hidden) (empty) (no description set)
+    ○  kkmpptxz/2 1553c5e8 (hidden) 1
+    ○  kkmpptxz/3 eb943711 (hidden) (empty) 1
     [EOF]
     ");
     insta::assert_snapshot!(get_evolog(&work_dir, "subject(2)"), @r"
     ○    zsuskuln dd109863 2
     ├─╮
-    │ ○  vruxwmqv/0 hidden 761492a8 (no description set)
-    │ ○  vruxwmqv/1 hidden 48c7d8fa (empty) (no description set)
-    ○  zsuskuln/1 hidden 8edd60a2 2
-    ○    zsuskuln/2 hidden 95568809 2
+    │ ○  vruxwmqv/0 761492a8 (hidden) (no description set)
+    │ ○  vruxwmqv/1 48c7d8fa (hidden) (empty) (no description set)
+    ○  zsuskuln/1 8edd60a2 (hidden) 2
+    ○    zsuskuln/2 95568809 (hidden) 2
     ├─╮
-    │ ○  mzvwutvl/0 hidden 0b307741 (no description set)
-    │ ○  mzvwutvl/1 hidden f2709b4e (empty) (no description set)
-    ○  zsuskuln/3 hidden 36fad385 2
-    ○  zsuskuln/4 hidden 561fbce9 (empty) 2
+    │ ○  mzvwutvl/0 0b307741 (hidden) (no description set)
+    │ ○  mzvwutvl/1 f2709b4e (hidden) (empty) (no description set)
+    ○  zsuskuln/3 36fad385 (hidden) 2
+    ○  zsuskuln/4 561fbce9 (hidden) (empty) 2
     [EOF]
     ");
 }

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -436,12 +436,12 @@ fn test_bisect_run_jj_command() {
     Working copy  (@) now at: kmkuslsw 17e2a972 (empty) (no description set)
     Parent commit (@-)      : zsuskuln 123b4d91 b | b
     Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: kmkuslsw/0 55b3b4a8 (empty) testing
-    Parent commit (@-)      : kmkuslsw/1 17e2a972 (empty) (no description set)
+    Working copy  (@) now at: kmkuslsw/0 55b3b4a8 (divergent) (empty) testing
+    Parent commit (@-)      : kmkuslsw/1 17e2a972 (divergent) (empty) (no description set)
     Working copy  (@) now at: msksykpx 2f6e298d (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
     Added 0 files, modified 0 files, removed 1 files
-    Working copy  (@) now at: kmkuslsw/0 2f80658c (empty) testing
+    Working copy  (@) now at: kmkuslsw/0 2f80658c (divergent) (empty) testing
     Parent commit (@-)      : msksykpx 2f6e298d (empty) (no description set)
     [EOF]
     ");

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1439,20 +1439,20 @@ fn test_bookmark_track_conflict() {
     ------- stderr -------
     Started tracking 1 remote bookmarks.
     main (conflicted):
-      + qpvuntsm/0 467e027c (empty) c
-      + qpvuntsm/2 48ded843 (empty) a
-      @origin (behind by 1 commits): qpvuntsm/2 48ded843 (empty) a
+      + qpvuntsm/0 467e027c (divergent) (empty) c
+      + qpvuntsm/2 48ded843 (divergent) (empty) a
+      @origin (behind by 1 commits): qpvuntsm/2 48ded843 (divergent) (empty) a
     [EOF]
     ");
 
     // origin2 differs but is not in conflict
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main (conflicted):
-      + qpvuntsm/0 467e027c (empty) c
-      + qpvuntsm/2 48ded843 (empty) a
-      @origin (behind by 1 commits): qpvuntsm/2 48ded843 (empty) a
-      @origin2 (ahead by 1 commits, behind by 2 commits): qpvuntsm/1 hidden 579e0acd (empty) b
-      @origin3 (behind by 1 commits): qpvuntsm/0 467e027c (empty) c
+      + qpvuntsm/0 467e027c (divergent) (empty) c
+      + qpvuntsm/2 48ded843 (divergent) (empty) a
+      @origin (behind by 1 commits): qpvuntsm/2 48ded843 (divergent) (empty) a
+      @origin2 (ahead by 1 commits, behind by 2 commits): qpvuntsm/1 579e0acd (hidden) (empty) b
+      @origin3 (behind by 1 commits): qpvuntsm/0 467e027c (divergent) (empty) c
     [EOF]
     ");
 
@@ -1465,10 +1465,10 @@ fn test_bookmark_track_conflict() {
     ------- stderr -------
     Started tracking 1 remote bookmarks.
     main (conflicted):
-      + qpvuntsm/0 467e027c (empty) c
-      + qpvuntsm/2 48ded843 (empty) a
-      + qpvuntsm/1 579e0acd (empty) b
-      @origin2 (behind by 2 commits): qpvuntsm/1 579e0acd (empty) b
+      + qpvuntsm/0 467e027c (divergent) (empty) c
+      + qpvuntsm/2 48ded843 (divergent) (empty) a
+      + qpvuntsm/1 579e0acd (divergent) (empty) b
+      @origin2 (behind by 2 commits): qpvuntsm/1 579e0acd (divergent) (empty) b
     [EOF]
     ");
 }
@@ -2047,7 +2047,7 @@ fn test_bookmark_list_filtered() {
       @origin: zsuskuln 0e6b7968 (empty) remote-delete
     remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2063,7 +2063,7 @@ fn test_bookmark_list_filtered() {
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
     remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
@@ -2073,19 +2073,19 @@ fn test_bookmark_list_filtered() {
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
     remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
     // Select bookmarks by name.
     insta::assert_snapshot!(query(&["remote-rewrite"]), @r"
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ");
     insta::assert_snapshot!(query(&["-rbookmarks(remote-rewrite)"]), @r"
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
@@ -2094,13 +2094,13 @@ fn test_bookmark_list_filtered() {
     insta::assert_snapshot!(query(&["--all-remotes", "remote-rewrite"]), @r"
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
       @git: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ");
     insta::assert_snapshot!(query(&["--all-remotes", "-rbookmarks(remote-rewrite)"]), @r"
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
       @git: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ");
 
@@ -2111,7 +2111,7 @@ fn test_bookmark_list_filtered() {
     remote-keep: rlvkpnrz c2f2ee40 (empty) remote-keep
       @origin: rlvkpnrz c2f2ee40 (empty) remote-keep
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2136,7 +2136,7 @@ fn test_bookmark_list_filtered() {
       @origin: rlvkpnrz c2f2ee40 (empty) remote-keep
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
       @git: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ------- stderr -------
     Hint: Bookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.
@@ -2191,7 +2191,7 @@ fn test_bookmark_list_filtered() {
     insta::assert_snapshot!(query(&["local-keep", "-rbookmarks(remote-rewrite)"]), @r"
     local-keep: kpqxywon 4b2bc95c (empty) local-keep
     remote-rewrite: royxmykx e6970e0e (empty) rewritten
-      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 hidden 331d500d (empty) remote-rewrite
+      @origin (ahead by 1 commits, behind by 1 commits): royxmykx/1 331d500d (hidden) (empty) remote-rewrite
     [EOF]
     ");
 

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -554,9 +554,9 @@ fn test_log_evolog_divergence() {
         .success();
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @r"
-    @  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 556daeb7
+    @  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 556daeb7 (divergent)
     │  description 1
-    │ ○  qpvuntsm/0 test.user@example.com 2001-02-03 08:05:10 5cea51a1
+    │ ○  qpvuntsm/0 test.user@example.com 2001-02-03 08:05:10 5cea51a1 (divergent)
     ├─╯  description 2
     ◆  zzzzzzzz root() 00000000
     [EOF]
@@ -568,9 +568,9 @@ fn test_log_evolog_divergence() {
     // Color
     let output = work_dir.run_jj(["log", "--color=always"]);
     insta::assert_snapshot!(output, @r"
-    [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m [38;5;9m(divergent)[39m[0m
     │  [1mdescription 1[0m
-    │ ○  [1m[38;5;1mq[0m[38;5;8mpvuntsm[1m[38;5;1m/0[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m5c[0m[38;5;8mea51a1[39m
+    │ ○  [1m[38;5;1mq[0m[38;5;8mpvuntsm[1m[38;5;1m/0[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m5c[0m[38;5;8mea51a1[39m [38;5;1m(divergent)[39m
     ├─╯  description 2
     [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
     [EOF]
@@ -579,13 +579,13 @@ fn test_log_evolog_divergence() {
     // Evolog and hidden divergent
     let output = work_dir.run_jj(["evolog"]);
     insta::assert_snapshot!(output, @r"
-    @  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 556daeb7
+    @  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 556daeb7 (divergent)
     │  description 1
     │  -- operation fec5a045b947 describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
-    ○  qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:08 d0c049cd
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 d0c049cd (hidden)
     │  (no description set)
     │  -- operation 911e64a1b666 snapshot working copy
-    ○  qpvuntsm/3 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -594,13 +594,13 @@ fn test_log_evolog_divergence() {
     // Colored evolog
     let output = work_dir.run_jj(["evolog", "--color=always"]);
     insta::assert_snapshot!(output, @r"
-    [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m [38;5;9m(divergent)[39m[0m
     │  [1mdescription 1[0m
     │  [38;5;8m--[39m operation [38;5;4mfec5a045b947[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
-    ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/2[0m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4md[0m[38;5;8m0c049cd[39m
+    ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4md[0m[38;5;8m0c049cd[39m (hidden)
     │  [38;5;3m(no description set)[39m
     │  [38;5;8m--[39m operation [38;5;4m911e64a1b666[39m snapshot working copy
-    ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/3[0m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m
+    ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden)
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
        [38;5;8m--[39m operation [38;5;4m8f47435a3990[39m add workspace 'default'
     [EOF]

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1384,7 +1384,7 @@ fn test_files() {
     │  M f_modified
     │  M f_not_yet_copied
     │  R {f_not_yet_renamed => f_renamed}
-    │ ×  royxmykx test.user@example.com 2001-02-03 08:05:14 conflicted 16d833c2 conflict
+    │ ×  royxmykx test.user@example.com 2001-02-03 08:05:14 conflicted 16d833c2 (conflict)
     ├─╯  conflicted
     │    A f_added_2
     │    A f_dir/dir_file_1

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -2471,13 +2471,13 @@ fn test_diff_conflict_sides_differ() {
     // left1+right1.
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @r"
-    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left2+right2 fc3e5042 conflict
+    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left2+right2 fc3e5042 (conflict)
     ├─╮  (empty) left2+right2
     │ ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 right2 e57450eb
     │ │  right2
     ○ │  royxmykx test.user@example.com 2001-02-03 08:05:13 left2 b50b218b
     │ │  left2
-    │ │ ×  kmkuslsw test.user@example.com 2001-02-03 08:05:18 left1+right1 e65cbbc2 conflict
+    │ │ ×  kmkuslsw test.user@example.com 2001-02-03 08:05:18 left1+right1 e65cbbc2 (conflict)
     ╭─┬─╯  (empty) left1+right1
     │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 right1 3fe2e860
     │ │  right1
@@ -2783,7 +2783,7 @@ fn test_diff_conflict_bases_differ() {
     // left1+right1.
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @r"
-    ×    nkmrtpmo test.user@example.com 2001-02-03 08:05:22 left2+right2 c5c906ec conflict
+    ×    nkmrtpmo test.user@example.com 2001-02-03 08:05:22 left2+right2 c5c906ec (conflict)
     ├─╮  (empty) left2+right2
     │ ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 right2 656695c3
     │ │  right2
@@ -2791,7 +2791,7 @@ fn test_diff_conflict_bases_differ() {
     ├─╯  left2
     ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 base2 3c4d67e6
     │  base2
-    │ ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left1+right1 eb28084c conflict
+    │ ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 left1+right1 eb28084c (conflict)
     │ ├─╮  (empty) left1+right1
     │ │ ○  royxmykx test.user@example.com 2001-02-03 08:05:13 right1 3087be1f
     ├───╯  right1
@@ -2956,11 +2956,11 @@ fn test_diff_conflict_three_sides() {
     // Test the setup
     work_dir.run_jj(["new", "root()"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r~@"]), @r"
-    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 side1+side2+side3 4fc2729a conflict
+    ×    lylxulpl test.user@example.com 2001-02-03 08:05:20 side1+side2+side3 4fc2729a (conflict)
     ├─╮  (empty) side1+side2+side3
     │ ○  znkkpsqq test.user@example.com 2001-02-03 08:05:17 side3 f73063c9
     │ │  side3
-    × │    kmkuslsw test.user@example.com 2001-02-03 08:05:18 side1+side2 46d2298b conflict
+    × │    kmkuslsw test.user@example.com 2001-02-03 08:05:18 side1+side2 46d2298b (conflict)
     ├───╮  (empty) side1+side2
     │ │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:15 side2 bc176227
     │ │ │  side2

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -35,13 +35,13 @@ fn test_evolog_with_or_without_diff() {
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
     │  -- operation 59d1d4d21725 snapshot working copy
-    ×  rlvkpnrz/1 hidden test.user@example.com 2001-02-03 08:05:09 68ee7b1b conflict
+    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 68ee7b1b (hidden) (conflict)
     │  my description
     │  -- operation 3369465d33a0 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  rlvkpnrz/2 hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
+    ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
     │  -- operation 826347115e2d snapshot working copy
-    ○  rlvkpnrz/3 hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
+    ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
        -- operation e0f8e58b3800 new empty commit
     [EOF]
@@ -53,13 +53,13 @@ fn test_evolog_with_or_without_diff() {
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
     │  [1mmy description[0m
     │  [38;5;8m--[39m operation [38;5;4m59d1d4d21725[39m snapshot working copy
-    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/1[0m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m6[0m[38;5;8m8ee7b1b[39m [38;5;1mconflict[39m
+    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m6[0m[38;5;8m8ee7b1b[39m (hidden) [38;5;1m(conflict)[39m
     │  my description
     │  [38;5;8m--[39m operation [38;5;4m3369465d33a0[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/2[0m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m
+    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m (hidden)
     │  my description
     │  [38;5;8m--[39m operation [38;5;4m826347115e2d[39m snapshot working copy
-    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/3[0m hidden [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m
+    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m (hidden)
        [38;5;2m(empty)[39m my description
        [38;5;8m--[39m operation [38;5;4me0f8e58b3800[39m new empty commit
     [EOF]
@@ -81,10 +81,10 @@ fn test_evolog_with_or_without_diff() {
     │     6     : foo
     │     7     : bar
     │     8    1: >>>>>>> conflict 1 of 1 endsresolved
-    ×  rlvkpnrz/1 hidden test.user@example.com 2001-02-03 08:05:09 68ee7b1b conflict
+    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 68ee7b1b (hidden) (conflict)
     │  my description
     │  -- operation 3369465d33a0 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  rlvkpnrz/2 hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
+    ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
     │  -- operation 826347115e2d snapshot working copy
     │  Modified regular file file1:
@@ -92,7 +92,7 @@ fn test_evolog_with_or_without_diff() {
     │          2: bar
     │  Added regular file file2:
     │          1: foo
-    ○  rlvkpnrz/3 hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
+    ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
        -- operation e0f8e58b3800 new empty commit
        Modified commit description:
@@ -106,19 +106,19 @@ fn test_evolog_with_or_without_diff() {
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
     │  -- operation 59d1d4d21725 snapshot working copy
-    ×  rlvkpnrz/1 hidden test.user@example.com 2001-02-03 08:05:09 68ee7b1b conflict
+    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 68ee7b1b (hidden) (conflict)
     │  my description
     │  -- operation 3369465d33a0 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  rlvkpnrz/2 hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
+    ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
     │  -- operation 826347115e2d snapshot working copy
-    ○  rlvkpnrz/3 hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
+    ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
        -- operation e0f8e58b3800 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c664a51b
     │  (no description set)
     │  -- operation ca1226de0084 snapshot working copy
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -130,7 +130,7 @@ fn test_evolog_with_or_without_diff() {
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
     │  -- operation 59d1d4d21725 snapshot working copy
-    ×  rlvkpnrz/1 hidden test.user@example.com 2001-02-03 08:05:09 68ee7b1b conflict
+    ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 68ee7b1b (hidden) (conflict)
     │  my description
     │  -- operation 3369465d33a0 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     [EOF]
@@ -142,13 +142,13 @@ fn test_evolog_with_or_without_diff() {
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
     -- operation 59d1d4d21725 snapshot working copy
-    rlvkpnrz/1 hidden test.user@example.com 2001-02-03 08:05:09 68ee7b1b conflict
+    rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 68ee7b1b (hidden) (conflict)
     my description
     -- operation 3369465d33a0 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    rlvkpnrz/2 hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
+    rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
     -- operation 826347115e2d snapshot working copy
-    rlvkpnrz/3 hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
+    rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
     -- operation e0f8e58b3800 new empty commit
     [EOF]
@@ -174,10 +174,10 @@ fn test_evolog_with_or_without_diff() {
     -bar
     ->>>>>>> conflict 1 of 1 ends
     +resolved
-    rlvkpnrz/1 hidden test.user@example.com 2001-02-03 08:05:09 68ee7b1b conflict
+    rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 68ee7b1b (hidden) (conflict)
     my description
     -- operation 3369465d33a0 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    rlvkpnrz/2 hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
+    rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
     -- operation 826347115e2d snapshot working copy
     diff --git a/file1 b/file1
@@ -194,7 +194,7 @@ fn test_evolog_with_or_without_diff() {
     +++ b/file2
     @@ -0,0 +1,1 @@
     +foo
-    rlvkpnrz/3 hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
+    rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
     -- operation e0f8e58b3800 new empty commit
     diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
@@ -296,13 +296,13 @@ fn test_evolog_with_custom_symbols() {
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
     │  -- operation e06469ca0671 snapshot working copy
-    ┝  rlvkpnrz/1 hidden test.user@example.com 2001-02-03 08:05:09 68ee7b1b conflict
+    ┝  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 68ee7b1b (hidden) (conflict)
     │  my description
     │  -- operation 3369465d33a0 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ┝  rlvkpnrz/2 hidden test.user@example.com 2001-02-03 08:05:09 51e08f95
+    ┝  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
     │  -- operation 826347115e2d snapshot working copy
-    ┝  rlvkpnrz/3 hidden test.user@example.com 2001-02-03 08:05:08 b955b72e
+    ┝  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
        -- operation e0f8e58b3800 new empty commit
     [EOF]
@@ -330,7 +330,7 @@ fn test_evolog_word_wrap() {
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     │  (empty) first
     │  -- operation 75545f7ff2df describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -342,9 +342,8 @@ fn test_evolog_word_wrap() {
     │  -- operation 75545f7ff2df describe
     │  commit
     │  e8849ae12c709f2321908879bc724fdb2ab8a781
-    ○  qpvuntsm/1 hidden
-       test.user@example.com 2001-02-03
-       08:05:07 e8849ae1
+    ○  qpvuntsm/1 test.user@example.com
+       2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add
        workspace 'default'
@@ -354,7 +353,7 @@ fn test_evolog_word_wrap() {
     qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     (empty) first
     -- operation 75545f7ff2df describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
     -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -366,8 +365,8 @@ fn test_evolog_word_wrap() {
     -- operation 75545f7ff2df describe
     commit
     e8849ae12c709f2321908879bc724fdb2ab8a781
-    qpvuntsm/1 hidden test.user@example.com
-    2001-02-03 08:05:07 e8849ae1
+    qpvuntsm/1 test.user@example.com
+    2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
     -- operation 8f47435a3990 add workspace
     'default'
@@ -429,27 +428,27 @@ fn test_evolog_squash() {
     │ │ │     6    1: %%%%%%% diff from base #2 to side #3
     │ │ │     7     : +fifth
     │ │ │     8     : >>>>>>> conflict 1 of 1 ends
-    │ │ ○  vruxwmqv/0 hidden test.user@example.com 2001-02-03 08:05:15 770795d0
+    │ │ ○  vruxwmqv/0 test.user@example.com 2001-02-03 08:05:15 770795d0 (hidden)
     │ │ │  fifth
     │ │ │  -- operation b22b0aceb94e snapshot working copy
     │ │ │  Added regular file file5:
     │ │ │          1: foo5
-    │ │ ○  vruxwmqv/1 hidden test.user@example.com 2001-02-03 08:05:14 2e0123d1
+    │ │ ○  vruxwmqv/1 test.user@example.com 2001-02-03 08:05:14 2e0123d1 (hidden)
     │ │    (empty) fifth
     │ │    -- operation fc852ed87801 new empty commit
     │ │    Modified commit description:
     │ │            1: fifth
-    │ ○  yqosqzyt/0 hidden test.user@example.com 2001-02-03 08:05:14 ea8161b6
+    │ ○  yqosqzyt/0 test.user@example.com 2001-02-03 08:05:14 ea8161b6 (hidden)
     │ │  fourth
     │ │  -- operation 3b09d55dfa6e snapshot working copy
     │ │  Added regular file file4:
     │ │          1: foo4
-    │ ○  yqosqzyt/1 hidden test.user@example.com 2001-02-03 08:05:13 1de5fdb6
+    │ ○  yqosqzyt/1 test.user@example.com 2001-02-03 08:05:13 1de5fdb6 (hidden)
     │    (empty) fourth
     │    -- operation 9404a551035a new empty commit
     │    Modified commit description:
     │            1: fourth
-    ○    qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:12 5ec0619a
+    ○    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:12 5ec0619a (hidden)
     ├─╮  squashed 2
     │ │  -- operation fa9796d12627 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
     │ │  Modified commit description:
@@ -463,7 +462,7 @@ fn test_evolog_squash() {
     │ │     1     : foo2
     │ │  Removed regular file file3:
     │ │     1     : foo3
-    │ ○  zsuskuln/3 hidden test.user@example.com 2001-02-03 08:05:12 cce957f1
+    │ ○  zsuskuln/3 test.user@example.com 2001-02-03 08:05:12 cce957f1 (hidden)
     │ │  third
     │ │  -- operation de96267cd621 snapshot working copy
     │ │  Modified regular file file1:
@@ -474,15 +473,15 @@ fn test_evolog_squash() {
     │ │          1: foo2
     │ │  Added regular file file3:
     │ │          1: foo3
-    │ ○  zsuskuln/4 hidden test.user@example.com 2001-02-03 08:05:11 3a2a4253
+    │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 3a2a4253 (hidden)
     │ │  (empty) third
     │ │  -- operation 4611a6121e8a describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
     │ │  Modified commit description:
     │ │          1: third
-    │ ○  zsuskuln/5 hidden test.user@example.com 2001-02-03 08:05:10 ebec10f4
+    │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:10 ebec10f4 (hidden)
     │    (empty) (no description set)
     │    -- operation 65c81703100d squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
-    ○    qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:10 69085884
+    ○    qpvuntsm/2 test.user@example.com 2001-02-03 08:05:10 69085884 (hidden)
     ├─╮  squashed 1
     │ │  -- operation 65c81703100d squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     │ │  Modified commit description:
@@ -493,28 +492,28 @@ fn test_evolog_squash() {
     │ │     5     : second
     │ │     6     : >>>>>>> conflict 1 of 1 ends
     │ │          1: squashed 1
-    │ ○  kkmpptxz/0 hidden test.user@example.com 2001-02-03 08:05:10 a3759c9d
+    │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 a3759c9d (hidden)
     │ │  second
     │ │  -- operation a7b202f56742 snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
-    │ ○  kkmpptxz/1 hidden test.user@example.com 2001-02-03 08:05:09 a5b2f625
+    │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 a5b2f625 (hidden)
     │    (empty) second
     │    -- operation 26f649a0cdfa new empty commit
     │    Modified commit description:
     │            1: second
-    ○  qpvuntsm/3 hidden test.user@example.com 2001-02-03 08:05:09 5878cbe0
+    ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:09 5878cbe0 (hidden)
     │  first
     │  -- operation af15122a5868 snapshot working copy
     │  Added regular file file1:
     │          1: foo
-    ○  qpvuntsm/4 hidden test.user@example.com 2001-02-03 08:05:08 68a50538
+    ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:08 68a50538 (hidden)
     │  (empty) first
     │  -- operation 75545f7ff2df describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  Modified commit description:
     │          1: first
-    ○  qpvuntsm/5 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/5 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -536,18 +535,18 @@ fn test_evolog_abandoned_op() {
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
     │  -- operation 043c31d6dd84 describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:09 32cabcfa
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
     │  file1
     │  -- operation baef907e5b55 snapshot working copy
     │  A file2
-    ○  qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:08 cb5ebdc6
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 cb5ebdc6 (hidden)
     │  file1
     │  -- operation c4cf439c43a8 describe commit 093c3c9624b6cfe22b310586f5638792aa80e6d7
-    ○  qpvuntsm/3 hidden test.user@example.com 2001-02-03 08:05:08 093c3c96
+    ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 093c3c96 (hidden)
     │  (no description set)
     │  -- operation f41b80dc73b6 snapshot working copy
     │  A file1
-    ○  qpvuntsm/4 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -562,7 +561,7 @@ fn test_evolog_abandoned_op() {
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
     │  -- operation ab2192a635be describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:09 32cabcfa
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
        file1
        A file1
        A file2
@@ -624,13 +623,13 @@ fn test_evolog_reversed_no_graph() {
     work_dir.run_jj(["describe", "-m", "c"]).success();
     let output = work_dir.run_jj(["evolog", "--reversed", "--no-graph"]);
     insta::assert_snapshot!(output, @r"
-    qpvuntsm/3 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
     -- operation 8f47435a3990 add workspace 'default'
-    qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:08 b86e28cd
+    qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     (empty) a
     -- operation ab34d1de4875 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:09 9f43967b
+    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
     -- operation 3851e9877d51 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
@@ -641,7 +640,7 @@ fn test_evolog_reversed_no_graph() {
 
     let output = work_dir.run_jj(["evolog", "--limit=2", "--reversed", "--no-graph"]);
     insta::assert_snapshot!(output, @r"
-    qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:09 9f43967b
+    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
     -- operation 3851e9877d51 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
@@ -677,22 +676,22 @@ fn test_evolog_reverse_with_graph() {
         .success();
     let output = work_dir.run_jj(["evolog", "-r", "subject(c+d+e)", "--reversed"]);
     insta::assert_snapshot!(output, @r"
-    ○  qpvuntsm/4 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     │  (empty) (no description set)
     │  -- operation 8f47435a3990 add workspace 'default'
-    ○  qpvuntsm/3 hidden test.user@example.com 2001-02-03 08:05:08 b86e28cd
+    ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     │  (empty) a
     │  -- operation ab34d1de4875 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    ○  qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:09 9f43967b
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     │  (empty) b
     │  -- operation 3851e9877d51 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:10 b28cda4b
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:10 b28cda4b (hidden)
     │  (empty) c
     │  -- operation 5f4c7b5cb177 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
-    │ ○  mzvwutvl/0 hidden test.user@example.com 2001-02-03 08:05:11 6a4ff8aa
+    │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     ├─╯  (empty) d
     │    -- operation bc5f758ddd39 new empty commit
-    │ ○  royxmykx/0 hidden test.user@example.com 2001-02-03 08:05:12 7dea2d1d
+    │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
     │    -- operation 984a0df6c274 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
@@ -703,10 +702,10 @@ fn test_evolog_reverse_with_graph() {
 
     let output = work_dir.run_jj(["evolog", "-rsubject(c+d+e)", "--limit=3", "--reversed"]);
     insta::assert_snapshot!(output, @r"
-    ○  mzvwutvl/0 hidden test.user@example.com 2001-02-03 08:05:11 6a4ff8aa
+    ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     │  (empty) d
     │  -- operation bc5f758ddd39 new empty commit
-    │ ○  royxmykx/0 hidden test.user@example.com 2001-02-03 08:05:12 7dea2d1d
+    │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
     │    -- operation 984a0df6c274 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -860,7 +860,7 @@ fn test_git_fetch_all() {
     a2: yqosqzyt d4d535f1 a2
       @origin: yqosqzyt d4d535f1 a2
     b: yostqsxw 0fbbc495 new_descr_for_b_to_create_conflict
-      @origin (ahead by 1 commits, behind by 1 commits): yostqsxw/1 hidden bc83465a b
+      @origin (ahead by 1 commits, behind by 1 commits): yostqsxw/1 bc83465a (hidden) b
     trunk1: kkmpptxz 38288177 trunk1
       @origin: kkmpptxz 38288177 trunk1
     [EOF]
@@ -881,10 +881,10 @@ fn test_git_fetch_all() {
     a2: yqosqzyt baad96fe a2
       @origin: yqosqzyt baad96fe a2
     b (conflicted):
-      - yostqsxw/2 hidden bc83465a b
-      + yostqsxw/1 0fbbc495 new_descr_for_b_to_create_conflict
-      + yostqsxw/0 6fc6fe17 b
-      @origin (behind by 1 commits): yostqsxw/0 6fc6fe17 b
+      - yostqsxw/2 bc83465a (hidden) b
+      + yostqsxw/1 0fbbc495 (divergent) new_descr_for_b_to_create_conflict
+      + yostqsxw/0 6fc6fe17 (divergent) b
+      @origin (behind by 1 commits): yostqsxw/0 6fc6fe17 (divergent) b
     trunk1: kkmpptxz 38288177 trunk1
       @origin: kkmpptxz 38288177 trunk1
     trunk2: uyznsvlq e80d998a trunk2
@@ -1086,10 +1086,10 @@ fn test_git_fetch_some_of_many_bookmarks() {
     a2: yqosqzyt d4d535f1 a2
       @origin: yqosqzyt d4d535f1 a2
     b (conflicted):
-      - yostqsxw/2 hidden bc83465a b
-      + yostqsxw/1 c62db311 new_descr_for_b_to_create_conflict
-      + yostqsxw/0 2b30dbc9 b
-      @origin (behind by 1 commits): yostqsxw/0 2b30dbc9 b
+      - yostqsxw/2 bc83465a (hidden) b
+      + yostqsxw/1 c62db311 (divergent) new_descr_for_b_to_create_conflict
+      + yostqsxw/0 2b30dbc9 (divergent) b
+      @origin (behind by 1 commits): yostqsxw/0 2b30dbc9 (divergent) b
     [EOF]
     ");
     // Now, let's fetch a2 and double-check that fetching a1 and b again doesn't do
@@ -1122,10 +1122,10 @@ fn test_git_fetch_some_of_many_bookmarks() {
     a2: yqosqzyt 841140b1 a2
       @origin: yqosqzyt 841140b1 a2
     b (conflicted):
-      - yostqsxw/2 hidden bc83465a b
-      + yostqsxw/1 c62db311 new_descr_for_b_to_create_conflict
-      + yostqsxw/0 2b30dbc9 b
-      @origin (behind by 1 commits): yostqsxw/0 2b30dbc9 b
+      - yostqsxw/2 bc83465a (hidden) b
+      + yostqsxw/1 c62db311 (divergent) new_descr_for_b_to_create_conflict
+      + yostqsxw/0 2b30dbc9 (divergent) b
+      @origin (behind by 1 commits): yostqsxw/0 2b30dbc9 (divergent) b
     [EOF]
     ");
 }
@@ -1431,7 +1431,7 @@ fn test_fetch_undo_what() {
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     b (deleted)
-      @origin: yostqsxw/0 hidden bc83465a b
+      @origin: yostqsxw/0 bc83465a (hidden) b
     [EOF]
     ");
 
@@ -1442,7 +1442,7 @@ fn test_fetch_undo_what() {
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     b (deleted)
-      @origin: yostqsxw/0 hidden bc83465a b
+      @origin: yostqsxw/0 bc83465a (hidden) b
     newbookmark: qpvuntsm e8849ae1 (empty) (no description set)
       @origin (not created yet)
     [EOF]

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -41,7 +41,7 @@ fn test_resolution_of_git_tracking_bookmarks() {
         .success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm 384a1421 (empty) new_message
-      @git (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden a7f9930b (empty) old_message
+      @git (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 a7f9930b (hidden) (empty) old_message
     [EOF]
     ");
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -106,7 +106,7 @@ fn test_git_push_current_bookmark() {
     // Check the setup
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: qpvuntsm e5ce6d9a (empty) modified bookmark1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 9b2e76de (empty) description 1
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 9b2e76de (hidden) (empty) description 1
     bookmark2: yostqsxw 88ca14a7 (empty) foo
       @origin (behind by 1 commits): zsuskuln 38a20473 (empty) description 2
     my-bookmark: yostqsxw 88ca14a7 (empty) foo
@@ -133,7 +133,7 @@ fn test_git_push_current_bookmark() {
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     bookmark1: qpvuntsm e5ce6d9a (empty) modified bookmark1 commit
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 9b2e76de (empty) description 1
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 9b2e76de (hidden) (empty) description 1
     bookmark2: yostqsxw 88ca14a7 (empty) foo
       @origin: yostqsxw 88ca14a7 (empty) foo
     my-bookmark: yostqsxw 88ca14a7 (empty) foo
@@ -643,7 +643,7 @@ fn test_git_push_locally_created_and_rewritten() {
     bookmark2: zsuskuln 38a20473 (empty) description 2
       @origin: zsuskuln 38a20473 (empty) description 2
     my: vruxwmqv 9ebc3217 (empty) local 2
-      @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv/1 hidden e0cba5e4 (empty) local 1
+      @origin (ahead by 1 commits, behind by 1 commits): vruxwmqv/1 e0cba5e4 (hidden) (empty) local 1
     [EOF]
     ");
     let output = work_dir.run_jj(["git", "push"]);

--- a/cli/tests/test_identical_commits.rs
+++ b/cli/tests/test_identical_commits.rs
@@ -93,7 +93,7 @@ fn test_identical_commits_by_cycling_rewrite() {
     @  oxmtprsl test.user@example.com 2001-01-01 11:00:00 c5abd225
     │  (empty) test2
     │  -- operation f184243937e9 describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
-    ○  oxmtprsl/1 hidden test.user@example.com 2001-01-01 11:00:00 053222c2
+    ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 053222c2 (hidden)
        (empty) test1
        -- operation 509c18587028 new empty commit
     [EOF]
@@ -125,7 +125,7 @@ fn test_identical_commits_by_convergent_rewrite() {
     // TODO: The "test3" commit should have either "test1" or "test2" as predecessor
     // (or both?)
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @r"
-    @  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 c5abd225
+    @  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
        -- operation a1561db9359b new empty commit
     [EOF]
@@ -161,7 +161,7 @@ fn test_identical_commits_by_convergent_rewrite_one_operation() {
     // TODO: The "test3" commit should have either "test1" or "test2" as predecessor
     // (or both?)
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @r"
-    @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 c5abd225
+    @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
        -- operation a1561db9359b new empty commit
     [EOF]
@@ -202,13 +202,13 @@ fn test_identical_commits_swap_by_reordering() {
     ");
     // TODO: Each commit should be a predecessor of the other
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@"]), @r"
-    @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 5bae90c9
+    @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 5bae90c9 (divergent)
        (empty) test
        -- operation 380fbe20623e new empty commit
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@-"]), @r"
-    ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 e94ed463
+    ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 e94ed463 (divergent)
        (empty) test
        -- operation 40e37b931010 new empty commit
     [EOF]

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -247,7 +247,7 @@ fn test_rewrite_immutable_commands() {
     insta::assert_snapshot!(output, @r"
     @  yqosqzyt test.user@example.com 2001-02-03 08:05:14 55c97dc7
     │  (no description set)
-    │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 7065a923 conflict
+    │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 7065a923 (conflict)
     ╭─┤  merge
     │ │
     │ ~

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -641,10 +641,10 @@ fn test_new_change_id() {
     ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 b 01d6741e
     │  (no description set)
     │  -- operation adf0af78a0fd edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    ○  kkmpptxz/0 hidden test.user@example.com 2001-02-03 08:05:11 75591b18
+    ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:11 75591b18 (hidden)
     │  (no description set)
     │  -- operation 4b33c26502f8 snapshot working copy
-    ○  kkmpptxz/1 hidden test.user@example.com 2001-02-03 08:05:09 acebf2bd
+    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 acebf2bd (hidden)
        (empty) (no description set)
        -- operation 686c6e44c08d new empty commit
     [EOF]
@@ -653,10 +653,10 @@ fn test_new_change_id() {
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 0c3fe2d8
     │  (no description set)
     │  -- operation adf0af78a0fd edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
-    ○  mzvwutvl/1 hidden test.user@example.com 2001-02-03 08:05:13 22be6c4e
+    ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:13 22be6c4e (hidden)
     │  (no description set)
     │  -- operation 92fee3ece32c snapshot working copy
-    ○  mzvwutvl/2 hidden test.user@example.com 2001-02-03 08:05:11 b9f5490a
+    ○  mzvwutvl/2 test.user@example.com 2001-02-03 08:05:11 b9f5490a (hidden)
        (empty) (no description set)
        -- operation e3fbc5040416 new empty commit
     [EOF]

--- a/cli/tests/test_op_revert_command.rs
+++ b/cli/tests/test_op_revert_command.rs
@@ -112,7 +112,7 @@ fn test_git_push_revert() {
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm d9a9f6a0 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 3a44d6c5 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 3a44d6c5 (hidden) (empty) AA
     [EOF]
     ");
     let pre_push_opid = work_dir.current_operation_id();
@@ -139,7 +139,7 @@ fn test_git_push_revert() {
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm d9a9f6a0 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 3a44d6c5 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 3a44d6c5 (hidden) (empty) AA
     [EOF]
     ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
@@ -156,10 +156,10 @@ fn test_git_push_revert() {
     // become a no-op.
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main (conflicted):
-      - qpvuntsm/2 hidden 3a44d6c5 (empty) AA
-      + qpvuntsm/0 1e742089 (empty) CC
-      + qpvuntsm/1 d9a9f6a0 (empty) BB
-      @origin (behind by 1 commits): qpvuntsm/1 d9a9f6a0 (empty) BB
+      - qpvuntsm/2 3a44d6c5 (hidden) (empty) AA
+      + qpvuntsm/0 1e742089 (divergent) (empty) CC
+      + qpvuntsm/1 d9a9f6a0 (divergent) (empty) BB
+      @origin (behind by 1 commits): qpvuntsm/1 d9a9f6a0 (divergent) (empty) BB
     [EOF]
     ");
 }
@@ -194,7 +194,7 @@ fn test_git_push_revert_with_import() {
     //    remote-tracking  | AA      |   AA   | AA
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm d9a9f6a0 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 3a44d6c5 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 3a44d6c5 (hidden) (empty) AA
     [EOF]
     ");
     let pre_push_opid = work_dir.current_operation_id();
@@ -221,7 +221,7 @@ fn test_git_push_revert_with_import() {
     //    remote-tracking  | AA      |   AA   | BB
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm d9a9f6a0 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 3a44d6c5 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 3a44d6c5 (hidden) (empty) AA
     [EOF]
     ");
 
@@ -247,7 +247,7 @@ fn test_git_push_revert_with_import() {
     // was essentially a no-op.
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm 1e742089 (empty) CC
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden d9a9f6a0 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 d9a9f6a0 (hidden) (empty) BB
     [EOF]
     ");
 }
@@ -283,7 +283,7 @@ fn test_git_push_revert_colocated() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm d9a9f6a0 (empty) BB
       @git: qpvuntsm d9a9f6a0 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 3a44d6c5 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 3a44d6c5 (hidden) (empty) AA
     [EOF]
     ");
     let pre_push_opid = work_dir.current_operation_id();
@@ -320,7 +320,7 @@ fn test_git_push_revert_colocated() {
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm d9a9f6a0 (empty) BB
       @git: qpvuntsm d9a9f6a0 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 3a44d6c5 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 3a44d6c5 (hidden) (empty) AA
     [EOF]
     ");
     test_env.advance_test_rng_seed_to_multiple_of(100_000);
@@ -330,11 +330,11 @@ fn test_git_push_revert_colocated() {
     // same result in a seemingly different way?
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main (conflicted):
-      - qpvuntsm/2 hidden 3a44d6c5 (empty) AA
-      + qpvuntsm/0 1e742089 (empty) CC
-      + qpvuntsm/1 d9a9f6a0 (empty) BB
-      @git (behind by 1 commits): qpvuntsm/0 1e742089 (empty) CC
-      @origin (behind by 1 commits): qpvuntsm/1 d9a9f6a0 (empty) BB
+      - qpvuntsm/2 3a44d6c5 (hidden) (empty) AA
+      + qpvuntsm/0 1e742089 (divergent) (empty) CC
+      + qpvuntsm/1 d9a9f6a0 (divergent) (empty) BB
+      @git (behind by 1 commits): qpvuntsm/0 1e742089 (divergent) (empty) CC
+      @origin (behind by 1 commits): qpvuntsm/1 d9a9f6a0 (divergent) (empty) BB
     [EOF]
     ");
 }
@@ -368,7 +368,7 @@ fn test_git_push_revert_repo_only() {
     work_dir.run_jj(["describe", "-m", "BB"]).success();
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm d9a9f6a0 (empty) BB
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden 3a44d6c5 (empty) AA
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 3a44d6c5 (hidden) (empty) AA
     [EOF]
     ");
     let pre_push_opid = work_dir.current_operation_id();
@@ -389,7 +389,7 @@ fn test_git_push_revert_repo_only() {
     // This currently gives an identical result to `test_git_push_revert_import`.
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     main: qpvuntsm 1e742089 (empty) CC
-      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 hidden d9a9f6a0 (empty) BB
+      @origin (ahead by 1 commits, behind by 1 commits): qpvuntsm/1 d9a9f6a0 (hidden) (empty) BB
     [EOF]
     ");
 }

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -87,11 +87,11 @@ fn test_op_log() {
     │
     │  Changed commits:
     │  ○  + qpvuntsm 3ae22e7f (empty) description 0
-    │     - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+    │     - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     │
     │  Changed working copy default@:
     │  + qpvuntsm 3ae22e7f (empty) description 0
-    │  - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+    │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
@@ -113,11 +113,11 @@ fn test_op_log() {
     │
     │  Changed commits:
     │  ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
-    │     [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m hidden [1m[38;5;4me[0m[38;5;8m8849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    │     [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     │
     │  Changed working copy [38;5;2mdefault@[39m:
     │  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
-    │  [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m hidden [1m[38;5;4me[0m[38;5;8m8849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    │  [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     ○  [38;5;4m8f47435a3990[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
     │  add workspace 'default'
     │
@@ -524,14 +524,14 @@ fn test_op_log_word_wrap() {
     │  Changed commits:
     │  ○  + qpvuntsm 79f0968d (no
     │     description set)
-    │     - qpvuntsm/1 hidden e8849ae1
+    │     - qpvuntsm/1 e8849ae1 (hidden)
     │     (empty) (no description set)
     │
     │  Changed working copy default@:
     │  + qpvuntsm 79f0968d (no description
     │  set)
-    │  - qpvuntsm/1 hidden e8849ae1 (empty)
-    │  (no description set)
+    │  - qpvuntsm/1 e8849ae1 (hidden)
+    │  (empty) (no description set)
     ○  8f47435a3990
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
@@ -562,7 +562,7 @@ fn test_op_log_word_wrap() {
     │  Changed commits:
     │  ○  + qpvuntsm 79f0968d (no
     │     description set)
-    │     - qpvuntsm/1 hidden e8849ae1
+    │     - qpvuntsm/1 e8849ae1 (hidden)
     │     (empty) (no description set)
     │     file1 | 100 ++++++++++++++++++++++
     │     1 file changed, 100 insertions(+), 0 deletions(-)
@@ -570,8 +570,8 @@ fn test_op_log_word_wrap() {
     │  Changed working copy default@:
     │  + qpvuntsm 79f0968d (no description
     │  set)
-    │  - qpvuntsm/1 hidden e8849ae1 (empty)
-    │  (no description set)
+    │  - qpvuntsm/1 e8849ae1 (hidden)
+    │  (empty) (no description set)
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @r"
@@ -584,15 +584,15 @@ fn test_op_log_word_wrap() {
 
     Changed commits:
     + qpvuntsm 79f0968d (no description set)
-    - qpvuntsm/1 hidden e8849ae1 (empty) (no
-    description set)
+    - qpvuntsm/1 e8849ae1 (hidden) (empty)
+    (no description set)
     file1 | 100 ++++++++++++++++++++++++++++
     1 file changed, 100 insertions(+), 0 deletions(-)
 
     Changed working copy default@:
     + qpvuntsm 79f0968d (no description set)
-    - qpvuntsm/1 hidden e8849ae1 (empty) (no
-    description set)
+    - qpvuntsm/1 e8849ae1 (hidden) (empty)
+    (no description set)
     [EOF]
     ");
 
@@ -1000,9 +1000,9 @@ fn test_op_recover_from_bad_gc() {
     // The repo should no longer be corrupt.
     let output = work_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @r"
-    @  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:12 29d07a2d
+    @  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:12 29d07a2d (divergent)
     │  (empty) 4
-    │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:15 bc027e2c
+    │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:15 bc027e2c (divergent)
     ├─╯  (empty) 4.1
     ○  zsuskuln test.user@example.com 2001-02-03 08:05:10 c2934cfb
     │  (empty) (no description set)
@@ -1237,30 +1237,30 @@ fn test_op_diff() {
       To operation: 000000000000 root()
 
     Changed commits:
-    ○  - rnnslrkn/0 hidden 4ff62539 Commit 2
-    ○  - rnnkyono/0 hidden 11671e4c Commit 3
-    ○  - pukowqtp/0 hidden 0cb7e07e Commit 1
-    ○  - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    ○  - rnnslrkn/0 4ff62539 (hidden) Commit 2
+    ○  - rnnkyono/0 11671e4c (hidden) Commit 3
+    ○  - pukowqtp/0 0cb7e07e (hidden) Commit 1
+    ○  - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + (absent)
-    - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed local bookmarks:
     bookmark-1:
     + (absent)
-    - pukowqtp/0 hidden 0cb7e07e Commit 1
+    - pukowqtp/0 0cb7e07e (hidden) Commit 1
 
     Changed remote bookmarks:
     bookmark-1@origin:
     + untracked (absent)
-    - tracked pukowqtp/0 hidden 0cb7e07e Commit 1
+    - tracked pukowqtp/0 0cb7e07e (hidden) Commit 1
     bookmark-2@origin:
     + untracked (absent)
-    - untracked rnnslrkn/0 hidden 4ff62539 Commit 2
+    - untracked rnnslrkn/0 4ff62539 (hidden) Commit 2
     bookmark-3@origin:
     + untracked (absent)
-    - untracked rnnkyono/0 hidden 11671e4c Commit 3
+    - untracked rnnkyono/0 11671e4c (hidden) Commit 3
     [EOF]
     ");
 
@@ -1368,7 +1368,7 @@ fn test_op_diff() {
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
     ○  + zkmtkqvo 0dee6313 bookmark-1?? bookmark-1@origin | Commit 4
-    ○  - rnnkyono/0 hidden 11671e4c Commit 3
+    ○  - rnnkyono/0 11671e4c (hidden) Commit 3
 
     Changed local bookmarks:
     bookmark-1:
@@ -1386,7 +1386,7 @@ fn test_op_diff() {
     - untracked rnnslrkn 4ff62539 bookmark-1?? | Commit 2
     bookmark-3@origin:
     + untracked (absent)
-    - untracked rnnkyono/0 hidden 11671e4c Commit 3
+    - untracked rnnkyono/0 11671e4c (hidden) Commit 3
     [EOF]
     ");
 
@@ -1471,11 +1471,11 @@ fn test_op_diff() {
 
     Changed commits:
     ○  + xlzxqlsl 731ab199 (empty) new commit
-    ○  - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    ○  - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + xlzxqlsl 731ab199 (empty) new commit
-    - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
     [EOF]
     ");
 
@@ -1565,7 +1565,7 @@ fn test_op_diff_patch() {
 
     Changed commits:
     ○  + qpvuntsm 6b57e33c (no description set)
-       - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+       - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
        diff --git a/file b/file
        new file mode 100644
        index 0000000000..7898192261
@@ -1576,7 +1576,7 @@ fn test_op_diff_patch() {
 
     Changed working copy default@:
     + qpvuntsm 6b57e33c (no description set)
-    - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+    - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@", "-p", "--git"]);
@@ -1610,8 +1610,8 @@ fn test_op_diff_patch() {
     Changed commits:
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
     ○  + qpvuntsm 7aa2ec5d (no description set)
-       - qpvuntsm/1 hidden 6b57e33c (no description set)
-       - rlvkpnrz/0 hidden 05a2969e (no description set)
+       - qpvuntsm/1 6b57e33c (hidden) (no description set)
+       - rlvkpnrz/0 05a2969e (hidden) (no description set)
        diff --git a/file b/file
        index 7898192261..6178079822 100644
        --- a/file
@@ -1622,7 +1622,7 @@ fn test_op_diff_patch() {
 
     Changed working copy default@:
     + mzvwutvl 6cbd01ae (empty) (no description set)
-    - rlvkpnrz/0 hidden 05a2969e (no description set)
+    - rlvkpnrz/0 05a2969e (hidden) (no description set)
     [EOF]
     ");
 
@@ -1643,11 +1643,11 @@ fn test_op_diff_patch() {
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
-    ○  - mzvwutvl/0 hidden 6cbd01ae (empty) (no description set)
+    ○  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + yqosqzyt c97a8573 (empty) (no description set)
-    - mzvwutvl/0 hidden 6cbd01ae (empty) (no description set)
+    - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
     [EOF]
     ");
 }
@@ -1735,18 +1735,18 @@ fn test_op_diff_sibling() {
       To operation: 252ff3a5a0e6 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
 
     Changed commits:
-    ○    - mzvwutvl/0 hidden 08c63613 (empty) A
+    ○    - mzvwutvl/0 08c63613 (hidden) (empty) A
     ├─╮
-    │ ○  - kkmpptxz/0 hidden 6c70a4f7 A.1
+    │ ○  - kkmpptxz/0 6c70a4f7 (hidden) A.1
     │    A file1
-    ○  - zsuskuln/0 hidden 47b9525e A.2
+    ○  - zsuskuln/0 47b9525e (hidden) A.2
        A file2
     ○  + qpvuntsm b1ca67e2 (empty) B
-       - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+       - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + qpvuntsm b1ca67e2 (empty) B
-    - mzvwutvl/0 hidden 08c63613 (empty) A
+    - mzvwutvl/0 08c63613 (hidden) (empty) A
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1765,7 +1765,7 @@ fn test_op_diff_sibling() {
       To operation: 7bba3a63b73b (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
-    ○  - qpvuntsm/0 hidden b1ca67e2 (empty) B
+    ○  - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
     ○    + mzvwutvl 08c63613 (empty) A
     ├─╮
     │ ○  + kkmpptxz 6c70a4f7 A.1
@@ -1775,7 +1775,7 @@ fn test_op_diff_sibling() {
 
     Changed working copy default@:
     + mzvwutvl 08c63613 (empty) A
-    - qpvuntsm/0 hidden b1ca67e2 (empty) B
+    - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
     [EOF]
     ");
 
@@ -1797,7 +1797,7 @@ fn test_op_diff_sibling() {
       To operation: 7bba3a63b73b (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
-    - qpvuntsm/0 hidden b1ca67e2 (empty) B
+    - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
     + mzvwutvl 08c63613 (empty) A
     + zsuskuln 47b9525e A.2
     A file2
@@ -1806,7 +1806,7 @@ fn test_op_diff_sibling() {
 
     Changed working copy default@:
     + mzvwutvl 08c63613 (empty) A
-    - qpvuntsm/0 hidden b1ca67e2 (empty) B
+    - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
     [EOF]
     ");
 }
@@ -1829,9 +1829,9 @@ fn test_op_diff_divergent_change() {
     work_dir.write_file("file", "1\n2b\n");
     work_dir.run_jj(["desc", "-m2b"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["log"]), @r"
-    @  rlvkpnrz/0 test.user@example.com 2001-02-03 08:05:11 c5cad9ab
+    @  rlvkpnrz/0 test.user@example.com 2001-02-03 08:05:11 c5cad9ab (divergent)
     │  2b
-    │ ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 f189cafa
+    │ ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 f189cafa (divergent)
     ├─╯  2a
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 8a06f3b3
     │  1
@@ -1868,14 +1868,14 @@ fn test_op_diff_divergent_change() {
       To operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
-    ○  + rlvkpnrz/0 c5cad9ab 2b
-       - rlvkpnrz/4 hidden 4f7a567a (empty) (no description set)
-    ○  + rlvkpnrz/2 f189cafa 2a
-       - rlvkpnrz/4 hidden 4f7a567a (empty) (no description set)
+    ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
+       - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
+    ○  + rlvkpnrz/2 f189cafa (divergent) 2a
+       - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
 
     Changed working copy default@:
-    + rlvkpnrz/0 c5cad9ab 2b
-    - rlvkpnrz/4 hidden 4f7a567a (empty) (no description set)
+    + rlvkpnrz/0 c5cad9ab (divergent) 2b
+    - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
     [EOF]
     ");
 
@@ -1894,12 +1894,12 @@ fn test_op_diff_divergent_change() {
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
-       - rlvkpnrz/1 hidden c5cad9ab 2b
-       - rlvkpnrz/3 hidden f189cafa 2a
+       - rlvkpnrz/1 c5cad9ab (hidden) 2b
+       - rlvkpnrz/3 f189cafa (hidden) 2a
 
     Changed working copy default@:
     + rlvkpnrz 17d68d92 2ab
-    - rlvkpnrz/1 hidden c5cad9ab 2b
+    - rlvkpnrz/1 c5cad9ab (hidden) 2b
     [EOF]
     ");
 
@@ -1918,8 +1918,8 @@ fn test_op_diff_divergent_change() {
       To operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
-    ○  + rlvkpnrz/0 c5cad9ab 2b
-       - rlvkpnrz/4 hidden 4f7a567a (empty) (no description set)
+    ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
+       - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
        diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
        --- JJ-COMMIT-DESCRIPTION
        +++ JJ-COMMIT-DESCRIPTION
@@ -1932,8 +1932,8 @@ fn test_op_diff_divergent_change() {
        @@ -1,1 +1,2 @@
         1
        +2b
-    ○  + rlvkpnrz/2 f189cafa 2a
-       - rlvkpnrz/4 hidden 4f7a567a (empty) (no description set)
+    ○  + rlvkpnrz/2 f189cafa (divergent) 2a
+       - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
        diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
        --- JJ-COMMIT-DESCRIPTION
        +++ JJ-COMMIT-DESCRIPTION
@@ -1948,8 +1948,8 @@ fn test_op_diff_divergent_change() {
         1
 
     Changed working copy default@:
-    + rlvkpnrz/0 c5cad9ab 2b
-    - rlvkpnrz/4 hidden 4f7a567a (empty) (no description set)
+    + rlvkpnrz/0 c5cad9ab (divergent) 2b
+    - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
     [EOF]
     ");
 
@@ -1969,8 +1969,8 @@ fn test_op_diff_divergent_change() {
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
-       - rlvkpnrz/1 hidden c5cad9ab 2b
-       - rlvkpnrz/3 hidden f189cafa 2a
+       - rlvkpnrz/1 c5cad9ab (hidden) 2b
+       - rlvkpnrz/3 f189cafa (hidden) 2a
        diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
        --- JJ-COMMIT-DESCRIPTION
        +++ JJ-COMMIT-DESCRIPTION
@@ -1988,7 +1988,7 @@ fn test_op_diff_divergent_change() {
 
     Changed working copy default@:
     + rlvkpnrz 17d68d92 2ab
-    - rlvkpnrz/1 hidden c5cad9ab 2b
+    - rlvkpnrz/1 c5cad9ab (hidden) 2b
     [EOF]
     ");
 
@@ -2006,14 +2006,14 @@ fn test_op_diff_divergent_change() {
       To operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
-    ○  + rlvkpnrz/1 c5cad9ab 2b
-       - rlvkpnrz/0 hidden 17d68d92 2ab
-    ○  + rlvkpnrz/3 f189cafa 2a
-       - rlvkpnrz/0 hidden 17d68d92 2ab
+    ○  + rlvkpnrz/1 c5cad9ab (divergent) 2b
+       - rlvkpnrz/0 17d68d92 (hidden) 2ab
+    ○  + rlvkpnrz/3 f189cafa (divergent) 2a
+       - rlvkpnrz/0 17d68d92 (hidden) 2ab
 
     Changed working copy default@:
-    + rlvkpnrz/1 c5cad9ab 2b
-    - rlvkpnrz/0 hidden 17d68d92 2ab
+    + rlvkpnrz/1 c5cad9ab (divergent) 2b
+    - rlvkpnrz/0 17d68d92 (hidden) 2ab
     [EOF]
     ");
 
@@ -2032,12 +2032,12 @@ fn test_op_diff_divergent_change() {
 
     Changed commits:
     ○  + rlvkpnrz 4f7a567a (empty) (no description set)
-       - rlvkpnrz/2 hidden f189cafa 2a
-       - rlvkpnrz/0 hidden c5cad9ab 2b
+       - rlvkpnrz/2 f189cafa (hidden) 2a
+       - rlvkpnrz/0 c5cad9ab (hidden) 2b
 
     Changed working copy default@:
     + rlvkpnrz 4f7a567a (empty) (no description set)
-    - rlvkpnrz/0 hidden c5cad9ab 2b
+    - rlvkpnrz/0 c5cad9ab (hidden) 2b
     [EOF]
     ");
 }
@@ -2054,9 +2054,9 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     work_dir.run_jj(["desc", "--at-op=@-", "-m2b"]).success();
 
     insta::assert_snapshot!(work_dir.run_jj(["log"]), @r"
-    @  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 7ed5a610
+    @  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 7ed5a610 (divergent)
     │  (empty) 2a
-    │ ○  rlvkpnrz/0 test.user@example.com 2001-02-03 08:05:11 8f35f6a6
+    │ ○  rlvkpnrz/0 test.user@example.com 2001-02-03 08:05:11 8f35f6a6 (divergent)
     ├─╯  (empty) 2b
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 6666e5c3
     │  (empty) 1
@@ -2076,8 +2076,8 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
       To operation: ac3c7e679e31 (2001-02-03 08:05:11) reconcile divergent operations
 
     Changed commits:
-    ○  + rlvkpnrz/1 8f35f6a6 (empty) 2b
-       - rlvkpnrz/0 hidden 4545eaf5 (empty) 2b
+    ○  + rlvkpnrz/1 8f35f6a6 (divergent) (empty) 2b
+       - rlvkpnrz/0 4545eaf5 (hidden) (empty) 2b
     [EOF]
     ");
 
@@ -2100,24 +2100,24 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     │ │
     │ │  Changed commits:
     │ │  ○  + rlvkpnrz 7ed5a610 (empty) 2a
-    │ │  │  - rlvkpnrz/1 hidden ab92d1a8 (empty) 2a
+    │ │  │  - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
     │ │  ○  + qpvuntsm 6666e5c3 (empty) 1
-    │ │     - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+    │ │     - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     │ │
     │ │  Changed working copy default@:
     │ │  + rlvkpnrz 7ed5a610 (empty) 2a
-    │ │  - rlvkpnrz/1 hidden ab92d1a8 (empty) 2a
+    │ │  - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
     │ ○  0c5076ddf77d test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
     │    args: jj describe '--at-op=@-' -m2b
     │
     │    Changed commits:
     │    ○  + rlvkpnrz 50ec12eb (empty) 2b
-    │       - rlvkpnrz/1 hidden ab92d1a8 (empty) 2a
+    │       - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
     │
     │    Changed working copy default@:
     │    + rlvkpnrz 50ec12eb (empty) 2b
-    │    - rlvkpnrz/1 hidden ab92d1a8 (empty) 2a
+    │    - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
     [EOF]
     ");
 }
@@ -2166,14 +2166,14 @@ fn test_op_diff_word_wrap() {
        | Commit 3
        some-file | 1 +
        1 file changed, 1 insertion(+), 0 deletions(-)
-    ○  - qpvuntsm/0 hidden e8849ae1 (empty)
-       (no description set)
+    ○  - qpvuntsm/0 e8849ae1 (hidden)
+       (empty) (no description set)
        0 files changed, 0 insertions(+), 0 deletions(-)
 
     Changed working copy default@:
     + sqpuoqvx f6f32c19 (no description set)
-    - qpvuntsm/0 hidden e8849ae1 (empty) (no
-    description set)
+    - qpvuntsm/0 e8849ae1 (hidden) (empty)
+    (no description set)
 
     Changed local bookmarks:
     bookmark-1:
@@ -2412,7 +2412,7 @@ fn test_op_show() {
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
     ○  + zkmtkqvo 0dee6313 bookmark-1?? bookmark-1@origin | Commit 4
-    ○  - rnnkyono/0 hidden 11671e4c Commit 3
+    ○  - rnnkyono/0 11671e4c (hidden) Commit 3
 
     Changed local bookmarks:
     bookmark-1:
@@ -2430,7 +2430,7 @@ fn test_op_show() {
     - untracked rnnslrkn 4ff62539 bookmark-1?? | Commit 2
     bookmark-3@origin:
     + untracked (absent)
-    - untracked rnnkyono/0 hidden 11671e4c Commit 3
+    - untracked rnnkyono/0 11671e4c (hidden) Commit 3
     [EOF]
     ");
 
@@ -2518,11 +2518,11 @@ fn test_op_show() {
 
     Changed commits:
     ○  + tlkvzzqu 8f340dd7 (empty) new commit
-    ○  - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    ○  - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + tlkvzzqu 8f340dd7 (empty) new commit
-    - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
     [EOF]
     ");
 
@@ -2601,11 +2601,11 @@ fn test_op_show() {
 
     Changed commits:
     + tlkvzzqu 8f340dd7 (empty) new commit
-    - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + tlkvzzqu 8f340dd7 (empty) new commit
-    - qpvuntsm/0 hidden e8849ae1 (empty) (no description set)
+    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
     [EOF]
     ");
 }
@@ -2633,7 +2633,7 @@ fn test_op_show_patch() {
 
     Changed commits:
     ○  + qpvuntsm 6b57e33c (no description set)
-       - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+       - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
        diff --git a/file b/file
        new file mode 100644
        index 0000000000..7898192261
@@ -2644,7 +2644,7 @@ fn test_op_show_patch() {
 
     Changed working copy default@:
     + qpvuntsm 6b57e33c (no description set)
-    - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+    - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show", "@", "-p", "--git"]);
@@ -2680,8 +2680,8 @@ fn test_op_show_patch() {
     Changed commits:
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
     ○  + qpvuntsm 7aa2ec5d (no description set)
-       - qpvuntsm/1 hidden 6b57e33c (no description set)
-       - rlvkpnrz/0 hidden 05a2969e (no description set)
+       - qpvuntsm/1 6b57e33c (hidden) (no description set)
+       - rlvkpnrz/0 05a2969e (hidden) (no description set)
        diff --git a/file b/file
        index 7898192261..6178079822 100644
        --- a/file
@@ -2692,7 +2692,7 @@ fn test_op_show_patch() {
 
     Changed working copy default@:
     + mzvwutvl 6cbd01ae (empty) (no description set)
-    - rlvkpnrz/0 hidden 05a2969e (no description set)
+    - rlvkpnrz/0 05a2969e (hidden) (no description set)
     [EOF]
     ");
 
@@ -2714,11 +2714,11 @@ fn test_op_show_patch() {
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
-    ○  - mzvwutvl/0 hidden 6cbd01ae (empty) (no description set)
+    ○  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
 
     Changed working copy default@:
     + yqosqzyt c97a8573 (empty) (no description set)
-    - mzvwutvl/0 hidden 6cbd01ae (empty) (no description set)
+    - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
     [EOF]
     ");
 
@@ -2731,11 +2731,11 @@ fn test_op_show_patch() {
     │
     │  Changed commits:
     │  ○  + yqosqzyt c97a8573 (empty) (no description set)
-    │  ○  - mzvwutvl/0 hidden 6cbd01ae (empty) (no description set)
+    │  ○  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
     │
     │  Changed working copy default@:
     │  + yqosqzyt c97a8573 (empty) (no description set)
-    │  - mzvwutvl/0 hidden 6cbd01ae (empty) (no description set)
+    │  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
     ○  cfb8edbeae42 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     │  args: jj squash
@@ -2743,8 +2743,8 @@ fn test_op_show_patch() {
     │  Changed commits:
     │  ○  + mzvwutvl 6cbd01ae (empty) (no description set)
     │  ○  + qpvuntsm 7aa2ec5d (no description set)
-    │     - qpvuntsm/1 hidden 6b57e33c (no description set)
-    │     - rlvkpnrz/0 hidden 05a2969e (no description set)
+    │     - qpvuntsm/1 6b57e33c (hidden) (no description set)
+    │     - rlvkpnrz/0 05a2969e (hidden) (no description set)
     │     diff --git a/file b/file
     │     index 7898192261..6178079822 100644
     │     --- a/file
@@ -2755,14 +2755,14 @@ fn test_op_show_patch() {
     │
     │  Changed working copy default@:
     │  + mzvwutvl 6cbd01ae (empty) (no description set)
-    │  - rlvkpnrz/0 hidden 05a2969e (no description set)
+    │  - rlvkpnrz/0 05a2969e (hidden) (no description set)
     ○  36a5d140ea10 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash
     │
     │  Changed commits:
     │  ○  + rlvkpnrz 05a2969e (no description set)
-    │     - rlvkpnrz/1 hidden c1c924b8 (empty) (no description set)
+    │     - rlvkpnrz/1 c1c924b8 (hidden) (empty) (no description set)
     │     diff --git a/file b/file
     │     index 7898192261..6178079822 100644
     │     --- a/file
@@ -2773,7 +2773,7 @@ fn test_op_show_patch() {
     │
     │  Changed working copy default@:
     │  + rlvkpnrz 05a2969e (no description set)
-    │  - rlvkpnrz/1 hidden c1c924b8 (empty) (no description set)
+    │  - rlvkpnrz/1 c1c924b8 (hidden) (empty) (no description set)
     ○  ed6f6674bcf8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new
@@ -2790,7 +2790,7 @@ fn test_op_show_patch() {
     │
     │  Changed commits:
     │  ○  + qpvuntsm 6b57e33c (no description set)
-    │     - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+    │     - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     │     diff --git a/file b/file
     │     new file mode 100644
     │     index 0000000000..7898192261
@@ -2801,7 +2801,7 @@ fn test_op_show_patch() {
     │
     │  Changed working copy default@:
     │  + qpvuntsm 6b57e33c (no description set)
-    │  - qpvuntsm/1 hidden e8849ae1 (empty) (no description set)
+    │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
     ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
@@ -2856,11 +2856,11 @@ fn test_op_show_template() {
     Changed commits:
     ○  + rlvkpnrz e4863b8c (empty) (no description set)
     ○  + qpvuntsm b52b7cb5 first commit
-       - qpvuntsm/1 hidden 0883ea50 (no description set)
+       - qpvuntsm/1 0883ea50 (hidden) (no description set)
 
     Changed working copy default@:
     + rlvkpnrz e4863b8c (empty) (no description set)
-    - qpvuntsm/1 hidden 0883ea50 (no description set)
+    - qpvuntsm/1 0883ea50 (hidden) (no description set)
     [EOF]
     ");
 }

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -3005,7 +3005,7 @@ fn test_rebase_skip_duplicate_divergent() {
     insta::assert_snapshot!(work_dir.run_jj(["rebase", "-r", "c::", "-o", "d"]), @r"
     ------- stderr -------
     Abandoned 1 divergent commits that were already present in the destination:
-      zsuskuln/0 3f194323 b2 | b2
+      zsuskuln/0 3f194323 b2 | (divergent) b2
     Rebased 1 commits to destination
     [EOF]
     ");
@@ -3023,7 +3023,7 @@ fn test_rebase_skip_duplicate_divergent() {
     insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "b1", "-o", "b2"]), @r"
     ------- stderr -------
     Abandoned 1 divergent commits that were already present in the destination:
-      zsuskuln/1 48bf33ab b1 | b2
+      zsuskuln/1 48bf33ab b1 | (divergent) b2
     Rebased 1 commits to destination
     Working copy  (@) now at: znkkpsqq 81e83d0f d | d
     Parent commit (@-)      : zsuskuln 3f194323 b1 b2 | b2

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -127,14 +127,14 @@ fn test_report_conflicts_with_divergent_commits() {
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits to destination
-    Working copy  (@) now at: zsuskuln/1 36220952 (conflict) C2
+    Working copy  (@) now at: zsuskuln/1 36220952 (divergent) (conflict) C2
     Parent commit (@-)      : kkmpptxz d3d00356 (conflict) B
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 3 commits:
-      zsuskuln/0 4950cd98 (conflict) C3
-      zsuskuln/1 36220952 (conflict) C2
+      zsuskuln/0 4950cd98 (divergent) (conflict) C3
+      zsuskuln/1 36220952 (divergent) (conflict) C2
       kkmpptxz d3d00356 (conflict) B
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
@@ -149,7 +149,7 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
-    Working copy  (@) now at: zsuskuln/1 27ef05d9 C2
+    Working copy  (@) now at: zsuskuln/1 27ef05d9 (divergent) C2
     Parent commit (@-)      : kkmpptxz 9039ed49 B
     Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from 3 commits.
@@ -161,13 +161,13 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: zsuskuln/0 ab0a21e6 (conflict) C2
+    Working copy  (@) now at: zsuskuln/0 ab0a21e6 (divergent) (conflict) C2
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
     New conflicts appeared in 1 commits:
-      zsuskuln/0 ab0a21e6 (conflict) C2
+      zsuskuln/0 ab0a21e6 (divergent) (conflict) C2
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new zsuskuln
@@ -182,7 +182,7 @@ fn test_report_conflicts_with_divergent_commits() {
     ------- stderr -------
     Rebased 1 commits to destination
     New conflicts appeared in 1 commits:
-      zsuskuln/0 dbfbac97 (conflict) C3
+      zsuskuln/0 dbfbac97 (divergent) (conflict) C3
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new zsuskuln
@@ -196,7 +196,7 @@ fn test_report_conflicts_with_divergent_commits() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
-    Working copy  (@) now at: zsuskuln/0 3fcf2fd2 C2
+    Working copy  (@) now at: zsuskuln/0 3fcf2fd2 (divergent) C2
     Parent commit (@-)      : kkmpptxz 9039ed49 B
     Added 0 files, modified 1 files, removed 0 files
     Existing conflicts were resolved or abandoned from 1 commits.

--- a/cli/tests/test_resolve_command.rs
+++ b/cli/tests/test_resolve_command.rs
@@ -1318,7 +1318,7 @@ fn test_resolve_change_delete_executable() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["log", "--git"]), @r"
-    @    kmkuslsw test.user@example.com 2001-02-03 08:05:18 conflict 2cdaed10 conflict
+    @    kmkuslsw test.user@example.com 2001-02-03 08:05:18 conflict 2cdaed10 (conflict)
     ├─╮  (empty) conflict
     │ ○  vruxwmqv test.user@example.com 2001-02-03 08:05:17 b 888b6cc3
     │ │  b

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -407,13 +407,13 @@ fn test_split_with_descendants() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:12 74306e35
     │  Add file1
     │  -- operation 994b490f285d split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:08 1d2499e7
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
     │  -- operation adf4f33386c9 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
-    ○  qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:08 f5700f8e
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
     │  -- operation 78ead2155fcc snapshot working copy
-    ○  qpvuntsm/3 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -426,13 +426,13 @@ fn test_split_with_descendants() {
     ○  royxmykx test.user@example.com 2001-02-03 08:05:12 0a37745e
     │  Add file2
     │  -- operation 994b490f285d split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:08 1d2499e7
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
     │  -- operation adf4f33386c9 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
-    ○  qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:08 f5700f8e
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
     │  -- operation 78ead2155fcc snapshot working copy
-    ○  qpvuntsm/3 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -563,10 +563,10 @@ fn test_split_parallel_no_descendants() {
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 7bcd474c
     │  TESTED=TODO
     │  -- operation 2b21c33e1596 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:08 f5700f8e
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
     │  -- operation 1663cd1cc445 snapshot working copy
-    ○  qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]
@@ -579,10 +579,10 @@ fn test_split_parallel_no_descendants() {
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 431886f6
     │  (no description set)
     │  -- operation 2b21c33e1596 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
-    ○  qpvuntsm/1 hidden test.user@example.com 2001-02-03 08:05:08 f5700f8e
+    ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
     │  -- operation 1663cd1cc445 snapshot working copy
-    ○  qpvuntsm/2 hidden test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
        -- operation 8f47435a3990 add workspace 'default'
     [EOF]

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -2058,28 +2058,28 @@ fn test_squash_to_new_commit() {
     ○    pkstwlsy test.user@example.com 2001-02-03 08:05:35 41510a56
     ├─╮  file 3&4
     │ │  -- operation ad1aa66374f6 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
-    │ ○  zsuskuln/0 hidden test.user@example.com 2001-02-03 08:05:35 a5bc761f
+    │ ○  zsuskuln/0 test.user@example.com 2001-02-03 08:05:35 a5bc761f (hidden)
     │ │  file4
     │ │  -- operation ad1aa66374f6 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
-    │ ○  zsuskuln/4 hidden test.user@example.com 2001-02-03 08:05:11 38778966
+    │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 38778966 (hidden)
     │ │  file4
     │ │  -- operation 83489d186f66 commit 89a30a7539466ed176c1ef122a020fd9cb15848e
-    │ ○  zsuskuln/5 hidden test.user@example.com 2001-02-03 08:05:11 89a30a75
+    │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:11 89a30a75 (hidden)
     │ │  (no description set)
     │ │  -- operation e23fd04aab50 snapshot working copy
-    │ ○  zsuskuln/6 hidden test.user@example.com 2001-02-03 08:05:10 bbf04d26
+    │ ○  zsuskuln/6 test.user@example.com 2001-02-03 08:05:10 bbf04d26 (hidden)
     │    (empty) (no description set)
     │    -- operation 19d57874b952 commit c23c424826221bc4fdee9487926595324e50ee95
-    ○  kkmpptxz/0 hidden test.user@example.com 2001-02-03 08:05:35 ce3b0a58
+    ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:35 ce3b0a58 (hidden)
     │  file3
     │  -- operation ad1aa66374f6 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
-    ○  kkmpptxz/3 hidden test.user@example.com 2001-02-03 08:05:10 0d254956
+    ○  kkmpptxz/3 test.user@example.com 2001-02-03 08:05:10 0d254956 (hidden)
     │  file3
     │  -- operation 19d57874b952 commit c23c424826221bc4fdee9487926595324e50ee95
-    ○  kkmpptxz/4 hidden test.user@example.com 2001-02-03 08:05:10 c23c4248
+    ○  kkmpptxz/4 test.user@example.com 2001-02-03 08:05:10 c23c4248 (hidden)
     │  (no description set)
     │  -- operation d19ad3734aa6 snapshot working copy
-    ○  kkmpptxz/5 hidden test.user@example.com 2001-02-03 08:05:09 c1272e87
+    ○  kkmpptxz/5 test.user@example.com 2001-02-03 08:05:09 c1272e87 (hidden)
        (empty) (no description set)
        -- operation fdee458ae5f2 commit cb58ff1c6f1af92f827661e7275941ceb4d910c5
     [EOF]
@@ -2248,7 +2248,7 @@ fn test_squash_to_new_commit() {
     ○  pyoswmwk test.user@example.com 2001-02-03 08:05:50 991d0644
     │  (empty) (no description set)
     │  -- operation 60d056329b43 squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
-    ○  szrrkvty/0 hidden test.user@example.com 2001-02-03 08:05:50 f5e47d01
+    ○  szrrkvty/0 test.user@example.com 2001-02-03 08:05:50 f5e47d01 (hidden)
        (empty) (no description set)
        -- operation 31e408225067 new empty commit
     [EOF]

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -139,7 +139,7 @@ fn test_status_conflicted_bookmarks() {
     let output = work_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @r"
     The working copy has no changes.
-    Working copy  (@) : qpvuntsm/1 99025a24 local_bookmark?? | (empty) a
+    Working copy  (@) : qpvuntsm/1 99025a24 local_bookmark?? | (divergent) (empty) a
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     Warning: These bookmarks have conflicts:
       local_bookmark
@@ -182,7 +182,7 @@ fn test_status_conflicted_bookmarks() {
     let output = work_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @r"
     The working copy has no changes.
-    Working copy  (@) : qpvuntsm/1 99025a24 local_bookmark?? | (empty) a
+    Working copy  (@) : qpvuntsm/1 99025a24 local_bookmark?? | (divergent) (empty) a
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     Warning: These bookmarks have conflicts:
       local_bookmark
@@ -242,11 +242,11 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["log", "-r", "::"]);
 
     insta::assert_snapshot!(output, @r"
-    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 conflict
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 (conflict)
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change
@@ -316,11 +316,11 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     │  fixed 2
     ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 34c4a9b1
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 conflict
+    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 (conflict)
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change
@@ -352,11 +352,11 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     │  fixed 2
     @  kmkuslsw test.user@example.com 2001-02-03 08:05:19 34c4a9b1
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 conflict
+    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 (conflict)
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change
@@ -390,11 +390,11 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     │  fixed 2
     ○  kmkuslsw test.user@example.com 2001-02-03 08:05:19 34c4a9b1
     │  fixed 1
-    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 conflict
+    ×  yqosqzyt test.user@example.com 2001-02-03 08:05:13 94a62648 (conflict)
     │  (empty) boom-cont-2
-    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 conflict
+    ×  royxmykx test.user@example.com 2001-02-03 08:05:12 23973408 (conflict)
     │  (empty) boom-cont
-    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 conflict
+    ×    mzvwutvl test.user@example.com 2001-02-03 08:05:11 2dd6c136 (conflict)
     ├─╮  (empty) boom
     │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:10 bb11a679
     │ │  First part of conflicting change

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -169,6 +169,7 @@ fn test_templater_alias() {
     'recurse2()' = 'recurse'
     'identity(x)' = 'x'
     'coalesce(x, y)' = 'if(x, x, y)'
+    'format_commit_summary_with_refs(x, y)' = 'x.commit_id()'
     'builtin_log_node' = '"#"'
     'builtin_op_log_node' = '"#"'
     'builtin_log_node_ascii' = '"#"'

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -561,7 +561,7 @@ fn test_workspaces_conflicting_edits() {
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
-    Working copy  (@) now at: pmmvwywv/2 90f3d42e (empty) (no description set)
+    Working copy  (@) now at: pmmvwywv/2 90f3d42e (divergent) (empty) (no description set)
     Parent commit (@-)      : qpvuntsm b853f7c8 (no description set)
     Added 0 files, modified 1 files, removed 0 files
     Updated working copy to fresh commit 90f3d42e0bff
@@ -900,7 +900,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
         │  -- operation 0a26da4b0149 snapshot working copy
-        ○  kmkuslsw/1 hidden test.user@example.com 2001-02-03 08:05:18 866928d1
+        ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
            -- operation 83f707034db1 recovery commit
         [EOF]
@@ -910,7 +910,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
         │  -- operation 0f876590219e snapshot working copy
-        ○  kmkuslsw/1 hidden test.user@example.com 2001-02-03 08:05:18 866928d1
+        ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
            -- operation 83f707034db1 recovery commit
         [EOF]

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -352,10 +352,10 @@ $ jj evolog
 @  lnvvtrzo jjfan@example.org 2025-02-28 21:01:10 31a347e0
 │  featureA
 │  -- operation 3cb7392c092c snapshot working copy
-○  lnvvtrzo/1 hidden jjfan@example.org 2025-02-28 21:00:51 b8004ab8
+○  lnvvtrzo/1 jjfan@example.org 2025-02-28 21:00:51 b8004ab8 (hidden)
 │  featureA
 │  -- operation 1280bfaec893 snapshot working copy
-○  lnvvtrzo/2 hidden jjfan@example.org 2025-02-28 20:50:05 e4d831d
+○  lnvvtrzo/2 jjfan@example.org 2025-02-28 20:50:05 e4d831d (hidden)
    (no description set)
    -- operation 0418a5aa94b5 snapshot working copy
 ```
@@ -385,7 +385,7 @@ $ jj evolog --patch --git  # We use `--git` to make diffs clear without colors
 │  @@ -1,1 +1,2 @@
 │   Done with feature A
 │  +Working on feature B
-○  lnvvtrzo/1 hidden jjfan@example.org 2025-02-28 21:00:51 b8004ab8
+○  lnvvtrzo/1 jjfan@example.org 2025-02-28 21:00:51 b8004ab8 (hidden)
 │  featureA
 │  -- operation 1280bfaec893 snapshot working copy
 │  diff --git a/file b/file
@@ -395,7 +395,7 @@ $ jj evolog --patch --git  # We use `--git` to make diffs clear without colors
 │  @@ -1,1 +1,1 @@
 │  -Working on feature A
 │  +Done with feature A
-○  lnvvtrzo/2 hidden jjfan@example.org 2025-02-28 20:50:05 e4d831d
+○  lnvvtrzo/2 jjfan@example.org 2025-02-28 20:50:05 e4d831d (hidden)
    (no description set)
    -- operation 0418a5aa94b5 snapshot working copy
    diff --git a/file b/file
@@ -431,7 +431,7 @@ First, we create a new empty child commit on top of `b80`:
 ```console
 $ jj new b80 -m "featureB"
 Working copy  (@) now at: pvnrkl 47171aa (empty) featureB
-Parent commit (@-)      : lnvvtr/1 b8004ab featureA
+Parent commit (@-)      : lnvvtr/1 b8004ab (divergent) featureA
 ```
 
 There are now two visible commits with change ID `lnvvtr` (commit `b8004ab`
@@ -449,7 +449,7 @@ Next, restore the contents of `31a347e0` into the working copy:
 ```console
 $ jj restore --from 31a347e0
 Working copy  (@) now at: pvnrkl 468104c featureB
-Parent commit (@-)      : lnvvtr/1 b8004ea featureA
+Parent commit (@-)      : lnvvtr/1 b8004ea (divergent) featureA
 $ cat file
 Done with feature A
 Working on feature B

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -116,8 +116,8 @@ call that a [divergent change](#divergent-change).
 ## Divergent change
 
 A divergent change is a [change](#change) that has more than one
-[visible commit](#visible-commits). These changes are displayed with a
-[change offset](#change-offset) after their change ID.
+[visible commit](#visible-commits). These changes are displayed with a label of
+"divergent" in the log.
 
 ## Head
 

--- a/docs/guides/divergence.md
+++ b/docs/guides/divergence.md
@@ -3,13 +3,12 @@
 ## What are divergent changes?
 
 A [divergent change] occurs when multiple [visible commits] have the same change
-ID.
-
-These changes are displayed with a [change offset] after their change ID:
+ID. These changes are displayed with a [change offset] after their change ID and
+a label of "divergent":
 
 ```shell
 $ jj log
-@  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:12 29d07a2d divergent
+@  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:12 29d07a2d (divergent)
 │  a divergent change
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -287,9 +287,9 @@ Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 
 $ jj log
-@  qzvqqupx martinvonz@google.com 2023-02-12 15:08:33 1978b534 conflict
+@  qzvqqupx martinvonz@google.com 2023-02-12 15:08:33 1978b534 (conflict)
 │  C
-×  puqltutt martinvonz@google.com 2023-02-12 15:08:33 f7fb5943 conflict
+×  puqltutt martinvonz@google.com 2023-02-12 15:08:33 f7fb5943 (conflict)
 │  B2
 │ ○  ovknlmro martinvonz@google.com 2023-02-12 15:07:24 7d7c6e6b
 ├─╯  B1
@@ -428,9 +428,9 @@ Then run `jj squash` to move the resolution into the conflicted commit.
 $ jj log
 @  zxoosnnp martinvonz@google.com 2023-02-12 19:34:09 63874fe6
 │  (no description set)
-│ ×  qzvqqupx martinvonz@google.com 2023-02-12 15:08:33 1978b534 conflict
+│ ×  qzvqqupx martinvonz@google.com 2023-02-12 15:08:33 1978b534 (conflict)
 ├─╯  C
-×  puqltutt martinvonz@google.com 2023-02-12 15:08:33 f7fb5943 conflict
+×  puqltutt martinvonz@google.com 2023-02-12 15:08:33 f7fb5943 (conflict)
 │  B2
 │ ○  ovknlmro martinvonz@google.com 2023-02-12 15:07:24 7d7c6e6b
 ├─╯  B1


### PR DESCRIPTION
Follow up to #7194.

It would be good to include the word "divergent" in the log when a change is divergent, since users are often unsure what's happening when they see a divergent change, and giving them a term to search for would be helpful. However, I don't think it looks good to put this label next to the change ID itself if both are the same color, since it ends up being hard to distinguish from the change offset at a glance. Also, putting the label next to the change ID also messes up the alignment of fields in the log. Therefore, I think it looks better to put the "divergent" label at the end of the line.

Since divergence and hidden commits are similar, it makes sense for both labels to be in the same place, so I also moved the hidden label to the end for consistency.

One downside is that the labels are less obviously connected with the change ID itself due to them being farther apart. I think this could be fine, since they are still visually connected by being the same color.

## Log

<details>
<summary>Before</summary>

<img width="1243" height="748" alt="image" src="https://github.com/user-attachments/assets/39270093-0d05-484b-8fdf-0050c7dcdc0e" />

</details>

After:

<img width="1458" height="729" alt="image" src="https://github.com/user-attachments/assets/817b2f5d-7b0d-4972-b5a5-e83095cf15c4" />

## Evolog

<details>
<summary>Before</summary>

<img width="1324" height="442" alt="image" src="https://github.com/user-attachments/assets/2631df6f-303f-4d29-8a5a-d1671fd8abbc" />

</details>

After:

<img width="1418" height="438" alt="image" src="https://github.com/user-attachments/assets/c1e84d89-892c-4d7c-a7dc-dd401efb6316" />

## Commit summary

<details>
<summary>Before</summary>

<img width="1240" height="85" alt="image" src="https://github.com/user-attachments/assets/308ab54d-3913-4efc-8d8d-f3f34e7a3ea6" />

</details>

After:

<img width="1240" height="85" alt="image" src="https://github.com/user-attachments/assets/eb8d01fa-eba0-4f09-bdd6-76c32602b9b8" />

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
