### PR TITLE
cli: remove newline insertion after template expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * The deprecated `commit_id.normal_hex()` template method has been removed.
 
+* Template expansion that did not produce a terminating newline will not be
+  fixed up to provide one by `jj log`, `jj evolog`, or `jj op log`.
+
 ### Deprecations
 
 * The `git_head()` and `git_refs()` functions will be removed from revsets and

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -174,9 +174,6 @@ pub(crate) fn cmd_evolog(
             within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
                 template.format(&entry, formatter)
             })?;
-            if !buffer.ends_with(b"\n") {
-                buffer.push(b'\n');
-            }
             if let Some(renderer) = &diff_renderer {
                 let predecessors: Vec<_> = entry.predecessors().try_collect()?;
                 let mut formatter = ui.new_formatter(&mut buffer);

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -273,9 +273,6 @@ pub(crate) fn cmd_log(
                 within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
                     template.format(&commit, formatter)
                 })?;
-                if !buffer.ends_with(b"\n") {
-                    buffer.push(b'\n');
-                }
                 if let Some(renderer) = &diff_renderer {
                     let mut formatter = ui.new_formatter(&mut buffer);
                     renderer

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -208,9 +208,6 @@ pub fn show_op_diff(
                         modified_change,
                     )
                 })?;
-                if !buffer.ends_with(b"\n") {
-                    buffer.push(b'\n');
-                }
                 if let Some(diff_renderer) = diff_renderer {
                     let mut formatter = ui.new_formatter(&mut buffer);
                     show_change_diff(
@@ -346,7 +343,6 @@ pub fn show_op_diff(
                 )
             })?;
         }
-        writeln!(formatter)?;
     }
 
     let ignored_remote = default_ignored_remote_name(current_repo.store());

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -223,9 +223,6 @@ fn do_op_log(
             within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
                 template.format(&op, formatter)
             })?;
-            if !buffer.ends_with(b"\n") {
-                buffer.push(b'\n');
-            }
             if let Some(show) = &maybe_show_op_diff {
                 let mut formatter = ui.new_formatter(&mut buffer);
                 show(ui, formatter.as_mut(), &op, &within_graph)?;

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -3319,13 +3319,11 @@ fn test_diff_external_available_width() {
         cmd.args(["log", "--tool=echo", "-T''"])
             .env("COLUMNS", "50")
     });
-    insta::assert_snapshot!(output, @r"
-    @
-    │  47
-    │ ○
-    ├─╯  45
-    ◆
-       47
+    insta::assert_snapshot!(output, @"
+    @  47
+    │ ○  45
+    ├─╯
+    ◆  47
     [EOF]
     ");
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -237,14 +237,13 @@ fn test_log_with_or_without_diff() {
     │  1 file changed, 1 insertion(+), 0 deletions(-)
     │  Added regular file file1:
     │          1: foo
-    ◆
-       0 files changed, 0 insertions(+), 0 deletions(-)
+    ◆  0 files changed, 0 insertions(+), 0 deletions(-)
     [EOF]
     ");
 
     // `--stat` is short format, which should be printed first
     let output = work_dir.run_jj(["log", "-T", "description", "--git", "--stat"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     @  a new commit
     │  file1 | 1 +
     │  1 file changed, 1 insertion(+), 0 deletions(-)
@@ -265,8 +264,7 @@ fn test_log_with_or_without_diff() {
     │  +++ b/file1
     │  @@ -0,0 +1,1 @@
     │  +foo
-    ◆
-       0 files changed, 0 insertions(+), 0 deletions(-)
+    ◆  0 files changed, 0 insertions(+), 0 deletions(-)
     [EOF]
     ");
 

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -601,7 +601,6 @@ fn test_op_log_word_wrap() {
     insta::assert_snapshot!(
         render(&["op", "log", "-T''", "--op-diff", "-n1", "--config", config], 15, true), @r"
     @
-    │
     │  Changed
     │  commits:
     │  ○  + 0 1 2 3

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -2111,8 +2111,7 @@ fn test_squash_to_new_commit() {
     │  A file2
     ○  qpvuntsmwlqt bm1 file1
     │  A file1
-    ○  soqnvnyzoxuu
-    │  A file3
+    ○  soqnvnyzoxuuA file3
     │  A file4
     ◆  zzzzzzzzzzzz
     [EOF]


### PR DESCRIPTION
In graph mode, a newline is appended whether or not there is content (diffs, file listings, op changes) following the expanded template.  This does not happen in no-graph mode, causing unwanted concatenation, which is particularly problematic for diff headers.

[several edits later]

After several attempts at addressing this, the approved solution is to remove the newline addition.  Built-in templates are unaffected, but users get exactly what they ask for when using a custom template.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
