### PR TITLE
backend: use Arc instead of Box for Backend trait objects

### DIFF
--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
@@ -60,7 +61,7 @@ fn create_store_factories() -> StoreFactories {
     // must match `Backend::name()`.
     store_factories.add_backend(
         "jit",
-        Box::new(|settings, store_path| Ok(Box::new(JitBackend::load(settings, store_path)?))),
+        Box::new(|settings, store_path| Ok(Arc::new(JitBackend::load(settings, store_path)?))),
     );
     store_factories
 }
@@ -78,7 +79,7 @@ fn run_custom_command(
             Workspace::init_with_backend(
                 &settings,
                 wc_path,
-                &|settings, store_path| Ok(Box::new(JitBackend::init(settings, store_path)?)),
+                &|settings, store_path| Ok(Arc::new(JitBackend::init(settings, store_path)?)),
                 Signer::from_settings(&settings).map_err(WorkspaceInitError::SignInit)?,
             )?;
             Ok(())

--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -65,8 +65,8 @@ fn run_custom_command(
             let wc_path = command_helper.cwd();
             let settings = command_helper.settings_for_new_workspace(wc_path)?;
             let backend_initializer = |settings: &UserSettings, store_path: &Path| {
-                let backend: Box<dyn Backend> =
-                    Box::new(GitBackend::init_internal(settings, store_path)?);
+                let backend: Arc<dyn Backend> =
+                    Arc::new(GitBackend::init_internal(settings, store_path)?);
                 Ok(backend)
             };
             Workspace::init_with_factories(

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -54,7 +54,7 @@ const TREE_CACHE_CAPACITY: usize = 1000;
 /// Wraps the low-level backend and makes it return more convenient types. Also
 /// adds caching.
 pub struct Store {
-    backend: Box<dyn Backend>,
+    backend: Arc<dyn Backend>,
     signer: Signer,
     commit_cache: Mutex<CLruCache<CommitId, Arc<backend::Commit>>>,
     tree_cache: Mutex<CLruCache<(RepoPathBuf, TreeId), Arc<backend::Tree>>>,
@@ -71,7 +71,7 @@ impl Debug for Store {
 
 impl Store {
     pub fn new(
-        backend: Box<dyn Backend>,
+        backend: Arc<dyn Backend>,
         signer: Signer,
         merge_options: MergeOptions,
     ) -> Arc<Self> {

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -189,7 +189,7 @@ impl Workspace {
         workspace_root: &Path,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let backend_initializer: &BackendInitializer =
-            &|_settings, store_path| Ok(Box::new(SimpleBackend::init(store_path)));
+            &|_settings, store_path| Ok(Arc::new(SimpleBackend::init(store_path)));
         let signer = Signer::from_settings(user_settings)?;
         Self::init_with_backend(user_settings, workspace_root, backend_initializer, signer)
     }
@@ -202,7 +202,7 @@ impl Workspace {
         workspace_root: &Path,
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let backend_initializer: &BackendInitializer = &|settings, store_path| {
-            Ok(Box::new(crate::git_backend::GitBackend::init_internal(
+            Ok(Arc::new(crate::git_backend::GitBackend::init_internal(
                 settings, store_path,
             )?))
         };
@@ -219,7 +219,7 @@ impl Workspace {
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let backend_initializer = |settings: &UserSettings,
                                    store_path: &Path|
-         -> Result<Box<dyn crate::backend::Backend>, _> {
+         -> Result<Arc<dyn crate::backend::Backend>, _> {
             // TODO: Clean up path normalization. store_path is canonicalized by
             // ReadonlyRepo::init(). workspace_root will be canonicalized by
             // Workspace::new(), but it's not yet here.
@@ -234,7 +234,7 @@ impl Workspace {
                 store_path,
                 &store_relative_workspace_root,
             )?;
-            Ok(Box::new(backend))
+            Ok(Arc::new(backend))
         };
         let signer = Signer::from_settings(user_settings)?;
         Self::init_with_backend(user_settings, workspace_root, &backend_initializer, signer)
@@ -252,7 +252,7 @@ impl Workspace {
     ) -> Result<(Self, Arc<ReadonlyRepo>), WorkspaceInitError> {
         let backend_initializer = |settings: &UserSettings,
                                    store_path: &Path|
-         -> Result<Box<dyn crate::backend::Backend>, _> {
+         -> Result<Arc<dyn crate::backend::Backend>, _> {
             // If the git repo is inside the workspace, use a relative path to it so the
             // whole workspace can be moved without breaking.
             // TODO: Clean up path normalization. store_path is canonicalized by
@@ -274,7 +274,7 @@ impl Workspace {
                 store_path,
                 &store_relative_git_repo_path,
             )?;
-            Ok(Box::new(backend))
+            Ok(Arc::new(backend))
         };
         let signer = Signer::from_settings(user_settings)?;
         Self::init_with_backend(user_settings, workspace_root, &backend_initializer, signer)

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1582,7 +1582,7 @@ impl GitRepoData {
             &settings,
             &jj_repo_dir,
             &|settings, store_path| {
-                Ok(Box::new(GitBackend::init_external(
+                Ok(Arc::new(GitBackend::init_external(
                     settings,
                     store_path,
                     git_repo.path(),
@@ -3158,7 +3158,7 @@ fn test_init() {
         &settings,
         &jj_repo_dir,
         &|settings, store_path| {
-            Ok(Box::new(GitBackend::init_external(
+            Ok(Arc::new(GitBackend::init_external(
                 settings,
                 store_path,
                 git_repo.path(),
@@ -3952,7 +3952,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
         settings,
         &jj_repo_dir,
         &|settings, store_path| {
-            Ok(Box::new(GitBackend::init_external(
+            Ok(Arc::new(GitBackend::init_external(
                 settings,
                 store_path,
                 clone_repo.path(),

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -179,12 +179,12 @@ impl TestEnvironment {
         let mut factories = StoreFactories::default();
         factories.add_backend("test", {
             let factory = self.test_backend_factory.clone();
-            Box::new(move |_settings, store_path| Ok(Box::new(factory.load(store_path))))
+            Box::new(move |_settings, store_path| Ok(Arc::new(factory.load(store_path))))
         });
         factories.add_backend(
             SecretBackend::name(),
             Box::new(|settings, store_path| {
-                Ok(Box::new(SecretBackend::load(settings, store_path)?))
+                Ok(Arc::new(SecretBackend::load(settings, store_path)?))
             }),
         );
         factories
@@ -221,11 +221,11 @@ impl TestRepoBackend {
         env: &TestEnvironment,
         settings: &UserSettings,
         store_path: &Path,
-    ) -> Result<Box<dyn Backend>, BackendInitError> {
+    ) -> Result<Arc<dyn Backend>, BackendInitError> {
         match self {
-            Self::Git => Ok(Box::new(GitBackend::init_internal(settings, store_path)?)),
-            Self::Simple => Ok(Box::new(SimpleBackend::init(store_path))),
-            Self::Test => Ok(Box::new(env.test_backend_factory.init(store_path))),
+            Self::Git => Ok(Arc::new(GitBackend::init_internal(settings, store_path)?)),
+            Self::Simple => Ok(Arc::new(SimpleBackend::init(store_path))),
+            Self::Test => Ok(Arc::new(env.test_backend_factory.init(store_path))),
         }
     }
 }


### PR DESCRIPTION
# Change description

Previously `Store::new` took a `Box<dyn Backend>`, in which it assumed full ownership over the `Backend`. In multithreaded/server environments, it's not uncommon for multiple objects to want to share one single `Backend` -- loading it only once, leveraging internal caching, wrapping it with additional adapters beyond `Store`, etc.

# Additional context

FWIW in my particular motivating case, I would like to be able to share a `dyn Backend` between `Store` and an adapter to an interface which issues buffered/batched writes to a backend.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
