### PR TITLE
cli: document -r as alias for positional revision arguments

### DIFF
--- a/cli/src/commands/abandon.rs
+++ b/cli/src/commands/abandon.rs
@@ -43,7 +43,7 @@ use crate::ui::Ui;
 /// commit. This is true in general; it is not specific to this command.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct AbandonArgs {
-    /// The revision(s) to abandon (default: @)
+    /// The revision(s) to abandon (default: @) [aliases: -r]
     #[arg(
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable),

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -47,7 +47,7 @@ use crate::ui::Ui;
 /// will be $EDITOR, or `nano` if that's not defined (`Notepad` on Windows).
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct DescribeArgs {
-    /// The revision(s) whose description to edit (default: @)
+    /// The revision(s) whose description to edit (default: @) [aliases: -r]
     #[arg(
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable)

--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -52,7 +52,7 @@ use crate::ui::Ui;
 /// This can be customized with the `templates.duplicate_description` setting.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct DuplicateArgs {
-    /// The revision(s) to duplicate (default: @)
+    /// The revision(s) to duplicate (default: @) [aliases: -r]
     #[arg(
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),

--- a/cli/src/commands/edit.rs
+++ b/cli/src/commands/edit.rs
@@ -34,7 +34,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(clap::ArgGroup::new("revision").required(true)))]
 pub(crate) struct EditArgs {
-    /// The commit to edit
+    /// The commit to edit [aliases: -r]
     #[arg(
         group = "revision",
         value_name = "REVSET",

--- a/cli/src/commands/metaedit.rs
+++ b/cli/src/commands/metaedit.rs
@@ -39,13 +39,12 @@ use crate::ui::Ui;
 /// `--config user.name` and `--config user.email`.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct MetaeditArgs {
-    /// The revision(s) to modify (default: @)
+    /// The revision(s) to modify (default: @) [aliases: -r]
     #[arg(
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_mutable)
     )]
     revisions_pos: Vec<RevisionArg>,
-
     #[arg(
         short = 'r',
         hide = true,

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -48,7 +48,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(clap::ArgGroup::new("revisions").multiple(true)))]
 pub(crate) struct NewArgs {
-    /// Parent(s) of the new change [default: @]
+    /// Parent(s) of the new change [default: @] [aliases: -o, -r]
     #[arg(
         group = "revisions",
         value_name = "REVSETS",

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -32,6 +32,7 @@ use crate::ui::Ui;
 #[command(mut_arg("ignore_space_change", |a| a.short('b')))]
 pub(crate) struct ShowArgs {
     /// Show changes in this revision, compared to its parent(s) [default: @]
+    /// [aliases: -r]
     #[arg(
         group = "revision",
         value_name = "REVSET",

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -239,7 +239,7 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
 ###### **Arguments:**
 
-* `<REVSETS>` — The revision(s) to abandon (default: @)
+* `<REVSETS>` — The revision(s) to abandon (default: @) [aliases: -r]
 
 ###### **Options:**
 
@@ -823,7 +823,7 @@ Starts an editor to let you edit the description of changes. The editor will be 
 
 ###### **Arguments:**
 
-* `<REVSETS>` — The revision(s) whose description to edit (default: @)
+* `<REVSETS>` — The revision(s) whose description to edit (default: @) [aliases: -r]
 
 ###### **Options:**
 
@@ -948,7 +948,7 @@ By default, the duplicated commits retain the descriptions of the originals. Thi
 
 ###### **Arguments:**
 
-* `<REVSETS>` — The revision(s) to duplicate (default: @)
+* `<REVSETS>` — The revision(s) to duplicate (default: @) [aliases: -r]
 
 ###### **Options:**
 
@@ -970,7 +970,7 @@ Note: it is [generally recommended] to instead use `jj new` and `jj squash`.
 
 ###### **Arguments:**
 
-* `<REVSET>` — The commit to edit
+* `<REVSET>` — The commit to edit [aliases: -r]
 
 
 
@@ -1904,7 +1904,7 @@ Whenever any metadata is updated, the committer name, email, and timestamp are a
 
 ###### **Arguments:**
 
-* `<REVSETS>` — The revision(s) to modify (default: @)
+* `<REVSETS>` — The revision(s) to modify (default: @) [aliases: -r]
 
 ###### **Options:**
 
@@ -1956,7 +1956,7 @@ Note that you can create a merge commit by specifying multiple revisions as argu
 
 ###### **Arguments:**
 
-* `<REVSETS>` — Parent(s) of the new change [default: @]
+* `<REVSETS>` — Parent(s) of the new change [default: @] [aliases: -o, -r]
 
 ###### **Options:**
 
@@ -2744,7 +2744,7 @@ Show commit description and changes in a revision
 
 ###### **Arguments:**
 
-* `<REVSET>` — Show changes in this revision, compared to its parent(s) [default: @]
+* `<REVSET>` — Show changes in this revision, compared to its parent(s) [default: @] [aliases: -r]
 
 ###### **Options:**
 


### PR DESCRIPTION
Several commands accept both positional arguments and a `-r` flag for
specifying revisions. The `-r` flag exists for consistency with other
commands, but was previously hidden from help output.

Instead of unhiding `-r` (which would clutter the Options section),
document the aliasing by adding `[aliases: -r]` to the positional
argument's help text. This makes the relationship discoverable while
keeping the help output clean.

Commands updated: abandon, describe, duplicate, edit, metaedit, new, show

Fixes https://github.com/jj-vcs/jj/issues/8104