### PR TITLE
docs: clarify that some template parameters require literal strings

### DIFF
--- a/docs/filesets.md
+++ b/docs/filesets.md
@@ -21,7 +21,7 @@ required:
 
 * `jj diff '~glob:**/*.rs'`
 
-[string-literals]: templates.md#string-literals
+[string-literals]: templates.md#stringliteral-type
 
 ## File patterns
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -45,7 +45,7 @@ something like `jj log -r '"x-"'`.
 
 [divergent-change]: glossary.md#divergent-change
 [change-offset]: glossary.md#change-offset
-[string-literals]: templates.md#string-literals
+[string-literals]: templates.md#stringliteral-type
 
 ### Priority
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -95,7 +95,7 @@ The following functions are defined.
   `separator` between **non-empty** `content`s.
 * `surround(prefix: Template, suffix: Template, content: Template) -> Template`:
   Surround **non-empty** content with texts such as parentheses.
-* `config(name: String) -> ConfigValue`: Look up configuration value by `name`.
+* `config(name: StringLiteral) -> ConfigValue`: Look up configuration value by `name`.
 
 ## Built-in Aliases
 
@@ -168,14 +168,14 @@ This type cannot be printed. The following methods are defined.
   of this commit. May not be available for some commits.
 * `.immutable() -> Boolean`: True if the commit is included in [the set of
   immutable commits](config.md#set-of-immutable-commits).
-* `.contained_in(revset: String) -> Boolean`: True if the commit is included in
+* `.contained_in(revset: StringLiteral) -> Boolean`: True if the commit is included in
   [the provided revset](revsets.md).
 * `.conflict() -> Boolean`: True if the commit contains merge conflicts.
 * `.empty() -> Boolean`: True if the commit modifies no files.
-* `.diff([files: String]) -> TreeDiff`: Changes from the parents within [the
+* `.diff([files: StringLiteral]) -> TreeDiff`: Changes from the parents within [the
   `files` expression](filesets.md). All files are compared by default, but it is
   likely to change in future version to respect the command line path arguments.
-* `.files([files: String]) -> List<TreeEntry>`: Files that exist in this commit,
+* `.files([files: StringLiteral]) -> List<TreeEntry>`: Files that exist in this commit,
   matching [the `files` expression](filesets.md). Use `.diff().files()` to list
   changed files.
 * `.conflicted_files() -> List<TreeEntry>`: Conflicted files in this commit.
@@ -510,7 +510,10 @@ defined.
   can use it in a template like `'{ "foo": ' ++ foo.escape_json() ++ ' }'` to
   return a JSON/JSONL.
 
-#### String literals
+### `StringLiteral` type
+
+A string literal known at parse time. Unlike `Stringify`, this cannot be a
+dynamic expression - it must be a literal value like `"main"` or `"format"`.
 
 String literals must be surrounded by single or double quotes (`'` or `"`).
 A double-quoted string literal supports the following escape sequences:
@@ -530,6 +533,10 @@ that don't form a valid escape sequence.
 
 A single-quoted string literal has no escape syntax. `'` can't be expressed
 inside a single-quoted string literal.
+
+String literals have their own type so that the value can be validated at parse
+time. For example, `contained_in(revset)` requires a literal so the revset can
+be parsed and checked before the template is evaluated.
 
 ### `Stringify` type
 
@@ -566,14 +573,14 @@ _Conversion: `Boolean`: no, `Serialize`: yes, `Template`: yes_
 The following methods are defined.
 
 * `.ago() -> String`: Format as relative timestamp.
-* `.format(format: String) -> String`: Format with [the specified strftime-like
+* `.format(format: StringLiteral) -> String`: Format with [the specified strftime-like
   format string](https://docs.rs/chrono/latest/chrono/format/strftime/).
 * `.utc() -> Timestamp`: Convert timestamp into UTC timezone.
 * `.local() -> Timestamp`: Convert timestamp into local timezone.
-* `.after(date: String) -> Boolean`: True if the timestamp is exactly at or
+* `.after(date: StringLiteral) -> Boolean`: True if the timestamp is exactly at or
   after the given date. Supported date formats are the same as the revset
   [Date pattern type].
-* `.before(date: String) -> Boolean`: True if the timestamp is before, but
+* `.before(date: StringLiteral) -> Boolean`: True if the timestamp is before, but
   not including, the given date. Supported date formats are the same as the
   revset [Date pattern type].
 


### PR DESCRIPTION
Rename parameter type `String` to `StringLiteral` where methods require a literal string known at parse time rather than a dynamic expression. This makes the documentation faithful to the underlying code, which uses `expect_string_literal()` and reports "Expected string literal" errors.

Add a new `StringLiteral` type section explaining the distinction.

Fixes #7068

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
