### PR TITLE
docs: clarify behavior of selected vs remaining changes

### DIFF
--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2880,13 +2880,60 @@ For example, if all you need is the `README.md` and the `lib/` directory, use `j
 
 Split a revision in two
 
-Starts a [diff editor] on the changes in the revision. Edit the right side of the diff until it has the content you want in the new revision. Once you close the editor, your edited content will replace the previous revision. The remaining changes will be put in a new revision on top.
+Starts a [diff editor] on the changes in the revision. Edit the right side
+of the diff until it has the content you want in the first commit. Once you
+close the editor, your revision will be split into two commits.
 
-[diff editor]: https://docs.jj-vcs.dev/latest/config/#editing-diffs
+[diff editor]:
+    https://docs.jj-vcs.dev/latest/config/#editing-diffs
 
-If the change you split had a description, you will be asked to enter a change description for each commit. If the change did not have a description, the remaining changes will not get a description, and you will be asked for a description only for the selected changes.
+By default, the selected changes stay in the original commit, and the
+remaining changes go into a new child commit:
 
-Splitting an empty commit is not supported because the same effect can be achieved with `jj new`.
+```text
+L                 L'
+|                 |
+K (split)   =>    K" (remaining)
+|                 |
+J                 K' (selected)
+                  |
+                  J
+```
+
+With `--parallel/-p`, the two parts become sibling commits instead of
+parent and child:
+
+```text
+                  L'
+L                / \
+|               K'  |  (selected)
+K (split)  =>   |   K" (remaining)
+|                \ /
+J                 J
+```
+
+With `-o`, `-A`, or `-B`, the selected changes are extracted into a new
+commit at the specified location, while the remaining changes stay in place:
+
+```text
+M                 M'
+|                 |
+L                 L'
+|                 |
+K (split)   =>    K' (remaining, stays here)
+|                 |
+J                 J'
+                  |
+                  K" (selected, inserted before J with -B J)
+```
+
+If the change you split had a description, you will be asked to enter a
+change description for each commit. If the change did not have a
+description, the second commit will not get a description, and you will be
+asked for a description only for the first commit.
+
+Splitting an empty commit is not supported because the same effect can be
+achieved with `jj new`.
 
 **Usage:** `jj split [OPTIONS] [FILESETS]...`
 
@@ -2903,12 +2950,18 @@ Splitting an empty commit is not supported because the same effect can be achiev
 * `-r`, `--revision <REVSET>` — The revision to split
 
   Default value: `@`
-* `-o`, `--onto <REVSETS>` — The revision(s) to base the new revision onto (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` — The revision(s) to rebase the selected changes onto (can be repeated to create a merge commit)
+
+   Extracts the selected changes into a new commit based on the given revision(s). The remaining changes stay in the original commit's location.
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
+
+   Extracts the selected changes into a new commit inserted after the given revision(s). The remaining changes stay in the original commit's location.
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
+
+   Extracts the selected changes into a new commit inserted before the given revision(s). The remaining changes stay in the original commit's location.
 * `-m`, `--message <MESSAGE>` — The change description to use (don't open editor)
 
-   The description is used for the commit with the selected changes. The source commit description is kept unchanged.
+   Sets the description for the first commit (the one containing the selected changes). The second commit keeps the original description.
 * `--editor` — Open an editor to edit the change description
 
    Forces an editor to open when using `--message` to allow the message to be edited afterwards.


### PR DESCRIPTION
The help text for `jj split` was confusing about what happens to "selected" vs "remaining" changes, especially with the `-o/-A/-B` flags.

This change:
- Adds ASCII diagrams showing the commit graph transformations for default split, --parallel, and -o/-A/-B modes
- Clarifies that by default, selected changes stay in the original commit while remaining changes go to a new child
- Explains that with -o/-A/-B, selected changes are extracted to a new commit at the destination while remaining changes stay in place
- Improves the --message flag description to clarify it applies to the first commit (containing selected changes)
- Adds explanatory text to the -o, -A, and -B flag descriptions


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
