### PR TITLE
watchman: replace #[tokio::main] with conditional usage of existing runtime

### DIFF
--- a/cli/src/commands/debug/watchman.rs
+++ b/cli/src/commands/debug/watchman.rs
@@ -24,6 +24,8 @@ use jj_lib::fsmonitor::WatchmanConfig;
 use jj_lib::local_working_copy::LocalWorkingCopy;
 #[cfg(feature = "watchman")]
 use jj_lib::working_copy::WorkingCopy;
+#[cfg(feature = "watchman")]
+use pollster::FutureExt as _;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
@@ -89,7 +91,7 @@ pub fn cmd_debug_watchman(
                 }
             };
             let wc = check_local_disk_wc(workspace_command.working_copy())?;
-            wc.query_watchman(&config)?;
+            wc.query_watchman(&config).block_on()?;
             writeln!(
                 ui.stdout(),
                 "The watchman server seems to be installed and working correctly."
@@ -97,7 +99,7 @@ pub fn cmd_debug_watchman(
             writeln!(
                 ui.stdout(),
                 "Background snapshotting is currently {}.",
-                if wc.is_watchman_trigger_registered(&config)? {
+                if wc.is_watchman_trigger_registered(&config).block_on()? {
                     "active"
                 } else {
                     "inactive"
@@ -106,12 +108,12 @@ pub fn cmd_debug_watchman(
         }
         DebugWatchmanCommand::QueryClock => {
             let wc = check_local_disk_wc(workspace_command.working_copy())?;
-            let (clock, _changed_files) = wc.query_watchman(&watchman_config)?;
+            let (clock, _changed_files) = wc.query_watchman(&watchman_config).block_on()?;
             writeln!(ui.stdout(), "Clock: {clock:?}")?;
         }
         DebugWatchmanCommand::QueryChangedFiles => {
             let wc = check_local_disk_wc(workspace_command.working_copy())?;
-            let (_clock, changed_files) = wc.query_watchman(&watchman_config)?;
+            let (_clock, changed_files) = wc.query_watchman(&watchman_config).block_on()?;
             writeln!(ui.stdout(), "Changed files: {changed_files:?}")?;
         }
         DebugWatchmanCommand::ResetClock => {

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -282,13 +282,15 @@ diff editing in mind and be a little inaccurate.
         let diff_wc = self.working_copies;
         // Snapshot changes in the temporary output directory.
         let mut output_tree_state = diff_wc.output.unwrap_or(diff_wc.right);
-        output_tree_state.snapshot(&SnapshotOptions {
-            base_ignores,
-            progress: None,
-            start_tracking_matcher: &EverythingMatcher,
-            force_tracking_matcher: &NothingMatcher,
-            max_new_file_size: u64::MAX,
-        })?;
+        output_tree_state
+            .snapshot(&SnapshotOptions {
+                base_ignores,
+                progress: None,
+                start_tracking_matcher: &EverythingMatcher,
+                force_tracking_matcher: &NothingMatcher,
+                max_new_file_size: u64::MAX,
+            })
+            .block_on()?;
         Ok(output_tree_state.current_tree().clone())
     }
 }

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -2037,7 +2037,10 @@ fn test_fsmonitor() {
             &settings,
         )
         .unwrap();
-        tree_state.snapshot(&empty_snapshot_options()).unwrap();
+        tree_state
+            .snapshot(&empty_snapshot_options())
+            .block_on()
+            .unwrap();
         tree_state
     };
 


### PR DESCRIPTION
Rationale: watchman_client requires tokio, but creating a runtime internally means that clients of jj-lib can't have a tokio runtime themselves. 

There are no user-visible changes, so I wasn't sure whether to update CHANGELOG.md.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
