### PR TITLE
split: warn instead of failing on empty commit with path argument

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3199,6 +3199,7 @@ impl DiffSelector {
     /// Only files matching the `matcher` will be copied to the new tree.
     pub fn select(
         &self,
+        ui: &Ui,
         trees: Diff<&MergedTree>,
         tree_labels: Diff<String>,
         matcher: &dyn Matcher,
@@ -3215,14 +3216,19 @@ impl DiffSelector {
         match self {
             Self::NonInteractive => Ok(selected_tree),
             Self::Interactive(editor) => {
-                // edit_diff_external() is designed to edit the right tree,
-                // whereas we want to update the left tree. Unmatched paths
-                // shouldn't be based off the right tree.
-                Ok(editor.edit(
-                    Diff::new(trees.before, &selected_tree),
-                    matcher,
-                    format_instructions,
-                )?)
+                if selected_tree.tree_ids() == trees.before.tree_ids() {
+                    writeln!(ui.warning_default(), "Empty diff - won't run diff editor.")?;
+                    Ok(selected_tree)
+                } else {
+                    // edit_diff_external() is designed to edit the right tree,
+                    // whereas we want to update the left tree. Unmatched paths
+                    // shouldn't be based off the right tree.
+                    Ok(editor.edit(
+                        Diff::new(trees.before, &selected_tree),
+                        matcher,
+                        format_instructions,
+                    )?)
+                }
             }
         }
     }

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -154,6 +154,7 @@ new working-copy commit.
         )
     };
     let tree = diff_selector.select(
+        ui,
         Diff::new(&base_tree, &commit.tree()),
         Diff::new(commit.parents_conflict_label()?, commit.conflict_label()),
         matcher.as_ref(),

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -155,6 +155,7 @@ pub(crate) fn cmd_restore(
         }
     };
     let new_tree = diff_selector.select(
+        ui,
         Diff::new(&to_tree, &from_tree),
         Diff::new(
             to_commit.conflict_label(),

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -42,7 +42,6 @@ use crate::cli_util::WorkspaceCommandTransaction;
 use crate::cli_util::compute_commit_location;
 use crate::cli_util::print_unmatched_explicit_paths;
 use crate::command_error::CommandError;
-use crate::command_error::user_error;
 use crate::complete;
 use crate::description_util::add_trailers;
 use crate::description_util::description_template;
@@ -208,13 +207,6 @@ impl SplitArgs {
         workspace_command: &WorkspaceCommandHelper,
     ) -> Result<ResolvedSplitArgs, CommandError> {
         let target_commit = workspace_command.resolve_single_rev(ui, &self.revision)?;
-        if target_commit.is_empty(workspace_command.repo().as_ref())? {
-            return Err(user_error(format!(
-                "Refusing to split empty commit {}.",
-                target_commit.id().hex()
-            ))
-            .hinted("Use `jj new` if you want to create another empty commit."));
-        }
         workspace_command.check_rewritable([target_commit.id()])?;
         let repo = workspace_command.repo();
         let fileset_expression = workspace_command.parse_file_patterns(ui, &self.paths)?;
@@ -556,6 +548,7 @@ The changes that are not selected will replace the original commit.
     };
     let parent_tree = target_commit.parent_tree(tx.repo())?;
     let selected_tree = diff_selector.select(
+        ui,
         Diff::new(&parent_tree, &target_commit.tree()),
         Diff::new(
             target_commit.parents_conflict_label()?,

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -312,7 +312,7 @@ pub(crate) fn cmd_squash(
     let text_editor = tx.base_workspace_helper().text_editor()?;
     let squashed_description = SquashedDescription::from_args(args);
 
-    let source_commits = select_diff(&tx, &sources, &destination, &matcher, &diff_selector)?;
+    let source_commits = select_diff(ui, &tx, &sources, &destination, &matcher, &diff_selector)?;
 
     print_unmatched_explicit_paths(
         ui,
@@ -457,6 +457,7 @@ impl SquashedDescription {
 }
 
 fn select_diff(
+    ui: &Ui,
     tx: &WorkspaceCommandTransaction,
     sources: &[Commit],
     destination: &Commit,
@@ -485,6 +486,7 @@ fn select_diff(
             }
         };
         let selected_tree = diff_selector.select(
+            ui,
             Diff::new(&parent_tree, &source_tree),
             Diff::new(source.parents_conflict_label()?, source.conflict_label()),
             matcher,


### PR DESCRIPTION
If the user does something like `jj split @` and the working copy is not empty, they will get warnings like this:

```
Warning: No matching entries for paths: @
Warning: No changes have been selected, so the new revision will be empty
```

If they run the same command when the working copy is empty, they will instead get this:

```
Error: Refusing to split empty commit e518dba7418a1b20a545c12ecb16cc870756efa3.
Hint: Use `jj new` if you want to create another empty commit.
```

That's probably less helpful because it's not clear that the `@` argument was interpreted as a path.

The rationale for the error (in 07559f24ece9) is that it's confusing that an empty diff editor pops up if you accidentally try to split an empty commit. This patch changes it so we print a warning when the diff is empty instead of starting the diff editor.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
