### PR TITLE
cli: change unused_revision from bool to u8 with ArgAction::Count

### DIFF
--- a/cli/src/commands/edit.rs
+++ b/cli/src/commands/edit.rs
@@ -37,8 +37,8 @@ pub(crate) struct EditArgs {
     #[arg(value_name = "REVSET", add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     revision: RevisionArg,
     /// Ignored (but lets you pass `-r` for consistency with other commands)
-    #[arg(short = 'r', hide = true)]
-    unused_revision: bool,
+    #[arg(short = 'r', hide = true, action = clap::ArgAction::Count)]
+    unused_revision: u8,
 }
 
 #[instrument(skip_all)]

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -38,8 +38,8 @@ pub(crate) struct ShowArgs {
     )]
     revision: RevisionArg,
     /// Ignored (but lets you pass `-r` for consistency with other commands)
-    #[arg(short = 'r', hide = true)]
-    unused_revision: bool,
+    #[arg(short = 'r', hide = true, action = clap::ArgAction::Count)]
+    unused_revision: u8,
     /// Render a revision using the given template
     ///
     /// You can specify arbitrary template expressions using the


### PR DESCRIPTION
This allows `-r` to be repeated (e.g., `jj show -r x -r y`) for consistency with other commands like `jj new`. With bool, clap would error on repeated flags, but with u8 and ArgAction::Count, it simply counts the occurrences.


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
