### PR TITLE
bookmark move: default `--from` revset to `closest_bookmarks(to)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj util gc` now prunes unreachable files in `.jj/repo/store/extra` to save
   disk space.
 
+* `jj bookmark move` now defaults to `--from 'closest_bookmarks(to)'` when no
+  bookmark name or source revisions are specified. This makes it easy to "tug"
+  a bookmark up to include a new commit by using `jj bookmark move --to @-`.
+
 ### Fixed bugs
 
 * Broken symlink on Windows. [#6934](https://github.com/jj-vcs/jj/issues/6934).

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -37,3 +37,5 @@ latest(
 
 'visible()' = '::visible_heads()'
 'hidden()' = '~visible()'
+
+'closest_bookmarks(to)' = 'heads(::to & bookmarks())'

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -486,11 +486,13 @@ If bookmark names are given, the specified bookmarks will be updated to point to
 
 If `--from` options are given, bookmarks currently pointing to the specified revisions will be updated. The bookmarks can also be filtered by names.
 
+If no bookmark names and no `--from` options are given, then `--from` will default to `closest_bookmarks(to)`.
+
 Example: pull up the nearest bookmarks to the working-copy parent
 
-$ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
+$ jj bookmark move --to @-
 
-**Usage:** `jj bookmark move [OPTIONS] <NAMES|--from <REVSETS>>`
+**Usage:** `jj bookmark move [OPTIONS] [NAMES]...`
 
 **Command Alias:** `m`
 
@@ -505,6 +507,8 @@ $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 ###### **Options:**
 
 * `-f`, `--from <REVSETS>` — Move bookmarks from the given revisions
+
+   If no bookmark names or source revisions are specified, then this revset defaults to `closest_bookmarks(to)`.
 * `-t`, `--to <REVSET>` — Move bookmarks to this revision
 
   Default value: `@`

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -411,19 +411,24 @@ fn test_bookmark_move_matching() {
     ");
     let setup_opid = work_dir.current_operation_id();
 
-    // The default could be considered "--from=all() *", but is disabled
+    // Defaults to `--from 'closest_bookmarks(@)'`
     let output = work_dir.run_jj(["bookmark", "move"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    error: the following required arguments were not provided:
-      <NAMES|--from <REVSETS>>
-
-    Usage: jj bookmark move <NAMES|--from <REVSETS>>
-
-    For more information, try '--help'.
+    Moved 1 bookmarks to vruxwmqv 0dd9a4b1 c1 | (empty) head2
     [EOF]
-    [exit status: 2]
     ");
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
+
+    // Defaults to `--from 'closest_bookmarks(subject(head1))`
+    let output = work_dir.run_jj(["bookmark", "move", "--to=subject(head1)"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Moved 2 bookmarks to kkmpptxz 9328ecc5 a1 a2 | (empty) head1
+    Hint: Specify bookmark by name to update just one of the bookmarks.
+    [EOF]
+    ");
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // No bookmarks pointing to the source revisions
     let output = work_dir.run_jj(["bookmark", "move", "--from=none()"]);

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -587,6 +587,10 @@ for a comprehensive list.
   this is *not* [the set of all previously visible
   commits](https://github.com/jj-vcs/jj/issues/2623).
 
+* `closest_bookmarks(to)`: The default bookmarks to move with `jj bookmark move`.
+  It is defined as `heads(::to & bookmarks())`, but it can be overridden to
+  change the behavior of `jj bookmark move` with no source argument.
+
 ## Examples
 
 Show the parent(s) of the working-copy commit (like `git log -1 HEAD`):


### PR DESCRIPTION
A common recommendation for new users is for them to add a `jj tug` alias. This change makes that alias less necessary, since a command like `jj bookmark move --to @-` can be used instead for most cases. We could also potentially improve this further by changing the default revset for `--to`, but that can be a separate discussion.

The `closest_bookmarks(to)` revset is inspired by the discussion in https://github.com/jj-vcs/jj/discussions/5568#discussioncomment-12674748. I think it makes sense for it to be plural though, since it is allowed for it to return multiple bookmarks.

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
