### PR TITLE
local_working_copy: handle circular symlinks during checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj gerrit upload` now correctly handles mixed explicit and implicit
   Change-Ids in chains of commits ([#8219](https://github.com/jj-vcs/jj/pull/8219))
 
+* Working copies with symlink loops clone correctly
+
 ## [0.36.0] - 2025-12-03
 
 ### Release highlights


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes


relevant issue:
https://github.com/jj-vcs/jj/issues/8348

please note Martin's comment around printing a warning– i don't fully understand the security implications here but would be interested in learning more.