### PR TITLE
working_copy: do not traverse symlinks when checking reserved paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * `jj workspace add` now prevents creating an empty workspace name.
 
+* Fixed checkout of symlinks pointing to themselves or `.git`/`.jj` on Unix. The
+  problem would still remain on Windows if symlinks are enabled.
+  [#8348](https://github.com/jj-vcs/jj/issues/8348)
+
 ## [0.36.0] - 2025-12-03
 
 ### Release highlights

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -61,7 +61,6 @@ rand_chacha = { workspace = true }
 rayon = { workspace = true }
 ref-cast = { workspace = true }
 regex = { workspace = true }
-same-file = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
 strsim = { workspace = true }
@@ -76,6 +75,7 @@ watchman_client = { workspace = true, optional = true }
 rustix = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
+same-file = { workspace = true }
 winreg = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #8348

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
