### PR TITLE
conflicts: show "noeol" state separately for each side of a diff

### DIFF
--- a/cli/tests/test_file_search_command.rs
+++ b/cli/tests/test_file_search_command.rs
@@ -77,7 +77,7 @@ fn test_file_search_conflicts() {
     // Test the setup
     insta::assert_snapshot!(work_dir.read_file("file1"), @r"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from: rlvkpnrz 958d516d (parents of rebased commit)
+    %%%%%%% diff from: rlvkpnrz 958d516d (parents of rebased commit) (no terminating newline)
     \\\\\\\        to: qpvuntsm 6da222ee (rebase destination) (no terminating newline)
     --bar-
     +-foo-

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -208,7 +208,8 @@ would look like this:
 <<<<<<< conflict 1 of 1
 +++++++ side #1 (no terminating newline)
 grapefruit
-%%%%%%% diff from base to side #2 (adds terminating newline)
+%%%%%%% diff from: base (no terminating newline)
+\\\\\\\        to: side #2
 -grape
 +grape
 >>>>>>> conflict 1 of 1 ends

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -645,7 +645,8 @@ fn test_materialize_conflict_no_newlines_at_eof() {
     insta::assert_snapshot!(materialized,
         @r"
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from base to side #1 (adds terminating newline)
+    %%%%%%% diff from: base (no terminating newline)
+    \\\\\\\        to: side #1
     -base
     +++++++ side #2 (no terminating newline)
     right
@@ -2114,7 +2115,8 @@ fn test_update_conflict_from_content_no_eol() {
     +++++++ side #1
     base
     left
-    %%%%%%% diff from base to side #2 (no terminating newline)
+    %%%%%%% diff from: base (no terminating newline)
+    \\\\\\\        to: side #2 (no terminating newline)
     -base
     +right
     >>>>>>> conflict 2 of 2 ends
@@ -2248,15 +2250,18 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
     <<<<<<< conflict 1 of 1
     +++++++ side #1
     side
-    %%%%%%% diff from base #1 to side #2 (adds terminating newline)
+    %%%%%%% diff from: base #1 (no terminating newline)
+    \\\\\\\        to: side #2
      add newline
     -line
     +line
-    %%%%%%% diff from base #2 to side #3 (removes terminating newline)
+    %%%%%%% diff from: base #2
+    \\\\\\\        to: side #3 (no terminating newline)
      remove newline
     -line
     +line
-    %%%%%%% diff from base #3 to side #4 (no terminating newline)
+    %%%%%%% diff from: base #3 (no terminating newline)
+    \\\\\\\        to: side #4 (no terminating newline)
      no newline
     -line 1
     +line 2
@@ -2302,7 +2307,8 @@ fn test_update_conflict_from_content_only_no_eol_change() {
         @r"
     line 1
     <<<<<<< conflict 1 of 1
-    %%%%%%% diff from base to side #1 (removes terminating newline)
+    %%%%%%% diff from: base
+    \\\\\\\        to: side #1 (no terminating newline)
     +line 2
     +++++++ side #2
     line 2


### PR DESCRIPTION
Now that we can put the "from" and "to" sides on separate lines, we can use the normal "(no terminating newline)" comment on each side separately. This should also be more clear, since previously the "(no terminating newline)" comment could possibly be confused for "(removes terminating newline)".

Before:

```
<<<<<<< conflict 1 of 1
+++++++ rtsqusxu 2768b0b9 "commit A" (no terminating newline)
grapefruit
%%%%%%% diff from: vpxusssl 38d49363 "merge base"
\\\\\\\        to: ysrnknol 7a20f389 "commit B" (adds terminating newline)
-grape
+grape
>>>>>>> conflict 1 of 1 ends
```

After:

```
<<<<<<< conflict 1 of 1
+++++++ rtsqusxu 2768b0b9 "commit A" (no terminating newline)
grapefruit
%%%%%%% diff from: vpxusssl 38d49363 "merge base" (no terminating newline)
\\\\\\\        to: ysrnknol 7a20f389 "commit B"
-grape
+grape
>>>>>>> conflict 1 of 1 ends
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
