### PR TITLE
cli: indicate -d as alias for -o in help

### DIFF
--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -69,9 +69,9 @@ pub(crate) struct DuplicateArgs {
     /// commit)
     #[arg(
         long,
-        alias = "destination",
+        visible_alias = "destination",
         short,
-        short_alias = 'd',
+        visible_short_alias = 'd',
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -339,7 +339,7 @@ pub struct RebaseDestinationArgs {
         long,
         alias = "destination",
         short,
-        short_alias = 'd',
+        visible_short_alias = 'd',
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]

--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -54,9 +54,9 @@ pub(crate) struct RevertArgs {
     /// The revision(s) to apply the reverse changes on top of
     #[arg(
         long,
-        alias = "destination",
+        visible_alias = "destination",
         short,
-        short_alias = 'd',
+        visible_short_alias = 'd',
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),
     )]

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -135,9 +135,9 @@ pub(crate) struct SplitArgs {
     /// location.
     #[arg(
         long,
-        alias = "destination",
+        visible_alias = "destination",
         short,
-        short_alias = 'd',
+        visible_short_alias = 'd',
         conflicts_with = "parallel",
         value_name = "REVSETS",
         add = ArgValueCompleter::new(complete::revset_expression_all),

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -118,9 +118,9 @@ pub(crate) struct SquashArgs {
     /// be repeated to create a merge commit)
     #[arg(
         long,
-        alias = "destination",
+        visible_alias = "destination",
         short,
-        short_alias = 'd',
+        visible_short_alias = 'd',
         conflicts_with = "into",
         conflicts_with = "revision",
         value_name = "REVSETS",

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -952,7 +952,7 @@ By default, the duplicated commits retain the descriptions of the originals. Thi
 
 ###### **Options:**
 
-* `-o`, `--onto <REVSETS>` — The revision(s) to duplicate onto (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to duplicate onto (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert before (can be repeated to create a merge commit)
 
@@ -2732,7 +2732,7 @@ The description of the new revisions can be customized with the `templates.rever
 ###### **Options:**
 
 * `-r`, `--revisions <REVSETS>` — The revision(s) to apply the reverse of
-* `-o`, `--onto <REVSETS>` — The revision(s) to apply the reverse changes on top of
+* `-o`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to apply the reverse changes on top of
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert the reverse changes after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert the reverse changes before (can be repeated to create a merge commit)
 
@@ -2960,7 +2960,7 @@ achieved with `jj new`.
 * `-r`, `--revision <REVSET>` — The revision to split
 
   Default value: `@`
-* `-o`, `--onto <REVSETS>` — The revision(s) to rebase the selected changes onto (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to rebase the selected changes onto (can be repeated to create a merge commit)
 
    Extracts the selected changes into a new commit based on the given revision(s). The remaining changes stay in the original commit's location.
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert after (can be repeated to create a merge commit)
@@ -3012,7 +3012,7 @@ An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. U
 * `-r`, `--revision <REVSET>` — Revision to squash into its parent (default: @). Incompatible with the experimental `-o`/`-A`/`-B` options
 * `-f`, `--from <REVSETS>` — Revision(s) to squash from (default: @)
 * `-t`, `--into <REVSET>` [alias: `to`] — Revision to squash into (default: @)
-* `-o`, `--onto <REVSETS>` — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)
+* `-o`, `--onto <REVSETS>` [alias: `destination`] — (Experimental) The revision(s) to use as parent for the new commit (can be repeated to create a merge commit)
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — (Experimental) The revision(s) to insert the new commit after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — (Experimental) The revision(s) to insert the new commit before (can be repeated to create a merge commit)
 * `-m`, `--message <MESSAGE>` — The description to use for squashed revision (don't open editor)


### PR DESCRIPTION
We have had two users at Google in the last few days how have wondered why there's no documentation for the `-d` flags. Of course, the answer is that they're deprecated, but given how long they have been available, many users are already use them frequently. Perhaps they then look at `jj rebase --help` to figure out what `-d` really means and how it's different from `-A` or `-B`. It's the confusing that they are not mentioned at all.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
