### PR TITLE
cli_util: use change offset in conflict hint when necessary

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -191,7 +191,7 @@ use crate::text_util;
 use crate::ui::ColorChoice;
 use crate::ui::Ui;
 
-const SHORT_CHANGE_ID_TEMPLATE_TEXT: &str = "format_short_change_id(self.change_id())";
+const SHORT_CHANGE_ID_TEMPLATE_TEXT: &str = "format_short_change_id_with_change_offset(self)";
 
 #[derive(Clone)]
 struct ChromeTracingFlushGuard {

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -170,7 +170,7 @@ fn test_report_conflicts_with_divergent_commits() {
       zsuskuln/0 ab0a21e6 (divergent) (conflict) C2
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new zsuskuln
+      jj new zsuskuln/0
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.
@@ -185,7 +185,7 @@ fn test_report_conflicts_with_divergent_commits() {
       zsuskuln/0 dbfbac97 (divergent) (conflict) C3
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
-      jj new zsuskuln
+      jj new zsuskuln/0
     Then use `jj resolve`, or edit the conflict markers in the file directly.
     Once the conflicts are resolved, you can inspect the result with `jj diff`.
     Then run `jj squash` to move the resolution into the conflicted commit.

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -168,7 +168,7 @@ fn test_templater_alias() {
     'recurse1' = 'recurse2()'
     'recurse2()' = 'recurse'
     'identity(x)' = 'x'
-    'coalesce(x, y)' = 'if(x, x, y)'
+    'coalesce2(x, y)' = 'if(x, x, y)'
     'format_commit_summary_with_refs(x, y)' = 'x.commit_id()'
     'builtin_log_node' = '"#"'
     'builtin_op_log_node' = '"#"'
@@ -315,26 +315,26 @@ fn test_templater_alias() {
     [exit status: 1]
     ");
 
-    insta::assert_snapshot!(render(r#"coalesce(label("x", "not boolean"), "")"#), @r#"
+    insta::assert_snapshot!(render(r#"coalesce2(label("x", "not boolean"), "")"#), @r#"
     ------- stderr -------
-    Error: Failed to parse template: In alias `coalesce(x, y)`
+    Error: Failed to parse template: In alias `coalesce2(x, y)`
     Caused by:
     1:  --> 1:1
       |
-    1 | coalesce(label("x", "not boolean"), "")
-      | ^-------------------------------------^
+    1 | coalesce2(label("x", "not boolean"), "")
+      | ^--------------------------------------^
       |
-      = In alias `coalesce(x, y)`
+      = In alias `coalesce2(x, y)`
     2:  --> 1:4
       |
     1 | if(x, x, y)
       |    ^
       |
       = In function parameter `x`
-    3:  --> 1:10
+    3:  --> 1:11
       |
-    1 | coalesce(label("x", "not boolean"), "")
-      |          ^-----------------------^
+    1 | coalesce2(label("x", "not boolean"), "")
+      |           ^-----------------------^
       |
       = Expected expression of type `Boolean`, but actual type is `Template`
     [EOF]


### PR DESCRIPTION
Resolves #8330. ~~It was also necessary to change the templater test to override `join()` instead of `coalesce()` because overriding `coalesce()` breaks `format_short_change_id_with_change_offset()`.~~

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
