### PR TITLE
docs: Remove mention of `jj gerrit send` from roadmap.md.

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,7 +16,7 @@ very large repos where detection would be too slow. See
 ## Forge integrations
 
 We would like to make it easier to work with various popular forges by providing
-something like `jj github submit`, `jj gitlab submit`, and `jj gerrit send`. For
+something like `jj github submit` and `jj gitlab submit`. For
 popular forges, we might include that support by default in the standard `jj`
 binary.
 


### PR DESCRIPTION
0.34.0 added the `jj gerrit upload` command:
- https://github.com/jj-vcs/jj/releases/tag/v0.34.0
- https://github.com/jj-vcs/jj/pull/7245
