### PR TITLE
roadmap: remove mention of `jj gerrit send`

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,9 +16,8 @@ very large repos where detection would be too slow. See
 ## Forge integrations
 
 We would like to make it easier to work with various popular forges by providing
-something like `jj github submit`, `jj gitlab submit`, and `jj gerrit send`. For
-popular forges, we might include that support by default in the standard `jj`
-binary.
+something like `jj github submit` and `jj gitlab submit`. For popular forges, we
+might include that support by default in the standard `jj` binary.
 
 ## Submodule support
 


### PR DESCRIPTION
A `jj gerrit upload` command was added in 35ad063b8546.

Based on a patch by @pelme.
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
