### PR TITLE
cli `config list` docs: explain config key format in templates

### DIFF
--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -49,7 +49,7 @@ pub struct ConfigListArgs {
     ///
     /// The following keywords are available in the template expression:
     ///
-    /// * `name: String`: Config name.
+    /// * `name: String`: Config name, in [TOML's "dotted key" format].
     /// * `value: ConfigValue`: Value to be formatted in TOML syntax.
     /// * `overridden: Boolean`: True if the value is shadowed by other.
     /// * `source: String`: Source of the value.
@@ -60,6 +60,8 @@ pub struct ConfigListArgs {
     /// template.
     ///
     /// See [`jj help -k templates`] for more information.
+    ///
+    /// [TOML's "dotted key" format]: https://toml.io/en/v1.0.0#keys
     ///
     /// [`jj help -k templates`]:
     ///     https://docs.jj-vcs.dev/latest/templates/

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -731,7 +731,7 @@ List variables set in config files, along with their values
 
    The following keywords are available in the template expression:
 
-   * `name: String`: Config name.
+   * `name: String`: Config name, in [TOML's "dotted key" format].
    * `value: ConfigValue`: Value to be formatted in TOML syntax.
    * `overridden: Boolean`: True if the value is shadowed by other.
    * `source: String`: Source of the value.
@@ -742,6 +742,8 @@ List variables set in config files, along with their values
    template.
 
    See [`jj help -k templates`] for more information.
+
+   [TOML's "dotted key" format]: https://toml.io/en/v1.0.0#keys
 
    [`jj help -k templates`]:
        https://docs.jj-vcs.dev/latest/templates/


### PR DESCRIPTION
A minor docs clarification for the template format.


This might be documenting an intermediate state of the templating (`name` might get its own type at some point instead of being a `String`), but I'm not sure how imminent any changes to this state would be.