### PR TITLE
cleanup: use single space consistently instead of two spaces in docs and comments

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -59,7 +59,7 @@ revisions)" is shown to indicate that `musnqzvt` descends from `tylynnzk`, but
 the nodes connecting them are not in the revset.
 
 To view the elided revisions, change the [revset expression](revsets.md) so it
-includes the connecting revisions.  The `connected()` revset function does
+includes the connecting revisions. The `connected()` revset function does
 exactly this:
 
 ```sh

--- a/docs/config.md
+++ b/docs/config.md
@@ -379,7 +379,7 @@ diff-args = ["--color=always", "$left", "$right"]
   not work for viewing diffs.
 
 By default `jj` will invoke external tools with a directory containing the left
-and right sides.  The `diff-invocation-mode` config can change this to file by file
+and right sides. The `diff-invocation-mode` config can change this to file by file
 invocations as follows:
 
 ```toml
@@ -896,7 +896,7 @@ Obviously, you would only set one line, don't copy them all in!
 ## Editing diffs
 
 The `ui.diff-editor` setting affects the default tool used for editing diffs
-(e.g.  `jj split`, `jj squash -i`). If it is not set, the special value
+(e.g. `jj split`, `jj squash -i`). If it is not set, the special value
 `:builtin` is used. It launches a built-in TUI tool (known as [scm-diff-editor])
 to edit the diff in your terminal.
 

--- a/docs/design/copy-tracking.md
+++ b/docs/design/copy-tracking.md
@@ -726,7 +726,7 @@ A rough implementation plan may look like this:
 8. Implement support for copy-tracking in the Git backend. This may involve
    backfilling, possibly lazily. Or it may involve new abstractions in the
    commit backend trait.
-9.  Implement CLI for recording copies and for resolving conflicts in copies
+9. Implement CLI for recording copies and for resolving conflicts in copies
 
 ## Alternatives considered
 

--- a/docs/design/sparse-v2.md
+++ b/docs/design/sparse-v2.md
@@ -12,9 +12,9 @@ end state.
 Redesign Sparse Patterns to accommodate more advanced features for native
 and custom implementations. This includes three main goals:
 
-1.  Sparse Patterns should be versioned with the working copy
-1.  Sparse Patterns should support more [flexible matching rules](https://github.com/jj-vcs/jj/issues/1896)
-1.  Sparse Patterns should support [client path remapping](https://github.com/jj-vcs/jj/issues/2288)
+1. Sparse Patterns should be versioned with the working copy
+1. Sparse Patterns should support more [flexible matching rules](https://github.com/jj-vcs/jj/issues/1896)
+1. Sparse Patterns should support [client path remapping](https://github.com/jj-vcs/jj/issues/2288)
 
 ## Current State (as of jj 0.13.0)
 

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -53,7 +53,7 @@ main disadvantage of that is that it's harder to inspect the conflict
 resolutions.
 
 With the `jj resolve` command, you can use an external merge tool to resolve
-conflicts that have 2 sides and a base.  There is not yet a good way of
+conflicts that have 2 sides and a base. There is not yet a good way of
 resolving conflicts between directories, files, and symlinks
 (<https://github.com/jj-vcs/jj/issues/19>). You can use `jj restore` to choose
 one side of the conflict, but there's no way to even see where the involved

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -561,7 +561,7 @@ pub trait Backend: Send + Sync + Debug {
         sign_with: Option<&mut SigningFn>,
     ) -> BackendResult<(CommitId, Commit)>;
 
-    /// Get copy records for the dag range `root..head`.  If `paths` is None
+    /// Get copy records for the dag range `root..head`. If `paths` is None
     /// include all paths, otherwise restrict to only `paths`.
     ///
     /// The exact order these are returned is unspecified, but it is guaranteed

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -103,7 +103,7 @@ pub mod watchman {
     ///
     /// This can be used to perform incremental queries. When making a query,
     /// the result will include an associated "clock" representing the time
-    /// that the query was made.  By passing the same clock into a future
+    /// that the query was made. By passing the same clock into a future
     /// query, we inform the filesystem monitor that we only wish to get
     /// changed files since the previous point in time.
     #[derive(Clone, Debug)]

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -169,7 +169,7 @@ impl MergedTree {
         // here to possibly reduce a complex conflict to a simpler one.
         let simplified = merged.simplify();
         // If debug assertions are enabled, check that the merge was idempotent. In
-        // particular,  that this last simplification doesn't enable further automatic
+        // particular, that this last simplification doesn't enable further automatic
         // resolutions
         if cfg!(debug_assertions) {
             let re_merged = merge_trees(simplified.clone()).block_on().unwrap();

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -1596,7 +1596,7 @@ fn test_merge_simplify_file_conflict() {
     assert_eq!(merged, expected_merged);
 
     // Also test the setup by checking that the unsimplified content conflict cannot
-    // be resolved. If we later change files::merge() so this no longer fails,  it
+    // be resolved. If we later change files::merge() so this no longer fails, it
     // probably means that we can delete this whole test (the Merge::simplify() call
     // in try_resolve_file_conflict() is just an optimization then).
     let text_merge = Merge::from_removes_adds(


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
