### PR TITLE
absorb: add conflict labels

### DIFF
--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -176,12 +176,12 @@ fn test_absorb_replace_single_line_hunk() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 1 revisions:
-      qpvuntsm 19034586 (conflict) 1
+      qpvuntsm a40c8704 (conflict) 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: mzvwutvl f9c426f2 (empty) (no description set)
-    Parent commit (@-)      : kkmpptxz a5f84679 2
+    Working copy  (@) now at: mzvwutvl ec00e275 (empty) (no description set)
+    Parent commit (@-)      : kkmpptxz 639fe391 2
     New conflicts appeared in 1 commits:
-      qpvuntsm 19034586 (conflict) 1
+      qpvuntsm a40c8704 (conflict) 1
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new qpvuntsm
@@ -191,43 +191,45 @@ fn test_absorb_replace_single_line_hunk() {
     [EOF]
     ");
 
-    insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
-    @  mzvwutvl f9c426f2 (empty) (no description set)
-    ○  kkmpptxz a5f84679 2
+    insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r#"
+    @  mzvwutvl ec00e275 (empty) (no description set)
+    ○  kkmpptxz 639fe391 2
     │  diff --git a/file1 b/file1
     │  index 0000000000..2f87e8e465 100644
     │  --- a/file1
     │  +++ b/file1
-    │  @@ -1,10 +1,3 @@
+    │  @@ -1,11 +1,3 @@
     │  -<<<<<<< conflict 1 of 1
-    │  -%%%%%%% diff from base to side #1
+    │  -%%%%%%% diff from: kkmpptxz 9d700628 "2" (parents of absorbed commit)
+    │  -\\\\\\\        to: qpvuntsm aa6cb9bc "1" (absorb destination)
     │  --2a
     │  - 1a
     │  --2b
-    │  -+++++++ side #2
+    │  -+++++++ absorbed changes (from zsuskuln 5d926f12)
     │   2a
     │   1A
     │   2b
     │  ->>>>>>> conflict 1 of 1 ends
-    ×  qpvuntsm 19034586 (conflict) 1
+    ×  qpvuntsm a40c8704 (conflict) 1
     │  diff --git a/file1 b/file1
     ~  new file mode 100644
        index 0000000000..0000000000
        --- /dev/null
        +++ b/file1
-       @@ -0,0 +1,10 @@
+       @@ -0,0 +1,11 @@
        +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from base to side #1
+       +%%%%%%% diff from: kkmpptxz 9d700628 "2" (parents of absorbed commit)
+       +\\\\\\\        to: qpvuntsm aa6cb9bc "1" (absorb destination)
        +-2a
        + 1a
        +-2b
-       ++++++++ side #2
+       ++++++++ absorbed changes (from zsuskuln 5d926f12)
        +2a
        +1A
        +2b
        +>>>>>>> conflict 1 of 1 ends
     [EOF]
-    ");
+    "#);
 }
 
 #[test]
@@ -551,14 +553,14 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Absorbed changes into 2 revisions:
-      kkmpptxz 9210e16d (conflict) 2
-      qpvuntsm a52f61f7 (conflict) 1
+      kkmpptxz 85b97cf2 (conflict) 2
+      qpvuntsm 708d7522 (conflict) 1
     Rebased 1 descendant commits.
-    Working copy  (@) now at: zsuskuln f8744d38 (no description set)
-    Parent commit (@-)      : kkmpptxz 9210e16d (conflict) 2
+    Working copy  (@) now at: zsuskuln 4191bac9 (no description set)
+    Parent commit (@-)      : kkmpptxz 85b97cf2 (conflict) 2
     New conflicts appeared in 2 commits:
-      kkmpptxz 9210e16d (conflict) 2
-      qpvuntsm a52f61f7 (conflict) 1
+      kkmpptxz 85b97cf2 (conflict) 2
+      qpvuntsm 708d7522 (conflict) 1
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
       jj new qpvuntsm
@@ -570,76 +572,82 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     [EOF]
     ");
 
-    insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r"
-    @  zsuskuln f8744d38 (no description set)
+    insta::assert_snapshot!(get_diffs(&work_dir, "mutable()"), @r#"
+    @  zsuskuln 4191bac9 (no description set)
     │  diff --git a/file2 b/file2
     │  deleted file mode 100644
     │  index 0000000000..0000000000
     │  --- a/file2
     │  +++ /dev/null
-    │  @@ -1,7 +0,0 @@
+    │  @@ -1,8 +0,0 @@
     │  -<<<<<<< conflict 1 of 1
-    │  -%%%%%%% diff from base to side #1
+    │  -%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed commit)
+    │  -\\\\\\\        to: kkmpptxz 33662096 "2" (absorb destination)
     │  --1a
     │  - 1b
-    │  -+++++++ side #2
+    │  -+++++++ absorbed changes (from zsuskuln d6492c8f)
     │  -1a
     │  ->>>>>>> conflict 1 of 1 ends
-    ×  kkmpptxz 9210e16d (conflict) 2
+    ×  kkmpptxz 85b97cf2 (conflict) 2
     │  diff --git a/file1 b/file1
     │  deleted file mode 100644
     │  index 0000000000..0000000000
     │  --- a/file1
     │  +++ /dev/null
-    │  @@ -1,6 +0,0 @@
+    │  @@ -1,7 +0,0 @@
     │  -<<<<<<< conflict 1 of 1
-    │  -%%%%%%% diff from base to side #1
+    │  -%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed commit)
+    │  -\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
     │  - 1a
     │  -+1b
-    │  -+++++++ side #2
+    │  -+++++++ absorbed changes (from zsuskuln d6492c8f)
     │  ->>>>>>> conflict 1 of 1 ends
     │  diff --git a/file2 b/file2
     │  --- a/file2
     │  +++ b/file2
-    │  @@ -1,7 +1,7 @@
+    │  @@ -1,8 +1,8 @@
     │   <<<<<<< conflict 1 of 1
-    │   %%%%%%% diff from base to side #1
+    │   %%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed commit)
+    │  -\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
     │  - 1a
     │  --1b
+    │  +\\\\\\\        to: kkmpptxz 33662096 "2" (absorb destination)
     │  +-1a
     │  + 1b
-    │   +++++++ side #2
+    │   +++++++ absorbed changes (from zsuskuln d6492c8f)
     │  -1b
     │  +1a
     │   >>>>>>> conflict 1 of 1 ends
-    ×  qpvuntsm a52f61f7 (conflict) 1
+    ×  qpvuntsm 708d7522 (conflict) 1
     │  diff --git a/file1 b/file1
     ~  new file mode 100644
        index 0000000000..0000000000
        --- /dev/null
        +++ b/file1
-       @@ -0,0 +1,6 @@
+       @@ -0,0 +1,7 @@
        +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from base to side #1
+       +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed commit)
+       +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
        + 1a
        ++1b
-       ++++++++ side #2
+       ++++++++ absorbed changes (from zsuskuln d6492c8f)
        +>>>>>>> conflict 1 of 1 ends
        diff --git a/file2 b/file2
        new file mode 100644
        index 0000000000..0000000000
        --- /dev/null
        +++ b/file2
-       @@ -0,0 +1,7 @@
+       @@ -0,0 +1,8 @@
        +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from base to side #1
+       +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed commit)
+       +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
        + 1a
        +-1b
-       ++++++++ side #2
+       ++++++++ absorbed changes (from zsuskuln d6492c8f)
        +1b
        +>>>>>>> conflict 1 of 1 ends
     [EOF]
-    ");
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
These conflicts can happen when adjacent lines were added or removed:

```
<<<<<<< conflict 1 of 1
%%%%%%% diff from: vpxusssl 38d49363 "B" (parents of absorbed commit)
\\\\\\\        to: rtsqusxu 2768b0b9 "A" (absorb destination)
 base
-added
+++++++ absorbed changes (from ysrnknol 7a20f389 "C")
absorbed changes
added
>>>>>>> conflict 1 of 1 ends
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
