### PR TITLE
cli: add `CommitEvolutionEntry.inter_diff([files])` template method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `TreeDiffEntry` now has a `status_char()` method that returns
   single-character status codes (M/A/D/C/R).
 
+* `CommitEvolutionEntry` type now has a `predecessors()` method which
+  returns the predecessor commits (previous versions) of the entry's commit.
+
+* `CommitEvolutionEntry` type now has a  `inter_diff()` method  which
+  returns a `TreeDiff` between the entry's commit and its predecessor version.
+  Optionally accepts a fileset literal to limit the diff.
+
 ### Fixed bugs
 
 * Broken symlink on Windows. [#6934](https://github.com/jj-vcs/jj/issues/6934).

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -190,6 +190,10 @@ This type cannot be printed. The following methods are defined.
 * `.commit() -> Commit`: New commit.
 * `.operation() -> Operation`: Operation where the commit was created or
   rewritten.
+* `.predecessors() -> List<Commit>`: Predecessor commits of this entry.
+* `.inter_diff([files: StringLiteral]) -> TreeDiff`: Changes between this commit and its
+  predecessor version(s), rebased onto the parents of this commit to avoid unrelated
+  changes (similar to `jj evolog -p`).
 
 ### `ChangeId` type
 


### PR DESCRIPTION
Add `CommitEvolutionEntry.predecessors() -> List<Commit>` to return the predecessor commits of the current evolution entry (loaded from the store).

Add `CommitEvolutionEntry.inter_diff([files]) -> TreeDiff` to render the tree changes between this entry and its predecessor version(s), optionally limited to a fileset literal.

Related to #8370.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
