### PR TITLE
Add functionality for pushing tags to remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `--insert-before` now accepts a revset that resolves to an empty set when
   used with `--insert-after`. The behavior is similar to `--onto`.
 
+* Tags can now be pushed to a remote, using `jj git push`. To push all local tags,
+  use `jj git push --tags`. To push a specific tag, use `jj git push --tag NAME`.
+
 ### Fixed bugs
 
 * Broken symlink on Windows. [#6934](https://github.com/jj-vcs/jj/issues/6934).

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Today, only the Git backend is production-ready. The Git backend uses the
 
 The Git backend is fully featured and maintained, and allows you to use Jujutsu
 with any Git remote. The commits you create will look like regular Git commits.
-You can fetch branches from a regular Git remote and push branches to the
+You can fetch branches from a regular Git remote and push branches and tags to the
 remote. You can always switch back to Git.
 
 Here is how you can explore a GitHub repository with `jj`.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2501,6 +2501,21 @@ impl WorkspaceCommandTransaction<'_> {
             .finish_transaction(ui, self.tx, description, &git_import_export_lock)
     }
 
+    /// Finishes the transaction even if the repo has no changes.
+    ///
+    /// This is useful for commands that perform side effects outside the repo
+    /// (for example, pushing to a remote) but still need to record an
+    /// operation without printing a spurious "Nothing changed." message.
+    pub fn finish_even_if_unchanged(
+        self,
+        ui: &Ui,
+        description: impl Into<String>,
+    ) -> Result<(), CommandError> {
+        let git_import_export_lock = self.helper.lock_git_import_export()?;
+        self.helper
+            .finish_transaction(ui, self.tx, description, &git_import_export_lock)
+    }
+
     /// Returns the wrapped [`Transaction`] for circumstances where
     /// finer-grained control is needed. The caller becomes responsible for
     /// finishing the `Transaction`, including rebasing descendants and updating

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1634,6 +1634,8 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 
    The set of private commits can be configured by the `git.private-commits` setting. The default is `none()`, meaning all commits are eligible to be pushed.
 * `-r`, `--revisions <REVSETS>` — Push bookmarks pointing to these commits (can be repeated)
+* `--tags` — Push all tags
+* `-t`, `--tag <TAG>` — Push only this tag (can be repeated)
 * `-c`, `--change <REVSETS>` — Push this commit by creating a bookmark (can be repeated)
 
    The created bookmark will be tracked automatically. Use the `templates.git_push_bookmark` setting to customize the generated bookmark name. The default is `"push-" ++ change_id.short()`.

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -84,6 +84,32 @@ fn test_git_push_nothing() {
 }
 
 #[test]
+fn test_git_push_tags() {
+    let test_env = TestEnvironment::default();
+    set_up(&test_env);
+    let work_dir = test_env.work_dir("local");
+    let origin_dir = test_env.work_dir("origin");
+    let origin_git_repo_path = git_repo_dir_for_jj_repo(&origin_dir);
+
+    // Create a local JJ tag pointing at the current working-copy commit.
+    work_dir.run_jj(["tag", "set", "-r@", "v1.0.0"]).success();
+
+    // Push it to the Git remote.
+    let output = work_dir.run_jj(["git", "push", "--tag", "v1.0.0"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Changes to push to origin:
+      Tags:
+        v1.0.0 -> 8d23abddc924
+    [EOF]
+    ");
+
+    // Verify the remote Git repo now has the tag.
+    let origin_git_repo = git::open(origin_git_repo_path);
+    assert!(origin_git_repo.find_reference("refs/tags/v1.0.0").is_ok());
+}
+
+#[test]
 fn test_git_push_current_bookmark() {
     let test_env = TestEnvironment::default();
     set_up(&test_env);
@@ -313,28 +339,28 @@ fn test_git_push_forward_unexpectedly_moved() {
 
     // Pushing should fail
     let output = work_dir.run_jj(["git", "push"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Move forward bookmark bookmark1 from 9b2e76de3920 to 624f94a35f00
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
 
     // The ref name should be colorized
     let output = work_dir.run_jj(["git", "push", "--color=always"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Move forward bookmark bookmark1 from 9b2e76de3920 to 624f94a35f00
-    [1m[38;5;1mError: [39mFailed to push some bookmarks[0m
+    [1m[38;5;1mError: [39mFailed to push some references[0m
     [1m[38;5;6mHint: [0m[39mThe following references unexpectedly moved on the remote:[39m
     [39m  [38;5;2mrefs/heads/bookmark1[39m (reason: stale info)[39m
-    [1m[38;5;6mHint: [0m[39mTry fetching from the remote, then make the bookmark point to where you want it to be, and push again.[39m
+    [1m[38;5;6mHint: [0m[39mTry fetching from the remote, then update your local refs as needed, and push again.[39m
     [EOF]
     [exit status: 1]
     ");
@@ -379,28 +405,28 @@ fn test_git_push_sideways_unexpectedly_moved() {
     ");
 
     let output = work_dir.run_jj(["git", "push"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark bookmark1 from 9b2e76de3920 to 827b8a385853
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
 
     // The ref name should be colorized
     let output = work_dir.run_jj(["git", "push", "--color=always"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark bookmark1 from 9b2e76de3920 to 827b8a385853
-    [1m[38;5;1mError: [39mFailed to push some bookmarks[0m
+    [1m[38;5;1mError: [39mFailed to push some references[0m
     [1m[38;5;6mHint: [0m[39mThe following references unexpectedly moved on the remote:[39m
     [39m  [38;5;2mrefs/heads/bookmark1[39m (reason: stale info)[39m
-    [1m[38;5;6mHint: [0m[39mTry fetching from the remote, then make the bookmark point to where you want it to be, and push again.[39m
+    [1m[38;5;6mHint: [0m[39mTry fetching from the remote, then update your local refs as needed, and push again.[39m
     [EOF]
     [exit status: 1]
     ");
@@ -445,14 +471,14 @@ fn test_git_push_deletion_unexpectedly_moved() {
     ");
 
     let output = work_dir.run_jj(["git", "push", "--bookmark", "bookmark1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Delete bookmark bookmark1 from 9b2e76de3920
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
@@ -494,14 +520,14 @@ fn test_git_push_unexpectedly_deleted() {
 
     // Pushing a moved bookmark fails if deleted on remote
     let output = work_dir.run_jj(["git", "push"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Move sideways bookmark bookmark1 from 9b2e76de3920 to 09919fb051bf
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
@@ -520,14 +546,14 @@ fn test_git_push_unexpectedly_deleted() {
     // git does not allow to push a deleted bookmark if we expect it to exist even
     // though it was already deleted
     let output = work_dir.run_jj(["git", "push", "-bbookmark1"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Delete bookmark bookmark1 from 9b2e76de3920
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
@@ -562,14 +588,14 @@ fn test_git_push_creation_unexpectedly_already_exists() {
     ");
 
     let output = work_dir.run_jj(["git", "push"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark bookmark1 to a43cb8011c85
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/bookmark1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
@@ -1210,14 +1236,14 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     // Make sure push still errors if we try to push a bookmark with the same name
     // to a different location.
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@-"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark b1 to aa9ad64cb4ce
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/b1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
@@ -1230,14 +1256,14 @@ fn test_git_push_changes_with_name_untracked_or_forgotten() {
     [EOF]
     ");
     let output = work_dir.run_jj(["git", "push", "--named", "b1=@+"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
       Add bookmark b1 to 9a0f76645905
-    Error: Failed to push some bookmarks
+    Error: Failed to push some references
     Hint: The following references unexpectedly moved on the remote:
       refs/heads/b1 (reason: stale info)
-    Hint: Try fetching from the remote, then make the bookmark point to where you want it to be, and push again.
+    Hint: Try fetching from the remote, then update your local refs as needed, and push again.
     [EOF]
     [exit status: 1]
     ");
@@ -2212,15 +2238,15 @@ fn test_git_push_rejected_by_remote() {
     let mut settings = insta::Settings::clone_current();
     settings.add_filter(r"\s*\n", "\n");
     settings.bind(|| {
-        insta::assert_snapshot!(output, @r"
+        insta::assert_snapshot!(output, @"
         ------- stderr -------
         Changes to push to origin:
           Move forward bookmark bookmark1 from 9b2e76de3920 to 0fc4cf312e83
         remote: error: hook declined to update refs/heads/bookmark1
-        Error: Failed to push some bookmarks
+        Error: Failed to push some references
         Hint: The remote rejected the following updates:
           refs/heads/bookmark1 (reason: hook declined)
-        Hint: Try checking if you have permission to push to all the bookmarks.
+        Hint: Try checking if you have permission to push these references.
         [EOF]
         [exit status: 1]
         ");

--- a/docs/design/tracking-branches.md
+++ b/docs/design/tracking-branches.md
@@ -194,7 +194,7 @@ In particular, a merge of local and remote targets is
          diff `[absent, remote] - absent` is noop. So it's not allowed to push
          deleted branch to untracked remote.
        * TODO: Copy Git's `--force-with-lease` behavior?
-     * ~`tags`~ (not implemented, but should be the same as `branches`)
+     * ~`tags`~ (not implemented, but should be the same as `branches`) - TODO(warrenbhw - update docs here once design is finalized)
   2. Pushes diff to the remote Git repo (as well as remote tracking branches
      in the backing Git repo.)
   3. Updates `remotes[remote]` and `git_refs` reflecting the push.

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -27,7 +27,7 @@ a comparison with Git, including how workflows are different, see the
   and [how they interoperate with Git](#branches).
 * **Tags: Partial.** You can check out tagged commits by name (pointed to by
   either annotated or lightweight tags). You can also create lightweight tags,
-  but you cannot create annotated tags.
+  but you cannot create annotated tags. You can push tags to a remote.
 * **.gitignore: Yes.** Patterns in `.gitignore` files are supported. So are
   ignores in `.git/info/exclude` or configured via Git's `core.excludesFile`
   config. Since working-copy files are snapshotted by almost every `jj` command,


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`) **TODO(warrenbhw) - ensure doc updates are updated after initial PR feedback**
- [x] I have updated the config schema (`cli/src/config-schema.json`) **N/A - no config changes required**
- [ ] I have added/updated tests to cover my changes **TODO(warrenbhw) - ensure that I have sufficient test coverage**
