### PR TITLE
git: add config to turn off hint about git clean

### DIFF
--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -249,7 +249,7 @@ pub fn cmd_git_clone(
         }
     }
 
-    if colocate {
+    if colocate && workspace_command.settings().get_bool("git.clean-hint")? {
         writeln!(
             ui.hint_default(),
             r"Running `git clean -xdf` will remove `.jj/`!",

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -133,7 +133,7 @@ pub fn cmd_git_init(
         r#"Initialized repo in "{}""#,
         relative_wc_path.display()
     )?;
-    if colocate {
+    if colocate && command.settings().get_bool("git.clean-hint")? {
         writeln!(
             ui.hint_default(),
             r"Running `git clean -xdf` will remove `.jj/`!",

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -394,6 +394,34 @@ fn test_git_clone_colocate() {
 }
 
 #[test]
+fn test_git_clone_colocate_git_clean_warning_off() {
+    let test_env = TestEnvironment::default();
+    let root_dir = test_env.work_dir("");
+    let git_repo_path = test_env.env_root().join("source");
+    let git_repo = git::init(git_repo_path);
+
+    test_env.add_config("git.colocate = true");
+    test_env.add_config("git.clean-hint = false");
+
+    set_up_non_empty_git_repo(&git_repo);
+
+    let output = root_dir.run_jj(["git", "clone", "source", "clone"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Fetching into new repo in "$TEST_ENV/clone"
+    bookmark: main@origin [new] tracked
+    Setting the revset alias `trunk()` to `main@origin`
+    Working copy  (@) now at: sqpuoqvx 1ca44815 (empty) (no description set)
+    Parent commit (@-)      : qomsplrm ebeb70d8 main | message
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    "#);
+    let clone_dir = test_env.work_dir("clone");
+    assert!(clone_dir.root().join("file").exists());
+    assert!(clone_dir.root().join(".git").exists());
+}
+
+#[test]
 fn test_git_clone_colocate_via_config() {
     let test_env = TestEnvironment::default();
     let root_dir = test_env.work_dir("");

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -958,6 +958,23 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
 }
 
 #[test]
+fn test_git_init_git_clean_hint() {
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    init_git_repo(work_dir.root(), false);
+
+    test_env.add_config("git.clean-hint = false");
+
+    let output = test_env.run_jj_in(".", ["git", "init", "--colocate", "repo"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Done importing changes from the underlying Git repo.
+    Initialized repo in "repo"
+    [EOF]
+    "#);
+}
+
+#[test]
 fn test_git_init_colocated_via_config_git_dir_exists() {
     let test_env = TestEnvironment::default();
     let work_dir = test_env.work_dir("repo");

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -14,6 +14,7 @@ abandon-unreachable-commits = true
 auto-local-bookmark = false
 executable-path = "git"
 write-change-id-header = true
+clean-hint = true
 
 [merge]
 hunk-level = "line"


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [X] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
   - Let me know if I should add more tests. I was not sure if I should duplicate all the tests where the hint previously existed. Perhaps there is a way to create branching logic for the snapshots within each test without duplication? Let me know if I should do this. 
   
This was previous submitted under https://github.com/jj-vcs/jj/pull/7456 and https://github.com/jj-vcs/jj/pull/7621. These were closed due to rebasing trouble and the Github PR breaking due to force pushing, respectively. 

I'm also happy to keep this on by default and switch to the config turning it off, whatever is preferred.