### PR TITLE
completions: fix minor panic when `COMPLETE` env var is empty

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3993,7 +3993,7 @@ impl<'a> CliRunner<'a> {
         migrate_config(&mut config)?;
         ui.reset(&config)?;
 
-        if env::var_os("COMPLETE").is_some() {
+        if env::var_os("COMPLETE").is_some_and(|v| !v.is_empty() && v != "0") {
             return handle_shell_completion(&Ui::null(), &self.app, &config, &cwd);
         }
 


### PR DESCRIPTION
Currently, `clap` ignores an empty COMPLETE var, so we should too. Previously this paniced.

Also, added a test for a bad shell value for completeness.


# Checklist

If applicable:

- (n/a?) I have updated `CHANGELOG.md`
- (n/a?) I have updated the documentation (`README.md`, `docs/`, `demos/`)
- (n/a) I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
