### PR TITLE
Add a new subcommand `operation record`

### DIFF
--- a/cli/src/commands/operation/mod.rs
+++ b/cli/src/commands/operation/mod.rs
@@ -15,6 +15,7 @@
 mod abandon;
 mod diff;
 mod log;
+mod new;
 mod restore;
 pub mod revert;
 mod show;
@@ -35,6 +36,8 @@ use show::cmd_op_show;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
+use crate::commands::operation::new::OperationNewArgs;
+use crate::commands::operation::new::cmd_op_new;
 use crate::commands::renamed_cmd;
 use crate::ui::Ui;
 
@@ -49,6 +52,7 @@ pub enum OperationCommand {
     Abandon(OperationAbandonArgs),
     Diff(OperationDiffArgs),
     Log(OperationLogArgs),
+    New(OperationNewArgs),
     Restore(OperationRestoreArgs),
     Revert(OperationRevertArgs),
     Show(OperationShowArgs),
@@ -66,6 +70,7 @@ pub fn cmd_operation(
         OperationCommand::Abandon(args) => cmd_op_abandon(ui, command, args),
         OperationCommand::Diff(args) => cmd_op_diff(ui, command, args),
         OperationCommand::Log(args) => cmd_op_log(ui, command, args),
+        OperationCommand::New(args) => cmd_op_new(ui, command, args),
         OperationCommand::Restore(args) => cmd_op_restore(ui, command, args),
         OperationCommand::Revert(args) => cmd_op_revert(ui, command, args),
         OperationCommand::Show(args) => cmd_op_show(ui, command, args),

--- a/cli/src/commands/operation/new.rs
+++ b/cli/src/commands/operation/new.rs
@@ -1,0 +1,48 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cli_util::CommandHelper;
+use crate::cli_util::start_repo_transaction;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Create a new operation with a custom description
+///
+/// Unconditionally creates a no-op operation with the provided description.
+///
+/// Unless --ignore-working-copy is specified, this command will still first
+/// snapshot any changes.
+#[derive(clap::Args, Clone, Debug)]
+pub struct OperationNewArgs {
+    /// The description of the operation to create
+    description: String,
+}
+
+pub fn cmd_op_new(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &OperationNewArgs,
+) -> Result<(), CommandError> {
+    // Will snapshot any changes if applicable
+    let workspace_helper = command.workspace_helper(ui)?;
+
+    let workspace = workspace_helper.workspace();
+    let repo_loader = workspace.repo_loader();
+
+    let op = command.resolve_operation(ui, repo_loader)?;
+    let repo = repo_loader.load_at(&op)?;
+    let transaction = start_repo_transaction(&repo, command.string_args());
+    transaction.commit(&args.description)?;
+    Ok(())
+}

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -78,6 +78,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj operation abandon`↴](#jj-operation-abandon)
 * [`jj operation diff`↴](#jj-operation-diff)
 * [`jj operation log`↴](#jj-operation-log)
+* [`jj operation new`↴](#jj-operation-new)
 * [`jj operation restore`↴](#jj-operation-restore)
 * [`jj operation revert`↴](#jj-operation-revert)
 * [`jj operation show`↴](#jj-operation-show)
@@ -2107,6 +2108,7 @@ See the [operation log documentation] for more information.
 * `abandon` — Abandon operation history
 * `diff` — Compare changes to the repository between two operations
 * `log` — Show the operation log
+* `new` — Create a new operation with a custom description
 * `restore` — Create a new operation that restores the repo to an earlier state
 * `revert` — Create a new operation that reverts an earlier operation
 * `show` — Show changes to the repository in an operation
@@ -2207,6 +2209,22 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
 * `--context <CONTEXT>` — Number of lines of context to show
 * `--ignore-all-space` — Ignore whitespace when comparing lines
 * `--ignore-space-change` — Ignore changes in amount of whitespace when comparing lines
+
+
+
+## `jj operation new`
+
+Create a new operation with a custom description
+
+Unconditionally creates a no-op operation with the provided description.
+
+Unless --ignore-working-copy is specified, this command will still first snapshot any changes.
+
+**Usage:** `jj operation new <DESCRIPTION>`
+
+###### **Arguments:**
+
+* `<DESCRIPTION>` — The description of the operation to create
 
 
 


### PR DESCRIPTION
The `operation record` subcommand adds a new transaction to the op log with a user-provided description.  This allows the user to later reconcile operations in the log with operations outside the log: for example, a tool invocation (whether LLM-driven or not) that mutates the repostory may record operations when it starts and when it ends, allowing the user to later see what it did.

Reconciliation from a named transaction is easier than trying to work out which snapshot or which arbitrary command invocation the tool may have performed.  For example, an automatic formatting tool will usually only show up in the log as a snapshot entry, and it would be inappropriate to create a separate commit.  But it may be helpful to have a record of the operation in the op log.

This fixes #8436

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
