### PR TITLE
gerrit: Implement `jj gerrit upload` options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Changed background snapshotting to suppress stdout and stderr to avoid long
   hangs.
 
+* `jj gerrit upload` now supports a variety of new flags documented in
+  [gerrit's documentation](https://gerrit-review.googlesource.com/Documentation/user-upload.html).
+  This includes, for example, `--reviewer=foo@example.com` and
+  `--label=Auto-Submit`.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1362,7 +1362,7 @@ Upload changes to Gerrit for code review, or update existing changes.
 
 Uploading in a set of revisions to Gerrit creates a single "change" for each revision included in the revset. These changes are then available for review on your Gerrit instance.
 
-Note: The gerrit commit Id may not match that of your local commit Id, since we add a `Change-Id` footer to the commit message if one does not already exist. This ID is based off the jj Change-Id, but is not the same.
+Note: The Gerrit commit Id may not match that of your local commit Id, since we add a `Change-Id` footer to the commit message if one does not already exist. This ID is based off the jj Change-Id, but is not the same.
 
 If a change already exists for a given revision (i.e. it contains the same `Change-Id`), this command will update the contents of the existing change to match.
 
@@ -1382,6 +1382,51 @@ Note: this command takes 1-or-more revsets arguments, each of which can resolve 
 
    Can be configured with the `gerrit.default-remote` repository option as well. This is typically a full SSH URL for your Gerrit instance.
 * `-n`, `--dry-run` — Do not actually push the changes to Gerrit
+* `--reviewer <REVIEWER>` — Add these emails as a reviewer (can be repeated)
+* `--cc <CC>` — CC these emails on the change (can be repeated)
+* `-l`, `--label <LABEL>` — Add the following labels configured by Gerrit (can be repeated)
+
+   Gerrit silently ignores labels not present on your gerrit host. Defaults to +1 if no value is set. Eg. --label=Commit-Queue will set the Commit-Queue label to +1. Eg. --label=Commit-Queue+2 will set it to +2.
+* `--topic <TOPIC>` — Applies a topic to the change
+
+   See https://gerrit-review.googlesource.com/Documentation/intro-user.html#topics. Changes can be grouped by topic, and Gerrit can be configured to submit all changes in a topic together in a single click.
+* `--hashtag <HASHTAG>` — Applies a hashtag to the change
+
+   See https://gerrit-review.googlesource.com/Documentation/intro-user.html#hashtags. Hashtags are freeform strings associated with a change, like on social media platforms. Similar to topics, hashtags can be used to group related changes together, and to search using the hashtag: operator. Unlike topics, a change can have multiple hashtags, and they are only used for informational grouping. Changes with the same hashtags are not necessarily submitted together.
+* `--wip` — Marks the change as WIP (work in progress)
+
+   See https://gerrit-review.googlesource.com/Documentation/intro-user.html#wip.
+* `--ready` — Unmarks the change as WIP (work in progress)
+* `--private` — Marks the change as private
+
+   See https://gerrit-review.googlesource.com/Documentation/intro-user.html#private-changes.
+* `--remove-private` — Unmarks the change as private
+* `--publish-comments` — Publishes any draft comments for the given change
+* `--no-publish-comments` — Disables publishing of any draft comments for the given change
+
+   This is only useful if the user has configured Gerrit to publish comments by default.
+* `--notify <NOTIFY>` — Who to email notifications to (defaults to all)
+
+  Possible values:
+  - `none`:
+    No emails
+  - `owner`:
+    Only the change owner is notified
+  - `owner-reviewers`:
+    Only the change owner and reviewers will be notified
+  - `all`:
+    All relevant users, including owner, reviewers, cc'd, users that have starred the change, and users who have configured a watch on files in the change
+
+* `--submit` — Directly submit the changes, bypassing code review
+* `--skip-validation` — When --submit is provided, skip performing validations
+* `--ignore-attention-set` — Do not modify the attention set upon uploading
+* `--deadline <DEADLINE>` — The deadline after which the push should be aborted
+* `--custom <CUSTOM>` — Send the following custom keyed values to Gerrit (can be repeated)
+
+   See https://gerrit-review.googlesource.com/Documentation/user-upload.html#custom_keyed_values
+* `--trace <TRACE>` — For debugging Gerrit
+
+   See https://gerrit-review.googlesource.com/Documentation/user-upload.html#trace
 
 
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3004,7 +3004,14 @@ pub fn push_branches(
         })
         .collect_vec();
 
-    let push_stats = push_updates(mut_repo, subprocess_options, remote, &ref_updates, callback)?;
+    let push_stats = push_updates(
+        mut_repo,
+        subprocess_options,
+        remote,
+        &ref_updates,
+        &[],
+        callback,
+    )?;
     tracing::debug!(?push_stats);
 
     let pushed: HashSet<&GitRefName> = push_stats.pushed.iter().map(AsRef::as_ref).collect();
@@ -3056,6 +3063,7 @@ pub fn push_updates(
     subprocess_options: GitSubprocessOptions,
     remote_name: &RemoteName,
     updates: &[GitRefUpdate],
+    extra_args: &[&str],
     callback: &mut dyn GitSubprocessCallback,
 ) -> Result<GitPushStats, GitPushError> {
     let mut qualified_remote_refs_expected_locations = HashMap::new();
@@ -3092,7 +3100,7 @@ pub fn push_updates(
         .map(|full_refspec| RefToPush::new(full_refspec, &qualified_remote_refs_expected_locations))
         .collect();
 
-    let mut push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, callback)?;
+    let mut push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, extra_args, callback)?;
     push_stats.pushed.sort();
     push_stats.rejected.sort();
     push_stats.remote_rejected.sort();

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -262,6 +262,7 @@ impl GitSubprocessContext {
         &self,
         remote_name: &RemoteName,
         references: &[RefToPush],
+        extra_args: &[&str],
         callback: &mut dyn GitSubprocessCallback,
     ) -> Result<GitPushStats, GitSubprocessError> {
         let mut command = self.create_command();
@@ -280,6 +281,7 @@ impl GitSubprocessContext {
                 .iter()
                 .map(|reference| format!("--force-with-lease={}", reference.to_git_lease())),
         );
+        command.args(extra_args);
         command.args(["--", remote_name.as_str()]);
         // with --force-with-lease we cannot have the forced refspec,
         // as it ignores the lease

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -4883,6 +4883,7 @@ fn test_push_updates_unexpectedly_moved_sideways_on_remote() {
             subprocess_options,
             "origin".as_ref(),
             &targets,
+            &[],
             &mut NullCallback,
         )
     };
@@ -4967,6 +4968,7 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote() {
             subprocess_options,
             "origin".as_ref(),
             &targets,
+            &[],
             &mut NullCallback,
         )
     };
@@ -5031,6 +5033,7 @@ fn test_push_updates_unexpectedly_exists_on_remote() {
             subprocess_options,
             "origin".as_ref(),
             &targets,
+            &[],
             &mut NullCallback,
         )
     };
@@ -5067,6 +5070,7 @@ fn test_push_updates_success() {
             expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
+        &[],
         &mut NullCallback,
     )
     .unwrap();
@@ -5113,6 +5117,7 @@ fn test_push_updates_no_such_remote() {
             expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
+        &[],
         &mut NullCallback,
     );
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
@@ -5133,6 +5138,7 @@ fn test_push_updates_invalid_remote() {
             expected_current_target: Some(setup.main_commit.id().clone()),
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
+        &[],
         &mut NullCallback,
     );
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));


### PR DESCRIPTION
See https://gerrit-review.googlesource.com/Documentation/user-upload.html.

Note that although some options only show how to use the %suffix in the documentation, I have tested and they also support the `-o` flag on push.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
