### PR TITLE
docs: Mention -o flag instead of -d

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -47,12 +47,12 @@ use crate::ui::Ui;
 /// * `jj commit` doesn't have a `-r` option. It always acts on the working-copy
 ///   commit (@).
 ///
-/// * `jj split` (without `-d`/`-A`/`-B`) will move bookmarks forward from the
+/// * `jj split` (without `-o`/`-A`/`-B`) will move bookmarks forward from the
 ///   old change to the child change. `jj commit` doesn't move bookmarks
 ///   forward.
 ///
 /// * `jj split` allows you to move the selected changes to a different
-///   destination with `-d`/`-A`/`-B`.
+///   destination with `-o`/`-A`/`-B`.
 #[derive(clap::Args, Clone, Debug)]
 pub(crate) struct CommitArgs {
     /// Interactively choose which changes to include in the current commit

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -623,9 +623,9 @@ When using `--interactive` or path arguments, the selected changes stay in the c
 
 * `jj commit` doesn't have a `-r` option. It always acts on the working-copy commit (@).
 
-* `jj split` (without `-d`/`-A`/`-B`) will move bookmarks forward from the old change to the child change. `jj commit` doesn't move bookmarks forward.
+* `jj split` (without `-o`/`-A`/`-B`) will move bookmarks forward from the old change to the child change. `jj commit` doesn't move bookmarks forward.
 
-* `jj split` allows you to move the selected changes to a different destination with `-d`/`-A`/`-B`.
+* `jj split` allows you to move the selected changes to a different destination with `-o`/`-A`/`-B`.
 
 **Usage:** `jj commit [OPTIONS] [FILESETS]...`
 


### PR DESCRIPTION
Replaces a mention of the `-d` flag for the `split` command.

The `-d` flag is still used in some tests, but these are the only user-facing instances I found.