### PR TITLE
cli: add template argument for commit, split, describe and squash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `TreeDiffEntry` now has a `status_char()` method that returns
   single-character status codes (M/A/D/C/R).
 
+* Commands `commit`, `split`, squash and `describe` accept `-T` argument to
+  select commit description template. In addition, the default template can be
+  changed with `ui.commit-description-template` configuration field.
+
 ### Fixed bugs
 
 * Broken symlink on Windows. [#6934](https://github.com/jj-vcs/jj/issues/6934).

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -104,6 +104,24 @@ pub(crate) struct CommitArgs {
         value_parser = parse_author
     )]
     author: Option<(String, String)>,
+    /// Render commit description using the given template
+    ///
+    /// Run `jj commit -T` to list the built-in templates.
+    ///
+    /// You can also specify arbitrary template expressions using the
+    /// [built-in keywords]. See [`jj help -k templates`] for more
+    /// information.
+    ///
+    /// If not specified, this defaults to `template.draft_commit_description`
+    /// setting.
+    ///
+    /// [built-in keywords]:
+    ///     https://docs.jj-vcs.dev/latest/templates/#commit-keywords
+    ///
+    /// [`jj help -k templates`]:
+    ///     https://docs.jj-vcs.dev/latest/templates/
+    #[arg(long, short = 'T', add = ArgValueCandidates::new(complete::template_aliases))]
+    template: Option<String>,
 }
 
 #[instrument(skip_all)]
@@ -197,7 +215,7 @@ new working-copy commit.
         commit_builder.set_description(description);
         let temp_commit = commit_builder.write_hidden()?;
         let intro = "";
-        let description = description_template(ui, &tx, intro, &temp_commit)?;
+        let description = description_template(ui, &tx, intro, &temp_commit, &args.template)?;
         let description = edit_description(&text_editor, &description)?;
         if description.is_empty() {
             writedoc!(

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -222,6 +222,10 @@
                         }
                     ]
                 },
+                "commit-description-template": {
+                    "description": "Default template to use on commit, split, describe and squash",
+                    "type": "string"
+                },
                 "merge-editor": {
                     "description": "Tool to use for resolving three-way merges. Behavior for a given tool name can be configured in merge-tools.TOOL tables",
                     "default": ":builtin",
@@ -239,7 +243,7 @@
                 },
                 "revsets-use-glob-by-default": {
                     "type": "boolean",
-                    "default": true,
+                   "default": true,
                     "description": "Whether to use glob string patterns in revsets by default"
                 },
                 "show-cryptographic-signatures": {

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -142,6 +142,19 @@ concat(
 )
 '''
 
+builtin_draft_commit_description_verbose = '''
+concat(
+  coalesce(description, default_commit_description, "\n"),
+  "\n",
+  "JJ: Change ID: " ++ format_short_change_id(change_id),
+  "\n",
+  surround(
+    "JJ: This commit contains the following changes:\n", "",
+    indent("JJ:     ", diff.git()),
+  ),
+)
+'''
+
 builtin_evolog_compact = '''
 concat(
   builtin_log_compact(commit),

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -641,6 +641,17 @@ When using `--interactive` or path arguments, the selected changes stay in the c
 * `--editor` — Open an editor to edit the change description
 
    Forces an editor to open when using `--message` to allow the message to be edited afterwards.
+* `-T`, `--template <TEMPLATE>` — Render commit description using the given template
+
+   Run `jj commit -T` to list the built-in templates.
+
+   You can also specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
+
+   If not specified, this defaults to `template.draft_commit_description` setting.
+
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#commit-keywords
+
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -837,6 +848,17 @@ Starts an editor to let you edit the description of changes. The editor will be 
 * `--editor` — Open an editor to edit the change description
 
    Forces an editor to open when using `--stdin` or `--message` to allow the message to be edited afterwards.
+* `-T`, `--template <TEMPLATE>` — Render commit description using the given template
+
+   Run `jj describe -T` to list the built-in templates.
+
+   You can also specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
+
+   If not specified, this defaults to `template.draft_commit_description` setting.
+
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#commit-keywords
+
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -2983,6 +3005,17 @@ achieved with `jj new`.
 
    Forces an editor to open when using `--message` to allow the message to be edited afterwards.
 * `-p`, `--parallel` — Split the revision into two parallel revisions instead of a parent and child
+* `-T`, `--template <TEMPLATE>` — Render commit description using the given template
+
+   Run `jj split -T` to list the built-in templates.
+
+   You can also specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
+
+   If not specified, this defaults to `template.draft_commit_description` setting.
+
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#commit-keywords
+
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 
@@ -3030,6 +3063,17 @@ An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. U
 * `-i`, `--interactive` — Interactively choose which parts to squash
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-k`, `--keep-emptied` — The source revision will not be abandoned
+* `-T`, `--template <TEMPLATE>` — Render commit description using the given template
+
+   Run `jj squash -T` to list the built-in templates.
+
+   You can also specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
+
+   If not specified, this defaults to `template.draft_commit_description` setting.
+
+   [built-in keywords]: https://docs.jj-vcs.dev/latest/templates/#commit-keywords
+
+   [`jj help -k templates`]: https://docs.jj-vcs.dev/latest/templates/
 
 
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1197,6 +1197,7 @@ fn test_template_alias() {
     builtin_config_list
     builtin_config_list_detailed
     builtin_draft_commit_description
+    builtin_draft_commit_description_verbose
     builtin_evolog_compact
     builtin_log_comfortable
     builtin_log_compact

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -585,6 +585,7 @@ fn test_evolog_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_verbose
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -48,6 +48,7 @@ fn test_log_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_verbose
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -193,6 +193,7 @@ fn test_op_log_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_verbose
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -336,6 +336,7 @@ fn test_show_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_verbose
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -131,7 +131,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword `builtin` doesn't exist
-    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`?
+    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_draft_commit_description_verbose`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`?
     [EOF]
     [exit status: 1]
     ");

--- a/docs/config.md
+++ b/docs/config.md
@@ -248,6 +248,23 @@ keys can be supplied here, the first key is the most significant.
 When the `--sort` option is used with `jj bookmark list`, the configuration
 is ignored.
 
+### Commit description template
+
+You can configure default commit description template. That template is shown
+when you describe, commit, split or anything else that ask you to write a
+commit description.
+
+By default, the template `draft_commit_description` is used. You can use
+`builtin_draft_commit_description_verbose` as an alternativ to see a diff
+of what you're describing. Like `git commit -v` would do.
+
+```toml
+[ui]
+commit-description-template = "builtin_draft_commit_description_verbose"
+```
+
+That configuration is overriden by the `-T` argument.
+
 ### Commit trailers
 
 You can configure automatic addition of one or more trailers to commit


### PR DESCRIPTION
The goal of that commit is to be able with jj to see what we modified in the editor when we're describing. Like `git commit -v` does.

- add a template argument `-T` with `draft_commit_description` as default for concerned commands (commit, split, describe, squash)
- add setting `ui.commit-description-template` to replace the default template
- add `builtin_draft_commit_description_verbose` template that print full diff instead of just summary

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
