### PR TITLE
cli: track copies/renames (copy_records) in inter_diff of evolog

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -1472,11 +1472,19 @@ fn builtin_commit_evolution_entry_methods<'repo>()
                 let predecessors: Vec<_> = entry.predecessors().try_collect()?;
                 let from_tree = rebase_to_dest_parent(repo, &predecessors, &entry.commit)?;
                 let to_tree = entry.commit.tree();
+                let mut copy_records = CopyRecords::default();
+                let records = diff_util::get_copy_records_for_trees(
+                    repo.store(),
+                    &from_tree,
+                    &to_tree,
+                    &*matcher,
+                )?;
+                copy_records.add_records(records)?;
                 Ok(TreeDiff {
                     from_tree,
                     to_tree,
                     matcher: matcher.clone(),
-                    copy_records: CopyRecords::default(), // TODO: copy tracking
+                    copy_records,
                 })
             });
             Ok(out_property.into_dyn_wrapped())

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -90,8 +90,7 @@ fn test_evolog_with_or_without_diff() {
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
-    │  Added regular file file2:
-    │          1: foo
+    │  Modified regular file file2 (file1 => file2):
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
        -- operation e0f8e58b3800 new empty commit
@@ -187,13 +186,9 @@ fn test_evolog_with_or_without_diff() {
     @@ -1,1 +1,2 @@
      foo
     +bar
-    diff --git a/file2 b/file2
-    new file mode 100644
-    index 0000000000..257cc5642c
-    --- /dev/null
-    +++ b/file2
-    @@ -0,0 +1,1 @@
-    +foo
+    diff --git a/file1 b/file2
+    copy from file1
+    copy to file2
     rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
     -- operation e0f8e58b3800 new empty commit

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -498,6 +498,95 @@ impl GitBackend {
             .try_into_tree()
             .map_err(|err| to_read_object_err(err, &tree_id))
     }
+
+    fn read_tree_for_tree_id<'repo>(
+        &self,
+        repo: &'repo gix::Repository,
+        id: &TreeId,
+    ) -> BackendResult<gix::Tree<'repo>> {
+        let gix_id = validate_git_object_id(id)?;
+        repo.find_object(gix_id)
+            .map_err(|err| map_not_found_err(err, id))?
+            .try_into_tree()
+            .map_err(|err| to_read_object_err(err, id))
+    }
+
+    fn collect_copy_records_for_git_trees(
+        &self,
+        root_tree: gix::Tree<'_>,
+        head_tree: gix::Tree<'_>,
+        paths: Option<&[RepoPathBuf]>,
+    ) -> BackendResult<Vec<BackendResult<CopyRecord>>> {
+        let root_tree_id = TreeId::from_bytes(root_tree.id.as_bytes());
+        let head_tree_id = TreeId::from_bytes(head_tree.id.as_bytes());
+        let change_to_copy_record =
+            |change: gix::object::tree::diff::Change| -> BackendResult<Option<CopyRecord>> {
+                let gix::object::tree::diff::Change::Rewrite {
+                    source_location,
+                    source_entry_mode,
+                    source_id,
+                    entry_mode: dest_entry_mode,
+                    location: dest_location,
+                    ..
+                } = change
+                else {
+                    return Ok(None);
+                };
+                // TODO: Renamed symlinks cannot be returned because CopyRecord
+                // expects `source_file: FileId`.
+                if !source_entry_mode.is_blob() || !dest_entry_mode.is_blob() {
+                    return Ok(None);
+                }
+
+                let source = str::from_utf8(source_location)
+                    .map_err(|err| to_invalid_utf8_err(err, &root_tree_id))?;
+                let dest = str::from_utf8(dest_location)
+                    .map_err(|err| to_invalid_utf8_err(err, &head_tree_id))?;
+
+                let target = RepoPathBuf::from_internal_string(dest).unwrap();
+                if !paths.is_none_or(|paths| paths.contains(&target)) {
+                    return Ok(None);
+                }
+
+                Ok(Some(CopyRecord {
+                    target,
+                    target_commit: None,
+                    source: RepoPathBuf::from_internal_string(source).unwrap(),
+                    source_file: FileId::from_bytes(source_id.as_bytes()),
+                    source_commit: None,
+                }))
+            };
+
+        let mut records: Vec<BackendResult<CopyRecord>> = Vec::new();
+        root_tree
+            .changes()
+            .map_err(|err| BackendError::Other(err.into()))?
+            .options(|opts| {
+                opts.track_path().track_rewrites(Some(gix::diff::Rewrites {
+                    copies: Some(gix::diff::rewrites::Copies {
+                        source: gix::diff::rewrites::CopySource::FromSetOfModifiedFiles,
+                        percentage: Some(0.5),
+                    }),
+                    percentage: Some(0.5),
+                    limit: 1000,
+                    track_empty: false,
+                }));
+            })
+            .for_each_to_obtain_tree_with_cache(
+                &head_tree,
+                &mut self.new_diff_platform()?,
+                |change| -> BackendResult<_> {
+                    match change_to_copy_record(change) {
+                        Ok(None) => {}
+                        Ok(Some(change)) => records.push(Ok(change)),
+                        Err(err) => records.push(Err(err)),
+                    }
+                    Ok(gix::object::tree::diff::Action::Continue)
+                },
+            )
+            .map_err(|err| BackendError::Other(err.into()))?;
+        Ok(records)
+    }
 }
 
 /// Canonicalizes the given `path` except for the last `".git"` component.
@@ -1381,75 +1470,31 @@ impl Backend for GitBackend {
         head_id: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
         let repo = self.git_repo();
-        let root_tree = self.read_tree_for_commit(&repo, root_id)?;
-        let head_tree = self.read_tree_for_commit(&repo, head_id)?;
-
-        let change_to_copy_record =
-            |change: gix::object::tree::diff::Change| -> BackendResult<Option<CopyRecord>> {
-                let gix::object::tree::diff::Change::Rewrite {
-                    source_location,
-                    source_entry_mode,
-                    source_id,
-                    entry_mode: dest_entry_mode,
-                    location: dest_location,
-                    ..
-                } = change
-                else {
-                    return Ok(None);
-                };
-                // TODO: Renamed symlinks cannot be returned because CopyRecord
-                // expects `source_file: FileId`.
-                if !source_entry_mode.is_blob() || !dest_entry_mode.is_blob() {
-                    return Ok(None);
-                }
-
-                let source = str::from_utf8(source_location)
-                    .map_err(|err| to_invalid_utf8_err(err, root_id))?;
-                let dest = str::from_utf8(dest_location)
-                    .map_err(|err| to_invalid_utf8_err(err, head_id))?;
-
-                let target = RepoPathBuf::from_internal_string(dest).unwrap();
-                if !paths.is_none_or(|paths| paths.contains(&target)) {
-                    return Ok(None);
-                }
-
-                Ok(Some(CopyRecord {
-                    target,
-                    target_commit: head_id.clone(),
-                    source: RepoPathBuf::from_internal_string(source).unwrap(),
-                    source_file: FileId::from_bytes(source_id.as_bytes()),
-                    source_commit: root_id.clone(),
-                }))
-            };
-
-        let mut records: Vec<BackendResult<CopyRecord>> = Vec::new();
-        root_tree
-            .changes()
-            .map_err(|err| BackendError::Other(err.into()))?
-            .options(|opts| {
-                opts.track_path().track_rewrites(Some(gix::diff::Rewrites {
-                    copies: Some(gix::diff::rewrites::Copies {
-                        source: gix::diff::rewrites::CopySource::FromSetOfModifiedFiles,
-                        percentage: Some(0.5),
-                    }),
-                    percentage: Some(0.5),
-                    limit: 1000,
-                    track_empty: false,
-                }));
+        let root_id = root_id.clone();
+        let head_id = head_id.clone();
+        let root_tree = self.read_tree_for_commit(&repo, &root_id)?;
+        let head_tree = self.read_tree_for_commit(&repo, &head_id)?;
+        let records = self.collect_copy_records_for_git_trees(root_tree, head_tree, paths)?;
+        let records = records.into_iter().map(move |record| {
+            record.map(|mut record| {
+                record.target_commit = Some(head_id.clone());
+                record.source_commit = Some(root_id.clone());
+                record
             })
-            .for_each_to_obtain_tree_with_cache(
-                &head_tree,
-                &mut self.new_diff_platform()?,
-                |change| -> BackendResult<_> {
-                    match change_to_copy_record(change) {
-                        Ok(None) => {}
-                        Ok(Some(change)) => records.push(Ok(change)),
-                        Err(err) => records.push(Err(err)),
-                    }
-                    Ok(gix::object::tree::diff::Action::Continue)
-                },
-            )
-            .map_err(|err| BackendError::Other(err.into()))?;
+        });
+        Ok(Box::pin(futures::stream::iter(records)))
+    }
+
+    fn get_copy_records_for_tree_ids(
+        &self,
+        paths: Option<&[RepoPathBuf]>,
+        root_tree_id: &TreeId,
+        head_tree_id: &TreeId,
+    ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
+        let repo = self.git_repo();
+        let root_tree = self.read_tree_for_tree_id(&repo, root_tree_id)?;
+        let head_tree = self.read_tree_for_tree_id(&repo, head_tree_id)?;
+        let records = self.collect_copy_records_for_git_trees(root_tree, head_tree, paths)?;
         Ok(Box::pin(futures::stream::iter(records)))
     }
 

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -203,6 +203,16 @@ impl Backend for SecretBackend {
         self.inner.get_copy_records(paths, root, head)
     }
 
+    fn get_copy_records_for_tree_ids(
+        &self,
+        paths: Option<&[RepoPathBuf]>,
+        root_tree_id: &TreeId,
+        head_tree_id: &TreeId,
+    ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
+        self.inner
+            .get_copy_records_for_tree_ids(paths, root_tree_id, head_tree_id)
+    }
+
     fn gc(&self, index: &dyn Index, keep_newer: SystemTime) -> BackendResult<()> {
         self.inner.gc(index, keep_newer)
     }

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -111,6 +111,16 @@ impl Store {
         self.backend.get_copy_records(paths, root, head)
     }
 
+    pub fn get_copy_records_for_tree_ids(
+        &self,
+        paths: Option<&[RepoPathBuf]>,
+        root_tree_id: &TreeId,
+        head_tree_id: &TreeId,
+    ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
+        self.backend
+            .get_copy_records_for_tree_ids(paths, root_tree_id, head_tree_id)
+    }
+
     pub fn commit_id_length(&self) -> usize {
         self.backend.commit_id_length()
     }

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -14,7 +14,6 @@
 
 use futures::StreamExt as _;
 use itertools::Itertools as _;
-use jj_lib::backend::CommitId;
 use jj_lib::backend::CopyRecord;
 use jj_lib::backend::FileId;
 use jj_lib::backend::TreeValue;
@@ -708,8 +707,8 @@ fn create_copy_records(paths: &[(&RepoPath, &RepoPath)]) -> CopyRecords {
             Ok(CopyRecord {
                 source: source.to_owned(),
                 target: target.to_owned(),
-                target_commit: CommitId::new(vec![]),
-                source_commit: CommitId::new(vec![]),
+                target_commit: None,
+                source_commit: None,
                 source_file: FileId::new(vec![]),
             })
         }))


### PR DESCRIPTION
Add tree-based copy-record support so inter-diffs of evolog can show copy/rename semantics (instead of delete+add).

- cli: add `diff_util::get_copy_records_for_trees()` and use it from `DiffRenderer::show_inter_diff()` and `CommitEvolutionEntry.inter_diff()`.
- lib: make `CopyRecord` commit fields optional for synthetic-tree results.
- lib: add `Backend::get_copy_records_for_tree_ids()` defaulting to an empty stream, with `Store/SecretBackend` forwarding.
- git backend: implement tree-id copy detection by diffing two trees with `track_rewrites`, and attach commit ids only in commit-based `get_copy_records()`.

The motivation for this PR is that `inter_diff` often compares against a synthetic "rebased-to-destination-parents" tree (via `rebase_to_dest_parent()`), so copy/rename tracking wasn’t available and the output frequently misrepresented simple renames/copies as "delete + add". This makes `jj evolog -p/--git` and `CommitEvolutionEntry.inter_diff()` harder to read and less trustworthy when reviewing how a change evolved. By enabling copy/rename detection for tree-to-tree inter-diffs, evolog can present the same higher-level intent (rename/copy) that users expect from other diff views.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
