### PR TITLE
commit: allow Unicode characters in conflict labels

### DIFF
--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -217,7 +217,10 @@ impl Commit {
             format!(
                 "{} \"{}\"",
                 self.conflict_label_short(),
-                subject.escape_default()
+                // Control characters shouldn't be written in conflict markers, and '\0' isn't
+                // supported by the Git backend, so we just remove them. Unicode characters are
+                // supported, so we don't have to remove them.
+                subject.trim().replace(char::is_control, "")
             )
         } else {
             self.conflict_label_short()

--- a/lib/tests/test_git_backend.rs
+++ b/lib/tests/test_git_backend.rs
@@ -475,7 +475,10 @@ fn test_conflict_headers_roundtrip() {
         ]),
         ConflictLabels::from_vec(vec![
             "".into(),
-            "base 1".into(),
+            // Test that various UTF-8 characters can be encoded and decoded. Git doesn't allow
+            // storing arbitrary binary data in headers, but it does allow storing UTF-8 encoded
+            // strings as long as they don't contain U+0000 codepoints.
+            "base 1 \"utf8 \u{67d4}\u{8853} \u{ba4}\u{bc1}\u{bb0}\u{bc1} \u{2699}\u{fe0f}\"".into(),
             "side 2".into(),
             "".into(),
             "side 3".into(),


### PR DESCRIPTION
We only need to remove control characters. Git has support for UTF-8 in headers, so we can just directly include Unicode characters without escaping or replacing them.

Fixes #8467.

*Edit: I verified this by checking the Git source code as well as testing it locally using `git fsck` and `git cat-file -p`. The [Git code for parsing extra headers](https://github.com/git/git/blob/68cb7f9e92a5d8e9824f5b52ac3d0a9d8f653dbe/commit.c#L1487) doesn't rely on any particular encoding, since it only checks for `'\n'` to separate lines, as well as checking that continuation lines start with a space character. Separately, Git does check that the entire commit buffer (including extra headers) is valid UTF-8 [when writing commits](https://github.com/git/git/blob/68cb7f9e92a5d8e9824f5b52ac3d0a9d8f653dbe/commit.c#L1813). So it should be fine to write non-ASCII text as long as it is valid UTF-8, which Rust already guarantees for `String`.*

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
