### PR TITLE
file annotate: display an error for non-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   returns a `TreeDiff` between the entry's commit and its predecessor version.
   Optionally accepts a fileset literal to limit the diff.
 
+* `jj file annotate` now reports an error for non-files instead of succeeding
+  and displaying no content.
+
 ### Fixed bugs
 
 * Broken symlink on Windows. [#6934](https://github.com/jj-vcs/jj/issues/6934).

--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -78,10 +78,11 @@ pub(crate) fn cmd_file_annotate(
     let file_path = workspace_command.parse_file_path(&args.path)?;
     let file_value = starting_commit.tree().path_value(&file_path)?;
     let ui_path = workspace_command.format_file_path(&file_path);
+
     if file_value.is_absent() {
         return Err(user_error(format!("No such path: {ui_path}")));
     }
-    if file_value.is_tree() {
+    if file_value.to_file_merge().is_none() {
         return Err(user_error(format!(
             "Path exists but is not a regular file: {ui_path}"
         )));

--- a/cli/tests/test_file_annotate_command.rs
+++ b/cli/tests/test_file_annotate_command.rs
@@ -78,9 +78,13 @@ fn test_annotate_non_file() {
 
     if check_symlink_support().unwrap() {
         symlink_file("target", work_dir.root().join("symlink")).unwrap();
-
         let output = work_dir.run_jj(["file", "annotate", "symlink"]);
-        insta::assert_snapshot!(output, @"");
+        insta::assert_snapshot!(output, @"
+        ------- stderr -------
+        Error: Path exists but is not a regular file: symlink
+        [EOF]
+        [exit status: 1]
+        ");
     }
 }
 


### PR DESCRIPTION
`jj file annotate symlink` currently succeeds but displays nothing, which doesn't seem correct.

~NB: I am not sure about my new logic - I think that if a file wasn't _always_ a file, I may have made it an error.~
Turns out I misunderstood what the `path_value()` produced, and my logic seems OK.  Feedback still welcome.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
