### PR TITLE
split: add conflict labels

### DIFF
--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -738,6 +738,96 @@ fn test_split_parallel_with_merge_child() {
     ");
 }
 
+#[test]
+fn test_split_parallel_with_conflict() {
+    let mut test_env = TestEnvironment::default();
+    let diff_editor = test_env.set_up_fake_diff_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file", "line 1\nline 2\nline 3\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file", "line 1\nline 2.1\nline 2.2\nline 3\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file", "line 1\nline 3\n");
+    work_dir.run_jj(["prev", "--edit"]).success();
+    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    ○  kkmpptxzrspx false
+    @  rlvkpnrzqnoo false
+    ○  qpvuntsmwlqt false
+    ◆  zzzzzzzzzzzz true
+    [EOF]
+    ");
+
+    // Create a conflict by splitting two consecutive lines into parallel commits.
+    std::fs::write(
+        diff_editor,
+        ["write file\nline 1\nline 2.1\nline 3\n"].join("\0"),
+    )
+    .unwrap();
+    let output = work_dir.run_jj(["split", "--parallel", "-i", "-m="]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Selected changes : rlvkpnrz abe15fea (no description set)
+    Remaining changes: royxmykx ec55f25f (conflict) (no description set)
+    Working copy  (@) now at: royxmykx ec55f25f (conflict) (no description set)
+    Parent commit (@-)      : qpvuntsm ee8e9376 (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    Warning: There are unresolved conflicts at these paths:
+    file    2-sided conflict
+    New conflicts appeared in 1 commits:
+      royxmykx ec55f25f (conflict) (no description set)
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
+      jj new royxmykx
+    Then use `jj resolve`, or edit the conflict markers in the file directly.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
+    Then run `jj squash` to move the resolution into the conflicted commit.
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    ○    kkmpptxzrspx false
+    ├─╮
+    │ @  royxmykxtrkr false
+    ○ │  rlvkpnrzqnoo false
+    ├─╯
+    ○  qpvuntsmwlqt false
+    ◆  zzzzzzzzzzzz true
+    [EOF]
+    ");
+
+    // The new commit should be conflicted.
+    insta::assert_snapshot!(work_dir.read_file("file"), @r"
+    line 1
+    <<<<<<< conflict 1 of 1
+    %%%%%%% diff from: selected changes for split (from rlvkpnrz 35382813)
+    \\\\\\\        to: split revision (rlvkpnrz 35382813)
+     line 2.1
+    +line 2.2
+    +++++++ qpvuntsm ee8e9376 (parents of split revision)
+    line 2
+    >>>>>>> conflict 1 of 1 ends
+    line 3
+    ");
+
+    // The old commit shouldn't be conflicted, since it matches the selection from
+    // the editor.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=@+-~@", "file"]), @r"
+    line 1
+    line 2.1
+    line 3
+    [EOF]
+    ");
+
+    // The child merge commit should keep the same contents.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=@+", "file"]), @r"
+    line 1
+    line 3
+    [EOF]
+    ");
+}
+
 // Make sure `jj split` would refuse to split an empty commit.
 #[test]
 fn test_split_empty() {


### PR DESCRIPTION
Example of conflict resulting from split:

```
<<<<<<< conflict 1 of 1
%%%%%%% diff from: selected changes for split (from rlvkpnrz 35382813)
\\\\\\\        to: split revision (rlvkpnrz 35382813)
 line 2.1
+line 2.2
+++++++ qpvuntsm ee8e9376 (parents of split revision)
line 2
>>>>>>> conflict 1 of 1 ends
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
