### PR TITLE
docs: update changelog explanation for new conflict markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Template expansion that did not produce a terminating newline will not be
   fixed up to provide one by `jj log`, `jj evolog`, or `jj op log`.
 
+* The `diff` conflict marker style can now use `\\\\\\\` markers to indicate
+  the continuation of a conflict label from the previous line.
+
 ### Deprecations
 
 * The `git_head()` and `git_refs()` functions will be removed from revsets and
@@ -76,9 +79,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Early version of a `jj file search` command for searching for a pattern in
   files (like `git grep`).
 
-* Conflict labels can now contain information about where the sides of a
-  conflict came from (currently this is only supported for conflicts created by
-  certain commands).
+* Conflict labels now contain information about where the sides of a conflict
+  came from (e.g. `nlqwxzwn 7dd24e73 "first line of description"`).
 
 * `--insert-before` now accepts a revset that resolves to an empty set when
   used with `--insert-after`. The behavior is similar to `--onto`.


### PR DESCRIPTION
After #8471, every command supports conflict labels, so that note no longer makes sense. Also, we're missing a note about `\\\\\\\` which could break external tools that rely on our conflict markers.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
