### PR TITLE
merged_tree: fix panic when building tree with different number of sides

### DIFF
--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -1042,6 +1042,15 @@ impl MergedTreeBuilder {
         match new_tree_ids.simplify().into_resolved() {
             Ok(single_tree_id) => Ok(MergedTree::resolved(store, single_tree_id)),
             Err(tree_ids) => {
+                let labels = if labels.num_sides() == Some(tree_ids.num_sides()) {
+                    labels
+                } else {
+                    // If the number of sides changed, we need to discard the conflict labels,
+                    // otherwise `MergedTree::new` would panic.
+                    // TODO: we should preserve conflict labels when setting conflicted tree values
+                    // originating from a different tree than the base tree.
+                    ConflictLabels::unlabeled()
+                };
                 let tree = MergedTree::new(store, tree_ids, labels);
                 tree.resolve().block_on()
             }


### PR DESCRIPTION
`MergedTreeBuilder` supports setting conflicted tree values with different numbers of sides than the base tree. Currently this results in a panic when the tree has conflict labels because the labels end up with the wrong number of sides. This is a temporary fix to prevent that panic. Ideally we would preserve the conflict labels from every tree somehow, especially for `rewrite::restore_tree`.

@martinvonz This should fix the panic you found in https://github.com/jj-vcs/jj/pull/8472#issuecomment-3704039962 until we can implement a better solution.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
