### PR TITLE
git: ensure tracked remote refs are created for pushed bookmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj git push` now ensures that tracked remote bookmarks are updated even if
+  there are no mappings in the Git fetch refspecs.
+  [#5115](https://github.com/jj-vcs/jj/issues/5115)
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -885,6 +885,7 @@ Done";
             pushed,
             rejected,
             remote_rejected,
+            unexported_bookmarks: _,
         } = parse_ref_pushes(SAMPLE_PUSH_REFS_PORCELAIN_OUTPUT).unwrap();
         assert_eq!(
             pushed,


### PR DESCRIPTION
Fixes #5115

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
