### PR TITLE
`bookmark track`: basic completion for the --remote argument

### DIFF
--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -64,6 +64,8 @@ pub struct BookmarkTrackArgs {
     /// [string pattern syntax]:
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(long = "remote", value_name = "REMOTE")]
+    // TODO: Make this skip the remotes already tracked
+    #[arg(add = ArgValueCandidates::new(complete::git_remotes))]
     remotes: Option<Vec<String>>,
 }
 

--- a/cli/src/commands/bookmark/untrack.rs
+++ b/cli/src/commands/bookmark/untrack.rs
@@ -61,6 +61,8 @@ pub struct BookmarkUntrackArgs {
     /// [string pattern syntax]:
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(long = "remote", value_name = "REMOTE")]
+    // TODO: Make this skip untracked remotes
+    #[arg(add = ArgValueCandidates::new(complete::git_remotes))]
     remotes: Option<Vec<String>>,
 }
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -294,6 +294,22 @@ fn test_bookmark_names() {
     [EOF]
     ");
 
+    // TODO: Make it so this only lists untracked remotes
+    let output = work_dir.complete_fish(["bookmark", "track", "a", "--remote", ""]);
+    insta::assert_snapshot!(output, @"
+    origin
+    upstream
+    [EOF]
+    ");
+
+    // TODO: Make it so this only lists tracked remotes
+    let output = work_dir.complete_fish(["bookmark", "untrack", "a", "--remote", ""]);
+    insta::assert_snapshot!(output, @"
+    origin
+    upstream
+    [EOF]
+    ");
+
     let output = work_dir.complete_fish(["git", "push", "-b", "a"]);
     insta::assert_snapshot!(output, @r"
     aaa-local	x


### PR DESCRIPTION
This can be improved, see TODOs inline (and I might get to it), but something now is better than nothing.


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
