### PR TITLE
util: use user_error().hinted() in place of user_error_with_hint()

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -183,13 +183,6 @@ pub fn user_error(err: impl Into<Box<dyn error::Error + Send + Sync>>) -> Comman
     CommandError::new(CommandErrorKind::User, err)
 }
 
-pub fn user_error_with_hint(
-    err: impl Into<Box<dyn error::Error + Send + Sync>>,
-    hint: impl Into<String>,
-) -> CommandError {
-    user_error(err).hinted(hint)
-}
-
 pub fn user_error_with_message(
     message: impl Into<String>,
     source: impl Into<Box<dyn error::Error + Send + Sync>>,
@@ -489,14 +482,10 @@ impl From<MergeToolConfigError> for CommandError {
         match &err {
             MergeToolConfigError::MergeArgsNotConfigured { tool_name } => {
                 let tool_name = tool_name.clone();
-                user_error_with_hint(
-                    err,
-                    format!(
-                        "To use `{tool_name}` as a merge tool, the config \
-                         `merge-tools.{tool_name}.merge-args` must be defined (see docs for \
-                         details)"
-                    ),
-                )
+                user_error(err).hinted(format!(
+                    "To use `{tool_name}` as a merge tool, the config \
+                     `merge-tools.{tool_name}.merge-args` must be defined (see docs for details)"
+                ))
             }
             _ => user_error_with_message("Failed to load tool configuration", err),
         }
@@ -574,10 +563,9 @@ jj currently does not support partial clones. To use jj with this repository, tr
         fn from(err: GitFetchError) -> Self {
             match err {
                 GitFetchError::NoSuchRemote(_) => user_error(err),
-                GitFetchError::RemoteName(_) => user_error_with_hint(
-                    err,
-                    "Run `jj git remote rename` to give a different name.",
-                ),
+                GitFetchError::RemoteName(_) => {
+                    user_error(err).hinted("Run `jj git remote rename` to give a different name.")
+                }
                 GitFetchError::Subprocess(_) => user_error(err),
             }
         }
@@ -595,10 +583,8 @@ jj currently does not support partial clones. To use jj with this repository, tr
     impl From<GitRefExpansionError> for CommandError {
         fn from(err: GitRefExpansionError) -> Self {
             match &err {
-                GitRefExpansionError::Expression(_) => user_error_with_hint(
-                    err,
-                    "Specify patterns in `(positive | ...) & ~(negative | ...)` form.",
-                ),
+                GitRefExpansionError::Expression(_) => user_error(err)
+                    .hinted("Specify patterns in `(positive | ...) & ~(negative | ...)` form."),
                 GitRefExpansionError::InvalidBranchPattern(_) => user_error(err),
             }
         }
@@ -608,10 +594,9 @@ jj currently does not support partial clones. To use jj with this repository, tr
         fn from(err: GitPushError) -> Self {
             match err {
                 GitPushError::NoSuchRemote(_) => user_error(err),
-                GitPushError::RemoteName(_) => user_error_with_hint(
-                    err,
-                    "Run `jj git remote rename` to give a different name.",
-                ),
+                GitPushError::RemoteName(_) => {
+                    user_error(err).hinted("Run `jj git remote rename` to give a different name.")
+                }
                 GitPushError::Subprocess(_) => user_error(err),
                 GitPushError::UnexpectedBackend(_) => user_error(err),
             }

--- a/cli/src/commands/bookmark/create.rs
+++ b/cli/src/commands/bookmark/create.rs
@@ -22,7 +22,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::has_tracked_remote_bookmarks;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::revset_util;
 use crate::ui::Ui;
@@ -58,23 +58,22 @@ pub fn cmd_bookmark_create(
     let bookmark_names = &args.names;
     for name in bookmark_names {
         if view.get_local_bookmark(name).is_present() {
-            return Err(user_error_with_hint(
-                format!("Bookmark already exists: {name}", name = name.as_symbol()),
-                "Use `jj bookmark set` to update it.",
-            ));
+            return Err(user_error(format!(
+                "Bookmark already exists: {name}",
+                name = name.as_symbol()
+            ))
+            .hinted("Use `jj bookmark set` to update it."));
         }
         if has_tracked_remote_bookmarks(repo, name) {
-            return Err(user_error_with_hint(
-                format!(
-                    "Tracked remote bookmarks exist for deleted bookmark: {name}",
-                    name = name.as_symbol()
-                ),
-                format!(
-                    "Use `jj bookmark set` to recreate the local bookmark. Run `jj bookmark \
-                     untrack {name}` to disassociate them.",
-                    name = name.as_symbol()
-                ),
-            ));
+            return Err(user_error(format!(
+                "Tracked remote bookmarks exist for deleted bookmark: {name}",
+                name = name.as_symbol()
+            ))
+            .hinted(format!(
+                "Use `jj bookmark set` to recreate the local bookmark. Run `jj bookmark untrack \
+                 {name}` to disassociate them.",
+                name = name.as_symbol()
+            )));
         }
     }
     if target_commit.is_discardable(repo)? {

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -26,7 +26,7 @@ use super::warn_unmatched_local_bookmarks;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::revset_util::parse_union_name_patterns;
 use crate::ui::Ui;
@@ -126,13 +126,11 @@ pub fn cmd_bookmark_move(
             },
         )?
     {
-        return Err(user_error_with_hint(
-            format!(
-                "Refusing to move bookmark backwards or sideways: {name}",
-                name = name.as_symbol()
-            ),
-            "Use --allow-backwards to allow it.",
-        ));
+        return Err(user_error(format!(
+            "Refusing to move bookmark backwards or sideways: {name}",
+            name = name.as_symbol()
+        ))
+        .hinted("Use --allow-backwards to allow it."));
     }
     if target_commit.is_discardable(repo.as_ref())? {
         writeln!(ui.warning_default(), "Target revision is empty.")?;

--- a/cli/src/commands/bookmark/set.rs
+++ b/cli/src/commands/bookmark/set.rs
@@ -26,7 +26,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::has_tracked_remote_bookmarks;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::revset_util;
 use crate::ui::Ui;
@@ -79,13 +79,11 @@ pub fn cmd_bookmark_set(
             moved_bookmark_count += 1;
         }
         if !args.allow_backwards && !is_fast_forward(repo, old_target, target_commit.id())? {
-            return Err(user_error_with_hint(
-                format!(
-                    "Refusing to move bookmark backwards or sideways: {name}",
-                    name = name.as_symbol()
-                ),
-                "Use --allow-backwards to allow it.",
-            ));
+            return Err(user_error(format!(
+                "Refusing to move bookmark backwards or sideways: {name}",
+                name = name.as_symbol()
+            ))
+            .hinted("Use --allow-backwards to allow it."));
         }
     }
     if target_commit.is_discardable(repo)? {

--- a/cli/src/commands/diff.rs
+++ b/cli/src/commands/diff.rs
@@ -28,7 +28,7 @@ use crate::cli_util::RevisionArg;
 use crate::cli_util::print_unmatched_explicit_paths;
 use crate::cli_util::short_commit_hash;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
 use crate::diff_util::get_copy_records;
@@ -153,13 +153,12 @@ pub(crate) fn cmd_diff(
             )
             .evaluate_to_commit_ids()?;
         if let Some(commit_id) = gaps_revset.next() {
-            return Err(user_error_with_hint(
-                "Cannot diff revsets with gaps in.",
-                format!(
+            return Err(
+                user_error("Cannot diff revsets with gaps in.").hinted(format!(
                     "Revision {} would need to be in the set.",
                     short_commit_hash(&commit_id?)
-                ),
-            ));
+                )),
+            );
         }
         let heads: Vec<_> = workspace_command
             .attach_revset_evaluator(target_expression.heads())

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -26,7 +26,7 @@ use crate::cli_util::export_working_copy_changes_to_git;
 use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::print_unmatched_explicit_paths;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::ui::Ui;
 
@@ -91,8 +91,7 @@ pub(crate) fn cmd_file_untrack(
             } else {
                 format!("'{ui_path}' is not ignored.")
             };
-            return Err(user_error_with_hint(
-                message,
+            return Err(user_error(message).hinted(
                 "Files that are not ignored will be added back by the next command.
 Make sure they're ignored, then try again.",
             ));

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -38,7 +38,6 @@ use crate::cli_util::short_change_hash;
 use crate::command_error::CommandError;
 use crate::command_error::internal_error;
 use crate::command_error::user_error;
-use crate::command_error::user_error_with_hint;
 use crate::command_error::user_error_with_message;
 use crate::git_util::print_push_stats;
 use crate::git_util::with_remote_git_callbacks;
@@ -221,23 +220,21 @@ pub fn cmd_gerrit_upload(
     // Immediately error and reject any commits that shouldn't be uploaded.
     for commit in &to_upload {
         if commit.is_empty(tx.repo_mut())? {
-            return Err(user_error_with_hint(
-                format!(
-                    "Refusing to upload revision {} because it is empty",
-                    short_change_hash(commit.change_id())
-                ),
+            return Err(user_error(format!(
+                "Refusing to upload revision {} because it is empty",
+                short_change_hash(commit.change_id())
+            ))
+            .hinted(
                 "Perhaps you squashed then ran upload? Maybe you meant to upload the parent \
                  commit instead (eg. @-)",
             ));
         }
         if commit.description().is_empty() {
-            return Err(user_error_with_hint(
-                format!(
-                    "Refusing to upload revision {} because it is has no description",
-                    short_change_hash(commit.change_id())
-                ),
-                "Maybe you meant to upload the parent commit instead (eg. @-)",
-            ));
+            return Err(user_error(format!(
+                "Refusing to upload revision {} because it is has no description",
+                short_change_hash(commit.change_id())
+            ))
+            .hinted("Maybe you meant to upload the parent commit instead (eg. @-)"));
         }
     }
 

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -35,7 +35,7 @@ use crate::cli_util::start_repo_transaction;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::command_error::internal_error;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::command_error::user_error_with_message;
 use crate::commands::git::maybe_add_gitignore;
 use crate::config::ConfigEnv;
@@ -162,11 +162,12 @@ fn do_init(
         if colocated_git_repo_path.exists() {
             // Refuse to colocate inside a Git worktree
             if is_linked_git_worktree(workspace_root) {
-                return Err(user_error_with_hint(
-                    "Cannot create a colocated jj repo inside a Git worktree.",
-                    "Run `jj git init` in the main Git repository instead, or use `jj workspace \
-                     add` to create additional jj workspaces.",
-                ));
+                return Err(
+                    user_error("Cannot create a colocated jj repo inside a Git worktree.").hinted(
+                        "Run `jj git init` in the main Git repository instead, or use `jj \
+                         workspace add` to create additional jj workspaces.",
+                    ),
+                );
             }
             GitInitMode::External(colocated_git_repo_path)
         } else {
@@ -184,8 +185,10 @@ fn do_init(
         GitInitMode::External(git_repo_path)
     } else {
         if colocated_git_repo_path.exists() {
-            return Err(user_error_with_hint(
+            return Err(user_error(
                 "Did not create a jj repo because there is an existing Git repo in this directory.",
+            )
+            .hinted(
                 "To create a repo backed by the existing Git repo, run `jj git init --colocate` \
                  instead.",
             ));

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -59,7 +59,6 @@ use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::command_error::cli_error_with_message;
 use crate::command_error::user_error;
-use crate::command_error::user_error_with_hint;
 use crate::command_error::user_error_with_message;
 use crate::commands::git::get_single_remote;
 use crate::complete;
@@ -805,19 +804,20 @@ fn classify_bookmark_update(
 fn ensure_new_bookmark_name(repo: &dyn Repo, name: &RefName) -> Result<(), CommandError> {
     let symbol = name.as_symbol();
     if repo.view().get_local_bookmark(name).is_present() {
-        return Err(user_error_with_hint(
-            format!("Bookmark already exists: {symbol}"),
-            format!("Use 'jj bookmark move' to move it, and 'jj git push -b {symbol}' to push it"),
-        ));
+        return Err(
+            user_error(format!("Bookmark already exists: {symbol}")).hinted(format!(
+                "Use 'jj bookmark move' to move it, and 'jj git push -b {symbol}' to push it"
+            )),
+        );
     }
     if has_tracked_remote_bookmarks(repo, name) {
-        return Err(user_error_with_hint(
-            format!("Tracked remote bookmarks exist for deleted bookmark: {symbol}"),
-            format!(
-                "Use `jj bookmark set` to recreate the local bookmark. Run `jj bookmark untrack \
-                 {symbol}` to disassociate them."
-            ),
-        ));
+        return Err(user_error(format!(
+            "Tracked remote bookmarks exist for deleted bookmark: {symbol}"
+        ))
+        .hinted(format!(
+            "Use `jj bookmark set` to recreate the local bookmark. Run `jj bookmark untrack \
+             {symbol}` to disassociate them."
+        )));
     }
     Ok(())
 }

--- a/cli/src/commands/sign.rs
+++ b/cli/src/commands/sign.rs
@@ -25,7 +25,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::print_updated_commits;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::ui::Ui;
 
@@ -63,8 +63,8 @@ pub fn cmd_sign(ui: &mut Ui, command: &CommandHelper, args: &SignArgs) -> Result
     let mut workspace_command = command.workspace_helper(ui)?;
 
     if !workspace_command.repo().store().signer().can_sign() {
-        return Err(user_error_with_hint(
-            "No signing backend configured",
+        return Err(user_error(
+            "No signing backend configured").hinted(
             "For configuring a signing backend, see https://docs.jj-vcs.dev/latest/config/#commit-signing",
         ));
     }

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -42,7 +42,7 @@ use crate::cli_util::WorkspaceCommandTransaction;
 use crate::cli_util::compute_commit_location;
 use crate::cli_util::print_unmatched_explicit_paths;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::description_util::add_trailers;
 use crate::description_util::description_template;
@@ -209,13 +209,11 @@ impl SplitArgs {
     ) -> Result<ResolvedSplitArgs, CommandError> {
         let target_commit = workspace_command.resolve_single_rev(ui, &self.revision)?;
         if target_commit.is_empty(workspace_command.repo().as_ref())? {
-            return Err(user_error_with_hint(
-                format!(
-                    "Refusing to split empty commit {}.",
-                    target_commit.id().hex()
-                ),
-                "Use `jj new` if you want to create another empty commit.",
-            ));
+            return Err(user_error(format!(
+                "Refusing to split empty commit {}.",
+                target_commit.id().hex()
+            ))
+            .hinted("Use `jj new` if you want to create another empty commit."));
         }
         workspace_command.check_rewritable([target_commit.id()])?;
         let repo = workspace_command.repo();

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -39,7 +39,6 @@ use crate::cli_util::compute_commit_location;
 use crate::cli_util::print_unmatched_explicit_paths;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
-use crate::command_error::user_error_with_hint;
 use crate::complete;
 use crate::description_util::add_trailers;
 use crate::description_util::combine_messages_for_editing;
@@ -219,10 +218,10 @@ pub(crate) fn cmd_squash(
             .resolve_single_rev(ui, args.revision.as_ref().unwrap_or(&RevisionArg::AT))?;
         let mut parents: Vec<_> = source.parents().try_collect()?;
         if parents.len() != 1 {
-            return Err(user_error_with_hint(
-                "Cannot squash merge commits without a specified destination",
-                "Use `--into` to specify which parent to squash into",
-            ));
+            return Err(
+                user_error("Cannot squash merge commits without a specified destination")
+                    .hinted("Use `--into` to specify which parent to squash into"),
+            );
         }
         sources = vec![source];
         pre_existing_destination = Some(parents.pop().unwrap());

--- a/cli/src/commands/tag/set.rs
+++ b/cli/src/commands/tag/set.rs
@@ -21,7 +21,7 @@ use jj_lib::ref_name::RefNameBuf;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::command_error::CommandError;
-use crate::command_error::user_error_with_hint;
+use crate::command_error::user_error;
 use crate::complete;
 use crate::revset_util;
 use crate::ui::Ui;
@@ -66,10 +66,11 @@ pub fn cmd_tag_set(
         // TODO: If we add support for tracked remote tags, deleted tags should
         // be considered present until they get pushed. See cmd_bookmark_set().
         if old_target.is_present() && !args.allow_move {
-            return Err(user_error_with_hint(
-                format!("Refusing to move tag: {name}", name = name.as_symbol()),
-                "Use --allow-move to update existing tags.",
-            ));
+            return Err(user_error(format!(
+                "Refusing to move tag: {name}",
+                name = name.as_symbol()
+            ))
+            .hinted("Use --allow-move to update existing tags."));
         }
         if old_target.is_absent() {
             new_count += 1;

--- a/cli/src/commands/undo.rs
+++ b/cli/src/commands/undo.rs
@@ -21,7 +21,6 @@ use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::command_error::internal_error;
 use crate::command_error::user_error;
-use crate::command_error::user_error_with_hint;
 #[cfg(feature = "git")]
 use crate::commands::git::is_push_operation;
 use crate::commands::operation::DEFAULT_REVERT_WHAT;
@@ -164,10 +163,8 @@ pub fn cmd_undo(ui: &mut Ui, command: &CommandHelper, args: &UndoArgs) -> Result
         Ok(Some(parent_of_op_to_undo)) => parent_of_op_to_undo?,
         Ok(None) => return Err(user_error("Cannot undo root operation")),
         Err(_) => {
-            return Err(user_error_with_hint(
-                "Cannot undo a merge operation",
-                "Consider using `jj op restore` instead",
-            ));
+            return Err(user_error("Cannot undo a merge operation")
+                .hinted("Consider using `jj op restore` instead"));
         }
     };
 

--- a/cli/src/movement_util.rs
+++ b/cli/src/movement_util.rs
@@ -29,7 +29,6 @@ use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::short_commit_hash;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
-use crate::command_error::user_error_with_hint;
 use crate::ui::Ui;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -167,10 +166,8 @@ fn get_target_commit(
             .heads()
             .contains(working_commit_id)
     {
-        return Err(user_error_with_hint(
-            "The working copy must not have any children",
-            "Create a new commit on top of this one or use `--edit`",
-        ));
+        return Err(user_error("The working copy must not have any children")
+            .hinted("Create a new commit on top of this one or use `--edit`"));
     }
 
     // If we're editing, start at the working-copy commit. Otherwise, start from


### PR DESCRIPTION
user_error_with_hint() is longer and doesn't seem to enhance the code in a significant way

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
