### PR TITLE
codespell: never run codespell on svg files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ check-hidden = true
 # this list by running e.g. `uv run codespell --skip=./rendered-docs`
 # if you have less common ignored files or globally ignored files present.
 # Alternatively, try `uv run codespell $(jj file list)`.
-skip = "./target,./.jj,*.lock,./.git,./.venv,./.direnv,./demos/*.svg"
+skip = "./target,./.jj,*.lock,./.git,./.venv,./.direnv,**/*.svg"
 ignore-words-list = "crate,ser,NotIn,Wirth,abd,ratatui,grey"
 dictionary = ".config/codespell-additional-dict,-"
 builtin = "clear,rare,en-GB_to_en-US"


### PR DESCRIPTION
depending on how it is called, the files names may or may not include a leading './'. Our exclusion of svg files were not propely working if the path didn't have the leading './'.

fix: #8435

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
