### PR TITLE
templater: add object and array literal syntax for `json()`

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -495,6 +495,10 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
         Self::Core(CoreTemplatePropertyKind::wrap_list_template(template))
     }
 
+    fn wrap_json_value(property: BoxedSerializeProperty<'repo>) -> Self {
+        Self::Core(CoreTemplatePropertyKind::wrap_json_value(property))
+    }
+
     fn type_name(&self) -> &'static str {
         match self {
             Self::Core(property) => property.type_name(),

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -180,6 +180,10 @@ where
         Self::Core(CoreTemplatePropertyKind::wrap_list_template(template))
     }
 
+    fn wrap_json_value(property: BoxedSerializeProperty<'a>) -> Self {
+        Self::Core(CoreTemplatePropertyKind::wrap_json_value(property))
+    }
+
     fn type_name(&self) -> &'static str {
         match self {
             Self::Core(property) => property.type_name(),

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -293,6 +293,10 @@ impl CoreTemplatePropertyVar<'static> for OperationTemplateLanguagePropertyKind 
         Self::Core(CoreTemplatePropertyKind::wrap_list_template(template))
     }
 
+    fn wrap_json_value(property: BoxedSerializeProperty<'static>) -> Self {
+        Self::Core(CoreTemplatePropertyKind::wrap_json_value(property))
+    }
+
     fn type_name(&self) -> &'static str {
         match self {
             Self::Core(property) => property.type_name(),

--- a/cli/src/template.pest
+++ b/cli/src/template.pest
@@ -91,6 +91,15 @@ formal_parameters = {
   | ""
 }
 
+// Object literal: {"key": value, "key2": value2}
+// Keys must be quoted strings; trailing commas are allowed.
+object_entry = { string_literal ~ ":" ~ template }
+object_literal = { "{" ~ (object_entry ~ ("," ~ object_entry)* ~ ","?)? ~ "}" }
+
+// Array literal: [value1, value2, value3]
+// Trailing commas are allowed.
+array_literal = { "[" ~ (template ~ ("," ~ template)* ~ ","?)? ~ "]" }
+
 // NOTE: string pattern identifiers additionally allow "-" in them, which
 // results in some oddness with the `-` operator, though does not yet cause
 // ambiguity. This may prove annoying at some future point.
@@ -103,6 +112,8 @@ string_pattern = ${
 
 primary = {
   ("(" ~ template ~ ")")
+  | object_literal
+  | array_literal
   | function
   | lambda
   | string_pattern


### PR DESCRIPTION
This change adds support for constructing JSON objects and arrays directly in templates:
- Object literals: `{"key": value, "key2": value2}`
- Array literals: `[value1, value2, value3]`

This enables structured JSON output without relying on tab-delimited formatting for subprocess parsing:

```bash
jj log -T 'json({"id": commit_id, "desc": description.first_line()})'
```

Features:
- Trailing commas allowed
- Keys preserve insertion order, using `IndexMap`
- Nesting supported
- Expressions allowed as values, but they must be serializable types

Literals that produce a `SerializableValue` type can only be used with the `json()` template function (is that the right AOL keyword?). Using a `SerializableValue` outside of a `json()` template will result in a clear diagnostic error.

After I shared this change at ERSC, @ilyagr pointed me to @yuja's https://github.com/jj-vcs/jj/pull/6869 and told me about the existence of `json(self)`. This PR diverges from Yuya's by:
- adding support for arrays
- mimicking the JSON object syntax, like [`serde_json::json!`](https://docs.rs/serde_json/latest/serde_json/macro.json.html) macro does.
- Error reporting with spans.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes

<details>
<summary>A philosophical rant around programmability</summary>

While `jj log --no-graph -T 'json(self) ++ "\n"'  --config 'ui.log-word-wrap=false' --color never` would solve _my_ immediate issue, I still think JSON object/array literals are great affordances for jj to have, even if `json` handles a lot of uses. The analogy I'd like to draw here—that basically *nobody* will understand this comparison—but I view adding JSON object literals is morally equivalent to buck2's BXL, whereas `json(self)` feels like a Bazel aspect—the former is (marginally) more programmable/flexible than the latter, and I think the programmability makes products as a whole more hackable/accessible.

</details>