### PR TITLE
completion: only suggest set options for `jj config unset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   warnings. The configured `trunk()` alias will temporarily be disabled.
   [#8501](https://github.com/jj-vcs/jj/issues/8501)
 
+* Dynamic shell completion for `jj config unset` now only completes
+  configuration options which are set.
+  [#7774](https://github.com/jj-vcs/jj/issues/7774)
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights

--- a/cli/src/commands/config/unset.rs
+++ b/cli/src/commands/config/unset.rs
@@ -28,7 +28,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub struct ConfigUnsetArgs {
     #[arg(required = true)]
-    #[arg(add = ArgValueCandidates::new(complete::leaf_config_keys))]
+    #[arg(add = ArgValueCandidates::new(complete::config_keys_to_unset))]
     name: ConfigNamePathBuf,
 
     #[command(flatten)]


### PR DESCRIPTION
Fixes #7774.

For a config option to be used with `jj config unset`, it has to have been given a user-defined value in either of the user, repo, or workspace config files. It does not make any sense to unset an option which has not been set. However, the dynamic completions previously completed config options in the same way for both `jj config set` and `jj config unset`, using the config schema as the static list of viable options. Aside from the multitude of potentially irrelevant defaulted options, this also meant that user-defined options such as (revset-)aliases or templates were not completed.

This is fixed now by drawing on the information provided by `jj config list` to get the user-defined options. Unfortunately, clap_complete does not provide a way to inspect the preceding arguments, so in order to whittle down the list according to the specified config "level" (`--user`, `--repo`, `--workspace`), the completer function has to attempt some rudimentary manual command line argument parsing. If no level has been specified yet (i.e., to the left of the cursor's position when triggering completion), options from all three levels are suggested. However, the user will have to add the corresponding flag explicitly for the unset command to succeed.

In shells which support completion candidate help (Zsh, Fish, PowerShell with PSCompletions), the help string includes both the applicable config level and the value that would be unset.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- ~~[ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
- ~~[ ] I have updated the config schema (`cli/src/config-schema.json`)~~
- [x] I have added/updated tests to cover my changes
