### PR TITLE
changelog: use canonical `--branch` option name for `jj git fetch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,7 +644,7 @@ Thanks to the people who made this release happen!
   (it only undid the last change).
 
 * `jj git fetch` will now only fetch the refspec patterns configured on remotes
-  when the `--bookmark` option is omitted. Only simple refspec patterns are
+  when the `--branch` option is omitted. Only simple refspec patterns are
   currently supported, and anything else (like refspecs which rename branches)
   will be ignored.
 


### PR DESCRIPTION
`--bookmark` is an alias for `--branch` and not shown in the help output for `jj git fetch`.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
