### PR TITLE
cli: use `conflicts_with` and `conflicts_with_all` consistently depending on number of arguments

### DIFF
--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -64,18 +64,18 @@ pub struct BookmarkListArgs {
     ///
     /// [string pattern syntax]:
     ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
-    #[arg(long = "remote", value_name = "REMOTE", conflicts_with_all = ["all_remotes"])]
+    #[arg(long = "remote", value_name = "REMOTE", conflicts_with = "all_remotes")]
     #[arg(add = ArgValueCandidates::new(complete::git_remotes))]
     remotes: Option<Vec<String>>,
 
     /// Show tracked remote bookmarks only
     ///
     /// This omits local Git-tracking bookmarks by default.
-    #[arg(long, short, conflicts_with_all = ["all_remotes"])]
+    #[arg(long, short, conflicts_with = "all_remotes")]
     tracked: bool,
 
     /// Show conflicted bookmarks only
-    #[arg(long, short, conflicts_with_all = ["all_remotes"])]
+    #[arg(long, short, conflicts_with = "all_remotes")]
     conflicted: bool,
 
     /// Show bookmarks whose local name matches

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -152,8 +152,7 @@ pub(crate) struct SplitArgs {
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "onto",
-        conflicts_with = "parallel",
+        conflicts_with_all = ["onto", "parallel"],
         value_name = "REVSETS"
     )]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
@@ -169,8 +168,7 @@ pub(crate) struct SplitArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "onto",
-        conflicts_with = "parallel",
+        conflicts_with_all = ["onto", "parallel"],
         value_name = "REVSETS"
     )]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -114,8 +114,7 @@ pub(crate) struct SquashArgs {
         visible_alias = "destination",
         short,
         visible_short_alias = 'd',
-        conflicts_with = "into",
-        conflicts_with = "revision",
+        conflicts_with_all = ["into", "revision"],
         value_name = "REVSETS"
     )]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
@@ -127,9 +126,7 @@ pub(crate) struct SquashArgs {
         long,
         short = 'A',
         visible_alias = "after",
-        conflicts_with = "onto",
-        conflicts_with = "into",
-        conflicts_with = "revision",
+        conflicts_with_all = ["onto", "into", "revision"],
         value_name = "REVSETS"
     )]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
@@ -141,9 +138,7 @@ pub(crate) struct SquashArgs {
         long,
         short = 'B',
         visible_alias = "before",
-        conflicts_with = "onto",
-        conflicts_with = "into",
-        conflicts_with = "revision",
+        conflicts_with_all = ["onto", "into", "revision"],
         value_name = "REVSETS"
     )]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
