### PR TITLE
cli parallelize: add `-r` option

### DIFF
--- a/cli/src/commands/parallelize.rs
+++ b/cli/src/commands/parallelize.rs
@@ -56,10 +56,14 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 #[command(verbatim_doc_comment)]
 pub(crate) struct ParallelizeArgs {
-    /// Revisions to parallelize
+    /// The revisions to parallelize [aliases: -r]
     #[arg(value_name = "REVSETS")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
-    revisions: Vec<RevisionArg>,
+    revisions_pos: Vec<RevisionArg>,
+
+    #[arg(short = 'r', hide = true, value_name = "REVSETS")]
+    #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
+    revisions_opt: Vec<RevisionArg>,
 }
 
 #[instrument(skip_all)]
@@ -72,7 +76,7 @@ pub(crate) fn cmd_parallelize(
     // The target commits are the commits being parallelized. They are ordered
     // here with children before parents.
     let target_commits: Vec<Commit> = workspace_command
-        .parse_union_revsets(ui, &args.revisions)?
+        .parse_union_revsets(ui, &[&*args.revisions_pos, &*args.revisions_opt].concat())?
         .evaluate_to_commits()?
         .try_collect()?;
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2354,7 +2354,7 @@ descendant, and it was an ancestor of 3 before, so it remains an ancestor.
 
 ###### **Arguments:**
 
-* `<REVSETS>` — Revisions to parallelize
+* `<REVSETS>` — The revisions to parallelize [aliases: -r]
 
 
 

--- a/cli/tests/test_parallelize_command.rs
+++ b/cli/tests/test_parallelize_command.rs
@@ -251,7 +251,7 @@ fn test_parallelize_disconnected_target_commits() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["parallelize", "subject(1)", "subject(3)"]);
+    let output = work_dir.run_jj(["parallelize", "subject(1)", "-r=subject(3)"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
@@ -442,7 +442,7 @@ fn test_parallelize_multiple_heads_with_and_without_children() {
     ");
 
     work_dir
-        .run_jj(["parallelize", "subject(0)", "subject(1)"])
+        .run_jj(["parallelize", "-r=subject(0)", "subject(1)"])
         .success();
     insta::assert_snapshot!(get_log_output(&work_dir), @r"
     @  96d58e6cf428 2 parents: 0


### PR DESCRIPTION
This brings `jj parallelize` in line with other commands such as `jj new` and `jj duplicate` that take a `-r` option in addition to the positional argument.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
