### PR TITLE
docs: document core.excludesFile in file untrack help 

### DIFF
--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -35,8 +35,9 @@ use crate::ui::Ui;
 pub(crate) struct FileUntrackArgs {
     /// Paths to untrack. They must already be ignored.
     ///
-    /// The paths could be ignored via a .gitignore or .git/info/exclude (in
-    /// colocated workspaces).
+    /// The paths could be ignored via `.gitignore` files,
+    /// `$XDG_CONFIG_HOME/git/ignore`, Git's `core.excludesFile` config, or
+    /// `.git/info/exclude` (in colocated workspaces).
     #[arg(required = true, value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
     #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
     paths: Vec<String>,

--- a/docs/working-copy.md
+++ b/docs/working-copy.md
@@ -64,7 +64,8 @@ control. You can tell Jujutsu to not automatically track certain files by using
 `.gitignore` files (there's no such thing as `.jjignore` yet). See
 <https://git-scm.com/docs/gitignore> for details about the format. `.gitignore`
 files are supported in any directory in the working copy, as well as in
-`$XDG_CONFIG_HOME/git/ignore` and `$GIT_DIR/info/exclude`.
+`$XDG_CONFIG_HOME/git/ignore`, Git's `core.excludesFile` config, and
+`$GIT_DIR/info/exclude`.
 
 Ignored files are never tracked automatically (regardless of the value of
 `snapshot.auto-track`), but files that were already tracked will remain tracked


### PR DESCRIPTION
For the longest time, I could not figure out why `jj file untrack` was not respecting my global gitignore wishes. The root cause was that i have set a different global config for core.excludesFile and this wasn't properly documented. I'm submitting this patch in the hopes that it saves someone else a few moments of their time.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
