### PR TITLE
docs: specify remote bookmark in bookmark@remote form

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -41,7 +41,7 @@ $ jj commit -m 'feat(bar): add support for bar'
 # on the working-copy commit's *parent* because the working copy itself is empty.
 $ jj bookmark create bar -r @- # `bar` now contains the previous two commits.
 # Set the bookmark to be tracked on the remote.
-$ jj bookmark track bar
+$ jj bookmark track bar@origin
 # Push the bookmark to GitHub (pushes only `bar`)
 $ jj git push
 ```


### PR DESCRIPTION
I was working through the tutorial at <https://docs.jj-vcs.dev/latest/github/> when I hit an error caused by the `jj bookmark track` command. This change should fix it.

The change makes an assumption that the local repository has a remote called origin.

# Checklist

If applicable:

- [x] ~~I have updated `CHANGELOG.md`~~ n/a
- [x] ~~I have updated the documentation (`README.md`, `docs/`, `demos/`)~~ n/a
- [x] ~~I have updated the config schema (`cli/src/config-schema.json`)~~ n/a
- [x] ~~I have added/updated tests to cover my changes~~ n/a
