### PR TITLE
config: add auto-track-created-bookmarks setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * New `divergent()` revset function for divergent changes.
 
+* A new config option `remotes.<name>.auto-track-created-bookmarks` behaves
+  similarly to `auto-track-bookmarks`, but it only applies to bookmarks created
+  locally. Setting it to `"*"` is now the closest replacement for the deprecated
+  `git.push-new-bookmarks` option.
+
 ### Fixed bugs
 
 * `jj git push` now ensures that tracked remote bookmarks are updated even if

--- a/cli/src/commands/bookmark/create.rs
+++ b/cli/src/commands/bookmark/create.rs
@@ -84,7 +84,7 @@ pub fn cmd_bookmark_create(
     let mut tx = workspace_command.start_transaction();
     let remote_settings = tx.settings().remote_settings()?;
     let remote_auto_track_matchers =
-        revset_util::parse_remote_auto_track_bookmarks_map(ui, &remote_settings)?;
+        revset_util::parse_remote_auto_track_bookmarks_map_for_new_bookmarks(ui, &remote_settings)?;
     let readonly_repo = tx.base_repo().clone();
     for name in bookmark_names {
         tx.repo_mut()

--- a/cli/src/commands/bookmark/set.rs
+++ b/cli/src/commands/bookmark/set.rs
@@ -92,7 +92,7 @@ pub fn cmd_bookmark_set(
     let mut tx = workspace_command.start_transaction();
     let remote_settings = tx.settings().remote_settings()?;
     let remote_auto_track_matchers =
-        revset_util::parse_remote_auto_track_bookmarks_map(ui, &remote_settings)?;
+        revset_util::parse_remote_auto_track_bookmarks_map_for_new_bookmarks(ui, &remote_settings)?;
     let readonly_repo = tx.base_repo().clone();
     for name in bookmark_names {
         tx.repo_mut()

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -522,6 +522,11 @@
                         "type": "string",
                         "description": "A string pattern describing the bookmarks to automatically track with this remote. It will be applied to any new bookmark, created or fetched. See https://docs.jj-vcs.dev/latest/config/#automatic-tracking-of-bookmarks",
                         "default": "~*"
+                    },
+                    "auto-track-created-bookmarks": {
+                        "type": "string",
+                        "description": "A string pattern describing the locally-created bookmarks which should track this remote automatically. It will be applied to new bookmarks created with `jj bookmark create` or `jj bookmark set`. See https://docs.jj-vcs.dev/latest/config/#automatic-tracking-of-bookmarks",
+                        "default": "~*"
                     }
                 }
             }

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -26,6 +26,7 @@ use jj_lib::config::ConfigSource;
 use jj_lib::config::StackedConfig;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::ref_name::RefNameBuf;
+use jj_lib::ref_name::RemoteName;
 use jj_lib::ref_name::RemoteNameBuf;
 use jj_lib::repo::Repo;
 use jj_lib::revset;
@@ -377,25 +378,70 @@ pub fn parse_remote_auto_track_bookmarks_map(
         let Some(text) = &settings.auto_track_bookmarks else {
             continue;
         };
-        let mut diagnostics = RevsetDiagnostics::new();
-        let expr = revset::parse_string_expression(&mut diagnostics, text).map_err(|err| {
-            // From<RevsetParseError>, but with different message and error kind
-            let hint = revset_parse_error_hint(&err);
-            let message = format!(
-                "Invalid `remotes.{}.auto-track-bookmarks`: {}",
-                name.as_symbol(),
-                err.kind()
-            );
-            let mut cmd_err = config_error_with_message(message, err);
-            cmd_err.extend_hints(hint);
-            cmd_err
-        })?;
-        print_parse_diagnostics(
-            ui,
-            &format!("In `remotes.{}.auto-track-bookmarks`", name.as_symbol()),
-            &diagnostics,
-        )?;
+        let expr = parse_remote_auto_track_text(ui, name, text, "auto-track-bookmarks")?;
         matchers.insert(name.clone(), expr.to_matcher());
     }
     Ok(matchers)
+}
+
+/// Parses the given `remotes.<name>.auto-track-bookmarks` and
+/// `remotes.<name>.auto-track-created-bookmarks` settings into a map of string
+/// matchers. If both settings exist for the same remote, the union of the
+/// settings will be matched.
+pub fn parse_remote_auto_track_bookmarks_map_for_new_bookmarks(
+    ui: &Ui,
+    remote_settings: &RemoteSettingsMap,
+) -> Result<HashMap<RemoteNameBuf, StringMatcher>, CommandError> {
+    let mut matchers = HashMap::new();
+    for (name, settings) in remote_settings {
+        let mut exprs = Vec::new();
+        if let Some(text) = &settings.auto_track_bookmarks {
+            exprs.push(parse_remote_auto_track_text(
+                ui,
+                name,
+                text,
+                "auto-track-bookmarks",
+            )?);
+        }
+        if let Some(text) = &settings.auto_track_created_bookmarks {
+            exprs.push(parse_remote_auto_track_text(
+                ui,
+                name,
+                text,
+                "auto-track-created-bookmarks",
+            )?);
+        }
+        matchers.insert(
+            name.clone(),
+            StringExpression::union_all(exprs).to_matcher(),
+        );
+    }
+    Ok(matchers)
+}
+
+fn parse_remote_auto_track_text(
+    ui: &Ui,
+    name: &RemoteName,
+    text: &str,
+    field_name: &str,
+) -> Result<StringExpression, CommandError> {
+    let mut diagnostics = RevsetDiagnostics::new();
+    let expr = revset::parse_string_expression(&mut diagnostics, text).map_err(|err| {
+        // From<RevsetParseError>, but with different message and error kind
+        let hint = revset_parse_error_hint(&err);
+        let message = format!(
+            "Invalid `remotes.{}.{field_name}`: {}",
+            name.as_symbol(),
+            err.kind()
+        );
+        let mut cmd_err = config_error_with_message(message, err);
+        cmd_err.extend_hints(hint);
+        cmd_err
+    })?;
+    print_parse_diagnostics(
+        ui,
+        &format!("In `remotes.{}.{field_name}`", name.as_symbol()),
+        &diagnostics,
+    )?;
+    Ok(expr)
 }

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2139,6 +2139,7 @@ fn test_git_fetch_auto_track_bookmarks() {
         "
         [remotes.origin]
         auto-track-bookmarks = 'mine/*'
+        auto-track-created-bookmarks = '*'
         ",
     );
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1592,6 +1592,21 @@ reasons to restrict which bookmarks to track:
   auto-track-bookmarks = "main"
   ```
 
+- If you're collaborating with people on the same remote, but your bookmark
+  names don't follow a pattern that allows a bookmark's "owner" to be identified
+  (e.g. `alice/*`), you can use `auto-track-created-bookmarks` instead:
+
+  ```toml
+  [remotes.origin]
+  auto-track-created-bookmarks = "*"
+  ```
+
+  This pattern will only apply to bookmarks you create with `jj bookmark create`
+  and `jj bookmark set`. The disadvantage of this option is the fact that you
+  will have to track your own bookmarks manually if you fetch them from the
+  remote. This may happen regularly if you use multiple computers to work on the
+  same project.
+
 - Lastly, you may be working on various projects with different conventions for
   bookmark names. In that case, it can be handy to apply different configuration
   to different (groups of) repositories. Read about how to do that in the

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -66,6 +66,10 @@ pub struct RemoteSettings {
     /// String matcher expression whether to track bookmarks automatically.
     #[serde(default)]
     pub auto_track_bookmarks: Option<String>,
+    /// String matcher expression whether to track locally-created bookmarks
+    /// automatically.
+    #[serde(default)]
+    pub auto_track_created_bookmarks: Option<String>,
 }
 
 impl RemoteSettings {


### PR DESCRIPTION
- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes

closes #8503