### PR TITLE
templates: make config() return Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* The `config()` template function now returns `Option<ConfigValue>` instead of
+  failing if the config value is not found. This allows checking if a config
+  exists (e.g. `if(config("user.email"), ...)`).
+
 * Updated the executable bit representation in the local working copy to allow
   ignoring executable bit changes on Unix. By default we try to detect the
   filesystem's behavior, but this can be overridden manually by setting

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -539,20 +539,7 @@ fn test_templater_config_function() {
     [EOF]
     [exit status: 1]
     ");
-    insta::assert_snapshot!(render("config('unknown')"), @r"
-    ------- stderr -------
-    Error: Failed to parse template: Failed to get config value
-    Caused by:
-    1:  --> 1:1
-      |
-    1 | config('unknown')
-      | ^----^
-      |
-      = Failed to get config value
-    2: Value not found for unknown
-    [EOF]
-    [exit status: 1]
-    ");
+    insta::assert_snapshot!(render("config('unknown')"), @"");
 }
 
 #[must_use]

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -101,6 +101,8 @@ The following functions are defined.
 * `surround(prefix: Template, suffix: Template, content: Template) -> Template`:
   Surround **non-empty** content with texts such as parentheses.
 * `config(name: StringLiteral) -> ConfigValue`: Look up configuration value by `name`.
+   value by `name`.
+* `config(name: StringLiteral) -> Option<ConfigValue>`: Look up configuration
 * `git_web_url([remote: String]) -> String`: Best-effort conversion of a git
   remote URL to an HTTPS web URL. Defaults to the "origin" remote. Returns an
   empty string on failure. SSH host alias resolution is currently unsupported.


### PR DESCRIPTION
For missing config keys, `config(key)` now returns `None` instead of failing evaluation.

Fixes #8491