### PR TITLE
diff: show end of file newline status in color-words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* In color-words diffs, adding or removing a newline to the end of a file
+  is now shown.
+
 ### Fixed bugs
 
 * `jj git push` now ensures that tracked remote bookmarks are updated even if

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -1611,9 +1611,11 @@ fn test_diff_missing_newline() {
     Modified regular file file1:
        1    1: foo
             2: bar
+    (no terminating newline)
     Modified regular file file2:
        1    1: foo
        2     : bar
+    (no terminating newline)
     [EOF]
     ");
 
@@ -1708,6 +1710,7 @@ fn test_color_words_diff_missing_newline() {
             7: g
             8: h
             9: i
+    (removed terminating newline)
     === Modify first line
     Modified regular file file1:
        1    1: aA
@@ -1715,6 +1718,7 @@ fn test_color_words_diff_missing_newline() {
        3    3: c
        4    4: d
         ...
+    (no terminating newline)
     === Modify middle line
     Modified regular file file1:
        1    1: A
@@ -1726,6 +1730,7 @@ fn test_color_words_diff_missing_newline() {
        7    7: g
        8    8: h
        9    9: i
+    (no terminating newline)
     === Modify last line
     Modified regular file file1:
         ...
@@ -1733,6 +1738,7 @@ fn test_color_words_diff_missing_newline() {
        7    7: g
        8    8: h
        9    9: iI
+    (no terminating newline)
     === Append newline
     Modified regular file file1:
         ...
@@ -1740,6 +1746,7 @@ fn test_color_words_diff_missing_newline() {
        7    7: g
        8    8: h
        9    9: I
+    (added terminating newline)
     === Remove newline
     Modified regular file file1:
         ...
@@ -1747,6 +1754,7 @@ fn test_color_words_diff_missing_newline() {
        7    7: g
        8    8: h
        9    9: I
+    (removed terminating newline)
     === Empty
     Modified regular file file1:
        1     : A
@@ -1758,6 +1766,7 @@ fn test_color_words_diff_missing_newline() {
        7     : g
        8     : h
        9     : I
+    (added terminating newline)
     [EOF]
     ");
 
@@ -1784,6 +1793,7 @@ fn test_color_words_diff_missing_newline() {
             7: g
             8: h
             9: i
+    (removed terminating newline)
     === Modify first line
     Modified regular file file1:
        1     : a
@@ -1792,6 +1802,7 @@ fn test_color_words_diff_missing_newline() {
        3    3: c
        4    4: d
         ...
+    (no terminating newline)
     === Modify middle line
     Modified regular file file1:
        1    1: A
@@ -1804,6 +1815,7 @@ fn test_color_words_diff_missing_newline() {
        7    7: g
        8    8: h
        9    9: i
+    (no terminating newline)
     === Modify last line
     Modified regular file file1:
         ...
@@ -1812,6 +1824,7 @@ fn test_color_words_diff_missing_newline() {
        8    8: h
        9     : i
             9: I
+    (no terminating newline)
     === Append newline
     Modified regular file file1:
         ...
@@ -1820,6 +1833,7 @@ fn test_color_words_diff_missing_newline() {
        8    8: h
        9     : I
             9: I
+    (added terminating newline)
     === Remove newline
     Modified regular file file1:
         ...
@@ -1828,6 +1842,7 @@ fn test_color_words_diff_missing_newline() {
        8    8: h
        9     : I
             9: I
+    (removed terminating newline)
     === Empty
     Modified regular file file1:
        1     : A
@@ -1839,6 +1854,7 @@ fn test_color_words_diff_missing_newline() {
        7     : g
        8     : h
        9     : I
+    (added terminating newline)
     [EOF]
     ");
 }
@@ -2031,6 +2047,7 @@ fn test_diff_skipped_context() {
             8: h
             9: i
            10: j
+    (removed terminating newline)
     === Must skip 2 lines
     Modified regular file file1:
        1    1: aA
@@ -2042,6 +2059,7 @@ fn test_diff_skipped_context() {
        8    8: h
        9    9: i
       10   10: jJ
+    (no terminating newline)
     === Don't skip 1 line
     Modified regular file file1:
        1    1: aA
@@ -2054,6 +2072,7 @@ fn test_diff_skipped_context() {
        8    8: h
        9    9: iI
       10   10: j
+    (no terminating newline)
     === No gap to skip
     Modified regular file file1:
        1    1: a
@@ -2066,6 +2085,7 @@ fn test_diff_skipped_context() {
        8    8: h
        9    9: iI
       10   10: j
+    (no terminating newline)
     === No gap to skip
     Modified regular file file1:
        1    1: a
@@ -2078,6 +2098,7 @@ fn test_diff_skipped_context() {
        8    8: h
        9    9: iI
       10   10: j
+    (no terminating newline)
     === 1 line at start
     Modified regular file file1:
        1    1: a
@@ -2089,6 +2110,7 @@ fn test_diff_skipped_context() {
        7    7: g
        8    8: h
         ...
+    (no terminating newline)
     === 1 line at end
     Modified regular file file1:
         ...
@@ -2100,6 +2122,7 @@ fn test_diff_skipped_context() {
        8    8: h
        9    9: i
       10   10: j
+    (no terminating newline)
     [EOF]
     ");
 }
@@ -2136,11 +2159,13 @@ context = 0
             3: c
             4: d
             5: e
+    (removed terminating newline)
     === Must show 0 context
     Modified regular file file1:
         ...
        3    3: cC
         ...
+    (no terminating newline)
     [EOF]
     ");
 }
@@ -2249,33 +2274,39 @@ fn test_diff_skipped_context_nondefault() {
             2: b
             3: c
             4: d
+    (removed terminating newline)
     === Must skip 2 lines
     Modified regular file file1:
        1    1: aA
         ...
        4    4: dD
+    (no terminating newline)
     === Don't skip 1 line
     Modified regular file file1:
        1    1: aA
        2    2: b
        3    3: cC
        4    4: d
+    (no terminating newline)
     === No gap to skip
     Modified regular file file1:
        1    1: a
        2    2: bB
        3    3: cC
        4    4: d
+    (no terminating newline)
     === 1 line at start
     Modified regular file file1:
        1    1: a
        2    2: bB
         ...
+    (no terminating newline)
     === 1 line at end
     Modified regular file file1:
         ...
        3    3: cC
        4    4: d
+    (no terminating newline)
     [EOF]
     ");
 }

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -162,7 +162,7 @@ fn test_chmod_nonfile() {
 
     symlink_file("target", work_dir.root().join("symlink")).unwrap();
     let output = work_dir.run_jj(["show"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     Commit ID: 82976318a088d30054540d1a11ffb4c79fb5d47e
     Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
@@ -172,6 +172,7 @@ fn test_chmod_nonfile() {
 
     Added symlink symlink:
             1: target
+    (removed terminating newline)
     [EOF]
     ");
 

--- a/cli/tests/test_restore_command.rs
+++ b/cli/tests/test_restore_command.rs
@@ -213,6 +213,7 @@ fn test_restore_conflicted_merge() {
        7     : b
        8     : >>>>>>> conflict 1 of 1 ends
             1: resolution
+    (removed terminating newline)
     [EOF]
     "#);
 
@@ -253,6 +254,7 @@ fn test_restore_conflicted_merge() {
        7     : b
        8     : >>>>>>> conflict 1 of 1 ends
             1: resolution
+    (removed terminating newline)
     [EOF]
     "#);
 


### PR DESCRIPTION
Closes #5988 

Inspired by https://discord.com/channels/968932220549103686/1459005938718605376/1459005938718605376

The hint shows up in the same places it shows when `diff --git`. However, instead of one message per side missing trailing newline, output a single message stating the status.

No newline on either side:
```diff
--- a/never-newline
+++ b/never-newline
@@ -1,1 +1,1 @@
-before
\ No newline at end of file
+after
\ No newline at end of file
```
```
Modified regular file never-newline:
   1    1: beforeafter
(no newline at end of file)
```

Added newline:
```diff
--- a/add-newline
+++ b/add-newline
@@ -1,1 +1,1 @@
-before
\ No newline at end of file
+after
```
```
Modified regular file add-newline:
   1    1: beforeafter
(added newline at end of file)
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
