### PR TITLE
local_working_copy: honor --include-ignored with fsmonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to get pushed to gerrit.
   [#8568](https://github.com/jj-vcs/jj/issues/8568)
 
+* `jj file track --include-ignored` now works when `fsmonitor.backend="watchman"`.
+  [#8427](https://github.com/jj-vcs/jj/issues/8427)
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -98,6 +98,7 @@ use crate::matchers::FilesMatcher;
 use crate::matchers::IntersectionMatcher;
 use crate::matchers::Matcher;
 use crate::matchers::PrefixMatcher;
+use crate::matchers::UnionMatcher;
 use crate::merge::Merge;
 use crate::merge::MergeBuilder;
 use crate::merge::MergedTreeValue;
@@ -1279,7 +1280,10 @@ impl TreeState {
             Some(fsmonitor_matcher) => fsmonitor_matcher.as_ref(),
         };
 
-        let matcher = IntersectionMatcher::new(sparse_matcher.as_ref(), fsmonitor_matcher);
+        let matcher = IntersectionMatcher::new(
+            sparse_matcher.as_ref(),
+            UnionMatcher::new(fsmonitor_matcher, force_tracking_matcher),
+        );
         if matcher.visit(RepoPath::root()).is_nothing() {
             // No need to load the current tree, set up channels, etc.
             self.watchman_clock = watchman_clock;


### PR DESCRIPTION
Expand the fsmonitor matcher with force_tracking_matcher so explicitly requested paths are visited even when fsmonitor reports no changes. Fixes `jj file track --include-ignored` failing under watchman.

Partially addresses #8427.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
