### PR TITLE
local_working_copy: rescan subtree on .gitignore changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The empty tree is now always written when the working copy is empty.
   [#8480](https://github.com/jj-vcs/jj/issues/8480)
 
+* When using the Watchman filesystem monitor, changes to .gitignore now trigger
+  a scan of the affected subtree so newly unignored files are discovered.
+  [#8427](https://github.com/jj-vcs/jj/issues/8427)
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights


### PR DESCRIPTION
When Watchman reports .gitignore updates, include the parent prefix in the fsmonitor matcher and union it with explicit file paths. This ensures newly unignored files are discovered without a full repo scan.

Partially addresses #8427.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
