### PR TITLE
Docs: clarify description() uses regex pattern by default

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -327,8 +327,9 @@ revsets (expressions) as arguments.
   [string pattern](#string-patterns).
 
   A non-empty description is usually terminated with newline character. For
-  example, `description("")` matches commits without description, and
-  `description("foo\n")` matches commits with description `"foo\n"`.
+  example, `description("foo\n")` matches commits with description `"foo\n"`.
+  Note that this uses a [regex pattern](#string-patterns), so
+  `description(exact:"")` matches commits without description.
 
 * `subject(pattern)`: Commits that have a subject matching the given [string
   pattern](#string-patterns). A subject is the first line of the description


### PR DESCRIPTION
Update the revset documentation to note that description() uses a regex pattern by default, so exact:"" should be used to match commits without a description.