### PR TITLE
workspaces: use relative paths for workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj workspace add` now links with relative paths. This enables workspaces to work
+  inside containers or when moved together. Existing workspaces with absolute paths
+  will continue to work as before.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/lib/src/workspace.rs
+++ b/lib/src/workspace.rs
@@ -326,6 +326,7 @@ impl Workspace {
                 workspace_name,
             )?;
             let repo_loader = repo.loader().clone();
+            let repo_dir = dunce::canonicalize(&repo_dir).context(&repo_dir)?;
             let workspace = Self::new(workspace_root, repo_dir, working_copy, repo_loader)?;
             workspace_store.add(workspace.workspace_name(), workspace.workspace_root())?;
             Ok((workspace, repo))
@@ -365,8 +366,15 @@ impl Workspace {
         let jj_dir = create_jj_dir(workspace_root)?;
 
         let repo_dir = dunce::canonicalize(repo_path).context(repo_path)?;
+        let jj_dir_abs = dunce::canonicalize(&jj_dir).context(&jj_dir)?;
+        let path_to_store = file_util::relative_path(&jj_dir_abs, &repo_dir);
+        let path_to_store = if path_to_store.is_relative() {
+            file_util::slash_path(&path_to_store).into_owned()
+        } else {
+            path_to_store
+        };
         let repo_dir_bytes =
-            file_util::path_to_bytes(&repo_dir).map_err(WorkspaceInitError::EncodeRepoPath)?;
+            file_util::path_to_bytes(&path_to_store).map_err(WorkspaceInitError::EncodeRepoPath)?;
         let repo_file_path = jj_dir.join("repo");
         fs::write(&repo_file_path, repo_dir_bytes).context(&repo_file_path)?;
 


### PR DESCRIPTION
Hello!

Closes #5913

This updates the `jj workspace add` command to store relative paths by
default. This enables workspaces to work inside containers or when moved
together.


Thanks!

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
