### PR TITLE
templating: add more list type methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Templates now support `first()`, `last()`, `get(index)`, `reverse()`,
+  `skip(count)`, and `take(count)` methods on list types for more flexible
+  list manipulation.
+
 * `jj workspace add` now links with relative paths. This enables workspaces to work
   inside containers or when moved together. Existing workspaces with absolute paths
   will continue to work as before.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -352,6 +352,14 @@ defined.
   the predicate `expression`. Example: `parents.any(|c| c.description().contains("fix"))`
 * `.all(|item| expression) -> Boolean`: Returns true if all elements satisfy
   the predicate `expression`. Example: `parents.all(|c| c.mine())`
+* `.first() -> T`: Returns the first element. Errors if the list is empty.
+* `.last() -> T`: Returns the last element. Errors if the list is empty.
+* `.get(index: Integer) -> T`: Returns the element at `index` (0-based). Errors
+  if the index is out of bounds.
+* `.reverse() -> List`: Returns the list in reverse order.
+* `.skip(count: Integer) -> List`: Skips the first `count` elements and
+  returns the rest.
+* `.take(count: Integer) -> List`: Returns only the first `count` elements.
 
 ### `List<Trailer>` type
 


### PR DESCRIPTION
Hello!

Closes #7702 

This allows users to more easily manipulate lists in templates.

I have a custom template for merge commit descriptions, and I've grown tired of having to always manually update the list of the parents because the templates currently have no way to better manipulate them---the "into" comment is the first one.

```toml
draft_commit_description = '''
concat(
  if(
    !description && parents.len() > 1,
    concat(separate(" ",
      "Merge",
      if(parents.len() > 2, "branches", "branch"),
      "into",
      parents.map(|p| coalesce(
        p.bookmarks().map(|b| b.name()).join(", "),
        p.commit_id().short(),
      )).join(", "),
    )),
  ),
  builtin_draft_commit_description,
  "\nJJ: ignore-rest\n",
  diff.git(),
)
'''
```

For example, for `jj new preview develop` this would result in `Merge branch into preview, develop` and I have to manually update it to say `Merge branch develop into preview`. The PR allows me to use:

```toml
draft_commit_description = '''
concat(
  if(
    !description && parents.len() > 1,
    concat(separate(" ",
      "Merge",
      if(parents.len() > 2, "branches", "branch"),
      parents.skip(1).map(|p| coalesce(
        p.bookmarks().map(|b| b.name()).join(", "),
        p.commit_id().short(),
      )).join(", "),
      "into",
      coalesce(
        parents.first().bookmarks().map(|b| b.name()).join(", "),
        parents.first().commit_id().short(),
      ),
    )),
  ),
  builtin_draft_commit_description,
  "\nJJ: ignore-rest\n",
  diff.git(),
)
'''
```

which should directly give me what I want.

Thanks!

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
