### PR TITLE
StringMatcher: make match_lines() also match empty last line

### DIFF
--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -4562,7 +4562,7 @@ fn test_evaluate_expression_diff_contains(indexed: bool) {
         query(&format!(
             "diff_contains(exact:'', {empty_clean_inserted_deleted:?})",
         )),
-        vec![]
+        vec![commit4.id().clone(), commit3.id().clone()]
     );
     assert_eq!(
         query(&format!(


### PR DESCRIPTION
I also made the yielded lines not include the newline character because it seemed odd to include it there but not when matching.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
