### PR TITLE
Fix gerrit upload failures from being swallowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Setting the editor via `ui.editor`, `$EDITOR`, or `JJ_EDITOR` now respects shell quoting.
 
+* `jj gerrit upload` will no longer swallow errors and surface if changes fail
+  to get pushed to gerrit.
+  [#8568](https://github.com/jj-vcs/jj/issues/8568)
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights


### PR DESCRIPTION
Example output:

```
> jj gerrit upload -r @ -b non-existent-branch
Found 1 heads to push to Gerrit (remote 'origin'), target branch 'non-existent-branch'
Pushing mrzmqkty b6ac437c push-mrzmqktynomo* | aaa
remote: Resolving deltas: 100% (1/1)
remote: Processing changes: refs: 1, done
Warning: The remote rejected the following updates:
  refs/for/non-existent-branch (reason: branch non-existent-branch not found)
Hint: Try checking if you have permission to push to all the bookmarks.
Error: Failed to push all changes to gerrit

> $?
zsh: command not found: 1
```

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
