### PR TITLE
git fetch: add --verbose flag to show abandoned commit details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj git fetch` now shows details of abandoned commits (change IDs and
+  descriptions) by default, matching the `jj abandon` output format.
+  [#3081](https://github.com/jj-vcs/jj/issues/3081)
+
 * `jj git push --bookmark <name>` will now automatically track the bookmark if
   it isn't tracked with any remote already.
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1282,7 +1282,7 @@ impl WorkspaceCommandHelper {
             crate::git_util::load_git_import_options(ui, &git_settings, &remote_settings)?;
         let mut tx = self.start_transaction();
         let stats = git::import_refs(tx.repo_mut(), &import_options)?;
-        crate::git_util::print_git_import_stats(ui, tx.repo(), &stats, false)?;
+        crate::git_util::print_git_import_stats_summary(ui, &stats)?;
         if !tx.repo().has_changes() {
             return Ok(());
         }

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -413,7 +413,7 @@ fn fetch_new_remote(
         let remote_symbol = name.to_remote_symbol(remote_name);
         tx.repo_mut().track_remote_bookmark(remote_symbol)?;
     }
-    print_git_import_stats(ui, tx.repo(), &import_stats, true)?;
+    print_git_import_stats(ui, &tx, &import_stats)?;
     if git_settings.auto_local_bookmark && !should_track_default {
         writeln!(
             ui.hint_default(),

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -180,7 +180,8 @@ pub fn cmd_git_fetch(
     }
 
     let import_stats = git_fetch.import_refs()?;
-    print_git_import_stats(ui, tx.repo(), &import_stats, true)?;
+    print_git_import_stats(ui, &tx, &import_stats)?;
+
     if let Some(bookmark_expr) = &common_bookmark_expr {
         warn_if_branches_not_found(ui, &tx, bookmark_expr, &matching_remotes)?;
     }

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -45,7 +45,7 @@ pub fn cmd_git_import(
     // That's why cmd_git_export() doesn't export the HEAD ref.
     git::import_head(tx.repo_mut())?;
     let stats = git::import_refs(tx.repo_mut(), &import_options)?;
-    print_git_import_stats(ui, tx.repo(), &stats, true)?;
+    print_git_import_stats(ui, &tx, &stats)?;
     tx.finish(ui, "import git refs")?;
     Ok(())
 }

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -43,7 +43,7 @@ use crate::formatter::FormatterExt as _;
 use crate::git_util::is_colocated_git_workspace;
 use crate::git_util::load_git_import_options;
 use crate::git_util::print_git_export_stats;
-use crate::git_util::print_git_import_stats;
+use crate::git_util::print_git_import_stats_summary;
 use crate::ui::Ui;
 
 /// Create a new Git backed repo.
@@ -241,7 +241,7 @@ fn init_git_refs(
     // There should be no old refs to abandon, but enforce it.
     import_options.abandon_unreachable_commits = false;
     let stats = git::import_refs(tx.repo_mut(), &import_options)?;
-    print_git_import_stats(ui, tx.repo(), &stats, false)?;
+    print_git_import_stats_summary(ui, &stats)?;
     if !tx.repo().has_changes() {
         return Ok(repo);
     }

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -27,6 +27,7 @@ use crossterm::terminal::Clear;
 use crossterm::terminal::ClearType;
 use indoc::writedoc;
 use itertools::Itertools as _;
+use jj_lib::commit::Commit;
 use jj_lib::fmt_util::binary_prefix;
 use jj_lib::git;
 use jj_lib::git::FailedRefExportReason;
@@ -45,6 +46,8 @@ use jj_lib::workspace::Workspace;
 use unicode_width::UnicodeWidthStr as _;
 
 use crate::cleanup_guard::CleanupGuard;
+use crate::cli_util::WorkspaceCommandTransaction;
+use crate::cli_util::print_updated_commits;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::command_error::user_error;
@@ -209,41 +212,50 @@ pub fn load_git_import_options(
 
 pub fn print_git_import_stats(
     ui: &Ui,
-    repo: &dyn Repo,
+    tx: &WorkspaceCommandTransaction<'_>,
     stats: &GitImportStats,
-    show_ref_stats: bool,
 ) -> Result<(), CommandError> {
     let Some(mut formatter) = ui.status_formatter() else {
         return Ok(());
     };
-    if show_ref_stats {
-        for (kind, changes) in [
-            (GitRefKind::Bookmark, &stats.changed_remote_bookmarks),
-            (GitRefKind::Tag, &stats.changed_remote_tags),
-        ] {
-            let refs_stats = changes
-                .iter()
-                .map(|(symbol, (remote_ref, ref_target))| {
-                    RefStatus::new(kind, symbol.as_ref(), remote_ref, ref_target, repo)
-                })
-                .collect_vec();
-            let Some(max_width) = refs_stats.iter().map(|x| x.symbol.width()).max() else {
-                continue;
-            };
-            for status in refs_stats {
-                status.output(max_width, &mut *formatter)?;
-            }
+    for (kind, changes) in [
+        (GitRefKind::Bookmark, &stats.changed_remote_bookmarks),
+        (GitRefKind::Tag, &stats.changed_remote_tags),
+    ] {
+        let refs_stats = changes
+            .iter()
+            .map(|(symbol, (remote_ref, ref_target))| {
+                RefStatus::new(kind, symbol.as_ref(), remote_ref, ref_target, tx.repo())
+            })
+            .collect_vec();
+        let Some(max_width) = refs_stats.iter().map(|x| x.symbol.width()).max() else {
+            continue;
+        };
+        for status in refs_stats {
+            status.output(max_width, &mut *formatter)?;
         }
     }
 
     if !stats.abandoned_commits.is_empty() {
         writeln!(
             formatter,
-            "Abandoned {} commits that are no longer reachable.",
+            "Abandoned {} commits that are no longer reachable:",
             stats.abandoned_commits.len()
         )?;
+        let abandoned_commits: Vec<Commit> = stats
+            .abandoned_commits
+            .iter()
+            .map(|id| tx.repo().store().get_commit(id))
+            .try_collect()?;
+        let template = tx.commit_summary_template();
+        print_updated_commits(&mut *formatter, &template, &abandoned_commits)?;
     }
 
+    print_failed_git_import(ui, stats)?;
+    Ok(())
+}
+
+fn print_failed_git_import(ui: &Ui, stats: &GitImportStats) -> Result<(), CommandError> {
     if !stats.failed_ref_names.is_empty() {
         writeln!(ui.warning_default(), "Failed to import some Git refs:")?;
         let mut formatter = ui.stderr_formatter();
@@ -267,7 +279,22 @@ pub fn print_git_import_stats(
             name = git::REMOTE_NAME_FOR_LOCAL_GIT_REPO.as_symbol(),
         )?;
     }
+    Ok(())
+}
 
+/// Prints only the summary of git import stats (abandoned count, failed refs).
+/// Use this when a WorkspaceCommandTransaction is not available.
+pub fn print_git_import_stats_summary(ui: &Ui, stats: &GitImportStats) -> Result<(), CommandError> {
+    if !stats.abandoned_commits.is_empty()
+        && let Some(mut formatter) = ui.status_formatter()
+    {
+        writeln!(
+            formatter,
+            "Abandoned {} commits that are no longer reachable.",
+            stats.abandoned_commits.len()
+        )?;
+    }
+    print_failed_git_import(ui, stats)?;
     Ok(())
 }
 

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1368,7 +1368,8 @@ fn test_bookmark_track_untrack() {
     bookmark: feature2@origin [updated] untracked
     bookmark: feature3@origin [new] tracked
     bookmark: main@origin     [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commits that are no longer reachable:
+      psynomvr 48ec79a4 commit 2
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -728,7 +728,9 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
     ------- stderr -------
     bookmark: B_to_delete@origin [deleted] untracked
     bookmark: C_to_move@origin   [updated] tracked
-    Abandoned 2 commits that are no longer reachable.
+    Abandoned 2 commits that are no longer reachable:
+      royxmykx/1 dd905bab C_to_move@git | (divergent) (empty) original C
+      zsuskuln b2ea51c0 B_to_delete@git | (empty) B_to_delete
     [EOF]
     ");
     // "original C" and "B_to_delete" are abandoned, as the corresponding bookmarks

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -872,7 +872,9 @@ fn test_git_fetch_all() {
     bookmark: a2@origin     [updated] tracked
     bookmark: b@origin      [updated] tracked
     bookmark: trunk2@origin [new] tracked
-    Abandoned 2 commits that are no longer reachable.
+    Abandoned 2 commits that are no longer reachable:
+      yqosqzyt/1 d4d535f1 (divergent) a2
+      mzvwutvl/1 c8303692 (divergent) a1
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @r"
@@ -1060,7 +1062,8 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ------- stderr -------
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commits that are no longer reachable:
+      mzvwutvl/1 c8303692 (divergent) a1
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -1098,7 +1101,8 @@ fn test_git_fetch_some_of_many_bookmarks() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a2@origin [updated] tracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commits that are no longer reachable:
+      yqosqzyt/1 d4d535f1 (divergent) a2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -1652,7 +1656,8 @@ fn test_git_fetch_removed_bookmark() {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a2@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commits that are no longer reachable:
+      yqosqzyt d4d535f1 a2
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -1735,7 +1740,8 @@ fn test_git_fetch_removed_parent_bookmark() {
     ------- stderr -------
     bookmark: a1@origin     [deleted] untracked
     bookmark: trunk1@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commits that are no longer reachable:
+      mzvwutvl c8303692 a1
     Warning: No matching branches found on any specified/configured remote: master
     [EOF]
     ");

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1444,7 +1444,8 @@ fn test_op_diff() {
     bookmark: bookmark-1@origin [updated] tracked
     bookmark: bookmark-2@origin [updated] untracked
     bookmark: bookmark-3@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commits that are no longer reachable:
+      rnnkyono 11671e4c Commit 3
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff"]);
@@ -2550,7 +2551,8 @@ fn test_op_show() {
     bookmark: bookmark-1@origin [updated] tracked
     bookmark: bookmark-2@origin [updated] untracked
     bookmark: bookmark-3@origin [deleted] untracked
-    Abandoned 1 commits that are no longer reachable.
+    Abandoned 1 commits that are no longer reachable:
+      rnnkyono 11671e4c Commit 3
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show"]);


### PR DESCRIPTION
## Summary

Closes #3081

Abandoned commits are now shown with their change IDs and descriptions when fetching, matching the `jj abandon` output format.

**Example output:**
```
bookmark: main@origin [updated] tracked
Abandoned 2 commits that are no longer reachable:
  qpvuntsm 12345678 local work that was rebased
  kkmpptxz 87654321 another local commit
```

## Changes

- Abandoned commit details are now shown by default (limited to 10 commits)
- Uses `print_updated_commits()` with `commit_summary_template()` for consistent formatting
- When `--quiet` is specified, no abandoned commit information is shown

## Test Plan

- [x] All 40 git fetch tests pass
- [x] Verified `--quiet` suppresses output
- [x] Clippy passes