### PR TITLE
templater: add builtin `hyperlink()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * New `remote_tags()` revset function to query remote tags.
 
+* New builtin `hyperlink()` template function that gracefully falls back to
+  text when outputting to a non-terminal, instead of emitting raw OSC 8 escape
+  codes. [#7592](https://github.com/jj-vcs/jj/issues/7592)
+
 ### Fixed bugs
 
 * `jj git init --colocate` now refuses to run inside a Git worktree, providing

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3088,7 +3088,7 @@ impl LogContentFormat {
         content_fn: impl FnOnce(&mut dyn Formatter) -> Result<(), E>,
     ) -> Result<(), E> {
         if self.word_wrap {
-            let mut recorder = FormatRecorder::new();
+            let mut recorder = FormatRecorder::new(formatter.maybe_color());
             content_fn(&mut recorder)?;
             text_util::write_wrapped(formatter, &recorder, self.width)?;
         } else {

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -142,7 +142,7 @@ impl CommandError {
         &mut self,
         write: impl FnOnce(&mut dyn Formatter) -> io::Result<()>,
     ) {
-        let mut formatter = FormatRecorder::new();
+        let mut formatter = FormatRecorder::new(true);
         write(&mut formatter).expect("write() to FormatRecorder should never fail");
         self.add_formatted_hint(formatter);
     }

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -79,14 +79,6 @@ if(
 '''
 
 [template-aliases]
-'hyperlink(url, text)' = '''
-concat(
-  raw_escape_sequence("\e]8;;" ++ url ++ "\e\\"),
-  text,
-  raw_escape_sequence("\e]8;;\e\\"),
-)
-'''
-
 'format_config_item(x)' = '''
 if(x.overridden(),
   indent("# ", x.name() ++ " = " ++ x.value()),

--- a/cli/src/text_util.rs
+++ b/cli/src/text_util.rs
@@ -770,8 +770,8 @@ mod tests {
 
     #[test]
     fn test_write_truncated_labeled() {
-        let ellipsis_recorder = FormatRecorder::new();
-        let mut recorder = FormatRecorder::new();
+        let ellipsis_recorder = FormatRecorder::new(false);
+        let mut recorder = FormatRecorder::new(false);
         for (label, word) in [("red", "foo"), ("cyan", "bar")] {
             recorder.push_label(label);
             write!(recorder, "{word}").unwrap();
@@ -845,8 +845,8 @@ mod tests {
 
     #[test]
     fn test_write_truncated_non_ascii_chars() {
-        let ellipsis_recorder = FormatRecorder::new();
-        let mut recorder = FormatRecorder::new();
+        let ellipsis_recorder = FormatRecorder::new(false);
+        let mut recorder = FormatRecorder::new(false);
         write!(recorder, "a\u{300}bc\u{300}一二三").unwrap();
 
         // Truncate start
@@ -928,8 +928,8 @@ mod tests {
 
     #[test]
     fn test_write_truncated_empty_content() {
-        let ellipsis_recorder = FormatRecorder::new();
-        let recorder = FormatRecorder::new();
+        let ellipsis_recorder = FormatRecorder::new(false);
+        let recorder = FormatRecorder::new(false);
 
         // Truncate start
         insta::assert_snapshot!(
@@ -963,7 +963,7 @@ mod tests {
     #[test]
     fn test_write_truncated_ellipsis_labeled() {
         let ellipsis_recorder = FormatRecorder::with_data("..");
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         for (label, word) in [("red", "foo"), ("cyan", "bar")] {
             recorder.push_label(label);
             write!(recorder, "{word}").unwrap();
@@ -1050,7 +1050,7 @@ mod tests {
     #[test]
     fn test_write_truncated_ellipsis_non_ascii_chars() {
         let ellipsis_recorder = FormatRecorder::with_data("..");
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         write!(recorder, "a\u{300}bc\u{300}一二三").unwrap();
 
         // Truncate start
@@ -1115,7 +1115,7 @@ mod tests {
     #[test]
     fn test_write_truncated_ellipsis_empty_content() {
         let ellipsis_recorder = FormatRecorder::with_data("..");
-        let recorder = FormatRecorder::new();
+        let recorder = FormatRecorder::new(false);
 
         // Truncate start, empty content
         insta::assert_snapshot!(
@@ -1148,7 +1148,7 @@ mod tests {
 
     #[test]
     fn test_write_padded_labeled_content() {
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         for (label, word) in [("red", "foo"), ("cyan", "bar")] {
             recorder.push_label(label);
             write!(recorder, "{word}").unwrap();
@@ -1206,7 +1206,7 @@ mod tests {
     #[test]
     fn test_write_padded_labeled_fill_char() {
         let recorder = FormatRecorder::with_data("foo");
-        let mut fill = FormatRecorder::new();
+        let mut fill = FormatRecorder::new(false);
         fill.push_label("red");
         write!(fill, "=").unwrap();
         fill.pop_label();
@@ -1272,7 +1272,7 @@ mod tests {
 
     #[test]
     fn test_write_padded_empty_content() {
-        let recorder = FormatRecorder::new();
+        let recorder = FormatRecorder::new(false);
         let fill = FormatRecorder::with_data("=");
 
         // Pad start
@@ -1375,7 +1375,7 @@ mod tests {
         };
 
         // Basic tests
-        let recorder = FormatRecorder::new();
+        let recorder = FormatRecorder::new(true);
         insta::assert_snapshot!(
             format_colored(
                 |formatter| write_indented(formatter, &recorder, |fmt| write_prefix(fmt))
@@ -1414,7 +1414,7 @@ mod tests {
         );
 
         // Preserve labels
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(true);
         for (label, word) in [("red", "foo"), ("cyan", "bar\nbaz\n\nquux")] {
             recorder.push_label(label);
             write!(recorder, "{word}").unwrap();
@@ -1508,7 +1508,7 @@ mod tests {
     #[test]
     fn test_write_wrapped() {
         // Split single label chunk
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         recorder.push_label("red");
         write!(recorder, "foo bar baz\nqux quux\n").unwrap();
         recorder.pop_label();
@@ -1523,7 +1523,7 @@ mod tests {
         );
 
         // Multiple label chunks in a line
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         for (i, word) in ["foo ", "bar ", "baz\n", "qux ", "quux"].iter().enumerate() {
             recorder.push_label(["red", "cyan"][i & 1]);
             write!(recorder, "{word}").unwrap();
@@ -1540,7 +1540,7 @@ mod tests {
         );
 
         // Empty lines should not cause panic
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         for (i, word) in ["", "foo", "", "bar baz", ""].iter().enumerate() {
             recorder.push_label(["red", "cyan"][i & 1]);
             writeln!(recorder, "{word}").unwrap();
@@ -1558,7 +1558,7 @@ mod tests {
         );
 
         // Split at label boundary
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         recorder.push_label("red");
         write!(recorder, "foo bar").unwrap();
         recorder.pop_label();
@@ -1575,7 +1575,7 @@ mod tests {
         );
 
         // Do not split at label boundary "ba|z" (since it's a single word)
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         recorder.push_label("red");
         write!(recorder, "foo bar ba").unwrap();
         recorder.pop_label();
@@ -1593,7 +1593,7 @@ mod tests {
 
     #[test]
     fn test_write_wrapped_leading_labeled_whitespace() {
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         recorder.push_label("red");
         write!(recorder, " ").unwrap();
         recorder.pop_label();
@@ -1608,7 +1608,7 @@ mod tests {
     fn test_write_wrapped_trailing_labeled_whitespace() {
         // data: "foo" " "
         // line:  ---
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         write!(recorder, "foo").unwrap();
         recorder.push_label("red");
         write!(recorder, " ").unwrap();
@@ -1620,7 +1620,7 @@ mod tests {
 
         // data: "foo" "\n"
         // line:  ---     -
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         write!(recorder, "foo").unwrap();
         recorder.push_label("red");
         writeln!(recorder).unwrap();
@@ -1632,7 +1632,7 @@ mod tests {
 
         // data: "foo\n" " "
         // line:  ---    -
-        let mut recorder = FormatRecorder::new();
+        let mut recorder = FormatRecorder::new(false);
         writeln!(recorder, "foo").unwrap();
         recorder.push_label("red");
         write!(recorder, " ").unwrap();

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -415,7 +415,7 @@ impl Ui {
     }
 
     pub fn color(&self) -> bool {
-        self.formatter_factory.is_color()
+        self.formatter_factory.maybe_color()
     }
 
     pub fn new_formatter<'output, W: Write + 'output>(

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1524,6 +1524,27 @@ fn test_log_word_wrap() {
 }
 
 #[test]
+fn test_log_word_wrap_with_hyperlinks() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let template = r#"hyperlink("http://example.com", "long line to force wrapping")"#;
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["log", "-r@", "-T", template, "--color=always"])
+            .arg("--config=ui.log-word-wrap=true")
+            .env("COLUMNS", "10")
+    });
+    insta::assert_snapshot!(output, @r"
+    [1m[38;5;2m@[0m  ]8;;http://example.com\long
+    │  line to
+    ~  force
+       wrapping]8;;\
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_log_diff_stat_width() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -75,6 +75,11 @@ The following functions are defined.
 * `label(label: Stringify, content: Template) -> Template`: Apply a custom
   [color label](#color-labels) to the content. The `label` is evaluated as a
   space-separated string.
+* `hyperlink(url: Stringify, text: Template, [fallback: Template]) -> Template`:
+  Render `text` as a hyperlink to `url` using [OSC 8 escape sequences](https://github.com/Alhadis/OSC8-Adoption)
+  when outputting with color enabled. Otherwise, renders `fallback` instead,
+  which defaults to `text`. Use `--color=always` to force hyperlinks when piping
+  output to a terminal emulator that supports OSC 8.
 * `raw_escape_sequence(content: Template) -> Template`: Preserves any escape
   sequences in `content` (i.e., bypasses sanitization) and strips labels.
   Note: This function is intended for escape sequences and as such, its output
@@ -99,12 +104,6 @@ The following functions are defined.
 * `git_web_url([remote: String]) -> String`: Best-effort conversion of a git
   remote URL to an HTTPS web URL. Defaults to the "origin" remote. Returns an
   empty string on failure. SSH host alias resolution is currently unsupported.
-
-## Built-in Aliases
-
-* `hyperlink(url, text)`: Creates a clickable hyperlink using [OSC8 escape sequences](https://github.com/Alhadis/OSC8-Adoption).
-  The `text` will be displayed and clickable, linking to the given `url` in
-  terminals that support OSC8 hyperlinks.
 
 ## Types
 


### PR DESCRIPTION
Alternative to #7688 to specifically address the issue with the `hyperlink()` template alias raised in #7592.