### PR TITLE
completion: do not resolve aliases in the argument the cursor sits at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   configuration options which are set.
   [#7774](https://github.com/jj-vcs/jj/issues/7774)
 
+* Dynamic shell completion no longer attempts to resolve aliases at the
+  completion position. This previously prevented a fully-typed alias from
+  being accepted on some shells and replaced it entirely with its expansion on
+  bash. Now, the completion will only resolve the alias, and suggest candidates
+  accordingly, after the cursor has been advanced to the next position.
+  [#7773](https://github.com/jj-vcs/jj/issues/7773)
+
 * Setting the editor via `ui.editor`, `$EDITOR`, or `JJ_EDITOR` now respects shell quoting.
 
 * `jj gerrit upload` will no longer swallow errors and surface if changes fail

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3704,7 +3704,8 @@ fn handle_shell_completion(
                 .chain(std::iter::repeat_n(OsString::new(), pad_len));
 
             // Expand aliases left of the completion index.
-            let mut expanded_args = expand_args(ui, app, padded_args.take(index + 1), config)?;
+            let mut expanded_args =
+                expand_args_for_completion(ui, app, padded_args.take(index + 1), config)?;
 
             // Adjust env var to compensate for shift of the completion point in the
             // expanded command line.
@@ -3729,7 +3730,7 @@ fn handle_shell_completion(
             expanded_args.extend(to_string_args(orig_args)?);
             expanded_args
         } else {
-            expand_args(ui, app, orig_args, config)?
+            expand_args_for_completion(ui, app, orig_args, config)?
         };
         args.extend(resolved_aliases.into_iter().map(OsString::from));
     }
@@ -3755,6 +3756,27 @@ pub fn expand_args(
     let string_args = to_string_args(args_os)?;
     let string_args = resolve_default_command(ui, config, app, string_args)?;
     resolve_aliases(ui, config, app, string_args)
+}
+
+fn expand_args_for_completion(
+    ui: &Ui,
+    app: &Command,
+    args_os: impl IntoIterator<Item = OsString>,
+    config: &StackedConfig,
+) -> Result<Vec<String>, CommandError> {
+    let string_args = to_string_args(args_os)?;
+
+    // If a subcommand has been given, including the potentially incomplete argument
+    // that is being completed, the default command is not resolved and the
+    // completion candidates for the subcommand are prioritized.
+    let mut string_args = resolve_default_command(ui, config, app, string_args)?;
+
+    // Resolution of subcommand aliases must not consider the argument that is being
+    // completed.
+    let cursor_arg = string_args.pop();
+    let mut resolved_args = resolve_aliases(ui, config, app, string_args)?;
+    resolved_args.extend(cursor_arg);
+    Ok(resolved_args)
 }
 
 fn to_string_args(


### PR DESCRIPTION
Fixes #7773.

Given a command alias "foo", the `expand_args` function applies the
expansion also to the completion arguments `["jj", "foo"]`, replacing
the `"foo"` token with whatever the alias resolves to. This is
undesirable as long as the cursor still sits at the alias subcommand:

The completion results pertaining to the resolved command are probably
not prefixed by the alias token that the completion has been invoked
on. Hence, zsh and fish ignored them (but also didn't insert a space to
advance the cursor to the next token), whereas bash replaced the alias
token with the last token of the expanded command.

This behavior was even troublesome when the alias happens to prefix the
aliased command, like for example the `"b"` alias for `bookmark`:
When completing after the `"b"`, the alias was resolved, causing the
completion to only suggest `bookmark`. However, there's now also the
`bisect` subcommand which should also be a viable completion candidate.

This is now fixed by excluding the last token (which the cursor sits at)
from the alias resolution during completion. Note that for the
resolution of the default command, the contents of the cursor matter, so
we cannot simply truncate the input to `expand_args`, we need to resolve
default command and aliases separately and differently in the context of
command completion.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
~~- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
~~- [ ] I have updated the config schema (`cli/src/config-schema.json`)~~
- [x] I have added/updated tests to cover my changes
