### PR TITLE
gitignore: honor ~/.config/git/ignore on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,6 +2426,7 @@ dependencies = [
  "digest",
  "dunce",
  "either",
+ "etcetera",
  "futures 0.3.31",
  "gix",
  "globset",

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1501,17 +1501,17 @@ to the current parents may contain changes from multiple commits.
                 // the "git" command would read the file at the work-tree directory.
                 Some(self.workspace_root().join(path))
             } else {
-                xdg_config_home().ok().map(|x| x.join("git").join("ignore"))
+                xdg_config_home().map(|x| x.join("git").join("ignore"))
             }
         };
 
-        fn xdg_config_home() -> Result<PathBuf, std::env::VarError> {
+        fn xdg_config_home() -> Option<PathBuf> {
             if let Ok(x) = std::env::var("XDG_CONFIG_HOME")
                 && !x.is_empty()
             {
-                return Ok(PathBuf::from(x));
+                return Some(PathBuf::from(x));
             }
-            std::env::var("HOME").map(|x| Path::new(&x).join(".config"))
+            etcetera::home_dir().ok().map(|home| home.join(".config"))
         }
 
         let mut git_ignores = GitIgnoreFile::empty();

--- a/cli/tests/common/test_environment.rs
+++ b/cli/tests/common/test_environment.rs
@@ -138,7 +138,8 @@ impl TestEnvironment {
             // https://doc.rust-lang.org/stable/std/env/fn.temp_dir.html
             cmd.env("TMPDIR", &self.tmp_dir);
         } else {
-            // Ensure that our tests don't write to the real %APPDATA%.
+            // Ensure that our tests don't write to the real %USERPROFILE% or %APPDATA%.
+            cmd.env("USERPROFILE", &self.home_dir);
             cmd.env("APPDATA", self.home_dir.join(".config"));
             // On Windows, "/tmp" mounted in Git Bash appears to be leaked to
             // other Git Bash processes running concurrently, so the TEMP path

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -41,6 +41,7 @@ clru = { workspace = true }
 digest = { workspace = true }
 dunce = { workspace = true }
 either = { workspace = true }
+etcetera = { workspace = true }
 futures = { workspace = true }
 gix = { workspace = true, optional = true }
 globset = { workspace = true }

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -122,12 +122,12 @@ pub fn path_to_bytes(path: &Path) -> Result<&[u8], BadPathEncoding> {
     platform::os_str_to_bytes(path.as_ref()).map_err(BadPathEncoding)
 }
 
-/// Expands "~/" to "$HOME/".
+/// Expands "~/" to the user's home directory.
 pub fn expand_home_path(path_str: &str) -> PathBuf {
     if let Some(remainder) = path_str.strip_prefix("~/")
-        && let Ok(home_dir_str) = std::env::var("HOME")
+        && let Ok(home_dir) = etcetera::home_dir()
     {
-        return PathBuf::from(home_dir_str).join(remainder);
+        return home_dir.join(remainder);
     }
     PathBuf::from(path_str)
 }


### PR DESCRIPTION
Fixes #7579

`jj` now respects `~/.config/git/ignore` on Windows. `HOME` is used when available, `%USERPROFILE%` is used otherwise.

#### Changes

Home directory detection is now done via the cross-platform [`etcetera`](https://docs.rs/etcetera/latest/etcetera/index.html) library.

`cli/src/cli_util.rs` - Updated `xdg_config_home()` to use `etcetera::home_dir()` as the final fallback, which correctly handles `%USERPROFILE%` on Windows.

`lib/src/file_util.rs` - Simplified `expand_home_path()` to use `etcetera::home_dir()` directly.