### PR TITLE
cli: added `:stat-summary` diff format

### DIFF
--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1392,6 +1392,7 @@ fn test_merge_tools() {
     insta::assert_snapshot!(output, @r"
     :summary
     :stat
+    :stat-summary
     :types
     :name-only
     :git


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Note: I attempted getting this result with a log template, but I was not able to achieve it through the templating system.

Also, is `stat-summary` the best name for this output? I was thinking either `stat-summary` or `short-summary`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
