### PR TITLE
diff: allow including tree entries in diff stream

### DIFF
--- a/docs/paid_contributors.md
+++ b/docs/paid_contributors.md
@@ -21,6 +21,7 @@ See [contribution docs](contributing.md#code-reviews) for details on this policy
 ## Google
 
 * 06393993
+* 2079884FDavid
 * algmyr
 * AM5800
 * aspotashev
@@ -30,8 +31,8 @@ See [contribution docs](contributing.md#code-reviews) for details on this policy
 * edre
 * emesterhazy
 * essiene
-* finque
 * ffyuanda
+* finque
 * honglooker
 * hooper
 * incognito124


### PR DESCRIPTION
Currently, `diff_stream_internal` skips tree entries when both sides are trees. This change adds an optional flag to include these tree objects in the resulting stream.

This allows callers to detect when something inside a directory has changed which can be useful for VFS.

My team at Google uses the jj-library in our product and having this new functionality available would make our lives significantly easier.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
