### PR TITLE
untrack: force scan paths with fsmonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj file track --include-ignored` now works when `fsmonitor.backend="watchman"`.
   [#8427](https://github.com/jj-vcs/jj/issues/8427)
 
+* `jj file untrack` now verifies the specified paths even when fsmonitor
+  doesn't report any changes, so unignored files are reliably added back.
+  [#7148](https://github.com/jj-vcs/jj/issues/7148)
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1475,6 +1475,7 @@ to the current parents may contain changes from multiple commits.
             start_tracking_matcher,
             force_tracking_matcher: &NothingMatcher,
             max_new_file_size,
+            force_scan_matcher: &NothingMatcher,
         })
     }
 

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -52,8 +52,9 @@ pub(crate) fn cmd_file_untrack(
     let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
     let matcher = fileset_expression.to_matcher();
     let auto_tracking_matcher = workspace_command.auto_tracking_matcher(ui)?;
-    let options =
+    let mut options =
         workspace_command.snapshot_options_with_start_tracking_matcher(&auto_tracking_matcher)?;
+    options.force_scan_matcher = matcher.as_ref();
 
     let working_copy_shared_with_git = workspace_command.working_copy_shared_with_git();
 

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -289,6 +289,7 @@ diff editing in mind and be a little inaccurate.
                 start_tracking_matcher: &EverythingMatcher,
                 force_tracking_matcher: &NothingMatcher,
                 max_new_file_size: u64::MAX,
+                force_scan_matcher: &NothingMatcher,
             })
             .block_on()?;
         Ok(output_tree_state.current_tree().clone())

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1264,6 +1264,7 @@ impl TreeState {
             start_tracking_matcher,
             force_tracking_matcher,
             max_new_file_size,
+            force_scan_matcher,
         } = options;
 
         let sparse_matcher = self.sparse_matcher();
@@ -1283,7 +1284,10 @@ impl TreeState {
 
         let matcher = IntersectionMatcher::new(
             sparse_matcher.as_ref(),
-            UnionMatcher::new(fsmonitor_matcher, force_tracking_matcher),
+            UnionMatcher::new(
+                fsmonitor_matcher,
+                UnionMatcher::new(force_tracking_matcher, force_scan_matcher),
+            ),
         );
         if matcher.visit(RepoPath::root()).is_nothing() {
             // No need to load the current tree, set up channels, etc.

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -230,6 +230,9 @@ pub struct SnapshotOptions<'a> {
     /// (depending on implementation)
     /// return `SnapshotError::NewFileTooLarge`.
     pub max_new_file_size: u64,
+    /// Paths that should always be scanned even if the filesystem monitor
+    /// doesn't report them as changed. This does not force tracking.
+    pub force_scan_matcher: &'a dyn Matcher,
 }
 
 /// A callback for getting progress updates.

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -151,6 +151,7 @@ pub fn empty_snapshot_options() -> SnapshotOptions<'static> {
         start_tracking_matcher: &EverythingMatcher,
         force_tracking_matcher: &NothingMatcher,
         max_new_file_size: u64::MAX,
+        force_scan_matcher: &NothingMatcher,
     }
 }
 


### PR DESCRIPTION
Ensure untrack validates specified paths even when fsmonitor reports no changes, so unignored files are reliably re-added.

Fixes #7148.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
