### PR TITLE
docs: fix race condition when pushing to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,7 @@ jobs:
 
   starlight-docs-build-deploy:
     # Deploy Starlight-based docs to /starlight for comparison with MkDocs version
+    needs: prerelease-docs-build-deploy
     permissions:
       contents: write
     if: github.repository_owner == 'jj-vcs' # Stops this job from running on forks


### PR DESCRIPTION
The starlight-docs-build-deploy and prerelease-docs-build-deploy jobs both push to the gh-pages branch. When running in parallel, whichever job finishes second would fail because the remote branch had been updated by the first job.

Add `needs: prerelease-docs-build-deploy` so the starlight job waits for the prerelease job to complete before running, ensuring sequential pushes.

I first noticed this failure here, the second time that we tried to deploy: https://github.com/jj-vcs/jj/actions/runs/20997628122/job/60358536629

In theory, a better fix would be to have both jobs update the gh-pages branch, and then have another job deploy once afterward, but given that this is expected to be a temporary situation, I don't want to over-complicate things.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
