### PR TITLE
docs: correct description of commit trailers

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -253,10 +253,11 @@ When the `--sort` option is used, the configuration is ignored.
 ### Commit trailers
 
 You can configure automatic addition of one or more trailers to commit
-descriptions using the `commit_trailers` template.
+descriptions using the `commit_trailers` template. Trailers are lines at the end
+of a commit description that have the format `Key: Value` (the value is
+optional).
 
-Each line of the template is an individual trailer, usually in `Key: Value`
-format.
+Each line of the template is an individual trailer.
 
 Trailers defined in this template are deduplicated with the existing
 description: if the entire line of a trailer is already present, it will not be
@@ -274,7 +275,7 @@ Some ready-to-use trailer templates are available for frequently used trailers:
 * `format_signed_off_by_trailer(commit)` creates a "Signed-off-by" trailer
   using the committer info.
 * `format_gerrit_change_id_trailer(commit)` creates a "Change-Id" trailer
-  suitable to be used with Gerrit. It is based Jujutsu's change id.
+  suitable to be used with Gerrit. It is based on Jujutsu's change id.
 
 Existing trailers are also accessible via `commit.trailers()`.
 


### PR DESCRIPTION
These aren't "usually" in `Key: Value` format, they are (currently) required to be.

I suspect that in the future we may want to make the trailer line format be a regex config variable, as different backends may use different formats, but for now, the `Key: Value` format is hardcoded.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
