### PR TITLE
docs: add newlines around details tags for proper rendering

### DIFF
--- a/web/docs/src/content/docs/revsets.md
+++ b/web/docs/src/content/docs/revsets.md
@@ -101,6 +101,7 @@ You can use parentheses to control evaluation order, such as `(x & y) | z` or
 
 <details>
 <summary>Examples</summary>
+
 Given this history:
 
 ```
@@ -192,6 +193,7 @@ o root()
 * `none()..D` ⇒ `{D,C,B,A,root()}`
 * `D..B` ⇒ `{}` (empty set)
 * `(C|B)..(C|B)` ⇒ `{}` (empty set)
+
 </details>
 
 ## Functions
@@ -201,6 +203,7 @@ revsets (expressions) as arguments.
 
 <details>
 <summary>Function argument syntax</summary>
+
 In this documentation, optional arguments are indicated with square
 brackets like `[arg]`. Some arguments also have an optional label which can
 be used to specify that argument without specifying all previous arguments.
@@ -213,6 +216,7 @@ indicates that all of the following usages are valid:
 * `remote_bookmarks("main", "origin")`
 * `remote_bookmarks("main", remote="origin")`
 * `remote_bookmarks(remote="origin")`
+
 </details>
 
 * `parents(x, [depth])`: `parents(x)` is the same as `x-`.
@@ -421,6 +425,7 @@ indicates that all of the following usages are valid:
 
 <details>
 <summary>Examples</summary>
+
 Given this history:
 
 ```
@@ -478,6 +483,7 @@ o root()
 * `fork_point(B|C)` ⇒ `{A}`
 * `fork_point(A)` ⇒ `{A}`
 * `fork_point(none())` ⇒ `{}`
+
 </details>
 
 ## String patterns


### PR DESCRIPTION
When you use HTML tags in a Markdown document, you need a blank line before you go back into "not HTML," and so this was causing a mis-rendering. This only really matters for the "function argument syntax" section, but for future proofing, and symmetry purposes, I did it on all of the ones in this file. I checked the other files and I believe they already are correct.

I don't think that it's strictly needed for the closing tags as well, but for similar symmetry reasons, added them there too.

Thank you to @scott2000 for reporting this on Discord!

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
