### PR TITLE
cli commit: add warning if specifying a commit message with `-m` would replace an existing description from other sources

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -180,6 +180,18 @@ new working-copy commit.
     }
 
     let description = if !args.message_paragraphs.is_empty() {
+        if !commit_builder.description().is_empty() {
+            // Warn that the new command line-given message replaces messages
+            // that may have come from other sources.
+            writeln!(
+                ui.warning_default(),
+                "
+                The commit message was specified while there is an existing commit message.
+                The new message overrides and replaces the existing commit message.
+                If this was not intentional, run `jj undo` to restore the previous state.
+                "
+            )?;
+        }
         let mut description = join_message_paragraphs(&args.message_paragraphs);
         if !description.is_empty() || args.editor {
             // The first trailer would become the first line of the description.


### PR DESCRIPTION
User reported that `jj commit -m "xyzzy"` overwrote the previously specified description of a change.

Alternatives considered:

1. if `jj commit -m ""` was executed and about to overwrite a previous commit message, fail the commit and suggest doing `jj commit` or `jj describe` (to edit the existing message) instead.
2. add a user option that when `jj commit -m ""` is executed, it would bring up $EDITOR, perhaps with the additional message prepended, as though there had been no message at all.
3. add a new option for `jj commit -M "this is a forced message"` where the `-M` means forced message and override, and the existing `-m` would warn or prepend the message to the existing commit message.
4. add a new option for `jj commit --prepend -m "this message is prepended"`.


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
