### PR TITLE
git: always store the empty tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Conflict labels are now preserved correctly when restoring files from commits
   with different conflict labels.
 
+* The empty tree is now always written when the working copy is empty.
+  [#8480](https://github.com/jj-vcs/jj/issues/8480)
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1295,6 +1295,18 @@ impl Backend for GitBackend {
             ));
         }
 
+        if tree_ids.iter().any(|id| id == &self.empty_tree_id) {
+            let tree = gix::objs::Tree::empty();
+            let tree_id =
+                locked_repo
+                    .write_object(&tree)
+                    .map_err(|err| BackendError::WriteObject {
+                        object_type: "tree",
+                        source: Box::new(err),
+                    })?;
+            assert!(tree_id.is_empty_tree());
+        }
+
         let extras = serialize_extras(&contents);
 
         // If two writers write commits of the same id with different metadata, they


### PR DESCRIPTION
Fixes #8480

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] ~~I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
- [x] ~~I have updated the config schema (`cli/src/config-schema.json`)~~
- [x] I have added/updated tests to cover my changes
