### PR TITLE
cli: fix --git-repo being ignored when git.colocate config is true

### DIFF
--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -97,7 +97,8 @@ pub struct GitInitArgs {
     /// same working directory), then both `jj` and `git` commands
     /// will work on the same repo. This is called a colocated workspace.
     ///
-    /// This option is mutually exclusive with `--colocate`.
+    /// This option is mutually exclusive with `--colocate`, and so if passed,
+    /// turns colocation off.
     #[arg(long, conflicts_with = "colocate", value_hint = clap::ValueHint::DirPath)]
     git_repo: Option<String>,
 }
@@ -158,7 +159,17 @@ fn do_init(
     }
 
     let colocated_git_repo_path = workspace_root.join(".git");
-    let init_mode = if colocate {
+    let init_mode = if let Some(path_str) = git_repo {
+        let mut git_repo_path = command.cwd().join(path_str);
+        if !git_repo_path.ends_with(".git") {
+            git_repo_path.push(".git");
+            // Undo if .git doesn't exist - likely a bare repo.
+            if !git_repo_path.exists() {
+                git_repo_path.pop();
+            }
+        }
+        GitInitMode::External(git_repo_path)
+    } else if colocate {
         if colocated_git_repo_path.exists() {
             // Refuse to colocate inside a Git worktree
             if is_linked_git_worktree(workspace_root) {
@@ -172,16 +183,6 @@ fn do_init(
         } else {
             GitInitMode::Colocate
         }
-    } else if let Some(path_str) = git_repo {
-        let mut git_repo_path = command.cwd().join(path_str);
-        if !git_repo_path.ends_with(".git") {
-            git_repo_path.push(".git");
-            // Undo if .git doesn't exist - likely a bare repo.
-            if !git_repo_path.exists() {
-                git_repo_path.pop();
-            }
-        }
-        GitInitMode::External(git_repo_path)
     } else {
         if colocated_git_repo_path.exists() {
             return Err(user_error_with_hint(

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1591,7 +1591,7 @@ Create a new Git backed repo
 
    If the specified `--git-repo` path happens to be the same as the `jj` repo path (both .jj and .git directories are in the same working directory), then both `jj` and `git` commands will work on the same repo. This is called a colocated workspace.
 
-   This option is mutually exclusive with `--colocate`.
+   This option is mutually exclusive with `--colocate`, and so if passed, turns colocation off.
 
 
 

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -210,6 +210,40 @@ fn test_git_init_external(bare: bool) {
     }
 }
 
+#[test]
+fn test_git_init_external_with_colocate_config() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("git-repo");
+    init_git_repo(&git_repo_path, true);
+
+    // Explicitly enable git.colocate (which is also the default)
+    test_env.add_config("git.colocate = true");
+
+    // --git-repo takes precedence over git.colocate.true
+    let output = test_env.run_jj_in(
+        ".",
+        [
+            "git",
+            "init",
+            "repo",
+            "--git-repo",
+            git_repo_path.to_str().unwrap(),
+        ],
+    );
+    insta::allow_duplicates! {
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Done importing changes from the underlying Git repo.
+    Working copy  (@) now at: sqpuoqvx ed6b5138 (empty) (no description set)
+    Parent commit (@-)      : nntyzxmz e80a42cc my-bookmark | My commit message
+    Added 1 files, modified 0 files, removed 0 files
+    Initialized repo in "repo"
+    Hint: Running `git clean -xdf` will remove `.jj/`!
+    [EOF]
+    "#);
+    }
+}
+
 #[test_case(false; "full")]
 #[test_case(true; "bare")]
 fn test_git_init_external_import_trunk(bare: bool) {


### PR DESCRIPTION
User @0xferrous reported on discord that `--git-repo` didn't seem to be working properly. @PhilipMetzger and I felt that the current behavior is a bug. Here's my current commit description, which should describe the situation:

---------

When `git.colocate` config is true (the default), the `--git-repo` flag for `jj git init` was silently ignored. This happened because the colocate logic was checked before the --git-repo logic:

    let colocate = if command.settings().get_bool("git.colocate")? {
        !args.no_colocate  // true unless --no-colocate passed
    } else {
        args.colocate
    };

Then in `do_init()`:

    let init_mode = if colocate {
        // takes this branch, ignoring --git-repo!
    } else if let Some(path_str) = git_repo {
        // --git-repo handling never reached
    }

This meant `--git-repo` was simply ignored unless `--no-colocate` was also passed.

This is a regression from when colocation became the default. Before that change, `--git-repo` worked without any additional flags because `colocate` defaulted to false. The fix preserves that original behavior by checking for `--git-repo` first and setting `colocate = false` when it's provided, allowing the --git-repo code path to be reached.

---------

So, I have some questions:

1. Do you agree this is a bug?
2. Should we do what this patch does, and have `--git-repo` override colocation? Or should we make `--git-repo` report an error unless you also pass `--no-colocate`? The former (as mentioned above) keeps the original behavior of the flag intact, but it would probably be more overall consistent to require `--no-colocate` to be passed. I'm happy to do it either way, I just picked one. Or any other way you'd prefer. I didn't bother with the checkboxes below because I want to get sign-off on the behavior we want here first, if I have to re-work the patch, I don't want to re-work those things :)
3. This is the first time I'm contributing tests to the test suite and so I think that this looks good, but I want to flag that I'm inexperienced here and so if I should do something different there as well, I'm quite happy to.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
