### PR TITLE
git: do not abandon commits still reachable by other heads

### DIFF
--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -676,9 +676,15 @@ fn abandon_unreachable_commits(
         RevsetExpression::root(),
     ]);
     let abandoned_expression = pinned_expression
-        .range(&RevsetExpression::commits(hidable_git_heads))
+        .range(&RevsetExpression::commits(hidable_git_heads.clone()))
         // Don't include already-abandoned commits in GitImportStats
-        .intersection(&RevsetExpression::visible_heads().ancestors());
+        .intersection(&RevsetExpression::visible_heads().ancestors())
+        // Don't include commits which are still reachable from the remaining visible heads
+        .minus(
+            &RevsetExpression::visible_heads()
+                .minus(&RevsetExpression::commits(hidable_git_heads))
+                .ancestors(),
+        );
     let abandoned_commit_ids: Vec<_> = abandoned_expression
         .evaluate(mut_repo)
         .map_err(|err| err.into_backend_error())?


### PR DESCRIPTION
Fixes #8076.

Importing from git auto-abandons all commits that have become unreachable as a result of the deletion of a ref (branch or tag) in the git repo. However, previously, any visible ancestor of the deleted ref has been deemed unreachable, even if it had other descendants which are still pointed to by one of the remaining branches or tags. These descendant were then rebased which could result in conflicts, which is an unexpected outcome of importing from a conflict-free git repo.

This commit fixes that by only abandoning those commits which are not reachable via any of the remaining visible heads. This should not result in commit being rebased anymore.

The tests have been extended to include scenarios where truly unreachable commits are abandoned has well as where only the bookmark is removed but the commits all remain reachable through another head. It also includes the particularly severe case reported in #8076 where a merge commit got rebased as a result of abandoning one of its parents, including its entire history up until `root()`. This resulted in an error because `root()` cannot be a merge parent.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- ~~[ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
- ~~[ ] I have updated the config schema (`cli/src/config-schema.json`)~~
- [x] I have added/updated tests to cover my changes
