### PR TITLE
git: add colocation-aware backend support 

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -173,6 +173,13 @@ use crate::diff_util::DiffRenderer;
 use crate::formatter::FormatRecorder;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
+use crate::git_util::is_colocated_git_workspace;
+#[cfg(feature = "git")]
+use crate::git_util::load_git_import_options;
+#[cfg(feature = "git")]
+use crate::git_util::print_git_export_stats;
+#[cfg(feature = "git")]
+use crate::git_util::print_git_import_stats_summary;
 use crate::merge_tools::DiffEditor;
 use crate::merge_tools::MergeEditor;
 use crate::merge_tools::MergeToolConfigError;
@@ -1082,8 +1089,16 @@ impl WorkspaceCommandHelper {
         let op_summary_template_text = settings.get_string("templates.op_summary")?;
         let may_update_working_copy =
             loaded_at_head && !env.command.global_args().ignore_working_copy;
+        // Only show warnings about unexpected .git directories if we're actually
+        // going to interact with the working copy. When --ignore-working-copy is set,
+        // the user is explicitly saying they don't care about working copy state.
+        let ui_for_warning = if may_update_working_copy {
+            Some(ui)
+        } else {
+            None
+        };
         let working_copy_shared_with_git =
-            crate::git_util::is_colocated_git_workspace(&workspace, &repo);
+            is_colocated_git_workspace(ui_for_warning, &workspace, &repo);
 
         let helper = Self {
             workspace,
@@ -1277,11 +1292,10 @@ impl WorkspaceCommandHelper {
         use jj_lib::git;
         let git_settings = git::GitSettings::from_settings(self.settings())?;
         let remote_settings = self.settings().remote_settings()?;
-        let import_options =
-            crate::git_util::load_git_import_options(ui, &git_settings, &remote_settings)?;
+        let import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
         let mut tx = self.start_transaction();
         let stats = git::import_refs(tx.repo_mut(), &import_options)?;
-        crate::git_util::print_git_import_stats_summary(ui, &stats)?;
+        print_git_import_stats_summary(ui, &stats)?;
         if !tx.repo().has_changes() {
             return Ok(());
         }
@@ -2135,7 +2149,7 @@ to the current parents may contain changes from multiple commits.
                 }
             }
             let stats = jj_lib::git::export_refs(tx.repo_mut())?;
-            crate::git_util::print_git_export_stats(ui, &stats)?;
+            print_git_export_stats(ui, &stats)?;
         }
 
         self.user_repo = ReadonlyUserRepo::new(tx.commit(description)?);
@@ -2405,7 +2419,7 @@ pub fn export_working_copy_changes_to_git(
     let repo = mut_repo.base_repo().as_ref();
     jj_lib::git::update_intent_to_add(repo, old_tree, new_tree)?;
     let stats = jj_lib::git::export_refs(mut_repo)?;
-    crate::git_util::print_git_export_stats(ui, &stats)?;
+    print_git_export_stats(ui, &stats)?;
     Ok(())
 }
 #[cfg(not(feature = "git"))]

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -14,6 +14,7 @@
 
 use std::io::ErrorKind;
 use std::io::Write as _;
+use std::process::Command;
 
 use itertools::Itertools as _;
 use jj_lib::commit::Commit;
@@ -47,8 +48,18 @@ pub struct GitColocationEnableArgs {}
 /// This moves the Git repository that is at the root of the Jujutsu
 /// workspace into the .jj directory. Once this is done you will no longer
 /// be able to use Git commands directly in the Jujutsu workspace.
+///
+/// If there are secondary colocated workspaces (created with
+/// `jj workspace add --colocate`), this command will fail unless --force
+/// is specified. Without --force, you should first forget those workspaces
+/// with `jj workspace forget`.
 #[derive(clap::Args, Clone, Debug)]
-pub struct GitColocationDisableArgs {}
+pub struct GitColocationDisableArgs {
+    /// Force disabling colocation even if secondary colocated workspaces exist.
+    /// This will leave those workspaces in a broken state.
+    #[arg(long)]
+    force: bool,
+}
 
 /// Manage Jujutsu repository colocation with Git
 #[derive(clap::Subcommand, Clone, Debug)]
@@ -100,7 +111,9 @@ fn cmd_git_colocation_status(
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
     let repo = workspace_command.repo();
-    let is_colocated = is_colocated_git_workspace(workspace_command.workspace(), repo);
+    // Use None for ui to skip warning - the warning is already shown during
+    // workspace loading, and this command is just reporting status.
+    let is_colocated = is_colocated_git_workspace(None, workspace_command.workspace(), repo);
     let git_head = repo.view().git_head();
 
     if is_colocated {
@@ -152,8 +165,13 @@ fn cmd_git_colocation_enable(
     // Make sure that the workspace supports git colocation commands
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
-    // Then ensure that the workspace is not already colocated before proceeding
-    if is_colocated_git_workspace(workspace_command.workspace(), workspace_command.repo()) {
+    // Then ensure that the workspace is not already colocated before proceeding.
+    // Use None for ui - the warning is already shown during workspace loading.
+    if is_colocated_git_workspace(
+        None,
+        workspace_command.workspace(),
+        workspace_command.repo(),
+    ) {
         writeln!(ui.status(), "Workspace is already colocated with Git.")?;
         return Ok(());
     }
@@ -211,17 +229,56 @@ fn cmd_git_colocation_enable(
 fn cmd_git_colocation_disable(
     ui: &mut Ui,
     command: &CommandHelper,
-    _args: &GitColocationDisableArgs,
+    args: &GitColocationDisableArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui)?;
 
     // Make sure that the repository supports git colocation commands
     workspace_supports_git_colocation_commands(&workspace_command)?;
 
-    // Then ensure that the repo is colocated before proceeding
-    if !is_colocated_git_workspace(workspace_command.workspace(), workspace_command.repo()) {
+    // Then ensure that the repo is colocated before proceeding.
+    // Use None for ui - the warning is already shown during workspace loading.
+    if !is_colocated_git_workspace(
+        None,
+        workspace_command.workspace(),
+        workspace_command.repo(),
+    ) {
         writeln!(ui.status(), "Workspace is already not colocated with Git.")?;
         return Ok(());
+    }
+
+    // Check for secondary colocated workspaces (git worktrees)
+    if !args.force {
+        let workspace_root = workspace_command.workspace_root();
+        let dot_git_path = workspace_root.join(".git");
+
+        // Use git worktree list to find secondary worktrees
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&dot_git_path)
+            .arg("worktree")
+            .arg("list")
+            .arg("--porcelain")
+            .output();
+
+        if let Ok(output) = output
+            && output.status.success()
+        {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // Count worktrees - each worktree block starts with "worktree "
+            let worktree_count = stdout
+                .lines()
+                .filter(|l| l.starts_with("worktree "))
+                .count();
+            if worktree_count > 1 {
+                return Err(user_error(
+                    "Cannot disable colocation: secondary colocated workspaces exist.\nThese \
+                     workspaces would become broken Git worktrees.\nEither:\n  - Run `jj \
+                     workspace forget <name>` for each secondary workspace first\n  - Use --force \
+                     to disable anyway (secondary workspaces will be broken)",
+                ));
+            }
+        }
     }
 
     let workspace_root = workspace_command.workspace_root();

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -20,6 +20,7 @@ use std::io::Write as _;
 use std::iter;
 use std::mem;
 use std::path::Path;
+use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -59,7 +60,20 @@ use crate::revset_util::parse_remote_auto_track_bookmarks_map;
 use crate::ui::ProgressOutput;
 use crate::ui::Ui;
 
-pub fn is_colocated_git_workspace(workspace: &Workspace, repo: &ReadonlyRepo) -> bool {
+/// Checks if the workspace is colocated with a Git repository.
+///
+/// Returns `true` if the workspace root has a `.git` directory/file/symlink
+/// that points to the same Git repository that jj uses internally.
+///
+/// If `ui` is provided and the workspace has an unexpected `.git` presence
+/// (exists but doesn't match jj's repo), a warning is shown to the user.
+///
+/// See `docs/design/colocated-workspaces.md` for corner case specifications.
+pub fn is_colocated_git_workspace(
+    ui: Option<&Ui>,
+    workspace: &Workspace,
+    repo: &ReadonlyRepo,
+) -> bool {
     let Ok(git_backend) = git::get_git_backend(repo.store()) else {
         return false;
     };
@@ -69,12 +83,120 @@ pub fn is_colocated_git_workspace(workspace: &Workspace, repo: &ReadonlyRepo) ->
     if git_workdir == workspace.workspace_root() {
         return true;
     }
+
     // Colocated workspace should have ".git" directory, file, or symlink. Compare
     // its parent as the git_workdir might be resolved from the real ".git" path.
-    let Ok(dot_git_path) = dunce::canonicalize(workspace.workspace_root().join(".git")) else {
-        return false;
+    if let Ok(dot_git_path) = dunce::canonicalize(workspace.workspace_root().join(".git")) {
+        if dunce::canonicalize(git_workdir).ok().as_deref() == dot_git_path.parent() {
+            return true;
+        }
+    }
+
+    if let Some(ui) = ui {
+        warn_about_unexpected_git_in_workspace(ui, workspace, git_backend);
+    }
+
+    false
+}
+
+/// Warns about unexpected `.git` presence in a non-colocated workspace.
+///
+/// Called when jj detects a `.git` at the workspace root but the backend
+/// doesn't consider itself colocated (i.e., the `common_dir()` paths don't
+/// match). This helps users diagnose configuration issues.
+///
+/// ## Warning Scenarios
+///
+/// | `.git` Type | Warning |
+/// |-------------|---------|
+/// | Symlink | "Workspace has a .git symlink ... that isn't pointing to jj's git repo" |
+/// | Directory | "Workspace has a .git directory that is not managed by jj" |
+/// | File (valid worktree to different repo) | "Workspace is also a Git worktree that is not managed by jj" |
+/// | File (broken worktree) | "Workspace is a broken Git worktree" + hint for `git worktree repair` |
+///
+/// ## Common Causes
+///
+/// - User created a separate Git repo in the jj workspace
+/// - Git worktree was moved and links are broken (repairable with `git worktree
+///   repair`)
+/// - `.git` symlink was created manually pointing elsewhere
+/// - jj workspace was created in an existing Git worktree of a different repo
+///
+/// See `docs/design/colocated-workspaces.md` for full specification.
+fn warn_about_unexpected_git_in_workspace(
+    ui: &Ui,
+    workspace: &Workspace,
+    git_backend: &jj_lib::git_backend::GitBackend,
+) {
+    let workspace_dot_git = workspace.workspace_root().join(".git");
+    let Ok(meta) = workspace_dot_git.symlink_metadata() else {
+        // No .git at all - nothing to warn about
+        return;
     };
-    dunce::canonicalize(git_workdir).ok().as_deref() == dot_git_path.parent()
+
+    // Check symlink first as is_dir follows symlinks
+    if meta.is_symlink() {
+        let target = std::fs::read_link(&workspace_dot_git)
+            .unwrap_or_else(|_| PathBuf::from("<could not read link>"));
+        writeln!(
+            ui.warning_default(),
+            "Workspace has a .git symlink (pointing to {}), that isn't pointing to jj's git repo",
+            target.display()
+        )
+        .ok();
+        writeln!(ui.hint_default(), "To remove this symlink, run `rm .git`").ok();
+        return;
+    }
+
+    if meta.is_dir() {
+        writeln!(
+            ui.warning_default(),
+            "Workspace has a .git directory that is not managed by jj"
+        )
+        .ok();
+        writeln!(
+            ui.hint_default(),
+            "To remove this directory, run `rm -rf .git`"
+        )
+        .ok();
+        return;
+    }
+
+    if gix::open(workspace.workspace_root()).is_ok() {
+        writeln!(
+            ui.warning_default(),
+            "Workspace is also a Git worktree that is not managed by jj",
+        )
+        .ok();
+        writeln!(
+            ui.hint_default(),
+            "To remove this worktree, run `git worktree remove .` from the parent Git repo"
+        )
+        .ok();
+        return;
+    }
+
+    // Broken worktree case - show detailed diagnostic info
+    let gitfile_contents = std::fs::read_to_string(&workspace_dot_git)
+        .unwrap_or_else(|_| "<could not read .git file>".to_string());
+    let gitdir = gitfile_contents
+        .strip_prefix("gitdir: ")
+        .unwrap_or(&gitfile_contents)
+        .trim();
+    writeln!(ui.warning_default(), "Workspace is a broken Git worktree").ok();
+    writeln!(ui.warning_no_heading(), "The .git file points at: {gitdir}").ok();
+    // work_dir may return Some even if colocated = false, because we may be in some
+    // secondary workspace, and we may have just opened the colocated primary
+    // workspace with a .git directory.
+    let git_repo = git_backend.git_repo();
+    let repair_dir = git_repo.workdir().unwrap_or(git_repo.common_dir());
+    writeln!(
+        ui.hint_default(),
+        "If this is meant to be a colocated jj workspace, you may like to try `git -C {} worktree \
+         repair`",
+        repair_dir.display()
+    )
+    .ok();
 }
 
 /// Parses user-specified remote URL or path to absolute form.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -35,7 +35,13 @@ pub mod git_util {
     use jj_lib::repo::ReadonlyRepo;
     use jj_lib::workspace::Workspace;
 
-    pub fn is_colocated_git_workspace(_workspace: &Workspace, _repo: &ReadonlyRepo) -> bool {
+    use crate::ui::Ui;
+
+    pub fn is_colocated_git_workspace(
+        _ui: Option<&Ui>,
+        _workspace: &Workspace,
+        _repo: &ReadonlyRepo,
+    ) -> bool {
         false
     }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1478,7 +1478,13 @@ Convert into a non-colocated Jujutsu/Git repository
 
 This moves the Git repository that is at the root of the Jujutsu workspace into the .jj directory. Once this is done you will no longer be able to use Git commands directly in the Jujutsu workspace.
 
-**Usage:** `jj git colocation disable`
+If there are secondary colocated workspaces (created with `jj workspace add --colocate`), this command will fail unless --force is specified. Without --force, you should first forget those workspaces with `jj workspace forget`.
+
+**Usage:** `jj git colocation disable [OPTIONS]`
+
+###### **Options:**
+
+* `--force` — Force disabling colocation even if secondary colocated workspaces exist. This will leave those workspaces in a broken state
 
 
 

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -15,6 +15,7 @@
 use std::fmt::Write as _;
 use std::path::Path;
 
+use assert_cmd::assert::OutputAssertExt as _;
 use testutils::git;
 
 use crate::common::CommandOutput;
@@ -48,12 +49,21 @@ fn test_git_colocated() {
     work_dir
         .run_jj(["git", "init", "--git-repo", "."])
         .success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  524826059adc6f74de30f6be8f8eb86715d75b62
-    ○  97358f54806c7cd005ed5ade68a779595efbae7e master initial
+    ○  97358f54806c7cd005ed5ade68a779595efbae7e master git_head() initial
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(
         git_repo.head_id().unwrap().to_string(),
         @"97358f54806c7cd005ed5ade68a779595efbae7e"
@@ -67,12 +77,21 @@ fn test_git_colocated() {
     // Modify the working copy. The working-copy commit should changed, but the Git
     // HEAD commit should not
     work_dir.write_file("file", "modified");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  9dfe8c7005c8dff6078ecdfd953c6bfddc633c90
-    ○  97358f54806c7cd005ed5ade68a779595efbae7e master initial
+    ○  97358f54806c7cd005ed5ade68a779595efbae7e master git_head() initial
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(
         git_repo.head_id().unwrap().to_string(),
         @"97358f54806c7cd005ed5ade68a779595efbae7e"
@@ -85,13 +104,22 @@ fn test_git_colocated() {
 
     // Create a new change from jj and check that it's reflected in Git
     work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  4ddddef596e9d68f729f1be9e1b2cdaaf45bef08
-    ○  9dfe8c7005c8dff6078ecdfd953c6bfddc633c90
+    ○  9dfe8c7005c8dff6078ecdfd953c6bfddc633c90 git_head()
     ○  97358f54806c7cd005ed5ade68a779595efbae7e master initial
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     assert!(git_repo.head().unwrap().is_detached());
     insta::assert_snapshot!(
         git_repo.head_id().unwrap().to_string(),
@@ -205,11 +233,20 @@ fn test_git_colocated_unborn_bookmark() {
         git_repo.head_name().unwrap().unwrap().as_bstr(),
         b"refs/heads/master"
     );
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
@@ -231,13 +268,22 @@ fn test_git_colocated_unborn_bookmark() {
         git_repo.head_name().unwrap().unwrap().as_bstr(),
         b"refs/heads/master"
     );
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  c2934cfbfb196d2c473959667beffcc19e71e5e8
     │ ○  e6669bb3438ef218fa618e1047a1911d2b3410dd
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
@@ -267,14 +313,23 @@ fn test_git_colocated_unborn_bookmark() {
         git_repo.head_id().unwrap().to_string(),
         @"ff5366846b039b25c6c4998fa74dca821c246243"
     );
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  2d7a8abb601ebf559df4037279e9f2e851a75e63
-    ○  ff5366846b039b25c6c4998fa74dca821c246243
+    ○  ff5366846b039b25c6c4998fa74dca821c246243 git_head()
     │ ○  e6669bb3438ef218fa618e1047a1911d2b3410dd
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: ff5366846b039b25c6c4998fa74dca821c246243
@@ -306,7 +361,7 @@ fn test_git_colocated_unborn_bookmark() {
     [EOF]
     ");
     assert!(git_repo.head().unwrap().is_unborn());
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  88e8407a4f0a5e6f40a7c6c494106764adc00fed
     │ ○  2dd7385602e703388fd266b939bba6f57a1439d3
     │ ○  ff5366846b039b25c6c4998fa74dca821c246243 master
@@ -315,7 +370,16 @@ fn test_git_colocated_unborn_bookmark() {
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
@@ -339,9 +403,9 @@ fn test_git_colocated_unborn_bookmark() {
     Parent commit (@-)      : wqnwkozp bb21bc2d (no description set)
     [EOF]
     ");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  2fb16499a987e632407402e38976ed250c939c42
-    ○  bb21bc2dce2af92973fdd6d42686d77bd16bc466
+    ○  bb21bc2dce2af92973fdd6d42686d77bd16bc466 git_head()
     │ ○  2dd7385602e703388fd266b939bba6f57a1439d3
     │ ○  ff5366846b039b25c6c4998fa74dca821c246243 master
     ├─╯
@@ -349,7 +413,16 @@ fn test_git_colocated_unborn_bookmark() {
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: bb21bc2dce2af92973fdd6d42686d77bd16bc466
@@ -374,20 +447,38 @@ fn test_git_colocated_export_bookmarks_on_snapshot() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "foo"])
         .success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  82a10a4d9ef783fd68b661f40ce10dd80d599d9e foo
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // The bookmark gets updated when we modify the working copy, and it should get
     // exported to Git without requiring any other changes
     work_dir.write_file("file", "modified");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  00fc09f48ccf5c8b025a0f93b0ec3b0e4294a598 foo
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(git_repo
         .find_reference("refs/heads/foo")
         .unwrap()
@@ -435,9 +526,9 @@ fn test_git_colocated_rebase_on_import() {
             "update ref",
         )
         .unwrap();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  d46583362b91d0e172aec469ea1689995540de81
-    ○  cbd6c887108743a4abb0919305646a6a914a665e master add a file
+    ○  cbd6c887108743a4abb0919305646a6a914a665e master git_head() add a file
     ◆  0000000000000000000000000000000000000000
     [EOF]
     ------- stderr -------
@@ -447,8 +538,15 @@ fn test_git_colocated_rebase_on_import() {
     Parent commit (@-)      : qpvuntsm cbd6c887 master | add a file
     Added 0 files, modified 1 files, removed 0 files
     Done importing changes from the underlying Git repo.
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
     [EOF]
-    ");
+    "#);
 }
 
 #[test]
@@ -461,14 +559,23 @@ fn test_git_colocated_bookmarks() {
         .success();
     work_dir.run_jj(["new", "-m", "foo"]).success();
     work_dir.run_jj(["new", "@-", "-m", "bar"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  95e79774f8e7c785fc36da2b798ecfe0dc864e02 bar
     │ ○  b51ab2e2c88fe2d38bd7ca6946c4d87f281ce7e2 foo
     ├─╯
-    ○  e8849ae12c709f2321908879bc724fdb2ab8a781
+    ○  e8849ae12c709f2321908879bc724fdb2ab8a781 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Create a bookmark in jj. It should be exported to Git even though it points
     // to the working-copy commit.
@@ -499,11 +606,11 @@ fn test_git_colocated_bookmarks() {
             "test",
         )
         .unwrap();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  507c0edcfc028f714f3c7a3027cb141f6610e867
     │ ○  b51ab2e2c88fe2d38bd7ca6946c4d87f281ce7e2 master foo
     ├─╯
-    ○  e8849ae12c709f2321908879bc724fdb2ab8a781
+    ○  e8849ae12c709f2321908879bc724fdb2ab8a781 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
     ------- stderr -------
@@ -511,8 +618,15 @@ fn test_git_colocated_bookmarks() {
     Working copy  (@) now at: yqosqzyt 507c0edc (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     Done importing changes from the underlying Git repo.
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
     [EOF]
-    ");
+    "#);
 }
 
 #[test]
@@ -527,12 +641,21 @@ fn test_git_colocated_bookmark_forget() {
     work_dir
         .run_jj(["bookmark", "create", "-r@", "foo"])
         .success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  43444d88b0096888ebfd664c0cf792c9d15e3f14 foo
-    ○  e8849ae12c709f2321908879bc724fdb2ab8a781
+    ○  e8849ae12c709f2321908879bc724fdb2ab8a781 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
     foo: rlvkpnrz 43444d88 (empty) (no description set)
       @git: rlvkpnrz 43444d88 (empty) (no description set)
@@ -666,14 +789,23 @@ fn test_git_colocated_checkout_non_empty_working_copy() {
         b"refs/heads/master"
     );
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  986aa548466ed43b48c059854720e70d8ec2bf71 new
     │ ○  6b0f7d59e0749d3a6ff2ecf686d5fa48023b7b93 two
     ├─╯
-    ○  97358f54806c7cd005ed5ade68a779595efbae7e master initial
+    ○  97358f54806c7cd005ed5ade68a779595efbae7e master git_head() initial
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: 97358f54806c7cd005ed5ade68a779595efbae7e
@@ -705,16 +837,25 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
     git::clone(clone_dir.root(), origin_dir.root().to_str().unwrap(), None);
     clone_dir.run_jj(["git", "init", "--git-repo=."]).success();
     clone_dir.run_jj(["new", "A"]).success();
-    insta::assert_snapshot!(get_log_output(&clone_dir), @r"
+    insta::assert_snapshot!(get_log_output(&clone_dir), @r#"
     @  0060713e4c7c46c4ce0d69a43ac16451582eda79
     │ ○  dd905babf5b4ad4689f2da1350fd4f0ac5568209 C_to_move original C
     ├─╯
     │ ○  b2ea51c027e11c0f2871cce2a52e648e194df771 B_to_delete B_to_delete
     ├─╯
-    ◆  8777db25171cace71ad014598663d5ffc4fae6b1 A A
+    ◆  8777db25171cace71ad014598663d5ffc4fae6b1 A git_head() A
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     origin_dir
         .run_jj(["bookmark", "delete", "B_to_delete"])
@@ -735,14 +876,23 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() {
     ");
     // "original C" and "B_to_delete" are abandoned, as the corresponding bookmarks
     // were deleted or moved on the remote (#864)
-    insta::assert_snapshot!(get_log_output(&clone_dir), @r"
+    insta::assert_snapshot!(get_log_output(&clone_dir), @r#"
     @  0060713e4c7c46c4ce0d69a43ac16451582eda79
     │ ○  fb297975e4ef98dc057f65b761aed2cdb0386598 C_to_move moved C
     ├─╯
-    ◆  8777db25171cace71ad014598663d5ffc4fae6b1 A A
+    ◆  8777db25171cace71ad014598663d5ffc4fae6b1 A git_head() A
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 }
 
 #[test]
@@ -785,12 +935,21 @@ fn test_git_colocated_rebase_dirty_working_copy() {
     Done importing changes from the underlying Git repo.
     [EOF]
     ");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  e23559e3bc6f22a5562297696fc357e2c581df77 feature??
-    ○  f99015d7d9b82a5912ec4d96a18d2a4afbd8dd49
+    ○  f99015d7d9b82a5912ec4d96a18d2a4afbd8dd49 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // The working-copy content shouldn't be lost.
     insta::assert_snapshot!(work_dir.read_file("file"), @"new");
@@ -820,52 +979,77 @@ fn test_git_colocated_external_checkout() {
     work_dir.run_jj(["new"]).success();
 
     // Checked out anonymous bookmark
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  6f8612f0e7f6d52efd8a72615796df06f8d64cdc
-    ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
+    ○  319eaafc8fd04c763a0683a000bba5452082feb3 git_head() B
     │ ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Check out another bookmark by external command
     git_check_out_ref("refs/heads/master");
 
     // The old working-copy commit gets abandoned, but the whole bookmark should not
     // be abandoned. (#1042)
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  7ceeaaae54c8ac99ad34eeed7fe1e896f535be99
-    ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
+    ○  8777db25171cace71ad014598663d5ffc4fae6b1 master git_head() A
     │ ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
     [EOF]
-    ");
+    "#);
 
     // Edit non-head commit
     work_dir.run_jj(["new", "subject(B)"]).success();
     work_dir.run_jj(["new", "-m=C", "--no-edit"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     ○  823204bc895aad19d46b895bc510fb3e9d0c97c7 C
     @  c6abf242550b7c4116d3821b69c79326889aeba0
-    ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
+    ○  319eaafc8fd04c763a0683a000bba5452082feb3 git_head() B
     │ ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
     ├─╯
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Check out another bookmark by external command
     git_check_out_ref("refs/heads/master");
 
     // The old working-copy commit shouldn't be abandoned. (#3747)
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  277b693c61dcdea59ac26d6982370f78751f6ef5
-    ○  8777db25171cace71ad014598663d5ffc4fae6b1 master A
+    ○  8777db25171cace71ad014598663d5ffc4fae6b1 master git_head() A
     │ ○  823204bc895aad19d46b895bc510fb3e9d0c97c7 C
     │ ○  c6abf242550b7c4116d3821b69c79326889aeba0
     │ ○  319eaafc8fd04c763a0683a000bba5452082feb3 B
@@ -874,8 +1058,15 @@ fn test_git_colocated_external_checkout() {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
     [EOF]
-    ");
+    "#);
 }
 
 #[test]
@@ -992,12 +1183,21 @@ fn test_git_colocated_undo_head_move() {
     insta::assert_snapshot!(
         git_repo.head_id().unwrap().to_string(),
         @"e8849ae12c709f2321908879bc724fdb2ab8a781");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  43444d88b0096888ebfd664c0cf792c9d15e3f14
-    ○  e8849ae12c709f2321908879bc724fdb2ab8a781
+    ○  e8849ae12c709f2321908879bc724fdb2ab8a781 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e8849ae12c709f2321908879bc724fdb2ab8a781
@@ -1007,11 +1207,20 @@ fn test_git_colocated_undo_head_move() {
     // HEAD should be unset
     work_dir.run_jj(["undo"]).success();
     assert!(git_repo.head().unwrap().is_unborn());
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
@@ -1021,13 +1230,22 @@ fn test_git_colocated_undo_head_move() {
     // Create commit on non-root commit
     work_dir.run_jj(["new"]).success();
     work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  5e37f1b8313299eb1b62221eefcf32881b0dc4c6
-    ○  23e6e06a7471634da3567ef975fadf883082658f
+    ○  23e6e06a7471634da3567ef975fadf883082658f git_head()
     ○  e8849ae12c709f2321908879bc724fdb2ab8a781
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: 23e6e06a7471634da3567ef975fadf883082658f
@@ -1051,12 +1269,21 @@ fn test_git_colocated_undo_head_move() {
     insta::assert_snapshot!(
         git_repo.head_id().unwrap().to_string(),
         @"e8849ae12c709f2321908879bc724fdb2ab8a781");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  23e6e06a7471634da3567ef975fadf883082658f
-    ○  e8849ae12c709f2321908879bc724fdb2ab8a781
+    ○  e8849ae12c709f2321908879bc724fdb2ab8a781 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e8849ae12c709f2321908879bc724fdb2ab8a781
@@ -1090,13 +1317,22 @@ fn test_git_colocated_update_index_preserves_timestamps() {
         .success();
     work_dir.run_jj(["new"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  a1886a45815f0dcca5cefcc334d11ffb908a1eb8
-    ○  8b0c962ef1fea901fb16f8a484e692a1f0dcbc59 commit2
+    ○  8b0c962ef1fea901fb16f8a484e692a1f0dcbc59 commit2 git_head()
     ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     insta::assert_snapshot!(get_index_state(work_dir.root()), @r"
     Unconflicted Mode(FILE) ed48318d9bf4 ctime=0:0 mtime=0:0 size=0 flags=0 file1.txt
@@ -1119,12 +1355,21 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     // touching the working copy
     work_dir.run_jj(["edit", "commit2"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  8b0c962ef1fea901fb16f8a484e692a1f0dcbc59 commit2
-    ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1
+    ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Index should contain stat for unchanged file still.
     insta::assert_snapshot!(get_index_state(work_dir.root()), @r"
@@ -1137,14 +1382,23 @@ fn test_git_colocated_update_index_preserves_timestamps() {
     // Create sibling commit, causing working copy to match index
     work_dir.run_jj(["new", "commit1"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  d9c7f1932e1135856d5905f1a0fc194ce2657065
     │ ○  8b0c962ef1fea901fb16f8a484e692a1f0dcbc59 commit2
     ├─╯
-    ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1
+    ○  d37eac5eea00fa74a41c1512839711f42aca2c35 commit1 git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Index should contain stat for unchanged file still.
     insta::assert_snapshot!(get_index_state(work_dir.root()), @r"
@@ -1201,16 +1455,25 @@ fn test_git_colocated_update_index_merge_conflict() {
     // Create merge conflict
     work_dir.run_jj(["new", "left", "right"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @    67305afbbe0f166da93da08aa67412bb870c1747
     ├─╮
     │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
-    ○ │  d0f55ffafa1e0e72980202c349af23d093f825be left
+    ○ │  d0f55ffafa1e0e72980202c349af23d093f825be left git_head()
     ├─╯
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Conflict should be added in index with correct blob IDs. The stat for
     // base.txt should not change.
@@ -1225,9 +1488,9 @@ fn test_git_colocated_update_index_merge_conflict() {
 
     work_dir.run_jj(["new"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  040579f58a38cfe5fba2a67c78c512c4798cf47c
-    ×    67305afbbe0f166da93da08aa67412bb870c1747
+    ×    67305afbbe0f166da93da08aa67412bb870c1747 git_head()
     ├─╮
     │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
     ○ │  d0f55ffafa1e0e72980202c349af23d093f825be left
@@ -1235,7 +1498,16 @@ fn test_git_colocated_update_index_merge_conflict() {
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Index should be the same after `jj new`.
     insta::assert_snapshot!(get_index_state(work_dir.root()), @r"
@@ -1279,14 +1551,23 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     work_dir.run_jj(["edit", "left"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  d0f55ffafa1e0e72980202c349af23d093f825be left
     │ ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
     ├─╯
-    ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
+    ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base git_head()
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     insta::assert_snapshot!(get_index_state(work_dir.root()), @r"
     Unconflicted Mode(FILE) df967b96a579 ctime=0:0 mtime=0:0 size=0 flags=0 base.txt
@@ -1308,13 +1589,22 @@ fn test_git_colocated_update_index_rebase_conflict() {
         .run_jj(["rebase", "-r", "left", "-o", "right"])
         .success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  b3e1abf04842a7756ba95d0a72d72f5f40243362 left
-    ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
+    ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right git_head()
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Index should contain files from parent commit, so there should be no conflict
     // in conflict.txt yet. The stat for base.txt should not change.
@@ -1327,14 +1617,23 @@ fn test_git_colocated_update_index_rebase_conflict() {
 
     work_dir.run_jj(["new"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  4f18f4ac428d3cd0e2ce9169e60222628fe04f4f
-    ×  b3e1abf04842a7756ba95d0a72d72f5f40243362 left
+    ×  b3e1abf04842a7756ba95d0a72d72f5f40243362 left git_head()
     ○  620e15db9fcd05fff912c52d2cafd36c9e01523c right
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Now the working copy commit's parent is conflicted, so the index should have
     // a conflict with correct blob IDs.
@@ -1404,18 +1703,27 @@ fn test_git_colocated_update_index_3_sided_conflict() {
         .run_jj(["new", "side-1", "side-2", "side-3"])
         .success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @      fc4cf6fcac1da27c71e4cd136bf87f6c33d25710
     ├─┬─╮
     │ │ ○  5008c8807feaa955d02e96cb1b0dcf51536fefb8 side-3
     │ ○ │  da6e0a03f8b72f6868a9ea33836123fe965c0cb4 side-2
     │ ├─╯
-    ○ │  ad7eaf61b769dce99884d2ceb0ddf48fc4eac463 side-1
+    ○ │  ad7eaf61b769dce99884d2ceb0ddf48fc4eac463 side-1 git_head()
     ├─╯
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // We can't add conflicts with more than 2 sides to the index, so we add a dummy
     // conflict instead. The stat for base.txt should not change.
@@ -1430,9 +1738,9 @@ fn test_git_colocated_update_index_3_sided_conflict() {
 
     work_dir.run_jj(["new"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  2527e09e99326385dfbe14bb3f23f1cc12b9090b
-    ×      fc4cf6fcac1da27c71e4cd136bf87f6c33d25710
+    ×      fc4cf6fcac1da27c71e4cd136bf87f6c33d25710 git_head()
     ├─┬─╮
     │ │ ○  5008c8807feaa955d02e96cb1b0dcf51536fefb8 side-3
     │ ○ │  da6e0a03f8b72f6868a9ea33836123fe965c0cb4 side-2
@@ -1442,7 +1750,16 @@ fn test_git_colocated_update_index_3_sided_conflict() {
     ○  1861378a9167e6561bf8ce4a6fef2d7c0897dd87 base
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Index should be the same after `jj new`.
     insta::assert_snapshot!(get_index_state(work_dir.root()), @r"
@@ -1492,6 +1809,16 @@ fn get_log_output(work_dir: &TestWorkDir) -> CommandOutput {
     )
     "#;
     work_dir.run_jj(["log", "-T", template, "-r=all()"])
+}
+
+/// Skips the test if git command is not available.
+/// Returns true if the test should be skipped.
+fn skip_if_git_unavailable() -> bool {
+    if Command::new("git").arg("--version").status().is_err() {
+        eprintln!("Skipping because git command might fail to run");
+        return true;
+    }
+    false
 }
 
 fn update_git_index(repo_path: &Path) {
@@ -1590,12 +1917,21 @@ fn test_git_colocated_unreachable_commits() {
     work_dir
         .run_jj(["git", "init", "--git-repo", "."])
         .success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  f3677b3e3b95a34e7017655ab612e1d11b59c713
-    ○  cd740e230992f334de13a0bd0b35709b3f7a89af master initial
+    ○  cd740e230992f334de13a0bd0b35709b3f7a89af master git_head() initial
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(
         git_repo.head_id().unwrap().to_string(),
         @"cd740e230992f334de13a0bd0b35709b3f7a89af"
@@ -1642,15 +1978,24 @@ fn test_git_colocated_operation_cleanup() {
         .success();
     work_dir.run_jj(["new"]).success();
 
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  40638ce20b8b74e94460e95709cb077f4307ad7c
-    ○  a50e55141dcd5f8f8d549acd2232ce4839eaa798 feature 3
+    ○  a50e55141dcd5f8f8d549acd2232ce4839eaa798 feature git_head() 3
     │ ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main 2
     ├─╯
     ○  87f64775047d7ce62b7ee81412b8e4cc07aea40a 1
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Start a rebase in Git and expect a merge conflict.
     let output = std::process::Command::new("git")
@@ -1669,9 +2014,9 @@ fn test_git_colocated_operation_cleanup() {
         .unwrap();
     assert!(output.status.success());
     insta::assert_snapshot!(String::from_utf8(output.stdout).unwrap(), @"UU file");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  588c505e689d116180684778b29c540fe7180268
-    ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main 2
+    ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main git_head() 2
     │ ○  a50e55141dcd5f8f8d549acd2232ce4839eaa798 feature 3
     ├─╯
     ○  87f64775047d7ce62b7ee81412b8e4cc07aea40a 1
@@ -1679,8 +2024,15 @@ fn test_git_colocated_operation_cleanup() {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
     [EOF]
-    ");
+    "#);
 
     // Reset the Git HEAD with Jujutsu.
     let output = work_dir.run_jj(["new", "main"]);
@@ -1691,17 +2043,26 @@ fn test_git_colocated_operation_cleanup() {
     Added 0 files, modified 1 files, removed 0 files
     [EOF]
     ");
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  aa14563cf5d892238f1e60260c5c284627d76e7c
     │ ○  588c505e689d116180684778b29c540fe7180268
     ├─╯
-    ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main 2
+    ○  cf3bb116ded416d9b202e71303f260e504c2eeb9 main git_head() 2
     │ ○  a50e55141dcd5f8f8d549acd2232ce4839eaa798 feature 3
     ├─╯
     ○  87f64775047d7ce62b7ee81412b8e4cc07aea40a 1
     ◆  0000000000000000000000000000000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: cf3bb116ded416d9b202e71303f260e504c2eeb9
@@ -1734,4 +2095,621 @@ fn get_colocation_status(work_dir: &TestWorkDir) -> CommandOutput {
         "--ignore-working-copy",
         "--quiet", // suppress hint
     ])
+}
+
+
+/// Tests that creating a non-colocated workspace from a colocated repo
+/// doesn't move git HEAD.
+///
+/// Note: This test verifies basic workspace creation behavior. The colocation
+/// detection reload logic is more thoroughly tested by the colocated workspace
+/// tests (test_colocated_workspace_*) which use actual git worktrees.
+#[test]
+fn test_git_colocated_create_workspace_not_moving_head() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["commit", "-m", "second_wc_parent"])
+        .success();
+    let output = work_dir
+        .run_jj(["log", "-Tcommit_id", "-r@-", "--no-graph"])
+        .success();
+    let second_wc_parent = output.stdout.normalized();
+
+    work_dir
+        .run_jj(["commit", "-m", "should be git head"])
+        .success();
+    work_dir
+        .run_jj(["workspace", "add", "../second", "-r", second_wc_parent])
+        .success();
+
+    // Verify git_head wasn't moved during workspace creation.
+    // The second workspace is non-colocated (no .git), so creating it
+    // should not affect git HEAD.
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
+    @  dff72cf4427ad90c331d81a97d68dbdd6b1b9894 default@
+    ○  b24869b3336626eca0f69ba14929c1be0a38e0e7 git_head() should be git head
+    │ ○  fa5c7df5654c7f8f4dd49ea881a4bb70a06c389e second@
+    ├─╯
+    ○  410296fbafc1655b3335548eff3b26753c6888c2 second_wc_parent
+    ◆  0000000000000000000000000000000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_colocated_workspace_git_symlink_to_wrong_repo() {
+    let test_env = TestEnvironment::default();
+
+    // Create a non-colocated jj repo
+    test_env
+        .run_jj_in(
+            test_env.env_root(),
+            ["git", "init", "--no-colocate", "repo"],
+        )
+        .success();
+    let work_dir = test_env.work_dir("repo");
+    let workspace_root = work_dir.root();
+
+    // Create another git repo that we'll symlink to
+    let other_git_repo = test_env.env_root().join("other-git-repo");
+    git::init(&other_git_repo);
+
+    // Create a .git symlink pointing to the other repo
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&other_git_repo, workspace_root.join(".git")).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&other_git_repo, workspace_root.join(".git")).unwrap();
+
+    // Run a jj command and verify the warning is shown
+    let output = work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output.stderr, @r"
+    Warning: Workspace has a .git symlink (pointing to $TEST_ENV/other-git-repo), that isn't pointing to jj's git repo
+    Hint: To remove this symlink, run `rm .git`
+    [EOF]
+    ");
+}
+
+/// Substitute for `jj workspace add --colocate` or similar using git CLI,
+/// please replace with the real thing when it lands.
+fn stopgap_workspace_colocate(
+    test_env: &TestEnvironment,
+    repo_path: &Path,
+    original_colocated: bool,
+    dst: &str,
+    initial_head: &str,
+) {
+    // Can't use gix/git2, as neither can repair the broken worktree we're about to
+    // create.
+    let repo_relative_path = if original_colocated {
+        dst.to_owned()
+    } else {
+        format!("../../../../{dst}")
+    };
+    Command::new("git")
+        .args(["worktree", "add", &repo_relative_path])
+        .arg(initial_head)
+        .current_dir(if original_colocated {
+            repo_path.to_path_buf()
+        } else {
+            repo_path.join(".jj/repo/store/git")
+        })
+        // NOTE: Ensure the output is in English.
+        .env("LANG", "C")
+        .assert()
+        .success()
+        .stderr(format!(
+            "Preparing worktree (detached HEAD {})
+",
+            &initial_head[..7]
+        ));
+    let dst_path = repo_path.join(dst);
+    let tmp_path = test_env.env_root().join("__tmp_worktree__");
+    if tmp_path.exists() {
+        std::fs::remove_dir_all(&tmp_path).unwrap();
+    }
+    std::fs::rename(&dst_path, &tmp_path).unwrap();
+    test_env
+        .work_dir("repo")
+        .run_jj(["workspace", "add", dst])
+        .success();
+    std::fs::rename(tmp_path.join(".git"), dst_path.join(".git")).unwrap();
+    std::fs::write(dst_path.join(".jj/.gitignore"), "*
+").unwrap();
+    Command::new("git")
+        .args(["worktree", "repair"])
+        .current_dir(&dst_path)
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("checkout")
+        .arg(initial_head)
+        .current_dir(&dst_path)
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_colocated_workspace_in_bare_repo() {
+    // TODO: Remove when this stops requiring git (stopgap_workspace_colocate)
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let default_work_dir = test_env.work_dir("repo");
+    let second_work_dir = test_env.work_dir("second");
+    //
+    // git init without --colocate creates a bare repo
+    default_work_dir.create_dir_all("");
+    default_work_dir.run_jj(["git", "init"]).success();
+    default_work_dir.write_file("file", b"contents");
+    default_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    let initial_commit = default_work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    // TODO: replace with workspace add, when it can create worktrees
+    stopgap_workspace_colocate(
+        &test_env,
+        default_work_dir.root(),
+        false,
+        "../second",
+        &initial_commit,
+    );
+
+    insta::assert_snapshot!(get_log_output(&second_work_dir), @r#"
+    @  fc6bba74c2ce22ba0a8c328f3ac49beffa6f5d75 second@
+    │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9 default@
+    ├─╯
+    ○  dda9521046c4649797052c184beab33a9cf9754b git_head() initial commit
+    ◆  0000000000000000000000000000000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+
+    second_work_dir
+        .run_jj(["commit", "-m", "commit in second workspace"])
+        .success();
+    insta::assert_snapshot!(get_log_output(&second_work_dir), @r#"
+    @  a176e11b40bb9d52ab3a3f0e2cb7e32701aa1cc3 second@
+    ○  c2cc3d0b65ae4ed1964de129433819554042e813 git_head() commit in second workspace
+    │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9 default@
+    ├─╯
+    ○  dda9521046c4649797052c184beab33a9cf9754b initial commit
+    ◆  0000000000000000000000000000000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+
+    // FIXME: There should still be no git HEAD in the default workspace, which
+    // is not colocated. However, git_head() is a property of the view. And
+    // currently, all colocated workspaces read and write from the same
+    // entry of the common view.
+    //
+    // let stdout = test_env.jj_cmd_success(&repo_path, &["log", "--no-graph",
+    // "-r", "git_head()"]); insta::assert_snapshot!(stdout, @r#""#);
+
+    let output = second_work_dir
+        .run_jj(["op", "log", "-Tself.description().first_line()"])
+        .success();
+    insta::assert_snapshot!(output, @r"
+    @  commit fc6bba74c2ce22ba0a8c328f3ac49beffa6f5d75
+    ○  import git head
+    ○  create initial working-copy commit in workspace second
+    ○  add workspace 'second'
+    ○  commit 006bd1130b84e90ab082adeabd7409270d5a86da
+    ○  snapshot working copy
+    ○  add workspace 'default'
+    ○
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_colocated_workspace_moved_original_on_disk() {
+    if Command::new("git").arg("--version").status().is_err() {
+        eprintln!("Skipping because git command might fail to run");
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let default_work_dir = test_env.work_dir("repo");
+    let second_work_dir = test_env.work_dir("second");
+    let new_repo_path = test_env.env_root().join("repo-moved");
+
+    default_work_dir.create_dir_all("");
+    default_work_dir
+        .run_jj(["git", "init", "--colocate"])
+        .success();
+    default_work_dir.write_file("file", b"contents");
+    default_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    let initial_commit = default_work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    // TODO: replace with workspace add, when it can create worktrees
+    stopgap_workspace_colocate(
+        &test_env,
+        default_work_dir.root(),
+        true,
+        "../second",
+        &initial_commit,
+    );
+
+    // Break our worktree by moving the original repo on disk
+    std::fs::rename(default_work_dir.root(), &new_repo_path).unwrap();
+    // imagine JJ were able to do this
+    std::fs::write(
+        second_work_dir.root().join(".jj/repo"),
+        new_repo_path
+            .join(".jj/repo")
+            .as_os_str()
+            .as_encoded_bytes(),
+    )
+    .unwrap();
+
+    // REVIEW: Is this the best way to do that?
+    let output = second_work_dir.run_jj(["status"]);
+    // hack for windows paths
+    let gitfile_contents = std::fs::read_to_string(second_work_dir.root().join(".git"))
+        .unwrap()
+        .strip_prefix("gitdir: ")
+        .unwrap()
+        .trim()
+        .to_owned();
+    let stderr = output
+        .stderr
+        .normalized()
+        .replace(&gitfile_contents, "$TEST_ENV/repo/.git/worktrees/second");
+    insta::assert_snapshot!(stderr, @r"
+    Warning: Workspace is a broken Git worktree
+    The .git file points at: $TEST_ENV/repo/.git/worktrees/second
+    Hint: If this is meant to be a colocated jj workspace, you may like to try `git -C $TEST_ENV/repo-moved worktree repair`
+    ");
+
+    Command::new("git")
+        .args(["worktree", "repair"])
+        .current_dir(&new_repo_path)
+        .assert()
+        .success();
+    insta::assert_snapshot!(get_log_output(&second_work_dir), @r#"
+    @  514e1b3adab7336794cf569e7b9c60c1dbcad1b4 second@
+    │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9 default@
+    ├─╯
+    ○  dda9521046c4649797052c184beab33a9cf9754b git_head() initial commit
+    ◆  0000000000000000000000000000000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_colocated_workspace_wrong_gitdir() {
+    // TODO: Remove when this stops requiring git (stopgap_workspace_colocate)
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let default_work_dir = test_env.work_dir("repo");
+    let second_work_dir = test_env.work_dir("second");
+    let other_work_dir = test_env.work_dir("other");
+    let other_second_work_dir = test_env.work_dir("other_second");
+
+    default_work_dir.create_dir_all("");
+    default_work_dir
+        .run_jj(["git", "init", "--colocate"])
+        .success();
+    default_work_dir.write_file("file", b"contents");
+    default_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    let initial_commit = default_work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    // TODO: replace with workspace add, when it can create worktrees
+    stopgap_workspace_colocate(
+        &test_env,
+        default_work_dir.root(),
+        true,
+        "../second",
+        &initial_commit,
+    );
+
+    other_work_dir.create_dir_all("");
+    other_work_dir
+        .run_jj(["git", "init", "--colocate"])
+        .success();
+    other_work_dir.write_file("file", b"contents2");
+    other_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    // REVIEW: Is this the best way to do that?
+    let other_initial_commit = other_work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    // TODO: replace with workspace add, when it can create worktrees
+    stopgap_workspace_colocate(
+        &test_env,
+        other_work_dir.root(),
+        true,
+        "../other_second",
+        &other_initial_commit,
+    );
+
+    // Break one of our worktrees
+    std::fs::copy(
+        other_second_work_dir.root().join(".git"),
+        second_work_dir.root().join(".git"),
+    )
+    .unwrap();
+
+    let output = second_work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output.stderr, @"
+    Warning: Workspace is also a Git worktree that is not managed by jj
+    Hint: To remove this worktree, run `git worktree remove .` from the parent Git repo
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_colocated_workspace_invalid_gitdir() {
+    // TODO: Remove when this stops requiring git (stopgap_workspace_colocate)
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let default_work_dir = test_env.work_dir("repo");
+    let second_work_dir = test_env.work_dir("second");
+
+    default_work_dir.create_dir_all("");
+    default_work_dir
+        .run_jj(["git", "init", "--colocate"])
+        .success();
+    default_work_dir.write_file("file", b"contents");
+    default_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    // REVIEW: Is this the best way to do that?
+    let initial_commit = default_work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    // TODO: replace with workspace add, when it can create worktrees
+    stopgap_workspace_colocate(
+        &test_env,
+        default_work_dir.root(),
+        true,
+        "../second",
+        &initial_commit,
+    );
+
+    // Break one of our worktrees
+    std::fs::write(second_work_dir.root().join(".git"), "invalid").unwrap();
+
+    let output = second_work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output.stderr, @r"
+    Warning: Workspace is a broken Git worktree
+    The .git file points at: invalid
+    Hint: If this is meant to be a colocated jj workspace, you may like to try `git -C $TEST_ENV/repo worktree repair`
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_colocated_workspace_independent_heads() {
+    // TODO: Remove when this stops requiring git (stopgap_workspace_colocate)
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let default_work_dir = test_env.work_dir("repo");
+    let second_work_dir = test_env.work_dir("second");
+
+    default_work_dir.create_dir_all("");
+    default_work_dir
+        .run_jj(["git", "init", "--colocate"])
+        .success();
+    // create a commit so that git can have a HEAD
+    default_work_dir.write_file("file", b"contents");
+    default_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    let initial_commit = default_work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    // TODO: replace with workspace add, when it can create worktrees
+    stopgap_workspace_colocate(
+        &test_env,
+        default_work_dir.root(),
+        true,
+        "../second",
+        &initial_commit,
+    );
+
+    {
+        let first_git = git::open(default_work_dir.root());
+        let mut first_head = first_git.head().unwrap();
+        assert!(first_head.is_detached());
+
+        let commit = first_head.peel_to_commit().unwrap().id();
+        assert_eq!(commit.to_string(), initial_commit);
+
+        let second_git = git::open(second_work_dir.root());
+        let mut second_head = second_git.head().unwrap();
+        assert!(second_head.is_detached());
+
+        let commit = second_head.peel_to_commit().unwrap().id();
+        assert_eq!(commit.to_string(), initial_commit);
+    }
+
+    // now commit again in the second worktree, and make sure the original
+    // repo's head does not move.
+    //
+    // This tests that we are writing HEAD to the corresponding worktree,
+    // rather than unconditionally to the default workspace.
+    default_work_dir.write_file("file", b"contents");
+    second_work_dir
+        .run_jj(["commit", "-m", "followup commit"])
+        .success();
+    let followup_commit = second_work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+
+    {
+        // git HEAD should not move in the default workspace
+        let first_git = git::open(default_work_dir.root());
+        let mut first_head = first_git.head().unwrap();
+        assert!(first_head.is_detached());
+        // still initial
+        assert_eq!(
+            first_head.peel_to_commit().unwrap().id().to_string(),
+            initial_commit,
+            "default workspace's git HEAD should not have moved from {initial_commit}"
+        );
+
+        let second_git = git::open(second_work_dir.root());
+        let mut second_head = second_git.head().unwrap();
+        assert!(second_head.is_detached());
+        assert_eq!(
+            second_head.peel_to_commit().unwrap().id().to_string(),
+            followup_commit,
+            "second workspace's git HEAD should have advanced to {followup_commit}"
+        );
+    }
+
+    // Finally, test imports. Test that a commit written to HEAD in one workspace
+    // does not get imported by the other workspace.
+
+    // Write in default, expect second not to import it
+    let new_commit = test_independent_import(&default_work_dir, &second_work_dir, &followup_commit);
+    // Write in second, expect default not to import it
+    test_independent_import(&second_work_dir, &default_work_dir, &new_commit);
+
+    fn test_independent_import(
+        commit_in: &TestWorkDir,
+        no_import_in_workspace: &TestWorkDir,
+        workspace_at: &str,
+    ) -> String {
+        // Commit in one workspace
+        let mut repo = gix::open(commit_in.root()).unwrap();
+        {
+            use gix::config::tree::*;
+            let mut config = repo.config_snapshot_mut();
+            let (name, email) = ("JJ test", "jj@example.com");
+            config.set_value(&Author::NAME, name).unwrap();
+            config.set_value(&Author::EMAIL, email).unwrap();
+            config.set_value(&Committer::NAME, name).unwrap();
+            config.set_value(&Committer::EMAIL, email).unwrap();
+        }
+        let tree = repo.head_tree_id().unwrap();
+        let current = repo.head_commit().unwrap().id;
+        let new_commit = repo
+            .commit(
+                "HEAD",
+                format!("empty commit in {}", commit_in.root().display()),
+                tree,
+                [current],
+            )
+            .unwrap()
+            .to_string();
+
+        let output = no_import_in_workspace.run_jj([
+            "log",
+            "--no-graph",
+            "-r",
+            "git_head()",
+            "-T",
+            "commit_id",
+        ]);
+        // Asserting no import message in stderr => no import occurred
+        // (note: git_head() revset is deprecated and produces a warning)
+        assert!(
+            !output.stderr.normalized().contains("imported"),
+            "Should not have imported HEAD in workspace {}",
+            no_import_in_workspace.root().display()
+        );
+        // And the commit_id should be pointing to what it was before
+        assert_eq!(
+            output.stdout.normalized(),
+            workspace_at,
+            "should still be at {workspace_at} in workspace {}",
+            no_import_in_workspace.root().display()
+        );
+
+        // Now we import the new HEAD in the commit_in workspace, so it's up to date.
+        let output = commit_in.run_jj(["log", "--no-graph", "-r", "git_head()", "-T", "commit_id"]);
+        // (note: git_head() revset is deprecated and produces a warning, so check
+        // contains)
+        assert!(
+            output
+                .stderr
+                .normalized()
+                .contains("Reset the working copy parent to the new Git HEAD."),
+            "should have imported HEAD in workspace {}",
+            commit_in.root().display()
+        );
+        assert_eq!(
+            output.stdout.normalized(),
+            new_commit,
+            "should have advanced to {new_commit} in workspace {}",
+            commit_in.root().display()
+        );
+        new_commit
+    }
 }

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -113,7 +113,14 @@ fn test_git_colocation_enable_empty() {
         )
         .success();
     let work_dir = test_env.work_dir("repo");
+    let workspace_root = work_dir.root();
     let setup_op_id = work_dir.current_operation_id();
+
+    // Verify initial state: no .git at workspace root
+    assert!(
+        !workspace_root.join(".git").exists(),
+        ".git should not exist before enable"
+    );
 
     // Run colocate command
     let output = work_dir.run_jj(["git", "colocation", "enable"]);
@@ -122,6 +129,22 @@ fn test_git_colocation_enable_empty() {
     Workspace successfully converted into a colocated Jujutsu/Git workspace.
     [EOF]
     ");
+
+    // Verify filesystem changes: .git now exists at workspace root
+    assert!(
+        workspace_root.join(".git").exists(),
+        ".git should exist after enable"
+    );
+    assert!(
+        !workspace_root
+            .join(".jj")
+            .join("repo")
+            .join("store")
+            .join("git")
+            .exists(),
+        "Internal git store should be moved"
+    );
+    assert_eq!(read_git_target(workspace_root), "../../../.git");
 
     // Verify that Git HEAD was set correctly
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
@@ -132,6 +155,13 @@ fn test_git_colocation_enable_empty() {
 
     // No repo change required
     assert_eq!(setup_op_id, work_dir.current_operation_id());
+
+    // Verify workspace is still functional
+    let output = work_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work after enable"
+    );
 }
 
 #[test]
@@ -173,8 +203,10 @@ fn test_git_colocation_enable_with_existing_git_dir() {
 
     // Try to colocate - should fail
     let output = work_dir.run_jj(["git", "colocation", "enable"]);
-    insta::assert_snapshot!(output.strip_stderr_last_line(), @r"
+    insta::assert_snapshot!(output.strip_stderr_last_line(), @"
     ------- stderr -------
+    Warning: Workspace has a .git directory that is not managed by jj
+    Hint: To remove this directory, run `rm -rf .git`
     Error: A .git directory already exists in the workspace root. Cannot colocate.
     [EOF]
     [exit status: 1]
@@ -251,7 +283,14 @@ fn test_git_colocation_disable_empty() {
         .run_jj_in(test_env.env_root(), ["git", "init", "--colocate", "repo"])
         .success();
     let work_dir = test_env.work_dir("repo");
+    let workspace_root = work_dir.root();
     let setup_op_id = work_dir.current_operation_id();
+
+    // Verify initial state: .git exists at workspace root
+    assert!(
+        workspace_root.join(".git").exists(),
+        ".git should exist before disable"
+    );
 
     // Verify that Git HEAD is unset
     insta::assert_snapshot!(get_colocation_status(&work_dir), @"
@@ -268,8 +307,31 @@ fn test_git_colocation_disable_empty() {
     [EOF]
     ");
 
+    // Verify filesystem changes: .git removed, internal git store exists
+    assert!(
+        !workspace_root.join(".git").exists(),
+        ".git should be removed after disable"
+    );
+    assert!(
+        workspace_root
+            .join(".jj")
+            .join("repo")
+            .join("store")
+            .join("git")
+            .exists(),
+        "Internal git store should be restored"
+    );
+    assert_eq!(read_git_target(workspace_root), "git");
+
     // No repo change required
     assert_eq!(setup_op_id, work_dir.current_operation_id());
+
+    // Verify workspace is still functional
+    let output = work_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work after disable"
+    );
 }
 
 #[test]

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -14,7 +14,9 @@
 
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
+use assert_cmd::assert::OutputAssertExt as _;
 use indoc::formatdoc;
 use test_case::test_case;
 use testutils::git;
@@ -54,6 +56,7 @@ fn get_log_output(work_dir: &TestWorkDir) -> CommandOutput {
     separate(" ",
       commit_id.short(),
       bookmarks,
+      if(git_head, "git_head()"),
       description,
     )"#;
     work_dir.run_jj(["log", "-T", template, "-r=all()"])
@@ -187,12 +190,21 @@ fn test_git_init_external(bare: bool) {
 
     // Check that the Git repo's HEAD got checked out
     insta::allow_duplicates! {
-        insta::assert_snapshot!(get_log_output(&work_dir), @r"
+        insta::assert_snapshot!(get_log_output(&work_dir), @r#"
         @  ed6b513890ae
-        ○  e80a42cccd06 my-bookmark My commit message
+        ○  e80a42cccd06 my-bookmark git_head() My commit message
         ◆  000000000000
         [EOF]
-        ");
+        ------- stderr -------
+        Warning: In template expression
+         --> 5:10
+          |
+        5 |       if(git_head, "git_head()"),
+          |          ^------^
+          |
+          = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+        [EOF]
+        "#);
         insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
         Workspace is currently not colocated with Git.
         Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -403,12 +415,21 @@ fn test_git_init_colocated_via_git_repo_path() {
     );
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  f3fe58bc88cc
-    ○  e80a42cccd06 my-bookmark My commit message
+    ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -417,13 +438,22 @@ fn test_git_init_colocated_via_git_repo_path() {
 
     // Check that the Git repo's HEAD moves
     work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  bacc067e7740
-    ○  f3fe58bc88cc
+    ○  f3fe58bc88cc git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
@@ -451,12 +481,21 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  f3fe58bc88cc
-    ○  e80a42cccd06 my-bookmark My commit message
+    ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -465,13 +504,22 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
 
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  bacc067e7740
-    ○  f3fe58bc88cc
+    ○  f3fe58bc88cc git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
@@ -499,12 +547,21 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  f3fe58bc88cc
-    ○  e80a42cccd06 my-bookmark My commit message
+    ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -513,13 +570,22 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() {
 
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  bacc067e7740
-    ○  f3fe58bc88cc
+    ○  f3fe58bc88cc git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
@@ -551,12 +617,21 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  f3fe58bc88cc
-    ○  e80a42cccd06 my-bookmark My commit message
+    ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -565,13 +640,22 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
 
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  bacc067e7740
-    ○  f3fe58bc88cc
+    ○  f3fe58bc88cc git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
@@ -606,12 +690,21 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  f3fe58bc88cc
-    ○  e80a42cccd06 my-bookmark My commit message
+    ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -620,13 +713,22 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() {
 
     // Check that the Git repo's HEAD moves
     jj_work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&jj_work_dir), @r#"
     @  bacc067e7740
-    ○  f3fe58bc88cc
+    ○  f3fe58bc88cc git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&jj_work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
@@ -825,28 +927,342 @@ fn test_git_init_external_but_git_dir_exists() {
     let output = work_dir.run_jj(["git", "init", "--git-repo", git_repo_path.to_str().unwrap()]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
+    Warning: Workspace has a .git directory that is not managed by jj
+    Hint: To remove this directory, run `rm -rf .git`
     Initialized repo in "."
     [EOF]
     "#);
 
     // The local ".git" repository is unrelated, so no commits should be imported
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  e8849ae12c70
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: Workspace has a .git directory that is not managed by jj
+    Hint: To remove this directory, run `rm -rf .git`
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
 
     // Check that Git HEAD is not set because this isn't a colocated workspace
     work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  1c1c95df80e5
     ○  e8849ae12c70
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: Workspace has a .git directory that is not managed by jj
+    Hint: To remove this directory, run `rm -rf .git`
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently not colocated with Git.
     Last imported/exported Git HEAD: (none)
+    [EOF]
+    ");
+}
+
+fn create_commit(
+    git_repo: &gix::Repository,
+    ref_name: &str,
+    msg: &str,
+    parents: &[gix::ObjectId],
+) -> gix::ObjectId {
+    let empty_tree_id = git_repo.empty_tree().id().detach();
+    git::write_commit(git_repo, ref_name, empty_tree_id, msg, parents)
+}
+
+fn add_worktree(
+    git_repo: &gix::Repository,
+    worktree_path: &Path,
+    checkout_ref: &gix::ObjectId,
+    branch_name: &str,
+) {
+    // NOTE: Using the `git` command here as it seems `gix` does not support
+    // creating worktrees.
+    Command::new("git")
+        .args(["worktree", "add", worktree_path.to_str().unwrap()])
+        .arg(checkout_ref.to_string())
+        .args(["-b", branch_name])
+        .current_dir(git_repo.path())
+        .env("LANG", "C")
+        .assert()
+        .success()
+        .stderr("Preparing worktree (new branch 'jj-worktree')\n");
+}
+
+#[test]
+fn test_git_init_external_pointing_at_worktree_from_outside() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let worktree_path = test_env.env_root().join("worktree");
+    let workspace_root = test_env.env_root().join("repo");
+    let work_dir = test_env.work_dir("repo");
+
+    let git_repo = git::init(&git_repo_path);
+    // Must create a commit so we can create a worktree
+    let initial_commit = create_commit(&git_repo, "refs/heads/main", "initial commit", &[]);
+    add_worktree(&git_repo, &worktree_path, &initial_commit, "jj-worktree");
+
+    // now commit in the worktree, so we know where we are importing from
+    let worktree_repo = git::open(&worktree_path);
+    let _initial_commit = create_commit(
+        &worktree_repo,
+        "refs/heads/jj-worktree",
+        "second commit",
+        &[worktree_repo.find_commit(initial_commit).unwrap().id],
+    )
+    .to_string();
+
+    std::fs::create_dir(&workspace_root).unwrap();
+    let output = work_dir.run_jj(["git", "init", "--git-repo", worktree_path.to_str().unwrap()]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Done importing changes from the underlying Git repo.
+    Working copy  (@) now at: sqpuoqvx ec8ff2c1 (empty) (no description set)
+    Parent commit (@-)      : swvxkrzu c8c6f2fd jj-worktree | (empty) second commit
+    Initialized repo in "."
+    [EOF]
+    "#);
+
+    assert_eq!(
+        dunce::canonicalize(PathBuf::from(read_git_target(&work_dir))).unwrap(),
+        dunce::canonicalize(worktree_path.join(".git")).unwrap()
+    );
+
+    // This is similar to a normal `jj git init --git-repo=` -- we import the
+    // commits, but in this case our HEAD@git comes from the worktree.
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
+    @  ec8ff2c11a77
+    ○  c8c6f2fd4467 jj-worktree git_head() second commit
+    ○  9b224cbd2bfd main initial commit
+    ◆  000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+
+    // The git HEAD should not advance, because this is not colocated
+    work_dir.run_jj(["new"]).success();
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
+    @  3946d5a0db9f
+    ○  ec8ff2c11a77
+    ○  c8c6f2fd4467 jj-worktree git_head() second commit
+    ○  9b224cbd2bfd main initial commit
+    ◆  000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_git_init_external_in_worktree_pointing_worktree() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let workspace_root = test_env.env_root().join("repo");
+    let work_dir = test_env.work_dir("repo");
+
+    let git_repo = git::init(&git_repo_path);
+    // Must create a commit so we can create a worktree
+    let initial_commit = create_commit(&git_repo, "refs/heads/main", "initial commit", &[]);
+    add_worktree(&git_repo, &workspace_root, &initial_commit, "jj-worktree");
+    assert!(workspace_root.join(".git").is_file());
+
+    // now commit in the worktree, so we know where we are importing from
+    let worktree_repo = git::open(&workspace_root);
+    let _initial_commit = create_commit(
+        &worktree_repo,
+        "refs/heads/jj-worktree",
+        "second commit",
+        &[worktree_repo.find_commit(initial_commit).unwrap().id],
+    )
+    .to_string();
+
+    let output = work_dir.run_jj(["git", "init", "--git-repo", "."]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Done importing changes from the underlying Git repo.
+    Initialized repo in "."
+    [EOF]
+    "#);
+
+    assert_eq!(read_git_target(&work_dir), "../../../.git");
+
+    // The local ".git" repository is related, so commits should be imported
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
+    @  ec8ff2c11a77
+    ○  c8c6f2fd4467 jj-worktree git_head() second commit
+    ○  9b224cbd2bfd main initial commit
+    ◆  000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+
+    // Check that Git HEAD is advanced because this is colocated
+    work_dir.run_jj(["new"]).success();
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
+    @  3946d5a0db9f
+    ○  ec8ff2c11a77 git_head()
+    ○  c8c6f2fd4467 jj-worktree second commit
+    ○  9b224cbd2bfd main initial commit
+    ◆  000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+
+    let output = work_dir.run_jj(OP_LOG_COMPACT);
+    insta::assert_snapshot!(output, @r"
+    @  bef16a4a7453 new empty commit
+    │  args: jj new
+    ○  89b191596eea import git head
+    │  args: jj git init --git-repo .
+    ○  ac6dadf8291e import git refs
+    │  args: jj git init --git-repo .
+    ○  8f47435a3990 add workspace 'default'
+    ○  000000000000
+    [EOF]
+    ");
+}
+
+const OP_LOG_COMPACT: &[&str] = &[
+    "op",
+    "log",
+    "-Tself.id().short() ++ ' ' ++ separate(\"\\n\", self.description().first_line(), self.tags())",
+];
+
+/// This one is a bit weird, but technically you can do it. Should be roughly
+/// equivalent to the --git-repo=. case, but with a different git_target file.
+#[test]
+fn test_git_init_external_in_worktree_pointing_commondir() {
+    let test_env = TestEnvironment::default();
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let workspace_root = test_env.env_root().join("repo");
+    let work_dir = test_env.work_dir("repo");
+
+    let git_repo = git::init(&git_repo_path);
+    // Must create a commit so we can create a worktree
+    let initial_commit = create_commit(&git_repo, "refs/heads/main", "initial commit", &[]);
+    add_worktree(&git_repo, &workspace_root, &initial_commit, "jj-worktree");
+    assert!(workspace_root.join(".git").is_file());
+
+    // now commit in the worktree, so we know where we are importing from
+    let worktree_repo = git::open(&workspace_root);
+    let _initial_commit = create_commit(
+        &worktree_repo,
+        "refs/heads/jj-worktree",
+        "second commit",
+        &[worktree_repo.find_commit(initial_commit).unwrap().id],
+    )
+    .to_string();
+
+    let output = work_dir.run_jj(["git", "init", "--git-repo", "../git-repo"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Done importing changes from the underlying Git repo.
+    Initialized repo in "."
+    [EOF]
+    "#);
+
+    assert_eq!(
+        dunce::canonicalize(PathBuf::from(read_git_target(&work_dir))).unwrap(),
+        dunce::canonicalize(git_repo_path.join(".git")).unwrap()
+    );
+
+    // The local ".git" repository is related, so commits should be imported,
+    // specifically from the worktree, not the original repo.
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
+    @  ec8ff2c11a77
+    ○  c8c6f2fd4467 jj-worktree git_head() second commit
+    ○  9b224cbd2bfd main initial commit
+    ◆  000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+
+    // Check that Git HEAD is advanced because this is colocated
+    work_dir.run_jj(["new"]).success();
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
+    @  3946d5a0db9f
+    ○  ec8ff2c11a77 git_head()
+    ○  c8c6f2fd4467 jj-worktree second commit
+    ○  9b224cbd2bfd main initial commit
+    ◆  000000000000
+    [EOF]
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
+
+    let output = work_dir.run_jj(OP_LOG_COMPACT);
+    insta::assert_snapshot!(output, @r"
+    @  9dd2def8f0dd new empty commit
+    │  args: jj new
+    ○  c823062eec4c import git head
+    │  args: jj git init --git-repo ../git-repo
+    ○  67e104bc9e52 import git refs
+    │  args: jj git init --git-repo ../git-repo
+    ○  8f47435a3990 add workspace 'default'
+    ○  000000000000
     [EOF]
     ");
 }
@@ -867,12 +1283,21 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     "#);
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  f3fe58bc88cc
-    ○  e80a42cccd06 my-bookmark My commit message
+    ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -881,13 +1306,22 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
 
     // Check that the Git repo's HEAD moves
     work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  bacc067e7740
-    ○  f3fe58bc88cc
+    ○  f3fe58bc88cc git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
@@ -913,12 +1347,21 @@ fn test_git_init_colocated_via_config_git_dir_exists() {
     "#);
 
     // Check that the Git repo's HEAD got checked out
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  f3fe58bc88cc
-    ○  e80a42cccd06 my-bookmark My commit message
+    ○  e80a42cccd06 my-bookmark git_head() My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: e80a42cccd069007c7a2bb427ac7f1d10b408633
@@ -927,13 +1370,22 @@ fn test_git_init_colocated_via_config_git_dir_exists() {
 
     // Check that the Git repo's HEAD moves
     work_dir.run_jj(["new"]).success();
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  bacc067e7740
-    ○  f3fe58bc88cc
+    ○  f3fe58bc88cc git_head()
     ○  e80a42cccd06 my-bookmark My commit message
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: f3fe58bc88ccfb820b930a21297d8e48bf76ac2a
@@ -970,11 +1422,20 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     [EOF]
     "#);
     // No HEAD ref is available yet
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  e8849ae12c70
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: (none)
@@ -988,11 +1449,20 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
 
     // If .git/HEAD pointed to the default bookmark, new working-copy commit would
     // be created on top.
-    insta::assert_snapshot!(get_log_output(&work_dir), @r"
+    insta::assert_snapshot!(get_log_output(&work_dir), @r#"
     @  e8849ae12c70 main master
     ◆  000000000000
     [EOF]
-    ");
+    ------- stderr -------
+    Warning: In template expression
+     --> 5:10
+      |
+    5 |       if(git_head, "git_head()"),
+      |          ^------^
+      |
+      = commit.git_head() is deprecated; use .contained_in('first_parent(@)') instead
+    [EOF]
+    "#);
     insta::assert_snapshot!(get_colocation_status(&work_dir), @r"
     Workspace is currently colocated with Git.
     Last imported/exported Git HEAD: (none)

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1541,6 +1541,136 @@ recover.
     Ok(id.detach())
 }
 
+/// Helper for the GitBackend to open a git repo and detect colocation.
+///
+/// A workspace is considered "colocated" when Git regards the workspace root
+/// as a working directory for the same repo that jj uses internally. This
+/// enables automatic import/export of Git refs on every jj command.
+///
+/// ## Detection Algorithm
+///
+/// Colocation is detected by comparing `common_dir()` paths (canonicalized):
+/// 1. Open the Git repository that jj's store points to
+/// 2. Attempt to open `<workspace_root>/.git` as a Git repository
+/// 3. If both succeed and their `common_dir()` paths match, we're colocated
+///
+/// The `common_dir()` comparison handles Git worktrees correctly, as all
+/// worktrees of a repository share the same common directory.
+///
+/// ## Supported Scenarios
+///
+/// - **Bare repo**: In `.jj/repo/store/git` directory (not colocated)
+/// - **Colocated non-bare**: `.git` directory at workspace root
+/// - **Git worktree**: `.git` file pointing to same repo as jj store
+/// - **Symlink**: `.git` symlink pointing to same repo as jj store
+///
+/// ## Corner Cases
+///
+/// When detection fails or finds a mismatch, jj is not colocated but may warn
+/// the user (see `warn_about_unexpected_git_in_workspace` in
+/// `cli/src/git_util.rs`):
+///
+/// - **gix::open fails**: Not colocated (e.g., broken worktree, invalid `.git`
+///   file)
+/// - **Canonicalization fails**: Assume not colocated (logged at debug level)
+/// - **common_dir mismatch**: Not colocated (`.git` exists but points
+///   elsewhere)
+///
+/// See `docs/design/colocated-workspaces.md` for full specification.
+pub(crate) struct MaybeColocatedGitRepo {
+    pub git_repo: gix::ThreadSafeRepository,
+    pub colocated: bool,
+}
+
+impl MaybeColocatedGitRepo {
+    /// Opens the Git repository and detects colocation with the workspace.
+    ///
+    /// First opens the repository at `store_repo_path` (which may be bare).
+    /// If `workspace_root` is provided, attempts to detect if the workspace
+    /// is colocated by checking for a `.git` directory/file/symlink that
+    /// points to the same underlying Git repository.
+    ///
+    /// Returns a `MaybeColocatedGitRepo` with `colocated = true` if:
+    /// - A `.git` exists at the workspace root
+    /// - It can be opened as a Git repository
+    /// - Its `common_dir()` matches the store repo's `common_dir()`
+    pub(crate) fn open_automatic(
+        store_repo_path: &Path,
+        workspace_root: Option<&Path>,
+        open_opts: gix::open::Options,
+    ) -> Result<Self, Box<gix::open::Error>> {
+        let maybe = Self::open_store_repo(store_repo_path, open_opts.clone())?;
+        if let Some(workspace_root) = workspace_root {
+            return Ok(maybe.try_detect_colocated_workspace(workspace_root, open_opts));
+        }
+        Ok(maybe)
+    }
+
+    fn open_store_repo(
+        store_repo_path: &Path,
+        open_opts: gix::open::Options,
+    ) -> Result<Self, Box<gix::open::Error>> {
+        let git_repo = gix::ThreadSafeRepository::open_opts(store_repo_path, open_opts)?;
+
+        Ok(Self {
+            git_repo,
+            colocated: false,
+        })
+    }
+
+    /// Try to open `<workspace_root>/.git` as a git repository.
+    ///
+    /// If it succeeds, and the commondir matches jj's backing repo, then the
+    /// workspace is colocated, and we return the newly opened repository.
+    ///
+    /// Easy to sanity check with git -- if `git` works and addresses the same
+    /// underlying repo (commondir), then the workspace will be colocated. So
+    /// things like worktrees, symlinks, etc just work.
+    fn try_detect_colocated_workspace(
+        self,
+        workspace_root: &Path,
+        open_opts: gix::open::Options,
+    ) -> Self {
+        let store_repo = &self.git_repo;
+
+        let Ok(workspace_repo) =
+            gix::ThreadSafeRepository::open_opts(workspace_root.join(".git"), open_opts)
+        else {
+            // If gix can't open it, we are not colocated.
+            return self;
+        };
+
+        // Especially for worktrees, common_dir() returns paths with ../.. in them,
+        // usually. Must canonicalize.
+        let workspace_common_dir_raw = workspace_repo.to_thread_local().common_dir().to_owned();
+        let Ok(workspace_common_dir) = workspace_common_dir_raw.canonicalize() else {
+            tracing::debug!(
+                ?workspace_root,
+                ?workspace_common_dir_raw,
+                "Failed to canonicalize workspace common_dir, assuming not colocated"
+            );
+            return self;
+        };
+        let store_common_dir_raw = store_repo.to_thread_local().common_dir().to_owned();
+        let Ok(store_common_dir) = store_common_dir_raw.canonicalize() else {
+            tracing::debug!(
+                ?store_common_dir_raw,
+                "Failed to canonicalize store common_dir, assuming not colocated"
+            );
+            return self;
+        };
+
+        if workspace_common_dir != store_common_dir {
+            return self;
+        }
+
+        Self {
+            git_repo: workspace_repo,
+            colocated: true,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;


### PR DESCRIPTION
## Summary

This PR picks up the colocated workspaces work from #4644 and #8252, aiming to address all outstanding maintainer feedback. It adds foundational support for colocated workspaces, allowing jj to properly detect and handle Git worktrees alongside jj workspaces.

Key changes:
- Make backend factories aware of the workspace root for colocation detection
- Add `MaybeColocatedGitRepo` helper in `git_backend.rs` for detecting colocation
- Make `GitBackend` colocation-aware so it correctly handles colocated vs non-colocated workspaces
- Add warnings when workspace has a `.git` that isn't managed by jj
- Add test infrastructure for colocated workspace scenarios

This PR lays the groundwork for future features like `jj workspace add --colocate` that would automatically create Git worktrees alongside jj workspaces.

## Attribution

This work is based on the contributions of:
- **@cormacrelf** (Cormac Relf) - Original implementation in #8252, included via `Co-authored-by` trailer
- **@ejpcmac** (Jean-Philippe Cugnet) - Original implementation in #4644 and #8252

Jean-Philippe's contributions would normally be credited via `Co-authored-by`, but this is not possible as they have not signed the Google CLA. Their work on the original PRs was instrumental to this implementation.

## Maintainer Feedback Addressed

Based on review comments from #4644:

- **Moved `MaybeColocatedGitRepo` to `git_backend.rs`** - colocation detection belongs with backend configuration, not operations
- **Use lowercase "jj"** in all messages (not "JJ")
- **Use `PathBuf::from()` instead of `Path::new().to_path_buf()`** for idiomatic Rust
- **Import functions by name** per project convention
- **Simplified `with_colocated(false)` calls** - removed redundant method since `self.colocated` was already `false`
- **Extracted warning logic** into separate `warn_about_unexpected_git_in_workspace()` function for better separation of concerns
- **Added debug tracing** for canonicalize failures to aid debugging
- **Fixed test clarity** - renamed and clarified `test_git_colocated_create_workspace_not_moving_head` with accurate documentation

## Background

- Tracking issue: #8052
- Original PR: #4644 (closed)
- Rebased from: #8252 by @ejpcmac

## PR Stack

This is the base PR. Follow-up PRs build on this:
1. **This PR** - Base colocation support
2. #8644 - `workspace add --colocate`
3. #8645 - Import commits from all worktrees' HEADs
4. #8646 - Clean up Git worktree on `workspace forget`
5. #8647 - Tests and documentation

## Feedback Welcome

I'm committed to following project conventions and would appreciate any feedback. I have a low bar for making requested changes, and explanations help me avoid similar issues in future contributions.

## Test plan

- [x] All existing tests pass
- [x] New tests added for:
  - Colocated workspace detection
  - Git worktree recognition  
  - Warning messages for `.git` not managed by jj
  - Workspace creation that doesn't move git HEAD