### PR TITLE
cli: remove legacy placeholder string for user/email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Deprecated `ui.always-allow-large-revsets` setting and `all:` revset modifier
   have been removed.
 
+* Legacy placeholder support used for unset `user.name` or `user.email` has been
+  removed. Commits containing these values will now be pushed with `jj git push`
+  without producing an error.
+
 ### Deprecations
 
 * The revset function `diff_contains()` has been renamed to `diff_lines()`.

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -45,7 +45,6 @@ use jj_lib::refs::LocalAndRemoteRef;
 use jj_lib::refs::classify_bookmark_push_action;
 use jj_lib::repo::Repo;
 use jj_lib::revset::RevsetExpression;
-use jj_lib::settings::UserSettings;
 use jj_lib::signing::SignBehavior;
 use jj_lib::str_util::StringExpression;
 use jj_lib::view::View;
@@ -539,13 +538,9 @@ fn validate_commits_ready_to_push(
             reasons.push("it has no description");
         }
         if commit.author().name.is_empty()
-            || commit.author().name == UserSettings::USER_NAME_PLACEHOLDER
             || commit.author().email.is_empty()
-            || commit.author().email == UserSettings::USER_EMAIL_PLACEHOLDER
             || commit.committer().name.is_empty()
-            || commit.committer().name == UserSettings::USER_NAME_PLACEHOLDER
             || commit.committer().email.is_empty()
-            || commit.committer().email == UserSettings::USER_EMAIL_PLACEHOLDER
         {
             reasons.push("it has no author and/or committer set");
         }

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -235,14 +235,10 @@ impl DetachedCommitBuilder {
         commit.committer = settings.signature();
         // If the user had not configured a name and email before but now they have,
         // update the author fields with the new information.
-        if commit.author.name.is_empty()
-            || commit.author.name == UserSettings::USER_NAME_PLACEHOLDER
-        {
+        if commit.author.name.is_empty() {
             commit.author.name.clone_from(&commit.committer.name);
         }
-        if commit.author.email.is_empty()
-            || commit.author.email == UserSettings::USER_EMAIL_PLACEHOLDER
-        {
+        if commit.author.email.is_empty() {
             commit.author.email.clone_from(&commit.committer.email);
         }
 

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -177,16 +177,9 @@ impl UserSettings {
         &self.data.user_name
     }
 
-    // Must not be changed to avoid git pushing older commits with no set name
-    pub const USER_NAME_PLACEHOLDER: &str = "(no name configured)";
-
     pub fn user_email(&self) -> &str {
         &self.data.user_email
     }
-
-    // Must not be changed to avoid git pushing older commits with no set email
-    // address
-    pub const USER_EMAIL_PLACEHOLDER: &str = "(no email configured)";
 
     pub fn commit_timestamp(&self) -> Option<Timestamp> {
         self.data.commit_timestamp


### PR DESCRIPTION
While working on #8580, I encountered some placeholder constants that @yuja says are [safe to delete.](https://github.com/jj-vcs/jj/pull/8580#discussion_r2697623312).

Jujutsu switched away from these placeholders in 0.9.0 with PR #2108 while ensuring they were unpushable and rewritten at the first opportunity.  This PR removes the placeholders; hopefully, ~2.5 years has been long enough.  There were no tests that used these values.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
