### PR TITLE
clippy: fix cloned_instead_of_copied lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ testutils = { path = "lib/testutils" }
 [workspace.lints.clippy]
 borrow_as_ptr = "warn"
 cast_lossless = "warn"
+cloned_instead_of_copied = "warn"
 explicit_into_iter_loop = "warn"
 explicit_iter_loop = "warn"
 flat_map_option = "warn"

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -172,7 +172,7 @@ fn test_concurrent_operations() {
 }
 
 fn assert_heads(repo: &dyn Repo, expected: Vec<&CommitId>) {
-    let expected = expected.iter().cloned().cloned().collect();
+    let expected = expected.iter().copied().cloned().collect();
     assert_eq!(*repo.view().heads(), expected);
 }
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#cloned_instead_of_copied
