### PR TITLE
cli bookmark track: track default remote if --remote is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   removed. Commits containing these values will now be pushed with `jj git push`
   without producing an error.
 
+* The command `jj bookmark track <name>` without the `--remote` flag now
+  defaults to the remote "origin" if there are multiple, instead of tracking the
+  bookmark with all remotes. To achieve the previous behavior, use
+  `jj bookmark track <name> --remote='*'` instead.
+
 ### Deprecations
 
 * The revset function `diff_contains()` has been renamed to `diff_lines()`.

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -35,7 +35,7 @@ use crate::cli_util::WorkspaceCommandHelper;
 use crate::cli_util::WorkspaceCommandTransaction;
 use crate::command_error::CommandError;
 use crate::command_error::user_error;
-use crate::commands::git::get_single_remote;
+use crate::commands::get_single_remote;
 use crate::complete;
 use crate::git_util::load_git_import_options;
 use crate::git_util::print_git_import_stats;

--- a/cli/src/commands/git/mod.rs
+++ b/cli/src/commands/git/mod.rs
@@ -28,11 +28,7 @@ use clap::Subcommand;
 use clap::ValueEnum;
 use jj_lib::config::ConfigFile;
 use jj_lib::config::ConfigSource;
-use jj_lib::git;
-use jj_lib::git::UnexpectedGitBackendError;
-use jj_lib::ref_name::RemoteNameBuf;
 use jj_lib::ref_name::RemoteRefSymbol;
-use jj_lib::store::Store;
 
 use self::clone::GitCloneArgs;
 use self::clone::cmd_git_clone;
@@ -115,14 +111,6 @@ pub fn maybe_add_gitignore(workspace_command: &WorkspaceCommandHelper) -> Result
     } else {
         Ok(())
     }
-}
-
-fn get_single_remote(store: &Store) -> Result<Option<RemoteNameBuf>, UnexpectedGitBackendError> {
-    let mut names = git::get_all_remote_names(store)?;
-    Ok(match names.len() {
-        1 => names.pop(),
-        _ => None,
-    })
 }
 
 /// Sets repository level `trunk()` alias to the specified remote symbol.

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1703,14 +1703,17 @@ fn test_bookmark_track_absent() {
     [EOF]
     ");
 
-    // Track newly-created bookmark: both remotes are tracked
+    // Track newly-created bookmark without --remote: default remote is tracked
     work_dir
         .run_jj(["bookmark", "create", "new-feature"])
         .success();
+    work_dir
+        .run_jj(["git", "remote", "add", "origin", "dummy-path"])
+        .success();
     insta::assert_snapshot!(
-        work_dir.run_jj(["bookmark", "track", "new-feature", "--remote=*"]), @r"
+        work_dir.run_jj(["bookmark", "track", "new-feature"]), @r"
     ------- stderr -------
-    Started tracking 2 remote bookmarks.
+    Started tracking 1 remote bookmarks.
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
@@ -1718,8 +1721,7 @@ fn test_bookmark_track_absent() {
       @remote1: quutswnw 3fb14832 commit
       @remote2 (not created yet)
     new-feature: qpvuntsm e8849ae1 (empty) (no description set)
-      @remote1 (not created yet)
-      @remote2 (not created yet)
+      @origin (not created yet)
     [EOF]
     ");
 }

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -135,9 +135,9 @@ fn test_git_push_default_remote_selection() {
         .run_jj(["git", "remote", "remove", "origin"])
         .success();
     let output = work_dir.run_jj(["git", "push", "-b", "bookmark1"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Hint: Pushing to the only existing remote: other
+    Hint: Defaulting to the only existing remote: other
     Changes to push to other:
       Add bookmark bookmark1 to 9b2e76de3920
     [EOF]


### PR DESCRIPTION
This is related to #8559, although it doesn't completely fix that issue. I think this is an improvement indenpendent of the other topics discussed on that issue.

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
