### PR TITLE
bisect: make abort into a non-error

### DIFF
--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -256,12 +256,16 @@ fn test_bisect_run_abort() {
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Evaluation command returned 127 (command not found) - aborting bisection.
+
+    Search complete. To discard any revisions created during search, run:
+      jj op restore 3b48f5aca4df
     [EOF]
     ------- stderr -------
     Working copy  (@) now at: vruxwmqv 538d9e7f (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
     Added 0 files, modified 0 files, removed 2 files
-    Error: Evaluation command returned 127 (command not found) - aborting bisection.
+    Error: Bisection aborted
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
An aborted bisect is currently treated like an error. This means that once an abort is triggered, any follow-up code from the bisection CLI doesn't get run.  Change the bisector to treat an aborted command as any other evaluation and have it return an aborted result when it encounters it.

This could be important for many future developments (putting bisect status in the op-log, interactive bisects, querying the state of a currently running bisect), but right now, it's mostly important for printing the reminder text about the right place to restore to in the op-log :)

(First time writing Rust "in anger", be nice :) )
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
