### PR TITLE
web/docs: add remark plugin for GitHub-compatible markdown links 

### DIFF
--- a/web/docs/astro.config.mjs
+++ b/web/docs/astro.config.mjs
@@ -5,6 +5,7 @@ import remarkDirective from 'remark-directive';
 import remarkGfm from 'remark-gfm';
 import remarkIncludeMarkdown from './plugins/remark-include-markdown.mjs';
 import remarkYamlTable from './plugins/remark-yaml-table.mjs';
+import starlightStripMdExtension from './plugins/starlight-strip-md-extension.mjs';
 import { fileURLToPath } from 'node:url';
 
 const docsDir = fileURLToPath(new URL('src/content/docs', import.meta.url));
@@ -22,6 +23,7 @@ export default defineConfig({
 	},
 	integrations: [
 		starlight({
+			plugins: [starlightStripMdExtension()],
 			title: 'Jujutsu docs',
 			favicon: "/images/jj-logo.svg",
 			customCss: ['./src/styles/custom.css'],

--- a/web/docs/package-lock.json
+++ b/web/docs/package-lock.json
@@ -1802,6 +1802,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1962,6 +1963,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.10.tgz",
       "integrity": "sha512-mBaRwFrqwCHiKDvvfNW2rRRkLAqnkj3lbkte6Vg4OzeUiDyEsdU4oOqTZxHJf/mxzZvBiU37BxG1oeh+tq1IUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -5039,6 +5041,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5367,6 +5370,7 @@
       "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
       "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-directive": "^3.0.0",
@@ -5539,6 +5543,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6262,6 +6267,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6460,6 +6466,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/docs/plugins/remark-strip-md-extension.mjs
+++ b/web/docs/plugins/remark-strip-md-extension.mjs
@@ -1,0 +1,92 @@
+/**
+ * Remark plugin to strip .md extensions from relative links and resolve paths.
+ *
+ * This allows markdown files to use links like [text](other-file.md) which
+ * work on GitHub, while producing clean URLs like /other-file/ in the built site.
+ *
+ * Links are kept relative (not absolute) so they work with any base path
+ * configuration. The key insight is that Starlight serves pages with trailing
+ * slashes (e.g., /guides/divergence/), which browsers treat as directories.
+ * For non-index files, we prepend ../ to counteract this behavior.
+ *
+ * Handles both inline links [text](url) and reference definitions [ref]: url
+ */
+
+import { visit } from 'unist-util-visit';
+import path from 'node:path';
+
+export default function remarkStripMdExtension() {
+  return (tree, file) => {
+    // Get the file's path relative to the content directory
+    const filePath = file.history[0];
+    const contentDocsMatch = filePath.match(/src\/content\/docs\/(.+)$/);
+    const relativePath = contentDocsMatch[1];
+    const currentDir = path.dirname(relativePath);
+
+    // Check if current file is an index file
+    const isIndex = path.basename(relativePath) === 'index.md';
+
+    // Calculate directory depth for absolute link conversion
+    const dirParts = currentDir === '.' ? [] : currentDir.split(path.sep);
+    const depth = dirParts.length;
+    visit(tree, ['link', 'definition'], (node) => {
+      const url = node.url;
+      if (!url || typeof url !== 'string') return;
+
+      // Skip external links and anchors
+      if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('#')) {
+        return;
+      }
+
+      // Separate the path from hash/query
+      const hashIndex = url.indexOf('#');
+      const queryIndex = url.indexOf('?');
+      let pathEnd = url.length;
+      if (hashIndex !== -1) pathEnd = Math.min(pathEnd, hashIndex);
+      if (queryIndex !== -1) pathEnd = Math.min(pathEnd, queryIndex);
+
+      const linkPath = url.slice(0, pathEnd);
+      const suffix = url.slice(pathEnd); // hash or query string
+
+      // Only process links with .md extension in the path (not in hash/query)
+      if (!linkPath.endsWith('.md')) {
+        return;
+      }
+
+      // Strip .md extension
+      const pathWithoutMd = linkPath.slice(0, -3);
+
+      let resultPath;
+
+      if (pathWithoutMd.startsWith('/')) {
+        // Absolute link: convert to relative
+        const targetPath = pathWithoutMd.slice(1); // Remove leading /
+        // Non-index files are served at an extra level due to trailing slash
+        const effectiveDepth = isIndex ? depth : depth + 1;
+        const prefix = '../'.repeat(effectiveDepth);
+        resultPath = prefix + targetPath;
+      } else {
+        // Relative link: prepend ../ for non-index files to counteract trailing slash
+        if (isIndex) {
+          resultPath = pathWithoutMd;
+        } else {
+          resultPath = '../' + pathWithoutMd;
+        }
+      }
+
+      // Normalize the path to resolve ../ sequences
+      // But keep it relative (don't let it become absolute)
+      resultPath = path.posix.normalize(resultPath);
+
+      // Handle index file targets: foo/index -> foo
+      resultPath = resultPath.replace(/\/index$/, '');
+
+      // Add trailing slash for Starlight's URL structure
+      if (!resultPath.endsWith('/')) {
+        resultPath += '/';
+      }
+
+      node.url = resultPath + suffix;
+    });
+  };
+}

--- a/web/docs/plugins/starlight-strip-md-extension.mjs
+++ b/web/docs/plugins/starlight-strip-md-extension.mjs
@@ -1,0 +1,31 @@
+/**
+ * Starlight plugin that wraps the remark-strip-md-extension plugin.
+ *
+ * This wrapper is needed because Starlight overrides the markdown.remarkPlugins
+ * configuration. By using a Starlight plugin, we ensure our remark plugin is
+ * properly integrated into Starlight's markdown processing pipeline.
+ */
+
+import remarkStripMdExtension from './remark-strip-md-extension.mjs';
+
+export default function starlightStripMdExtension() {
+  return {
+    name: 'starlight-strip-md-extension',
+    hooks: {
+      'config:setup'({ addIntegration }) {
+        addIntegration({
+          name: 'starlight-strip-md-extension-integration',
+          hooks: {
+            'astro:config:setup'({ updateConfig }) {
+              updateConfig({
+                markdown: {
+                  remarkPlugins: [remarkStripMdExtension],
+                },
+              });
+            },
+          },
+        });
+      },
+    },
+  };
+}


### PR DESCRIPTION
This adds a remark plugin that transforms .md links (e.g., [text](other.md))
into clean URLs (e.g., other/) that work in the built Starlight site while
keeping the original .md links functional on GitHub.

Key design decisions:

1. Uses relative paths instead of absolute paths. This ensures links work
   regardless of the base path configuration (e.g., --base /starlight/).
   Absolute paths like /glossary/ would break when deployed at a non-root
   base path.

2. Accounts for Starlight's trailing slash URL behavior. Pages like
   guides/divergence.md are served at /guides/divergence/, which browsers
   treat as a directory. For non-index files, the plugin prepends ../ to
   counteract this, so a link to ../glossary.md becomes ../../glossary/
   (which correctly resolves to /glossary/ from /guides/divergence/).

3. Wrapped in a Starlight plugin (starlight-strip-md-extension.mjs).
   This is required because Starlight overrides the markdown.remarkPlugins
   config for content collection .md files. Plugins in the top-level
   markdown config only run on .mdx files. The Starlight plugin wrapper
   hooks into Starlight's integration system to ensure the transformation
   runs on all content collection markdown files.