### PR TITLE
tests: improve template_builder coverage

### DIFF
--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -3465,7 +3465,7 @@ mod tests {
     }
 
     #[test]
-    fn test_signature() {
+    fn test_signature_and_email_methods() {
         let mut env = TestTemplateEnv::new();
 
         env.add_keyword("author", || {
@@ -3474,6 +3474,9 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#"author"#), @"Test User <test.user@example.com>");
         insta::assert_snapshot!(env.render_ok(r#"author.name()"#), @"Test User");
         insta::assert_snapshot!(env.render_ok(r#"author.email()"#), @"test.user@example.com");
+        insta::assert_snapshot!(env.render_ok("author.email().local()"), @"test.user");
+        insta::assert_snapshot!(env.render_ok("author.email().domain()"), @"example.com");
+        insta::assert_snapshot!(env.render_ok("author.timestamp()"), @"1970-01-01 00:00:00.000 +00:00");
 
         env.add_keyword("author", || {
             literal(new_signature("Another Test User", "test.user@example.com"))
@@ -3488,22 +3491,30 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#"author"#), @"Test User <test.user@invalid@example.com>");
         insta::assert_snapshot!(env.render_ok(r#"author.name()"#), @"Test User");
         insta::assert_snapshot!(env.render_ok(r#"author.email()"#), @"test.user@invalid@example.com");
+        insta::assert_snapshot!(env.render_ok("author.email().local()"), @"test.user");
+        insta::assert_snapshot!(env.render_ok("author.email().domain()"), @"invalid@example.com");
 
         env.add_keyword("author", || {
             literal(new_signature("Test User", "test.user"))
         });
         insta::assert_snapshot!(env.render_ok(r#"author"#), @"Test User <test.user>");
         insta::assert_snapshot!(env.render_ok(r#"author.email()"#), @"test.user");
+        insta::assert_snapshot!(env.render_ok("author.email().local()"), @"test.user");
+        insta::assert_snapshot!(env.render_ok("author.email().domain()"), @"");
 
         env.add_keyword("author", || {
             literal(new_signature("Test User", "test.user+tag@example.com"))
         });
         insta::assert_snapshot!(env.render_ok(r#"author"#), @"Test User <test.user+tag@example.com>");
         insta::assert_snapshot!(env.render_ok(r#"author.email()"#), @"test.user+tag@example.com");
+        insta::assert_snapshot!(env.render_ok("author.email().local()"), @"test.user+tag");
+        insta::assert_snapshot!(env.render_ok("author.email().domain()"), @"example.com");
 
         env.add_keyword("author", || literal(new_signature("Test User", "x@y")));
         insta::assert_snapshot!(env.render_ok(r#"author"#), @"Test User <x@y>");
         insta::assert_snapshot!(env.render_ok(r#"author.email()"#), @"x@y");
+        insta::assert_snapshot!(env.render_ok("author.email().local()"), @"x");
+        insta::assert_snapshot!(env.render_ok("author.email().domain()"), @"y");
 
         env.add_keyword("author", || {
             literal(new_signature("", "test.user@example.com"))
@@ -3516,6 +3527,8 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#"author"#), @"Test User");
         insta::assert_snapshot!(env.render_ok(r#"author.name()"#), @"Test User");
         insta::assert_snapshot!(env.render_ok(r#"author.email()"#), @"");
+        insta::assert_snapshot!(env.render_ok("author.email().local()"), @"");
+        insta::assert_snapshot!(env.render_ok("author.email().domain()"), @"");
 
         env.add_keyword("author", || literal(new_signature("", "")));
         insta::assert_snapshot!(env.render_ok(r#"author"#), @"");


### PR DESCRIPTION
This is my first foray out of straightforward command behaviors, so apologies in advance.  The file-local tests seemed pretty comprehensive, so I just expanded their coverage further.

Notable cases:
- String `lower()` was sprinkled into `test_parse_tree`, rather than build out a new test.
- Timestamp `local()` remains untested. I couldn't see a straightforward way to deterministically validate existing behavior.  Perhaps I could just verify that the method exists by comparing it to itself?

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
