### PR TITLE
workspace add --colocate: create Git worktree for colocated workspace

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -79,7 +79,11 @@ pub fn is_colocated_git_workspace(
         return false;
     };
     let Some(git_workdir) = git_backend.git_workdir() else {
-        return false; // Bare repository
+        // Bare repository - still check for unexpected .git
+        if let Some(ui) = ui {
+            warn_about_unexpected_git_in_workspace(ui, workspace, git_backend);
+        }
+        return false;
     };
     if git_workdir == workspace.workspace_root() {
         return true;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3465,6 +3465,14 @@ By default, the new workspace inherits the sparse patterns of the current worksp
   - `empty`:
     Clear all files from the workspace (it will be empty)
 
+* `--colocate` — Create a Git worktree for the new workspace
+
+   When used with a colocated Git repository, this creates a Git worktree at the new workspace location, allowing the workspace to also be colocated with Git.
+
+   This is the default when the parent workspace is colocated.
+* `--no-colocate` — Do not create a Git worktree for the new workspace
+
+   The new workspace will not be colocated with Git, even if the parent workspace is colocated.
 
 
 

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -201,11 +201,12 @@ fn test_git_colocation_enable_with_existing_git_dir() {
     std::fs::create_dir(workspace_root.join(".git")).unwrap();
     std::fs::write(workspace_root.join(".git").join("dummy"), "dummy").unwrap();
 
-    // Try to colocate - should fail
+    // Try to colocate - should fail (also warns about unmanaged .git)
     let output = work_dir.run_jj(["git", "colocation", "enable"]);
     insta::assert_snapshot!(output.strip_stderr_last_line(), @"
     ------- stderr -------
-    Error: A .git directory already exists in the workspace root. Cannot colocate.
+    Warning: Workspace has a .git directory that is not managed by jj
+    Hint: To remove this directory, run `rm -rf .git`
     [EOF]
     [exit status: 1]
     ");
@@ -436,4 +437,106 @@ fn test_git_colocation_in_secondary_workspace() {
     [EOF]
     [exit status: 1]
     ");
+}
+
+#[test]
+fn test_git_colocation_disable_with_secondary_workspaces_fails() {
+    // This test verifies that colocation disable fails with a helpful error
+    // when secondary colocated workspaces exist (since disabling would break them).
+    let test_env = TestEnvironment::default();
+    let primary_dir = test_env.work_dir("primary");
+
+    // 1. Create colocated repo with a commit
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_dir.write_file("file", "contents");
+    primary_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    // 2. Add colocated secondary workspace
+    primary_dir
+        .run_jj(["workspace", "add", "--colocate", "../secondary"])
+        .success();
+
+    // 3. Try to disable colocation - should fail
+    let output = primary_dir.run_jj(["git", "colocation", "disable"]);
+    assert!(!output.status.success());
+    insta::assert_snapshot!(output.stderr.normalized(), @r"
+    Error: Cannot disable colocation: secondary colocated workspaces exist.
+    These workspaces would become broken Git worktrees.
+    Either:
+      - Run `jj workspace forget <name>` for each secondary workspace first
+      - Use --force to disable anyway (secondary workspaces will be broken)
+    ");
+}
+
+#[test]
+fn test_git_colocation_disable_force_with_secondary_workspaces() {
+    // This test verifies that colocation disable --force succeeds even with
+    // secondary workspaces (though it leaves them broken).
+    let test_env = TestEnvironment::default();
+    let primary_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.work_dir("secondary");
+
+    // 1. Create colocated repo with a commit
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_dir.write_file("file", "contents");
+    primary_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    // 2. Add colocated secondary workspace
+    primary_dir
+        .run_jj(["workspace", "add", "--colocate", "../secondary"])
+        .success();
+
+    // Verify secondary workspace has the file
+    assert!(
+        secondary_dir.root().join("file").exists(),
+        "Secondary workspace should have file before disable"
+    );
+
+    // 3. Disable colocation with --force - should succeed
+    let output = primary_dir.run_jj(["git", "colocation", "disable", "--force"]);
+    assert!(output.status.success());
+
+    // 4. Verify primary is now non-colocated
+    let output = primary_dir.run_jj(["git", "colocation", "status"]);
+    assert!(output.stdout.normalized().contains("not colocated"));
+
+    // 5. Verify primary workspace data is preserved (critical: no data loss)
+    assert!(
+        primary_dir.root().join("file").exists(),
+        "Primary workspace file should be preserved after force disable"
+    );
+    let contents = std::fs::read_to_string(primary_dir.root().join("file")).unwrap();
+    assert_eq!(
+        contents, "contents",
+        "Primary workspace file contents should be unchanged"
+    );
+
+    // 6. Verify primary workspace is still functional
+    let output = primary_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work in primary workspace after force disable"
+    );
+
+    // 7. Verify secondary workspace directory and file still exist (data preserved)
+    assert!(
+        secondary_dir.root().exists(),
+        "Secondary workspace directory should still exist"
+    );
+    assert!(
+        secondary_dir.root().join("file").exists(),
+        "Secondary workspace file should be preserved (even if workspace is broken)"
+    );
+
+    // 8. Verify secondary workspace has a warning about broken git worktree
+    let output = secondary_dir.run_jj(["status"]);
+    let stderr = output.stderr.normalized();
+    assert!(
+        stderr.contains("broken Git worktree") || stderr.contains("Warning"),
+        "Secondary workspace should show warning about broken state, got: {stderr}"
+    );
 }

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1229,8 +1229,9 @@ fn test_colocated_workspace_update_stale() {
         .run_jj(["bookmark", "set", "-rsubject('old book1')", "book1"])
         .success();
 
+    // Use --no-colocate to keep secondary non-colocated for this test
     main_dir
-        .run_jj(["workspace", "add", "../secondary"])
+        .run_jj(["workspace", "add", "--no-colocate", "../secondary"])
         .success();
 
     // Rewrite the check-out commit from the secondary workspace.


### PR DESCRIPTION
## Summary

Adds a `--colocate` flag to `jj workspace add` that automatically creates a Git worktree when adding a new workspace in a colocated repository.

**Key changes:**
- Add `--colocate` flag to `WorkspaceAddArgs`
- Validate that the repository is colocated before allowing `--colocate`
- Create Git worktree using `git worktree add --orphan -B`
- Add `.gitignore` to `.jj/` directory in new workspace
- Add `GitWorktreeGuard` for automatic cleanup if later operations fail

## Usage

```bash
# In a colocated repository
jj workspace add --colocate ../secondary
```

## PR Stack

This PR is part of a stack implementing colocated workspaces (#8052):
1. #8667 - Base colocation support
2. **This PR** - `workspace add --colocate`
3. Next: Import commits from all worktrees' HEADs
4. Next: Clean up Git worktree on `workspace forget`

## Test plan

- [x] Tests added
- [x] All existing colocate tests pass