### PR TITLE
git import: check all worktrees' HEAD for external changes

### DIFF
--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -2521,3 +2521,194 @@ fn test_workspace_add_colocate_empty_repo() {
         ".git should be a file (worktree), not directory"
     );
 }
+
+// =============================================================================
+// Tests for import checking all worktrees' HEAD
+// =============================================================================
+
+#[test]
+fn test_import_detects_secondary_worktree_head_change() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_work_dir = test_env.work_dir("secondary");
+
+    // 1. Create colocated repo in primary/
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Create secondary workspace with --colocate
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../secondary"])
+        .success();
+
+    // 3. In secondary, make a git commit bypassing jj
+    // Note: workspace is created with orphan branch, so we create a root commit
+    {
+        let mut repo = gix::open(secondary_work_dir.root()).unwrap();
+        {
+            use gix::config::tree::*;
+            let mut config = repo.config_snapshot_mut();
+            let (name, email) = ("JJ test", "jj@example.com");
+            config.set_value(&Author::NAME, name).unwrap();
+            config.set_value(&Author::EMAIL, email).unwrap();
+            config.set_value(&Committer::NAME, name).unwrap();
+            config.set_value(&Committer::EMAIL, email).unwrap();
+        }
+        // Use empty tree since this is an orphan branch with no commits
+        let tree = gix::hash::ObjectId::empty_tree(repo.object_hash());
+        // Create root commit (no parents) since this is an orphan branch
+        let parents: [gix::ObjectId; 0] = [];
+        repo.commit("HEAD", "git commit in secondary worktree", tree, parents)
+            .unwrap();
+    }
+
+    // 4. In primary, run any jj command (triggers import)
+    let output = primary_work_dir
+        .run_jj(["log", "--no-graph", "-T", "description"])
+        .success();
+
+    // 5. Verify: The git commit appears in jj log
+    assert!(
+        output
+            .stdout
+            .normalized()
+            .contains("git commit in secondary worktree"),
+        "Git commit from secondary worktree should be imported, got: {}",
+        output.stdout.normalized()
+    );
+
+    // 6. Verify: The imported commit is usable (can be rebased)
+    // This is a critical test - if the commit structure is broken, rebase will fail
+    let output = primary_work_dir.run_jj([
+        "rebase",
+        "-r",
+        "description('git commit in secondary worktree')",
+        "-d",
+        "root()",
+        "--skip-emptied",
+    ]);
+    assert!(
+        output.status.success(),
+        "Should be able to rebase imported commit: {}",
+        output.stderr.normalized()
+    );
+
+    // 7. Verify: Primary workspace data is preserved and functional
+    assert!(
+        primary_work_dir.root().join("file").exists(),
+        "Primary workspace file should be preserved"
+    );
+    let output = primary_work_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work after import"
+    );
+}
+
+#[test]
+fn test_import_all_worktrees_heads() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_work_dir = test_env.work_dir("secondary");
+    let tertiary_work_dir = test_env.work_dir("tertiary");
+
+    // 1. Create colocated repo + 2 secondary workspaces
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../secondary"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../tertiary"])
+        .success();
+
+    // 2. Make git commits in both secondary workspaces
+    // Note: workspaces are created with orphan branches, so we need to create
+    // root commits (no parents) instead of using head_commit()
+    for (work_dir, msg) in [
+        (&secondary_work_dir, "commit from secondary"),
+        (&tertiary_work_dir, "commit from tertiary"),
+    ] {
+        let mut repo = gix::open(work_dir.root()).unwrap();
+        {
+            use gix::config::tree::*;
+            let mut config = repo.config_snapshot_mut();
+            let (name, email) = ("JJ test", "jj@example.com");
+            config.set_value(&Author::NAME, name).unwrap();
+            config.set_value(&Author::EMAIL, email).unwrap();
+            config.set_value(&Committer::NAME, name).unwrap();
+            config.set_value(&Committer::EMAIL, email).unwrap();
+        }
+        // Use empty tree since this is an orphan branch with no commits
+        let tree = gix::hash::ObjectId::empty_tree(repo.object_hash());
+        // Create root commit (no parents) since this is an orphan branch
+        let parents: [gix::ObjectId; 0] = [];
+        repo.commit("HEAD", msg, tree, parents).unwrap();
+    }
+
+    // 3. Run jj in primary
+    let output = primary_work_dir
+        .run_jj(["log", "--no-graph", "-T", "description"])
+        .success();
+
+    // 4. Verify: Both commits imported
+    let stdout = output.stdout.normalized();
+    assert!(
+        stdout.contains("commit from secondary"),
+        "Commit from secondary should be imported, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("commit from tertiary"),
+        "Commit from tertiary should be imported, got: {stdout}"
+    );
+
+    // 5. Verify: Both commits are usable (can be rebased)
+    // This is a critical test - if the commit structure is broken, rebase will fail
+    for commit_desc in ["commit from secondary", "commit from tertiary"] {
+        let output = primary_work_dir.run_jj([
+            "rebase",
+            "-r",
+            &format!("description('{commit_desc}')"),
+            "-d",
+            "root()",
+            "--skip-emptied",
+        ]);
+        assert!(
+            output.status.success(),
+            "Should be able to rebase '{}': {}",
+            commit_desc,
+            output.stderr.normalized()
+        );
+    }
+
+    // 6. Verify: Primary workspace data is preserved and functional
+    assert!(
+        primary_work_dir.root().join("file").exists(),
+        "Primary workspace file should be preserved"
+    );
+    let output = primary_work_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work after import"
+    );
+}

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -981,8 +981,8 @@ fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
 /// Unlike `reset_head()`, this function doesn't move the working-copy commit to
 /// the child of the new HEAD revision.
 pub fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
-    let store = mut_repo.store();
-    let git_backend = get_git_backend(store)?;
+    let store = mut_repo.store().clone();
+    let git_backend = get_git_backend(&store)?;
     let git_repo = git_backend.git_repo();
 
     let old_git_head = mut_repo.view().git_head();
@@ -992,6 +992,8 @@ pub fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
         None
     };
     if old_git_head.as_resolved() == Some(&new_git_head_id) {
+        // Even if the main HEAD hasn't changed, check worktrees
+        import_worktree_heads(mut_repo, git_backend, &git_repo)?;
         return Ok(());
     }
 
@@ -1015,6 +1017,101 @@ pub fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
     }
 
     mut_repo.set_git_head_target(RefTarget::resolved(new_git_head_id));
+
+    // Also import commits from other worktrees' HEADs
+    import_worktree_heads(mut_repo, git_backend, &git_repo)?;
+
+    Ok(())
+}
+
+/// Imports commits from all Git worktrees' HEADs.
+///
+/// This ensures that commits made via git in secondary worktrees are
+/// imported into the jj repo, even when running jj in a different workspace.
+fn import_worktree_heads(
+    mut_repo: &mut MutableRepo,
+    git_backend: &crate::git_backend::GitBackend,
+    git_repo: &gix::Repository,
+) -> Result<(), GitImportError> {
+    let worktrees = match git_repo.worktrees() {
+        Ok(wts) => wts,
+        Err(err) => {
+            tracing::debug!(?err, "Failed to enumerate git worktrees");
+            return Ok(());
+        }
+    };
+
+    for worktree in worktrees {
+        // Save git_dir for logging before consuming the worktree
+        let worktree_git_dir = worktree.git_dir().to_path_buf();
+
+        // Open the worktree as a repository to access its HEAD.
+        // Use the variant that works even if the worktree directory is inaccessible.
+        let wt_repo = match worktree.into_repo_with_possibly_inaccessible_worktree() {
+            Ok(repo) => repo,
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    ?worktree_git_dir,
+                    "Failed to open worktree as repository"
+                );
+                continue;
+            }
+        };
+
+        let commit_id = match wt_repo.head_id() {
+            Ok(id) => CommitId::from_bytes(id.as_bytes()),
+            Err(err) => {
+                tracing::debug!(?err, ?worktree_git_dir, "Failed to get worktree HEAD");
+                continue;
+            }
+        };
+
+        // Check if already in index
+        match mut_repo.index().has_id(&commit_id) {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    ?worktree_git_dir,
+                    "Failed to check index for worktree HEAD"
+                );
+                continue;
+            }
+        }
+
+        // Import the commit
+        if let Err(err) = git_backend.import_head_commits([&commit_id]) {
+            tracing::debug!(
+                ?err,
+                ?worktree_git_dir,
+                "Failed to import worktree HEAD commit"
+            );
+            continue;
+        }
+
+        // Add to heads
+        match mut_repo.store().get_commit(&commit_id) {
+            Ok(commit) => {
+                if let Err(err) = mut_repo.add_head(&commit) {
+                    tracing::debug!(
+                        ?err,
+                        ?worktree_git_dir,
+                        "Failed to add worktree HEAD as head"
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    ?worktree_git_dir,
+                    "Failed to get worktree HEAD commit"
+                );
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -255,7 +255,20 @@ pub struct View {
     pub remote_views: BTreeMap<RemoteNameBuf, RemoteView>,
     pub git_refs: BTreeMap<GitRefNameBuf, RefTarget>,
     /// The commit the Git HEAD points to.
-    // TODO: Support multiple Git worktrees?
+    ///
+    /// ## Known Limitation: Single git_head for Multiple Workspaces
+    ///
+    /// This field stores a single `git_head`, but when multiple colocated
+    /// workspaces exist (each with its own Git worktree), each worktree has
+    /// an independent HEAD. The value here reflects whichever workspace last
+    /// performed a Git export.
+    ///
+    /// **Impact:** The `git_head()` template may show incorrect values in
+    /// non-default workspaces.
+    ///
+    /// **Workaround:** Export now writes to each worktree's HEAD file
+    /// independently, but this field doesn't track per-workspace state.
+    // TODO: Support multiple Git worktrees by storing per-workspace git_head
     // TODO: Do we want to store the current bookmark name too?
     pub git_head: RefTarget,
     // The commit that *should be* checked out in the workspace. Note that the working copy


### PR DESCRIPTION
## Summary

Extends git import to check all Git worktrees' HEAD commits, ensuring that commits made via `git` in secondary colocated workspaces are imported into jj.

**Key changes:**
- Add `import_worktree_heads()` function using gix's worktrees API
- Import commits from each worktree's HEAD that aren't already in the index
- Use `into_repo_with_possibly_inaccessible_worktree()` to handle deleted worktrees gracefully

## Problem

When using colocated workspaces with Git worktrees, commits made via `git commit` in a secondary workspace weren't being imported when running jj commands in a different workspace.

## Solution

During git import, enumerate all linked worktrees using `git_repo.worktrees()` and import any HEAD commits that aren't already known to jj.

## PR Stack

This PR is part of a stack implementing colocated workspaces (#8052):
1. #8667 - Base colocation support
2. #8680 - `workspace add --colocate`
3. **This PR** - Import commits from all worktrees' HEADs
4. Next: Clean up Git worktree on `workspace forget`

## Test plan

- [x] Tests added
- [x] All existing git tests pass