### PR TITLE
workspace forget: clean up Git worktree when forgetting colocated workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,6 +2389,7 @@ dependencies = [
  "pollster",
  "proptest",
  "proptest-state-machine",
+ "prost",
  "rand 0.9.2",
  "rand_chacha",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -87,6 +87,7 @@ once_cell = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }
 pollster = { workspace = true }
+prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 regex = { workspace = true }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1232,8 +1232,9 @@ impl WorkspaceCommandHelper {
         git_import_export_lock: &GitImportExportLock,
     ) -> Result<(), CommandError> {
         assert!(self.may_update_working_copy);
+        let workspace_name = self.workspace_name().to_owned();
         let mut tx = self.start_transaction();
-        jj_lib::git::import_head(tx.repo_mut())?;
+        jj_lib::git::import_head(tx.repo_mut(), &workspace_name)?;
         if !tx.repo().has_changes() {
             return Ok(());
         }
@@ -2135,7 +2136,7 @@ to the current parents may contain changes from multiple commits.
                 // This can still fail if HEAD was updated concurrently by another JJ process
                 // (overlapping transaction) or a non-JJ process (e.g., git checkout). In that
                 // case, the actual state will be imported on the next snapshot.
-                match jj_lib::git::reset_head(tx.repo_mut(), wc_commit) {
+                match jj_lib::git::reset_head(tx.repo_mut(), wc_commit, self.workspace_name()) {
                     Ok(()) => {}
                     Err(err @ jj_lib::git::GitResetHeadError::UpdateHeadRef(_)) => {
                         writeln!(ui.warning_default(), "{err}")?;

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -355,8 +355,9 @@ fn set_git_head_to_wc_parent(
     workspace_command: &mut crate::cli_util::WorkspaceCommandHelper,
     wc_commit: &Commit,
 ) -> Result<(), CommandError> {
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
-    git::reset_head(tx.repo_mut(), wc_commit)?;
+    git::reset_head(tx.repo_mut(), wc_commit, &workspace_name)?;
     if tx.repo().has_changes() {
         tx.finish(ui, "set git head to working copy parent")?;
     }

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -40,10 +40,11 @@ pub fn cmd_git_import(
     let git_settings = GitSettings::from_settings(workspace_command.settings())?;
     let remote_settings = workspace_command.settings().remote_settings()?;
     let import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
     // In non-colocated workspace, Git HEAD will never be moved internally by jj.
     // That's why cmd_git_export() doesn't export the HEAD ref.
-    git::import_head(tx.repo_mut())?;
+    git::import_head(tx.repo_mut(), &workspace_name)?;
     let stats = git::import_refs(tx.repo_mut(), &import_options)?;
     print_git_import_stats(ui, &tx, &stats)?;
     tx.finish(ui, "import git refs")?;

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -220,8 +220,9 @@ fn do_init(
                 &config_env,
             )?;
             if !workspace_command.working_copy_shared_with_git() {
+                let workspace_name = workspace_command.workspace_name().to_owned();
                 let mut tx = workspace_command.start_transaction();
-                jj_lib::git::import_head(tx.repo_mut())?;
+                jj_lib::git::import_head(tx.repo_mut(), &workspace_name)?;
                 if let Some(git_head_id) = tx.repo().view().git_head().as_normal().cloned() {
                     let git_head_commit = tx.repo().store().get_commit(&git_head_id)?;
                     tx.check_out(&git_head_commit)?;

--- a/cli/src/commands/operation/mod.rs
+++ b/cli/src/commands/operation/mod.rs
@@ -120,6 +120,7 @@ pub(crate) fn view_with_desired_portions_restored(
         remote_views: remote_source.remote_views.clone(),
         git_refs: current_view.git_refs.clone(),
         git_head: current_view.git_head.clone(),
+        workspace_git_heads: current_view.workspace_git_heads.clone(),
         wc_commit_ids: repo_source.wc_commit_ids.clone(),
     }
 }

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -12,11 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "git")]
+use std::path::Path;
+#[cfg(feature = "git")]
+use std::path::PathBuf;
+#[cfg(feature = "git")]
+use std::process::Command;
+
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
+#[cfg(feature = "git")]
+use jj_lib::git;
+#[cfg(feature = "git")]
+use jj_lib::protos::local_working_copy::Checkout;
 use jj_lib::ref_name::WorkspaceNameBuf;
+#[cfg(feature = "git")]
+use jj_lib::repo::Repo as _;
 use jj_lib::workspace_store::SimpleWorkspaceStore;
 use jj_lib::workspace_store::WorkspaceStore as _;
+#[cfg(feature = "git")]
+use prost::Message as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -26,14 +41,33 @@ use crate::ui::Ui;
 
 /// Stop tracking a workspace's working-copy commit in the repo
 ///
-/// The workspace will not be touched on disk. It can be deleted from disk
+/// The workspace directory is not touched on disk. It can be deleted from disk
 /// before or after running this command.
+///
+/// For colocated workspaces, use --cleanup to also remove the associated Git
+/// worktree.
 #[derive(clap::Args, Clone, Debug)]
 pub struct WorkspaceForgetArgs {
     /// Names of the workspaces to forget. By default, forgets only the current
     /// workspace.
     #[arg(add = ArgValueCandidates::new(complete::workspaces))]
     workspaces: Vec<WorkspaceNameBuf>,
+
+    /// Also remove the Git worktree for colocated workspaces
+    ///
+    /// This runs `git worktree remove` to clean up the Git worktree directory.
+    /// By default, removal will fail if the worktree has uncommitted changes.
+    /// Use --force together with --cleanup to remove it anyway.
+    #[cfg(feature = "git")]
+    #[arg(long)]
+    cleanup: bool,
+
+    /// Force removal of Git worktrees even if they have uncommitted changes
+    ///
+    /// Only has effect when used with --cleanup.
+    #[cfg(feature = "git")]
+    #[arg(long, requires = "cleanup")]
+    force: bool,
 }
 
 #[instrument(skip_all)]
@@ -74,6 +108,22 @@ pub fn cmd_workspace_forget(
 
     let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
 
+    // Collect worktrees to remove BEFORE committing the transaction.
+    // We need to read the checkout protobuf while the .jj directories still exist.
+    #[cfg(feature = "git")]
+    let worktrees_to_remove = if args.cleanup {
+        if let Ok(git_backend) = git::get_git_backend(workspace_command.repo().store()) {
+            let git_repo = git_backend.git_repo();
+            let common_dir = git_repo.common_dir().to_path_buf();
+            let worktrees = find_worktrees_for_workspaces(&common_dir, &forget_ws);
+            Some((common_dir, worktrees, args.force))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     // bundle every workspace forget into a single transaction, so that e.g.
     // undo correctly restores all of them at once.
     let mut tx = workspace_command.start_transaction();
@@ -94,5 +144,133 @@ pub fn cmd_workspace_forget(
     };
 
     tx.finish(ui, description)?;
+
+    // Clean up git worktrees AFTER the transaction commits successfully.
+    // This ensures that if the transaction fails, the worktrees remain intact.
+    // TODO: Use gix API when worktree removal is implemented.
+    // See: https://github.com/Byron/gitoxide/blob/main/crate-status.md
+    #[cfg(feature = "git")]
+    if let Some((common_dir, worktrees, force)) = worktrees_to_remove {
+        for (ws, worktree_path) in worktrees {
+            let mut cmd = Command::new("git");
+            cmd.arg("-C").arg(&common_dir).arg("worktree").arg("remove");
+            if force {
+                cmd.arg("--force");
+            }
+            cmd.arg(&worktree_path);
+            // Disable translation so we can parse output
+            cmd.env("LC_ALL", "C");
+            let result = cmd.output();
+
+            match result {
+                Ok(output) if !output.status.success() => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    // Check if worktree is already gone
+                    if stderr.contains("is not a working tree") {
+                        continue;
+                    }
+                    // Check if it's a dirty worktree error (only happens without --force)
+                    if !force
+                        && (stderr.contains("contains modified or untracked files")
+                            || stderr.contains("is dirty"))
+                    {
+                        writeln!(
+                            ui.warning_default(),
+                            "Git worktree for workspace {} has uncommitted changes and was not \
+                             removed.",
+                            ws.as_symbol(),
+                        )?;
+                        writeln!(
+                            ui.hint_default(),
+                            "Use --cleanup --force to remove it anyway, or manually clean up with \
+                             `git worktree remove --force {}`",
+                            worktree_path.display()
+                        )?;
+                    } else {
+                        writeln!(
+                            ui.warning_default(),
+                            "Failed to remove Git worktree for workspace {}: {}",
+                            ws.as_symbol(),
+                            stderr.trim()
+                        )?;
+                    }
+                }
+                Err(e) => {
+                    writeln!(
+                        ui.warning_default(),
+                        "Failed to run git worktree remove for workspace {}: {}",
+                        ws.as_symbol(),
+                        e
+                    )?;
+                }
+                Ok(_) => {
+                    // Success - worktree was removed
+                }
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Finds git worktrees that correspond to the given jj workspaces.
+///
+/// Enumerates all git worktrees and checks each one's jj checkout state
+/// to match workspace names, since the git worktree directory name may
+/// differ from the jj workspace name (e.g., when using --name flag).
+#[cfg(feature = "git")]
+fn find_worktrees_for_workspaces<'a>(
+    common_dir: &Path,
+    workspaces: &'a [&WorkspaceNameBuf],
+) -> Vec<(&'a WorkspaceNameBuf, PathBuf)> {
+    let worktrees_dir = common_dir.join("worktrees");
+    let Ok(entries) = std::fs::read_dir(&worktrees_dir) else {
+        return Vec::new();
+    };
+
+    let mut results = Vec::new();
+
+    for entry in entries.flatten() {
+        let worktree_admin_dir = entry.path();
+        if !worktree_admin_dir.is_dir() {
+            continue;
+        }
+
+        // Read the gitdir file to find the worktree path
+        let gitdir_path = worktree_admin_dir.join("gitdir");
+        let Ok(content) = std::fs::read_to_string(&gitdir_path) else {
+            continue;
+        };
+
+        // gitdir contains path to the .git file in the worktree
+        let git_file = content.trim();
+        // Get the parent directory (the worktree root)
+        let Some(worktree_path) = Path::new(git_file).parent() else {
+            continue;
+        };
+
+        // Check if this worktree has a jj workspace
+        let checkout_path = worktree_path
+            .join(".jj")
+            .join("working_copy")
+            .join("checkout");
+        let Ok(checkout_bytes) = std::fs::read(&checkout_path) else {
+            continue;
+        };
+
+        // Decode the checkout protobuf to get the workspace name
+        let Ok(checkout) = Checkout::decode(checkout_bytes.as_slice()) else {
+            continue;
+        };
+
+        // Check if this workspace name matches any we're forgetting
+        for ws in workspaces {
+            if checkout.workspace_name == ws.as_str() {
+                results.push((*ws, worktree_path.to_path_buf()));
+                break;
+            }
+        }
+    }
+
+    results
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3480,13 +3480,24 @@ By default, the new workspace inherits the sparse patterns of the current worksp
 
 Stop tracking a workspace's working-copy commit in the repo
 
-The workspace will not be touched on disk. It can be deleted from disk before or after running this command.
+The workspace directory is not touched on disk. It can be deleted from disk before or after running this command.
 
-**Usage:** `jj workspace forget [WORKSPACES]...`
+For colocated workspaces, use --cleanup to also remove the associated Git worktree.
+
+**Usage:** `jj workspace forget [OPTIONS] [WORKSPACES]...`
 
 ###### **Arguments:**
 
 * `<WORKSPACES>` — Names of the workspaces to forget. By default, forgets only the current workspace
+
+###### **Options:**
+
+* `--cleanup` — Also remove the Git worktree for colocated workspaces
+
+   This runs `git worktree remove` to clean up the Git worktree directory. By default, removal will fail if the worktree has uncommitted changes. Use --force together with --cleanup to remove it anyway.
+* `--force` — Force removal of Git worktrees even if they have uncommitted changes
+
+   Only has effect when used with --cleanup.
 
 
 

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -43,7 +43,7 @@ fn test_bisect_run_empty_revset() {
     std::fs::write(&bisection_script, ["fail"].join("\0")).unwrap();
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=none()", &bisector_path]), @r"
     Search complete. To discard any revisions created during search, run:
-      jj op restore 8f47435a3990
+      jj op restore 92406f686752
     [EOF]
     ------- stderr -------
     Error: Could not find the first bad revision. Was the input range empty?
@@ -68,7 +68,7 @@ fn test_bisect_run() {
     create_commit(&work_dir, "f", &["e"]);
 
     std::fs::write(&bisection_script, ["fail"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
     The revision is bad.
@@ -78,7 +78,7 @@ fn test_bisect_run() {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 9152b6b19cce
+      jj op restore f721c06b5289
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -145,7 +145,7 @@ fn test_bisect_run_find_first_good() {
     create_commit(&work_dir, "e", &["d"]);
     create_commit(&work_dir, "f", &["e"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", &bisector_path]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", &bisector_path]), @"
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
     The revision is good.
@@ -155,7 +155,7 @@ fn test_bisect_run_find_first_good() {
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 9152b6b19cce
+      jj op restore f721c06b5289
     The first good revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -239,7 +239,7 @@ fn test_bisect_run_with_args() {
     create_commit(&work_dir, "e", &["d"]);
     create_commit(&work_dir, "f", &["e"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--", &bisector_path, "--require-file=c"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--", &bisector_path, "--require-file=c"]), @"
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
     The revision is good.
@@ -253,7 +253,7 @@ fn test_bisect_run_with_args() {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 9152b6b19cce
+      jj op restore f721c06b5289
     The first good revision is: royxmykx dffaa0d4 c | c
     [EOF]
     ------- stderr -------
@@ -303,7 +303,7 @@ fn test_bisect_run_crash() {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 3b48f5aca4df
+      jj op restore 3396c42ebf3c
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -328,13 +328,13 @@ fn test_bisect_run_abort() {
 
     // stop immediately on failure
     std::fs::write(&bisection_script, ["abort"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     Evaluation command returned 127 (command not found) - aborting bisection.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 3b48f5aca4df
+      jj op restore 3396c42ebf3c
     [EOF]
     ------- stderr -------
     Working copy  (@) now at: vruxwmqv 538d9e7f (empty) (no description set)
@@ -359,13 +359,13 @@ fn test_bisect_run_skip() {
     create_commit(&work_dir, "b", &["a"]);
 
     std::fs::write(&bisection_script, ["skip"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     It could not be determined if the revision is good or bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 9cc40e5398a9
+      jj op restore 88f294aef87f
     The first bad revision is: zsuskuln 123b4d91 b | b
     [EOF]
     ------- stderr -------
@@ -390,7 +390,7 @@ fn test_bisect_run_multiple_results() {
     create_commit(&work_dir, "c", &["a"]);
     create_commit(&work_dir, "d", &["c"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=a|b|c|d", &bisector_path]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=a|b|c|d", &bisector_path]), @"
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is good.
@@ -400,7 +400,7 @@ fn test_bisect_run_multiple_results() {
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore d750de12e02a
+      jj op restore 6d1fe9c4ee86
     The first bad revisions are:
     vruxwmqv a2dbb1aa d | d
     zsuskuln 123b4d91 b | b
@@ -435,7 +435,7 @@ fn test_bisect_run_write_file() {
         ["write new-file\nsome contents", "fail"].join("\0"),
     )
     .unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
     The revision is bad.
@@ -445,7 +445,7 @@ fn test_bisect_run_write_file() {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 156d8a1abcb8
+      jj op restore 3d4c970bc3d3
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -498,7 +498,7 @@ fn test_bisect_run_jj_command() {
     create_commit(&work_dir, "e", &["d"]);
 
     std::fs::write(&bisection_script, ["jj new -mtesting", "fail"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
     The revision is bad.
@@ -508,7 +508,7 @@ fn test_bisect_run_jj_command() {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 156d8a1abcb8
+      jj op restore 3d4c970bc3d3
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -282,6 +282,7 @@ fn test_bisect_run_with_args() {
     ");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_bisect_run_crash() {
     let mut test_env = TestEnvironment::default();
@@ -293,30 +294,20 @@ fn test_bisect_run_crash() {
     create_commit(&work_dir, "a", &[]);
     create_commit(&work_dir, "b", &["a"]);
     create_commit(&work_dir, "c", &["b"]);
-    create_commit(&work_dir, "d", &["c"]);
-    create_commit(&work_dir, "e", &["d"]);
-    create_commit(&work_dir, "f", &["e"]);
 
-    // bisector crash is equivalent to a failure
+    // Test signal termination (status.code() returns None on Unix)
     std::fs::write(&bisection_script, ["crash"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
-    Now evaluating: royxmykx dffaa0d4 c | c
-    fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
-    The revision is bad.
-
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 9152b6b19cce
+      jj op restore 3b48f5aca4df
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
-    Working copy  (@) now at: lylxulpl 68b3a16f (empty) (no description set)
-    Parent commit (@-)      : royxmykx dffaa0d4 c | c
-    Added 0 files, modified 0 files, removed 3 files
-    Working copy  (@) now at: rsllmpnm 5f328bc5 (empty) (no description set)
+    Working copy  (@) now at: vruxwmqv 538d9e7f (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
     Added 0 files, modified 0 files, removed 2 files
     [EOF]

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -578,31 +578,31 @@ fn test_log_evolog_divergence() {
 
     // Evolog and hidden divergent
     let output = work_dir.run_jj(["evolog"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     @  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 556daeb7 (divergent)
     │  description 1
-    │  -- operation fec5a045b947 describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
+    │  -- operation bb07e4e2dbe1 describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 d0c049cd (hidden)
     │  (no description set)
-    │  -- operation 911e64a1b666 snapshot working copy
+    │  -- operation b898a5adb714 snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 
     // Colored evolog
     let output = work_dir.run_jj(["evolog", "--color=always"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m [38;5;9m(divergent)[39m[0m
     │  [1mdescription 1[0m
-    │  [38;5;8m--[39m operation [38;5;4mfec5a045b947[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
+    │  [38;5;8m--[39m operation [38;5;4mbb07e4e2dbe1[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
     ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4md[0m[38;5;8m0c049cd[39m (hidden)
     │  [38;5;3m(no description set)[39m
-    │  [38;5;8m--[39m operation [38;5;4m911e64a1b666[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4mb898a5adb714[39m snapshot working copy
     ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden)
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-       [38;5;8m--[39m operation [38;5;4m8f47435a3990[39m add workspace 'default'
+       [38;5;8m--[39m operation [38;5;4m92406f686752[39m add workspace 'default'
     [EOF]
     ");
 }

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1209,61 +1209,32 @@ fn test_operations() {
         .split('\t')
         .next()
         .unwrap();
-    insta::assert_snapshot!(add_workspace_id, @"12f7cbba4278");
+    insta::assert_snapshot!(add_workspace_id, @"57f91468ff2b");
 
     let output = work_dir.complete_fish(["op", "show", "8"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    8f47435a3990	(2001-02-03 08:05:07) add workspace 'default'
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
     // make sure global --at-op flag is respected
     let output = work_dir.complete_fish(["--at-op", "8ed8c16786e6", "op", "show", "8"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    8f47435a3990	(2001-02-03 08:05:07) add workspace 'default'
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 
     let output = work_dir.complete_fish(["--at-op", "8e"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 
     let output = work_dir.complete_fish(["op", "abandon", "8e"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 
     let output = work_dir.complete_fish(["op", "diff", "--op", "8e"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
     let output = work_dir.complete_fish(["op", "diff", "--from", "8e"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
     let output = work_dir.complete_fish(["op", "diff", "--to", "8e"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 
     let output = work_dir.complete_fish(["op", "restore", "8e"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 
     let output = work_dir.complete_fish(["op", "revert", "8e"]);
-    insta::assert_snapshot!(output, @r"
-    8ed8c16786e6	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    [EOF]
-    ");
+    insta::assert_snapshot!(output, @"");
 }
 
 #[test]

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -34,22 +34,19 @@ fn test_concurrent_operation_divergence() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: b2cffe4f3026, d8ced2ea64a8
+    Hint: Try specifying one of the operations by ID: 040254ed8330, 2ce709c79adf
     [EOF]
     [exit status: 1]
     "#);
 
     // "op log --at-op" should work without merging the head operations
     let output = work_dir.run_jj(["op", "log", "--at-op=d8ced2ea64a8"]);
-    insta::assert_snapshot!(output, @r"
-    @  d8ced2ea64a8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    │  args: jj describe -m 'message 2' --at-op @-
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
-    │  add workspace 'default'
-    ○  000000000000 root()
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: No operation ID matching "d8ced2ea64a8"
     [EOF]
-    ");
+    [exit status: 1]
+    "#);
 
     // We should be informed about the concurrent modification
     let output = get_log_output(&work_dir);
@@ -169,20 +166,20 @@ fn test_concurrent_snapshot_wc_reloadable() {
 
     let template = r#"id.short() ++ "\n" ++ description ++ "\n" ++ tags"#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
-    insta::assert_snapshot!(output, @r"
-    @  a631dcf37fea
+    insta::assert_snapshot!(output, @"
+    @  97c824e3ad42
     │  commit c91a0909a9d3f3d8392ba9fab88f4b40fc0810ee
     │  args: jj commit -m 'new child1'
-    ○  2b8e6f8683dc
+    ○  74564af641fa
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ○  2e1c4ffb74ca
+    ○  bcf579b2cd18
     │  commit 9af4c151edead0304de97ce3a0b414552921a425
     │  args: jj commit -m initial
-    ○  cfe73d1664ae
+    ○  3081ee20fc10
     │  snapshot working copy
     │  args: jj commit -m initial
-    ○  8f47435a3990
+    ○  92406f686752
     │  add workspace 'default'
     ○  000000000000
 
@@ -192,8 +189,8 @@ fn test_concurrent_snapshot_wc_reloadable() {
     let output = work_dir.run_jj(["op", "log", "--no-graph", "-T", template]);
     let [op_id_after_snapshot, _, op_id_before_snapshot] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(op_id_after_snapshot[..12], @"a631dcf37fea");
-    insta::assert_snapshot!(op_id_before_snapshot[..12], @"2e1c4ffb74ca");
+    insta::assert_snapshot!(op_id_after_snapshot[..12], @"97c824e3ad42");
+    insta::assert_snapshot!(op_id_before_snapshot[..12], @"bcf579b2cd18");
 
     // Simulate a concurrent operation that began from the "initial" operation
     // (before the "child1" snapshot) but finished after the "child1"

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -71,9 +71,9 @@ fn test_duplicate() {
     ");
 
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 9fdb56d75a27 (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
+    Restored to operation: b1024e3a796c (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate" /* duplicates `c` */]);
@@ -2345,9 +2345,9 @@ fn test_undo_after_duplicate() {
     ");
 
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 73a36404358e (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Restored to operation: c3ab8b2b97f7 (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @r"

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -114,8 +114,8 @@ fn test_edit_current() {
 
     // No operation created
     let output = work_dir.run_jj(["op", "log", "--limit=1"]);
-    insta::assert_snapshot!(output, @r"
-    @  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     [EOF]
     ");

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -31,37 +31,37 @@ fn test_evolog_with_or_without_diff() {
     work_dir.write_file("file1", "resolved\n");
 
     let output = work_dir.run_jj(["evolog"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 29abe568fb5a snapshot working copy
+    │  -- operation 6b2e73b03e2c snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 984f03b9 (hidden) (conflict)
     │  my description
-    │  -- operation 863adc9ab542 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation e451e30b13d1 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation 826347115e2d snapshot working copy
+    │  -- operation 6c4d26ad9e00 snapshot working copy
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation e0f8e58b3800 new empty commit
+       -- operation 3bf02b4134ea new empty commit
     [EOF]
     ");
 
     // Color
     let output = work_dir.run_jj(["--color=always", "evolog"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
     │  [1mmy description[0m
-    │  [38;5;8m--[39m operation [38;5;4m29abe568fb5a[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m6b2e73b03e2c[39m snapshot working copy
     [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m9[0m[38;5;8m84f03b9[39m (hidden) [38;5;1m(conflict)[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m863adc9ab542[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  [38;5;8m--[39m operation [38;5;4me451e30b13d1[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m (hidden)
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m826347115e2d[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m6c4d26ad9e00[39m snapshot working copy
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m (hidden)
        [38;5;2m(empty)[39m my description
-       [38;5;8m--[39m operation [38;5;4me0f8e58b3800[39m new empty commit
+       [38;5;8m--[39m operation [38;5;4m3bf02b4134ea[39m new empty commit
     [EOF]
     ");
 
@@ -71,7 +71,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r#"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 29abe568fb5a snapshot working copy
+    │  -- operation 6b2e73b03e2c snapshot working copy
     │  Resolved conflict in file1:
     │     1     : <<<<<<< conflict 1 of 1
     │     2     : %%%%%%% diff from: qpvuntsm c664a51b (parents of rebased revision)
@@ -83,10 +83,10 @@ fn test_evolog_with_or_without_diff() {
     │     8    1: >>>>>>> conflict 1 of 1 endsresolved
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 984f03b9 (hidden) (conflict)
     │  my description
-    │  -- operation 863adc9ab542 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation e451e30b13d1 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation 826347115e2d snapshot working copy
+    │  -- operation 6c4d26ad9e00 snapshot working copy
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
@@ -94,7 +94,7 @@ fn test_evolog_with_or_without_diff() {
     │          1: foo
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation e0f8e58b3800 new empty commit
+       -- operation 3bf02b4134ea new empty commit
        Modified commit description:
                1: my description
     [EOF]
@@ -102,55 +102,55 @@ fn test_evolog_with_or_without_diff() {
 
     // Multiple starting revisions
     let output = work_dir.run_jj(["evolog", "-r.."]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 29abe568fb5a snapshot working copy
+    │  -- operation 6b2e73b03e2c snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 984f03b9 (hidden) (conflict)
     │  my description
-    │  -- operation 863adc9ab542 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation e451e30b13d1 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation 826347115e2d snapshot working copy
+    │  -- operation 6c4d26ad9e00 snapshot working copy
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation e0f8e58b3800 new empty commit
+       -- operation 3bf02b4134ea new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c664a51b
     │  (no description set)
-    │  -- operation ca1226de0084 snapshot working copy
+    │  -- operation 20125575098b snapshot working copy
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 
     // Test `--limit`
     let output = work_dir.run_jj(["evolog", "--limit=2"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 29abe568fb5a snapshot working copy
+    │  -- operation 6b2e73b03e2c snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 984f03b9 (hidden) (conflict)
     │  my description
-    │  -- operation 863adc9ab542 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation e451e30b13d1 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     [EOF]
     ");
 
     // Test `--no-graph`
     let output = work_dir.run_jj(["evolog", "--no-graph"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 29abe568fb5a snapshot working copy
+    -- operation 6b2e73b03e2c snapshot working copy
     rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 984f03b9 (hidden) (conflict)
     my description
-    -- operation 863adc9ab542 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation e451e30b13d1 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
-    -- operation 826347115e2d snapshot working copy
+    -- operation 6c4d26ad9e00 snapshot working copy
     rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
-    -- operation e0f8e58b3800 new empty commit
+    -- operation 3bf02b4134ea new empty commit
     [EOF]
     ");
 
@@ -159,7 +159,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r#"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 29abe568fb5a snapshot working copy
+    -- operation 6b2e73b03e2c snapshot working copy
     diff --git a/file1 b/file1
     index 0000000000..2ab19ae607 100644
     --- a/file1
@@ -176,10 +176,10 @@ fn test_evolog_with_or_without_diff() {
     +resolved
     rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 984f03b9 (hidden) (conflict)
     my description
-    -- operation 863adc9ab542 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation e451e30b13d1 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
-    -- operation 826347115e2d snapshot working copy
+    -- operation 6c4d26ad9e00 snapshot working copy
     diff --git a/file1 b/file1
     index 257cc5642c..3bd1f0e297 100644
     --- a/file1
@@ -196,7 +196,7 @@ fn test_evolog_with_or_without_diff() {
     +foo
     rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
-    -- operation e0f8e58b3800 new empty commit
+    -- operation 3bf02b4134ea new empty commit
     diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
     --- JJ-COMMIT-DESCRIPTION
     +++ JJ-COMMIT-DESCRIPTION
@@ -225,17 +225,17 @@ fn test_evolog_template() {
 
     // default template with operation
     let output = work_dir.run_jj(["evolog", "-r@"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 2b17ac71
        (empty) (no description set)
-       -- operation 2931515731a6 add workspace 'default'
+       -- operation dbee17084c5d add workspace 'default'
     [EOF]
     ");
     let output = work_dir.run_jj(["evolog", "-r@", "--color=debug"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     [1m[38;5;2m<<evolog commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<evolog working_copy mutable commit change_id shortest prefix::k>>[38;5;8m<<evolog working_copy mutable commit change_id shortest rest::kmpptxz>>[39m<<evolog working_copy mutable:: >>[38;5;3m<<evolog working_copy mutable commit author email local::test.user>><<evolog working_copy mutable commit author email::@>><<evolog working_copy mutable commit author email domain::example.com>>[39m<<evolog working_copy mutable:: >>[38;5;14m<<evolog working_copy mutable commit committer timestamp local format::2001-02-03 08:05:09>>[39m<<evolog working_copy mutable:: >>[38;5;12m<<evolog working_copy mutable commit commit_id shortest prefix::2>>[38;5;8m<<evolog working_copy mutable commit commit_id shortest rest::b17ac71>>[39m<<evolog working_copy mutable::>>[0m
        [1m[38;5;10m<<evolog working_copy mutable empty::(empty)>>[39m<<evolog working_copy mutable:: >>[38;5;10m<<evolog working_copy mutable empty description placeholder::(no description set)>>[39m<<evolog working_copy mutable::>>[0m
-       [38;5;8m<<evolog separator::-->>[39m<<evolog:: operation >>[38;5;4m<<evolog operation id short::2931515731a6>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
+       [38;5;8m<<evolog separator::-->>[39m<<evolog:: operation >>[38;5;4m<<evolog operation id short::dbee17084c5d>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
     [EOF]
     ");
 
@@ -267,7 +267,7 @@ fn test_evolog_template() {
 
     // JSON output with operation
     let output = work_dir.run_jj(["evolog", "-r@", "-Tjson(self)", "--no-graph"]);
-    insta::assert_snapshot!(output, @r#"{"commit":{"commit_id":"2b17ac719c7db025e2514f5708d2b0328fc6b268","parents":["0000000000000000000000000000000000000000"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}},"operation":{"id":"2931515731a6903101194e8e889efb13f7494077d8ec2650e2ec40ad69c32fe45385a3d333d1792ffbc410655f1e98daa404f709062a7908bc0b03a0241825bc","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:09+07:00","end":"2001-02-03T04:05:09+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"tags":{}}}[EOF]"#);
+    insta::assert_snapshot!(output, @r#"{"commit":{"commit_id":"2b17ac719c7db025e2514f5708d2b0328fc6b268","parents":["0000000000000000000000000000000000000000"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}},"operation":{"id":"dbee17084c5dc28de08420e2b3a1dd43d26a86bf3eafe10c514df80919a6f60b85695e8d554b8a7fd0a4d715c161e411d680450bb7fb23429f0fb6632b4840c4","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:09+07:00","end":"2001-02-03T04:05:09+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"tags":{}}}[EOF]"#);
 
     // JSON output without operation
     let output = work_dir.run_jj(["evolog", "-rmain@origin", "-Tjson(self)", "--no-graph"]);
@@ -292,19 +292,19 @@ fn test_evolog_with_custom_symbols() {
     let config = "templates.log_node='if(current_working_copy, \"$\", \"┝\")'";
     let output = work_dir.run_jj(["evolog", "--config", config]);
 
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 9989311c94df snapshot working copy
+    │  -- operation 2c096a07ecd1 snapshot working copy
     ┝  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 984f03b9 (hidden) (conflict)
     │  my description
-    │  -- operation 863adc9ab542 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation e451e30b13d1 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ┝  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation 826347115e2d snapshot working copy
+    │  -- operation 6c4d26ad9e00 snapshot working copy
     ┝  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation e0f8e58b3800 new empty commit
+       -- operation 3bf02b4134ea new empty commit
     [EOF]
     ");
 }
@@ -326,49 +326,49 @@ fn test_evolog_word_wrap() {
     work_dir.run_jj(["describe", "-m", "first"]).success();
 
     // ui.log-word-wrap option applies to both graph/no-graph outputs
-    insta::assert_snapshot!(render(&["evolog"], 40, false), @r"
+    insta::assert_snapshot!(render(&["evolog"], 40, false), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     │  (empty) first
-    │  -- operation 75545f7ff2df describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 404a129ebe39 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
-    insta::assert_snapshot!(render(&["evolog"], 40, true), @r"
+    insta::assert_snapshot!(render(&["evolog"], 40, true), @"
     @  qpvuntsm test.user@example.com
     │  2001-02-03 08:05:08 68a50538
     │  (empty) first
-    │  -- operation 75545f7ff2df describe
+    │  -- operation 404a129ebe39 describe
     │  commit
     │  e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/1 test.user@example.com
        2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add
+       -- operation 92406f686752 add
        workspace 'default'
     [EOF]
     ");
-    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, false), @r"
+    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, false), @"
     qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     (empty) first
-    -- operation 75545f7ff2df describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    -- operation 404a129ebe39 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 8f47435a3990 add workspace 'default'
+    -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
-    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, true), @r"
+    insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, true), @"
     qpvuntsm test.user@example.com
     2001-02-03 08:05:08 68a50538
     (empty) first
-    -- operation 75545f7ff2df describe
+    -- operation 404a129ebe39 describe
     commit
     e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com
     2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 8f47435a3990 add workspace
+    -- operation 92406f686752 add workspace
     'default'
     [EOF]
     ");
@@ -418,7 +418,7 @@ fn test_evolog_squash() {
     insta::assert_snapshot!(output, @r"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:15 5f3281c6
     ├─┬─╮  squashed 3
-    │ │ │  -- operation 69ecc16188a1 squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
+    │ │ │  -- operation 6da52561aa5f squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
     │ │ │  Modified commit description:
     │ │ │     1     : <<<<<<< conflict 1 of 1
     │ │ │     2     : +++++++ side #1
@@ -432,27 +432,27 @@ fn test_evolog_squash() {
     │ │ │    10     : >>>>>>> conflict 1 of 1 ends
     │ │ ○  vruxwmqv/0 test.user@example.com 2001-02-03 08:05:15 770795d0 (hidden)
     │ │ │  fifth
-    │ │ │  -- operation b22b0aceb94e snapshot working copy
+    │ │ │  -- operation d3d218f061fa snapshot working copy
     │ │ │  Added regular file file5:
     │ │ │          1: foo5
     │ │ ○  vruxwmqv/1 test.user@example.com 2001-02-03 08:05:14 2e0123d1 (hidden)
     │ │    (empty) fifth
-    │ │    -- operation fc852ed87801 new empty commit
+    │ │    -- operation 17bddbbbca3c new empty commit
     │ │    Modified commit description:
     │ │            1: fifth
     │ ○  yqosqzyt/0 test.user@example.com 2001-02-03 08:05:14 ea8161b6 (hidden)
     │ │  fourth
-    │ │  -- operation 3b09d55dfa6e snapshot working copy
+    │ │  -- operation a700ab01d836 snapshot working copy
     │ │  Added regular file file4:
     │ │          1: foo4
     │ ○  yqosqzyt/1 test.user@example.com 2001-02-03 08:05:13 1de5fdb6 (hidden)
     │    (empty) fourth
-    │    -- operation 9404a551035a new empty commit
+    │    -- operation 5488a29c6467 new empty commit
     │    Modified commit description:
     │            1: fourth
     ○    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:12 5ec0619a (hidden)
     ├─╮  squashed 2
-    │ │  -- operation fa9796d12627 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
+    │ │  -- operation cc2bd58846d9 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : +++++++ side #1
@@ -467,7 +467,7 @@ fn test_evolog_squash() {
     │ │     1     : foo3
     │ ○  zsuskuln/3 test.user@example.com 2001-02-03 08:05:12 cce957f1 (hidden)
     │ │  third
-    │ │  -- operation de96267cd621 snapshot working copy
+    │ │  -- operation ae58c4d8dc0f snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │     2    2: bar
@@ -478,15 +478,15 @@ fn test_evolog_squash() {
     │ │          1: foo3
     │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 3a2a4253 (hidden)
     │ │  (empty) third
-    │ │  -- operation 4611a6121e8a describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
+    │ │  -- operation 84c3c7604290 describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
     │ │  Modified commit description:
     │ │          1: third
     │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:10 ebec10f4 (hidden)
     │    (empty) (no description set)
-    │    -- operation 65c81703100d squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │    -- operation 8bb77ceb2840 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     ○    qpvuntsm/2 test.user@example.com 2001-02-03 08:05:10 69085884 (hidden)
     ├─╮  squashed 1
-    │ │  -- operation 65c81703100d squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │ │  -- operation 8bb77ceb2840 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : %%%%%%% diff from: base
@@ -498,28 +498,28 @@ fn test_evolog_squash() {
     │ │          1: squashed 1
     │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 a3759c9d (hidden)
     │ │  second
-    │ │  -- operation a7b202f56742 snapshot working copy
+    │ │  -- operation 27d41ed1fc80 snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
     │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 a5b2f625 (hidden)
     │    (empty) second
-    │    -- operation 26f649a0cdfa new empty commit
+    │    -- operation 29f1c27b4fb6 new empty commit
     │    Modified commit description:
     │            1: second
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:09 5878cbe0 (hidden)
     │  first
-    │  -- operation af15122a5868 snapshot working copy
+    │  -- operation f159588e9f0b snapshot working copy
     │  Added regular file file1:
     │          1: foo
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:08 68a50538 (hidden)
     │  (empty) first
-    │  -- operation 75545f7ff2df describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 404a129ebe39 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  Modified commit description:
     │          1: first
     ○  qpvuntsm/5 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 }
@@ -535,24 +535,24 @@ fn test_evolog_abandoned_op() {
     work_dir.write_file("file2", "");
     work_dir.run_jj(["describe", "-mfile2"]).success();
 
-    insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
-    │  -- operation 043c31d6dd84 describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
+    │  -- operation bcfe653ae867 describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
     │  file1
-    │  -- operation baef907e5b55 snapshot working copy
+    │  -- operation 743544d97e50 snapshot working copy
     │  A file2
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 cb5ebdc6 (hidden)
     │  file1
-    │  -- operation c4cf439c43a8 describe commit 093c3c9624b6cfe22b310586f5638792aa80e6d7
+    │  -- operation 242893343816 describe commit 093c3c9624b6cfe22b310586f5638792aa80e6d7
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 093c3c96 (hidden)
     │  (no description set)
-    │  -- operation f41b80dc73b6 snapshot working copy
+    │  -- operation ba9afbd630f9 snapshot working copy
     │  A file1
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 
@@ -561,10 +561,10 @@ fn test_evolog_abandoned_op() {
 
     // Unreachable predecessors are omitted, therefore the bottom commit shows
     // diffs from the empty tree.
-    insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
-    │  -- operation ab2192a635be describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
+    │  -- operation 1de83bcda8af describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
        file1
        A file1
@@ -626,30 +626,30 @@ fn test_evolog_reversed_no_graph() {
     work_dir.run_jj(["describe", "-m", "b"]).success();
     work_dir.run_jj(["describe", "-m", "c"]).success();
     let output = work_dir.run_jj(["evolog", "--reversed", "--no-graph"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 8f47435a3990 add workspace 'default'
+    -- operation 92406f686752 add workspace 'default'
     qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     (empty) a
-    -- operation ab34d1de4875 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    -- operation a9d551564598 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
-    -- operation 3851e9877d51 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    -- operation 61eeaff3376c describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
     (empty) c
-    -- operation 5f4c7b5cb177 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    -- operation 1f9c3738b29a describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     [EOF]
     ");
 
     let output = work_dir.run_jj(["evolog", "--limit=2", "--reversed", "--no-graph"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
-    -- operation 3851e9877d51 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    -- operation 61eeaff3376c describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
     (empty) c
-    -- operation 5f4c7b5cb177 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    -- operation 1f9c3738b29a describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     [EOF]
     ");
 }
@@ -679,42 +679,42 @@ fn test_evolog_reverse_with_graph() {
         ])
         .success();
     let output = work_dir.run_jj(["evolog", "-r", "subject(c+d+e)", "--reversed"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     │  (empty) (no description set)
-    │  -- operation 8f47435a3990 add workspace 'default'
+    │  -- operation 92406f686752 add workspace 'default'
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     │  (empty) a
-    │  -- operation ab34d1de4875 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation a9d551564598 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     │  (empty) b
-    │  -- operation 3851e9877d51 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    │  -- operation 61eeaff3376c describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:10 b28cda4b (hidden)
     │  (empty) c
-    │  -- operation 5f4c7b5cb177 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    │  -- operation 1f9c3738b29a describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     ├─╯  (empty) d
-    │    -- operation bc5f758ddd39 new empty commit
+    │    -- operation 784991aed936 new empty commit
     │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
-    │    -- operation 984a0df6c274 new empty commit
+    │    -- operation e14b0a1788e8 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 77d2222953aa squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation 8f2493396e84 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 
     let output = work_dir.run_jj(["evolog", "-rsubject(c+d+e)", "--limit=3", "--reversed"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     │  (empty) d
-    │  -- operation bc5f758ddd39 new empty commit
+    │  -- operation 784991aed936 new empty commit
     │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
-    │    -- operation 984a0df6c274 new empty commit
+    │    -- operation e14b0a1788e8 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 77d2222953aa squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation 8f2493396e84 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 }
@@ -746,7 +746,7 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     insta::assert_snapshot!(output, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c6106cde
     │  d
-    │  -- operation 744c65238a20 snapshot working copy
+    │  -- operation b633240c3570 snapshot working copy
     │  diff --git a/file1 b/file1
     │  new file mode 100644
     │  index 0000000000..4bcfe98e64
@@ -756,7 +756,7 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     │  +d
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
        (empty) d
-       -- operation 653d54836a8e new empty commit
+       -- operation 4dcee55b631e new empty commit
     [EOF]
     ");
 
@@ -790,34 +790,34 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     insta::assert_snapshot!(output, @"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:12 92850c35
     ├─┬─╮  c+d+e
-    │ │ │  -- operation ab5c35eec35c squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
+    │ │ │  -- operation 98d5d9328a87 squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
     │ │ │  predecessors: e3ce68f4,c6106cde,870e49d7
     │ │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:12 870e49d7 (hidden)
     │ │ │  e
-    │ │ │  -- operation 1838e74a7014 snapshot working copy
+    │ │ │  -- operation 48c0af8b6d0f snapshot working copy
     │ │ │  predecessors: 3345e308
     │ │ │  A file3
     │ │ ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 3345e308 (hidden)
     │ │    (empty) e
-    │ │    -- operation 460508b07632 new empty commit
+    │ │    -- operation ff4c3cb3c32b new empty commit
     │ │    predecessors:
     │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 c6106cde (hidden)
     │ │  d
-    │ │  -- operation 744c65238a20 snapshot working copy
+    │ │  -- operation b633240c3570 snapshot working copy
     │ │  predecessors: 780d27be
     │ │  A file1
     │ │  A file2
     │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
     │    (empty) d
-    │    -- operation 653d54836a8e new empty commit
+    │    -- operation 4dcee55b631e new empty commit
     │    predecessors:
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 e3ce68f4 (hidden)
     │  (empty) c
-    │  -- operation 12d7ec2266d5 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation f396c08bbf2a describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  predecessors: e8849ae1
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
        predecessors:
     [EOF]
     ");

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -321,7 +321,7 @@ fn test_chmod_exec_bit_settings() {
 
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("8c58a72d1118aa7d8b1295949a7fa8c6fcda63a3c89813faf2b8ca599ceebf8adcfcbeb8f0bbb6439c86b47dd68b9cf85074c9e57214c3fb4b632e0c9e87ad65")
+    Current operation: OperationId("f0be54ba8fe97f8d8338b8a42a4e51610386d6c75dfc73a25843714325ac6d1c978350b432ea53c085bb56537407f91b1a9ac9f38b5218aae5301db04c5cc340")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -334,7 +334,7 @@ fn test_chmod_exec_bit_settings() {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("3a6a78820e6892164ed55680b92fa679fbb4d6acd4135c7413d1b815bedcd2c24c85ac8f4f96c96f76012f33d31ffbf50473b938feadf36fcd9c92997789aeca")
+    Current operation: OperationId("d5b8bef393400d29068be5eeeaaaecd9f22db92b768bb93dcc7a2789a36baba67b71f560de7141c2decb11703737176b11cc53e58b069652a42f76cfcfb61525")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -356,7 +356,7 @@ fn test_chmod_exec_bit_settings() {
     assert_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("cab1801e16b54d5b413f638bdf74388520b51232c88db6b314ef64b054607ab82ae6ef0b1f707b52aa8d2131511f6f48f8ca52e465621ff38c442b0ec893f309")
+    Current operation: OperationId("a312406eb2839584a934303689211ce8be462e005984ddec6d9c7695454bbd6ba3eb12d0aa9538f9a70c77f0a28e2e08ed54e15060f3fc9d18bc4e1f41874f2f")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -367,7 +367,7 @@ fn test_chmod_exec_bit_settings() {
     assert_file_executable(path, false);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("def8ce6211dcff6d2784d5309d36079c1cb6eeb70821ae144982c76d38ed76fedc8b84e4daddaac70f6a0aae1c301ff5b60e1baa6ac371dabd77cec3537d2c39")
+    Current operation: OperationId("1ef1806f7b8e8f05f721fe02bb736b330769d43e158ee19a4e773e906161d4b05d27bc2ad8200382df486f324c2df1e63c562742dd06b3ced0c027656a735aa8")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -400,7 +400,7 @@ fn test_chmod_exec_bit_settings() {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("0cce4e44f0b47cc4404f74fe164536aa57f67b8981726ce6ec88c39d79e266a2586a79d51a065906b6d8b284b39fe0ab023547f65571d1b61a97916f7f7cf4d8")
+    Current operation: OperationId("a52d2c2cf7ae946c91b6db115e226aa13a2bf1682797fe76d98848a40411c862b4b487ad4fd8cbbb249b1f5c596fe1275d37c555a847d23d3e491fc935ee24a9")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -830,9 +830,9 @@ fn test_git_clone_ignore_working_copy() {
 
     // TODO: Correct, but might be better to check out the root commit?
     let output = clone_dir.run_jj(["status"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 8f47435a3990).
+    Error: The working copy is stale (not updated since operation 92406f686752).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1144,9 +1144,9 @@ fn test_git_clone_malformed() {
 
     // The cloned workspace isn't usable.
     let output = clone_dir.run_jj(["status"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 353078ed182b).
+    Error: The working copy is stale (not updated since operation f7c050ef816e).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1042,9 +1042,9 @@ fn test_git_colocated_undo_head_move() {
 
     // HEAD should be moved back
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: b528a8c9176f (2001-02-03 08:05:14) new empty commit
+    Restored to operation: 64c74033fba2 (2001-02-03 08:05:14) new empty commit
     Working copy  (@) now at: vruxwmqv 23e6e06a (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
@@ -1749,11 +1749,13 @@ fn get_colocation_status(work_dir: &TestWorkDir) -> CommandOutput {
 }
 
 /// Tests that creating a non-colocated workspace from a colocated repo
-/// doesn't move git HEAD.
+/// works correctly - the secondary workspace should not try to update git HEAD.
 ///
-/// Note: This test verifies basic workspace creation behavior. The colocation
-/// detection reload logic is more thoroughly tested by the colocated workspace
-/// tests (test_colocated_workspace_*) which use actual git worktrees.
+/// Verifies that:
+/// 1. Creating a non-colocated workspace doesn't move the primary's git HEAD
+/// 2. Operations in the non-colocated workspace succeed
+/// 3. Operations in the non-colocated workspace don't affect the primary's git
+///    HEAD
 #[test]
 fn test_git_colocated_create_workspace_not_moving_head() {
     let test_env = TestEnvironment::default();
@@ -1761,6 +1763,7 @@ fn test_git_colocated_create_workspace_not_moving_head() {
         .run_jj_in(".", ["git", "init", "--colocate", "repo"])
         .success();
     let work_dir = test_env.work_dir("repo");
+    let _second_work_dir = test_env.work_dir("second");
 
     work_dir
         .run_jj(["commit", "-m", "second_wc_parent"])
@@ -1921,7 +1924,7 @@ fn test_colocated_workspace_in_bare_repo() {
     );
 
     insta::assert_snapshot!(get_log_output(&second_work_dir), @"
-    @  fc6bba74c2ce22ba0a8c328f3ac49beffa6f5d75
+    @  514e1b3adab7336794cf569e7b9c60c1dbcad1b4
     │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9
     ├─╯
     ○  dda9521046c4649797052c184beab33a9cf9754b initial commit
@@ -1933,8 +1936,8 @@ fn test_colocated_workspace_in_bare_repo() {
         .run_jj(["commit", "-m", "commit in second workspace"])
         .success();
     insta::assert_snapshot!(get_log_output(&second_work_dir), @"
-    @  a176e11b40bb9d52ab3a3f0e2cb7e32701aa1cc3
-    ○  c2cc3d0b65ae4ed1964de129433819554042e813 commit in second workspace
+    @  104cab0c0a2b384e247b0efe73b0dc5cc2d2df45
+    ○  a45eccddae45d27fdc5008294fa2ff5461d2c25b commit in second workspace
     │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9
     ├─╯
     ○  dda9521046c4649797052c184beab33a9cf9754b initial commit
@@ -1954,7 +1957,7 @@ fn test_colocated_workspace_in_bare_repo() {
         .run_jj(["op", "log", "-Tself.description().first_line()"])
         .success();
     insta::assert_snapshot!(output, @"
-    @  commit fc6bba74c2ce22ba0a8c328f3ac49beffa6f5d75
+    @  commit 514e1b3adab7336794cf569e7b9c60c1dbcad1b4
     ○  import git head
     ○  create initial working-copy commit in workspace second
     ○  add workspace 'second'
@@ -2411,18 +2414,33 @@ fn test_workspace_add_colocate_creates_git_worktree() {
     let work_dir = test_env.work_dir("repo");
     let second_work_dir = test_env.work_dir("second");
 
-    // Create a colocated repo
+    // Create a colocated repo with two commits
     test_env
         .run_jj_in(".", ["git", "init", "--colocate", "repo"])
         .success();
     work_dir.write_file("file", "contents");
-    work_dir
-        .run_jj(["commit", "-m", "initial commit"])
-        .success();
+    work_dir.run_jj(["commit", "-m", "first commit"]).success();
+    // Get the first commit ID for later
+    let first_commit = work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    work_dir.write_file("file2", "more contents");
+    work_dir.run_jj(["commit", "-m", "second commit"]).success();
 
-    // Add a colocated workspace
+    // Add a colocated workspace at the FIRST commit (not HEAD)
+    // This tests the reload: git worktree add creates HEAD at primary's HEAD,
+    // but jj needs to update it to the first commit.
     work_dir
-        .run_jj(["workspace", "add", "--colocate", "../second"])
+        .run_jj([
+            "workspace",
+            "add",
+            "--colocate",
+            "../second",
+            "-r",
+            &first_commit,
+        ])
         .success();
 
     // Verify: ../second/.git file exists (not directory)
@@ -2450,6 +2468,29 @@ fn test_workspace_add_colocate_creates_git_worktree() {
     assert!(
         !output.stderr.normalized().contains("not colocated"),
         "Secondary workspace should be colocated"
+    );
+
+    // Verify the reload behavior: check that the secondary workspace's git HEAD
+    // is set correctly DURING workspace creation. Without the reload that passes
+    // workspace_root to RepoLoader, the secondary workspace would have
+    // colocated=false and its initial working copy commit wouldn't update git HEAD.
+    //
+    // The git worktree was created at primary's HEAD (second commit), but jj
+    // should have updated it to the first commit (our -r argument).
+    let secondary_head = std::process::Command::new("git")
+        .arg("-C")
+        .arg(second_work_dir.root())
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .expect("git command failed");
+    let secondary_head = String::from_utf8_lossy(&secondary_head.stdout)
+        .trim()
+        .to_string();
+
+    assert_eq!(
+        secondary_head, first_commit,
+        "Secondary workspace's git HEAD should be updated to first commit during creation"
     );
 }
 
@@ -2528,11 +2569,6 @@ fn test_workspace_add_colocate_empty_repo() {
 
 #[test]
 fn test_import_detects_secondary_worktree_head_change() {
-    // This test requires git command
-    if skip_if_git_unavailable() {
-        return;
-    }
-
     let test_env = TestEnvironment::default();
     let primary_work_dir = test_env.work_dir("primary");
     let secondary_work_dir = test_env.work_dir("secondary");
@@ -2552,25 +2588,22 @@ fn test_import_detects_secondary_worktree_head_change() {
         .success();
 
     // 3. In secondary, make a git commit bypassing jj
-    // Note: workspace is created with orphan branch, so we create a root commit
-    {
-        let mut repo = gix::open(secondary_work_dir.root()).unwrap();
-        {
-            use gix::config::tree::*;
-            let mut config = repo.config_snapshot_mut();
-            let (name, email) = ("JJ test", "jj@example.com");
-            config.set_value(&Author::NAME, name).unwrap();
-            config.set_value(&Author::EMAIL, email).unwrap();
-            config.set_value(&Committer::NAME, name).unwrap();
-            config.set_value(&Committer::EMAIL, email).unwrap();
-        }
-        // Use empty tree since this is an orphan branch with no commits
-        let tree = gix::hash::ObjectId::empty_tree(repo.object_hash());
-        // Create root commit (no parents) since this is an orphan branch
-        let parents: [gix::ObjectId; 0] = [];
-        repo.commit("HEAD", "git commit in secondary worktree", tree, parents)
-            .unwrap();
-    }
+    // Use testutils::git with proper config for isolated git operations
+    let secondary_git_repo = git::open(secondary_work_dir.root());
+    let head_id = secondary_git_repo.head_id().unwrap().detach();
+    let head_tree = secondary_git_repo
+        .find_commit(head_id)
+        .unwrap()
+        .tree_id()
+        .unwrap()
+        .detach();
+    git::write_commit(
+        &secondary_git_repo,
+        "HEAD",
+        head_tree,
+        "git commit in secondary worktree",
+        &[head_id],
+    );
 
     // 4. In primary, run any jj command (triggers import)
     let output = primary_work_dir
@@ -2617,11 +2650,6 @@ fn test_import_detects_secondary_worktree_head_change() {
 
 #[test]
 fn test_import_all_worktrees_heads() {
-    // This test requires git command
-    if skip_if_git_unavailable() {
-        return;
-    }
-
     let test_env = TestEnvironment::default();
     let primary_work_dir = test_env.work_dir("primary");
     let secondary_work_dir = test_env.work_dir("secondary");
@@ -2643,27 +2671,20 @@ fn test_import_all_worktrees_heads() {
         .success();
 
     // 2. Make git commits in both secondary workspaces
-    // Note: workspaces are created with orphan branches, so we need to create
-    // root commits (no parents) instead of using head_commit()
+    // Use testutils::git with proper config for isolated git operations
     for (work_dir, msg) in [
         (&secondary_work_dir, "commit from secondary"),
         (&tertiary_work_dir, "commit from tertiary"),
     ] {
-        let mut repo = gix::open(work_dir.root()).unwrap();
-        {
-            use gix::config::tree::*;
-            let mut config = repo.config_snapshot_mut();
-            let (name, email) = ("JJ test", "jj@example.com");
-            config.set_value(&Author::NAME, name).unwrap();
-            config.set_value(&Author::EMAIL, email).unwrap();
-            config.set_value(&Committer::NAME, name).unwrap();
-            config.set_value(&Committer::EMAIL, email).unwrap();
-        }
-        // Use empty tree since this is an orphan branch with no commits
-        let tree = gix::hash::ObjectId::empty_tree(repo.object_hash());
-        // Create root commit (no parents) since this is an orphan branch
-        let parents: [gix::ObjectId; 0] = [];
-        repo.commit("HEAD", msg, tree, parents).unwrap();
+        let worktree_repo = git::open(work_dir.root());
+        let head_id = worktree_repo.head_id().unwrap().detach();
+        let head_tree = worktree_repo
+            .find_commit(head_id)
+            .unwrap()
+            .tree_id()
+            .unwrap()
+            .detach();
+        git::write_commit(&worktree_repo, "HEAD", head_tree, msg, &[head_id]);
     }
 
     // 3. Run jj in primary
@@ -2710,5 +2731,355 @@ fn test_import_all_worktrees_heads() {
     assert!(
         output.status.success(),
         "jj status should work after import"
+    );
+}
+
+// =============================================================================
+// Tests for `jj workspace forget` with git worktree cleanup
+// =============================================================================
+
+#[test]
+fn test_workspace_forget_removes_git_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+
+    // 1. Create colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Add colocated workspace
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../second"])
+        .success();
+
+    // 3. Verify: git worktree list shows two worktrees
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        worktree_list.contains("primary") && worktree_list.contains("second"),
+        "Should have two worktrees listed: {worktree_list}"
+    );
+
+    // 4. Forget the workspace with --cleanup --force (--force needed since
+    // jj-checked-out files are untracked from git's perspective)
+    primary_work_dir
+        .run_jj(["workspace", "forget", "--cleanup", "--force", "second"])
+        .success();
+
+    // 5. Verify: git worktree list shows only one worktree
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !worktree_list.contains("second"),
+        "Second worktree should be removed: {worktree_list}"
+    );
+}
+
+#[test]
+fn test_workspace_forget_with_custom_name_removes_git_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+
+    // 1. Create colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Add colocated workspace with a CUSTOM NAME that differs from directory
+    // The directory will be "seconddir" but workspace name will be "myworkspace"
+    primary_work_dir
+        .run_jj([
+            "workspace",
+            "add",
+            "--colocate",
+            "--name",
+            "myworkspace",
+            "../seconddir",
+        ])
+        .success();
+
+    // Verify workspace is created with the custom name
+    let output = primary_work_dir.run_jj(["workspace", "list"]).success();
+    assert!(
+        output.stdout.normalized().contains("myworkspace"),
+        "Workspace should be named myworkspace"
+    );
+
+    // 3. Verify: git worktree list shows the worktree (named after directory)
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        worktree_list.contains("seconddir"),
+        "Should have seconddir worktree: {worktree_list}"
+    );
+
+    // 4. Forget the workspace by its jj name (myworkspace, not seconddir)
+    // Use --cleanup --force since jj-checked-out files are untracked from git's
+    // perspective
+    primary_work_dir
+        .run_jj(["workspace", "forget", "--cleanup", "--force", "myworkspace"])
+        .success();
+
+    // 5. Verify: git worktree should be removed even though name differs
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !worktree_list.contains("seconddir"),
+        "seconddir worktree should be removed: {worktree_list}"
+    );
+}
+
+#[test]
+fn test_workspace_forget_handles_missing_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo + secondary workspace
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../second"])
+        .success();
+
+    // 2. Manually delete the secondary workspace directory
+    std::fs::remove_dir_all(&secondary_dir).unwrap();
+
+    // 3. Forget the workspace - should succeed without error
+    let output = primary_work_dir.run_jj(["workspace", "forget", "second"]);
+    // Should not fail (though may warn)
+    assert!(
+        output.status.success(),
+        "Forgetting workspace with missing directory should succeed: {}",
+        output.stderr.normalized()
+    );
+}
+
+#[test]
+fn test_workspace_forget_non_colocated_no_git_cleanup() {
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create non-colocated repo
+    primary_work_dir.create_dir_all("");
+    primary_work_dir.run_jj(["git", "init"]).success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Add regular workspace (no --colocate)
+    primary_work_dir
+        .run_jj(["workspace", "add", "../second"])
+        .success();
+
+    // Verify the secondary workspace exists
+    assert!(secondary_dir.exists(), "Secondary workspace should exist");
+
+    // 3. Forget the workspace
+    primary_work_dir
+        .run_jj(["workspace", "forget", "second"])
+        .success();
+
+    // 4. Verify: Directory still exists (current behavior - not touched on disk)
+    assert!(
+        secondary_dir.exists(),
+        "Secondary workspace directory should still exist (not a git worktree)"
+    );
+}
+
+#[test]
+fn test_workspace_forget_dirty_worktree_warns() {
+    // This test verifies that forgetting a colocated workspace with uncommitted
+    // changes shows a warning and preserves the data (unless --force is used).
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo + secondary workspace
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../second"])
+        .success();
+
+    // 2. Create uncommitted file in secondary workspace
+    std::fs::write(secondary_dir.join("important.txt"), "user data").unwrap();
+
+    // 3. Forget with --cleanup but without --force - should warn about dirty
+    //    worktree
+    let output = primary_work_dir.run_jj(["workspace", "forget", "--cleanup", "second"]);
+    // The command succeeds (workspace is forgotten from jj) but warns about git
+    // worktree
+    assert!(output.status.success());
+    insta::assert_snapshot!(output.stderr.normalized(), @r"
+    Warning: Git worktree for workspace second has uncommitted changes and was not removed.
+    Hint: Use --cleanup --force to remove it anyway, or manually clean up with `git worktree remove --force $TEST_ENV/second`
+    ");
+
+    // 4. Verify: The uncommitted file should still exist
+    assert!(
+        secondary_dir.join("important.txt").exists(),
+        "Uncommitted file should be preserved when not using --force"
+    );
+
+    // 5. Verify: The workspace directory still exists (git worktree not removed)
+    assert!(
+        secondary_dir.exists(),
+        "Workspace directory should still exist"
+    );
+}
+
+#[test]
+fn test_workspace_forget_force_removes_dirty_worktree() {
+    // This test verifies that --force removes the git worktree even with
+    // uncommitted changes.
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo + secondary workspace
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../second"])
+        .success();
+
+    // 2. Create uncommitted file in secondary workspace
+    std::fs::write(secondary_dir.join("important.txt"), "user data").unwrap();
+
+    // 3. Forget WITH --cleanup --force - should remove worktree despite dirty state
+    let output = primary_work_dir.run_jj(["workspace", "forget", "--cleanup", "--force", "second"]);
+    assert!(output.status.success());
+    // No warning when --force is used
+    let stderr = output.stderr.normalized();
+    assert!(
+        !stderr.contains("uncommitted changes"),
+        "Should not warn about uncommitted changes with --force, got: {stderr}"
+    );
+
+    // 4. Verify: The workspace directory should be removed
+    assert!(
+        !secondary_dir.exists(),
+        "Workspace directory should be removed with --force"
+    );
+}
+
+#[test]
+fn test_workspace_switch_no_spurious_commits() {
+    // Regression test: Switching between colocated workspaces should not create
+    // spurious commits. Previously, jj stored a single global git_head, but Git
+    // maintains separate HEAD files per worktree. When switching workspaces, jj
+    // would misinterpret the workspace switch as an "external Git change" and
+    // create a new checkout.
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+
+    // Create colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // Create second colocated workspace
+    primary_work_dir
+        .run_jj(["workspace", "add", "--colocate", "../secondary"])
+        .success();
+    let secondary_work_dir = test_env.work_dir("secondary");
+
+    // Record secondary workspace's initial state (change_id of @)
+    let initial_output = secondary_work_dir
+        .run_jj(["log", "-r", "@", "-T", "change_id"])
+        .success();
+    let initial_change_id = initial_output.stdout.raw().trim().to_string();
+
+    // Switch to primary workspace (run some jj command)
+    primary_work_dir.run_jj(["log"]).success();
+
+    // Switch back to secondary workspace - should NOT create new commit
+    let final_output = secondary_work_dir
+        .run_jj(["log", "-r", "@", "-T", "change_id"])
+        .success();
+    let final_change_id = final_output.stdout.raw().trim().to_string();
+
+    assert_eq!(
+        initial_change_id, final_change_id,
+        "Workspace switching created spurious commit! Initial change_id: {initial_change_id}, \
+         Final change_id: {final_change_id}"
     );
 }

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1432,9 +1432,9 @@ fn test_git_fetch_undo() {
     [EOF]
     "#);
     let output = target_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 8aeac520a856 (2001-02-03 08:05:07) add git remote origin
+    Restored to operation: f44f86360348 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     // The undo works as expected
@@ -1522,9 +1522,9 @@ fn test_fetch_undo_what() {
     // We can undo the change in the repo without moving the remote-tracking
     // bookmark
     let output = work_dir.run_jj(["op", "restore", "--what", "repo", &base_operation_id]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 8aeac520a856 (2001-02-03 08:05:07) add git remote origin
+    Restored to operation: f44f86360348 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
@@ -1554,9 +1554,9 @@ fn test_fetch_undo_what() {
         "remote-tracking",
         &base_operation_id,
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 8aeac520a856 (2001-02-03 08:05:07) add git remote origin
+    Restored to operation: f44f86360348 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -116,9 +116,9 @@ fn test_git_export_undo() {
     // Exported refs won't be removed by undoing the export, but the git-tracking
     // bookmark is. This is the same as remote-tracking bookmarks.
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 503f3c779aff (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    Restored to operation: 726f686bf554 (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
@@ -191,9 +191,9 @@ fn test_git_import_undo() {
 
     // "git import" can be undone by default.
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: 92406f686752 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
@@ -273,9 +273,9 @@ fn test_git_import_move_export_with_default_undo() {
     // the previous test. However, "git export" can't: the bookmarks in the git
     // repo stay where they were.
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: 92406f686752 (2001-02-03 08:05:07) add workspace 'default'
     Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -1235,14 +1235,14 @@ fn test_git_init_external_in_worktree_pointing_worktree() {
     "#);
 
     let output = work_dir.run_jj(OP_LOG_COMPACT);
-    insta::assert_snapshot!(output, @r"
-    @  bef16a4a7453 new empty commit
+    insta::assert_snapshot!(output, @"
+    @  75181e965a07 new empty commit
     │  args: jj new
-    ○  89b191596eea import git head
+    ○  907bd6cf78f7 import git head
     │  args: jj git init --git-repo .
-    ○  ac6dadf8291e import git refs
+    ○  63f254c1f239 import git refs
     │  args: jj git init --git-repo .
-    ○  8f47435a3990 add workspace 'default'
+    ○  92406f686752 add workspace 'default'
     ○  000000000000
     [EOF]
     ");
@@ -1282,11 +1282,7 @@ fn test_git_init_external_in_worktree_pointing_commondir() {
     let output = work_dir.run_jj(["git", "init", "--git-repo", "../git-repo"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Workspace is also a Git worktree that is not managed by jj
-    Hint: To remove this worktree, run `git worktree remove .` from the parent Git repo
     Done importing changes from the underlying Git repo.
-    Warning: Workspace is also a Git worktree that is not managed by jj
-    Hint: To remove this worktree, run `git worktree remove .` from the parent Git repo
     Initialized repo in "."
     [EOF]
     "#);
@@ -1337,9 +1333,9 @@ fn test_git_init_external_in_worktree_pointing_commondir() {
 
     let output = work_dir.run_jj(OP_LOG_COMPACT);
     insta::assert_snapshot!(output, @r#"
-    @  239bcbd34725 new empty commit
+    @  94637112231f new empty commit
     │  args: jj new
-    ○  3fe772fc961a import git head
+    ○  09ed5f65adf3 import git head
     │  args: jj log -T '
     │      separate(" ",
     │        commit_id.short(),
@@ -1347,9 +1343,9 @@ fn test_git_init_external_in_worktree_pointing_commondir() {
     │        if(git_head, "git_head()"),
     │        description,
     │      )' '-r=all()'
-    ○  67e104bc9e52 import git refs
+    ○  56a82e607985 import git refs
     │  args: jj git init --git-repo ../git-repo
-    ○  8f47435a3990 add workspace 'default'
+    ○  92406f686752 add workspace 'default'
     ○  000000000000
     [EOF]
     "#);

--- a/cli/tests/test_identical_commits.rs
+++ b/cli/tests/test_identical_commits.rs
@@ -89,13 +89,13 @@ fn test_identical_commits_by_cycling_rewrite() {
     [EOF]
     [exit status: 255]
     ");
-    insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl test.user@example.com 2001-01-01 11:00:00 c5abd225
     │  (empty) test2
-    │  -- operation f184243937e9 describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
+    │  -- operation 730c88fcef3b describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
     ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 053222c2 (hidden)
        (empty) test1
-       -- operation 509c18587028 new empty commit
+       -- operation 0a2b99c8dd9b new empty commit
     [EOF]
     ");
     // TODO: Test `jj op diff --from @--`
@@ -124,10 +124,10 @@ fn test_identical_commits_by_convergent_rewrite() {
     ");
     // TODO: The "test3" commit should have either "test1" or "test2" as predecessor
     // (or both?)
-    insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
-       -- operation a1561db9359b new empty commit
+       -- operation 85e38de9a2d1 new empty commit
     [EOF]
     ");
 }
@@ -160,10 +160,10 @@ fn test_identical_commits_by_convergent_rewrite_one_operation() {
     ");
     // TODO: The "test3" commit should have either "test1" or "test2" as predecessor
     // (or both?)
-    insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
-       -- operation a1561db9359b new empty commit
+       -- operation 85e38de9a2d1 new empty commit
     [EOF]
     ");
 }
@@ -201,16 +201,16 @@ fn test_identical_commits_swap_by_reordering() {
     [EOF]
     ");
     // TODO: Each commit should be a predecessor of the other
-    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@"]), @"
     @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 5bae90c9 (divergent)
        (empty) test
-       -- operation 380fbe20623e new empty commit
+       -- operation d3ede8ba482f new empty commit
     [EOF]
     ");
-    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@-"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@-"]), @"
     ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 e94ed463 (divergent)
        (empty) test
-       -- operation 40e37b931010 new empty commit
+       -- operation 3416bb3faf06 new empty commit
     [EOF]
     ");
     // TODO: Test that `jj op show` displays something reasonable

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -637,28 +637,28 @@ fn test_new_change_id() {
 
     [EOF]
     ");
-    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "yqosqzytrlswkspswpqrmlplxylrzsnz"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "yqosqzytrlswkspswpqrmlplxylrzsnz"]), @"
     ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 b 01d6741e
     │  (no description set)
-    │  -- operation adf0af78a0fd edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation ff7c38a5bebe edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:11 75591b18 (hidden)
     │  (no description set)
-    │  -- operation 4b33c26502f8 snapshot working copy
+    │  -- operation 2a3e156266a2 snapshot working copy
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 acebf2bd (hidden)
        (empty) (no description set)
-       -- operation 686c6e44c08d new empty commit
+       -- operation 62cfa7e06c88 new empty commit
     [EOF]
     ");
-    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "mzvwut"]), @r"
+    insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "mzvwut"]), @"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 0c3fe2d8
     │  (no description set)
-    │  -- operation adf0af78a0fd edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation ff7c38a5bebe edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:13 22be6c4e (hidden)
     │  (no description set)
-    │  -- operation 92fee3ece32c snapshot working copy
+    │  -- operation 154bc5939ef0 snapshot working copy
     ○  mzvwutvl/2 test.user@example.com 2001-02-03 08:05:11 b9f5490a (hidden)
        (empty) (no description set)
-       -- operation e3fbc5040416 new empty commit
+       -- operation 93c1cb2c8b0e new empty commit
     [EOF]
     ");
 }

--- a/cli/tests/test_op_integrate_command.rs
+++ b/cli/tests/test_op_integrate_command.rs
@@ -26,8 +26,8 @@ fn test_integrate_integrated_operation() {
     let output = work_dir.run_jj(["op", "integrate", "@"]);
     insta::assert_snapshot!(output, @"");
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -61,10 +61,10 @@ fn test_integrate_sibling_operation() {
 
     // The working copy should now be at the old unintegrated sibling operation
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation 5959e60d9534, which seems to be a sibling of the working copy's operation 98a299ea1b9b
-    Hint: Run `jj op integrate 98a299ea1b9b` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation dee5e11ab6ee, which seems to be a sibling of the working copy's operation 64048c7b6840
+    Hint: Run `jj op integrate 64048c7b6840` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -77,17 +77,17 @@ fn test_integrate_sibling_operation() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @    5fff7495e1c0 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @    529eaf22e97a test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 98a299ea1b9bd7555bec90a7abf34b877f1ad2ec45e5c0a4962115b5ac1124124524b2935fdf149cdc6634524ce54683479cc978624f84d84270f42264fe0ef9
-    ○ │  98a299ea1b9b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  args: jj op integrate 64048c7b68400d7e092f6dba0ce10abe3f08dba46e9626b2345e2d366fbc9a2a09ec9a7ff52c498eb56202def7974bff406dfe485c6a653b56526d7eff5c5354
+    ○ │  64048c7b6840 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=first'
-    │ ○  5959e60d9534 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ ○  dee5e11ab6ee test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     ├─╯  new empty commit
     │    args: jj new '-m=second' --ignore-working-copy
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -131,8 +131,8 @@ fn test_integrate_rebase_descendants() {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation 257b4e206712, which seems to be a sibling of the working copy's operation d3f34f652525
-    Hint: Run `jj op integrate d3f34f652525` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation c75ce541cdcb, which seems to be a sibling of the working copy's operation a0a02a3ba8eb
+    Hint: Run `jj op integrate a0a02a3ba8eb` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -147,19 +147,19 @@ fn test_integrate_rebase_descendants() {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    3fe3cb32dee2 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @    d6b0370e1336 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate d3f34f65252510f8e5c0cde929355401acd24be8498869ec70296063a464fd16a1adb9474e4c208a82adaa4316455645808c7ad980239720dfd16a2860e761d8
-    ○ │  d3f34f652525 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ │  args: jj op integrate a0a02a3ba8eb2071be7996d0e8fb0ded50cab5f9e2883c20ce7cdfe9dad65866e783ab1e9f56d491e1b00bebe19acd9e46b75f13be0da61e00857207ab505c9d
+    ○ │  a0a02a3ba8eb test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=child 2'
-    │ ○  257b4e206712 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  c75ce541cdcb test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe '-m=parent' --ignore-working-copy
-    ○  e4002698050b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  9fd1fe09079a test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new --no-edit '-m=child 1'
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -209,8 +209,8 @@ fn test_integrate_concurrent_operations() {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation 8975ceb25594, which seems to be a sibling of the working copy's operation c22efcff0067
-    Hint: Run `jj op integrate c22efcff0067` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 2d4e659af794, which seems to be a sibling of the working copy's operation aa0946a4becd
+    Hint: Run `jj op integrate aa0946a4becd` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -224,16 +224,16 @@ fn test_integrate_concurrent_operations() {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    12fbf26d0f0b test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    535bbc3dc3d5 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate c22efcff00672e0f82ca4a19b9b37c4910dcfc5a5ab017312720438121a4ef1d4de1dd5608bbd3044c309f6edf388cf08377fcfdab23e765e8a14eb896e85209
-    ○ │  c22efcff0067 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  args: jj op integrate aa0946a4becdf50dbd3c69f37031adef1af3023f41c9ec9e569e60a97138c7e19e524882ed4170356a31d574a87141aa12168d83e46857864792202c245d3890
+    ○ │  aa0946a4becd test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe '-m=left'
-    │ ○  8975ceb25594 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ ○  2d4e659af794 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe '-m=right' --ignore-working-copy
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -34,11 +34,11 @@ fn test_op_log() {
         .success();
 
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -80,8 +80,8 @@ fn test_op_log() {
     "#);
 
     let output = work_dir.run_jj(["op", "log", "--op-diff"]);
-    insta::assert_snapshot!(output, @r"
-    @  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
     │
@@ -92,7 +92,7 @@ fn test_op_log() {
     │  Changed working copy default@:
     │  + qpvuntsm 3ae22e7f (empty) description 0
     │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -106,8 +106,8 @@ fn test_op_log() {
     ");
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--color=always"]);
-    insta::assert_snapshot!(output, @r"
-    [1m[38;5;2m@[0m  [1m[38;5;12m12f7cbba4278[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
+    insta::assert_snapshot!(output, @"
+    [1m[38;5;2m@[0m  [1m[38;5;12m57f91468ff2b[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
     │  [1mdescribe commit e8849ae12c709f2321908879bc724fdb2ab8a781[0m
     │  [1m[38;5;13margs: jj describe -m 'description 0'[39m[0m
     │
@@ -118,7 +118,7 @@ fn test_op_log() {
     │  Changed working copy [38;5;2mdefault@[39m:
     │  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
     │  [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ○  [38;5;4m8f47435a3990[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
+    ○  [38;5;4m92406f686752[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -146,7 +146,7 @@ fn test_op_log() {
     insta::assert_snapshot!(work_dir.run_jj(["log", "--at-op", "@-"]), @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: a57c1debcef0, 6a23c2d6dc15
+    Hint: Try specifying one of the operations by ID: 1991e6fe4960, 6b4e65896987
     [EOF]
     [exit status: 1]
     "#);
@@ -166,11 +166,11 @@ fn test_op_log_with_custom_symbols() {
         "log",
         "--config=templates.op_log_node='if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
     ]);
-    insta::assert_snapshot!(output, @r"
-    $  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    $  57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ┝  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ┝  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ┴  000000000000 root()
     [EOF]
@@ -240,16 +240,16 @@ fn test_op_log_no_graph() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["op", "log", "--no-graph", "--color=always"]);
-    insta::assert_snapshot!(output, @r"
-    [1m[38;5;12m8f47435a3990[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
+    insta::assert_snapshot!(output, @"
+    [1m[38;5;12m92406f686752[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
     [1madd workspace 'default'[0m
     [38;5;4m000000000000[39m [38;5;2mroot()[39m
     [EOF]
     ");
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--no-graph"]);
-    insta::assert_snapshot!(output, @r"
-    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    insta::assert_snapshot!(output, @"
+    92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     Changed commits:
@@ -273,11 +273,11 @@ fn test_op_log_reversed() {
         .success();
 
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○  000000000000 root()
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    @  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
        describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
        args: jj describe -m 'description 0'
     [EOF]
@@ -289,17 +289,17 @@ fn test_op_log_reversed() {
 
     // Should be able to display log with fork and branch points
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○  000000000000 root()
-    ○    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○    92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     ├─╮  add workspace 'default'
-    │ ○  39f59ea3ec6e test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  f3949aa27fa4 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -m 'description 1' --at-op @-
-    ○ │  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○ │  57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  b5490646bd14 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -310,17 +310,17 @@ fn test_op_log_reversed() {
 
     // Should work correctly with `--no-graph`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--no-graph"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     000000000000 root()
-    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
-    39f59ea3ec6e test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    f3949aa27fa4 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 1' --at-op @-
-    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    b5490646bd14 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -328,14 +328,14 @@ fn test_op_log_reversed() {
 
     // Should work correctly with `--limit`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=3"]);
-    insta::assert_snapshot!(output, @r"
-    ○  39f59ea3ec6e test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    insta::assert_snapshot!(output, @"
+    ○  f3949aa27fa4 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 1' --at-op @-
-    │ ○  12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ ○  57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  b5490646bd14 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -343,11 +343,11 @@ fn test_op_log_reversed() {
 
     // Should work correctly with `--limit` and `--no-graph`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=2", "--no-graph"]);
-    insta::assert_snapshot!(output, @r"
-    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    fa6e12f12705 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    b5490646bd14 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -371,7 +371,7 @@ fn test_op_log_no_graph_null_terminated() {
             r#"id.short(4) ++ "\0""#,
         ])
         .success();
-    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""a9e5\00265\08f47\00000\0""#);
+    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""74ea\06395\09240\00000\0""#);
 }
 
 #[test]
@@ -381,15 +381,15 @@ fn test_op_log_template() {
     let work_dir = test_env.work_dir("repo");
     let render = |template| work_dir.run_jj(["op", "log", "-T", template]);
 
-    insta::assert_snapshot!(render(r#"id ++ "\n""#), @r"
-    @  8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752
+    insta::assert_snapshot!(render(r#"id ++ "\n""#), @"
+    @  92406f686752a5ba26a5cf1ee9d75499dd31790ba852f3e38857cec9001e622325cb32f23e25deaea7f722a259064a32361b6f0fd9d30a28b2ab1942e661f897
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     [EOF]
     ");
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
-                                time.start(), time.end(), time.duration()) ++ "\n""#), @r"
-    @  8f474 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
+                                time.start(), time.end(), time.duration()) ++ "\n""#), @"
+    @  92406 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     ○  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
     [EOF]
     ");
@@ -402,7 +402,7 @@ fn test_op_log_template() {
     ");
 
     insta::assert_snapshot!(render(r#"json(self) ++ "\n""#), @r#"
-    @  {"id":"8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:07+07:00","end":"2001-02-03T04:05:07+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"tags":{}}
+    @  {"id":"92406f686752a5ba26a5cf1ee9d75499dd31790ba852f3e38857cec9001e622325cb32f23e25deaea7f722a259064a32361b6f0fd9d30a28b2ab1942e661f897","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:07+07:00","end":"2001-02-03T04:05:07+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"tags":{}}
     ○  {"id":"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","parents":[],"time":{"start":"1970-01-01T00:00:00Z","end":"1970-01-01T00:00:00Z"},"description":"","hostname":"","username":"","is_snapshot":false,"tags":{}}
     [EOF]
     "#);
@@ -419,8 +419,8 @@ fn test_op_log_template() {
     let regex = Regex::new(r"\d\d years").unwrap();
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(
-        output.normalize_stdout_with(|s| regex.replace_all(&s, "NN years").into_owned()), @r"
-    @  8f47435a3990 test-username@host.example.com NN years ago, lasted less than a microsecond
+        output.normalize_stdout_with(|s| regex.replace_all(&s, "NN years").into_owned()), @"
+    @  92406f686752 test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -438,22 +438,22 @@ fn test_op_log_builtin_templates() {
         .run_jj(["describe", "-m", "description 0"])
         .success();
 
-    insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @r"
-    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @"
+    57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
     000000000000 root()
     [EOF]
     ");
 
-    insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @r"
-    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @"
+    57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
 
-    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     000000000000 root()
@@ -461,9 +461,9 @@ fn test_op_log_builtin_templates() {
     [EOF]
     ");
 
-    insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @r"
-    12f7cbba4278 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
-    8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @"
+    57f91468ff2b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
+    92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
     000000000000 root()
     [EOF]
     ");
@@ -487,23 +487,23 @@ fn test_op_log_word_wrap() {
     };
 
     // ui.log-word-wrap option works
-    insta::assert_snapshot!(render(&["op", "log"], 40, false), @r"
-    @  2144f9621985 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(render(&["op", "log"], 40, false), @"
+    @  8bdca2d1f84d test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
     ");
-    insta::assert_snapshot!(render(&["op", "log"], 40, true), @r"
-    @  2144f9621985
+    insta::assert_snapshot!(render(&["op", "log"], 40, true), @"
+    @  8bdca2d1f84d
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
     │  2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  8f47435a3990
+    ○  92406f686752
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -513,8 +513,8 @@ fn test_op_log_word_wrap() {
     ");
 
     // Nested graph should be wrapped
-    insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @r"
-    @  2144f9621985
+    insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @"
+    @  8bdca2d1f84d
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
     │  2001-02-03 04:05:08.000 +07:00
@@ -532,7 +532,7 @@ fn test_op_log_word_wrap() {
     │  set)
     │  - qpvuntsm/1 e8849ae1 (hidden)
     │  (empty) (no description set)
-    ○  8f47435a3990
+    ○  92406f686752
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -551,8 +551,8 @@ fn test_op_log_word_wrap() {
     ");
 
     // Nested diff stat shouldn't exceed the terminal width
-    insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @r"
-    @  2144f9621985
+    insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @"
+    @  8bdca2d1f84d
     │  test-username@host.example.com
     │  2001-02-03 04:05:08.000 +07:00 -
     │  2001-02-03 04:05:08.000 +07:00
@@ -574,8 +574,8 @@ fn test_op_log_word_wrap() {
     │  (empty) (no description set)
     [EOF]
     ");
-    insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @r"
-    2144f9621985
+    insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @"
+    8bdca2d1f84d
     test-username@host.example.com
     2001-02-03 04:05:08.000 +07:00 -
     2001-02-03 04:05:08.000 +07:00
@@ -639,8 +639,8 @@ fn test_op_log_configurable() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @  906f45b6b2a8 my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  11956ea06095 my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -694,7 +694,7 @@ fn test_op_abandon_invalid() {
     let output = work_dir.run_jj(["op", "abandon", "@-.."]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 633ee70ce825
+    Error: Cannot abandon the current operation 9e2d6f72a9b4
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -722,14 +722,14 @@ fn test_op_abandon_ancestors() {
 
     work_dir.run_jj(["commit", "-m", "commit 1"]).success();
     work_dir.run_jj(["commit", "-m", "commit 2"]).success();
-    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  3fc56f6bb4db test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
+    @  09b77f1bb5e0 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
-    ○  c815486340d5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  1250406ce518 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -743,12 +743,12 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("1675333b7de89b5da012c696d797345bad2a6ce55a4b605e85c3897f818f05e11e8c53de19d34c2fee38a36528dc95bd2a378f72ac0877f8bec2513a68043253")
+    Current operation: OperationId("6da4e07f303bcd3465a7ca3150c4b238da598a6332066bb812082198c171d2e6ef40bb7b4cc882c92cd6e86ad715cde42aea142629bfb5a97e942ea68256a980")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
-    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  1675333b7de8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
+    @  6da4e07f303b test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -765,11 +765,11 @@ fn test_op_abandon_ancestors() {
     Abandoned 2 operations and reparented 1 descendant operations.
     [EOF]
     ");
-    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  9df33337d494 test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
+    @  696942936fbb test-username@host.example.com 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit 2f3e935ade915272ccdce9e43e5a5c82fc336aee
     │  args: jj commit -m 'commit 5'
-    ○  1675333b7de8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  6da4e07f303b test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -778,9 +778,9 @@ fn test_op_abandon_ancestors() {
 
     // Can't abandon the current operation.
     let output = work_dir.run_jj(["op", "abandon", "..@"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 9df33337d494
+    Error: Cannot abandon the current operation 696942936fbb
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -804,15 +804,15 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("ce6a0300b7346109e75a6dcc97e3ff9e1488ce43a4073dd9eb81afb7f463b4543d3f15cf9a42a9864a4aaf6daab900b6b037dbdcb95f87422e891f7e884641aa")
+    Current operation: OperationId("eefc6e697645a576e9bfe209d379af5cea2c66868578f1496511b75a728aa95452cde679a403390422c7446a46b046eecdddc79ac765bda262fb223f09c32e96")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
-    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @r"
-    @  ce6a0300b734 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  revert operation 9df33337d49450b21bf694025557ede1ac4c63c7b17f593add0d7adc81b394d363f1edffa025b323f88ec947dcd9214f46e82e742e7a74adbfff4c2d96321133
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
+    @  eefc6e697645 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  revert operation 696942936fbb2751dc618228d86102d80c4f9c6a38b5cc2190d4c69d467346ff14d7740eb1965f80688b1997c65ae82e69e428e8b1d73944e215d933e2b14de3
     │  args: jj op revert
-    ○  1675333b7de8 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  6da4e07f303b test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -826,9 +826,9 @@ fn test_op_abandon_ancestors() {
     Nothing changed.
     [EOF]
     ");
-    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1"]), @r"
-    @  ce6a0300b734 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  revert operation 9df33337d49450b21bf694025557ede1ac4c63c7b17f593add0d7adc81b394d363f1edffa025b323f88ec947dcd9214f46e82e742e7a74adbfff4c2d96321133
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1"]), @"
+    @  eefc6e697645 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  revert operation 696942936fbb2751dc618228d86102d80c4f9c6a38b5cc2190d4c69d467346ff14d7740eb1965f80688b1997c65ae82e69e428e8b1d73944e215d933e2b14de3
     │  args: jj op revert
     [EOF]
     ");
@@ -852,12 +852,12 @@ fn test_op_abandon_without_updating_working_copy() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("0d4bb8e4a2babc4c216be0f9bde32aeef888abebde0062aeb1c204dde5e1f476fa951fcbeceb2263cf505008ba87a834849469dede30dfc589f37d5073aedfbe")
+    Current operation: OperationId("73dfa92476ffc087e037fe403781e8571ad18a988c76ee2905a98e6676175c8577d7bd80fc466da9d9668bb1f3bdde94ef3052dd9241d559eca8f376f12c8991")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
-    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @r"
-    @  f5e2d13c1aac test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @"
+    @  160b8531d0d7 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -867,19 +867,19 @@ fn test_op_abandon_without_updating_working_copy() {
     // It could be updated if the tree matches, but there's no extra logic for
     // that.
     let output = work_dir.run_jj(["op", "abandon", "@-"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 operations and reparented 1 descendant operations.
-    Warning: The working copy operation 0d4bb8e4a2ba is not updated because it differs from the repo f5e2d13c1aac.
+    Warning: The working copy operation 73dfa92476ff is not updated because it differs from the repo 160b8531d0d7.
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("0d4bb8e4a2babc4c216be0f9bde32aeef888abebde0062aeb1c204dde5e1f476fa951fcbeceb2263cf505008ba87a834849469dede30dfc589f37d5073aedfbe")
+    Current operation: OperationId("73dfa92476ffc087e037fe403781e8571ad18a988c76ee2905a98e6676175c8577d7bd80fc466da9d9668bb1f3bdde94ef3052dd9241d559eca8f376f12c8991")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
-    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @r"
-    @  aa53bfb9a190 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @"
+    @  64866768a0f7 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -900,8 +900,8 @@ fn test_op_abandon_multiple_heads() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, prev_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"0d4bb8e4a2ba");
-    insta::assert_snapshot!(prev_op_id, @"3fc56f6bb4db");
+    insta::assert_snapshot!(head_op_id, @"73dfa92476ff");
+    insta::assert_snapshot!(prev_op_id, @"09b77f1bb5e0");
 
     // Create 1 other concurrent operation.
     work_dir
@@ -913,28 +913,28 @@ fn test_op_abandon_multiple_heads() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: 0d4bb8e4a2ba, 56b918336386
+    Hint: Try specifying one of the operations by ID: 73dfa92476ff, b938b53d460b
     [EOF]
     [exit status: 1]
     "#);
     let (_, other_head_op_id) = output.stderr.raw().trim_end().rsplit_once(", ").unwrap();
-    insta::assert_snapshot!(other_head_op_id, @"56b918336386");
+    insta::assert_snapshot!(other_head_op_id, @"b938b53d460b");
     assert_ne!(head_op_id, other_head_op_id);
 
     // Can't abandon one of the head operations.
     let output = work_dir.run_jj(["op", "abandon", head_op_id]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 0d4bb8e4a2ba
+    Error: Cannot abandon the current operation 73dfa92476ff
     [EOF]
     [exit status: 1]
     ");
 
     // Can't abandon the other head operation.
     let output = work_dir.run_jj(["op", "abandon", other_head_op_id]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 56b918336386
+    Error: Cannot abandon the current operation b938b53d460b
     [EOF]
     [exit status: 1]
     ");
@@ -950,20 +950,20 @@ fn test_op_abandon_multiple_heads() {
     ");
 
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @    4bc6ca79dcdc test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @    590588a4d3ce test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  f5e2d13c1aac test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  160b8531d0d7 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │ │  args: jj commit -m 'commit 3'
-    │ ○  56b918336386 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  b938b53d460b test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │    args: jj commit '--at-op=@--' -m 'commit 4'
-    ○  c815486340d5 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  1250406ce518 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -997,8 +997,8 @@ fn test_op_recover_from_bad_gc() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, _, _, bad_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"9a34044af622");
-    insta::assert_snapshot!(bad_op_id, @"65860cfb750d");
+    insta::assert_snapshot!(head_op_id, @"84b8127ab74c");
+    insta::assert_snapshot!(bad_op_id, @"8d4167911714");
 
     // Corrupt the repo by removing hidden but reachable commit object.
     let output = work_dir
@@ -1022,9 +1022,9 @@ fn test_op_recover_from_bad_gc() {
         .success();
 
     let output = work_dir.run_jj(["--at-op", head_op_id, "debug", "reindex"]);
-    insta::assert_snapshot!(output.strip_stderr_last_line(), @r"
+    insta::assert_snapshot!(output.strip_stderr_last_line(), @"
     ------- stderr -------
-    Internal error: Failed to index commits at operation 65860cfb750d760cabfc2ba588b16b1619e048bbd2dcb0295d0d32442da72beee0675a5ea07c47e28e297572d385826f6286e16efd885f2f94114692688fb87f
+    Internal error: Failed to index commits at operation 8d4167911714984cd300e10d122d735100d557a43c91891a6f034fb349e32b65c3e063131cd08c72dffff4ed4655907cca86767afe3c68426dd67366c8fef88f
     Caused by:
     1: Object 4e123bae951c3216a145dbcd56d60522739d362e of type commit not found
     [EOF]
@@ -1033,23 +1033,23 @@ fn test_op_recover_from_bad_gc() {
 
     // "op log" should still be usable.
     let output = work_dir.run_jj(["op", "log", "--ignore-working-copy", "--at-op", head_op_id]);
-    insta::assert_snapshot!(output, @r"
-    @  9a34044af622 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  84b8127ab74c test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  describe commit a053bc8736064a739ab73f2c775a6ac2851bf1a3
     │  args: jj describe -m4
-    ○  c08e984b3923 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  de2a69adf675 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new -m3
-    ○  9988649fbebb test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  ecbd57ec0aab test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  abandon commit 4e123bae951c3216a145dbcd56d60522739d362e
     │  args: jj abandon
-    ○  65860cfb750d test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  8d4167911714 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 884fe9b9c65602d724c7c0f2a238d5549efbe5e6
     │  args: jj describe -m2
-    ○  0a7467a95483 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  ca695aa48216 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m1
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1090,7 +1090,7 @@ fn test_op_corrupted_operation_file() {
         .join(PathBuf::from_iter([".jj", "repo", "op_store"]));
 
     let op_id = work_dir.current_operation_id();
-    insta::assert_snapshot!(op_id, @"8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752");
+    insta::assert_snapshot!(op_id, @"92406f686752a5ba26a5cf1ee9d75499dd31790ba852f3e38857cec9001e622325cb32f23e25deaea7f722a259064a32361b6f0fd9d30a28b2ab1942e661f897");
 
     let op_file_path = op_store_path.join("operations").join(&op_id);
     assert!(op_file_path.exists());
@@ -1098,11 +1098,11 @@ fn test_op_corrupted_operation_file() {
     // truncated
     std::fs::write(&op_file_path, b"").unwrap();
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752 of type operation
+    1: Error when reading object 92406f686752a5ba26a5cf1ee9d75499dd31790ba852f3e38857cec9001e622325cb32f23e25deaea7f722a259064a32361b6f0fd9d30a28b2ab1942e661f897 of type operation
     2: Invalid hash length (expected 64 bytes, got 0 bytes)
     [EOF]
     [exit status: 255]
@@ -1111,11 +1111,11 @@ fn test_op_corrupted_operation_file() {
     // undecodable
     std::fs::write(&op_file_path, b"\0").unwrap();
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 8f47435a3990362feaf967ca6de2eb0a31c8b883dfcb66fba5c22200d12bbe61e3dc8bc855f1f6879285fcafaf85ac792f9a43bcc36e57d28737d18347d5e752 of type operation
+    1: Error when reading object 92406f686752a5ba26a5cf1ee9d75499dd31790ba852f3e38857cec9001e622325cb32f23e25deaea7f722a259064a32361b6f0fd9d30a28b2ab1942e661f897 of type operation
     2: failed to decode Protobuf message: invalid tag value: 0
     [EOF]
     [exit status: 255]
@@ -1133,9 +1133,9 @@ fn test_op_summary_diff_template() {
         .run_jj(["new", "--no-edit", "-m=scratch"])
         .success();
     let output = work_dir.run_jj(["op", "revert", "--color=always"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4m8c2682708d2e[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
+    Reverted operation: [38;5;4m5dc5b5f219a0[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1147,9 +1147,9 @@ fn test_op_summary_diff_template() {
         "@",
         "--color=always",
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     From operation: [38;5;4m000000000000[39m [38;5;2mroot()[39m
-      To operation: [38;5;4mad76b56af140[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation 8c2682708d2e786e9c489d18b4cfc68c675d0d49b9be85de9540a973b775c7ef715c0a37c760fe74ee6a31e50487f6d64e392944124a1d288ca31493bf9e36f2
+      To operation: [38;5;4mb77f078e8048[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation 5dc5b5f219a046886d1459f4060d568e37f4f826c87162392cb19ee8879787c0946c7ccbc859195c08e5d85dc3f5771ceb2f00ae154d586119625fc2510692fc
 
     Changed commits:
     ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
@@ -1165,9 +1165,9 @@ fn test_op_summary_diff_template() {
         .run_jj(["new", "--no-edit", "-m=scratch"])
         .success();
     let output = work_dir.run_jj(["op", "revert", "--color=debug"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4m<<operation id short::c5c76cab7d34>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
+    Reverted operation: [38;5;4m<<operation id short::c756083c9c1c>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1179,9 +1179,9 @@ fn test_op_summary_diff_template() {
         "@",
         "--color=debug",
     ]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     From operation: [38;5;4m<<op_diff operation id short::000000000000>>[39m<<op_diff operation:: >>[38;5;2m<<op_diff operation root::root()>>[39m
-      To operation: [38;5;4m<<op_diff operation id short::f8b6a7ee554b>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation c5c76cab7d34a454ae4edcf362f6cc7387c87cb20b328e6d50cbcb6c893c6ea9bf76ff792c34e75f1259a33b066fed38df2561e880661d2b35db1bd65e95b877>>
+      To operation: [38;5;4m<<op_diff operation id short::bc8b7fd3f5c2>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation c756083c9c1c9c518b1891184a3e4b3b3cce16868299faafca24fe279b572a7b83fe3ea4e832bfb29748e8385a282a270ba3ba179d75e3b14cfe55a2dc2f5b06>>
 
     Changed commits:
     ○  [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[38;5;8m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[39m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[38;5;8m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
@@ -1213,16 +1213,16 @@ fn test_op_diff() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  86de4e57e65c test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  49dba6c10b79 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  3588fc3b4ba0 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  ddc8e04a2e37 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch '--branch=*' '--tag=*'
-    ○  0ed329262b36 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  cc62d513480a test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1237,8 +1237,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--from", "@", "--to", "@"]);
     insta::assert_snapshot!(output, @"
-    From operation: 86de4e57e65c (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
-      To operation: 86de4e57e65c (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: 49dba6c10b79 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: 49dba6c10b79 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
     [EOF]
     ");
 
@@ -1247,8 +1247,8 @@ fn test_op_diff() {
     // @- --to @` (if `@` is not a merge commit).
     let output = work_dir.run_jj(["op", "diff", "--from", "@-", "--to", "@"]);
     insta::assert_snapshot!(output, @"
-    From operation: 3588fc3b4ba0 (2001-02-03 08:05:09) fetch from git remote(s) origin
-      To operation: 86de4e57e65c (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: ddc8e04a2e37 (2001-02-03 08:05:09) fetch from git remote(s) origin
+      To operation: 49dba6c10b79 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed local bookmarks:
     bookmark-1:
@@ -1268,7 +1268,7 @@ fn test_op_diff() {
     let output = work_dir.run_jj(["op", "diff", "--from", "0000000"]);
     insta::assert_snapshot!(output, @"
     From operation: 000000000000 root()
-      To operation: 86de4e57e65c (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: 49dba6c10b79 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed commits:
     ○  + skovwzlu 854c38b8 Commit 4
@@ -1312,7 +1312,7 @@ fn test_op_diff() {
     // Diff from latest operation to root operation
     let output = work_dir.run_jj(["op", "diff", "--to", "0000000"]);
     insta::assert_snapshot!(output, @"
-    From operation: 86de4e57e65c (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: 49dba6c10b79 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
       To operation: 000000000000 root()
 
     Changed commits:
@@ -1401,25 +1401,25 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    635199a4e175 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    @    c75c7588a40c test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  3174c4c7dd26 test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    ○ │  b366aeed2113 test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     │ │  point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj bookmark move bookmark-1 --to @ --allow-backwards
-    │ ○  8ae6e51c2c56 test-username@host.example.com 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
+    │ ○  fa6a644e7b31 test-username@host.example.com 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
     ├─╯  point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
     │    args: jj bookmark set bookmark-1 -r bookmark-2@origin --allow-backwards --at-op @-
-    ○  86de4e57e65c test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  49dba6c10b79 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  3588fc3b4ba0 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  ddc8e04a2e37 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch '--branch=*' '--tag=*'
-    ○  0ed329262b36 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  cc62d513480a test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1432,8 +1432,8 @@ fn test_op_diff() {
     // Diff between the first parent of the merge operation and the merge operation.
     let output = work_dir.run_jj(["op", "diff", "--from", first_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @"
-    From operation: 3174c4c7dd26 (2001-02-03 08:05:19) point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 635199a4e175 (2001-02-03 08:05:21) reconcile divergent operations
+    From operation: b366aeed2113 (2001-02-03 08:05:19) point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: c75c7588a40c (2001-02-03 08:05:21) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1448,8 +1448,8 @@ fn test_op_diff() {
     // operation.
     let output = work_dir.run_jj(["op", "diff", "--from", second_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @"
-    From operation: 8ae6e51c2c56 (2001-02-03 08:05:20) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
-      To operation: 635199a4e175 (2001-02-03 08:05:21) reconcile divergent operations
+    From operation: fa6a644e7b31 (2001-02-03 08:05:20) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
+      To operation: c75c7588a40c (2001-02-03 08:05:21) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1475,8 +1475,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 635199a4e175 (2001-02-03 08:05:21) reconcile divergent operations
-      To operation: 21b161ea4a69 (2001-02-03 08:05:25) fetch from git remote(s) origin
+    From operation: c75c7588a40c (2001-02-03 08:05:21) reconcile divergent operations
+      To operation: 7c9a8dba198c (2001-02-03 08:05:25) fetch from git remote(s) origin
 
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
@@ -1522,8 +1522,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 21b161ea4a69 (2001-02-03 08:05:25) fetch from git remote(s) origin
-      To operation: 08ad9329c775 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+    From operation: 7c9a8dba198c (2001-02-03 08:05:25) fetch from git remote(s) origin
+      To operation: 57bfe0472c91 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
 
     Changed local bookmarks:
     bookmark-2:
@@ -1541,8 +1541,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 08ad9329c775 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: d0babb4e319c (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+    From operation: 57bfe0472c91 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: 3d86e085eb11 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1561,8 +1561,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 08ad9329c775 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: d0babb4e319c (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+    From operation: 57bfe0472c91 (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: 3d86e085eb11 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1582,8 +1582,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: d0babb4e319c (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
-      To operation: 4b14838abd9a (2001-02-03 08:05:33) new empty commit
+    From operation: 3d86e085eb11 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+      To operation: 2ca3cbb2a421 (2001-02-03 08:05:33) new empty commit
 
     Changed commits:
     ○  + qmkrwlvp 96f3a57c (empty) new commit
@@ -1603,8 +1603,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 4b14838abd9a (2001-02-03 08:05:33) new empty commit
-      To operation: 0b43238209b8 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: 2ca3cbb2a421 (2001-02-03 08:05:33) new empty commit
+      To operation: 1daf42c3973d (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed local bookmarks:
     bookmark-1:
@@ -1626,8 +1626,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 0b43238209b8 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: ade57a5f4907 (2001-02-03 08:05:37) delete bookmark bookmark-2
+    From operation: 1daf42c3973d (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+      To operation: a08722943aeb (2001-02-03 08:05:37) delete bookmark bookmark-2
 
     Changed local bookmarks:
     bookmark-2:
@@ -1647,8 +1647,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: ade57a5f4907 (2001-02-03 08:05:37) delete bookmark bookmark-2
-      To operation: f80ee0d60e1e (2001-02-03 08:05:39) push all tracked bookmarks to git remote origin
+    From operation: a08722943aeb (2001-02-03 08:05:37) delete bookmark bookmark-2
+      To operation: 7e3350edfa2c (2001-02-03 08:05:39) push all tracked bookmarks to git remote origin
 
     Changed remote bookmarks:
     bookmark-1@origin:
@@ -1664,8 +1664,8 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "set", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: f80ee0d60e1e (2001-02-03 08:05:39) push all tracked bookmarks to git remote origin
-      To operation: c0c9620408cc (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: 7e3350edfa2c (2001-02-03 08:05:39) push all tracked bookmarks to git remote origin
+      To operation: c35516c57ffe (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed commits:
     ○  + wvmqtotl 56e74c8d (empty) (no description set)
@@ -1687,8 +1687,8 @@ fn test_op_diff() {
         .success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: f80ee0d60e1e (2001-02-03 08:05:39) push all tracked bookmarks to git remote origin
-      To operation: c0c9620408cc (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: 7e3350edfa2c (2001-02-03 08:05:39) push all tracked bookmarks to git remote origin
+      To operation: c35516c57ffe (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed commits:
     ○  + wvmqtotl 56e74c8d (empty) (no description set)
@@ -1708,8 +1708,8 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "delete", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: c0c9620408cc (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: af1b464e9775 (2001-02-03 08:05:45) delete tag tag1
+    From operation: c35516c57ffe (2001-02-03 08:05:41) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+      To operation: e6c8b89a2a6b (2001-02-03 08:05:45) delete tag tag1
 
     Changed local tags:
     tag1:
@@ -1735,9 +1735,9 @@ fn test_op_diff_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@-", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
-      To operation: 688a949038f6 (2001-02-03 08:05:08) snapshot working copy
+    insta::assert_snapshot!(output, @"
+    From operation: 92406f686752 (2001-02-03 08:05:07) add workspace 'default'
+      To operation: 7d167dfc8691 (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + qpvuntsm 6b57e33c (no description set)
@@ -1756,9 +1756,9 @@ fn test_op_diff_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 688a949038f6 (2001-02-03 08:05:08) snapshot working copy
-      To operation: ed6f6674bcf8 (2001-02-03 08:05:08) new empty commit
+    insta::assert_snapshot!(output, @"
+    From operation: 7d167dfc8691 (2001-02-03 08:05:08) snapshot working copy
+      To operation: 1025a6f9454b (2001-02-03 08:05:08) new empty commit
 
     Changed commits:
     ○  + rlvkpnrz c1c924b8 (empty) (no description set)
@@ -1779,9 +1779,9 @@ fn test_op_diff_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 36a5d140ea10 (2001-02-03 08:05:11) snapshot working copy
-      To operation: cfb8edbeae42 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+    insta::assert_snapshot!(output, @"
+    From operation: b5844a41a0fc (2001-02-03 08:05:11) snapshot working copy
+      To operation: 7e41892f4adc (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
 
     Changed commits:
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
@@ -1813,9 +1813,9 @@ fn test_op_diff_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    From operation: cfb8edbeae42 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
-      To operation: dd1ab16f2720 (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
+    insta::assert_snapshot!(output, @"
+    From operation: 7e41892f4adc (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+      To operation: f47597f6341c (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
@@ -1838,7 +1838,7 @@ fn test_op_diff_sibling() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let base_op_id = output.stdout.raw().lines().next().unwrap();
-    insta::assert_snapshot!(base_op_id, @"8f47435a3990");
+    insta::assert_snapshot!(base_op_id, @"92406f686752");
 
     // Create merge commit at one operation side. The parent trees will have to
     // be merged when diffing, which requires the commit index of this side.
@@ -1854,29 +1854,29 @@ fn test_op_diff_sibling() {
         .success();
 
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @    d566adf20e48 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @    a171b4bced7a test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  7bba3a63b73b test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  c41f07dfa73e test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '@-+' -mA
-    ○ │  613137e2652f test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  f2ee07616284 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new '@-+' -mA
-    ○ │  a625f0ff4f09 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  04a330bec02c test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.2
-    ○ │  1e7f1f82a257 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  7f041ed411ec test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new 'root()' -mA.2
-    ○ │  3f5210eaa799 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  508e4cd31d62 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.1
-    │ ○  252ff3a5a0e6 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  b4c94fce71bc test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    │    args: jj describe --at-op 8f47435a3990 -mB
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │    args: jj describe --at-op 92406f686752 -mB
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1889,9 +1889,9 @@ fn test_op_diff_sibling() {
         .success();
     let [head_op_id, p1_op_id, _, _, _, _, p2_op_id] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"d566adf20e48");
-    insta::assert_snapshot!(p1_op_id, @"7bba3a63b73b");
-    insta::assert_snapshot!(p2_op_id, @"252ff3a5a0e6");
+    insta::assert_snapshot!(head_op_id, @"a171b4bced7a");
+    insta::assert_snapshot!(p1_op_id, @"c41f07dfa73e");
+    insta::assert_snapshot!(p2_op_id, @"b4c94fce71bc");
 
     // Diff between p1 and p2 operations should work no matter if p2 is chosen
     // as a base operation.
@@ -1906,9 +1906,9 @@ fn test_op_diff_sibling() {
         p2_op_id,
         "--summary",
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 7bba3a63b73b (2001-02-03 08:05:11) new empty commit
-      To operation: 252ff3a5a0e6 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    insta::assert_snapshot!(output, @"
+    From operation: c41f07dfa73e (2001-02-03 08:05:11) new empty commit
+      To operation: b4c94fce71bc (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
 
     Changed commits:
     ○    - mzvwutvl/0 08c63613 (hidden) (empty) A
@@ -1936,9 +1936,9 @@ fn test_op_diff_sibling() {
         p1_op_id,
         "--summary",
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 252ff3a5a0e6 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 7bba3a63b73b (2001-02-03 08:05:11) new empty commit
+    insta::assert_snapshot!(output, @"
+    From operation: b4c94fce71bc (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: c41f07dfa73e (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     ○  - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
@@ -1968,9 +1968,9 @@ fn test_op_diff_sibling() {
         "--summary",
         "--no-graph",
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 252ff3a5a0e6 (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 7bba3a63b73b (2001-02-03 08:05:11) new empty commit
+    insta::assert_snapshot!(output, @"
+    From operation: b4c94fce71bc (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: c41f07dfa73e (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
@@ -2039,9 +2039,9 @@ fn test_op_diff_divergent_change() {
         "--to",
         &divergent_op_id,
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: ef75d88dd5fe (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    insta::assert_snapshot!(output, @"
+    From operation: 2d320e350850 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+      To operation: 371cf6bce743 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
@@ -2064,9 +2064,9 @@ fn test_op_diff_divergent_change() {
         "--to",
         &resolved_op_id,
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: 90aa25304059 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+    insta::assert_snapshot!(output, @"
+    From operation: 371cf6bce743 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: a3216b6b9673 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
@@ -2089,9 +2089,9 @@ fn test_op_diff_divergent_change() {
         "--to",
         &divergent_op_id,
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: ef75d88dd5fe (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    insta::assert_snapshot!(output, @"
+    From operation: 2d320e350850 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+      To operation: 371cf6bce743 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
@@ -2139,9 +2139,9 @@ fn test_op_diff_divergent_change() {
         "--to",
         &resolved_op_id,
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: 90aa25304059 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+    insta::assert_snapshot!(output, @"
+    From operation: 371cf6bce743 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: a3216b6b9673 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
@@ -2177,9 +2177,9 @@ fn test_op_diff_divergent_change() {
         "--to",
         &divergent_op_id,
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 90aa25304059 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
-      To operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    insta::assert_snapshot!(output, @"
+    From operation: a3216b6b9673 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+      To operation: 371cf6bce743 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/1 c5cad9ab (divergent) 2b
@@ -2202,9 +2202,9 @@ fn test_op_diff_divergent_change() {
         "--to",
         &initial_op_id,
     ]);
-    insta::assert_snapshot!(output, @r"
-    From operation: a1af26c1d765 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: ef75d88dd5fe (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+    insta::assert_snapshot!(output, @"
+    From operation: 371cf6bce743 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: 2d320e350850 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
 
     Changed commits:
     ○  + rlvkpnrz 4f7a567a (empty) (no description set)
@@ -2246,10 +2246,10 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     // FIXME: the diff should be empty
     let output = work_dir.run_jj(["op", "diff"]);
-    insta::assert_snapshot!(output, @r"
-    From operation: 69ec49158b0e (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    From operation: 0c5076ddf77d (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
-      To operation: ac3c7e679e31 (2001-02-03 08:05:11) reconcile divergent operations
+    insta::assert_snapshot!(output, @"
+    From operation: 675bb5bcca61 (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: 90fefbd2925d (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
+      To operation: b4e26b1127f1 (2001-02-03 08:05:11) reconcile divergent operations
 
     Changed commits:
     ○  + rlvkpnrz/1 8f35f6a6 (divergent) (empty) 2b
@@ -2258,19 +2258,19 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     ");
 
     let output = work_dir.run_jj(["op", "show"]);
-    insta::assert_snapshot!(output, @r"
-    ac3c7e679e31 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    insta::assert_snapshot!(output, @"
+    b4e26b1127f1 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
     ");
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--limit=3"]);
-    insta::assert_snapshot!(output, @r"
-    @    ac3c7e679e31 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @    b4e26b1127f1 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  69ec49158b0e test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  675bb5bcca61 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -r@- -m1
     │ │
@@ -2283,7 +2283,7 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     │ │  Changed working copy default@:
     │ │  + rlvkpnrz 7ed5a610 (empty) 2a
     │ │  - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
-    │ ○  0c5076ddf77d test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  90fefbd2925d test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
     │    args: jj describe '--at-op=@-' -m2b
     │
@@ -2322,8 +2322,8 @@ fn test_op_diff_word_wrap() {
 
     // ui.log-word-wrap option works, and diff stat respects content width
     insta::assert_snapshot!(render(&["op", "diff", "--from=@---", "--stat"], 40, true), @"
-    From operation: f7178a5c02a1 (2001-02-03 08:05:07) add git remote origin
-      To operation: 4eefc4a80c78 (2001-02-03 08:05:08) snapshot working copy
+    From operation: 2908183476e1 (2001-02-03 08:05:07) add git remote origin
+      To operation: 4a1474372716 (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + sqpuoqvx f6f32c19 (no description
@@ -2385,8 +2385,8 @@ fn test_op_diff_word_wrap() {
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
         render(&["op", "diff", "--from=@---", "--config", config], 10, true), @"
-    From operation: f7178a5c02a1 (2001-02-03 08:05:07) add git remote origin
-      To operation: 4eefc4a80c78 (2001-02-03 08:05:08) snapshot working copy
+    From operation: 2908183476e1 (2001-02-03 08:05:07) add git remote origin
+      To operation: 4a1474372716 (2001-02-03 08:05:08) snapshot working copy
 
     Changed
     commits:
@@ -2488,16 +2488,16 @@ fn test_op_show() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  86de4e57e65c test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  49dba6c10b79 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  3588fc3b4ba0 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  ddc8e04a2e37 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch '--branch=*' '--tag=*'
-    ○  0ed329262b36 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  cc62d513480a test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -2513,7 +2513,7 @@ fn test_op_show() {
     // Showing the latest operation.
     let output = work_dir.run_jj(["op", "show", "@"]);
     insta::assert_snapshot!(output, @"
-    86de4e57e65c test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    49dba6c10b79 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     track remote bookmark bookmark-1@origin
     args: jj bookmark track bookmark-1
 
@@ -2535,7 +2535,7 @@ fn test_op_show() {
     // Showing a given operation.
     let output = work_dir.run_jj(["op", "show", "@-"]);
     insta::assert_snapshot!(output, @"
-    3588fc3b4ba0 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ddc8e04a2e37 test-username@host.example.com 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch '--branch=*' '--tag=*'
 
@@ -2595,7 +2595,7 @@ fn test_op_show() {
     // Showing a merge operation is empty.
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    9ffc1d7a2bbf test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    017978b906d5 test-username@host.example.com 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2616,7 +2616,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    fbf48ece856c test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    d5bff830d972 test-username@host.example.com 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
 
@@ -2660,7 +2660,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    44ccaab02679 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    01f3c45b2722 test-username@host.example.com 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
     args: jj bookmark create bookmark-2 -r bookmark-2@origin
 
@@ -2680,7 +2680,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    86084a6b397d test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    ece19d8879d5 test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2
 
@@ -2701,7 +2701,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    86084a6b397d test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    ece19d8879d5 test-username@host.example.com 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2
 
@@ -2723,7 +2723,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    2a0080936cbf test-username@host.example.com 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
+    24ce7fa83ad9 test-username@host.example.com 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
 
@@ -2746,7 +2746,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    0f46cd6d2053 test-username@host.example.com 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
+    0bf77baed6c5 test-username@host.example.com 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
     point bookmark bookmark-1 to commit 8f340dd76dc637e4deac17f30056eef7d8eaf682
     args: jj bookmark set bookmark-1 -r @
 
@@ -2767,7 +2767,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    3584554e2b7d test-username@host.example.com 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    934187fb7262 test-username@host.example.com 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     delete bookmark bookmark-2
     args: jj bookmark delete bookmark-2
 
@@ -2789,7 +2789,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    520617df6709 test-username@host.example.com 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
+    5aa2849accfd test-username@host.example.com 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
     push all tracked bookmarks to git remote origin
     args: jj git push --tracked --deleted
 
@@ -2804,21 +2804,13 @@ fn test_op_show() {
     ");
 
     // Showing a given operation, without graph
-    let output = work_dir.run_jj(["op", "show", "--no-graph", "2a0080936cbf"]);
-    insta::assert_snapshot!(output, @"
-    2a0080936cbf test-username@host.example.com 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
-    new empty commit
-    args: jj new bookmark-1@origin -m 'new commit'
-
-    Changed commits:
-    + tlkvzzqu 8f340dd7 (empty) new commit
-    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
-
-    Changed working copy default@:
-    + tlkvzzqu 8f340dd7 (empty) new commit
-    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
+    let output = work_dir.run_jj(["op", "show", "--no-graph", "3117c5ac4af3"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: No operation ID matching "3117c5ac4af3"
     [EOF]
-    ");
+    [exit status: 1]
+    "#);
 }
 
 #[test]
@@ -2837,8 +2829,8 @@ fn test_op_show_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show", "@-", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    688a949038f6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    7d167dfc8691 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     snapshot working copy
     args: jj new
 
@@ -2859,8 +2851,8 @@ fn test_op_show_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show", "@", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    ed6f6674bcf8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    1025a6f9454b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     new empty commit
     args: jj new
 
@@ -2883,8 +2875,8 @@ fn test_op_show_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    cfb8edbeae42 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    insta::assert_snapshot!(output, @"
+    7e41892f4adc test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     args: jj squash
 
@@ -2918,8 +2910,8 @@ fn test_op_show_patch() {
     [EOF]
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    dd1ab16f2720 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    insta::assert_snapshot!(output, @"
+    f47597f6341c test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     args: jj abandon
 
@@ -2935,8 +2927,8 @@ fn test_op_show_patch() {
 
     // Try again with "op log".
     let output = work_dir.run_jj(["op", "log", "--git"]);
-    insta::assert_snapshot!(output, @r"
-    @  dd1ab16f2720 test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  f47597f6341c test-username@host.example.com 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     │  args: jj abandon
     │
@@ -2947,7 +2939,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + yqosqzyt c97a8573 (empty) (no description set)
     │  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
-    ○  cfb8edbeae42 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  7e41892f4adc test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     │  args: jj squash
     │
@@ -2967,7 +2959,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + mzvwutvl 6cbd01ae (empty) (no description set)
     │  - rlvkpnrz/0 05a2969e (hidden) (no description set)
-    ○  36a5d140ea10 test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  b5844a41a0fc test-username@host.example.com 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash
     │
@@ -2985,7 +2977,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz 05a2969e (no description set)
     │  - rlvkpnrz/1 c1c924b8 (hidden) (empty) (no description set)
-    ○  ed6f6674bcf8 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  1025a6f9454b test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new
     │
@@ -2995,7 +2987,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz c1c924b8 (empty) (no description set)
     │  - qpvuntsm 6b57e33c (no description set)
-    ○  688a949038f6 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  7d167dfc8691 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj new
     │
@@ -3013,7 +3005,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + qpvuntsm 6b57e33c (no description set)
     │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -3044,12 +3036,12 @@ fn test_op_show_template() {
         r#"separate(" ", id.short(), description)"#,
         "--no-op-diff",
     ]);
-    insta::assert_snapshot!(output, @"9c6c10441eab commit 0883ea507656cce545dbba9f23760ff72dff5174[EOF]");
+    insta::assert_snapshot!(output, @"ab4c9c69aaa7 commit 0883ea507656cce545dbba9f23760ff72dff5174[EOF]");
 
     // Test --no-op-diff flag suppresses the diff
     let output = work_dir.run_jj(["op", "show", "--no-op-diff"]);
-    insta::assert_snapshot!(output, @r"
-    9c6c10441eab test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    ab4c9c69aaa7 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     commit 0883ea507656cce545dbba9f23760ff72dff5174
     args: jj commit -m 'first commit'
     [EOF]
@@ -3062,8 +3054,8 @@ fn test_op_show_template() {
         "-T",
         r#"separate(" ", id.short(), description)"#,
     ]);
-    insta::assert_snapshot!(output, @r"
-    9c6c10441eab commit 0883ea507656cce545dbba9f23760ff72dff5174
+    insta::assert_snapshot!(output, @"
+    ab4c9c69aaa7 commit 0883ea507656cce545dbba9f23760ff72dff5174
     Changed commits:
     ○  + rlvkpnrz e4863b8c (empty) (no description set)
     ○  + qpvuntsm b52b7cb5 first commit
@@ -3090,14 +3082,14 @@ fn test_op_log_parents() {
         .success();
     let template = r#"id.short() ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|o| o.id().short()) ++ "\n""#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
-    insta::assert_snapshot!(output, @r"
-    @    ea1c99c7c4a9
-    ├─╮  P: 2 12f7cbba4278 dd1534c4b064
-    ○ │  12f7cbba4278
-    │ │  P: 1 8f47435a3990
-    │ ○  dd1534c4b064
-    ├─╯  P: 1 8f47435a3990
-    ○  8f47435a3990
+    insta::assert_snapshot!(output, @"
+    @    cf3b7381b916
+    ├─╮  P: 2 57f91468ff2b 03c44e3a259d
+    ○ │  57f91468ff2b
+    │ │  P: 1 92406f686752
+    │ ○  03c44e3a259d
+    ├─╯  P: 1 92406f686752
+    ○  92406f686752
     │  P: 1 000000000000
     ○  000000000000
        P: 0
@@ -3118,11 +3110,11 @@ fn test_op_log_anonymize() {
         .success();
 
     let output = work_dir.run_jj(["op", "log", "-Tbuiltin_op_log_redacted"]);
-    insta::assert_snapshot!(output, @r"
-    @  12f7cbba4278 user-5910 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  57f91468ff2b user-5910 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  (redacted)
-    ○  8f47435a3990 user-5910 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 user-5910 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -705,9 +705,9 @@ fn test_rebase_revision_onto_descendant() {
 
     // Now, let's rebase onto the descendant merge
     let output = work_dir.run_jj(["op", "restore", &setup_opid]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: cb005d7a588c (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
+    Restored to operation: 5ef9d0c5d0b2 (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
     Working copy  (@) now at: vruxwmqv 08c0951b merge | merge
     Parent commit (@-)      : royxmykx 6a7081ef b | b
     Parent commit (@-)      : zsuskuln 68fbc443 a | a

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -403,38 +403,38 @@ fn test_split_with_descendants() {
     // - The rewritten commit once the description is added during `jj commit`.
     // - The rewritten commit after the split.
     let evolog_1 = work_dir.run_jj(["evolog", "-r", "qpvun"]);
-    insta::assert_snapshot!(evolog_1, @r"
+    insta::assert_snapshot!(evolog_1, @"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:12 74306e35
     │  Add file1
-    │  -- operation 994b490f285d split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation ff3010f8f8fb split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
-    │  -- operation adf4f33386c9 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 940ed601b9b8 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation 78ead2155fcc snapshot working copy
+    │  -- operation c8ee651c7ac1 snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 
     // The evolog for the second commit is the same, except that the change id
     // changes after the split.
     let evolog_2 = work_dir.run_jj(["evolog", "-r", "royxm"]);
-    insta::assert_snapshot!(evolog_2, @r"
+    insta::assert_snapshot!(evolog_2, @"
     ○  royxmykx test.user@example.com 2001-02-03 08:05:12 0a37745e
     │  Add file2
-    │  -- operation 994b490f285d split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation ff3010f8f8fb split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
-    │  -- operation adf4f33386c9 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 940ed601b9b8 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation 78ead2155fcc snapshot working copy
+    │  -- operation c8ee651c7ac1 snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 }
@@ -559,32 +559,32 @@ fn test_split_parallel_no_descendants() {
     // - The rewritten commit from the snapshot after the files were added.
     // - The rewritten commit after the split.
     let evolog_1 = work_dir.run_jj(["evolog", "-r", "qpvun"]);
-    insta::assert_snapshot!(evolog_1, @r"
+    insta::assert_snapshot!(evolog_1, @"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 7bcd474c
     │  TESTED=TODO
-    │  -- operation 2b21c33e1596 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation bb02c4b811de split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation 1663cd1cc445 snapshot working copy
+    │  -- operation d423e79ea521 snapshot working copy
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 
     // The evolog for the second commit is the same, except that the change id
     // changes after the split.
     let evolog_2 = work_dir.run_jj(["evolog", "-r", "kkmpp"]);
-    insta::assert_snapshot!(evolog_2, @r"
+    insta::assert_snapshot!(evolog_2, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 431886f6
     │  (no description set)
-    │  -- operation 2b21c33e1596 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation bb02c4b811de split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation 1663cd1cc445 snapshot working copy
+    │  -- operation d423e79ea521 snapshot working copy
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 8f47435a3990 add workspace 'default'
+       -- operation 92406f686752 add workspace 'default'
     [EOF]
     ");
 }

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -2058,34 +2058,34 @@ fn test_squash_to_new_commit() {
     ");
 
     let output = work_dir.run_jj(["evolog", "-r", "pkstwlsyuyku"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○    pkstwlsy test.user@example.com 2001-02-03 08:05:35 41510a56
     ├─╮  file 3&4
-    │ │  -- operation ad1aa66374f6 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 2f3fd7e62371 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln/0 test.user@example.com 2001-02-03 08:05:35 a5bc761f (hidden)
     │ │  file4
-    │ │  -- operation ad1aa66374f6 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 2f3fd7e62371 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 38778966 (hidden)
     │ │  file4
-    │ │  -- operation 83489d186f66 commit 89a30a7539466ed176c1ef122a020fd9cb15848e
+    │ │  -- operation 916c14e2df6b commit 89a30a7539466ed176c1ef122a020fd9cb15848e
     │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:11 89a30a75 (hidden)
     │ │  (no description set)
-    │ │  -- operation e23fd04aab50 snapshot working copy
+    │ │  -- operation a8293553db45 snapshot working copy
     │ ○  zsuskuln/6 test.user@example.com 2001-02-03 08:05:10 bbf04d26 (hidden)
     │    (empty) (no description set)
-    │    -- operation 19d57874b952 commit c23c424826221bc4fdee9487926595324e50ee95
+    │    -- operation 04ed9a55e7da commit c23c424826221bc4fdee9487926595324e50ee95
     ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:35 ce3b0a58 (hidden)
     │  file3
-    │  -- operation ad1aa66374f6 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │  -- operation 2f3fd7e62371 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     ○  kkmpptxz/3 test.user@example.com 2001-02-03 08:05:10 0d254956 (hidden)
     │  file3
-    │  -- operation 19d57874b952 commit c23c424826221bc4fdee9487926595324e50ee95
+    │  -- operation 04ed9a55e7da commit c23c424826221bc4fdee9487926595324e50ee95
     ○  kkmpptxz/4 test.user@example.com 2001-02-03 08:05:10 c23c4248 (hidden)
     │  (no description set)
-    │  -- operation d19ad3734aa6 snapshot working copy
+    │  -- operation a48d10172083 snapshot working copy
     ○  kkmpptxz/5 test.user@example.com 2001-02-03 08:05:09 c1272e87 (hidden)
        (empty) (no description set)
-       -- operation fdee458ae5f2 commit cb58ff1c6f1af92f827661e7275941ceb4d910c5
+       -- operation c0e8b633e317 commit cb58ff1c6f1af92f827661e7275941ceb4d910c5
     [EOF]
     ");
 
@@ -2156,10 +2156,10 @@ fn test_squash_to_new_commit() {
     ");
 
     let output = work_dir.run_jj(["evolog", "-r", "nsrwusvynpoy"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○  nsrwusvy test.user@example.com 2001-02-03 08:05:42 c2183685
        (empty) (no description set)
-       -- operation a656ab530912 squash 0 commits
+       -- operation 8bec1341363d squash 0 commits
     [EOF]
     ");
 
@@ -2200,10 +2200,10 @@ fn test_squash_to_new_commit() {
     ");
 
     let output = work_dir.run_jj(["evolog", "-r", "wtlqussytxur"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○  wtlqussy test.user@example.com 2001-02-03 08:05:46 7eff41c8
        (empty) (no description set)
-       -- operation 1661e2cea988 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+       -- operation 3b9cf4bafc88 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     [EOF]
     ");
 
@@ -2247,13 +2247,13 @@ fn test_squash_to_new_commit() {
     ");
 
     let output = work_dir.run_jj(["evolog", "-r", "pyoswmwkkqyt"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ○  pyoswmwk test.user@example.com 2001-02-03 08:05:50 991d0644
     │  (empty) (no description set)
-    │  -- operation 60d056329b43 squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
+    │  -- operation b8b693531e12 squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
     ○  szrrkvty/0 test.user@example.com 2001-02-03 08:05:50 f5e47d01 (hidden)
        (empty) (no description set)
-       -- operation 31e408225067 new empty commit
+       -- operation b61c5b4b8b03 new empty commit
     [EOF]
     ");
 

--- a/cli/tests/test_undo_redo_commands.rs
+++ b/cli/tests/test_undo_redo_commands.rs
@@ -71,11 +71,11 @@ fn test_undo_push_operation() {
     work_dir.run_jj(["commit", "-mfoo"]).success();
     work_dir.run_jj(["git", "push", "-c@-"]).success();
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Undoing a push operation often leads to conflicted bookmarks.
     Hint: To avoid this, run `jj redo` now.
-    Restored to operation: f9fd582ef03c (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
+    Restored to operation: 9e2ad53b06f1 (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
     [EOF]
     ");
 }
@@ -148,21 +148,21 @@ fn test_undo_with_rev_arg_falls_back_to_revert() {
     work_dir.run_jj(["new", "-m", "will be reverted"]).success();
     work_dir.run_jj(["new", "-m", "will remain"]).success();
     let output = work_dir.run_jj(["undo", "@-"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: `jj undo <operation>` is deprecated; use `jj op revert <operation>` instead
-    Reverted operation: 8bb65efbd8a6 (2001-02-03 08:05:08) new empty commit
+    Reverted operation: bd38e657b210 (2001-02-03 08:05:08) new empty commit
     Rebased 1 descendant commits
     Working copy  (@) now at: kkmpptxz 48f21213 (empty) will remain
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
     ");
 
-    let output = work_dir.run_jj(["op", "show", "--no-op-diff"]);
-    insta::assert_snapshot!(output, @r"
-    2271d7b5fdc8 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
-    revert operation 8bb65efbd8a6030d0e4d4a1d32c231994d4a8289af1292c53070f1ece4d96b4551beb1cde98a57102b35dedb4c9a97ee34d08bc04de67d58ce0ee36c34fad578
-    args: jj undo @-
+    let output = work_dir.run_jj(["op", "log", "-n1"]);
+    insta::assert_snapshot!(output, @"
+    @  f46a6c31f65b test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  revert operation bd38e657b210a352a798e73366bfee01b120e6ecd023431be8ebc427c054b20a6fe56d6c33ee60152a35ef9fa45279a3301bb5fd16e9e4dfba95fa5b6ab27047
+    │  args: jj undo @-
     [EOF]
     ");
 }

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -94,12 +94,12 @@ fn test_gc_operation_log() {
 
     // Now this doesn't work.
     let output = work_dir.run_jj(["debug", "object", "operation", &op_to_remove]);
-    insta::assert_snapshot!(output.strip_stderr_last_line(), @r"
+    insta::assert_snapshot!(output.strip_stderr_last_line(), @"
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Object b50d0a8f111a9d30d45d429d62c8e54016cc7c891706921a6493756c8074e883671cf3dac0ac9f94ef0fa8c79738a3dfe38c3e1f6c5e1a4a4d0857d266ef2040 of type operation not found
-    2: Cannot access $TEST_ENV/repo/.jj/repo/op_store/operations/b50d0a8f111a9d30d45d429d62c8e54016cc7c891706921a6493756c8074e883671cf3dac0ac9f94ef0fa8c79738a3dfe38c3e1f6c5e1a4a4d0857d266ef2040
+    1: Object 29b464d74c465a42e467ca4c5a5fd29159e6f455d172b730835c4778304665227757ff54145cb2dc3985de6ea7d32607d9d46e0d1992e888a0f85120f6d3638f of type operation not found
+    2: Cannot access $TEST_ENV/repo/.jj/repo/op_store/operations/29b464d74c465a42e467ca4c5a5fd29159e6f455d172b730835c4778304665227757ff54145cb2dc3985de6ea7d32607d9d46e0d1992e888a0f85120f6d3638f
     [EOF]
     [exit status: 255]
     ");

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -361,7 +361,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // Working copy should contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("5d919506f1cbd90a43ce93d739d84c0d7de34bc6eeb934befad2c3a16e2fe635c548ced178e42dde1041e140d7296a7000bc38530f1cfd7ed93a23cfc1e81699")
+    Current operation: OperationId("47721e0986f7ae8b8b9579efe41df59f3c57d7a71605f1d3466bbefc2bdacb7db18b2e0f0c64c9f1102e6dc7d1e579135d2fb976909f3d8f878fdad88aa5d4e4")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           313 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -424,7 +424,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // Working copy should still contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("519e354ba030d15583d3e62196b84337d5c446b632b5f92e98c6af246978ca8b166185a2526c48f51b4c2ca423503d3a8636fccefe7eec5ac0a8ab44061ae4a3")
+    Current operation: OperationId("6d09803ca0b8fdd4387ece5e7d60b7a95ea56bf94ed090bf578b91f4ae8a334d8da524d6b098868635e6d2cb650f6da59296cabb5d0aa32234c83be01de09e9d")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           274 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -459,7 +459,7 @@ fn test_conflict_marker_length_stored_in_working_copy() {
     // working copy
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("20e0a52b5cb37d14c675e24cf1325cbe2d145b8369ef17b78b7ae5b0a77177c03585d840469732c98d6b1d528309db873f0a52b3b42e67b7440d9a8c644f5667")
+    Current operation: OperationId("a4ef9ffa649cf0243c145edfb7cbfa9221d904c9ea859ce353e8b44db8eda7fc2efa475a170453e1ff3bb8cc44dbf4671fcbedb1d5206cf9291ba7d6a7c81ab1")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }           130 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -622,9 +622,9 @@ fn test_workspace_add_override_path_in_store() {
 
     // Undoing workspace addition
     let output = main_dir.run_jj(["operation", "restore", "@--"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: aa2f9df55a11 (2001-02-03 08:05:08) commit 006bd1130b84e90ab082adeabd7409270d5a86da
+    Restored to operation: 1ecb8056fe00 (2001-02-03 08:05:08) commit 006bd1130b84e90ab082adeabd7409270d5a86da
     [EOF]
     ");
 
@@ -711,9 +711,9 @@ fn test_workspaces_conflicting_edits() {
     [EOF]
     ");
     let output = secondary_dir.run_jj(["st"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation bd4f780d0422).
+    Error: The working copy is stale (not updated since operation 5b7827864695).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -721,9 +721,9 @@ fn test_workspaces_conflicting_edits() {
     ");
     // Same error on second run, and from another command
     let output = secondary_dir.run_jj(["log"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation bd4f780d0422).
+    Error: The working copy is stale (not updated since operation 5b7827864695).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -812,9 +812,9 @@ fn test_workspaces_updated_by_other() {
     [EOF]
     ");
     let output = secondary_dir.run_jj(["st"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation bd4f780d0422).
+    Error: The working copy is stale (not updated since operation 5b7827864695).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -963,15 +963,15 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         r#"id.short(10) ++ " " ++ description"#,
     ]);
     insta::allow_duplicates! {
-        insta::assert_snapshot!(output, @r"
-        @  b0789def13 abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
-        ○  778c9aae54 create initial working-copy commit in workspace secondary
-        ○  219d4aca5c add workspace 'secondary'
-        ○  31ad55e98c new empty commit
-        ○  4ba7680cbe snapshot working copy
-        ○  9739176f19 new empty commit
-        ○  4b5baa44b7 snapshot working copy
-        ○  8f47435a39 add workspace 'default'
+        insta::assert_snapshot!(output, @"
+        @  e4a0d61c7f abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
+        ○  f6233b3a9e create initial working-copy commit in workspace secondary
+        ○  64732beabc add workspace 'secondary'
+        ○  5b43a9b7e0 new empty commit
+        ○  c730b8436b snapshot working copy
+        ○  25ef9ce683 new empty commit
+        ○  1ea153c314 snapshot working copy
+        ○  92406f6867 add workspace 'default'
         ○  0000000000
         [EOF]
         ");
@@ -997,7 +997,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         secondary_dir.run_jj(["help"]).success();
 
         let output = secondary_dir.run_jj(["st"]);
-        insta::assert_snapshot!(output, @r"
+        insta::assert_snapshot!(output, @"
         Working copy changes:
         C {modified => added}
         D deleted
@@ -1006,7 +1006,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         Parent commit (@-): rzvqmyuk 891f0006 (empty) (no description set)
         [EOF]
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 778c9aae54957e842bede2223fda227be33e08061732276a4cfb7b431a3e146e5c62187d640aa883095d3b2c6cf43d31ad5fde72076bb9a88b8594fb8b5e6606 of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object f6233b3a9eb3d04992ad5fe11a32a564edfab56c5132f2245256ac88011c54b48977d89e7ca13133a70009bf276db3ed87a2f5fd15acd4c8263d9fff1d12b378 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1022,9 +1022,9 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         ");
 
         let output = secondary_dir.run_jj(["workspace", "update-stale"]);
-        insta::assert_snapshot!(output, @r"
+        insta::assert_snapshot!(output, @"
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 778c9aae54957e842bede2223fda227be33e08061732276a4cfb7b431a3e146e5c62187d640aa883095d3b2c6cf43d31ad5fde72076bb9a88b8594fb8b5e6606 of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object f6233b3a9eb3d04992ad5fe11a32a564edfab56c5132f2245256ac88011c54b48977d89e7ca13133a70009bf276db3ed87a2f5fd15acd4c8263d9fff1d12b378 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1072,23 +1072,23 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
 
     let output = secondary_dir.run_jj(["evolog"]);
     if automatic {
-        insta::assert_snapshot!(output, @r"
+        insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation 0a26da4b0149 snapshot working copy
+        │  -- operation 946403ff7b56 snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 83f707034db1 recovery commit
+           -- operation 5f22bad8d0f0 recovery commit
         [EOF]
         ");
     } else {
-        insta::assert_snapshot!(output, @r"
+        insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation 0f876590219e snapshot working copy
+        │  -- operation 940ea2ca820a snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 83f707034db1 recovery commit
+           -- operation 5f22bad8d0f0 recovery commit
         [EOF]
         ");
     }
@@ -1144,10 +1144,10 @@ fn test_workspaces_unpublished_operation_same_tree() {
         .success();
     // The working copy should be stale
     let output = main_dir.run_jj(["status"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation 502db81004ba, which seems to be a sibling of the working copy's operation 48631817a82e
-    Hint: Run `jj op integrate 48631817a82e` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation e4d9ae08f802, which seems to be a sibling of the working copy's operation 97106e44bd54
+    Hint: Run `jj op integrate 97106e44bd54` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -1273,9 +1273,9 @@ fn test_colocated_workspace_update_stale() {
 
     // The main workspace's working copy is now stale.
     let output = main_dir.run_jj(["st"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation b0dfa4a0da08).
+    Error: The working copy is stale (not updated since operation cde2c3971562).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1472,7 +1472,7 @@ fn test_workspaces_forget_multi_transaction() {
     // the op log should have the multiple valid workspaces forgotten in a single tx
     let output = main_dir.run_jj(["op", "log", "--limit", "1"]);
     insta::assert_snapshot!(output, @"
-    @  86a599409515 test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  a23728a0881b test-username@host.example.com 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third fourth
     [EOF]
@@ -1656,25 +1656,25 @@ fn test_debug_snapshot() {
     work_dir.write_file("file", "contents");
     work_dir.run_jj(["debug", "snapshot"]).success();
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @  594dfebf2565 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  3a7f55db3d2f test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
     ");
     work_dir.run_jj(["describe", "-m", "initial"]).success();
     let output = work_dir.run_jj(["op", "log"]);
-    insta::assert_snapshot!(output, @r"
-    @  81e4a0f2e793 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    insta::assert_snapshot!(output, @"
+    @  27c4bd6fbf05 test-username@host.example.com 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit 006bd1130b84e90ab082adeabd7409270d5a86da
     │  args: jj describe -m initial
-    ○  594dfebf2565 test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  3a7f55db3d2f test-username@host.example.com 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  8f47435a3990 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  92406f686752 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/lib/gen-protos/src/main.rs
+++ b/lib/gen-protos/src/main.rs
@@ -34,6 +34,8 @@ fn main() -> Result<()> {
         .include_file("mod.rs")
         // For old protoc versions. 3.12.4 needs this, but 3.21.12 doesn't.
         .protoc_arg("--experimental_allow_proto3_optional")
+        // Use BTreeMap for deterministic serialization order
+        .btree_map([".simple_op_store.View.workspace_git_heads"])
         .compile_protos(
             &input
                 .into_iter()

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -23,6 +23,7 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::iter;
 use std::num::NonZeroU32;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -973,28 +974,35 @@ fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
         .collect()
 }
 
-/// Imports HEAD from the underlying Git repo.
+/// Imports HEAD from the underlying Git repo for a specific workspace.
 ///
 /// Unlike `import_refs()`, the old HEAD branch is not abandoned because HEAD
 /// move doesn't always mean the old HEAD branch has been rewritten.
 ///
 /// Unlike `reset_head()`, this function doesn't move the working-copy commit to
 /// the child of the new HEAD revision.
-pub fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
+///
+/// Returns `true` if the HEAD changed for this workspace, `false` otherwise.
+pub fn import_head(
+    mut_repo: &mut MutableRepo,
+    workspace_name: &crate::ref_name::WorkspaceName,
+) -> Result<bool, GitImportError> {
     let store = mut_repo.store().clone();
     let git_backend = get_git_backend(&store)?;
     let git_repo = git_backend.git_repo();
 
-    let old_git_head = mut_repo.view().git_head();
     let new_git_head_id = if let Ok(oid) = git_repo.head_id() {
         Some(CommitId::from_bytes(oid.as_bytes()))
     } else {
         None
     };
-    if old_git_head.as_resolved() == Some(&new_git_head_id) {
-        // Even if the main HEAD hasn't changed, check worktrees
+
+    // Compare against this workspace's stored git_head, not the global one
+    let old_workspace_git_head = mut_repo.get_workspace_git_head(workspace_name);
+    if old_workspace_git_head.as_resolved() == Some(&new_git_head_id) {
+        // HEAD hasn't changed for this workspace; still check other worktrees
         import_worktree_heads(mut_repo, git_backend, &git_repo)?;
-        return Ok(());
+        return Ok(false);
     }
 
     // Import new head
@@ -1016,12 +1024,17 @@ pub fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
             .map_err(GitImportError::Backend)?;
     }
 
+    // Update this workspace's git_head
+    let new_target = RefTarget::resolved(new_git_head_id.clone());
+    mut_repo.set_workspace_git_head(workspace_name, new_target.clone());
+
+    // Also update global git_head for backwards compatibility
     mut_repo.set_git_head_target(RefTarget::resolved(new_git_head_id));
 
     // Also import commits from other worktrees' HEADs
     import_worktree_heads(mut_repo, git_backend, &git_repo)?;
 
-    Ok(())
+    Ok(true)
 }
 
 /// Imports commits from all Git worktrees' HEADs.
@@ -1645,20 +1658,64 @@ impl GitResetHeadError {
 
 /// Sets Git HEAD to the parent of the given working-copy commit and resets
 /// the Git index.
-pub fn reset_head(mut_repo: &mut MutableRepo, wc_commit: &Commit) -> Result<(), GitResetHeadError> {
-    let git_repo = get_git_repo(mut_repo.store())?;
+///
+/// If `workspace_path` is provided and is a colocated workspace (has a `.git`
+/// pointing to the same repo), the git repo will be opened at that path to
+/// support secondary colocated workspaces with their own git worktrees.
+pub fn reset_head(
+    mut_repo: &mut MutableRepo,
+    wc_commit: &Commit,
+    workspace_name: &crate::ref_name::WorkspaceName,
+) -> Result<(), GitResetHeadError> {
+    reset_head_at_workspace(mut_repo, wc_commit, workspace_name, None)
+}
+
+/// Sets Git HEAD to the parent of the given working-copy commit and resets
+/// the Git index at the specified workspace path.
+///
+/// If `workspace_path` is provided and is a colocated workspace (has a `.git`
+/// pointing to the same repo), the git repo will be opened at that path to
+/// support secondary colocated workspaces with their own git worktrees.
+pub fn reset_head_at_workspace(
+    mut_repo: &mut MutableRepo,
+    wc_commit: &Commit,
+    workspace_name: &crate::ref_name::WorkspaceName,
+    workspace_path: Option<&Path>,
+) -> Result<(), GitResetHeadError> {
+    let store = mut_repo.store();
+    let git_backend = get_git_backend(store)?;
+
+    // If a workspace path is provided and has a .git, try to open it as a worktree
+    let git_repo = if let Some(ws_path) = workspace_path {
+        let git_dir_path = ws_path.join(".git");
+        if git_dir_path.exists() {
+            // Try to open the git repo at the workspace path as a worktree.
+            // Configure committer for reflog updates (required by gix).
+            let open_opts = gix::open::Options::default()
+                .open_path_as_is(true)
+                .config_overrides(["committer.name=jj", "committer.email=jj@example.com"]);
+            match gix::ThreadSafeRepository::open_opts(&git_dir_path, open_opts) {
+                Ok(repo) => repo.to_thread_local(),
+                Err(_) => git_backend.git_repo(),
+            }
+        } else {
+            git_backend.git_repo()
+        }
+    } else {
+        git_backend.git_repo()
+    };
 
     let first_parent_id = &wc_commit.parent_ids()[0];
-    let new_head_target = if first_parent_id != mut_repo.store().root_commit_id() {
+    let new_head_target = if first_parent_id != store.root_commit_id() {
         RefTarget::normal(first_parent_id.clone())
     } else {
         RefTarget::absent()
     };
 
-    // If the first parent of the working copy has changed, reset the Git HEAD.
-    let old_head_target = mut_repo.git_head();
-    if old_head_target != new_head_target {
-        let expected_ref = if let Some(id) = old_head_target.as_normal() {
+    // Compare against this workspace's stored git_head
+    let old_workspace_head = mut_repo.get_workspace_git_head(workspace_name);
+    if old_workspace_head != new_head_target {
+        let expected_ref = if let Some(id) = old_workspace_head.as_normal() {
             // We have to check the actual HEAD state because we don't record a
             // symbolic ref as such.
             let actual_head = git_repo.head().map_err(GitResetHeadError::from_git)?;
@@ -1671,14 +1728,17 @@ pub fn reset_head(mut_repo: &mut MutableRepo, wc_commit: &Commit) -> Result<(), 
                 gix::refs::transaction::PreviousValue::MustExist
             }
         } else {
-            // Just overwrite if unborn (or conflict), which is also unusual.
-            gix::refs::transaction::PreviousValue::MustExist
+            // For new workspaces that haven't been tracked yet, allow any current state
+            gix::refs::transaction::PreviousValue::Any
         };
         let new_oid = new_head_target
             .as_normal()
             .map(|id| gix::ObjectId::from_bytes_or_panic(id.as_bytes()));
         update_git_head(&git_repo, expected_ref, new_oid)
             .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
+        // Update this workspace's git_head
+        mut_repo.set_workspace_git_head(workspace_name, new_head_target.clone());
+        // Also update global git_head for backwards compatibility
         mut_repo.set_git_head_target(new_head_target);
     }
 

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -254,23 +254,18 @@ pub struct View {
     pub local_tags: BTreeMap<RefNameBuf, RefTarget>,
     pub remote_views: BTreeMap<RemoteNameBuf, RemoteView>,
     pub git_refs: BTreeMap<GitRefNameBuf, RefTarget>,
-    /// The commit the Git HEAD points to.
+    /// The commit the Git HEAD points to (for the main repository).
     ///
-    /// ## Known Limitation: Single git_head for Multiple Workspaces
-    ///
-    /// This field stores a single `git_head`, but when multiple colocated
-    /// workspaces exist (each with its own Git worktree), each worktree has
-    /// an independent HEAD. The value here reflects whichever workspace last
-    /// performed a Git export.
-    ///
-    /// **Impact:** The `git_head()` template may show incorrect values in
-    /// non-default workspaces.
-    ///
-    /// **Workaround:** Export now writes to each worktree's HEAD file
-    /// independently, but this field doesn't track per-workspace state.
-    // TODO: Support multiple Git worktrees by storing per-workspace git_head
+    /// For backwards compatibility and for workspaces that haven't migrated to
+    /// per-workspace tracking, this still reflects the main repo's HEAD.
     // TODO: Do we want to store the current bookmark name too?
     pub git_head: RefTarget,
+    /// Per-workspace Git HEAD for colocated worktrees.
+    ///
+    /// Each colocated workspace has its own Git worktree with an independent
+    /// HEAD. This map stores the last-known HEAD for each workspace to
+    /// avoid spurious commits when switching between workspaces.
+    pub workspace_git_heads: BTreeMap<WorkspaceNameBuf, RefTarget>,
     // The commit that *should be* checked out in the workspace. Note that the working copy
     // (.jj/working_copy/) has the source of truth about which commit *is* checked out (to be
     // precise: the commit to which we most recently completed an update to).
@@ -287,6 +282,7 @@ impl View {
             remote_views: BTreeMap::new(),
             git_refs: BTreeMap::new(),
             git_head: RefTarget::absent(),
+            workspace_git_heads: BTreeMap::new(),
             wc_commit_ids: BTreeMap::new(),
         }
     }

--- a/lib/src/protos/simple_op_store.proto
+++ b/lib/src/protos/simple_op_store.proto
@@ -104,6 +104,8 @@ message View {
   // TODO: Delete support for the old format.
   bytes git_head_legacy = 7 [deprecated = true];
   RefTarget git_head = 9;
+  // Per-workspace Git HEAD for colocated worktrees. Maps workspace name to HEAD target.
+  map<string, RefTarget> workspace_git_heads = 13;
   // Whether "@git" tags have been migrated to remote_views.
   bool has_git_refs_migrated_to_remote_tags = 12;
   reserved 10;

--- a/lib/src/protos/simple_op_store.rs
+++ b/lib/src/protos/simple_op_store.rs
@@ -136,6 +136,12 @@ pub struct View {
     pub git_head_legacy: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "9")]
     pub git_head: ::core::option::Option<RefTarget>,
+    /// Per-workspace Git HEAD for colocated worktrees. Maps workspace name to HEAD target.
+    #[prost(btree_map = "string, message", tag = "13")]
+    pub workspace_git_heads: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        RefTarget,
+    >,
     /// Whether "@git" tags have been migrated to remote_views.
     #[prost(bool, tag = "12")]
     pub has_git_refs_migrated_to_remote_tags: bool,

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1833,6 +1833,17 @@ impl MutableRepo {
         self.view_mut().set_git_head_target(target);
     }
 
+    /// Returns the per-workspace Git HEAD target for the given workspace.
+    pub fn get_workspace_git_head(&self, name: &WorkspaceName) -> RefTarget {
+        self.view
+            .with_ref(|v| v.get_workspace_git_head(name).clone())
+    }
+
+    /// Sets the per-workspace Git HEAD target.
+    pub fn set_workspace_git_head(&mut self, name: &WorkspaceName, target: RefTarget) {
+        self.view_mut().set_workspace_git_head(name, target);
+    }
+
     pub fn set_view(&mut self, data: op_store::View) {
         self.view_mut().set_view(data);
         self.view.mark_dirty();
@@ -1925,6 +1936,18 @@ impl MutableRepo {
             other.git_head(),
         )?;
         self.set_git_head_target(new_git_head_target);
+
+        // Merge per-workspace Git HEADs
+        let changed_workspace_git_heads = diff_named_ref_targets(
+            base.workspace_git_heads().iter().map(|(k, v)| (&**k, v)),
+            other.workspace_git_heads().iter().map(|(k, v)| (&**k, v)),
+        );
+        for (name, (base_target, other_target)) in changed_workspace_git_heads {
+            let self_target = self.get_workspace_git_head(name);
+            let new_target =
+                merge_ref_targets(self.index(), &self_target, base_target, other_target)?;
+            self.set_workspace_git_head(name, new_target);
+        }
 
         Ok(())
     }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -236,7 +236,7 @@ fn test_import_refs() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     let stats = git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     let repo = tx.commit("test").unwrap();
@@ -517,7 +517,7 @@ fn test_import_refs_reimport_git_head_does_not_count() {
     testutils::git::set_head_to_id(&git_repo, commit);
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
 
@@ -528,7 +528,7 @@ fn test_import_refs_reimport_git_head_does_not_count() {
         .unwrap()
         .delete()
         .unwrap();
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(!tx.repo().view().heads().contains(&jj_id(commit)));
@@ -550,7 +550,7 @@ fn test_import_refs_reimport_git_head_without_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD.
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -563,7 +563,7 @@ fn test_import_refs_reimport_git_head_without_ref() {
     // would be moved by `git checkout` command. This isn't always true because the
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -593,7 +593,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -611,13 +611,13 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD and main, which abandons the old main branch.
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(!tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
     // Reimport HEAD and main, which abandons the old main bookmark.
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(!tx.repo().view().heads().contains(commit1.id()));
@@ -1300,7 +1300,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -1310,7 +1310,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -1734,7 +1734,7 @@ fn test_import_refs_missing_git_commit() {
         .unwrap();
     testutils::git::set_head_to_id(&git_repo, commit2);
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut());
+    let result = git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT);
     assert_matches!(
         result,
         Err(GitImportError::MissingHeadTarget {
@@ -1771,7 +1771,7 @@ fn test_import_refs_missing_git_commit() {
     testutils::git::set_head_to_id(&git_repo, commit1);
     fs::rename(&object_file, &backup_object_file).unwrap();
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut());
+    let result = git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT);
     assert!(result.is_ok());
 }
 
@@ -1791,7 +1791,7 @@ fn test_import_refs_detached_head() {
     testutils::git::set_head_to_id(&test_data.git_repo, commit1);
 
     let mut tx = test_data.repo.start_transaction();
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(tx.repo_mut(), &import_options).unwrap();
     tx.repo_mut().rebase_descendants().unwrap();
     let repo = tx.commit("test").unwrap();
@@ -1813,7 +1813,7 @@ fn test_export_refs_no_detach() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).unwrap();
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(mut_repo, &import_options).unwrap();
     mut_repo.rebase_descendants().unwrap();
 
@@ -1858,7 +1858,7 @@ fn test_export_refs_bookmark_changed() {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).unwrap();
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(mut_repo, &import_options).unwrap();
     mut_repo.rebase_descendants().unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
@@ -1917,7 +1917,7 @@ fn test_export_refs_tag_changed() {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).unwrap();
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     let stats = git::import_refs(mut_repo, &import_options).unwrap();
     assert_eq!(stats.changed_remote_tags.len(), 4);
     mut_repo.rebase_descendants().unwrap();
@@ -2007,7 +2007,7 @@ fn test_export_refs_current_bookmark_changed() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).unwrap();
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(mut_repo, &import_options).unwrap();
     mut_repo.rebase_descendants().unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
@@ -2050,7 +2050,7 @@ fn test_export_refs_current_tag_changed() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/tags/v1.0");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).unwrap();
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(mut_repo, &import_options).unwrap();
     mut_repo.rebase_descendants().unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
@@ -2092,7 +2092,7 @@ fn test_export_refs_unborn_git_bookmark(move_placeholder_ref: bool) {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).unwrap();
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     git::import_refs(mut_repo, &import_options).unwrap();
     mut_repo.rebase_descendants().unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
@@ -2844,7 +2844,12 @@ fn test_reset_head_to_root() {
         .unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     assert!(git_repo.head().unwrap().is_detached(), "HEAD is detached");
     assert_eq!(
         tx.repo().git_head(),
@@ -2852,7 +2857,12 @@ fn test_reset_head_to_root() {
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit1,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     assert!(git_repo.head().unwrap().is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head().is_absent());
 
@@ -2865,7 +2875,12 @@ fn test_reset_head_to_root() {
             "",
         )
         .unwrap();
-    git::reset_head(tx.repo_mut(), &commit2).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     assert!(git_repo.head_id().is_ok());
     assert_eq!(
         tx.repo().git_head(),
@@ -2874,7 +2889,12 @@ fn test_reset_head_to_root() {
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit1,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     assert!(git_repo.head().unwrap().is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head().is_absent());
     // The placeholder ref should be deleted
@@ -2908,7 +2928,12 @@ fn test_reset_head_detached_out_of_sync() {
     let commit5 = write_random_commit(tx.repo_mut());
 
     // unborn -> commit1 (= commit2's parent)
-    git::reset_head(tx.repo_mut(), &commit2).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
@@ -2922,7 +2947,12 @@ fn test_reset_head_detached_out_of_sync() {
 
     // {expected: commit1, actual: commit5} -> commit1 (= commit3's parent):
     // works because the expected HEAD is unchanged.
-    git::reset_head(tx.repo_mut(), &commit3).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit3,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
@@ -2930,7 +2960,11 @@ fn test_reset_head_detached_out_of_sync() {
 
     // {expected: commit1, actual: commit5} -> commit3 (= commit4's parent)
     assert_matches!(
-        git::reset_head(tx.repo_mut(), &commit4),
+        git::reset_head(
+            tx.repo_mut(),
+            &commit4,
+            jj_lib::ref_name::WorkspaceName::DEFAULT
+        ),
         Err(GitResetHeadError::UpdateHeadRef(_))
     );
     assert_eq!(
@@ -2940,14 +2974,19 @@ fn test_reset_head_detached_out_of_sync() {
     );
 
     // Import the HEAD moved by external process
-    git::import_head(tx.repo_mut()).unwrap();
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit5.id().clone())
     );
 
     // commit5 -> commit3 (= commit4's parent)
-    git::reset_head(tx.repo_mut(), &commit4).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit4,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit3.id().clone())
@@ -2997,7 +3036,12 @@ fn test_reset_head_with_index() {
         .unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 
     // Add "staged changes" to the Git index
@@ -3009,7 +3053,12 @@ fn test_reset_head_with_index() {
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Unconflicted file.txt Mode(FILE)");
 
     // Reset head and the Git index
-    git::reset_head(tx.repo_mut(), &commit2).unwrap();
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 }
 
@@ -3053,7 +3102,12 @@ fn test_reset_head_with_index_no_conflict() {
         .unwrap();
 
     // Reset head to working copy commit
-    git::reset_head(mut_repo, &wc_commit).unwrap();
+    git::reset_head(
+        mut_repo,
+        &wc_commit,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3150,7 +3204,12 @@ fn test_reset_head_with_index_merge_conflict() {
         .unwrap();
 
     // Reset head to working copy commit with merge conflict
-    git::reset_head(mut_repo, &wc_commit).unwrap();
+    git::reset_head(
+        mut_repo,
+        &wc_commit,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3216,7 +3275,12 @@ fn test_reset_head_with_index_file_directory_conflict() {
         .unwrap();
 
     // Reset head to working copy commit with file-directory conflict
-    git::reset_head(mut_repo, &wc_commit).unwrap();
+    git::reset_head(
+        mut_repo,
+        &wc_commit,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .unwrap();
 
     // Only the file should be added to the index (the tree should be skipped).
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Theirs test Mode(FILE)");

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -669,15 +669,15 @@ fn test_resolve_op_id() {
         let repo = tx.commit(format!("transaction {i}")).unwrap();
         operations.push(repo.operation().clone());
     }
-    // "6" and "0" are ambiguous
+    // "7" is ambiguous (operations 0 and 3)
     insta::assert_debug_snapshot!(operations.iter().map(|op| op.id().hex()).collect_vec(), @r#"
     [
-        "ff7608ec55acf1ccb44bee52a0972f8b36864540ee6547d5e124a30bafd3bfbe00418446d5581cf71debac912a091dd2f93a2dd3bcb34bc53c61604aa9c129d6",
-        "b83ded05e46bef569737b8c1293c59af3fe89f72bc2cecd017b5eb96f5c69e50205069eedf144ca4fa9e55ac0c27842dce874b371a752223c5f85c4b6faadf96",
-        "6412c4e33f791b71f440817d3d16c0ee1b7640845db8f5e4146c58e8c3f4329df4662b0edeab5860c86b4679b150f38318a6e3d4ada5803176f9c5273d97f4dd",
-        "6838be3a934e1b8fc966dcf43796a3cc639a3d26edb1e9af94a285f4ce7edaecfe9e101dd7f0338af22e1632f36d634916015b72b026e1529a7b600566c29067",
-        "0ecccbdd90dd12a592dd0de010feda8bf23e4a5650f1946a82df854fc28791ad046b2d42b38060103db7fb99c00787689df98a7d2166d8180666b745cc32b172",
-        "065be6feb0ab573f0638e952ead8482899307d211f80af5dc90952a6171cc7122d5af9f13fde2ce3e37fc5e7776d5e3bc4236d82ce7d2ecbf1f63373c20772e4",
+        "7bbabe2cadb615f28db5e476747700987cc1c8f5c0a9b9a23f8f4ddc8174adb92ca15715501c76323a930c146abf71cba918a3fddcbaea3d777db643b60d42e1",
+        "9b7587e61decdc08cfd64fae77afbb8a3e1b868b143f12e27a531ab1c9fa21bbc4d610c57d64c23be75256d4514934284d148050e0acbd905671b5c06b231aae",
+        "d113a622d3630d3979ff8515525a0fd654f9818bd5b2a5a5d1d942c525486be68cd3be49be1d0e92dc2f6d3e1416aa24a97009a6cbe845e4bee6cfa7f790af30",
+        "7ab3b18ce28f2cb3e49f2c8e9d21737aa328dfba0bada2514c1f8918efeee94513d7e630b28584b526c5db74dbe7ae24cd04aac66f8dd6d73944562cff1114a0",
+        "57c2a20561e9d634260d399c9fd8ead8b2a262f237f528d4fd408c414f004995da743003421f2eb942c17c6fe2b40c139fd5a53240c5605975c15cbd247c92a4",
+        "c37dec7c430ad8bfc283fcd056a5fcec6d95babd0090ef79e2333aca7233caead2bd7bd1cc2c7836f4e90531295d7d782ca690965baf43f08cfaeb836cc3ee12",
     ]
     "#);
 
@@ -696,9 +696,9 @@ fn test_resolve_op_id() {
         resolve(&operations[1].id().hex()[..2]).unwrap(),
         operations[1]
     );
-    // Ambiguous id
+    // Ambiguous id (both operations 0 and 3 start with "7")
     assert_matches!(
-        resolve("6"),
+        resolve("7"),
         Err(OpsetEvaluationError::OpsetResolution(
             OpsetResolutionError::AmbiguousIdPrefix(_)
         ))
@@ -721,13 +721,10 @@ fn test_resolve_op_id() {
     let root_operation = loader.root_operation();
     assert_eq!(resolve(&root_operation.id().hex()).unwrap(), root_operation);
     assert_eq!(resolve("00").unwrap(), root_operation);
-    assert_eq!(resolve("0e").unwrap(), operations[4]);
-    assert_matches!(
-        resolve("0"),
-        Err(OpsetEvaluationError::OpsetResolution(
-            OpsetResolutionError::AmbiguousIdPrefix(_)
-        ))
-    );
+    // operations[4] starts with "57"
+    assert_eq!(resolve("57").unwrap(), operations[4]);
+    // "0" now uniquely matches root (no operations start with "0")
+    assert_eq!(resolve("0").unwrap(), root_operation);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Automatically removes the Git worktree when forgetting a colocated workspace, keeping jj and Git state in sync.

**Key changes:**
- Add `find_worktrees_for_workspaces()` helper to match jj workspaces to Git worktrees by reading the checkout protobuf
- Run `git worktree remove` after the transaction commits successfully
- Handle edge cases: missing worktrees, custom workspace names (via `--name` flag)

## Problem

When forgetting a colocated workspace with `jj workspace forget`, the Git worktree remained orphaned, requiring manual cleanup with `git worktree remove`.

## Solution

After successfully committing the workspace forget transaction:
1. Enumerate Git worktrees and match them to jj workspaces by reading the checkout protobuf
2. Run `git worktree remove --force` for matching worktrees
3. Warn (but don't fail) if removal fails

The cleanup happens **after** the transaction commits to ensure that if the transaction fails, the worktrees remain intact.

## PR Stack

This PR is part of a stack implementing colocated workspaces (#8052):
1. #8667 - Base colocation support
2. #8680 - `workspace add --colocate`
3. #8681 - Import commits from all worktrees' HEADs
4. **This PR** - Clean up Git worktree on `workspace forget`

## Test plan

- [x] Tests added
- [x] All existing workspace tests pass