### PR TITLE
templater: Add Timestamp::since()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   highlighted as "added" in editors when checking out a conflicted commit in a
   colocated workspace.
 
+* New template function `Timestamp::since(ts)` that returns the `TimestampRange`
+  between two timestamps. It can be used in conjunction with `.duration()` in
+  order to obtain a human-friendly duration between two `Timestamp`s.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -32,6 +32,7 @@ use itertools::Itertools as _;
 use jj_lib::backend::BackendResult;
 use jj_lib::backend::ChangeId;
 use jj_lib::backend::CommitId;
+use jj_lib::backend::Timestamp;
 use jj_lib::backend::TreeValue;
 use jj_lib::commit::Commit;
 use jj_lib::conflict_labels::ConflictLabels;
@@ -577,6 +578,14 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
         match self {
             Self::Core(property) => property.try_into_integer(),
             Self::Operation(property) => property.try_into_integer(),
+            _ => None,
+        }
+    }
+
+    fn try_into_timestamp(self) -> Option<BoxedTemplateProperty<'repo, Timestamp>> {
+        match self {
+            Self::Core(property) => property.try_into_timestamp(),
+            Self::Operation(property) => property.try_into_timestamp(),
             _ => None,
         }
     }

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -201,6 +201,13 @@ where
         }
     }
 
+    fn try_into_timestamp(self) -> Option<BoxedTemplateProperty<'a, jj_lib::backend::Timestamp>> {
+        match self {
+            Self::Core(property) => property.try_into_timestamp(),
+            Self::Self_(_) => None,
+        }
+    }
+
     fn try_into_stringify(self) -> Option<BoxedTemplateProperty<'a, String>> {
         match self {
             Self::Core(property) => property.try_into_stringify(),

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::io;
 
 use itertools::Itertools as _;
+use jj_lib::backend::Timestamp;
 use jj_lib::extensions_map::ExtensionsMap;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::op_store::OperationId;
@@ -209,6 +210,10 @@ impl<'a> OperationTemplatePropertyKind<'a> {
         None
     }
 
+    pub fn try_into_timestamp(self) -> Option<BoxedTemplateProperty<'a, Timestamp>> {
+        None
+    }
+
     pub fn try_into_stringify(self) -> Option<BoxedTemplateProperty<'a, String>> {
         let template = self.try_into_template()?;
         Some(PlainTextFormattedProperty::new(template).into_dyn())
@@ -311,6 +316,15 @@ impl CoreTemplatePropertyVar<'static> for OperationTemplateLanguagePropertyKind 
         match self {
             Self::Core(property) => property.try_into_integer(),
             Self::Operation(property) => property.try_into_integer(),
+        }
+    }
+
+    fn try_into_timestamp(
+        self,
+    ) -> Option<BoxedTemplateProperty<'static, jj_lib::backend::Timestamp>> {
+        match self {
+            Self::Core(property) => property.try_into_timestamp(),
+            Self::Operation(property) => property.try_into_timestamp(),
         }
     }
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -599,6 +599,9 @@ The following methods are defined.
 * `.before(date: StringLiteral) -> Boolean`: True if the timestamp is before, but
   not including, the given date. Supported date formats are the same as the
   revset [Date pattern type].
+* `.since(start: Timestamp) -> TimestampRange`: The TimestampRange between `start` and
+  `self`. It may be used in conjunction with `TimestampRange::duration` to obtain
+  a human-friendly duration between two `Timestamp`s.
 
 [Date pattern type]: revsets.md#date-patterns
 


### PR DESCRIPTION
- Timestamp::since() 
- ~~TimestampRange::duration_short()~~ (Deferred until #8038 )

# Motivation

When displaying timestamps in templates, it is useful to display them in
relation to each other. For example in a `jj log` line it may be desirable to
display the modified time of the commit in relation to the authoring
time as follows.

```
author.timestamp().since(committer.timestamp()).duration()
```

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
