### PR TITLE
tests: improve template parser coverage

### DIFF
--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -983,8 +983,8 @@ mod tests {
             parse_normalized("((x.f()) || (y == y)) || z"),
         );
         assert_eq!(
-            parse_normalized("x || y == y && z.h() == z"),
-            parse_normalized("x || ((y == y) && ((z.h()) == z))"),
+            parse_normalized("x || y == y && z.h() > z"),
+            parse_normalized("x || ((y == y) && ((z.h()) > z))"),
         );
         assert_eq!(
             parse_normalized("x == y || y != z && !z"),


### PR DESCRIPTION
Unlike `template_builder.rs`, the tests in `template_parser.rs` do not exercise the entirety of the file.  Still, I found a couple functions that *were* well-exercised by existing co-located tests that I was able to improve coverage for.

I will look for more opportunities to improve parser coverage when I review the various other template-related tests.

One notable observation (at least to me): nothing ever seems to `fold` an `AliasExpression`, anywhere in the test suite.  Perhaps this should be an unreachable panic?

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
