### PR TITLE
cli: use NonZero<u16> for terminal width

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -19,6 +19,7 @@ use std::io;
 use std::io::Write as _;
 use std::iter;
 use std::mem;
+use std::num::NonZero;
 use std::path::Path;
 use std::time::Duration;
 use std::time::Instant;
@@ -412,11 +413,8 @@ impl Progress {
         let control_chars = self.buffer.len();
         write!(self.buffer, "{: >3.0}% ", 100.0 * progress.overall()).unwrap();
 
-        let bar_width = output
-            .term_width()
-            .map(usize::from)
-            .unwrap_or(0)
-            .saturating_sub(self.buffer.len() - control_chars + 2);
+        let line_width: usize = output.term_width().map_or(0, NonZero::get).into();
+        let bar_width = line_width.saturating_sub(self.buffer.len() - control_chars + 2);
         self.buffer.push('[');
         draw_progress(progress.overall(), &mut self.buffer, bar_width);
         self.buffer.push(']');

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -1,3 +1,4 @@
+use std::num::NonZero;
 use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -50,7 +51,7 @@ pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + use<>> {
             );
         }
 
-        let line_width = state.output.term_width().map(usize::from).unwrap_or(80);
+        let line_width: usize = state.output.term_width().map_or(80, NonZero::get).into();
         let max_path_width = line_width.saturating_sub(13); // Account for "Snapshotting "
         let fs_path = path.to_fs_path_unchecked(Path::new(""));
         let (display_path, _) =

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -25,6 +25,7 @@ use std::io::StdoutLock;
 use std::io::Write;
 use std::iter;
 use std::mem;
+use std::num::NonZero;
 use std::process::Child;
 use std::process::ChildStdin;
 use std::process::Stdio;
@@ -688,14 +689,14 @@ impl Ui {
     }
 
     pub fn term_width(&self) -> usize {
-        term_width().unwrap_or(80).into()
+        get_term_width().map_or(80, NonZero::get).into()
     }
 }
 
 #[derive(Debug)]
 pub struct ProgressOutput<W> {
     output: W,
-    term_width: Option<u16>,
+    term_width: Option<NonZero<u16>>,
 }
 
 impl ProgressOutput<io::Stderr> {
@@ -711,13 +712,13 @@ impl<W> ProgressOutput<W> {
     pub fn for_test(output: W, term_width: u16) -> Self {
         Self {
             output,
-            term_width: Some(term_width),
+            term_width: NonZero::new(term_width),
         }
     }
 
-    pub fn term_width(&self) -> Option<u16> {
+    pub fn term_width(&self) -> Option<NonZero<u16>> {
         // Terminal can be resized while progress is displayed, so don't cache it.
-        self.term_width.or_else(term_width)
+        self.term_width.or_else(get_term_width)
     }
 
     /// Construct a guard object which writes `text` when dropped. Useful for
@@ -769,10 +770,13 @@ fn format_error_with_sources(err: &dyn error::Error) -> impl fmt::Display {
     iter::successors(Some(err), |&err| err.source()).format(": ")
 }
 
-fn term_width() -> Option<u16> {
-    if let Some(cols) = env::var("COLUMNS").ok().and_then(|s| s.parse().ok()) {
-        Some(cols)
-    } else {
-        crossterm::terminal::size().ok().map(|(cols, _)| cols)
-    }
+fn get_term_width() -> Option<NonZero<u16>> {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .or_else(|| {
+            crossterm::terminal::size()
+                .ok()
+                .and_then(|(cols, _)| NonZero::new(cols))
+        })
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1502,13 +1502,9 @@ fn test_log_word_wrap() {
 
     // Shouldn't panic with $COLUMNS < graph_width
     insta::assert_snapshot!(render(&["log", "-r@"], 0, true), @r"
-    @  mzvwutvl
-    │  test.user@example.com
-    ~  2001-02-03
-       08:05:11
-       bafb1ee5
-       (empty)
-       merge
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 bafb1ee5
+    │  (empty) merge
+    ~
     [EOF]
     ");
     insta::assert_snapshot!(render(&["log", "-r@"], 1, true), @r"


### PR DESCRIPTION
- If the `COLUMNS` environment variable is 0 (null), set the number of columns according to the terminal window size
- Fix [`map_unwrap_or clippy`](https://rust-lang.github.io/rust-clippy/master/index.html#map_unwrap_or) lints

References:

- This variable shall represent a decimal integer >0: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html#:~:text=Variables-,COLUMNS,decimal%20integer%20%3E0,-used
