### PR TITLE
Add a `user.commit-timestamp-granularity` privacy setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   locally. Setting it to `"*"` is now the closest replacement for the deprecated
   `git.push-new-bookmarks` option.
 
+* A new optional config option `user.commit-timestamp-granularity` allows the
+ user to specify a maximum granularity for commit timestamps to preserve
+ their privacy. For example, setting `user.commit-timestamp-granularity = "day"`
+ truncates commit timestamps to midnight.
+
 * `jj tag list` can now be filtered by revset.
 
 * Conflict markers will use LF or CRLF as the line ending according to the

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -17,6 +17,15 @@
                     "type": "string",
                     "description": "User's email address, used in commits",
                     "format": "email"
+                },
+                "commit-timestamp-granularity": {
+                    "type": "string",
+                    "description": "If set, the granularity used to truncate commit timestamps for privacy.",
+                    "enum": [
+                        "day",
+                        "month",
+                        "year"
+                    ]
                 }
             }
         },

--- a/docs/config.md
+++ b/docs/config.md
@@ -80,6 +80,8 @@ very short if you ever need to check.
 [user]
 name = "YOUR NAME"
 email = "YOUR_EMAIL@example.com"
+# Possible values are "day", "month", and "year".
+# commit-timestamp-granularity = <none>
 ```
 
 Don't forget to change these to your own details!

--- a/lib/src/config/misc.toml
+++ b/lib/src/config/misc.toml
@@ -48,6 +48,8 @@ conflict-marker-style = "diff"
 [user]
 email = ""
 name = ""
+# Possible values are "day", "month", and "year".
+# commit-timestamp-granularity = <none>
 
 [working-copy]
 eol-conversion = "none"


### PR DESCRIPTION
This allows users to specify a granularity that new commit timestamps will be truncated to. This is a privacy setting that allows the user to control their commit metadata without resorting to rewriting commits or changing their system datetime.

For example, a user can set `user.commit-timestamp-granularity = "day"` to have all new commits truncated to midnight of the same day.

The current options are:

- "day"
- "month"
- "year"

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
