### PR TITLE
tests: improve templater coverage

### DIFF
--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -4322,6 +4322,8 @@ mod tests {
         insta::assert_snapshot!(
             env.render_ok(r#"separate(" ", "a", if(true, "", "f"))"#), @"a");
         insta::assert_snapshot!(
+            env.render_ok(r#"separate(" ", "a", if(false, "t"))"#), @"a");
+        insta::assert_snapshot!(
             env.render_ok(r#"separate(" ", "a", if(false, "t", ""))"#), @"a");
         insta::assert_snapshot!(
             env.render_ok(r#"separate(" ", "a", if(true, "t", "f"))"#), @"a t");


### PR DESCRIPTION
It turns out that the tests in `template_builder.rs` and `template_parser.rs` cover nearly all of `templater.rs`, without requiring CLI tests.  This PR exercises a few extra cases in the latter two files.

Notable errata for `templater.rs` is listed below. Any ideas on how to trigger the latter two conditions?
- `PropertyPlaceholder.default` never seems to be called.
- I can't figure out how to get `ListPropertyTemplate.format` to produce an error on `property.extract`.
- I can't figure out how to display any successors for `format_property_error_inline`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
