### PR TITLE
Implement "diff_lines_added" and "diff_lines_removed" revset functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates now support `Serialize` operations on the result of `map()` and
   `if()`, when supported by the underlying type.
 
+* New `diff_lines_added()` and `diff_lines_removed()` revset functions for
+  matching content on only one side of a diff.
+
 * `jj bookmark rename` now supports `--overwrite-existing` to allow renaming a
   bookmark even if the new name already exists, effectively replacing the
   existing bookmark.

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -429,6 +429,12 @@ revsets (expressions) as arguments.
   For example, `diff_lines("*TODO*", "src")` will search revisions where "TODO"
   is added to or removed from files under "src".
 
+* `diff_lines_added(text, [files])`: like `diff_lines()` above, but matches only
+  the "added" side of the diff.
+
+* `diff_lines_removed(text, [files])`: like `diff_lines()` above, but matches
+  only the "removed" side of the diff.
+
 * `conflicts()`: Commits that have files in a conflicted state.
 
 * `divergent()`: Commits that are [divergent](glossary.md#divergent-change).

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -58,6 +58,7 @@ use crate::object_id::HexPrefix;
 use crate::object_id::ObjectId as _;
 use crate::object_id::PrefixResolution;
 use crate::repo_path::RepoPath;
+use crate::revset::DiffMatchSide;
 use crate::revset::GENERATION_RANGE_FULL;
 use crate::revset::ResolvedExpression;
 use crate::revset::ResolvedPredicateExpression;
@@ -1316,9 +1317,10 @@ fn build_predicate_fn(
                 Ok(has_diff_from_parent(&store, index, &commit, &*matcher).block_on()?)
             })
         }
-        RevsetFilterPredicate::DiffLines { text, files } => {
+        RevsetFilterPredicate::DiffLines { text, files, side } => {
             let text_matcher = Rc::new(text.to_matcher());
             let files_matcher: Rc<dyn Matcher> = files.to_matcher().into();
+            let side = *side;
             box_pure_predicate_fn(move |index, pos| {
                 let narrowed_files_matcher;
                 let files_matcher = if let Some(paths) = index.changed_paths().changed_paths(pos) {
@@ -1335,10 +1337,15 @@ fn build_predicate_fn(
                 };
                 let entry = index.commits().entry_by_pos(pos);
                 let commit = store.get_commit(&entry.commit_id())?;
-                Ok(
-                    matches_diff_from_parent(&store, index, &commit, &text_matcher, files_matcher)
-                        .block_on()?,
+                Ok(matches_diff_from_parent(
+                    &store,
+                    index,
+                    &commit,
+                    &text_matcher,
+                    files_matcher,
+                    side,
                 )
+                .block_on()?)
             })
         }
         RevsetFilterPredicate::HasConflict => box_pure_predicate_fn(move |index, pos| {
@@ -1403,6 +1410,7 @@ async fn matches_diff_from_parent(
     commit: &Commit,
     text_matcher: &StringMatcher,
     files_matcher: &dyn Matcher,
+    side: DiffMatchSide,
 ) -> BackendResult<bool> {
     let parents = commit.parents().await?;
     // Conflict resolution is expensive, try that only for matched files.
@@ -1427,7 +1435,13 @@ async fn matches_diff_from_parent(
         let left_contents = to_file_content(&entry.path, left_value).await?;
         let right_contents = to_file_content(&entry.path, right_value).await?;
         let merge_options = store.merge_options();
-        if diff_match_lines(&left_contents, &right_contents, text_matcher, merge_options)? {
+        if diff_match_lines(
+            &left_contents,
+            &right_contents,
+            text_matcher,
+            merge_options,
+            side,
+        )? {
             return Ok(true);
         }
     }
@@ -1439,10 +1453,13 @@ fn diff_match_lines(
     rights: &Merge<BString>,
     matcher: &StringMatcher,
     merge_options: &MergeOptions,
+    side: DiffMatchSide,
 ) -> BackendResult<bool> {
     // Filter lines prior to comparison. This might produce inferior hunks due
     // to lack of contexts, but is way faster than full diff.
-    if let (Some(left), Some(right)) = (lefts.as_resolved(), rights.as_resolved()) {
+    if side == DiffMatchSide::Either
+        && let (Some(left), Some(right)) = (lefts.as_resolved(), rights.as_resolved())
+    {
         let left_lines = matcher.match_lines(left);
         let right_lines = matcher.match_lines(right);
         Ok(left_lines.ne(right_lines))
@@ -1452,8 +1469,15 @@ fn diff_match_lines(
         let lefts = files::merge(&lefts, merge_options);
         let rights = files::merge(&rights, merge_options);
         let diff = ContentDiff::by_line(itertools::chain(&lefts, &rights));
-        let different = files::conflict_diff_hunks(diff.hunks(), lefts.as_slice().len())
-            .any(|hunk| hunk.kind == DiffHunkKind::Different);
+        let mut hunks = files::conflict_diff_hunks(diff.hunks(), lefts.as_slice().len());
+        let different = hunks.any(|hunk| {
+            hunk.kind == DiffHunkKind::Different
+                && match side {
+                    DiffMatchSide::Either => true,
+                    DiffMatchSide::Left => hunk.lefts.iter().any(|lines| !lines.is_empty()),
+                    DiffMatchSide::Right => hunk.rights.iter().any(|lines| !lines.is_empty()),
+                }
+        });
         Ok(different)
     }
 }
@@ -1878,78 +1902,262 @@ mod tests {
         let (conflict1, conflict2) = diff_match_lines_samples();
         let left1 = Merge::resolved(conflict1.first().clone());
         let left2 = Merge::resolved(conflict2.first().clone());
+        let options = MergeOptions {
+            hunk_level: FileMergeHunkLevel::Line,
+            same_change: SameChange::Accept,
+        };
         let diff = |needle: &str| {
             let matcher = StringPattern::substring(needle).to_matcher();
-            let options = MergeOptions {
-                hunk_level: FileMergeHunkLevel::Line,
-                same_change: SameChange::Accept,
-            };
-            diff_match_lines(&left1, &left2, &matcher, &options).unwrap()
+            diff_match_lines(&left1, &left2, &matcher, &options, DiffMatchSide::Either).unwrap()
+        };
+        let diff_left1 = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(&left1, &left2, &matcher, &options, DiffMatchSide::Left).unwrap()
+        };
+        let diff_left2 = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(&left1, &left2, &matcher, &options, DiffMatchSide::Right).unwrap()
         };
 
         assert!(diff(""));
+        assert!(diff_left1(""));
+        assert!(diff_left2(""));
+
         assert!(!diff("no match"));
+        assert!(!diff_left1("no_match"));
+        assert!(!diff_left2("no_match"));
+
         assert!(diff("line "));
+        assert!(diff_left1("line "));
+        assert!(!diff_left2("line "));
+
         assert!(diff(" 1"));
+        assert!(diff_left1(" 1"));
+        assert!(diff_left2(" 1"));
+
         assert!(!diff(" 2"));
+        assert!(!diff_left1(" 2"));
+        assert!(!diff_left2(" 2"));
+
         assert!(diff(" 3"));
+        assert!(!diff_left1(" 3"));
+        assert!(diff_left2(" 3"));
+
         assert!(!diff(" 3.1"));
+        assert!(!diff_left1(" 3.1"));
+        assert!(!diff_left2(" 3.1"));
+
         assert!(!diff(" 3.2"));
+        assert!(!diff_left1(" 3.2"));
+        assert!(!diff_left2(" 3.2"));
+
         assert!(diff(" 3.3"));
+        assert!(!diff_left1(" 3.3"));
+        assert!(diff_left2(" 3.3"));
+
         assert!(!diff(" 4"));
+        assert!(!diff_left1(" 4"));
+        assert!(!diff_left2(" 4"));
+
         assert!(!diff(" 5"));
+        assert!(!diff_left1(" 5"));
+        assert!(!diff_left2(" 5"));
     }
 
     #[test]
     fn test_diff_match_lines_between_conflicts() {
         let (conflict1, conflict2) = diff_match_lines_samples();
+        let options = MergeOptions {
+            hunk_level: FileMergeHunkLevel::Line,
+            same_change: SameChange::Accept,
+        };
         let diff = |needle: &str| {
             let matcher = StringPattern::substring(needle).to_matcher();
-            let options = MergeOptions {
-                hunk_level: FileMergeHunkLevel::Line,
-                same_change: SameChange::Accept,
-            };
-            diff_match_lines(&conflict1, &conflict2, &matcher, &options).unwrap()
+            diff_match_lines(
+                &conflict1,
+                &conflict2,
+                &matcher,
+                &options,
+                DiffMatchSide::Either,
+            )
+            .unwrap()
+        };
+        let diff_c1 = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(
+                &conflict1,
+                &conflict2,
+                &matcher,
+                &options,
+                DiffMatchSide::Left,
+            )
+            .unwrap()
+        };
+        let diff_c2 = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(
+                &conflict1,
+                &conflict2,
+                &matcher,
+                &options,
+                DiffMatchSide::Right,
+            )
+            .unwrap()
         };
 
         assert!(diff(""));
+        assert!(diff_c1(""));
+        assert!(diff_c2(""));
+
         assert!(!diff("no match"));
+        assert!(!diff_c1("no_match"));
+        assert!(!diff_c2("no_match"));
+
         assert!(diff("line "));
+        assert!(diff_c1("line "));
+        assert!(!diff_c2("line "));
+
         assert!(diff(" 1"));
+        assert!(diff_c1(" 1"));
+        assert!(diff_c2(" 1"));
+
         assert!(!diff(" 2"));
+        assert!(!diff_c1(" 2"));
+        assert!(!diff_c2(" 2"));
+
         assert!(diff(" 3"));
+        assert!(diff_c1(" 3"));
+        assert!(diff_c2(" 3"));
+
         // " 3.1" and " 3.2" could be considered different because the hunk
         // includes a changed line " 3.3". However, we filters out unmatched
         // lines first, therefore the changed line is omitted from the hunk.
         assert!(!diff(" 3.1"));
+        assert!(!diff_c1(" 3.1"));
+        assert!(!diff_c2(" 3.1"));
+
         assert!(!diff(" 3.2"));
+        assert!(!diff_c1(" 3.2"));
+        assert!(!diff_c2(" 3.2"));
+
         assert!(diff(" 3.3"));
+        assert!(!diff_c1(" 3.3"));
+        assert!(diff_c2(" 3.3"));
+
         assert!(!diff(" 4"));
+        assert!(!diff_c1(" 4"));
+        assert!(!diff_c2(" 4"));
+
         assert!(!diff(" 5")); // per A-B+A=A rule
+        assert!(!diff_c1(" 5"));
+        assert!(!diff_c2(" 5"));
     }
 
     #[test]
     fn test_diff_match_lines_between_resolved_and_conflict() {
         let (_conflict1, conflict2) = diff_match_lines_samples();
         let base = Merge::resolved(conflict2.get_remove(0).unwrap().clone());
+        let options = MergeOptions {
+            hunk_level: FileMergeHunkLevel::Line,
+            same_change: SameChange::Accept,
+        };
         let diff = |needle: &str| {
             let matcher = StringPattern::substring(needle).to_matcher();
-            let options = MergeOptions {
-                hunk_level: FileMergeHunkLevel::Line,
-                same_change: SameChange::Accept,
-            };
-            diff_match_lines(&base, &conflict2, &matcher, &options).unwrap()
+            diff_match_lines(&base, &conflict2, &matcher, &options, DiffMatchSide::Either).unwrap()
+        };
+        let diff_base = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(&base, &conflict2, &matcher, &options, DiffMatchSide::Left).unwrap()
+        };
+        let diff_c2 = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(&base, &conflict2, &matcher, &options, DiffMatchSide::Right).unwrap()
         };
 
         assert!(diff(""));
+        assert!(diff_base(""));
+        assert!(diff_c2(""));
+
         assert!(!diff("no match"));
+        assert!(!diff_base("no match"));
+        assert!(!diff_c2("no match"));
+
         assert!(diff("line "));
+        assert!(diff_base("line "));
+        assert!(diff_c2("line "));
+
         assert!(diff(" 1"));
+        assert!(diff_base(" 1"));
+        assert!(diff_c2(" 1"));
+
         assert!(!diff(" 2"));
+        assert!(!diff_base(" 2"));
+        assert!(!diff_c2(" 2"));
+
         assert!(diff(" 3"));
+        assert!(diff_base(" 3"));
+        assert!(diff_c2(" 3"));
+
         assert!(diff(" 3.1"));
+        assert!(!diff_base(" 3.1"));
+        assert!(diff_c2(" 3.1"));
+
         assert!(diff(" 3.2"));
+        assert!(!diff_base(" 3.2"));
+        assert!(diff_c2(" 3.2"));
+
         assert!(!diff(" 4"));
+        assert!(!diff_base(" 4"));
+        assert!(!diff_c2(" 4"));
+
         assert!(diff(" 5"));
+        assert!(!diff_base(" 5"));
+        assert!(diff_c2(" 5"));
+    }
+
+    #[test]
+    fn test_diff_match_lines_with_repeated_lines() {
+        let left = Merge::resolved(BString::from(indoc! {"
+            twice_left
+            twice_left
+            twice_both
+            twice_both
+            twice_right
+        "}));
+        let right = Merge::resolved(BString::from(indoc! {"
+            twice_left
+            twice_both
+            twice_both
+            twice_right
+            twice_right
+        "}));
+        let options = MergeOptions {
+            hunk_level: FileMergeHunkLevel::Line,
+            same_change: SameChange::Accept,
+        };
+        let diff = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(&left, &right, &matcher, &options, DiffMatchSide::Either).unwrap()
+        };
+        let diff_left = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(&left, &right, &matcher, &options, DiffMatchSide::Left).unwrap()
+        };
+        let diff_right = |needle: &str| {
+            let matcher = StringPattern::substring(needle).to_matcher();
+            diff_match_lines(&left, &right, &matcher, &options, DiffMatchSide::Right).unwrap()
+        };
+
+        assert!(diff("twice_left"));
+        assert!(diff_left("twice_left"));
+        assert!(!diff_right("twice_left"));
+
+        assert!(!diff("twice_both"));
+        assert!(!diff_left("twice_both"));
+        assert!(!diff_right("twice_both"));
+
+        assert!(diff("twice_right"));
+        assert!(!diff_left("twice_right"));
+        assert!(diff_right("twice_right"));
     }
 }

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -182,6 +182,13 @@ impl dyn RevsetFilterExtension {
     }
 }
 
+#[derive(Eq, Copy, Clone, Debug, PartialEq)]
+pub enum DiffMatchSide {
+    Either,
+    Left,
+    Right,
+}
+
 #[derive(Clone, Debug)]
 pub enum RevsetFilterPredicate {
     /// Commits with number of parents in the range.
@@ -208,6 +215,7 @@ pub enum RevsetFilterPredicate {
     DiffLines {
         text: StringExpression,
         files: FilesetExpression,
+        side: DiffMatchSide,
     },
     /// Commits with conflicts
     HasConflict,
@@ -1122,20 +1130,34 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
         }
         let ([text_arg], [files_opt_arg]) = function.expect_arguments()?;
         let text = expect_string_expression(diagnostics, text_arg, context)?;
-        let files = if let Some(files_arg) = files_opt_arg {
-            let fileset_context = context.fileset_parse_context().ok_or_else(|| {
-                RevsetParseError::with_span(
-                    RevsetParseErrorKind::FsPathWithoutWorkspace,
-                    files_arg.span,
-                )
-            })?;
-            expect_fileset_expression(diagnostics, files_arg, &fileset_context)?
-        } else {
-            // TODO: defaults to CLI path arguments?
-            // https://github.com/jj-vcs/jj/issues/2933#issuecomment-1925870731
-            FilesetExpression::all()
+        let files = expand_optional_files_arg(files_opt_arg, diagnostics, context)?;
+        let predicate = RevsetFilterPredicate::DiffLines {
+            text,
+            files,
+            side: DiffMatchSide::Either,
         };
-        let predicate = RevsetFilterPredicate::DiffLines { text, files };
+        Ok(RevsetExpression::filter(predicate))
+    });
+    map.insert("diff_lines_added", |diagnostics, function, context| {
+        let ([text_arg], [files_opt_arg]) = function.expect_arguments()?;
+        let text = expect_string_expression(diagnostics, text_arg, context)?;
+        let files = expand_optional_files_arg(files_opt_arg, diagnostics, context)?;
+        let predicate = RevsetFilterPredicate::DiffLines {
+            text,
+            files,
+            side: DiffMatchSide::Right,
+        };
+        Ok(RevsetExpression::filter(predicate))
+    });
+    map.insert("diff_lines_removed", |diagnostics, function, context| {
+        let ([text_arg], [files_opt_arg]) = function.expect_arguments()?;
+        let text = expect_string_expression(diagnostics, text_arg, context)?;
+        let files = expand_optional_files_arg(files_opt_arg, diagnostics, context)?;
+        let predicate = RevsetFilterPredicate::DiffLines {
+            text,
+            files,
+            side: DiffMatchSide::Left,
+        };
         Ok(RevsetExpression::filter(predicate))
     });
     // TODO: Remove diff_contains() in jj 0.44+
@@ -1175,6 +1197,26 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
     });
     map
 });
+
+fn expand_optional_files_arg(
+    files_opt_arg: Option<&ExpressionNode>,
+    diagnostics: &mut RevsetDiagnostics,
+    context: &LoweringContext,
+) -> Result<FilesetExpression, RevsetParseError> {
+    if let Some(files_arg) = files_opt_arg {
+        let fileset_context = context.fileset_parse_context().ok_or_else(|| {
+            RevsetParseError::with_span(
+                RevsetParseErrorKind::FsPathWithoutWorkspace,
+                files_arg.span,
+            )
+        })?;
+        expect_fileset_expression(diagnostics, files_arg, &fileset_context)
+    } else {
+        // TODO: defaults to CLI path arguments?
+        // https://github.com/jj-vcs/jj/issues/2933#issuecomment-1925870731
+        Ok(FilesetExpression::all())
+    }
+}
 
 /// Parses the given `node` as a fileset expression.
 pub fn expect_fileset_expression(

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -4768,13 +4768,39 @@ fn test_evaluate_expression_diff_lines(indexed: bool) {
         ]
     );
     assert_eq!(
+        query("diff_lines_added(*2*)"),
+        vec![commit3.id().clone(), commit2.id().clone()]
+    );
+    assert_eq!(
+        query("diff_lines_removed(*2*)"),
+        vec![commit4.id().clone(), commit3.id().clone()]
+    );
+
+    assert_eq!(
         query("diff_lines(*3*)"),
         vec![commit4.id().clone(), commit3.id().clone()]
     );
+    assert_eq!(query("diff_lines_added(*3*)"), vec![commit3.id().clone()]);
+    assert_eq!(query("diff_lines_removed(*3*)"), vec![commit4.id().clone()]);
+
     assert_eq!(query("diff_lines('*2 3*')"), vec![commit3.id().clone()]);
+    assert_eq!(
+        query("diff_lines_added('*2 3*')"),
+        vec![commit3.id().clone()]
+    );
+    assert_eq!(query("diff_lines_removed('*2 3*')"), vec![]);
+
     assert_eq!(
         query("diff_lines('*1 3*')"),
         vec![commit4.id().clone(), commit3.id().clone()]
+    );
+    assert_eq!(
+        query("diff_lines_added('*1 3*')"),
+        vec![commit3.id().clone()]
+    );
+    assert_eq!(
+        query("diff_lines_removed('*1 3*')"),
+        vec![commit4.id().clone()]
     );
 
     // should match line with eol
@@ -4784,6 +4810,18 @@ fn test_evaluate_expression_diff_lines(indexed: bool) {
         )),
         vec![commit3.id().clone(), commit1.id().clone()]
     );
+    assert_eq!(
+        query(&format!(
+            "diff_lines_added('1', {normal_inserted_modified_removed:?})",
+        )),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        query(&format!(
+            "diff_lines_removed('1', {normal_inserted_modified_removed:?})",
+        )),
+        vec![commit3.id().clone()]
+    );
 
     // should match line without eol
     assert_eq!(
@@ -4791,6 +4829,18 @@ fn test_evaluate_expression_diff_lines(indexed: bool) {
             "diff_lines('1', {noeol_modified_modified_clean:?})",
         )),
         vec![commit2.id().clone(), commit1.id().clone()]
+    );
+    assert_eq!(
+        query(&format!(
+            "diff_lines_added('1', {noeol_modified_modified_clean:?})",
+        )),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        query(&format!(
+            "diff_lines_removed('1', {noeol_modified_modified_clean:?})",
+        )),
+        vec![commit2.id().clone()]
     );
 
     // exact:'' should match blank line
@@ -4880,12 +4930,38 @@ fn test_evaluate_expression_diff_lines_conflict(indexed: bool) {
         vec![commit1.id().clone()]
     );
     assert_eq!(
+        resolve_commit_ids(mut_repo, "diff_lines_added('0')"),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "diff_lines_removed('0')"),
+        vec![]
+    );
+
+    assert_eq!(
         resolve_commit_ids(mut_repo, "diff_lines('1')"),
         vec![commit2.id().clone(), commit1.id().clone()]
     );
     assert_eq!(
+        resolve_commit_ids(mut_repo, "diff_lines_added('1')"),
+        vec![commit1.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "diff_lines_removed('1')"),
+        vec![commit2.id().clone()]
+    );
+
+    assert_eq!(
         resolve_commit_ids(mut_repo, "diff_lines('2')"),
         vec![commit2.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "diff_lines_added('2')"),
+        vec![commit2.id().clone()]
+    );
+    assert_eq!(
+        resolve_commit_ids(mut_repo, "diff_lines_removed('2')"),
+        vec![]
     );
 }
 
@@ -4953,6 +5029,20 @@ fn test_evaluate_expression_file_merged_parents(indexed: bool) {
         ]
     );
     assert_eq!(
+        query("diff_lines_added(regex:'[1234]', 'file1')"),
+        vec![
+            commit4.id().clone(),
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+        ]
+    );
+    assert_eq!(
+        query("diff_lines_removed(regex:'[1234]', 'file1')"),
+        vec![commit4.id().clone()]
+    );
+
+    assert_eq!(
         query("diff_lines(regex:'[1234]', 'file2')"),
         vec![
             commit3.id().clone(),
@@ -4960,6 +5050,15 @@ fn test_evaluate_expression_file_merged_parents(indexed: bool) {
             commit1.id().clone(),
         ]
     );
+    assert_eq!(
+        query("diff_lines_added(regex:'[1234]', 'file2')"),
+        vec![
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone(),
+        ]
+    );
+    assert_eq!(query("diff_lines_removed(regex:'[1234]', 'file2')"), vec![]);
 }
 
 #[test]


### PR DESCRIPTION
This is change adds revset functions to match lines added or removed. This fixes #7595. 

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
