### PR TITLE
git: bump minimum "git" version to 2.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* The minimum supported `git` command version is now 2.41.0. macOS users will
+  need to either upgrade "Developer Tools" to 26 or install Git from
+  e.g. Homebrew.
+
 * Deprecated `ui.always-allow-large-revsets` setting and `all:` revset modifier
   have been removed.
 

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -40,13 +40,10 @@ use crate::ref_name::GitRefNameBuf;
 use crate::ref_name::RefNameBuf;
 use crate::ref_name::RemoteName;
 
-// This is not the minimum required version, that would be 2.29.0, which
-// introduced the `--no-write-fetch-head` option. However, that by itself
-// is quite old and unsupported, so we don't want to encourage users to
-// update to that.
-//
-// 2.40 still receives security patches (latest one was in Jan/2025)
-const MINIMUM_GIT_VERSION: &str = "2.40.4";
+// * 2.29.0 introduced `git fetch --no-write-fetch-head`
+// * 2.40 still receives security patches (latest one was in Jan/2025)
+// * 2.41.0 introduced `git fetch --porcelain`
+const MINIMUM_GIT_VERSION: &str = "2.41.0";
 
 /// Error originating by a Git subprocess
 #[derive(Error, Debug)]


### PR DESCRIPTION


# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
