### PR TITLE
ui: hide progress bar when `--quiet` is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a scan of the affected subtree so newly unignored files are discovered.
   [#8427](https://github.com/jj-vcs/jj/issues/8427)
 
+* `--quiet` now hides progress bars.
+
 ## [0.37.0] - 2026-01-07
 
 ### Release highlights

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -472,7 +472,9 @@ impl Ui {
     /// operations
     pub fn use_progress_indicator(&self) -> bool {
         match &self.output {
-            UiOutput::Terminal { stderr, .. } => self.progress_indicator && stderr.is_terminal(),
+            UiOutput::Terminal { stderr, .. } => {
+                !self.quiet && self.progress_indicator && stderr.is_terminal()
+            }
             UiOutput::Paged { .. } => false,
             UiOutput::BuiltinPaged { .. } => false,
             UiOutput::Null => false,


### PR DESCRIPTION
I found it surprising that `--quiet` did not suppress progress bars.

I have a script which clones a bunch of repositories at the same time and used `--quiet` to suppress all output as it wasn't very useful, but the progress bar seems to have slipped through.