### PR TITLE
gerrit: add support for change id in `Link` trailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   This includes, for example, `--reviewer=foo@example.com` and
   `--label=Auto-Submit`.
 
+* `jj gerrit upload` now recognizes Change-Id explicitly set via the alternative
+  trailer `Link`, and will generate a `Link: <review-url>/id/<change-id>` trailer
+  if `gerrit.review-url` option is set.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -537,6 +537,10 @@
                 "default-remote-branch": {
                     "type": "string",
                     "description": "The default branch to propose changes for"
+                },
+                "review-url": {
+                    "type": "string",
+                    "description": "Generate Link trailers with this URL instead of Change-Id trailers in `jj gerrit upload`"
                 }
             }
         },

--- a/docs/gerrit.md
+++ b/docs/gerrit.md
@@ -148,3 +148,12 @@ footers associated with the desired changes. Be sure not to duplicate the same
 `Change-Id` across different changes. Gerrit will reject pushes that contain
 duplicate `Change-Id`s, but if the uploads are done separately, you may
 unintentionally overwrite an existing change.
+
+## Alternative `Link` trailer
+
+Since version 3.3.1 Gerrit supports an alternative to the `Change-Id` trailer,
+using a `Link` trailer in the format of `<reviewUrl>/id/I<changeid>`. It is only
+documented in the [commig-msg hook documentation]. Jujutsu's `jj gerrit upload`
+will do the same if you set `jj config set --repo gerrit.review-url <reviewUrl>`.
+
+[commig-msg hook documentation]: https://gerrit-documentation.storage.googleapis.com/Documentation/3.3.1/cmd-hook-commit-msg.html


### PR DESCRIPTION
We're using the alternative `Link` trailer to track Gerrit change IDs at $work. This adds the support for this option to `jj gerrit upload` in a similar way to Gerrit's default commit-msg hook.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
