### PR TITLE
cli: rename `FixError::IO` to `FixError::Io`

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -745,7 +745,7 @@ impl From<FixError> for CommandError {
         match err {
             FixError::Backend(err) => err.into(),
             FixError::RevsetEvaluation(err) => err.into(),
-            FixError::IO(err) => err.into(),
+            FixError::Io(err) => err.into(),
             FixError::FixContent(err) => internal_error_with_message(
                 "An error occurred while attempting to fix file content",
                 err,

--- a/lib/src/fix.rs
+++ b/lib/src/fix.rs
@@ -66,7 +66,7 @@ pub enum FixError {
     RevsetEvaluation(#[from] RevsetEvaluationError),
     /// Error occurred while reading/writing file content.
     #[error(transparent)]
-    IO(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     /// Error occurred while processing the file content.
     #[error(transparent)]
     FixContent(Box<dyn std::error::Error + Send + Sync>),


### PR DESCRIPTION
Use capitalization consistent with the rest of the codebase, e.g. `ConflictResolveError::Io` and `DiffRenderError::Io`.
