### PR TITLE
docs: Note that description usually ends with \n if non-blank.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -222,13 +222,16 @@ original commit.
 [templates]
 duplicate_description = '''
 concat(
-  description,
-  "\n(cherry picked from commit ",
+  description.trim_end(),
+  "\n\n(cherry picked from commit ",
   commit_id,
-  ")"
+  ")\n"
 )
 '''
 ```
+
+Note that `description` usually ends with a `\n` if it is not blank. Use
+`.trim_end()` to remove the `\n`.
 
 ### Bookmark/tag listing order
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -144,7 +144,7 @@ _Conversion: `Boolean`: no, `Serialize`: yes, `Template`: no_
 
 This type cannot be printed. The following methods are defined.
 
-* `.description() -> String`
+* `.description() -> String`: Usually ends with a trailing `\n`, if non-blank.
 * `.trailers() -> List<Trailer>`: The trailers at the end of the commit
   description that are formatted as `<key>: <value>`. These are returned in the
   same order as they appear in the description, and there may be multiple


### PR DESCRIPTION
Alter the suggested 'duplicate_description' to normalize input and
outputted newlines.

See #8772

## Personal notes

This PR attempts to avert the misunderstanding that led me to log #8772.

Say I run `jj desc -m "First commit"`. Jujutsu automatically adds a trailing `\n`, storing `First commit\n`. This is done by `cleanup_description_lines()`. The `\n` is consistent with git (`git commit -m`), but slightly surprising for template writers, who expect e.g.:
```
jj desc -m "First commit"
jj log -G -r@ -T 'description++"!"'
```
to emit `First commit!`, not
```
First commit
!
```
This baked-in `\n`, combined with `jj log`'s behaviour of only showing the first line, makes it appear that `jj duplicate` is not using its template:
```
$ mkdir /tmp/testrepo; cd /tmp/testrepo; jj git init
$ jj config set --repo templates.duplicate_description "'description++\" (duplicated)\"'"
$ jj desc -m "First commit"
$ jj log -n2 -G
ywymxoxm jeff@redradishtech.com 2026-02-03 02:32:44 66c58837
(empty) First commit
omyxwwxt jeff@redradishtech.com 2026-02-03 02:30:40 d316abbd
(empty) First commit
```

I think the likely presence of `\n` in `description` is worth documenting:

```markdown
> * `.description() -> String`: Usually ends with a trailing `\n`, if non-blank.
```
The weasel word 'Usually' is there because, unfortunately, the trailing `\n` is not _always_ present. If the description is created from a template (`duplicate_description`, `revert_description`), it will not have a trailing `\n` unless the template adds it:

```bash
$ jj config set --repo templates.duplicate_description "'\"Hardcoded-no-newline\"'"
$ jj desc -m "First commit"
$ jj duplicate
$ $ jj log -G -r $DUPLICATED -T 'description++"!"'
Hardcoded-no-newline!
```

It's a bit unfortunate that template-derived descriptions are allowed to create newline-less descriptions that break the convention. Perhaps they should have the same `\n` normalization applied as hand-entered descriptions?

For now, I think the template in the docs should be:

```toml
[templates]
duplicate_description = '''
concat(
  description.trim_end(),
  "\n\n(cherry picked from commit ",
  commit_id,
  ")\n"
)
'''
```
(_edited after feedback_)

The trailing `\n` respects the existing convention, while the `description.trim_end()` acknowledges the possibly messy reality.

For comparison, see the builtin `revert_description` template which also does the right thing:

https://github.com/jj-vcs/jj/blob/44bf7e4c74d44b3bd45c317d21de3bc3a977d6d5/cli/src/config/templates.toml#L35-L41

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
