### PR TITLE
RFC: workspace add: register git worktree

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -62,8 +62,12 @@ a comparison with Git, including how workflows are different, see the
 * **Shallow clones: Kind of.** Shallow commits all have the virtual root commit
   as their parent. However, deepening or fully unshallowing a repository is
   currently not yet supported and will cause issues.
-* **git-worktree: No.** However, there's native support for multiple working
-  copies backed by a single repo. See the `jj workspace` family of commands.
+* **git-worktree: Partially.** In colocated repos, `jj workspace add` registers
+  the new workspace as a Git worktree on a best-effort basis so tools can see a
+  Git repository. "Best-effort" means jj will attempt to create the worktree
+  but won't fail the command if Git refuses. If this happens, jj will continue
+  with a normal workspace and print a warning. See the `jj workspace` family of
+  commands for native support.
 * **Sparse checkouts: No.** However, there's native support for sparse
   checkouts. See the `jj sparse` command.
 * **Signed commits: Yes.**

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -23,6 +23,7 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::iter;
 use std::num::NonZeroU32;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -138,6 +139,14 @@ impl GitSubprocessOptions {
 }
 
 #[derive(Debug, Error)]
+pub enum GitWorktreeError {
+    #[error(transparent)]
+    Subprocess(#[from] GitSubprocessError),
+    #[error(transparent)]
+    UnexpectedBackend(#[from] UnexpectedGitBackendError),
+}
+
+#[derive(Debug, Error)]
 pub enum GitRemoteNameError {
     #[error(
         "Git remote named '{name}' is reserved for local Git repository",
@@ -146,6 +155,21 @@ pub enum GitRemoteNameError {
     ReservedForLocalGitRepo,
     #[error("Git remotes with slashes are incompatible with jj: {}", .0.as_symbol())]
     WithSlash(RemoteNameBuf),
+}
+
+pub fn add_worktree(
+    repo: &dyn Repo,
+    worktree_path: &Path,
+    head_commit_id: &CommitId,
+    subprocess_options: GitSubprocessOptions,
+) -> Result<(), GitWorktreeError> {
+    // Prefer gix for local Git operations, but it does not yet support
+    // worktree management. Use a git subprocess as a pragmatic fallback.
+    let git_backend = get_git_backend(repo.store())?;
+    let git_ctx = GitSubprocessContext::from_git_backend(git_backend, subprocess_options);
+    let commit_hex = head_commit_id.hex();
+    git_ctx.spawn_worktree_add(worktree_path, &commit_hex)?;
+    Ok(())
 }
 
 fn validate_remote_name(name: &RemoteName) -> Result<(), GitRemoteNameError> {


### PR DESCRIPTION
**RFC**: Register Git worktrees on a best-effort basis for colocated workspaces so tools see a Git repo.

**Goal:** expose the workspace to Git tooling by writing worktree metadata.

**Limitation:** per-worktree Git `HEAD`/`index` is *not* synchronized (that's a bunch of more involved work), so Git commands that depend on worktree state may be inaccurate.

**Nit:** gix doesn't support worktree management, so this is currently implemented as a shell-out to `git` as a proof of concept.

**Questions:**
1. Is some version of *this concept* even **desirable**?
  * I think **yes**, because otherwise tools that "know" about git worktrees (such as your excessively friendly neighbourhood coding agent) will completely break when presented with workspaces.
2. Is *this implementation* **sufficient**?
  * I think **no**, because the lack of `HEAD` or `index` tracking means that git will keel over in a fake worktree.
  * Also, it would presumably be much preferable to extend gix to add basic worktree management support, rather than shelling out to `git`.

Tests:
- cargo test -p jj-cli test_workspace_add_registers_git_worktree_in_colocated_repo

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
