### PR TITLE
complete: fix completion text for deleted bookmarks

### DIFF
--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -47,22 +47,20 @@ use crate::ui::Ui;
 
 const BOOKMARK_HELP_TEMPLATE: &str = r#"template-aliases.'bookmark_help()'='''
 " " ++
-if(normal_target,
-    if(normal_target.description(),
-        normal_target.description().first_line(),
-        "(no description set)",
-    ),
-    "(conflicted bookmark)",
+coalesce(
+    if(!present, "(deleted bookmark)"),
+    if(!normal_target, "(conflicted bookmark)"),
+    if(!normal_target.description(), "(no description set)"),
+    normal_target.description().first_line(),
 )
 '''"#;
 const TAG_HELP_TEMPLATE: &str = r#"template-aliases.'tag_help()'='''
 " " ++
-if(normal_target,
-    if(normal_target.description(),
-        normal_target.description().first_line(),
-        "(no description set)",
-    ),
-    "(conflicted tag)",
+coalesce(
+    if(!present, "(deleted tag)"),
+    if(!normal_target, "(conflicted tag)"),
+    if(!normal_target.description(), "(no description set)"),
+    normal_target.description().first_line(),
 )
 '''"#;
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1014,7 +1014,7 @@ fn test_revisions() {
     let output = work_dir.complete_fish(["diff", "--from", ""]);
     insta::assert_snapshot!(output, @"
     conflicted_bookmark	conflicted
-    deleted_bookmark	(conflicted bookmark)
+    deleted_bookmark	(deleted bookmark)
     immutable_bookmark	immutable
     mutable_bookmark	mutable 1
     wv	working_copy
@@ -1037,7 +1037,7 @@ fn test_revisions() {
     let output = work_dir.complete_fish(["log", "-r", ".."]);
     insta::assert_snapshot!(output, @"
     ..conflicted_bookmark	conflicted
-    ..deleted_bookmark	(conflicted bookmark)
+    ..deleted_bookmark	(deleted bookmark)
     ..immutable_bookmark	immutable
     ..mutable_bookmark	mutable 1
     ..wv	working_copy
@@ -1112,7 +1112,7 @@ fn test_revisions() {
     let output = work_dir.complete_fish(["-r", ""]);
     insta::assert_snapshot!(output, @"
     conflicted_bookmark	conflicted
-    deleted_bookmark	(conflicted bookmark)
+    deleted_bookmark	(deleted bookmark)
     immutable_bookmark	immutable
     mutable_bookmark	mutable 1
     wv	working_copy
@@ -1143,7 +1143,7 @@ fn test_revisions() {
     let output = work_dir.complete_fish(["git", "push", "--named", "a="]);
     insta::assert_snapshot!(output, @"
     a=conflicted_bookmark	conflicted
-    a=deleted_bookmark	(conflicted bookmark)
+    a=deleted_bookmark	(deleted bookmark)
     a=immutable_bookmark	immutable
     a=mutable_bookmark	mutable 1
     a=wv	working_copy


### PR DESCRIPTION
For consistency, I also updated the tag template to match, but this is currently unused as we don't have any completions for remote tags.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
