### PR TITLE
docs: small improvement around --change/-c

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -23,7 +23,7 @@ $ jj commit -m 'feat(bar): add support for bar'
 # Let Jujutsu generate a bookmark name and push that to GitHub. Note that we
 # push the working-copy commit's *parent* because the working-copy commit
 # itself is empty.
-$ jj git push -c @-
+$ jj git push --change @- # or -c for short
 ```
 
 ### Using a named bookmark
@@ -91,7 +91,7 @@ $ # Do your work
 $ jj commit
 $ # Push change "mw", letting Jujutsu automatically create a bookmark called
 $ # "push-mwmpwkwknuz"
-$ jj git push --change mw
+$ jj git push -c mw
 ```
 
 ## Addressing review comments


### PR DESCRIPTION
As part of #8771, this makes the docs use --change first, but mention -c, and then use -c later.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
