### PR TITLE
docs: simplify pr feedback part of github.md

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -120,46 +120,22 @@ $ # Push it to your remote
 $ jj git push
 ```
 
-Notably, the above workflow creates a new commit for you. The same can be
-achieved without creating a new commit.
-
-!!! warning
-
-    We strongly suggest to `jj new` after the example below, as all further edits
-    still get amended to the previous commit.
-
-```shell
-$ # Create a new commit on top of the `your-feature` bookmark from above.
-$ jj new your-feature
-$ # Address the comments by updating the code. Then review the changes.
-$ jj diff
-$ # Give the fix a description.
-$ jj describe -m 'address pr comments'
-$ # Update the bookmark to point to the current commit.
-$ jj bookmark move your-feature --to @
-$ # Push it to your remote
-$ jj git push
-```
-
 ### Rewriting commits
 
-If your project prefers that you keep commits clean, you can do that by doing
-something like this:
+If your project prefers that you rewrite existing commits, you can do that by
+doing something like this:
 
 ```shell
-$ # Create a new commit on top of the second-to-last commit in `your-feature`,
-$ # as reviewers requested a fix there.
-$ jj new your-feature- # NOTE: the trailing hyphen is not a typo!
+$ # Reviewers asked for changes to xyz
+$ jj new xyz
 $ # Address the comments by updating the code. Then review the changes.
 $ jj diff
-$ # Squash the changes into the parent commit
+$ # Squash the changes into the parent, xyz
 $ jj squash
 $ # Push the updated bookmark to the remote. Jujutsu automatically makes it a
 $ # force push
 $ jj git push --bookmark your-feature
 ```
-
-The hyphen after `your-feature` comes from the [revset](revsets.md) syntax.
 
 ## Working with other people's bookmarks
 


### PR DESCRIPTION
As part of #8771, I'm simplifying this section a little bit. Having two ways of doing this here is trying to gesture at the 'edit workflow vs squash workflow' concept, but we don't have that in the docs yet,so let's just show the most straightforward one.

I also took the opportunity to simplify the rewriting commits portion, let's make it a bit less judge-y about clean commits, and then rather than introduce the `-` revset operator, just point out that you'd do this for the desired change.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
