### PR TITLE
revset: relax restriction on sequential '-' in unquoted identifier names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj undo` now also outputs what operation was undone, in addition to the
   operation restored to.
 
+* Bookmarks with two or more consecutive `-` characters no longer need to be quoted
+  in revsets. For example, `jj diff -r '"foo--bar"'` can now be written as `jj diff -r foo--bar`.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/lib/src/revset.pest
+++ b/lib/src/revset.pest
@@ -22,8 +22,10 @@ whitespace = _{ " " | "\t" | "\r" | "\n" | "\x0c" }
 // *: glob characters that won't be used as operators
 // /: sometimes used as a tag/bookmark namespace separator
 identifier_part = @{ (XID_CONTINUE | "_" | "*" | "/")+ }
+// '..' conflicts with the range operator, '++' conflicts with template concatenation,
+// but '--' has no known conflicts.
 identifier = @{
-  identifier_part ~ (("." | "-" | "+") ~ identifier_part)*
+  identifier_part ~ (("." | "-"+ | "+") ~ identifier_part)*
 }
 // TODO: remove "/", ".", "+" for consistency with fileset?
 strict_identifier_part = @{ (ASCII_ALPHANUMERIC | "_" | "/")+ }

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -1083,6 +1083,15 @@ mod tests {
             parse_normalized("foo.bar-v1+7-"),
             parse_normalized("(foo.bar-v1+7)-")
         );
+        // Multiple '-' are allowed
+        assert_eq!(
+            parse_into_kind("foo--bar"),
+            Ok(ExpressionKind::Identifier("foo--bar"))
+        );
+        assert_eq!(
+            parse_into_kind("foo----bar"),
+            Ok(ExpressionKind::Identifier("foo----bar"))
+        );
         // '.' is not allowed at the beginning or end
         assert_eq!(
             parse_into_kind(".foo"),
@@ -1092,13 +1101,13 @@ mod tests {
             parse_into_kind("foo."),
             Err(RevsetParseErrorKind::SyntaxError)
         );
-        // Multiple '.', '-', '+' are not allowed
+        // Multiple '.' and '+', or together with '-', are not allowed
         assert_eq!(
             parse_into_kind("foo.+bar"),
             Err(RevsetParseErrorKind::SyntaxError)
         );
         assert_eq!(
-            parse_into_kind("foo--bar"),
+            parse_into_kind("foo++bar"),
             Err(RevsetParseErrorKind::SyntaxError)
         );
         assert_eq!(


### PR DESCRIPTION
Per [discussion](https://discord.com/channels/968932220549103686/968932220549103689/1468721231527411885) on Discord, sequential dashes in bookmark/identifier names probably won't cause any problems, and I think they're slightly "normal" in git? Maybe certain tools?

The only test that failed after making this change was the test that ensured it was prevented :)

Before:

```
jj log -r '"my--bookmark"'
```

After:

```
jj log -r my--bookmark
``` 

Sequential `+` and combining `+` and `-` sequentially could uh, maybe be relaxed too? But I don't see much need to do that.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] (N/A) I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] (N/A) I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes