### PR TITLE
undo: output undone operation in addition to current operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inside containers or when moved together. Existing workspaces with absolute paths
   will continue to work as before.
 
+* `jj undo` now also outputs what operation was undone, in addition to the
+  operation restored to.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/src/commands/undo.rs
+++ b/cli/src/commands/undo.rs
@@ -199,8 +199,13 @@ pub fn cmd_undo(ui: &mut Ui, command: &CommandHelper, args: &UndoArgs) -> Result
     );
     tx.repo_mut().set_view(new_view);
     if let Some(mut formatter) = ui.status_formatter() {
-        write!(formatter, "Restored to operation: ")?;
         let template = tx.base_workspace_helper().operation_summary_template();
+
+        write!(formatter, "Undid operation: ")?;
+        template.format(&op_to_undo, formatter.as_mut())?;
+        writeln!(formatter)?;
+
+        write!(formatter, "Restored to operation: ")?;
         template.format(&op_to_restore, formatter.as_mut())?;
         writeln!(formatter)?;
     }

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -71,8 +71,9 @@ fn test_duplicate() {
     ");
 
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
+    Undid operation: 76386e059136 (2001-02-03 08:05:17) duplicate 1 commit(s)
     Restored to operation: 9fdb56d75a27 (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
     [EOF]
     ");
@@ -2345,8 +2346,9 @@ fn test_undo_after_duplicate() {
     ");
 
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
+    Undid operation: 87bf87a7f06f (2001-02-03 08:05:11) duplicate 1 commit(s)
     Restored to operation: 73a36404358e (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     [EOF]
     ");

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1040,8 +1040,9 @@ fn test_git_colocated_undo_head_move() {
 
     // HEAD should be moved back
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
+    Undid operation: 65d1097d37a5 (2001-02-03 08:05:15) new empty commit
     Restored to operation: b528a8c9176f (2001-02-03 08:05:14) new empty commit
     Working copy  (@) now at: vruxwmqv 23e6e06a (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1432,8 +1432,9 @@ fn test_git_fetch_undo() {
     [EOF]
     "#);
     let output = target_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
+    Undid operation: c726c5873ddf (2001-02-03 08:05:20) fetch from git remote(s) origin
     Restored to operation: 8aeac520a856 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -116,8 +116,9 @@ fn test_git_export_undo() {
     // Exported refs won't be removed by undoing the export, but the git-tracking
     // bookmark is. This is the same as remote-tracking bookmarks.
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
+    Undid operation: a99955438397 (2001-02-03 08:05:10) export git refs
     Restored to operation: 503f3c779aff (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");

--- a/cli/tests/test_undo_redo_commands.rs
+++ b/cli/tests/test_undo_redo_commands.rs
@@ -21,8 +21,9 @@ fn test_undo_root_operation() {
     let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
+    Undid operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
     Restored to operation: 000000000000 root()
     [EOF]
     ");
@@ -71,10 +72,11 @@ fn test_undo_push_operation() {
     work_dir.run_jj(["commit", "-mfoo"]).success();
     work_dir.run_jj(["git", "push", "-c@-"]).success();
     let output = work_dir.run_jj(["undo"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
     Warning: Undoing a push operation often leads to conflicted bookmarks.
     Hint: To avoid this, run `jj redo` now.
+    Undid operation: ca2f478e5a86 (2001-02-03 08:05:10) push bookmark push-rlvkpnrzqnoo to git remote origin
     Restored to operation: f9fd582ef03c (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
     [EOF]
     ");


### PR DESCRIPTION
<img width="1060" height="108" alt="image" src="https://github.com/user-attachments/assets/015c9b93-390c-42cb-b6d4-b93e95c3f706" />

Personally I think this would be helpful, to let you know what you just "undid".

I took the simple approach here of always adding another line. Another approach would be to add say, a `undid_operation` property to the template, and change the default template to output `separate("\n", format(undid_operation), format(self))`. I went with the easier approach here, but am totally willing to do the full template approach too.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] (N/A) I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] (N/A) I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
