### PR TITLE
Add `--atomic` flag to `jj git push`

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -362,6 +362,7 @@ pub fn cmd_gerrit_upload(
                 new_target: Some(new_commit.id().clone()),
             }],
             &mut GitSubprocessUi::new(ui),
+            false,
         )
         // Despite the fact that a manual git push will error out with 'no new
         // changes' if you're up to date, this git backend appears to silently

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -200,6 +200,10 @@ pub struct GitPushArgs {
     /// Only display what will change on the remote
     #[arg(long)]
     dry_run: bool,
+
+    /// Push all changes atomically
+    #[arg(long)]
+    atomic: bool,
 }
 
 fn make_bookmark_term(bookmark_names: &[impl fmt::Display]) -> String {
@@ -469,6 +473,7 @@ pub fn cmd_git_push(
         remote,
         &targets,
         &mut GitSubprocessUi::new(ui),
+        args.atomic,
     )?;
     print_push_stats(ui, &push_stats)?;
     // TODO: On partial success, locally-created --change/--named bookmarks will

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1661,6 +1661,7 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 
    Automatically tracks the bookmark if it is new.
 * `--dry-run` — Only display what will change on the remote
+* `--atomic` — Push all changes atomically
 
 
 

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -263,6 +263,7 @@ impl GitSubprocessContext {
         remote_name: &RemoteName,
         references: &[RefToPush],
         callback: &mut dyn GitSubprocessCallback,
+        atomic: bool,
     ) -> Result<GitPushStats, GitSubprocessError> {
         let mut command = self.create_command();
         command.stdout(Stdio::piped());
@@ -274,6 +275,9 @@ impl GitSubprocessContext {
         command.args(["push", "--porcelain", "--no-verify"]);
         if callback.needs_progress() {
             command.arg("--progress");
+        }
+        if atomic {
+            command.arg("--atomic");
         }
         command.args(
             references

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -4404,6 +4404,7 @@ fn test_push_bookmarks_success() {
         "origin".as_ref(),
         &targets,
         &mut NullCallback,
+        false,
     )
     .unwrap();
     insta::assert_debug_snapshot!(stats, @r#"
@@ -4483,6 +4484,7 @@ fn test_push_bookmarks_deletion() {
         "origin".as_ref(),
         &targets,
         &mut NullCallback,
+        false,
     )
     .unwrap();
     insta::assert_debug_snapshot!(stats, @r#"
@@ -4561,6 +4563,7 @@ fn test_push_bookmarks_mixed_deletion_and_addition() {
         "origin".as_ref(),
         &targets,
         &mut NullCallback,
+        false,
     )
     .unwrap();
     insta::assert_debug_snapshot!(stats, @r#"
@@ -4642,6 +4645,7 @@ fn test_push_bookmarks_not_fast_forward() {
         "origin".as_ref(),
         &targets,
         &mut NullCallback,
+        false,
     )
     .unwrap();
     insta::assert_debug_snapshot!(stats, @r#"
@@ -4695,6 +4699,7 @@ fn test_push_bookmarks_partial_success() {
         "origin".as_ref(),
         &targets,
         &mut NullCallback,
+        false,
     )
     .unwrap();
     insta::assert_debug_snapshot!(stats, @r#"
@@ -4804,6 +4809,7 @@ fn test_push_bookmarks_unmapped_refs() {
         "origin".as_ref(),
         &targets,
         &mut NullCallback,
+        false,
     )
     .unwrap();
     insta::assert_debug_snapshot!(stats, @r#"
@@ -4901,6 +4907,7 @@ fn test_push_updates_unexpectedly_moved_sideways_on_remote() {
             "origin".as_ref(),
             &targets,
             &mut NullCallback,
+            false,
         )
     };
 
@@ -4985,6 +4992,7 @@ fn test_push_updates_unexpectedly_moved_forward_on_remote() {
             "origin".as_ref(),
             &targets,
             &mut NullCallback,
+            false,
         )
     };
 
@@ -5049,6 +5057,7 @@ fn test_push_updates_unexpectedly_exists_on_remote() {
             "origin".as_ref(),
             &targets,
             &mut NullCallback,
+            false,
         )
     };
 
@@ -5085,6 +5094,7 @@ fn test_push_updates_success() {
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
         &mut NullCallback,
+        false,
     )
     .unwrap();
     insta::assert_debug_snapshot!(stats, @r#"
@@ -5131,6 +5141,7 @@ fn test_push_updates_no_such_remote() {
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
         &mut NullCallback,
+        false,
     );
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
 }
@@ -5151,6 +5162,7 @@ fn test_push_updates_invalid_remote() {
             new_target: Some(setup.child_of_main_commit.id().clone()),
         }],
         &mut NullCallback,
+        false,
     );
     assert!(matches!(result, Err(GitPushError::NoSuchRemote(_))));
 }
@@ -5184,6 +5196,7 @@ fn test_push_environment_options() {
         "origin".as_ref(),
         &targets,
         &mut NullCallback,
+        false,
     )
     .unwrap();
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->
Added a new `--atomic` flag to `jj git push` that will be propagated to the `git push` invocation ([Git docs](https://git-scm.com/docs/git-push#Documentation/git-push.txt---atomic)), as discussed briefly [in Discord](https://discord.com/channels/968932220549103686/1466511509202010256). `jj gerrit upload` does not use the flag because Gerrit apparently doesn't support atomic pushes.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
