### PR TITLE
merge: update doc comment on `.with_new_file_ids()`

### DIFF
--- a/lib/src/merge.rs
+++ b/lib/src/merge.rs
@@ -828,7 +828,7 @@ where
     }
 
     /// Creates a new merge with the file ids from the given merge. In other
-    /// words, only the executable bits from `self` will be preserved.
+    /// words, the executable bits and copy IDs from `self` will be preserved.
     ///
     /// The given `file_ids` should have the same shape as `self`. Only the
     /// `FileId` values may differ.


### PR DESCRIPTION
The doc comment was never updated after the addition of copy history to note that both executable bits and copy IDs are preserved when overriding file IDs.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
