### PR TITLE
rebase: Allow empty revsets for `branch` and `source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   as `jj simplify-parents` on the rebased commits.
   [#7711](https://github.com/jj-vcs/jj/issues/7711)
 
+* `jj rebase --branch` and `jj rebase --source` will no longer return an error
+  if the given argument resolves to an empty revision set.
+  `jj rebase --revisions` already behaved this way.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -464,7 +464,7 @@ fn plan_rebase_source(
     source: &[RevisionArg],
     rebase_destination: &RebaseDestinationArgs,
 ) -> Result<MoveCommitsLocation, CommandError> {
-    let source_commit_ids = Vec::from_iter(workspace_command.resolve_some_revsets(ui, source)?);
+    let source_commit_ids = Vec::from_iter(workspace_command.resolve_revsets_ordered(ui, source)?);
     workspace_command.check_rewritable(&source_commit_ids)?;
 
     let (new_parent_ids, new_child_ids) = compute_commit_location(
@@ -504,7 +504,7 @@ fn plan_rebase_branch(
         ]
     } else {
         workspace_command
-            .resolve_some_revsets(ui, branch)?
+            .resolve_revsets_ordered(ui, branch)?
             .into_iter()
             .collect()
     };

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -139,29 +139,26 @@ fn test_rebase_empty_sets() {
     create_commit(&work_dir, "a", &[]);
     create_commit(&work_dir, "b", &["a"]);
 
-    // TODO: Make all of these say "Nothing changed"?
-    let output = work_dir.run_jj(["rebase", "-r=none()", "-d=b"]);
+    let output = work_dir.run_jj(["rebase", "-r=none()", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.
     [EOF]
     ");
-    let output = work_dir.run_jj(["rebase", "-s=none()", "-d=b"]);
+    let output = work_dir.run_jj(["rebase", "-s=none()", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Empty revision set
+    Nothing changed.
     [EOF]
-    [exit status: 1]
     ");
-    let output = work_dir.run_jj(["rebase", "-b=none()", "-d=b"]);
+    let output = work_dir.run_jj(["rebase", "-b=none()", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Empty revision set
+    Nothing changed.
     [EOF]
-    [exit status: 1]
     ");
     // Empty because "b..a" is empty
-    let output = work_dir.run_jj(["rebase", "-b=a", "-d=b"]);
+    let output = work_dir.run_jj(["rebase", "-b=a", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Nothing changed.


### PR DESCRIPTION
Also removed a TODO from #5078 (5a1b325f0e440e27ce17dc87b1c93d494637d80f).

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
