### PR TITLE
bookmarks: Add `jj tug` inspired `advance` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj gerrit upload` no longer requires the `-r` flag, and will default to
   uploading what you're currently working on.
 
+* New command `jj bookmark advance` automatically moves bookmarks forward to a
+  target revision (defaults to `@`). With customization points
+  `revsets.bookmark-advance-from` and `revsets.bookmark-advance-to`.
+  The command is heavily inspired by the longstanding community alias `jj tug`.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/src/commands/bookmark/advance.rs
+++ b/cli/src/commands/bookmark/advance.rs
@@ -1,0 +1,217 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap_complete::ArgValueCandidates;
+use clap_complete::ArgValueCompleter;
+use itertools::Itertools as _;
+use jj_lib::dsl_util::ExpressionNode;
+use jj_lib::iter_util::fallible_any;
+use jj_lib::iter_util::fallible_find;
+use jj_lib::object_id::ObjectId as _;
+use jj_lib::op_store::RefTarget;
+use jj_lib::revset;
+use jj_lib::revset::ExpressionKind;
+use jj_lib::revset::RevsetDiagnostics;
+
+use super::is_fast_forward;
+use super::warn_unmatched_local_bookmarks;
+use crate::cli_util::CommandHelper;
+use crate::cli_util::RevisionArg;
+use crate::command_error::CommandError;
+use crate::command_error::print_parse_diagnostics;
+use crate::command_error::user_error;
+use crate::complete;
+use crate::revset_util::parse_union_name_patterns;
+use crate::ui::Ui;
+
+/// Advance the closest bookmarks to a target revision
+///
+/// The target `--to` defaults to `revsets.bookmark-advance-to`
+/// (which defaults to `@`).
+///
+/// The bookmarks to advance are determined by `revsets.bookmark-advance-from`
+/// (which defaults to `heads(::to & bookmarks())`).
+///
+/// Note that the from revset has access to `to`.
+///
+/// Positional bookmark name arguments can target specific bookmarks to advance
+/// to the target, in this case the default from revset is ignored.
+///
+/// Example:
+///
+/// `jj bookmark advance --to x` - Does the equivalent of
+/// `jj bookmark move --from 'heads(::x & bookmarks())' --to x`.
+#[derive(clap::Args, Clone, Debug)]
+pub struct BookmarkAdvanceArgs {
+    /// Move bookmarks matching the given name patterns
+    ///
+    /// By default, the specified pattern matches bookmark names with glob
+    /// syntax. You can also use other [string pattern syntax].
+    ///
+    /// [string pattern syntax]:
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
+    #[arg(add = ArgValueCandidates::new(complete::local_bookmarks))]
+    names: Option<Vec<String>>,
+
+    /// Move bookmarks to this revision
+    ///
+    /// Defaults to `revsets.bookmark-advance-to`.
+    #[arg(long, short, value_name = "REVSET")]
+    #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
+    to: Option<RevisionArg>,
+}
+
+pub fn cmd_bookmark_advance(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &BookmarkAdvanceArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui)?;
+
+    let to = if let Some(to) = &args.to {
+        to.clone()
+    } else {
+        RevisionArg::from(
+            workspace_command
+                .settings()
+                .get_string("revsets.bookmark-advance-to")?,
+        )
+    };
+
+    let target_commit = workspace_command
+        .resolve_single_rev(ui, &to)
+        .map_err(|error| {
+            if args.to.is_none() {
+                error.hinted(
+                    "`revsets.bookmark-advance-to` controls the default target. You can also \
+                     specify a specific target with `--to`.",
+                )
+            } else {
+                error
+            }
+        })?;
+
+    let repo = workspace_command.repo().clone();
+
+    let matched_bookmarks = {
+        let mut bookmarks: Vec<_> = match &args.names {
+            Some(texts) => {
+                let name_expr = parse_union_name_patterns(ui, texts)?;
+                let name_matcher = name_expr.to_matcher();
+                let result = repo
+                    .view()
+                    .local_bookmarks_matching(&name_matcher)
+                    .collect();
+                warn_unmatched_local_bookmarks(ui, repo.view(), &name_expr)?;
+                result
+            }
+            None => {
+                // Get the default-from revset config, and provide `to`.
+                let from_revset_str = workspace_command
+                    .settings()
+                    .get_string("revsets.bookmark-advance-from")?;
+                let mut context = workspace_command.env().revset_parse_context();
+                let commit_hex = target_commit.id().hex();
+                context.local_variables.insert(
+                    "to",
+                    ExpressionNode {
+                        kind: ExpressionKind::String(commit_hex.clone()),
+                        span: pest::Span::new(commit_hex.as_str(), 0, commit_hex.len())
+                            .expect("programmatic span shouldn't fail"),
+                    },
+                );
+
+                let mut diags = RevsetDiagnostics::default();
+                let expression = revset::parse(&mut diags, &from_revset_str, &context)?;
+                print_parse_diagnostics(ui, "In revsets.bookmark-advance-from", &diags)?;
+
+                let is_source_commit = workspace_command
+                    .attach_revset_evaluator(expression)
+                    .evaluate()?
+                    .containing_fn();
+                let is_source_ref = |target: &RefTarget| -> Result<bool, CommandError> {
+                    Ok(fallible_any(target.added_ids(), &is_source_commit)?)
+                };
+
+                repo.view()
+                    .local_bookmarks()
+                    .filter_map(|(name, target)| {
+                        is_source_ref(target)
+                            .map(|matched| matched.then_some((name, target)))
+                            .transpose()
+                    })
+                    .try_collect()?
+            }
+        };
+        // Noop matches aren't errors, but should be excluded from stats.
+        bookmarks.retain(|(_, old_target)| old_target.as_normal() != Some(target_commit.id()));
+        bookmarks
+    };
+
+    if matched_bookmarks.is_empty() {
+        writeln!(ui.status(), "No bookmarks to update.")?;
+        return Ok(());
+    }
+
+    if let Some((name, _)) = fallible_find(
+        matched_bookmarks.iter(),
+        |(_, old_target)| -> Result<_, CommandError> {
+            let is_ff = is_fast_forward(repo.as_ref(), old_target, target_commit.id())?;
+            Ok(!is_ff)
+        },
+    )? {
+        return Err(user_error(format!(
+            "Refusing to advance bookmark backwards or sideways: {name}",
+            name = name.as_symbol()
+        )));
+    }
+    if target_commit.is_discardable(repo.as_ref())? {
+        writeln!(ui.warning_default(), "Target revision is empty.")?;
+    }
+
+    let mut tx = workspace_command.start_transaction();
+    for (name, _) in &matched_bookmarks {
+        tx.repo_mut()
+            .set_local_bookmark_target(name, RefTarget::normal(target_commit.id().clone()));
+    }
+
+    if let Some(mut formatter) = ui.status_formatter() {
+        write!(
+            formatter,
+            "Advanced {} bookmarks to ",
+            matched_bookmarks.len()
+        )?;
+        tx.write_commit_summary(formatter.as_mut(), &target_commit)?;
+        writeln!(formatter)?;
+    }
+    if matched_bookmarks.len() > 1 && args.names.is_none() {
+        writeln!(
+            ui.hint_default(),
+            "Specify bookmark by name to update just one of the bookmarks."
+        )?;
+    }
+
+    tx.finish(
+        ui,
+        format!(
+            "point bookmark {names} to commit {id}",
+            names = matched_bookmarks
+                .iter()
+                .map(|(name, _)| name.as_symbol())
+                .join(", "),
+            id = target_commit.id().hex()
+        ),
+    )?;
+    Ok(())
+}

--- a/cli/src/commands/bookmark/mod.rs
+++ b/cli/src/commands/bookmark/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod advance;
 mod create;
 mod delete;
 mod forget;
@@ -37,6 +38,8 @@ use jj_lib::str_util::StringExpression;
 use jj_lib::str_util::StringMatcher;
 use jj_lib::view::View;
 
+use self::advance::BookmarkAdvanceArgs;
+use self::advance::cmd_bookmark_advance;
 use self::create::BookmarkCreateArgs;
 use self::create::cmd_bookmark_create;
 use self::delete::BookmarkDeleteArgs;
@@ -71,6 +74,8 @@ use crate::ui::Ui;
 ///     https://docs.jj-vcs.dev/latest/bookmarks
 #[derive(clap::Subcommand, Clone, Debug)]
 pub enum BookmarkCommand {
+    #[command(visible_alias("a"))]
+    Advance(BookmarkAdvanceArgs),
     #[command(visible_alias("c"))]
     Create(BookmarkCreateArgs),
     #[command(visible_alias("d"))]
@@ -96,6 +101,7 @@ pub fn cmd_bookmark(
     subcommand: &BookmarkCommand,
 ) -> Result<(), CommandError> {
     match subcommand {
+        BookmarkCommand::Advance(args) => cmd_bookmark_advance(ui, command, args),
         BookmarkCommand::Create(args) => cmd_bookmark_create(ui, command, args),
         BookmarkCommand::Delete(args) => cmd_bookmark_delete(ui, command, args),
         BookmarkCommand::Forget(args) => cmd_bookmark_forget(ui, command, args),

--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -107,7 +107,7 @@ pub fn cmd_bookmark_move(
             })
             .try_collect()?;
         warn_unmatched_local_bookmarks(ui, repo.view(), &name_expr)?;
-        // Noop matches aren't error, but should be excluded from stats.
+        // Noop matches aren't errors, but should be excluded from stats.
         bookmarks.retain(|(_, old_target)| old_target.as_normal() != Some(target_commit.id()));
         bookmarks
     };

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -668,6 +668,16 @@
                     "type": "string",
                     "description": "Set of revisions to prioritize when rendering the graph for jj log",
                     "default": "present(@)"
+                },
+                "bookmark-advance-to": {
+                    "type": "string",
+                    "description": "Default revision to advance bookmarks to when no explicit revision is given to jj advance `--to`",
+                    "default": "@"
+                },
+                "bookmark-advance-from": {
+                    "type": "string",
+                    "description": "Default set of revisions to advance bookmarks from for jj advance (has access to `to`, the advance destination)",
+                    "default": "heads(::to & bookmarks())"
                 }
             },
             "additionalProperties": {

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -12,6 +12,8 @@ log = "present(@) | ancestors(immutable_heads().., 2) | trunk()"
 # This also helps stabilize output order.
 log-graph-prioritize = "present(@)"
 sign = "reachable(@, mutable())"
+bookmark-advance-to = "@"
+bookmark-advance-from = "heads(::to & bookmarks())"
 
 [revset-aliases]
 # trunk() can be overridden as '<bookmark>@<remote>'.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -17,6 +17,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj bisect`↴](#jj-bisect)
 * [`jj bisect run`↴](#jj-bisect-run)
 * [`jj bookmark`↴](#jj-bookmark)
+* [`jj bookmark advance`↴](#jj-bookmark-advance)
 * [`jj bookmark create`↴](#jj-bookmark-create)
 * [`jj bookmark delete`↴](#jj-bookmark-delete)
 * [`jj bookmark forget`↴](#jj-bookmark-forget)
@@ -347,6 +348,7 @@ See [`jj help -k bookmarks`] for more information.
 
 ###### **Subcommands:**
 
+* `advance` — Advance the closest bookmarks to a target revision
 * `create` — Create a new bookmark
 * `delete` — Delete an existing bookmark and propagate the deletion to remotes on the next push
 * `forget` — Forget a bookmark without marking it as a deletion to be pushed
@@ -356,6 +358,42 @@ See [`jj help -k bookmarks`] for more information.
 * `set` — Create a new bookmark, or update an existing one by name
 * `track` — Start tracking given remote bookmarks
 * `untrack` — Stop tracking given remote bookmarks
+
+
+
+## `jj bookmark advance`
+
+Advance the closest bookmarks to a target revision
+
+The target `--to` defaults to `revsets.bookmark-advance-to` (which defaults to `@`).
+
+The bookmarks to advance are determined by `revsets.bookmark-advance-from` (which defaults to `heads(::to & bookmarks())`).
+
+Note that the from revset has access to `to`.
+
+Positional bookmark name arguments can target specific bookmarks to advance to the target, in this case the default from revset is ignored.
+
+Example:
+
+`jj bookmark advance --to x` - Does the equivalent of `jj bookmark move --from 'heads(::x & bookmarks())' --to x`.
+
+**Usage:** `jj bookmark advance [OPTIONS] [NAMES]...`
+
+**Command Alias:** `a`
+
+###### **Arguments:**
+
+* `<NAMES>` — Move bookmarks matching the given name patterns
+
+   By default, the specified pattern matches bookmark names with glob syntax. You can also use other [string pattern syntax].
+
+   [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
+
+###### **Options:**
+
+* `-t`, `--to <REVSET>` — Move bookmarks to this revision
+
+   Defaults to `revsets.bookmark-advance-to`.
 
 
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -865,23 +865,23 @@ fn test_aliases_are_completed(shell: Shell) {
         .take_stdout_n_lines(2);
     match shell {
         Shell::Bash => {
-            insta::assert_snapshot!(output, @"
+            insta::assert_snapshot!(output, @r"
+            advance
             create
-            delete
             [EOF]
             ");
         }
         Shell::Zsh => {
-            insta::assert_snapshot!(output, @"
+            insta::assert_snapshot!(output, @r"
+            advance:Advance the closest bookmarks to a target revision
             create:Create a new bookmark
-            delete:Delete an existing bookmark and propagate the deletion to remotes on the next push
             [EOF]
             ");
         }
         Shell::Fish => {
-            insta::assert_snapshot!(output, @"
+            insta::assert_snapshot!(output, @r"
+            advance	Advance the closest bookmarks to a target revision
             create	Create a new bookmark
-            delete	Delete an existing bookmark and propagate the deletion to remotes on the next push
             [EOF]
             ");
         }


### PR DESCRIPTION
Adapted from #8345.

A common recommendation for new users is for them to add a `jj tug`
alias. This change makes that alias unnecessary by adding a native
version.

The command has customization points `revsets.advance-default-to`
and `revset-aliases.closest_bookmarks(to)` to adapt to different workflows.

The default target is `@` for parity with other bookmark commands.

Possible useful revsets to use can be found in https://github.com/jj-vcs/jj/discussions/5568#discussioncomment-12674748.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] ~I have updated the config schema (`cli/src/config-schema.json`)~
- [x] I have added/updated tests to cover my changes
