### PR TITLE
merge_tools: add weave entry

### DIFF
--- a/cli/src/config/merge_tools.toml
+++ b/cli/src/config/merge_tools.toml
@@ -101,3 +101,15 @@ conflict-marker-style = "git"
 diff-args=["--diff", "$left", "$right", "--wait"]
 diff-invocation-mode="file-by-file"
 edit-args = []
+
+[merge-tools.weave]
+# Entity-level semantic merge driver. Parses code into semantic entities
+# (functions, classes, interfaces, etc.) via tree-sitter and merges at
+# the entity level. Different entities changed = auto-resolved, no conflict.
+# https://github.com/Ataraxy-Labs/weave
+program = "weave-driver"
+merge-args = ["$base", "$left", "$right", "-o", "$output", "-l", "$marker_length", "-p", "$path"]
+merge-conflict-exit-codes = [1]
+# Non-interactive merge tool
+edit-args = []
+diff-args = []

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1568,6 +1568,7 @@ fn test_merge_tools() {
     vimdiff
     vscode
     vscodium
+    weave
     [EOF]
     ");
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1105,7 +1105,7 @@ by `jj resolve`. For example:
 ```toml
 [ui]
 # Use merge-tools.meld.merge-args
-merge-editor = "meld"  # Or "vscode" or "vscodium" or "kdiff3" or "vimdiff"
+merge-editor = "meld"  # Or "vscode" or "vscodium" or "kdiff3" or "vimdiff" or "weave"
 # Specify merge-args inline
 merge-editor = ["meld", "$left", "$base", "$right", "-o", "$output"]
 ```
@@ -1118,6 +1118,7 @@ The following tools can be used out of the box, as long as they are installed:
 - "vimdiff"
 - "vscode"
 - "vscodium"
+- "weave"
 
 Using VS Code as a merge tool works well with VS Code's [Remote
 Development](https://code.visualstudio.com/docs/remote/remote-overview)


### PR DESCRIPTION
Adds [weave](https://github.com/Ataraxy-Labs/weave) as a built-in merge tool configuration, alongside the existing mergiraf entry.

Weave is an entity-level semantic merge driver that parses code into semantic entities (functions, classes, interfaces, etc.) via tree-sitter, matches them across versions by identity, and merges at the entity level rather than the line level. It auto-resolves false conflicts where two sides modify different entities in the same file.

The configuration uses weave-driver's `-o`, `-l`, and `-p` flags which were added specifically for jj compatibility (jj writes to a separate `$output` file, while Git overwrites `%A` in place).

Install via `brew install ataraxy-labs/tap/weave` or `cargo install` from source.