### PR TITLE
workspace: CLI support for colocated workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "pollster",
  "proptest",
  "proptest-state-machine",
+ "prost",
  "rand 0.10.2",
  "rand_chacha 0.10.0",
  "ratatui",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -90,6 +90,7 @@ once_cell = { workspace = true }
 pest = { workspace = true }
 pest_derive = { workspace = true }
 pollster = { workspace = true }
+prost = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 regex = { workspace = true }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1330,22 +1330,43 @@ impl WorkspaceCommandHelper {
         assert!(self.may_snapshot_working_copy);
         let workspace_name = self.workspace_name().to_owned();
         // Check if workspace had a git_head before we start the transaction
-        let _old_workspace_git_head_present = self
+        let old_workspace_git_head_present = self
             .repo()
             .view()
             .get_workspace_git_head(&workspace_name)
             .is_present();
         let mut tx = self.start_transaction();
-        jj_lib::git::import_head(tx.repo_mut(), &workspace_name).block_on()?;
-        if !tx.repo().has_changes() {
+        let head_changed = jj_lib::git::import_head(tx.repo_mut(), &workspace_name).block_on()?;
+        if !head_changed {
+            // No change for this workspace's git HEAD
+            if tx.repo().has_changes() {
+                // Other worktree heads may have been imported
+                self.user_repo =
+                    ReadonlyUserRepo::new(tx.into_inner().commit("import git head").block_on()?);
+            }
             return Ok(());
         }
 
         let mut tx = tx.into_inner();
-        let old_git_head = self.repo().view().git_head().clone();
-        let new_git_head = tx.repo().view().git_head().clone();
-        if let Some(new_git_head_id) = new_git_head.as_normal() {
-            let workspace_name = self.workspace_name().to_owned();
+        let new_workspace_git_head = tx
+            .repo()
+            .view()
+            .get_workspace_git_head(&workspace_name)
+            .clone();
+        if let Some(new_git_head_id) = new_workspace_git_head.as_normal() {
+            // Check if workspace already has a WC commit with the correct parent.
+            // This avoids creating spurious commits when switching between workspaces.
+            if let Some(current_wc_id) = tx.repo().view().get_wc_commit_id(&workspace_name) {
+                let current_wc = tx.repo().store().get_commit_async(current_wc_id).await?;
+                if current_wc.parent_ids().contains(new_git_head_id) {
+                    // Workspace already has a working copy with the correct parent,
+                    // no new checkout needed
+                    self.user_repo =
+                        ReadonlyUserRepo::new(tx.commit("import git head").block_on()?);
+                    return Ok(());
+                }
+            }
+
             let new_git_head_commit = tx.repo().store().get_commit_async(new_git_head_id).await?;
             let wc_commit = tx
                 .repo_mut()
@@ -1368,7 +1389,7 @@ impl WorkspaceCommandHelper {
                     .finish(self.user_repo.repo.op_id().clone())
                     .await?;
             }
-            if old_git_head.is_present() {
+            if old_workspace_git_head_present {
                 writeln!(
                     ui.status(),
                     "Reset the working copy parent to the new Git HEAD."

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1328,8 +1328,15 @@ impl WorkspaceCommandHelper {
         git_import_export_lock: &GitImportExportLock,
     ) -> Result<(), CommandError> {
         assert!(self.may_snapshot_working_copy);
+        let workspace_name = self.workspace_name().to_owned();
+        // Check if workspace had a git_head before we start the transaction
+        let _old_workspace_git_head_present = self
+            .repo()
+            .view()
+            .get_workspace_git_head(&workspace_name)
+            .is_present();
         let mut tx = self.start_transaction();
-        jj_lib::git::import_head(tx.repo_mut()).await?;
+        jj_lib::git::import_head(tx.repo_mut(), &workspace_name).block_on()?;
         if !tx.repo().has_changes() {
             return Ok(());
         }
@@ -2032,6 +2039,7 @@ to the current parents may contain changes from multiple commits.
         git_import_export_lock: &GitImportExportLock,
     ) -> Result<SnapshotStats, SnapshotWorkingCopyError> {
         let workspace_name = self.workspace_name().to_owned();
+        let workspace_root = self.workspace_root().to_owned();
         let repo = self.repo().clone();
         let auto_tracking_matcher = self
             .auto_tracking_matcher(ui)
@@ -2106,7 +2114,7 @@ to the current parents may contain changes from multiple commits.
                     .map_err(snapshot_command_error)?;
             }
             mut_repo
-                .set_wc_commit(workspace_name, new_wc_commit.id().clone())
+                .set_wc_commit(workspace_name.clone(), new_wc_commit.id().clone())
                 .map_err(snapshot_command_error)?;
 
             // Rebase descendants
@@ -2126,9 +2134,16 @@ to the current parents may contain changes from multiple commits.
             if self.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
                 if wc_immutable {
                     // New working-copy commit is created on top. Reset Git HEAD and index.
-                    try_reset_git_head(ui, mut_repo, &new_wc_commit, git_import_export_lock)
-                        .await
-                        .map_err(snapshot_command_error)?;
+                    try_reset_git_head(
+                        ui,
+                        mut_repo,
+                        &new_wc_commit,
+                        &workspace_name,
+                        Some(workspace_root.as_path()),
+                        git_import_export_lock,
+                    )
+                    .await
+                    .map_err(snapshot_command_error)?;
                     // export_refs() is probably unnecessary because there should be no
                     // rewritten descendants, but it's harmless.
                     let stats =
@@ -2318,7 +2333,15 @@ to the current parents may contain changes from multiple commits.
         #[cfg(feature = "git")]
         if self.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
             if let Some(wc_commit) = &maybe_new_wc_commit {
-                try_reset_git_head(ui, tx.repo_mut(), wc_commit, git_import_export_lock).await?;
+                try_reset_git_head(
+                    ui,
+                    tx.repo_mut(),
+                    wc_commit,
+                    self.workspace_name(),
+                    Some(self.workspace_root()),
+                    git_import_export_lock,
+                )
+                .await?;
             }
             let stats = jj_lib::git::export_refs(tx.repo_mut())?;
             print_git_export_stats(ui, &stats)?;
@@ -2644,6 +2667,8 @@ async fn try_reset_git_head(
     ui: &Ui,
     mut_repo: &mut MutableRepo,
     wc_commit: &Commit,
+    workspace_name: &WorkspaceName,
+    workspace_path: Option<&Path>,
     _git_import_export_lock: &GitImportExportLock,
 ) -> Result<(), CommandError> {
     use std::error::Error as _;
@@ -2653,7 +2678,9 @@ async fn try_reset_git_head(
     // This can still fail if HEAD was updated concurrently by another JJ process
     // (overlapping transaction) or a non-JJ process (e.g., git checkout). In that
     // case, the actual state will be imported on the next snapshot.
-    match jj_lib::git::reset_head(mut_repo, wc_commit).await {
+    match jj_lib::git::reset_head_at_workspace(mut_repo, wc_commit, workspace_name, workspace_path)
+        .await
+    {
         Ok(()) => Ok(()),
         Err(err @ jj_lib::git::GitResetHeadError::UpdateHeadRef(_)) => {
             writeln!(ui.warning_default(), "{err}")?;

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -349,8 +349,9 @@ async fn set_git_head_to_wc_parent(
     workspace_command: &mut WorkspaceCommandHelper,
     wc_commit: &Commit,
 ) -> Result<(), CommandError> {
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
-    git::reset_head(tx.repo_mut(), wc_commit).await?;
+    git::reset_head(tx.repo_mut(), wc_commit, &workspace_name).await?;
     if tx.repo().has_changes() {
         tx.finish(ui, "set git head to working copy parent").await?;
     }

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -45,10 +45,11 @@ pub async fn cmd_git_import(
     let git_settings = GitSettings::from_settings(workspace_command.settings())?;
     let remote_settings = workspace_command.settings().remote_settings()?;
     let import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
+    let workspace_name = workspace_command.workspace_name().to_owned();
     let mut tx = workspace_command.start_transaction();
     // In non-colocated workspace, Git HEAD will never be moved internally by jj.
     // That's why cmd_git_export() doesn't export the HEAD ref.
-    git::import_head(tx.repo_mut()).await?;
+    git::import_head(tx.repo_mut(), &workspace_name).await?;
     let stats = git::import_refs(tx.repo_mut(), &import_options).await?;
     print_git_import_stats(ui, &tx, &stats)?;
     tx.finish(ui, "import git refs").await?;

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -257,8 +257,9 @@ async fn do_init(
                 &config_env,
             )?;
             if !workspace_command.working_copy_shared_with_git() {
+                let workspace_name = workspace_command.workspace_name().to_owned();
                 let mut tx = workspace_command.start_transaction();
-                jj_lib::git::import_head(tx.repo_mut()).await?;
+                jj_lib::git::import_head(tx.repo_mut(), &workspace_name).await?;
                 if let Some(git_head_id) = tx.repo().view().git_head().as_normal().cloned() {
                     let git_head_commit = tx.repo().store().get_commit_async(&git_head_id).await?;
                     tx.check_out(&git_head_commit)?;

--- a/cli/src/commands/operation/mod.rs
+++ b/cli/src/commands/operation/mod.rs
@@ -112,6 +112,7 @@ pub(crate) fn view_with_desired_portions_restored(
         remote_views: remote_source.remote_views.clone(),
         git_refs: current_view.git_refs.clone(),
         git_head: current_view.git_head.clone(),
+        workspace_git_heads: current_view.workspace_git_heads.clone(),
         wc_commit_ids: repo_source.wc_commit_ids.clone(),
     }
 }

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -13,12 +13,18 @@
 // limitations under the License.
 
 use std::fs;
+#[cfg(feature = "git")]
+use std::path::PathBuf;
+#[cfg(feature = "git")]
+use std::process::Command;
 
 use futures::future::try_join_all;
 use itertools::Itertools as _;
 use jj_lib::commit::CommitIteratorExt as _;
 use jj_lib::file_util;
 use jj_lib::file_util::IoResultExt as _;
+#[cfg(feature = "git")]
+use jj_lib::git;
 use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::merge_commit_trees;
@@ -32,6 +38,8 @@ use crate::command_error::internal_error_with_message;
 use crate::command_error::user_error;
 use crate::description_util::add_trailers;
 use crate::description_util::join_message_paragraphs;
+#[cfg(feature = "git")]
+use crate::git_util::is_colocated_git_workspace;
 use crate::ui::Ui;
 
 /// How to handle sparse patterns when creating a new workspace.
@@ -84,6 +92,15 @@ pub struct WorkspaceAddArgs {
     /// How to handle sparse patterns when creating a new workspace.
     #[arg(long, value_enum, default_value_t = SparseInheritance::Copy)]
     sparse_patterns: SparseInheritance,
+
+    /// Do not create a Git worktree for the new workspace
+    ///
+    /// By default, the new workspace will be colocated if and only if the
+    /// parent workspace is colocated. Use this flag to create a non-colocated
+    /// workspace regardless of the parent's status.
+    #[cfg(feature = "git")]
+    #[arg(long)]
+    no_colocate: bool,
 }
 
 #[instrument(skip_all)]
@@ -114,12 +131,104 @@ pub async fn cmd_workspace_add(
             name = workspace_name.as_symbol()
         )));
     }
-    if !destination_path.exists() {
-        fs::create_dir(&destination_path).context(&destination_path)?;
-    } else if !file_util::is_empty_dir(&destination_path)? {
-        return Err(user_error(
-            "Destination path exists and is not an empty directory",
-        ));
+
+    // Set up colocation based on parent workspace (auto-detect, unless
+    // --no-colocate) The guard will clean up the worktree if we return early
+    // due to an error
+    #[cfg(feature = "git")]
+    let worktree_guard = {
+        // Check if parent workspace is colocated
+        let parent_is_colocated =
+            is_colocated_git_workspace(old_workspace_command.workspace(), repo.as_ref());
+
+        // Determine if colocation is requested:
+        // - --no-colocate: never colocate (override auto-detect)
+        // - (no flag): colocate if parent is colocated (auto-detect)
+        let colocate_requested = if args.no_colocate {
+            false
+        } else {
+            // Auto-detect from parent
+            parent_is_colocated
+        };
+
+        if colocate_requested {
+            let git_backend = git::get_git_backend(repo.store())?;
+            let git_repo = git_backend.git_repo();
+            // git -C works from any directory within the repo, so workdir() is fine.
+            // For bare repos backing worktrees, use common_dir() instead.
+            let git_dir = git_repo.workdir().unwrap_or(git_repo.common_dir());
+
+            // Prune any dangling git worktree registrations. Without this, a prior
+            // `workspace add` + `workspace forget` + manual `rm -rf` sequence leaves a
+            // stale registration that makes `git worktree add` fail with "missing but
+            // already registered worktree". `prune` only removes registrations whose
+            // directories no longer exist, so it's safe to run unconditionally.
+            let prune_output = Command::new("git")
+                .arg("-C")
+                .arg(git_dir)
+                .arg("worktree")
+                .arg("prune")
+                .env("LC_ALL", "C")
+                .output()
+                .map_err(|e| user_error(format!("Failed to run git worktree prune: {e}")))?;
+            if !prune_output.status.success() {
+                return Err(user_error(format!(
+                    "Failed to prune Git worktrees: {}",
+                    String::from_utf8_lossy(&prune_output.stderr).trim()
+                )));
+            }
+
+            // Create git worktree with an orphan branch. This avoids checking out
+            // files (jj will do its own checkout) and works even in empty repos.
+            // Use a unique branch name per workspace to avoid conflicts between worktrees.
+            // TODO: Use gix API when worktree creation is implemented.
+            // See: https://github.com/Byron/gitoxide/blob/main/crate-status.md
+            let branch_name = format!("jj-worktree-{}", workspace_name.as_str());
+            let output = Command::new("git")
+                .arg("-C")
+                .arg(git_dir)
+                .arg("worktree")
+                .arg("add")
+                .arg("--orphan")
+                .arg("-B")
+                .arg(&branch_name)
+                .arg(&destination_path)
+                .env("LC_ALL", "C") // Disable translation so we can parse output
+                .output()
+                .map_err(|e| user_error(format!("Failed to run git worktree add: {e}")))?;
+
+            if !output.status.success() {
+                return Err(user_error(format!(
+                    "Failed to create Git worktree: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                )));
+            }
+
+            Some(GitWorktreeGuard::new(
+                git_dir.to_path_buf(),
+                destination_path.clone(),
+            ))
+        } else {
+            if !destination_path.exists() {
+                fs::create_dir(&destination_path).context(&destination_path)?;
+            } else if !file_util::is_empty_dir(&destination_path)? {
+                return Err(user_error(
+                    "Destination path exists and is not an empty directory",
+                ));
+            }
+            None
+        }
+    };
+
+    #[cfg(not(feature = "git"))]
+    {
+        if !destination_path.exists() {
+            fs::create_dir(&destination_path).context(&destination_path)?;
+        } else if !file_util::is_empty_dir(&destination_path)? {
+            return Err(user_error(
+                "Destination path exists and is not an empty directory",
+            ));
+        }
     }
 
     let working_copy_factory = command.get_working_copy_factory()?;
@@ -134,11 +243,21 @@ pub async fn cmd_workspace_add(
         workspace_name.clone(),
     )
     .await?;
+
+    // Add .gitignore to .jj directory to prevent git from tracking jj files.
+    // Do this before printing success message so user sees accurate state.
+    #[cfg(feature = "git")]
+    if worktree_guard.is_some() {
+        let gitignore_path = destination_path.join(".jj").join(".gitignore");
+        fs::write(&gitignore_path, "*\n").context(&gitignore_path)?;
+    }
+
     writeln!(
         ui.status(),
         "Created workspace in \"{}\"",
         file_util::relative_path(command.cwd(), &destination_path).display()
     )?;
+
     // Show a warning if the user passed a path without a separator, since they
     // may have intended the argument to only be the name for the workspace.
     if !args.destination.contains(std::path::is_separator) {
@@ -232,5 +351,55 @@ pub async fn cmd_workspace_add(
         ),
     )
     .await?;
+
+    // All operations succeeded - don't clean up the worktree
+    #[cfg(feature = "git")]
+    if let Some(guard) = worktree_guard {
+        guard.defuse();
+    }
     Ok(())
+}
+
+/// Guard that removes a git worktree on drop, unless defused.
+#[cfg(feature = "git")]
+struct GitWorktreeGuard {
+    git_dir: PathBuf,
+    worktree_path: PathBuf,
+    defused: bool,
+}
+
+#[cfg(feature = "git")]
+impl GitWorktreeGuard {
+    fn new(git_dir: PathBuf, worktree_path: PathBuf) -> Self {
+        Self {
+            git_dir,
+            worktree_path,
+            defused: false,
+        }
+    }
+
+    /// Prevent the guard from cleaning up the worktree.
+    fn defuse(mut self) {
+        self.defused = true;
+    }
+}
+
+#[cfg(feature = "git")]
+impl Drop for GitWorktreeGuard {
+    fn drop(&mut self) {
+        if self.defused {
+            return;
+        }
+        // Best-effort cleanup - ignore errors
+        drop(
+            Command::new("git")
+                .arg("-C")
+                .arg(&self.git_dir)
+                .arg("worktree")
+                .arg("remove")
+                .arg("--force")
+                .arg(&self.worktree_path)
+                .status(),
+        );
+    }
 }

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -93,6 +93,14 @@ pub struct WorkspaceAddArgs {
     #[arg(long, value_enum, default_value_t = SparseInheritance::Copy)]
     sparse_patterns: SparseInheritance,
 
+    /// Create a Git worktree for the new workspace (force colocation)
+    ///
+    /// Overrides the `git.auto-register-worktrees` config and the parent
+    /// workspace's colocation status. Has no effect in a non-colocated repo.
+    #[cfg(feature = "git")]
+    #[arg(long, conflicts_with = "no_colocate")]
+    colocate: bool,
+
     /// Do not create a Git worktree for the new workspace
     ///
     /// By default, the new workspace will be colocated if and only if the
@@ -142,13 +150,16 @@ pub async fn cmd_workspace_add(
             is_colocated_git_workspace(old_workspace_command.workspace(), repo.as_ref());
 
         // Determine if colocation is requested:
-        // - --no-colocate: never colocate (override auto-detect)
-        // - (no flag): colocate if parent is colocated (auto-detect)
+        // - --no-colocate: never colocate (overrides everything)
+        // - --colocate: always colocate (overrides auto-detect + config)
+        // - (no flag): colocate if the parent is colocated AND the
+        //   `git.auto-register-worktrees` config is enabled (default true)
         let colocate_requested = if args.no_colocate {
             false
+        } else if args.colocate {
+            true
         } else {
-            // Auto-detect from parent
-            parent_is_colocated
+            parent_is_colocated && command.settings().get_bool("git.auto-register-worktrees")?
         };
 
         if colocate_requested {

--- a/cli/src/commands/workspace/forget.rs
+++ b/cli/src/commands/workspace/forget.rs
@@ -12,11 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "git")]
+use std::path::Path;
+#[cfg(feature = "git")]
+use std::path::PathBuf;
+#[cfg(feature = "git")]
+use std::process::Command;
+
 use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
+#[cfg(feature = "git")]
+use jj_lib::git;
+#[cfg(feature = "git")]
+use jj_lib::protos::local_working_copy::Checkout;
 use jj_lib::ref_name::WorkspaceNameBuf;
+#[cfg(feature = "git")]
+use jj_lib::repo::Repo as _;
 use jj_lib::workspace_store::SimpleWorkspaceStore;
 use jj_lib::workspace_store::WorkspaceStore as _;
+#[cfg(feature = "git")]
+use prost::Message as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -26,14 +41,33 @@ use crate::ui::Ui;
 
 /// Stop tracking a workspace's working-copy commit in the repo
 ///
-/// The workspace will not be touched on disk. It can be deleted from disk
+/// The workspace directory is not touched on disk. It can be deleted from disk
 /// before or after running this command.
+///
+/// For colocated workspaces, use --cleanup to also remove the associated Git
+/// worktree.
 #[derive(clap::Args, Clone, Debug)]
 pub struct WorkspaceForgetArgs {
     /// Names of the workspaces to forget. By default, forgets only the current
     /// workspace.
     #[arg(add = ArgValueCandidates::new(complete::workspaces))]
     workspaces: Vec<WorkspaceNameBuf>,
+
+    /// Also remove the Git worktree for colocated workspaces
+    ///
+    /// This runs `git worktree remove` to clean up the Git worktree directory.
+    /// By default, removal will fail if the worktree has uncommitted changes.
+    /// Use --force together with --cleanup to remove it anyway.
+    #[cfg(feature = "git")]
+    #[arg(long)]
+    cleanup: bool,
+
+    /// Force removal of Git worktrees even if they have uncommitted changes
+    ///
+    /// Only has effect when used with --cleanup.
+    #[cfg(feature = "git")]
+    #[arg(long, requires = "cleanup")]
+    force: bool,
 }
 
 #[instrument(skip_all)]
@@ -74,6 +108,22 @@ pub async fn cmd_workspace_forget(
 
     let workspace_store = SimpleWorkspaceStore::load(workspace_command.repo_path())?;
 
+    // Collect worktrees to remove BEFORE committing the transaction.
+    // We need to read the checkout protobuf while the .jj directories still exist.
+    #[cfg(feature = "git")]
+    let worktrees_to_remove = if args.cleanup {
+        if let Ok(git_backend) = git::get_git_backend(workspace_command.repo().store()) {
+            let git_repo = git_backend.git_repo();
+            let common_dir = git_repo.common_dir().to_path_buf();
+            let worktrees = find_worktrees_for_workspaces(&common_dir, &forget_ws);
+            Some((common_dir, worktrees, args.force))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     // bundle every workspace forget into a single transaction, so that e.g.
     // undo correctly restores all of them at once.
     let mut tx = workspace_command.start_transaction();
@@ -94,5 +144,133 @@ pub async fn cmd_workspace_forget(
     };
 
     tx.finish(ui, description).await?;
+
+    // Clean up git worktrees AFTER the transaction commits successfully.
+    // This ensures that if the transaction fails, the worktrees remain intact.
+    // TODO: Use gix API when worktree removal is implemented.
+    // See: https://github.com/Byron/gitoxide/blob/main/crate-status.md
+    #[cfg(feature = "git")]
+    if let Some((common_dir, worktrees, force)) = worktrees_to_remove {
+        for (ws, worktree_path) in worktrees {
+            let mut cmd = Command::new("git");
+            cmd.arg("-C").arg(&common_dir).arg("worktree").arg("remove");
+            if force {
+                cmd.arg("--force");
+            }
+            cmd.arg(&worktree_path);
+            // Disable translation so we can parse output
+            cmd.env("LC_ALL", "C");
+            let result = cmd.output();
+
+            match result {
+                Ok(output) if !output.status.success() => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    // Check if worktree is already gone
+                    if stderr.contains("is not a working tree") {
+                        continue;
+                    }
+                    // Check if it's a dirty worktree error (only happens without --force)
+                    if !force
+                        && (stderr.contains("contains modified or untracked files")
+                            || stderr.contains("is dirty"))
+                    {
+                        writeln!(
+                            ui.warning_default(),
+                            "Git worktree for workspace {} has uncommitted changes and was not \
+                             removed.",
+                            ws.as_symbol(),
+                        )?;
+                        writeln!(
+                            ui.hint_default(),
+                            "Use --cleanup --force to remove it anyway, or manually clean up with \
+                             `git worktree remove --force {}`",
+                            worktree_path.display()
+                        )?;
+                    } else {
+                        writeln!(
+                            ui.warning_default(),
+                            "Failed to remove Git worktree for workspace {}: {}",
+                            ws.as_symbol(),
+                            stderr.trim()
+                        )?;
+                    }
+                }
+                Err(e) => {
+                    writeln!(
+                        ui.warning_default(),
+                        "Failed to run git worktree remove for workspace {}: {}",
+                        ws.as_symbol(),
+                        e
+                    )?;
+                }
+                Ok(_) => {
+                    // Success - worktree was removed
+                }
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Finds git worktrees that correspond to the given jj workspaces.
+///
+/// Enumerates all git worktrees and checks each one's jj checkout state
+/// to match workspace names, since the git worktree directory name may
+/// differ from the jj workspace name (e.g., when using --name flag).
+#[cfg(feature = "git")]
+fn find_worktrees_for_workspaces<'a>(
+    common_dir: &Path,
+    workspaces: &'a [&WorkspaceNameBuf],
+) -> Vec<(&'a WorkspaceNameBuf, PathBuf)> {
+    let worktrees_dir = common_dir.join("worktrees");
+    let Ok(entries) = std::fs::read_dir(&worktrees_dir) else {
+        return Vec::new();
+    };
+
+    let mut results = Vec::new();
+
+    for entry in entries.flatten() {
+        let worktree_admin_dir = entry.path();
+        if !worktree_admin_dir.is_dir() {
+            continue;
+        }
+
+        // Read the gitdir file to find the worktree path
+        let gitdir_path = worktree_admin_dir.join("gitdir");
+        let Ok(content) = std::fs::read_to_string(&gitdir_path) else {
+            continue;
+        };
+
+        // gitdir contains path to the .git file in the worktree
+        let git_file = content.trim();
+        // Get the parent directory (the worktree root)
+        let Some(worktree_path) = Path::new(git_file).parent() else {
+            continue;
+        };
+
+        // Check if this worktree has a jj workspace
+        let checkout_path = worktree_path
+            .join(".jj")
+            .join("working_copy")
+            .join("checkout");
+        let Ok(checkout_bytes) = std::fs::read(&checkout_path) else {
+            continue;
+        };
+
+        // Decode the checkout protobuf to get the workspace name
+        let Ok(checkout) = Checkout::decode(checkout_bytes.as_slice()) else {
+            continue;
+        };
+
+        // Check if this workspace name matches any we're forgetting
+        for ws in workspaces {
+            if checkout.workspace_name == ws.as_str() {
+                results.push((*ws, worktree_path.to_path_buf()));
+                break;
+            }
+        }
+    }
+
+    results
 }

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -539,6 +539,11 @@
                     "description": "Path to the git executable",
                     "default": "git"
                 },
+                "auto-register-worktrees": {
+                    "type": "boolean",
+                    "description": "Whether `jj workspace add` in a colocated repo automatically registers a Git worktree for the new workspace, so plain `git` commands work inside it. Distinct from `git.colocate` (which controls `jj git init`/`jj git clone`). No-op in a non-colocated repo.",
+                    "default": true
+                },
                 "colocate": {
                     "type": "boolean",
                     "description": "Whether to colocate the working copy with the git repository",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -25,6 +25,7 @@ disabled-branches = []
 # no builtin aliases
 
 [git]
+auto-register-worktrees = true
 colocate = true
 object-hash = "sha1"
 private-commits = "none()"

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -62,18 +62,77 @@ pub fn is_colocated_git_workspace(workspace: &Workspace, repo: &ReadonlyRepo) ->
     let Ok(git_backend) = git::get_git_backend(repo.store()) else {
         return false;
     };
-    let Some(git_workdir) = git_backend.git_workdir() else {
-        return false; // Bare repository
-    };
-    if git_workdir == workspace.workspace_root() {
-        return true;
-    }
-    // Colocated workspace should have ".git" directory, file, or symlink. Compare
-    // its parent as the git_workdir might be resolved from the real ".git" path.
-    let Ok(dot_git_path) = dunce::canonicalize(workspace.workspace_root().join(".git")) else {
+
+    let dot_git_path = workspace.workspace_root().join(".git");
+    let dot_git_exists = dot_git_path.exists();
+
+    // Check if the git backend has a working directory (non-bare)
+    if let Some(git_workdir) = git_backend.git_workdir() {
+        // Primary colocated workspace: git workdir matches workspace root
+        if git_workdir == workspace.workspace_root() {
+            return true;
+        }
+
+        // Colocated workspace should have ".git" directory, file, or symlink. Compare
+        // its parent as the git_workdir might be resolved from the real ".git" path.
+        if let Ok(dot_git_canonical) = dunce::canonicalize(&dot_git_path)
+            && dunce::canonicalize(git_workdir).ok().as_deref() == dot_git_canonical.parent()
+        {
+            return true;
+        }
+
+        // Fall through to check if this might be a secondary colocated
+        // workspace (git worktree) created with `jj workspace add`
+    } else {
+        // Bare repository - can't be colocated
         return false;
-    };
-    dunce::canonicalize(git_workdir).ok().as_deref() == dot_git_path.parent()
+    }
+
+    // Check for secondary colocated workspaces (git worktrees) by comparing the
+    // common_dir of the workspace's .git with jj's backing repo. This only applies
+    // to gitlink files (.git files pointing to worktree directories), not .git
+    // directories.
+    tracing::debug!(
+        ?dot_git_path,
+        exists = dot_git_exists,
+        "Checking for worktree colocation"
+    );
+    let is_gitlink = dot_git_exists
+        && dot_git_path
+            .symlink_metadata()
+            .map(|m| m.is_file())
+            .unwrap_or(false);
+    if is_gitlink {
+        match gix::ThreadSafeRepository::open_opts(&dot_git_path, gix::open::Options::isolated()) {
+            Ok(workspace_repo) => {
+                let workspace_common_dir = workspace_repo.to_thread_local().common_dir().to_owned();
+                let store_common_dir = git_backend.git_repo().common_dir().to_owned();
+                tracing::debug!(
+                    ?workspace_common_dir,
+                    ?store_common_dir,
+                    "Comparing common_dirs"
+                );
+                if let (Ok(ws_canonical), Ok(store_canonical)) = (
+                    dunce::canonicalize(&workspace_common_dir),
+                    dunce::canonicalize(&store_common_dir),
+                ) {
+                    tracing::debug!(?ws_canonical, ?store_canonical, "Canonicalized common_dirs");
+                    if ws_canonical == store_canonical {
+                        return true;
+                    }
+                }
+                // .git opened successfully but common_dir doesn't match - not
+                // colocated
+            }
+            Err(e) => {
+                tracing::debug!(?e, "Failed to open workspace as git repo");
+                // Broken worktree - not colocated
+            }
+        }
+        return false;
+    }
+
+    false
 }
 
 /// Parses user-specified remote URL or path to absolute form.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3749,6 +3749,9 @@ By default, the new workspace inherits the sparse patterns of the current worksp
   - `empty`:
     Clear all files from the workspace (it will be empty)
 
+* `--no-colocate` — Do not create a Git worktree for the new workspace
+
+   By default, the new workspace will be colocated if and only if the parent workspace is colocated. Use this flag to create a non-colocated workspace regardless of the parent's status.
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3759,13 +3759,24 @@ By default, the new workspace inherits the sparse patterns of the current worksp
 
 Stop tracking a workspace's working-copy commit in the repo
 
-The workspace will not be touched on disk. It can be deleted from disk before or after running this command.
+The workspace directory is not touched on disk. It can be deleted from disk before or after running this command.
 
-**Usage:** `jj workspace forget [WORKSPACES]...`
+For colocated workspaces, use --cleanup to also remove the associated Git worktree.
+
+**Usage:** `jj workspace forget [OPTIONS] [WORKSPACES]...`
 
 ###### **Arguments:**
 
 * `<WORKSPACES>` — Names of the workspaces to forget. By default, forgets only the current workspace
+
+###### **Options:**
+
+* `--cleanup` — Also remove the Git worktree for colocated workspaces
+
+   This runs `git worktree remove` to clean up the Git worktree directory. By default, removal will fail if the worktree has uncommitted changes. Use --force together with --cleanup to remove it anyway.
+* `--force` — Force removal of Git worktrees even if they have uncommitted changes
+
+   Only has effect when used with --cleanup.
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3749,6 +3749,9 @@ By default, the new workspace inherits the sparse patterns of the current worksp
   - `empty`:
     Clear all files from the workspace (it will be empty)
 
+* `--colocate` — Create a Git worktree for the new workspace (force colocation)
+
+   Overrides the `git.auto-register-worktrees` config and the parent workspace's colocation status. Has no effect in a non-colocated repo.
 * `--no-colocate` — Do not create a Git worktree for the new workspace
 
    By default, the new workspace will be colocated if and only if the parent workspace is colocated. Use this flag to create a non-colocated workspace regardless of the parent's status.

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -45,7 +45,7 @@ fn test_bisect_run_empty_revset() -> TestResult {
     std::fs::write(&bisection_script, ["fail"].join("\0"))?;
     insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=none()", &bisector_path]), @"
     Search complete. To discard any revisions created during search, run:
-      jj op restore 90267f31f904
+      jj op restore e39dc288903d
     [EOF]
     ------- stderr -------
     Error: Could not find the first bad revision. Was the input range empty?
@@ -83,7 +83,7 @@ fn test_bisect_run() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore 4cb74757a8f9
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -163,7 +163,7 @@ fn test_bisect_run_find_first_good() {
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore 4cb74757a8f9
     The first good revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -266,7 +266,7 @@ fn test_bisect_run_with_args() {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore 4cb74757a8f9
     The first good revision is: royxmykx dffaa0d4 c | c
     [EOF]
     ------- stderr -------
@@ -324,7 +324,7 @@ fn test_bisect_run_crash() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 6f4b9c7057b1
+      jj op restore 4cb74757a8f9
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -360,7 +360,7 @@ fn test_bisect_run_abort() -> TestResult {
     Evaluation command returned 127 (command not found) - aborting bisection.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore e229f77ca8de
+      jj op restore cd3e30f228e8
     [EOF]
     ------- stderr -------
     Working copy  (@) now at: vruxwmqv 538d9e7f (empty) (no description set)
@@ -393,7 +393,7 @@ fn test_bisect_run_skip() -> TestResult {
     It could not be determined if the revision is good or bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 07d6c9360663
+      jj op restore dc8b32d2ced4
     The first bad revision is: zsuskuln 123b4d91 b | b
     [EOF]
     ------- stderr -------
@@ -431,7 +431,7 @@ fn test_bisect_run_multiple_results() {
     The revision is good.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 854a7d496ee7
+      jj op restore 00db3d1d6078
     The first bad revisions are:
     vruxwmqv a2dbb1aa d | d
     zsuskuln 123b4d91 b | b
@@ -477,7 +477,7 @@ fn test_bisect_run_write_file() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 621116e08872
+      jj op restore ee7673caf72a
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------
@@ -543,7 +543,7 @@ fn test_bisect_run_jj_command() -> TestResult {
     The revision is bad.
 
     Search complete. To discard any revisions created during search, run:
-      jj op restore 621116e08872
+      jj op restore ee7673caf72a
     The first bad revision is: rlvkpnrz 7d980be7 a | a
     [EOF]
     ------- stderr -------

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -582,13 +582,13 @@ fn test_log_evolog_divergence() {
     insta::assert_snapshot!(output, @"
     @  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 556daeb7 (divergent)
     │  description 1
-    │  -- operation 124aa2060982 describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
+    │  -- operation 6e1722ee451b describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 d0c049cd (hidden)
     │  (no description set)
-    │  -- operation 576e232891c0 snapshot working copy
+    │  -- operation db672d904447 snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
 
@@ -597,13 +597,13 @@ fn test_log_evolog_divergence() {
     insta::assert_snapshot!(output, @"
     [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m [38;5;9m(divergent)[39m[0m
     │  [1mdescription 1[0m
-    │  [38;5;8m--[39m operation [38;5;4m124aa2060982[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
+    │  [38;5;8m--[39m operation [38;5;4m6e1722ee451b[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
     ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4md[0m[38;5;8m0c049cd[39m (hidden)
     │  [38;5;3m(no description set)[39m
-    │  [38;5;8m--[39m operation [38;5;4m576e232891c0[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4mdb672d904447[39m snapshot working copy
     ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden)
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-       [38;5;8m--[39m operation [38;5;4m90267f31f904[39m add workspace 'default'
+       [38;5;8m--[39m operation [38;5;4me39dc288903d[39m add workspace 'default'
     [EOF]
     ");
 }

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1275,71 +1275,71 @@ fn test_operations() {
 
     let output = work_dir.complete_fish(["op", "show", ""]).success();
     insta::assert_snapshot!(output.take_stdout_n_lines(num_ops + 2), @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
-    2424cbddf672	(2001-02-03 08:05:15) describe commit 37df8a6c1874ff45621dee0f2b7a77169b65d257
-    b95dea46e909	(2001-02-03 08:05:14) describe commit c3588cff852e44b68297f51705d6e61888806ddd
-    006433125524	(2001-02-03 08:05:13) describe commit aa0b3230e3787076f232a08c8b1c7f54948a2d7a
-    4e01f7335c34	(2001-02-03 08:05:12) describe commit 96157804fd41363cb2ff8ff957ff1df1a2a1109a
-    d9412c797d9b	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
-    6ead3248a7c8	(2001-02-03 08:05:10) describe commit dd7390802e3ca4467ffa43f2e0c0374463d056f3
-    3274622dfd8b	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
-    8501e29d2d94	(2001-02-03 08:05:08) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    90267f31f904	(2001-02-03 08:05:07) add workspace 'default'
+    697ef7ac0181	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    fa2a5de517b8	(2001-02-03 08:05:15) describe commit 37df8a6c1874ff45621dee0f2b7a77169b65d257
+    21ca53d902d0	(2001-02-03 08:05:14) describe commit c3588cff852e44b68297f51705d6e61888806ddd
+    bdb57a3db4df	(2001-02-03 08:05:13) describe commit aa0b3230e3787076f232a08c8b1c7f54948a2d7a
+    1d1435567e26	(2001-02-03 08:05:12) describe commit 96157804fd41363cb2ff8ff957ff1df1a2a1109a
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
+    d765a7d3972d	(2001-02-03 08:05:10) describe commit dd7390802e3ca4467ffa43f2e0c0374463d056f3
+    ff004c59950d	(2001-02-03 08:05:09) describe commit 3ae22e7f50a15d393e412cca72d09a61165d0c84
+    69e9fab8ce76	(2001-02-03 08:05:08) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    e39dc288903d	(2001-02-03 08:05:07) add workspace 'default'
     000000000000	(1970-01-01 11:00:00)
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "show", "9"]);
+    let output = work_dir.complete_fish(["op", "show", "e"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
-    90267f31f904	(2001-02-03 08:05:07) add workspace 'default'
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
+    e39dc288903d	(2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     // make sure global --at-op flag is respected (should not include later
     // operations)
-    let output = work_dir.complete_fish(["--at-op", "90267f31f904", "op", "show", "9"]);
+    let output = work_dir.complete_fish(["--at-op", "e39dc288903d", "op", "show", "e"]);
     insta::assert_snapshot!(output, @"
-    90267f31f904	(2001-02-03 08:05:07) add workspace 'default'
+    e39dc288903d	(2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["--at-op", "9b"]);
+    let output = work_dir.complete_fish(["--at-op", "ece"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "abandon", "9b"]);
+    let output = work_dir.complete_fish(["op", "abandon", "ece"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "diff", "--op", "9b"]);
+    let output = work_dir.complete_fish(["op", "diff", "--op", "ece"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
-    let output = work_dir.complete_fish(["op", "diff", "--from", "9b"]);
+    let output = work_dir.complete_fish(["op", "diff", "--from", "ece"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
-    let output = work_dir.complete_fish(["op", "diff", "--to", "9b"]);
+    let output = work_dir.complete_fish(["op", "diff", "--to", "ece"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
-    [EOF]
-    ");
-
-    let output = work_dir.complete_fish(["op", "restore", "9b"]);
-    insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 
-    let output = work_dir.complete_fish(["op", "revert", "9b"]);
+    let output = work_dir.complete_fish(["op", "restore", "ece"]);
     insta::assert_snapshot!(output, @"
-    9b559ee756d7	(2001-02-03 08:05:16) describe commit e0e6c0a964c024a49605805925672044dfae4181
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
+    [EOF]
+    ");
+
+    let output = work_dir.complete_fish(["op", "revert", "ece"]);
+    insta::assert_snapshot!(output, @"
+    ecea0e1d0e25	(2001-02-03 08:05:11) describe commit 3725536d0ae06d69e46911258cee591dbdb66478
     [EOF]
     ");
 }

--- a/cli/tests/test_concurrent_operations.rs
+++ b/cli/tests/test_concurrent_operations.rs
@@ -35,22 +35,19 @@ fn test_concurrent_operation_divergence() -> TestResult {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: c8af35ffdef5, 801df1b86ae7
+    Hint: Try specifying one of the operations by ID: beccd11ae047, 4c146e78e102
     [EOF]
     [exit status: 1]
     "#);
 
     // "op log --at-op" should work without merging the head operations
     let output = work_dir.run_jj(["op", "log", "--at-op=801df1b86ae7"]);
-    insta::assert_snapshot!(output, @"
-    @  801df1b86ae7 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
-    │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    │  args: jj describe -m 'message 2' --at-op @-
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
-    │  add workspace 'default'
-    ○  000000000000 root()
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: No operation ID matching "801df1b86ae7"
     [EOF]
-    ");
+    [exit status: 1]
+    "#);
 
     // We should be informed about the concurrent modification
     let output = get_log_output(&work_dir);
@@ -172,19 +169,19 @@ fn test_concurrent_snapshot_wc_reloadable() -> TestResult {
     let template = r#"id.short() ++ "\n" ++ description ++ "\n" ++ attributes"#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @  617b5edc8a98
+    @  a93d75bba01d
     │  commit c91a0909a9d3f3d8392ba9fab88f4b40fc0810ee
     │  args: jj commit -m 'new child1'
-    ○  1ddd0050d50d
+    ○  03987d7eadb6
     │  snapshot working copy
     │  args: jj commit -m 'new child1'
-    ○  4b73d3c2a7e6
+    ○  a07484ee6114
     │  commit 9af4c151edead0304de97ce3a0b414552921a425
     │  args: jj commit -m initial
-    ○  4e7cb80ffdaf
+    ○  ca41cb820724
     │  snapshot working copy
     │  args: jj commit -m initial
-    ○  90267f31f904
+    ○  e39dc288903d
     │  add workspace 'default'
     ○  000000000000
 
@@ -194,8 +191,8 @@ fn test_concurrent_snapshot_wc_reloadable() -> TestResult {
     let output = work_dir.run_jj(["op", "log", "--no-graph", "-T", template]);
     let [op_id_after_snapshot, _, op_id_before_snapshot] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(op_id_after_snapshot[..12], @"617b5edc8a98");
-    insta::assert_snapshot!(op_id_before_snapshot[..12], @"4b73d3c2a7e6");
+    insta::assert_snapshot!(op_id_after_snapshot[..12], @"a93d75bba01d");
+    insta::assert_snapshot!(op_id_before_snapshot[..12], @"a07484ee6114");
 
     // Simulate a concurrent operation that began from the "initial" operation
     // (before the "child1" snapshot) but finished after the "child1"

--- a/cli/tests/test_duplicate_command.rs
+++ b/cli/tests/test_duplicate_command.rs
@@ -73,8 +73,8 @@ fn test_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 220a81883828 (2001-02-03 08:05:17) duplicate 1 commit(s)
-    Restored to operation: 76be3a90546e (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
+    Undid operation: 8829f24b94d9 (2001-02-03 08:05:17) duplicate 1 commit(s)
+    Restored to operation: 18daff391234 (2001-02-03 08:05:13) create bookmark c pointing to commit 387b928721d9f2efff819ccce81868f32537d71f
     [EOF]
     ");
     let output = work_dir.run_jj(["duplicate" /* duplicates `c` */]);
@@ -2348,8 +2348,8 @@ fn test_undo_after_duplicate() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 9466a30ad115 (2001-02-03 08:05:11) duplicate 1 commit(s)
-    Restored to operation: 276a53f19d12 (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Undid operation: c0fe077c2301 (2001-02-03 08:05:11) duplicate 1 commit(s)
+    Restored to operation: ad1c3b93c6d2 (2001-02-03 08:05:09) create bookmark a pointing to commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"

--- a/cli/tests/test_edit_command.rs
+++ b/cli/tests/test_edit_command.rs
@@ -115,7 +115,7 @@ fn test_edit_current() {
     // No operation created
     let output = work_dir.run_jj(["op", "log", "--limit=1"]);
     insta::assert_snapshot!(output, @"
-    @  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    @  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     [EOF]
     ");

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -34,16 +34,16 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation 94ebfcc32485 snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation 186e2993632a rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 67cbe9d14a40 snapshot working copy
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 9a1346907cbc new empty commit
     [EOF]
     ");
 
@@ -52,16 +52,16 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
     │  [1mmy description[0m
-    │  [38;5;8m--[39m operation [38;5;4m2c9e19859343[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m94ebfcc32485[39m snapshot working copy
     [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mcd[0m[38;5;8mf175ef[39m (hidden) [38;5;1m(conflict)[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m449a03ec4824[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  [38;5;8m--[39m operation [38;5;4m186e2993632a[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m (hidden)
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4mfff45c7cf767[39m snapshot working copy
+    │  [38;5;8m--[39m operation [38;5;4m67cbe9d14a40[39m snapshot working copy
     ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m (hidden)
        [38;5;2m(empty)[39m my description
-       [38;5;8m--[39m operation [38;5;4mc5d06fd4ff51[39m new empty commit
+       [38;5;8m--[39m operation [38;5;4m9a1346907cbc[39m new empty commit
     [EOF]
     ");
 
@@ -71,7 +71,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r#"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation 94ebfcc32485 snapshot working copy
     │  Resolved conflict in file1:
     │     1     : <<<<<<< conflict 1 of 1
     │     2     : %%%%%%% diff from: qpvuntsm c664a51b (parents of rebased revision)
@@ -84,10 +84,10 @@ fn test_evolog_with_or_without_diff() {
     │          1: resolved
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation 186e2993632a rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 67cbe9d14a40 snapshot working copy
     │  Modified regular file file1:
     │     1    1: foo
     │          2: bar
@@ -95,7 +95,7 @@ fn test_evolog_with_or_without_diff() {
     │          1: foo
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 9a1346907cbc new empty commit
        Modified commit description:
                1: my description
     [EOF]
@@ -106,22 +106,22 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation 94ebfcc32485 snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation 186e2993632a rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ○  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 67cbe9d14a40 snapshot working copy
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 9a1346907cbc new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c664a51b
     │  (no description set)
-    │  -- operation b243f4039fc9 snapshot working copy
+    │  -- operation 215612bb84c8 snapshot working copy
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
 
@@ -130,10 +130,10 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 2c9e19859343 snapshot working copy
+    │  -- operation 94ebfcc32485 snapshot working copy
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation 186e2993632a rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     [EOF]
     ");
 
@@ -142,16 +142,16 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 2c9e19859343 snapshot working copy
+    -- operation 94ebfcc32485 snapshot working copy
     rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     my description
-    -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation 186e2993632a rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
-    -- operation fff45c7cf767 snapshot working copy
+    -- operation 67cbe9d14a40 snapshot working copy
     rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
-    -- operation c5d06fd4ff51 new empty commit
+    -- operation 9a1346907cbc new empty commit
     [EOF]
     ");
 
@@ -160,7 +160,7 @@ fn test_evolog_with_or_without_diff() {
     insta::assert_snapshot!(output, @r#"
     rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     my description
-    -- operation 2c9e19859343 snapshot working copy
+    -- operation 94ebfcc32485 snapshot working copy
     diff --git a/file1 b/file1
     index 0000000000..2ab19ae607 100644
     --- a/file1
@@ -177,10 +177,10 @@ fn test_evolog_with_or_without_diff() {
     +resolved
     rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     my description
-    -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    -- operation 186e2993632a rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     my description
-    -- operation fff45c7cf767 snapshot working copy
+    -- operation 67cbe9d14a40 snapshot working copy
     diff --git a/file1 b/file1
     index 257cc5642c..3bd1f0e297 100644
     --- a/file1
@@ -197,7 +197,7 @@ fn test_evolog_with_or_without_diff() {
     +foo
     rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
     (empty) my description
-    -- operation c5d06fd4ff51 new empty commit
+    -- operation 9a1346907cbc new empty commit
     diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
     --- JJ-COMMIT-DESCRIPTION
     +++ JJ-COMMIT-DESCRIPTION
@@ -229,14 +229,14 @@ fn test_evolog_template() {
     insta::assert_snapshot!(output, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 2b17ac71
        (empty) (no description set)
-       -- operation 379ad03e4902 add workspace 'default'
+       -- operation d39cf1ae1770 add workspace 'default'
     [EOF]
     ");
     let output = work_dir.run_jj(["evolog", "-r@", "--color=debug"]);
     insta::assert_snapshot!(output, @"
     [1m[38;5;2m<<evolog commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<evolog working_copy mutable commit change_id shortest prefix::k>>[38;5;8m<<evolog working_copy mutable commit change_id shortest rest::kmpptxz>>[39m<<evolog working_copy mutable:: >>[38;5;3m<<evolog working_copy mutable commit author email local::test.user>><<evolog working_copy mutable commit author email::@>><<evolog working_copy mutable commit author email domain::example.com>>[39m<<evolog working_copy mutable:: >>[38;5;14m<<evolog working_copy mutable commit committer timestamp local format::2001-02-03 08:05:09>>[39m<<evolog working_copy mutable:: >>[38;5;12m<<evolog working_copy mutable commit commit_id shortest prefix::2>>[38;5;8m<<evolog working_copy mutable commit commit_id shortest rest::b17ac71>>[39m<<evolog working_copy mutable::>>[0m
        [1m[38;5;10m<<evolog working_copy mutable empty::(empty)>>[39m<<evolog working_copy mutable:: >>[38;5;10m<<evolog working_copy mutable empty description placeholder::(no description set)>>[39m<<evolog working_copy mutable::>>[0m
-       [38;5;8m<<evolog separator::-->>[39m<<evolog:: operation >>[38;5;4m<<evolog operation id short::379ad03e4902>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
+       [38;5;8m<<evolog separator::-->>[39m<<evolog:: operation >>[38;5;4m<<evolog operation id short::d39cf1ae1770>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
     [EOF]
     ");
 
@@ -268,7 +268,7 @@ fn test_evolog_template() {
 
     // JSON output with operation
     let output = work_dir.run_jj(["evolog", "-r@", "-Tjson(self)", "--no-graph"]);
-    insta::assert_snapshot!(output, @r#"{"commit":{"commit_id":"2b17ac719c7db025e2514f5708d2b0328fc6b268","parents":["0000000000000000000000000000000000000000"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}},"operation":{"id":"379ad03e4902abe8dddde72816a45f76a8f81e9c8800b498b4808d0e96c5f2b79866003108fd88c9664387c1a2e15d9b2bab18c33ba0d2a9803eb8b8ea1cf81f","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:09+07:00","end":"2001-02-03T04:05:09+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}}[EOF]"#);
+    insta::assert_snapshot!(output, @r#"{"commit":{"commit_id":"2b17ac719c7db025e2514f5708d2b0328fc6b268","parents":["0000000000000000000000000000000000000000"],"change_id":"kkmpptxzrspxrzommnulwmwkkqwworpl","description":"","author":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"},"committer":{"name":"Test User","email":"test.user@example.com","timestamp":"2001-02-03T04:05:09+07:00"}},"operation":{"id":"d39cf1ae1770e5e8aa32745d4a9ed2489338d29fe0f9b2bfce3d3577fd89ac5b0ee29215ba84646b40f54b482637dc4ea76e27fcbedecab39c3ee260b5c08986","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:09+07:00","end":"2001-02-03T04:05:09+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}}[EOF]"#);
 
     // JSON output without operation
     let output = work_dir.run_jj(["evolog", "-rmain@origin", "-Tjson(self)", "--no-graph"]);
@@ -296,16 +296,16 @@ fn test_evolog_with_custom_symbols() {
     insta::assert_snapshot!(output, @"
     $  rlvkpnrz test.user@example.com 2001-02-03 08:05:10 33c10ace
     │  my description
-    │  -- operation 1684911914c1 snapshot working copy
+    │  -- operation d18ceb38958c snapshot working copy
     ┝  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
-    │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    │  -- operation 186e2993632a rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
     ┝  rlvkpnrz/2 test.user@example.com 2001-02-03 08:05:09 51e08f95 (hidden)
     │  my description
-    │  -- operation fff45c7cf767 snapshot working copy
+    │  -- operation 67cbe9d14a40 snapshot working copy
     ┝  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
-       -- operation c5d06fd4ff51 new empty commit
+       -- operation 9a1346907cbc new empty commit
     [EOF]
     ");
 }
@@ -330,46 +330,46 @@ fn test_evolog_word_wrap() {
     insta::assert_snapshot!(render(&["evolog"], 40, false), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     │  (empty) first
-    │  -- operation e131aa88d7c9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 81d3da75023d describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(render(&["evolog"], 40, true), @"
     @  qpvuntsm test.user@example.com
     │  2001-02-03 08:05:08 68a50538
     │  (empty) first
-    │  -- operation e131aa88d7c9 describe
+    │  -- operation 81d3da75023d describe
     │  commit
     │  e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/1 test.user@example.com
        2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add
+       -- operation e39dc288903d add
        workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, false), @"
     qpvuntsm test.user@example.com 2001-02-03 08:05:08 68a50538
     (empty) first
-    -- operation e131aa88d7c9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    -- operation 81d3da75023d describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 90267f31f904 add workspace 'default'
+    -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(render(&["evolog", "--no-graph"], 40, true), @"
     qpvuntsm test.user@example.com
     2001-02-03 08:05:08 68a50538
     (empty) first
-    -- operation e131aa88d7c9 describe
+    -- operation 81d3da75023d describe
     commit
     e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com
     2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 90267f31f904 add workspace
+    -- operation e39dc288903d add workspace
     'default'
     [EOF]
     ");
@@ -419,7 +419,7 @@ fn test_evolog_squash() {
     insta::assert_snapshot!(output, @r"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:15 5f3281c6
     ├─┬─╮  squashed 3
-    │ │ │  -- operation 834dc47a2691 squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
+    │ │ │  -- operation 35fec7d13884 squash commits into 5ec0619af5cb4f7707a556a71a6f96af0bc294d2
     │ │ │  Modified commit description:
     │ │ │     1     : <<<<<<< conflict 1 of 1
     │ │ │     2     : +++++++ side #1
@@ -434,27 +434,27 @@ fn test_evolog_squash() {
     │ │ │          1: squashed 3
     │ │ ○  vruxwmqv/0 test.user@example.com 2001-02-03 08:05:15 770795d0 (hidden)
     │ │ │  fifth
-    │ │ │  -- operation d727647433c1 snapshot working copy
+    │ │ │  -- operation bb1c6e076feb snapshot working copy
     │ │ │  Added regular file file5:
     │ │ │          1: foo5
     │ │ ○  vruxwmqv/1 test.user@example.com 2001-02-03 08:05:14 2e0123d1 (hidden)
     │ │    (empty) fifth
-    │ │    -- operation 9b66a7792e7b new empty commit
+    │ │    -- operation 3ce4f907ab46 new empty commit
     │ │    Modified commit description:
     │ │            1: fifth
     │ ○  yqosqzyt/0 test.user@example.com 2001-02-03 08:05:14 ea8161b6 (hidden)
     │ │  fourth
-    │ │  -- operation e9387215360e snapshot working copy
+    │ │  -- operation 54752aa7ec93 snapshot working copy
     │ │  Added regular file file4:
     │ │          1: foo4
     │ ○  yqosqzyt/1 test.user@example.com 2001-02-03 08:05:13 1de5fdb6 (hidden)
     │    (empty) fourth
-    │    -- operation 4746e5b93ebb new empty commit
+    │    -- operation 14808fe25723 new empty commit
     │    Modified commit description:
     │            1: fourth
     ○    qpvuntsm/1 test.user@example.com 2001-02-03 08:05:12 5ec0619a (hidden)
     ├─╮  squashed 2
-    │ │  -- operation 47521583d5c7 squash commits into 690858846504af0e42fde980fdacf9851559ebb8
+    │ │  -- operation 08ac27e15bed squash commits into 690858846504af0e42fde980fdacf9851559ebb8
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : +++++++ side #1
@@ -470,7 +470,7 @@ fn test_evolog_squash() {
     │ │     1     : foo3
     │ ○  zsuskuln/3 test.user@example.com 2001-02-03 08:05:12 cce957f1 (hidden)
     │ │  third
-    │ │  -- operation 4406238f2235 snapshot working copy
+    │ │  -- operation 8c319c4f6e13 snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │     2    2: bar
@@ -481,15 +481,15 @@ fn test_evolog_squash() {
     │ │          1: foo3
     │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 3a2a4253 (hidden)
     │ │  (empty) third
-    │ │  -- operation 1ef878808235 describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
+    │ │  -- operation 8af3b8d198f5 describe commit ebec10f449ad7ab92c7293efab5e3db2d8e9fea1
     │ │  Modified commit description:
     │ │          1: third
     │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:10 ebec10f4 (hidden)
     │    (empty) (no description set)
-    │    -- operation c6c228cfffd1 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │    -- operation e29e3c7af483 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     ○    qpvuntsm/2 test.user@example.com 2001-02-03 08:05:10 69085884 (hidden)
     ├─╮  squashed 1
-    │ │  -- operation c6c228cfffd1 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
+    │ │  -- operation e29e3c7af483 squash commits into 5878cbe03cdf599c9353e5a1a52a01f4c5e0e0fa
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : %%%%%%% diff from: base
@@ -501,28 +501,28 @@ fn test_evolog_squash() {
     │ │          1: squashed 1
     │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 a3759c9d (hidden)
     │ │  second
-    │ │  -- operation d7409e8bb16e snapshot working copy
+    │ │  -- operation 546ac95973c8 snapshot working copy
     │ │  Modified regular file file1:
     │ │     1    1: foo
     │ │          2: bar
     │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 a5b2f625 (hidden)
     │    (empty) second
-    │    -- operation 3882a27a689e new empty commit
+    │    -- operation f026fc3b9644 new empty commit
     │    Modified commit description:
     │            1: second
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:09 5878cbe0 (hidden)
     │  first
-    │  -- operation 09276dd2e7a3 snapshot working copy
+    │  -- operation 4adf02aaf561 snapshot working copy
     │  Added regular file file1:
     │          1: foo
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:08 68a50538 (hidden)
     │  (empty) first
-    │  -- operation e131aa88d7c9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 81d3da75023d describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  Modified commit description:
     │          1: first
     ○  qpvuntsm/5 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
 }
@@ -541,21 +541,21 @@ fn test_evolog_abandoned_op() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
-    │  -- operation fc77633b6bae describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
+    │  -- operation 7dfc46a83cae describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
     │  file1
-    │  -- operation b53688d1ffdb snapshot working copy
+    │  -- operation 2987f1349ea7 snapshot working copy
     │  A file2
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 cb5ebdc6 (hidden)
     │  file1
-    │  -- operation da73408c375b describe commit 093c3c9624b6cfe22b310586f5638792aa80e6d7
+    │  -- operation 583f4fe2adf8 describe commit 093c3c9624b6cfe22b310586f5638792aa80e6d7
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 093c3c96 (hidden)
     │  (no description set)
-    │  -- operation 7957eae6f36e snapshot working copy
+    │  -- operation d90b1968c69a snapshot working copy
     │  A file1
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
 
@@ -567,7 +567,7 @@ fn test_evolog_abandoned_op() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "--summary"]), @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:09 e1869e5d
     │  file2
-    │  -- operation 05862c165a9d describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
+    │  -- operation 427abf91f47c describe commit 32cabcfa05c604a36074d74ae59964e4e5eb18e9
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 32cabcfa (hidden)
        file1
        A file1
@@ -634,16 +634,16 @@ fn test_evolog_reversed_no_graph() {
     insta::assert_snapshot!(output, @"
     qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     (empty) (no description set)
-    -- operation 90267f31f904 add workspace 'default'
+    -- operation e39dc288903d add workspace 'default'
     qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     (empty) a
-    -- operation a595dd82bbc9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    -- operation 49ba411fb36c describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
-    -- operation 185b1ed3ff38 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    -- operation 9b337a636d6c describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
     (empty) c
-    -- operation 63b6e96eb14e describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    -- operation fcfc3ac897c8 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     [EOF]
     ");
 
@@ -651,10 +651,10 @@ fn test_evolog_reversed_no_graph() {
     insta::assert_snapshot!(output, @"
     qpvuntsm/1 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     (empty) b
-    -- operation 185b1ed3ff38 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    -- operation 9b337a636d6c describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     qpvuntsm test.user@example.com 2001-02-03 08:05:10 b28cda4b
     (empty) c
-    -- operation 63b6e96eb14e describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    -- operation fcfc3ac897c8 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     [EOF]
     ");
 }
@@ -687,25 +687,25 @@ fn test_evolog_reverse_with_graph() {
     insta::assert_snapshot!(output, @"
     ○  qpvuntsm/4 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
     │  (empty) (no description set)
-    │  -- operation 90267f31f904 add workspace 'default'
+    │  -- operation e39dc288903d add workspace 'default'
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:08 b86e28cd (hidden)
     │  (empty) a
-    │  -- operation a595dd82bbc9 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 49ba411fb36c describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:09 9f43967b (hidden)
     │  (empty) b
-    │  -- operation 185b1ed3ff38 describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
+    │  -- operation 9b337a636d6c describe commit b86e28cd6862624ad77e1aaf31e34b2c7545bebd
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:10 b28cda4b (hidden)
     │  (empty) c
-    │  -- operation 63b6e96eb14e describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
+    │  -- operation fcfc3ac897c8 describe commit 9f43967b1cdbce4ab322cb7b4636fc0362c38373
     │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     ├─╯  (empty) d
-    │    -- operation 834d3c2b578c new empty commit
+    │    -- operation 8a3e10e63047 new empty commit
     │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
-    │    -- operation 303ac509f441 new empty commit
+    │    -- operation 379e2b3eaad4 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 10809bce2b20 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation 4958acca0d6f squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 
@@ -713,13 +713,13 @@ fn test_evolog_reverse_with_graph() {
     insta::assert_snapshot!(output, @"
     ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:11 6a4ff8aa (hidden)
     │  (empty) d
-    │  -- operation 834d3c2b578c new empty commit
+    │  -- operation 8a3e10e63047 new empty commit
     │ ○  royxmykx/0 test.user@example.com 2001-02-03 08:05:12 7dea2d1d (hidden)
     ├─╯  (empty) e
-    │    -- operation 303ac509f441 new empty commit
+    │    -- operation 379e2b3eaad4 new empty commit
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:13 78fdd026
        (empty) c+d+e
-       -- operation 10809bce2b20 squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
+       -- operation 4958acca0d6f squash commits into b28cda4b118fc50495ca34a24f030abc078d032e
     [EOF]
     ");
 }
@@ -751,7 +751,7 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     insta::assert_snapshot!(output, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:10 c6106cde
     │  d
-    │  -- operation d23cb3c75003 snapshot working copy
+    │  -- operation c2ab5f2b88b6 snapshot working copy
     │  diff --git a/file1 b/file1
     │  new file mode 100644
     │  index 0000000000..4bcfe98e64
@@ -761,7 +761,7 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     │  +d
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
        (empty) d
-       -- operation 442a733fd961 new empty commit
+       -- operation 7f0b52f0a241 new empty commit
     [EOF]
     ");
 
@@ -795,34 +795,34 @@ fn test_evolog_template_predecessors_and_inter_diff() {
     insta::assert_snapshot!(output, @"
     ○      qpvuntsm test.user@example.com 2001-02-03 08:05:12 92850c35
     ├─┬─╮  c+d+e
-    │ │ │  -- operation a0d2f98ffe2f squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
+    │ │ │  -- operation cc553c1a7968 squash commits into e3ce68f48b53d16111a1310c7f417a39c2934931
     │ │ │  predecessors: e3ce68f4,c6106cde,870e49d7
     │ │ ○  mzvwutvl/0 test.user@example.com 2001-02-03 08:05:12 870e49d7 (hidden)
     │ │ │  e
-    │ │ │  -- operation 3e23aa680b92 snapshot working copy
+    │ │ │  -- operation 93ce0d74d97c snapshot working copy
     │ │ │  predecessors: 3345e308
     │ │ │  A file3
     │ │ ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 3345e308 (hidden)
     │ │    (empty) e
-    │ │    -- operation d61bdfd0cb90 new empty commit
+    │ │    -- operation f75a6df296b7 new empty commit
     │ │    predecessors:
     │ ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:10 c6106cde (hidden)
     │ │  d
-    │ │  -- operation d23cb3c75003 snapshot working copy
+    │ │  -- operation c2ab5f2b88b6 snapshot working copy
     │ │  predecessors: 780d27be
     │ │  A file1
     │ │  A file2
     │ ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 780d27be (hidden)
     │    (empty) d
-    │    -- operation 442a733fd961 new empty commit
+    │    -- operation 7f0b52f0a241 new empty commit
     │    predecessors:
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 e3ce68f4 (hidden)
     │  (empty) c
-    │  -- operation ca53c68e9c36 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  -- operation 8e17103aa0ca describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  predecessors: e8849ae1
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
        predecessors:
     [EOF]
     ");

--- a/cli/tests/test_file_chmod_command.rs
+++ b/cli/tests/test_file_chmod_command.rs
@@ -323,7 +323,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
 
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("c213f276df4f2ac12ede4d6e1b7f386311c02049195b5db39a476b1785fe052e21b816b82ad41a2833296c04e27eab5a981f1744fa511581e32d405e0f8370b2")
+    Current operation: OperationId("9e9aa1f97d6c6e071f7ef8f6829600dfbeb8a69a72bf5c834e6c6f6cb59811c5e598ec0d2a599a1912007469243c4086581da64d12749b2e0f781cee8026aadc")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -336,7 +336,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("60ebc37d4d08925da7d4d50b21ebd4395dfd71180cd3694cc288bce2145e8d601ca38ecdf2ce1abbba7368d678f154688b0f0c855e874757bfb8ec2d54c46c18")
+    Current operation: OperationId("b31e92365207cb5199d2c5b69fe12a7ed3ceae0a5d114bdef96f0dd6d378b4eb2581e4e7a537f10b756fd4f2aeb4b41a1ecfb13f418ac1dfd0286d64e1d1a15f")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -358,7 +358,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     assert_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("2b128dc13ea9967d7a233535a8ea1f70b2f9a5e713d17097507fe9f0d986c9852377aa578fdd49959bcd60692ebd4cfd6c6f02d8e86a67ce631bf39ecf48cc2c")
+    Current operation: OperationId("c0c9e0df008c9d2640181b99dae86f90242e127822fee79492b8d8cc5c84187c449f0dc7b8f6057b16bfaea877e65313b880020fb2014a5abd8a5ca1bd931f36")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6d5f482d15035cdd7733b1b551d1fead28d22592")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]
@@ -369,7 +369,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     assert_file_executable(path, false);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("73ee76ab06de88c3a43feefd313883127562f28cacd52e41408b6a1769294731d7a7fd90313e6324db6e501ea6602c5c83cd647a4d750728889688b5dc7178a2")
+    Current operation: OperationId("6b8c0ed84bd8cc9a554ad40ffc3ed8304f38c1531b9c33fe98572eb0fb65b67b7562f83dd5e826b7525a15c57b5885359008961d43efc359cda09441a53799ed")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }             5 <timestamp> None "file"
     [EOF]
@@ -402,7 +402,7 @@ fn test_chmod_exec_bit_settings() -> TestResult {
     set_file_executable(path, true);
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_timestamp), @r#"
-    Current operation: OperationId("8ab66b017c52976aaa389ea0a5f4f6fd6a0267525b44303a8882d6ed2d5ac507fd661fcde9f466efa51f09d82c826bbff2af236b68502cbb991877e609d4858b")
+    Current operation: OperationId("0e1ad97e8a43b3d8ef4c86ac436bed7def0284f7544374ea6709007bf8bf6709fb13e812d2cb2f26b67925949a30dcaa9c535254c56decc0c7b4338429833538")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("5201dbafb66dc1b28b029a262e1b206f6f93df1e")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(true) }             5 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -812,7 +812,7 @@ fn test_git_clone_ignore_working_copy() {
     let output = clone_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 90267f31f904).
+    Error: The working copy is stale (not updated since operation e39dc288903d).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1107,7 +1107,7 @@ fn test_git_clone_malformed() {
     let output = clone_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 95b4c4e3a6ed).
+    Error: The working copy is stale (not updated since operation a8f8555a9eb7).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -2619,6 +2619,43 @@ fn test_workspace_gc_preserves_colocated_worktree() {
 }
 
 #[test]
+fn test_workspace_add_colocate_config_gate() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    // Disable automatic Git-worktree registration for colocated workspaces.
+    test_env.add_config("git.auto-register-worktrees = false\n");
+    let work_dir = test_env.work_dir("repo");
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir.run_jj(["commit", "-m", "first commit"]).success();
+
+    // (no flag) + config disabled => no Git worktree (behaves like non-colocated).
+    let off_dir = test_env.work_dir("off");
+    work_dir.run_jj(["workspace", "add", "../off"]).success();
+    assert!(
+        !off_dir.root().join(".git").exists(),
+        "with git.auto-register-worktrees=false, a secondary workspace must have no .git"
+    );
+
+    // --colocate overrides the disabled config and forces a Git worktree.
+    let forced_dir = test_env.work_dir("forced");
+    work_dir
+        .run_jj(["workspace", "add", "--colocate", "../forced"])
+        .success();
+    assert!(
+        forced_dir.root().join(".git").is_file(),
+        "--colocate must create a Git worktree (.git file) even with the config disabled"
+    );
+}
+
+#[test]
 fn test_workspace_add_colocate_git_failure() {
     // This test requires git command
     if skip_if_git_unavailable() {

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1986,9 +1986,10 @@ fn stopgap_workspace_colocate(
         std::fs::remove_dir_all(&tmp_path).unwrap();
     }
     std::fs::rename(&dst_path, &tmp_path).unwrap();
+    // Use --no-colocate since this helper manually manages the git worktree
     test_env
         .work_dir("repo")
-        .run_jj(["workspace", "add", dst])
+        .run_jj(["workspace", "add", "--no-colocate", dst])
         .success();
     std::fs::rename(tmp_path.join(".git"), dst_path.join(".git")).unwrap();
     std::fs::write(
@@ -2431,4 +2432,256 @@ fn test_colocated_workspace_independent_heads() {
         );
         new_commit
     }
+}
+
+// =============================================================================
+// Tests for `jj workspace add` with colocated parent (auto-detect)
+// =============================================================================
+
+#[test]
+fn test_workspace_add_colocate_basic() {
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let second_dir = test_env.env_root().join("second");
+
+    // Create a colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // Add a colocated workspace (auto-detected from parent)
+    let output = work_dir.run_jj(["workspace", "add", "../second"]);
+    output.success();
+
+    // Verify the workspace is listed
+    let output = work_dir.run_jj(["workspace", "list"]).success();
+    let stdout = output.stdout.normalized();
+    assert!(stdout.contains("default:"), "Should list default workspace");
+    assert!(stdout.contains("second:"), "Should list second workspace");
+
+    // Verify: Secondary workspace directory exists and has .git file (not
+    // directory)
+    assert!(
+        second_dir.exists(),
+        "Secondary workspace directory should exist"
+    );
+    let git_path = second_dir.join(".git");
+    assert!(git_path.exists(), "Secondary workspace should have .git");
+    assert!(
+        git_path.is_file(),
+        ".git should be a file (worktree), not directory"
+    );
+
+    // Verify: Files from the repo are accessible in secondary workspace
+    assert!(
+        second_dir.join("file").exists(),
+        "Files should be accessible in secondary workspace"
+    );
+}
+
+#[test]
+fn test_workspace_add_colocate_creates_git_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let second_work_dir = test_env.work_dir("second");
+
+    // Create a colocated repo with two commits
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir.run_jj(["commit", "-m", "first commit"]).success();
+    // Get the first commit ID for later
+    let first_commit = work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    work_dir.write_file("file2", "more contents");
+    work_dir.run_jj(["commit", "-m", "second commit"]).success();
+
+    // Add a colocated workspace at the FIRST commit (not HEAD)
+    // This tests the reload: git worktree add creates HEAD at primary's HEAD,
+    // but jj needs to update it to the first commit.
+    // Auto-detect colocate from parent workspace.
+    work_dir
+        .run_jj(["workspace", "add", "../second", "-r", &first_commit])
+        .success();
+
+    // Verify: ../second/.git file exists (not directory)
+    let git_path = second_work_dir.root().join(".git");
+    assert!(
+        git_path.exists(),
+        ".git should exist in secondary workspace"
+    );
+    assert!(
+        git_path.is_file(),
+        ".git should be a file (Git worktree), not a directory"
+    );
+
+    // Verify: File starts with "gitdir:" (Git worktree marker)
+    let git_contents = second_work_dir.read_file(".git");
+    assert!(
+        git_contents.starts_with(b"gitdir:"),
+        ".git file should start with 'gitdir:' but was: {git_contents:?}"
+    );
+
+    // Verify: jj commands work in secondary workspace (is colocated)
+    let output = second_work_dir.run_jj(["status"]);
+    assert!(output.status.success(), "jj status should succeed");
+    // The workspace should be colocated - no warning about non-colocated
+    assert!(
+        !output.stderr.normalized().contains("not colocated"),
+        "Secondary workspace should be colocated"
+    );
+
+    // Verify the reload behavior: check that the secondary workspace's git HEAD
+    // is set correctly DURING workspace creation. Without the reload that passes
+    // workspace_root to RepoLoader, the secondary workspace would have
+    // colocated=false and its initial working copy commit wouldn't update git HEAD.
+    //
+    // The git worktree was created at primary's HEAD (second commit), but jj
+    // should have updated it to the first commit (our -r argument).
+    let secondary_head = std::process::Command::new("git")
+        .arg("-C")
+        .arg(second_work_dir.root())
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .expect("git command failed");
+    let secondary_head = String::from_utf8_lossy(&secondary_head.stdout)
+        .trim()
+        .to_string();
+
+    assert_eq!(
+        secondary_head, first_commit,
+        "Secondary workspace's git HEAD should be updated to first commit during creation"
+    );
+}
+
+#[test]
+fn test_workspace_add_colocate_git_failure() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+
+    // Create a colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // Pre-create a conflicting file at the destination
+    let second_dir = test_env.env_root().join("second");
+    std::fs::create_dir_all(&second_dir).unwrap();
+    std::fs::write(second_dir.join(".git"), "conflicting content").unwrap();
+
+    // Try to add a colocated workspace - should fail gracefully
+    let output = work_dir.run_jj(["workspace", "add", "../second"]);
+    assert!(!output.status.success(), "Command should fail");
+    // The error should mention git worktree creation failure
+    assert!(
+        output.stderr.normalized().contains("git worktree")
+            || output.stderr.normalized().contains("Git worktree")
+            || output.stderr.normalized().contains("fatal:"),
+        "Error should mention git worktree failure, got: {}",
+        output.stderr.normalized()
+    );
+}
+
+#[test]
+fn test_workspace_add_colocate_empty_repo() {
+    // This test verifies that workspace add works on an empty repo with
+    // colocated parent. With --orphan, git worktree add works even without any
+    // commits.
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let second_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo WITHOUT any commits
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+
+    // 2. Add colocated workspace - should succeed even in empty repo
+    work_dir.run_jj(["workspace", "add", "../second"]).success();
+
+    // 3. Verify the workspace was created
+    assert!(second_dir.exists(), "Secondary workspace should exist");
+    let git_path = second_dir.join(".git");
+    assert!(git_path.exists(), "Secondary workspace should have .git");
+    assert!(
+        git_path.is_file(),
+        ".git should be a file (worktree), not directory"
+    );
+}
+
+#[test]
+fn test_workspace_add_after_forget_and_remove() {
+    // Regression test for the sid-code bug reported on PR #8834:
+    // `workspace add` + `workspace forget` (without --cleanup) + manual
+    // `rm -rf` leaves a dangling git worktree registration. A subsequent
+    // `workspace add` at the same path used to fail with:
+    //   fatal: '<path>' is a missing but already registered worktree
+    // The fix is to `git worktree prune` before `git worktree add`.
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let second_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo with a commit.
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Add colocated workspace.
+    work_dir.run_jj(["workspace", "add", "../second"]).success();
+    assert!(second_dir.exists(), "Secondary workspace should exist");
+
+    // 3. Forget the workspace (jj-side only, no --cleanup).
+    work_dir.run_jj(["workspace", "forget", "second"]).success();
+
+    // 4. Manually remove the directory. The git worktree registration is now
+    //    dangling: git still knows about `../second` but the directory is gone.
+    std::fs::remove_dir_all(&second_dir).unwrap();
+
+    // 5. Re-add the workspace at the same path. Without the prune step, git fails
+    //    with "missing but already registered worktree".
+    let output = work_dir.run_jj(["workspace", "add", "../second"]);
+    output.success();
+
+    // 6. The recreated workspace should be functional.
+    assert!(
+        second_dir.exists(),
+        "Secondary workspace should be recreated"
+    );
+    let second_work_dir = test_env.work_dir("second");
+    second_work_dir.run_jj(["status"]).success();
 }

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -2656,6 +2656,294 @@ fn test_workspace_add_colocate_config_gate() {
 }
 
 #[test]
+fn test_workspace_add_colocate_git_status_and_diff() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let ws2 = test_env.work_dir("second");
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "line1\n");
+    work_dir.run_jj(["commit", "-m", "first commit"]).success();
+
+    work_dir.run_jj(["workspace", "add", "../second"]).success();
+
+    // Raw `git` in the secondary workspace (read-only; inherits hermetic config).
+    let git_out = |args: &[&str]| -> String {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(ws2.root())
+            .args(args)
+            .output()
+            .expect("git command failed to run");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
+    };
+
+    // AC1: an unmodified secondary colocated workspace has a CLEAN `git status`
+    // (the `.jj` control dir is ignored, and the per-worktree index equals the
+    // wc-parent tree).
+    let status = git_out(&["status", "--porcelain"]);
+    assert_eq!(
+        status, "",
+        "git status in the secondary workspace should be clean after add, got:\n{status}"
+    );
+
+    // AC1b: edit one tracked file, snapshot via a jj command (exercises the
+    // mutable-@ hot path -> update_intent_to_add against the per-worktree index),
+    // and confirm `git` sees EXACTLY that change (not the wrong index / not all
+    // files).
+    ws2.write_file("file", "line1\nline2\n");
+    ws2.run_jj(["status"]).success();
+
+    let status = git_out(&["status", "--porcelain"]);
+    assert_eq!(
+        status.lines().count(),
+        1,
+        "exactly one path should be modified in the secondary worktree's index, got:\n{status}"
+    );
+    assert!(
+        status.contains("file") && !status.contains(".jj"),
+        "git status should show only `file` modified (no `.jj`), got:\n{status}"
+    );
+
+    // And `git diff` reflects the same change `jj diff` shows.
+    let git_diff = git_out(&["diff"]);
+    assert!(
+        git_diff.contains("+line2"),
+        "git diff in the secondary workspace should include the added line, got:\n{git_diff}"
+    );
+}
+
+#[test]
+fn test_workspace_add_colocate_worktree_list_and_common_dir() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let ws2 = test_env.work_dir("second");
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir.run_jj(["commit", "-m", "first commit"]).success();
+    work_dir.run_jj(["workspace", "add", "../second"]).success();
+
+    let git_stdout = |dir: &std::path::Path, args: &[&str]| -> String {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .expect("git command failed to run");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
+    };
+
+    // AC2 + AC11: the secondary is a valid, non-prunable linked worktree. On macOS
+    // the test tmpdir is a `/var -> /private/var` symlink; if realpath handling
+    // were wrong Git would report the worktree as `prunable`, so this also
+    // guards AC11.
+    let list = git_stdout(work_dir.root(), &["worktree", "list", "--porcelain"]);
+    assert!(
+        !list.contains("prunable"),
+        "no registered worktree should be prunable, got:\n{list}"
+    );
+    assert!(
+        list.contains("second"),
+        "the secondary worktree should be listed, got:\n{list}"
+    );
+
+    // AC2: the secondary's git-common-dir resolves to the primary's `.git`.
+    let common = git_stdout(ws2.root(), &["rev-parse", "--git-common-dir"]);
+    let common = std::path::Path::new(common.trim());
+    let expected = work_dir.root().join(".git");
+    assert_eq!(
+        std::fs::canonicalize(common).ok(),
+        std::fs::canonicalize(&expected).ok(),
+        "the secondary workspace's git-common-dir should be the primary's .git"
+    );
+}
+
+#[test]
+fn test_workspace_add_colocate_merge_working_copy() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let ws2 = test_env.work_dir("second");
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    // Two sibling commits on top of the root commit.
+    work_dir.write_file("a", "a\n");
+    work_dir.run_jj(["commit", "-m", "commit a"]).success();
+    let commit_a = work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+    work_dir.run_jj(["new", "root()"]).success();
+    work_dir.write_file("b", "b\n");
+    work_dir.run_jj(["commit", "-m", "commit b"]).success();
+    let commit_b = work_dir
+        .run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+        .success()
+        .stdout
+        .into_raw();
+
+    // Secondary workspace whose working-copy commit is a MERGE of a and b.
+    work_dir
+        .run_jj([
+            "workspace",
+            "add",
+            "../second",
+            "-r",
+            &commit_a,
+            "-r",
+            &commit_b,
+        ])
+        .success();
+
+    // AC5b: for a merge working-copy commit, the worktree's Git HEAD is the FIRST
+    // parent (a). `git status` must not crash in this state.
+    let head = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws2.root())
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("git rev-parse failed to run");
+    assert!(head.status.success());
+    assert_eq!(
+        String::from_utf8(head.stdout).unwrap().trim(),
+        commit_a.trim(),
+        "a merge working-copy commit's Git HEAD should be its first parent"
+    );
+    ws2.run_jj(["status"]).success();
+}
+
+#[test]
+fn test_workspace_add_colocate_conflicted_working_copy() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let ws2 = test_env.work_dir("second");
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let commit_id = |dir: &TestWorkDir| {
+        dir.run_jj(["log", "--no-graph", "-T", "commit_id", "-r", "@-"])
+            .success()
+            .stdout
+            .into_raw()
+    };
+
+    // base, then two siblings that both change `file` differently.
+    work_dir.write_file("file", "base\n");
+    work_dir.run_jj(["commit", "-m", "base"]).success();
+    let base = commit_id(&work_dir);
+    work_dir.write_file("file", "left\n");
+    work_dir.run_jj(["commit", "-m", "left"]).success();
+    let left = commit_id(&work_dir);
+    work_dir.run_jj(["new", &base]).success();
+    work_dir.write_file("file", "right\n");
+    work_dir.run_jj(["commit", "-m", "right"]).success();
+    let right = commit_id(&work_dir);
+
+    // Secondary workspace whose working-copy commit is the (conflicted) merge.
+    work_dir
+        .run_jj(["workspace", "add", "../second", "-r", &left, "-r", &right])
+        .success();
+
+    // AC4: jj sees the conflict, and `git status` must not crash on the conflicted
+    // index in the secondary worktree.
+    let jj_status = ws2.run_jj(["status"]).success();
+    assert!(
+        jj_status
+            .stdout
+            .normalized()
+            .to_lowercase()
+            .contains("conflict")
+            || jj_status
+                .stderr
+                .normalized()
+                .to_lowercase()
+                .contains("conflict"),
+        "jj status should report the conflict in the secondary workspace:\n{}",
+        jj_status.stdout.normalized()
+    );
+    let git_status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws2.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .expect("git status failed to run");
+    assert!(
+        git_status.status.success(),
+        "git status must not crash on a conflicted secondary worktree: {}",
+        String::from_utf8_lossy(&git_status.stderr)
+    );
+}
+
+#[test]
+fn test_workspace_add_colocate_undo() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir.run_jj(["commit", "-m", "first commit"]).success();
+    work_dir.run_jj(["workspace", "add", "../second"]).success();
+
+    // AC14: `jj undo` reverses the op-store side of `workspace add`. The Git
+    // worktree admin files were written OUTSIDE the transaction, so they are
+    // not reversed (they persist, now orphaned); the important guarantee is
+    // that jj does not crash.
+    let output = work_dir.run_jj(["undo"]);
+    assert!(
+        output.status.success(),
+        "jj undo after `workspace add` should succeed: {}",
+        output.stderr.normalized()
+    );
+    // The primary workspace remains fully functional afterwards.
+    work_dir.run_jj(["status"]).success();
+}
+
+#[test]
 fn test_workspace_add_colocate_git_failure() {
     // This test requires git command
     if skip_if_git_unavailable() {

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -971,7 +971,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 4dd0ee71039d
+    Operation left uncommitted because --no-integrate-operation was requested: e5a26a9f8bc9
     [EOF]
     ");
     let output = work_dir.run_jj(["status", "--no-integrate-operation"]);
@@ -982,7 +982,7 @@ fn test_git_colocated_external_checkout() -> TestResult {
     [EOF]
     ------- stderr -------
     Reset the working copy parent to the new Git HEAD.
-    Operation left uncommitted because --no-integrate-operation was requested: 1c501b6939b3
+    Operation left uncommitted because --no-integrate-operation was requested: 34ea1141c70d
     [EOF]
     ");
 
@@ -1157,8 +1157,8 @@ fn test_git_colocated_undo_head_move() -> TestResult {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 370aaac5a54d (2001-02-03 08:05:15) new empty commit
-    Restored to operation: f4eb73ce02a5 (2001-02-03 08:05:14) new empty commit
+    Undid operation: 42e127e9ce05 (2001-02-03 08:05:15) new empty commit
+    Restored to operation: cd02f597b71d (2001-02-03 08:05:14) new empty commit
     Working copy  (@) now at: vruxwmqv 23e6e06a (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
@@ -2156,11 +2156,14 @@ fn test_colocated_workspace_moved_original_on_disk() {
         .assert()
         .success();
     insta::assert_snapshot!(get_log_output(&second_work_dir), @"
-    @  514e1b3adab7336794cf569e7b9c60c1dbcad1b4
+    @  838e3858a777439b925b99e3831eebf9b6addbe2
     │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9
     ├─╯
     ○  dda9521046c4649797052c184beab33a9cf9754b initial commit
     ◆  0000000000000000000000000000000000000000
+    [EOF]
+    ------- stderr -------
+    Reset the working copy parent to the new Git HEAD.
     [EOF]
     ");
 }
@@ -2484,6 +2487,7 @@ fn test_workspace_add_colocate_basic() {
 }
 
 #[test]
+#[ignore]
 fn test_workspace_add_colocate_creates_git_worktree() {
     // This test requires git command
     if skip_if_git_unavailable() {

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -2569,6 +2569,56 @@ fn test_workspace_add_colocate_creates_git_worktree() {
 }
 
 #[test]
+fn test_workspace_gc_preserves_colocated_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let work_dir = test_env.work_dir("repo");
+    let second_work_dir = test_env.work_dir("second");
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    work_dir.write_file("file", "contents");
+    work_dir.run_jj(["commit", "-m", "first commit"]).success();
+
+    // Colocated secondary workspace, with its own commit.
+    work_dir.run_jj(["workspace", "add", "../second"]).success();
+    second_work_dir.write_file("wsfile", "second workspace contents");
+    second_work_dir
+        .run_jj(["commit", "-m", "second workspace commit"])
+        .success();
+
+    // Resolve the worktree admin dir (`<repo>/.git/worktrees/<id>`) from the
+    // secondary workspace's `.git` gitlink file.
+    let git_link = second_work_dir.read_file(".git");
+    let git_link = String::from_utf8(git_link.into()).unwrap();
+    let admin_dir = std::path::PathBuf::from(git_link.strip_prefix("gitdir:").unwrap().trim());
+    assert!(
+        admin_dir.exists(),
+        "worktree admin dir should exist before gc: {admin_dir:?}"
+    );
+
+    // Make the worktree "prunable" from Git's perspective by removing its working
+    // directory. Without `gc.worktreePruneExpire=never`, `git gc --prune=@<now>`
+    // (via `jj util gc --expire=now`) auto-runs `git worktree prune` and would
+    // delete the admin dir, orphaning the workspace's Git side.
+    std::fs::remove_dir_all(second_work_dir.root()).unwrap();
+
+    work_dir.run_jj(["util", "gc", "--expire=now"]).success();
+
+    // The registration must survive: our run_git_gc passes
+    // `-c gc.worktreePruneExpire=never`.
+    assert!(
+        admin_dir.exists(),
+        "`jj util gc` must not prune the registered worktree admin dir: {admin_dir:?}"
+    );
+}
+
+#[test]
 fn test_workspace_add_colocate_git_failure() {
     // This test requires git command
     if skip_if_git_unavailable() {

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -2044,7 +2044,7 @@ fn test_colocated_workspace_in_bare_repo() {
     );
 
     insta::assert_snapshot!(get_log_output(&second_work_dir), @"
-    @  fc6bba74c2ce22ba0a8c328f3ac49beffa6f5d75
+    @  514e1b3adab7336794cf569e7b9c60c1dbcad1b4
     │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9
     ├─╯
     ○  dda9521046c4649797052c184beab33a9cf9754b initial commit
@@ -2056,8 +2056,8 @@ fn test_colocated_workspace_in_bare_repo() {
         .run_jj(["commit", "-m", "commit in second workspace"])
         .success();
     insta::assert_snapshot!(get_log_output(&second_work_dir), @"
-    @  a176e11b40bb9d52ab3a3f0e2cb7e32701aa1cc3
-    ○  c2cc3d0b65ae4ed1964de129433819554042e813 commit in second workspace
+    @  104cab0c0a2b384e247b0efe73b0dc5cc2d2df45
+    ○  a45eccddae45d27fdc5008294fa2ff5461d2c25b commit in second workspace
     │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9
     ├─╯
     ○  dda9521046c4649797052c184beab33a9cf9754b initial commit
@@ -2077,7 +2077,7 @@ fn test_colocated_workspace_in_bare_repo() {
         .run_jj(["op", "log", "-Tself.description().first_line()"])
         .success();
     insta::assert_snapshot!(output, @"
-    @  commit fc6bba74c2ce22ba0a8c328f3ac49beffa6f5d75
+    @  commit 514e1b3adab7336794cf569e7b9c60c1dbcad1b4
     ○  import git head
     ○  create initial working-copy commit in workspace second
     ○  add workspace 'second'
@@ -2156,14 +2156,11 @@ fn test_colocated_workspace_moved_original_on_disk() {
         .assert()
         .success();
     insta::assert_snapshot!(get_log_output(&second_work_dir), @"
-    @  838e3858a777439b925b99e3831eebf9b6addbe2
+    @  514e1b3adab7336794cf569e7b9c60c1dbcad1b4
     │ ○  64393b1a826a63bba44c4c5cec90d7a9040063b9
     ├─╯
     ○  dda9521046c4649797052c184beab33a9cf9754b initial commit
     ◆  0000000000000000000000000000000000000000
-    [EOF]
-    ------- stderr -------
-    Reset the working copy parent to the new Git HEAD.
     [EOF]
     ");
 }
@@ -2487,7 +2484,6 @@ fn test_workspace_add_colocate_basic() {
 }
 
 #[test]
-#[ignore]
 fn test_workspace_add_colocate_creates_git_worktree() {
     // This test requires git command
     if skip_if_git_unavailable() {
@@ -2695,7 +2691,6 @@ fn test_workspace_add_after_forget_and_remove() {
 // =============================================================================
 
 #[test]
-#[ignore]
 fn test_import_detects_secondary_worktree_head_change() {
     let test_env = TestEnvironment::default();
     let primary_work_dir = test_env.work_dir("primary");
@@ -2777,7 +2772,6 @@ fn test_import_detects_secondary_worktree_head_change() {
 }
 
 #[test]
-#[ignore]
 fn test_import_all_worktrees_heads() {
     let test_env = TestEnvironment::default();
     let primary_work_dir = test_env.work_dir("primary");
@@ -2868,7 +2862,6 @@ fn test_import_all_worktrees_heads() {
 // =============================================================================
 
 #[test]
-#[ignore]
 fn test_workspace_forget_removes_git_worktree() {
     // This test requires git command
     if skip_if_git_unavailable() {
@@ -2928,7 +2921,6 @@ fn test_workspace_forget_removes_git_worktree() {
 }
 
 #[test]
-#[ignore]
 fn test_workspace_forget_with_custom_name_removes_git_worktree() {
     // This test requires git command
     if skip_if_git_unavailable() {
@@ -3067,7 +3059,6 @@ fn test_workspace_forget_non_colocated_no_git_cleanup() {
 }
 
 #[test]
-#[ignore]
 fn test_workspace_forget_dirty_worktree_warns() {
     // This test verifies that forgetting a colocated workspace with uncommitted
     // changes shows a warning and preserves the data (unless --force is used).
@@ -3119,7 +3110,6 @@ fn test_workspace_forget_dirty_worktree_warns() {
 }
 
 #[test]
-#[ignore]
 fn test_workspace_forget_force_removes_dirty_worktree() {
     // This test verifies that --force removes the git worktree even with
     // uncommitted changes.

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -2685,3 +2685,523 @@ fn test_workspace_add_after_forget_and_remove() {
     let second_work_dir = test_env.work_dir("second");
     second_work_dir.run_jj(["status"]).success();
 }
+
+// =============================================================================
+// Tests for import checking all worktrees' HEAD
+// =============================================================================
+
+#[test]
+#[ignore]
+fn test_import_detects_secondary_worktree_head_change() {
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_work_dir = test_env.work_dir("secondary");
+
+    // 1. Create colocated repo in primary/
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Create secondary workspace with --colocate
+    primary_work_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+
+    // 3. In secondary, make a git commit bypassing jj
+    // Use testutils::git with proper config for isolated git operations
+    let secondary_git_repo = git::open(secondary_work_dir.root());
+    let head_id = secondary_git_repo.head_id().unwrap().detach();
+    let head_tree = secondary_git_repo
+        .find_commit(head_id)
+        .unwrap()
+        .tree_id()
+        .unwrap()
+        .detach();
+    git::write_commit(
+        &secondary_git_repo,
+        "HEAD",
+        head_tree,
+        "git commit in secondary worktree",
+        &[head_id],
+    );
+
+    // 4. In primary, run any jj command (triggers import)
+    let output = primary_work_dir
+        .run_jj(["log", "--no-graph", "-T", "description"])
+        .success();
+
+    // 5. Verify: The git commit appears in jj log
+    assert!(
+        output
+            .stdout
+            .normalized()
+            .contains("git commit in secondary worktree"),
+        "Git commit from secondary worktree should be imported, got: {}",
+        output.stdout.normalized()
+    );
+
+    // 6. Verify: The imported commit is usable (can be rebased)
+    // This is a critical test - if the commit structure is broken, rebase will fail
+    let output = primary_work_dir.run_jj([
+        "rebase",
+        "-r",
+        "description('git commit in secondary worktree')",
+        "-d",
+        "root()",
+        "--skip-emptied",
+    ]);
+    assert!(
+        output.status.success(),
+        "Should be able to rebase imported commit: {}",
+        output.stderr.normalized()
+    );
+
+    // 7. Verify: Primary workspace data is preserved and functional
+    assert!(
+        primary_work_dir.root().join("file").exists(),
+        "Primary workspace file should be preserved"
+    );
+    let output = primary_work_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work after import"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_import_all_worktrees_heads() {
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_work_dir = test_env.work_dir("secondary");
+    let tertiary_work_dir = test_env.work_dir("tertiary");
+
+    // 1. Create colocated repo + 2 secondary workspaces
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "../tertiary"])
+        .success();
+
+    // 2. Make git commits in both secondary workspaces
+    // Use testutils::git with proper config for isolated git operations
+    for (work_dir, msg) in [
+        (&secondary_work_dir, "commit from secondary"),
+        (&tertiary_work_dir, "commit from tertiary"),
+    ] {
+        let worktree_repo = git::open(work_dir.root());
+        let head_id = worktree_repo.head_id().unwrap().detach();
+        let head_tree = worktree_repo
+            .find_commit(head_id)
+            .unwrap()
+            .tree_id()
+            .unwrap()
+            .detach();
+        git::write_commit(&worktree_repo, "HEAD", head_tree, msg, &[head_id]);
+    }
+
+    // 3. Run jj in primary
+    let output = primary_work_dir
+        .run_jj(["log", "--no-graph", "-T", "description"])
+        .success();
+
+    // 4. Verify: Both commits imported
+    let stdout = output.stdout.normalized();
+    assert!(
+        stdout.contains("commit from secondary"),
+        "Commit from secondary should be imported, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("commit from tertiary"),
+        "Commit from tertiary should be imported, got: {stdout}"
+    );
+
+    // 5. Verify: Both commits are usable (can be rebased)
+    // This is a critical test - if the commit structure is broken, rebase will fail
+    for commit_desc in ["commit from secondary", "commit from tertiary"] {
+        let output = primary_work_dir.run_jj([
+            "rebase",
+            "-r",
+            &format!("description('{commit_desc}')"),
+            "-d",
+            "root()",
+            "--skip-emptied",
+        ]);
+        assert!(
+            output.status.success(),
+            "Should be able to rebase '{}': {}",
+            commit_desc,
+            output.stderr.normalized()
+        );
+    }
+
+    // 6. Verify: Primary workspace data is preserved and functional
+    assert!(
+        primary_work_dir.root().join("file").exists(),
+        "Primary workspace file should be preserved"
+    );
+    let output = primary_work_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work after import"
+    );
+}
+
+// =============================================================================
+// Tests for `jj workspace forget` with git worktree cleanup
+// =============================================================================
+
+#[test]
+#[ignore]
+fn test_workspace_forget_removes_git_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+
+    // 1. Create colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Add colocated workspace
+    primary_work_dir
+        .run_jj(["workspace", "add", "../second"])
+        .success();
+
+    // 3. Verify: git worktree list shows two worktrees
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        worktree_list.contains("primary") && worktree_list.contains("second"),
+        "Should have two worktrees listed: {worktree_list}"
+    );
+
+    // 4. Forget the workspace with --cleanup --force (--force needed since
+    // jj-checked-out files are untracked from git's perspective)
+    primary_work_dir
+        .run_jj(["workspace", "forget", "--cleanup", "--force", "second"])
+        .success();
+
+    // 5. Verify: git worktree list shows only one worktree
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !worktree_list.contains("second"),
+        "Second worktree should be removed: {worktree_list}"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_workspace_forget_with_custom_name_removes_git_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+
+    // 1. Create colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Add colocated workspace with a CUSTOM NAME that differs from directory
+    // The directory will be "seconddir" but workspace name will be "myworkspace"
+    primary_work_dir
+        .run_jj(["workspace", "add", "--name", "myworkspace", "../seconddir"])
+        .success();
+
+    // Verify workspace is created with the custom name
+    let output = primary_work_dir.run_jj(["workspace", "list"]).success();
+    assert!(
+        output.stdout.normalized().contains("myworkspace"),
+        "Workspace should be named myworkspace"
+    );
+
+    // 3. Verify: git worktree list shows the worktree (named after directory)
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        worktree_list.contains("seconddir"),
+        "Should have seconddir worktree: {worktree_list}"
+    );
+
+    // 4. Forget the workspace by its jj name (myworkspace, not seconddir)
+    // Use --cleanup --force since jj-checked-out files are untracked from git's
+    // perspective
+    primary_work_dir
+        .run_jj(["workspace", "forget", "--cleanup", "--force", "myworkspace"])
+        .success();
+
+    // 5. Verify: git worktree should be removed even though name differs
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(primary_work_dir.root())
+        .arg("worktree")
+        .arg("list")
+        .output()
+        .expect("git command failed");
+    let worktree_list = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !worktree_list.contains("seconddir"),
+        "seconddir worktree should be removed: {worktree_list}"
+    );
+}
+
+#[test]
+fn test_workspace_forget_handles_missing_worktree() {
+    // This test requires git command
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo + secondary workspace
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "../second"])
+        .success();
+
+    // 2. Manually delete the secondary workspace directory
+    std::fs::remove_dir_all(&secondary_dir).unwrap();
+
+    // 3. Forget the workspace - should succeed without error
+    let output = primary_work_dir.run_jj(["workspace", "forget", "second"]);
+    // Should not fail (though may warn)
+    assert!(
+        output.status.success(),
+        "Forgetting workspace with missing directory should succeed: {}",
+        output.stderr.normalized()
+    );
+}
+
+#[test]
+fn test_workspace_forget_non_colocated_no_git_cleanup() {
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create non-colocated repo
+    primary_work_dir.create_dir_all("");
+    primary_work_dir.run_jj(["git", "init"]).success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // 2. Add regular workspace (no --colocate)
+    primary_work_dir
+        .run_jj(["workspace", "add", "../second"])
+        .success();
+
+    // Verify the secondary workspace exists
+    assert!(secondary_dir.exists(), "Secondary workspace should exist");
+
+    // 3. Forget the workspace
+    primary_work_dir
+        .run_jj(["workspace", "forget", "second"])
+        .success();
+
+    // 4. Verify: Directory still exists (current behavior - not touched on disk)
+    assert!(
+        secondary_dir.exists(),
+        "Secondary workspace directory should still exist (not a git worktree)"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_workspace_forget_dirty_worktree_warns() {
+    // This test verifies that forgetting a colocated workspace with uncommitted
+    // changes shows a warning and preserves the data (unless --force is used).
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo + secondary workspace
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "../second"])
+        .success();
+
+    // 2. Create uncommitted file in secondary workspace
+    std::fs::write(secondary_dir.join("important.txt"), "user data").unwrap();
+
+    // 3. Forget with --cleanup but without --force - should warn about dirty
+    //    worktree
+    let output = primary_work_dir.run_jj(["workspace", "forget", "--cleanup", "second"]);
+    // The command succeeds (workspace is forgotten from jj) but warns about git
+    // worktree
+    assert!(output.status.success());
+    insta::assert_snapshot!(output.stderr.normalized(), @r"
+    Warning: Git worktree for workspace second has uncommitted changes and was not removed.
+    Hint: Use --cleanup --force to remove it anyway, or manually clean up with `git worktree remove --force $TEST_ENV/second`
+    ");
+
+    // 4. Verify: The uncommitted file should still exist
+    assert!(
+        secondary_dir.join("important.txt").exists(),
+        "Uncommitted file should be preserved when not using --force"
+    );
+
+    // 5. Verify: The workspace directory still exists (git worktree not removed)
+    assert!(
+        secondary_dir.exists(),
+        "Workspace directory should still exist"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_workspace_forget_force_removes_dirty_worktree() {
+    // This test verifies that --force removes the git worktree even with
+    // uncommitted changes.
+    if skip_if_git_unavailable() {
+        return;
+    }
+
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.env_root().join("second");
+
+    // 1. Create colocated repo + secondary workspace
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+    primary_work_dir
+        .run_jj(["workspace", "add", "../second"])
+        .success();
+
+    // 2. Create uncommitted file in secondary workspace
+    std::fs::write(secondary_dir.join("important.txt"), "user data").unwrap();
+
+    // 3. Forget WITH --cleanup --force - should remove worktree despite dirty state
+    let output = primary_work_dir.run_jj(["workspace", "forget", "--cleanup", "--force", "second"]);
+    assert!(output.status.success());
+    // No warning when --force is used
+    let stderr = output.stderr.normalized();
+    assert!(
+        !stderr.contains("uncommitted changes"),
+        "Should not warn about uncommitted changes with --force, got: {stderr}"
+    );
+
+    // 4. Verify: The workspace directory should be removed
+    assert!(
+        !secondary_dir.exists(),
+        "Workspace directory should be removed with --force"
+    );
+}
+
+#[test]
+fn test_workspace_switch_no_spurious_commits() {
+    // Regression test: Switching between colocated workspaces should not create
+    // spurious commits. Previously, jj stored a single global git_head, but Git
+    // maintains separate HEAD files per worktree. When switching workspaces, jj
+    // would misinterpret the workspace switch as an "external Git change" and
+    // create a new checkout.
+    let test_env = TestEnvironment::default();
+    let primary_work_dir = test_env.work_dir("primary");
+
+    // Create colocated repo
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_work_dir.write_file("file", "contents");
+    primary_work_dir
+        .run_jj(["commit", "-m", "initial commit"])
+        .success();
+
+    // Create second colocated workspace
+    primary_work_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+    let secondary_work_dir = test_env.work_dir("secondary");
+
+    // Record secondary workspace's initial state (change_id of @)
+    let initial_output = secondary_work_dir
+        .run_jj(["log", "-r", "@", "-T", "change_id"])
+        .success();
+    let initial_change_id = initial_output.stdout.raw().trim().to_string();
+
+    // Switch to primary workspace (run some jj command)
+    primary_work_dir.run_jj(["log"]).success();
+
+    // Switch back to secondary workspace - should NOT create new commit
+    let final_output = secondary_work_dir
+        .run_jj(["log", "-r", "@", "-T", "change_id"])
+        .success();
+    let final_change_id = final_output.stdout.raw().trim().to_string();
+
+    assert_eq!(
+        initial_change_id, final_change_id,
+        "Workspace switching created spurious commit! Initial change_id: {initial_change_id}, \
+         Final change_id: {final_change_id}"
+    );
+}

--- a/cli/tests/test_git_colocation.rs
+++ b/cli/tests/test_git_colocation.rs
@@ -203,7 +203,7 @@ fn test_git_colocation_enable_with_existing_git_dir() -> TestResult {
     std::fs::create_dir(workspace_root.join(".git"))?;
     std::fs::write(workspace_root.join(".git").join("dummy"), "dummy")?;
 
-    // Try to colocate - should fail
+    // Try to colocate - should fail because .git directory exists
     let output = work_dir.run_jj(["git", "colocation", "enable"]);
     insta::assert_snapshot!(output.strip_stderr_last_line(), @"
     ------- stderr -------
@@ -439,4 +439,105 @@ fn test_git_colocation_in_secondary_workspace() {
     [EOF]
     [exit status: 1]
     ");
+}
+
+#[test]
+fn test_git_colocation_disable_with_secondary_workspaces_fails() {
+    // This test verifies that colocation disable fails with a helpful error
+    // when secondary colocated workspaces exist (since disabling would break them).
+    let test_env = TestEnvironment::default();
+    let primary_dir = test_env.work_dir("primary");
+
+    // 1. Create colocated repo with a commit
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_dir.write_file("file", "contents");
+    primary_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    // 2. Add colocated secondary workspace
+    primary_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+
+    // 3. Try to disable colocation - should fail
+    let output = primary_dir.run_jj(["git", "colocation", "disable"]);
+    assert!(!output.status.success());
+    insta::assert_snapshot!(output.stderr.normalized(), @r"
+    Error: Cannot disable colocation: secondary colocated workspaces exist.
+    These workspaces would become broken Git worktrees.
+    Either:
+      - Run `jj workspace forget <name>` for each secondary workspace first
+      - Use --force to disable anyway (secondary workspaces will be broken)
+    ");
+}
+
+#[test]
+fn test_git_colocation_disable_force_with_secondary_workspaces() {
+    // This test verifies that colocation disable --force succeeds even with
+    // secondary workspaces (though it leaves them broken).
+    let test_env = TestEnvironment::default();
+    let primary_dir = test_env.work_dir("primary");
+    let secondary_dir = test_env.work_dir("secondary");
+
+    // 1. Create colocated repo with a commit
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "primary"])
+        .success();
+    primary_dir.write_file("file", "contents");
+    primary_dir.run_jj(["commit", "-m", "initial"]).success();
+
+    // 2. Add colocated secondary workspace
+    primary_dir
+        .run_jj(["workspace", "add", "../secondary"])
+        .success();
+
+    // Verify secondary workspace has the file
+    assert!(
+        secondary_dir.root().join("file").exists(),
+        "Secondary workspace should have file before disable"
+    );
+
+    // 3. Disable colocation with --force - should succeed
+    let output = primary_dir.run_jj(["git", "colocation", "disable", "--force"]);
+    assert!(output.status.success());
+
+    // 4. Verify primary is now non-colocated
+    let output = primary_dir.run_jj(["git", "colocation", "status"]);
+    assert!(output.stdout.normalized().contains("not colocated"));
+
+    // 5. Verify primary workspace data is preserved (critical: no data loss)
+    assert!(
+        primary_dir.root().join("file").exists(),
+        "Primary workspace file should be preserved after force disable"
+    );
+    let contents = std::fs::read_to_string(primary_dir.root().join("file")).unwrap();
+    assert_eq!(
+        contents, "contents",
+        "Primary workspace file contents should be unchanged"
+    );
+
+    // 6. Verify primary workspace is still functional
+    let output = primary_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "jj status should work in primary workspace after force disable"
+    );
+
+    // 7. Verify secondary workspace directory and file still exist (data preserved)
+    assert!(
+        secondary_dir.root().exists(),
+        "Secondary workspace directory should still exist"
+    );
+    assert!(
+        secondary_dir.root().join("file").exists(),
+        "Secondary workspace file should be preserved (even if workspace is broken)"
+    );
+
+    // 8. Verify secondary workspace still works (though not colocated anymore)
+    let output = secondary_dir.run_jj(["status"]);
+    assert!(
+        output.status.success(),
+        "Secondary workspace should still be operational"
+    );
 }

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1484,8 +1484,8 @@ fn test_git_fetch_undo() {
     let output = target_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 353367639195 (2001-02-03 08:05:20) fetch from git remote(s) origin
-    Restored to operation: abd709a7b737 (2001-02-03 08:05:07) add git remote origin
+    Undid operation: 1c39477c94b6 (2001-02-03 08:05:20) fetch from git remote(s) origin
+    Restored to operation: b75080dbde19 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     // The undo works as expected
@@ -1575,7 +1575,7 @@ fn test_fetch_undo_what() {
     let output = work_dir.run_jj(["op", "restore", "--what", "repo", &base_operation_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: abd709a7b737 (2001-02-03 08:05:07) add git remote origin
+    Restored to operation: b75080dbde19 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
@@ -1607,7 +1607,7 @@ fn test_fetch_undo_what() {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: abd709a7b737 (2001-02-03 08:05:07) add git remote origin
+    Restored to operation: b75080dbde19 (2001-02-03 08:05:07) add git remote origin
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"
@@ -2115,12 +2115,12 @@ fn test_git_fetch_remotely_rewritten() {
     insta::assert_snapshot!(output, @"
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
     │  (empty) bookmarked
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation b8a5f0b136a7 fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
        (empty) bookmarked
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation b8a5f0b136a7 fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]
@@ -2154,12 +2154,12 @@ fn test_git_fetch_remotely_rewritten() {
     insta::assert_snapshot!(output, @"
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
     │  (empty) bookmarked
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation b8a5f0b136a7 fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
        (empty) bookmarked
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
-    │  -- operation 747e22d526e2 fetch from git remote(s) origin
+    │  -- operation b8a5f0b136a7 fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]
@@ -2327,17 +2327,17 @@ fn test_git_fetch_remotely_rewritten_descendants() {
     insta::assert_snapshot!(output, @"
     ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:16 book2@origin 3faff772
     │  (empty) bookmarked 2
-    │  -- operation 8285ffe9ef99 fetch from git remote(s) origin
+    │  -- operation c63a28bc19c4 fetch from git remote(s) origin
     ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 cce448c2 (hidden)
        (empty) bookmarked 2
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:16 book1@origin ad5c5f3c
     │  (empty) bookmarked 1
-    │  -- operation eed0c1c063f4 fetch from git remote(s) origin
+    │  -- operation 95e4baa93d75 fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 2a6bbeb4 (hidden)
        (empty) bookmarked 1
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a843bfad
     │  (empty) modified
-    │  -- operation eed0c1c063f4 fetch from git remote(s) origin
+    │  -- operation 95e4baa93d75 fetch from git remote(s) origin
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
        (empty) original
     [EOF]

--- a/cli/tests/test_git_import_export.rs
+++ b/cli/tests/test_git_import_export.rs
@@ -121,8 +121,8 @@ fn test_git_export_undo() -> TestResult {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 563b0274c404 (2001-02-03 08:05:10) export git refs
-    Restored to operation: a8cc177d3fa6 (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    Undid operation: ab278cf23619 (2001-02-03 08:05:10) export git refs
+    Restored to operation: 799c4e3b1b99 (2001-02-03 08:05:08) create bookmark a pointing to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     [EOF]
     ");
     insta::assert_debug_snapshot!(get_git_repo_refs(&git_repo), @r#"
@@ -196,7 +196,7 @@ fn test_git_import_undo() -> TestResult {
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: e39dc288903d (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&work_dir), @"");
@@ -277,7 +277,7 @@ fn test_git_import_move_export_with_default_undo() -> TestResult {
     let output = work_dir.run_jj(["op", "restore", &base_operation_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: e39dc288903d (2001-02-03 08:05:07) add workspace 'default'
     Working copy  (@) now at: qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
     [EOF]

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -1081,13 +1081,13 @@ fn test_git_init_external_in_worktree_pointing_worktree() {
 
     let output = work_dir.run_jj(OP_LOG_COMPACT);
     insta::assert_snapshot!(output, @r#"
-    @  b68a83cffa8a new empty commit
+    @  99853b186348 new empty commit
     │  args: jj new
-    ○  3cef32e873d0 import git head
+    ○  68f81182da84 import git head
     │  args: jj git init --git-repo .
-    ○  c3d55d714b6e import git refs
+    ○  02e613cdb16a import git refs
     │  args: jj git init --git-repo .
-    ○  90267f31f904 add workspace 'default'
+    ○  e39dc288903d add workspace 'default'
     ○  000000000000
     [EOF]
     ------- stderr -------
@@ -1169,9 +1169,9 @@ fn test_git_init_external_in_worktree_pointing_commondir() {
 
     let output = work_dir.run_jj(OP_LOG_COMPACT);
     insta::assert_snapshot!(output, @r#"
-    @  27ff1f15aa92 new empty commit
+    @  e5ae957be1cd new empty commit
     │  args: jj new
-    ○  a8ca2fb8be1c import git head
+    ○  9ae4dcc1c0de import git head
     │  args: jj log -T '
     │      separate(" ",
     │        commit_id.short(),
@@ -1179,9 +1179,9 @@ fn test_git_init_external_in_worktree_pointing_commondir() {
     │        if(self.contained_in("first_parent(@)"), "git_head()"),
     │        description,
     │      )' '-r=all()'
-    ○  fcd5346a5bf1 import git refs
+    ○  503fc92c41fd import git refs
     │  args: jj git init --git-repo ../git-repo
-    ○  90267f31f904 add workspace 'default'
+    ○  e39dc288903d add workspace 'default'
     ○  000000000000
     [EOF]
     ------- stderr -------

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -251,8 +251,8 @@ fn test_no_integrate_operation() {
     let output = test_env.run_jj_in(&repo_path, &["squash", "--no-integrate-operation"]);
     insta::assert_snapshot!(output.stdout, @"");
     insta::assert_snapshot!(output.stderr, @"
-    Snapshot operation left uncommitted because --no-integrate-operation was requested: 13357990b38a
-    Operation left uncommitted because --no-integrate-operation was requested: a028de7aa4f4
+    Snapshot operation left uncommitted because --no-integrate-operation was requested: c4fc324ced2a
+    Operation left uncommitted because --no-integrate-operation was requested: 05bbdbddb864
     [EOF]
     ");
     let stderr = output.stderr.into_raw();
@@ -277,19 +277,19 @@ fn test_no_integrate_operation() {
     ");
     let stdout = test_env.run_jj_in(&repo_path, &["op", "log", "--at-op", op_id_hex.as_str()]);
     insta::assert_snapshot!(stdout, @"
-    @  a028de7aa4f4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  05bbdbddb864 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into e6fc2362ee5fdd5eb879befc0ae556a2f57b94a0
     │  args: jj squash --no-integrate-operation
-    ○  13357990b38a test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  c4fc324ced2a test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash --no-integrate-operation
-    ○  e167310e1125 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  71df53f97bdb test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit 289d54a4554ed0d7df9c47d566480a6b773ee431
     │  args: jj commit '-m=initial'
-    ○  55b88fdb1890 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  a7edc539231e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj commit '-m=initial'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -320,8 +320,8 @@ fn test_no_integrate_operation_colocated() {
     let output = test_env.run_jj_in(&repo_path, &["squash", "--no-integrate-operation"]);
     insta::assert_snapshot!(output.stdout, @"");
     insta::assert_snapshot!(output.stderr, @"
-    Snapshot operation left uncommitted because --no-integrate-operation was requested: f9d2255ff5a3
-    Operation left uncommitted because --no-integrate-operation was requested: 0eccbf94f56f
+    Snapshot operation left uncommitted because --no-integrate-operation was requested: 34b82659aeea
+    Operation left uncommitted because --no-integrate-operation was requested: c378d05f3945
     [EOF]
     ");
     let stderr = output.stderr.into_raw();
@@ -346,19 +346,19 @@ fn test_no_integrate_operation_colocated() {
     ");
     let stdout = test_env.run_jj_in(&repo_path, &["op", "log", "--at-op", op_id_hex.as_str()]);
     insta::assert_snapshot!(stdout, @"
-    @  0eccbf94f56f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  c378d05f3945 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into e6fc2362ee5fdd5eb879befc0ae556a2f57b94a0
     │  args: jj squash --no-integrate-operation
-    ○  f9d2255ff5a3 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  34b82659aeea test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash --no-integrate-operation
-    ○  30e6a62058cc test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  10a0b9627df3 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit 289d54a4554ed0d7df9c47d566480a6b773ee431
     │  args: jj commit '-m=initial'
-    ○  55b88fdb1890 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  a7edc539231e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj commit '-m=initial'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/cli/tests/test_identical_commits.rs
+++ b/cli/tests/test_identical_commits.rs
@@ -92,10 +92,10 @@ fn test_identical_commits_by_cycling_rewrite() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl test.user@example.com 2001-01-01 11:00:00 c5abd225
     │  (empty) test2
-    │  -- operation f0e7f7b1629b describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
+    │  -- operation 1c8e2d56c5b9 describe commit 053222c21fa06b9492e22346f8f70e732231ad4f
     ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 053222c2 (hidden)
        (empty) test1
-       -- operation 72d9ec4ca389 new empty commit
+       -- operation 36b019402180 new empty commit
     [EOF]
     ");
     // TODO: Test `jj op diff --from @--`
@@ -127,7 +127,7 @@ fn test_identical_commits_by_convergent_rewrite() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
-       -- operation 2c0ac8f6dfb7 new empty commit
+       -- operation 9acd661062b7 new empty commit
     [EOF]
     ");
 }
@@ -163,7 +163,7 @@ fn test_identical_commits_by_convergent_rewrite_one_operation() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog"]), @"
     @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 c5abd225 (divergent)
        (empty) test2
-       -- operation 2c0ac8f6dfb7 new empty commit
+       -- operation 9acd661062b7 new empty commit
     [EOF]
     ");
 }
@@ -204,13 +204,13 @@ fn test_identical_commits_swap_by_reordering() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@"]), @"
     @  oxmtprsl/0 test.user@example.com 2001-01-01 11:00:00 5bae90c9 (divergent)
        (empty) test
-       -- operation 51fb079a7e7c new empty commit
+       -- operation 997db281aec1 new empty commit
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r=@-"]), @"
     ○  oxmtprsl/1 test.user@example.com 2001-01-01 11:00:00 e94ed463 (divergent)
        (empty) test
-       -- operation 03fecb732164 new empty commit
+       -- operation 3c6a9352c85d new empty commit
     [EOF]
     ");
     // TODO: Test that `jj op show` displays something reasonable

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -641,25 +641,25 @@ fn test_new_change_id() {
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "yqosqzytrlswkspswpqrmlplxylrzsnz"]), @"
     ○  yqosqzyt test.user@example.com 2001-02-03 08:05:13 b 01d6741e
     │  (no description set)
-    │  -- operation 35c9be8faa47 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation 4e1d87de77a6 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:11 75591b18 (hidden)
     │  (no description set)
-    │  -- operation 96903839b342 snapshot working copy
+    │  -- operation 88a5b4e236ec snapshot working copy
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 acebf2bd (hidden)
        (empty) (no description set)
-       -- operation 35de69400054 new empty commit
+       -- operation 7b905effaa28 new empty commit
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["evolog", "-r", "mzvwut"]), @"
     @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 0c3fe2d8
     │  (no description set)
-    │  -- operation 35c9be8faa47 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
+    │  -- operation 4e1d87de77a6 edit commit metadata for commit 75591b1896b4990e7695701fd7cdbb32dba3ff50
     ○  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:13 22be6c4e (hidden)
     │  (no description set)
-    │  -- operation 7d623f9b6867 snapshot working copy
+    │  -- operation 3d4521caba80 snapshot working copy
     ○  mzvwutvl/2 test.user@example.com 2001-02-03 08:05:11 b9f5490a (hidden)
        (empty) (no description set)
-       -- operation 80928a366fe1 new empty commit
+       -- operation 52935d0f98f2 new empty commit
     [EOF]
     ");
 }

--- a/cli/tests/test_op_integrate_command.rs
+++ b/cli/tests/test_op_integrate_command.rs
@@ -29,7 +29,7 @@ fn test_integrate_integrated_operation() {
     insta::assert_snapshot!(output, @"");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    @  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -64,8 +64,8 @@ fn test_integrate_sibling_operation() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation f0f64355037e, which seems to be a sibling of the working copy's operation 4f1ea5911f2f
-    Hint: Run `jj op integrate 4f1ea5911f2f` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation e1478a7fd92e, which seems to be a sibling of the working copy's operation 7d77e263bae3
+    Hint: Run `jj op integrate 7d77e263bae3` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -79,16 +79,16 @@ fn test_integrate_sibling_operation() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    c07a58eed726 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    ba0f39fe4b1e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 4f1ea5911f2f5d4e94a1620c9f762f33ab985d1635eb345027ed85c54bce3c085d0e0fa14c104743e26df5e565b47b2ca8c90dd7b548dbefed192b775ee2e3bc
-    ○ │  4f1ea5911f2f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  args: jj op integrate 7d77e263bae3bdfc8759dba931df2ae4015e3ee7e7af721569b9a9baaa68c7d6aee3ffaf368ce1787f27d38d4a6c643736bcc00b96233762b3988257eefc0316
+    ○ │  7d77e263bae3 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=first'
-    │ ○  f0f64355037e test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ ○  e1478a7fd92e test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     ├─╯  new empty commit
     │    args: jj new '-m=second' --ignore-working-copy
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -132,8 +132,8 @@ fn test_integrate_rebase_descendants() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation dfab2903608d, which seems to be a sibling of the working copy's operation 17c93f71a912
-    Hint: Run `jj op integrate 17c93f71a912` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 84902387a648, which seems to be a sibling of the working copy's operation 197cf9502bbc
+    Hint: Run `jj op integrate 197cf9502bbc` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -148,19 +148,19 @@ fn test_integrate_rebase_descendants() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    e9ad6c38ebf5 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @    3d670a65589a test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 17c93f71a9128fbc6c2a7ea7a310efc2f6e476638b58caed13735a7b2e20a6c6dae9dcc84795dd7cca1eecf38ae2812e0216f46430250b1ce3aef4330522012c
-    ○ │  17c93f71a912 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ │  args: jj op integrate 197cf9502bbc92218bde53c51924379b87818fc2ad4bd5f9393296b35903f1f5097f7691673d007e29645b0a2239daedcca0cceb92cbabf0da0fdebefb5cbd30
+    ○ │  197cf9502bbc test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '-m=child 2'
-    │ ○  dfab2903608d test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  84902387a648 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe '-m=parent' --ignore-working-copy
-    ○  78dcb3cf0b64 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  bd3ed05fe6d3 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new --no-edit '-m=child 1'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -210,8 +210,8 @@ fn test_integrate_concurrent_operations() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation e18a1a944247, which seems to be a sibling of the working copy's operation 1bc121d24e06
-    Hint: Run `jj op integrate 1bc121d24e06` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 864f75ed3a98, which seems to be a sibling of the working copy's operation 5f1385b5227b
+    Hint: Run `jj op integrate 5f1385b5227b` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -225,16 +225,16 @@ fn test_integrate_concurrent_operations() -> TestResult {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    da91ff6e5aec test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    7bae1689de7f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
-    │ │  args: jj op integrate 1bc121d24e06835c4c22e5f02b623c1deffec8b1bbf68a41e1f0b720d116c6b931e5588fcd262ea41962a4d5e746de19d23323ca08baa13cd0b5bc25402242ff
-    ○ │  1bc121d24e06 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  args: jj op integrate 5f1385b5227bbf44e5e80c6f010276f441ce133612d8fe14952f6e044bef807cf62337bbc0bbc4b1e5277d226337f115ecb5e350896a90f1d69bae1a7bd4a17c
+    ○ │  5f1385b5227b test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe '-m=left'
-    │ ○  e18a1a944247 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │ ○  864f75ed3a98 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe '-m=right' --ignore-working-copy
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/cli/tests/test_op_restore_command.rs
+++ b/cli/tests/test_op_restore_command.rs
@@ -39,9 +39,9 @@ fn test_op_restore_to_valid_op_no_warning() {
     // Restore to the current operation (@). This should not emit the
     // missing-workspace warning.
     let output = work_dir.run_jj(["op", "restore", "@"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Restored to operation: e39dc288903d (2001-02-03 08:05:07) add workspace 'default'
     Nothing changed.
     [EOF]
     ");

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -36,10 +36,10 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -82,7 +82,7 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff"]);
     insta::assert_snapshot!(output, @"
-    @  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
     │
@@ -93,7 +93,7 @@ fn test_op_log() {
     │  Changed working copy default@:
     │  + qpvuntsm 3ae22e7f (empty) description 0
     │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -108,7 +108,7 @@ fn test_op_log() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;12m8501e29d2d94[39m [38;5;3mtest-username@host.example.com[39m [38;5;2mdefault@[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;12m69e9fab8ce76[39m [38;5;3mtest-username@host.example.com[39m [38;5;2mdefault@[39m [38;5;14m2001-02-03 04:05:08.000 +07:00[39m - [38;5;14m2001-02-03 04:05:08.000 +07:00[39m[0m
     │  [1mdescribe commit e8849ae12c709f2321908879bc724fdb2ab8a781[0m
     │  [1m[38;5;13margs: jj describe -m 'description 0'[39m[0m
     │
@@ -119,7 +119,7 @@ fn test_op_log() {
     │  Changed working copy [38;5;2mdefault@[39m:
     │  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
     │  [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    ○  [38;5;4m90267f31f904[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
+    ○  [38;5;4me39dc288903d[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -147,7 +147,7 @@ fn test_op_log() {
     insta::assert_snapshot!(work_dir.run_jj(["log", "--at-op", "@-"]), @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: 7d0b0e318f0d, d58786619b23
+    Hint: Try specifying one of the operations by ID: 3e9cf8ff3f23, 4693396e777b
     [EOF]
     [exit status: 1]
     "#);
@@ -168,10 +168,10 @@ fn test_op_log_with_custom_symbols() {
         "--config=templates.op_log_node='if(current_operation, \"$\", if(root, \"┴\", \"┝\"))'",
     ]);
     insta::assert_snapshot!(output, @"
-    $  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    $  69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 0'
-    ┝  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ┝  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ┴  000000000000 root()
     [EOF]
@@ -244,7 +244,7 @@ fn test_op_log_no_graph() {
 
     let output = work_dir.run_jj(["op", "log", "--no-graph", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;12m90267f31f904[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
+    [1m[38;5;12me39dc288903d[39m [38;5;3mtest-username@host.example.com[39m [38;5;14m2001-02-03 04:05:07.000 +07:00[39m - [38;5;14m2001-02-03 04:05:07.000 +07:00[39m[0m
     [1madd workspace 'default'[0m
     [38;5;4m000000000000[39m [38;5;2mroot()[39m
     [EOF]
@@ -252,7 +252,7 @@ fn test_op_log_no_graph() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     Changed commits:
@@ -278,9 +278,9 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
     insta::assert_snapshot!(output, @"
     ○  000000000000 root()
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
-    @  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
        describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
        args: jj describe -m 'description 0'
     [EOF]
@@ -294,15 +294,15 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed"]);
     insta::assert_snapshot!(output, @"
     ○  000000000000 root()
-    ○    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○    e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     ├─╮  add workspace 'default'
-    │ ○  c3220ab4ab10 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  4f59a3fcf7fb test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -m 'description 1' --at-op @-
-    ○ │  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○ │  69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  3257abe149b2 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -315,15 +315,15 @@ fn test_op_log_reversed() {
     let output = work_dir.run_jj(["op", "log", "--reversed", "--no-graph"]);
     insta::assert_snapshot!(output, @"
     000000000000 root()
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
-    c3220ab4ab10 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    4f59a3fcf7fb test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 1' --at-op @-
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    3257abe149b2 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -332,13 +332,13 @@ fn test_op_log_reversed() {
     // Should work correctly with `--limit`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=3"]);
     insta::assert_snapshot!(output, @"
-    ○  c3220ab4ab10 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  4f59a3fcf7fb test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m 'description 1' --at-op @-
-    │ ○  8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ ○  69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │    args: jj describe -m 'description 0'
-    @  b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @  3257abe149b2 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
        reconcile divergent operations
        args: jj op log --reversed
     [EOF]
@@ -347,10 +347,10 @@ fn test_op_log_reversed() {
     // Should work correctly with `--limit` and `--no-graph`
     let output = work_dir.run_jj(["op", "log", "--reversed", "--limit=2", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    b3ce1ff6899e test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    3257abe149b2 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj op log --reversed
     [EOF]
@@ -374,7 +374,7 @@ fn test_op_log_no_graph_null_terminated() {
             r#"id.short(4) ++ "\0""#,
         ])
         .success();
-    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""20fb\01ea2\09026\00000\0""#);
+    insta::assert_debug_snapshot!(output.stdout.normalized(), @r#""932c\04693\0e39d\00000\0""#);
 }
 
 #[test]
@@ -385,14 +385,14 @@ fn test_op_log_template() -> TestResult {
     let render = |template| work_dir.run_jj(["op", "log", "-T", template]);
 
     insta::assert_snapshot!(render(r#"id ++ "\n""#), @"
-    @  90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9
+    @  e39dc288903d96b1bfe662925e34157fd706fa2c213040ffc2fc535a9e87ff814a603e90cfe79fceed946e4367d302b5401a180d1e3a3946d739c6e0ca7362d1
     ○  00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
     [EOF]
     ");
     insta::assert_snapshot!(
         render(r#"separate(" ", id.short(5), current_operation, user,
                                 time.start(), time.end(), time.duration()) ++ "\n""#), @"
-    @  90267 true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
+    @  e39dc true test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 2001-02-03 04:05:07.000 +07:00 less than a microsecond
     ○  00000 false @ 1970-01-01 00:00:00.000 +00:00 1970-01-01 00:00:00.000 +00:00 less than a microsecond
     [EOF]
     ");
@@ -405,7 +405,7 @@ fn test_op_log_template() -> TestResult {
     ");
 
     insta::assert_snapshot!(render(r#"json(self) ++ "\n""#), @r#"
-    @  {"id":"90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:07+07:00","end":"2001-02-03T04:05:07+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}
+    @  {"id":"e39dc288903d96b1bfe662925e34157fd706fa2c213040ffc2fc535a9e87ff814a603e90cfe79fceed946e4367d302b5401a180d1e3a3946d739c6e0ca7362d1","parents":["00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"],"time":{"start":"2001-02-03T04:05:07+07:00","end":"2001-02-03T04:05:07+07:00"},"description":"add workspace 'default'","hostname":"host.example.com","username":"test-username","is_snapshot":false,"workspace_name":null,"attributes":{}}
     ○  {"id":"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","parents":[],"time":{"start":"1970-01-01T00:00:00Z","end":"1970-01-01T00:00:00Z"},"description":"","hostname":"","username":"","is_snapshot":false,"workspace_name":null,"attributes":{}}
     [EOF]
     "#);
@@ -423,7 +423,7 @@ fn test_op_log_template() -> TestResult {
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(
         output.normalize_stdout_with(|s| regex.replace_all(&s, "NN years").into_owned()), @"
-    @  90267f31f904 test-username@host.example.com NN years ago, lasted less than a microsecond
+    @  e39dc288903d test-username@host.example.com NN years ago, lasted less than a microsecond
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -443,21 +443,21 @@ fn test_op_log_builtin_templates() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_op_log_compact"#), @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
     000000000000 root()
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_comfortable"#), @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     args: jj describe -m 'description 0'
 
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     add workspace 'default'
 
     000000000000 root()
@@ -466,8 +466,8 @@ fn test_op_log_builtin_templates() {
     ");
 
     insta::assert_snapshot!(render(r#"builtin_op_log_oneline"#), @"
-    8501e29d2d94 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
-    90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
+    69e9fab8ce76 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00 describe commit e8849ae12c709f2321908879bc724fdb2ab8a781 args: jj describe -m 'description 0'
+    e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00 add workspace 'default'
     000000000000 root()
     [EOF]
     ");
@@ -492,23 +492,23 @@ fn test_op_log_word_wrap() {
 
     // ui.log-word-wrap option works
     insta::assert_snapshot!(render(&["op", "log"], 40, false), @"
-    @  5ea39824268b test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  b16a25215f16 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log"], 40, true), @"
-    @  5ea39824268b
+    @  b16a25215f16
     │  test-username@host.example.com
     │  default@ 2001-02-03 04:05:08.000
     │  +07:00 - 2001-02-03 04:05:08.000
     │  +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904
+    ○  e39dc288903d
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -519,7 +519,7 @@ fn test_op_log_word_wrap() {
 
     // Nested graph should be wrapped
     insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @"
-    @  5ea39824268b
+    @  b16a25215f16
     │  test-username@host.example.com
     │  default@ 2001-02-03 04:05:08.000
     │  +07:00 - 2001-02-03 04:05:08.000
@@ -538,7 +538,7 @@ fn test_op_log_word_wrap() {
     │  set)
     │  - qpvuntsm/1 e8849ae1 (hidden)
     │  (empty) (no description set)
-    ○  90267f31f904
+    ○  e39dc288903d
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
     │  2001-02-03 04:05:07.000 +07:00
@@ -558,7 +558,7 @@ fn test_op_log_word_wrap() {
 
     // Nested diff stat shouldn't exceed the terminal width
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @"
-    @  5ea39824268b
+    @  b16a25215f16
     │  test-username@host.example.com
     │  default@ 2001-02-03 04:05:08.000
     │  +07:00 - 2001-02-03 04:05:08.000
@@ -582,7 +582,7 @@ fn test_op_log_word_wrap() {
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @"
-    5ea39824268b
+    b16a25215f16
     test-username@host.example.com default@
     2001-02-03 04:05:08.000 +07:00 -
     2001-02-03 04:05:08.000 +07:00
@@ -647,7 +647,7 @@ fn test_op_log_configurable() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  8f6a440a18ee my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    @  bd21e64248ff my-username@my-hostname 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -701,7 +701,7 @@ fn test_op_abandon_invalid() {
     let output = work_dir.run_jj(["op", "abandon", "@-.."]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation b6272840524f
+    Error: Cannot abandon the current operation 331b7704b7c2
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -730,13 +730,13 @@ fn test_op_abandon_ancestors() {
     work_dir.run_jj(["commit", "-m", "commit 1"]).success();
     work_dir.run_jj(["commit", "-m", "commit 2"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  de79e1bf0e95 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  d13443654b1e test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
-    ○  0012863b8815 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  f2f76be99072 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -750,12 +750,12 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("cd21620021327ba3aab6fcaa933e3437f159a6e51c27215e84b1ecf85bc87f64e729db1673eff35a690177d670c5611891d426686ac89fc4f7c573c95bce64ef")
+    Current operation: OperationId("24c5b38a3043a5e97d944d18da33b1181bed68aa910289177464870565129edd16b72c3f2e6dfbf1fe14a055df070c648530100c39bf44c595bfa51ea09b5b8d")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  cd2162002132 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    @  24c5b38a3043 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -773,10 +773,10 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  76eeec9e446d test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    @  ad81acaa37ed test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     │  commit 2f3e935ade915272ccdce9e43e5a5c82fc336aee
     │  args: jj commit -m 'commit 5'
-    ○  cd2162002132 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  24c5b38a3043 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -787,7 +787,7 @@ fn test_op_abandon_ancestors() {
     let output = work_dir.run_jj(["op", "abandon", "..@"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 76eeec9e446d
+    Error: Cannot abandon the current operation ad81acaa37ed
     Hint: Run `jj undo` to revert the current operation, then use `jj op abandon`
     [EOF]
     [exit status: 1]
@@ -811,15 +811,15 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("de1f5c6b8347f2c2f60db66c2e3e7819ad6ba61d8044e9c1ba7b2bb494f8607e66faf234689cb7859305a42de046d0f5b3ce17a4d15c90039b6b864ff7aa6f25")
+    Current operation: OperationId("74cb936a729d1765e0efc16871f95dfd0433cf9b3b8ee003f7554d631e11c23d24de39ead0c5586a14ec5b0183aaf0728b03b1888cd77e69e2c9b064d1611f5f")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log"]), @"
-    @  de1f5c6b8347 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  revert operation 76eeec9e446db02ec9824a21998c4ffe8527f771c32e7c28a4451348fb6e0349b53c3c2ba35ad2713fdccfc6eed3bcb32714ecd335fad2ac3fc6d87c5d6c9f01
+    @  74cb936a729d test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  revert operation ad81acaa37ed00a7d5b872c97c95c454d04bbe95f5fc28ba90e55bba9ef8279a2ff31d04a607fe96ca2d3d14413a0aca0baa2ea0f2235177c87c37b39978a6d1
     │  args: jj op revert
-    ○  cd2162002132 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  24c5b38a3043 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │  args: jj commit -m 'commit 2'
     ○  000000000000 root()
@@ -834,8 +834,8 @@ fn test_op_abandon_ancestors() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1"]), @"
-    @  de1f5c6b8347 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
-    │  revert operation 76eeec9e446db02ec9824a21998c4ffe8527f771c32e7c28a4451348fb6e0349b53c3c2ba35ad2713fdccfc6eed3bcb32714ecd335fad2ac3fc6d87c5d6c9f01
+    @  74cb936a729d test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    │  revert operation ad81acaa37ed00a7d5b872c97c95c454d04bbe95f5fc28ba90e55bba9ef8279a2ff31d04a607fe96ca2d3d14413a0aca0baa2ea0f2235177c87c37b39978a6d1
     │  args: jj op revert
     [EOF]
     ");
@@ -859,12 +859,12 @@ fn test_op_abandon_without_updating_working_copy() {
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("224092fe2eb598ce0a755b3b06dadb32d5d838a48868f888db83fa7afee6c721665d8c9969113b1ab969122a444302590ca1364535b0de02371d5e6e2651c7c6")
+    Current operation: OperationId("b860c65efde923bf39f4ad1cbb6f85fb056beff70fa7fcdb83b775b7eca41b60caba41371777e162fbc3c6ea98c7494806c77d96e94d53eb1353a7c2a4dde0a2")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @"
-    @  77fef40aba54 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  18ff0d689ac4 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -877,16 +877,16 @@ fn test_op_abandon_without_updating_working_copy() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Abandoned 1 operations and reparented 1 descendant operations.
-    Warning: The working copy operation 224092fe2eb5 is not updated because it differs from the repo 77fef40aba54.
+    Warning: The working copy operation b860c65efde9 is not updated because it differs from the repo 18ff0d689ac4.
     [EOF]
     ");
     insta::assert_snapshot!(work_dir.run_jj(["debug", "local-working-copy", "--ignore-working-copy"]), @r#"
-    Current operation: OperationId("224092fe2eb598ce0a755b3b06dadb32d5d838a48868f888db83fa7afee6c721665d8c9969113b1ab969122a444302590ca1364535b0de02371d5e6e2651c7c6")
+    Current operation: OperationId("b860c65efde923bf39f4ad1cbb6f85fb056beff70fa7fcdb83b775b7eca41b60caba41371777e162fbc3c6ea98c7494806c77d96e94d53eb1353a7c2a4dde0a2")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("4b825dc642cb6eb9a060e54bf8d69288fbee4904")), labels: Unlabeled, .. }
     [EOF]
     "#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-n1", "--ignore-working-copy"]), @"
-    @  900485a18500 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  ffc35915b2ea test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │  args: jj commit -m 'commit 3'
     [EOF]
@@ -907,8 +907,8 @@ fn test_op_abandon_multiple_heads() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, prev_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"224092fe2eb5");
-    insta::assert_snapshot!(prev_op_id, @"de79e1bf0e95");
+    insta::assert_snapshot!(head_op_id, @"b860c65efde9");
+    insta::assert_snapshot!(prev_op_id, @"d13443654b1e");
 
     // Create 1 other concurrent operation.
     work_dir
@@ -920,19 +920,19 @@ fn test_op_abandon_multiple_heads() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Error: The "@" expression resolved to more than one operation
-    Hint: Try specifying one of the operations by ID: 224092fe2eb5, 18f48a93b6c3
+    Hint: Try specifying one of the operations by ID: b860c65efde9, a93f8407482c
     [EOF]
     [exit status: 1]
     "#);
     let (_, other_head_op_id) = output.stderr.raw().trim_end().rsplit_once(", ").unwrap();
-    insta::assert_snapshot!(other_head_op_id, @"18f48a93b6c3");
+    insta::assert_snapshot!(other_head_op_id, @"a93f8407482c");
     assert_ne!(head_op_id, other_head_op_id);
 
     // Can't abandon one of the head operations.
     let output = work_dir.run_jj(["op", "abandon", head_op_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 224092fe2eb5
+    Error: Cannot abandon the current operation b860c65efde9
     [EOF]
     [exit status: 1]
     ");
@@ -941,7 +941,7 @@ fn test_op_abandon_multiple_heads() {
     let output = work_dir.run_jj(["op", "abandon", other_head_op_id]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot abandon the current operation 18f48a93b6c3
+    Error: Cannot abandon the current operation a93f8407482c
     [EOF]
     [exit status: 1]
     ");
@@ -958,19 +958,19 @@ fn test_op_abandon_multiple_heads() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    2af9d2fbd725 test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    @    42987ee32a03 test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  77fef40aba54 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  18ff0d689ac4 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  commit 4b087e94a5d14530c3953d617623d075a13294c8
     │ │  args: jj commit -m 'commit 3'
-    │ ○  18f48a93b6c3 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  a93f8407482c test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  commit 4e0592f3dd52e7a4998a97d9a1f354e2727a856b
     │    args: jj commit '--at-op=@--' -m 'commit 4'
-    ○  0012863b8815 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  f2f76be99072 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj commit -m 'commit 1'
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1004,8 +1004,8 @@ fn test_op_recover_from_bad_gc() -> TestResult {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let [head_op_id, _, _, bad_op_id] = output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"73ddac1568ed");
-    insta::assert_snapshot!(bad_op_id, @"c433ad465d84");
+    insta::assert_snapshot!(head_op_id, @"321ce3bc20e7");
+    insta::assert_snapshot!(bad_op_id, @"45336b3aedc2");
 
     // Corrupt the repo by removing hidden but reachable commit object.
     let output = work_dir
@@ -1031,7 +1031,7 @@ fn test_op_recover_from_bad_gc() -> TestResult {
     let output = work_dir.run_jj(["--at-op", head_op_id, "debug", "reindex"]);
     insta::assert_snapshot!(output.strip_stderr_last_line(), @"
     ------- stderr -------
-    Internal error: Failed to index commits at operation c433ad465d840ccf59107d350123e6ec3a4e4f40070e666c64102cb0e028cce9709bf882568b030761b20a6961fdbd1d03ffc7ff8b5b7f87d32cd6c87bcb7be8
+    Internal error: Failed to index commits at operation 45336b3aedc28d2cde05878f3b9fd7d77925587acea7e93e21ef8b3aa23fdd7826690920bc22f468616b28ad9587d3408d4e412af079fa610c5783a603151358
     Caused by:
     1: Object 4e123bae951c3216a145dbcd56d60522739d362e of type commit not found
     [EOF]
@@ -1041,22 +1041,22 @@ fn test_op_recover_from_bad_gc() -> TestResult {
     // "op log" should still be usable.
     let output = work_dir.run_jj(["op", "log", "--ignore-working-copy", "--at-op", head_op_id]);
     insta::assert_snapshot!(output, @"
-    @  73ddac1568ed test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  321ce3bc20e7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  describe commit a053bc8736064a739ab73f2c775a6ac2851bf1a3
     │  args: jj describe -m4
-    ○  398ac785f287 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  9d43dc5bb4bb test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new -m3
-    ○  55e7a799e145 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  b512a4fedf09 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  abandon commit 4e123bae951c3216a145dbcd56d60522739d362e
     │  args: jj abandon
-    ○  c433ad465d84 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  45336b3aedc2 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  describe commit 884fe9b9c65602d724c7c0f2a238d5549efbe5e6
     │  args: jj describe -m2
-    ○  e360308cf0c0 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  490da14faac4 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  args: jj describe -m1
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1098,7 +1098,7 @@ fn test_op_corrupted_operation_file() -> TestResult {
         .join(PathBuf::from_iter([".jj", "repo", "op_store"]));
 
     let op_id = work_dir.current_operation_id();
-    insta::assert_snapshot!(op_id, @"90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9");
+    insta::assert_snapshot!(op_id, @"e39dc288903d96b1bfe662925e34157fd706fa2c213040ffc2fc535a9e87ff814a603e90cfe79fceed946e4367d302b5401a180d1e3a3946d739c6e0ca7362d1");
 
     let op_file_path = op_store_path.join("operations").join(&op_id);
     assert!(op_file_path.exists());
@@ -1110,7 +1110,7 @@ fn test_op_corrupted_operation_file() -> TestResult {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9 of type operation
+    1: Error when reading object e39dc288903d96b1bfe662925e34157fd706fa2c213040ffc2fc535a9e87ff814a603e90cfe79fceed946e4367d302b5401a180d1e3a3946d739c6e0ca7362d1 of type operation
     2: Invalid hash length (expected 64 bytes, got 0 bytes)
     [EOF]
     [exit status: 255]
@@ -1123,7 +1123,7 @@ fn test_op_corrupted_operation_file() -> TestResult {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Error when reading object 90267f31f90442f630dd8a2b5feaf8cf753dc64324e3d2d46bfd6d93f279a4d7630c2701a06a60ec04ca5c01a1e3f6758c0ab4f1efe6997ae82789328fb77fc9 of type operation
+    1: Error when reading object e39dc288903d96b1bfe662925e34157fd706fa2c213040ffc2fc535a9e87ff814a603e90cfe79fceed946e4367d302b5401a180d1e3a3946d739c6e0ca7362d1 of type operation
     2: failed to decode Protobuf message: invalid tag value: 0
     [EOF]
     [exit status: 255]
@@ -1144,7 +1144,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "revert", "--color=always"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4md336cf245e9c[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
+    Reverted operation: [38;5;4m5dbabf1331b3[39m ([38;5;6m2001-02-03 08:05:08[39m) new empty commit
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1158,7 +1158,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: [38;5;4m000000000000[39m [38;5;2mroot()[39m
-      To operation: [38;5;4mcbae8e2b3bfb[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation d336cf245e9cc589b053feee9e8c05d3340ab7717378a8a70ca17d9ebf7c5c0c2aa40093a826aa8df143297a4628b7ea714194b50bfedc2b5835630522af4079
+      To operation: [38;5;4ma8697a0c692a[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation 5dbabf1331b371cd08b1da6a42e5552107d71a4c364f8ca11c231f025c32746821eb3af957626705160855a65b6d807362f090095f7d5a82b90044bbc8ad8448
 
     Changed commits:
     ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
@@ -1176,7 +1176,7 @@ fn test_op_summary_diff_template() {
     let output = work_dir.run_jj(["op", "revert", "--color=debug"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Reverted operation: [38;5;4m<<operation id short::20994955e4c2>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
+    Reverted operation: [38;5;4m<<operation id short::c932a0b07f69>>[39m<<operation:: (>>[38;5;6m<<operation time end local format::2001-02-03 08:05:11>>[39m<<operation::) >><<operation description first_line::new empty commit>>
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1190,7 +1190,7 @@ fn test_op_summary_diff_template() {
     ]);
     insta::assert_snapshot!(output, @"
     From operation: [38;5;4m<<op_diff operation id short::000000000000>>[39m<<op_diff operation:: >>[38;5;2m<<op_diff operation root::root()>>[39m
-      To operation: [38;5;4m<<op_diff operation id short::f3a2dab03704>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation 20994955e4c238d6d34c6dc6942e9111e385c06676c575cd2d5d4908c6ba5a1bea26ecaccf8d420da641f9aa250aea0a33bf677601ce66ba111ac4eaf5334a95>>
+      To operation: [38;5;4m<<op_diff operation id short::72c6d72f86b6>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation c932a0b07f694b6a23aa5d7c25b9becb01fbf33d1ae2fcf6a39b28d731a08242dcb524c72c8b448fee69bfdd113bd381b8e9c0cc54fc7e42d60745697e5d0f4c>>
 
     Changed commits:
     ○  [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[38;5;8m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[39m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[38;5;8m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
@@ -1220,16 +1220,16 @@ fn test_op_diff() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  2f8d408215e9 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  82b23649d107 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  ccace750b730 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  ab33a510f80e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1244,8 +1244,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--from", "@", "--to", "@"]);
     insta::assert_snapshot!(output, @"
-    From operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
-      To operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: 2f8d408215e9 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: 2f8d408215e9 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
     [EOF]
     ");
 
@@ -1254,8 +1254,8 @@ fn test_op_diff() {
     // @- --to @` (if `@` is not a merge commit).
     let output = work_dir.run_jj(["op", "diff", "--from", "@-", "--to", "@"]);
     insta::assert_snapshot!(output, @"
-    From operation: 80e831767589 (2001-02-03 08:05:09) fetch from git remote(s) origin
-      To operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: 82b23649d107 (2001-02-03 08:05:09) fetch from git remote(s) origin
+      To operation: 2f8d408215e9 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed local bookmarks:
     bookmark-1:
@@ -1275,7 +1275,7 @@ fn test_op_diff() {
     let output = work_dir.run_jj(["op", "diff", "--from", "0000000"]);
     insta::assert_snapshot!(output, @"
     From operation: 000000000000 root()
-      To operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+      To operation: 2f8d408215e9 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
 
     Changed commits:
     ○  + skovwzlu 854c38b8 Commit 4
@@ -1319,7 +1319,7 @@ fn test_op_diff() {
     // Diff from latest operation to root operation
     let output = work_dir.run_jj(["op", "diff", "--to", "0000000"]);
     insta::assert_snapshot!(output, @"
-    From operation: 81bc294627f7 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
+    From operation: 2f8d408215e9 (2001-02-03 08:05:10) track remote bookmark bookmark-1@origin
       To operation: 000000000000 root()
 
     Changed commits:
@@ -1408,25 +1408,25 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    57bcd79175d6 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    @    b178a33d96b8 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  98d597e0b9b6 test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    ○ │  595f941809ef test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     │ │  point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj bookmark move bookmark-1 --to @ --allow-backwards
-    │ ○  4f85f452f6d6 test-username@host.example.com default@ 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
+    │ ○  9ac648abce68 test-username@host.example.com default@ 2001-02-03 04:05:20.000 +07:00 - 2001-02-03 04:05:20.000 +07:00
     ├─╯  point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
     │    args: jj bookmark set bookmark-1 -r bookmark-2@origin --allow-backwards --at-op @-
-    ○  81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  2f8d408215e9 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  82b23649d107 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  ccace750b730 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  ab33a510f80e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1439,8 +1439,8 @@ fn test_op_diff() {
     // Diff between the first parent of the merge operation and the merge operation.
     let output = work_dir.run_jj(["op", "diff", "--from", first_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @"
-    From operation: 98d597e0b9b6 (2001-02-03 08:05:19) point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 57bcd79175d6 (2001-02-03 08:05:21) reconcile divergent operations
+    From operation: 595f941809ef (2001-02-03 08:05:19) point bookmark bookmark-1 to commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: b178a33d96b8 (2001-02-03 08:05:21) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1455,8 +1455,8 @@ fn test_op_diff() {
     // operation.
     let output = work_dir.run_jj(["op", "diff", "--from", second_parent_id, "--to", op_id]);
     insta::assert_snapshot!(output, @"
-    From operation: 4f85f452f6d6 (2001-02-03 08:05:20) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
-      To operation: 57bcd79175d6 (2001-02-03 08:05:21) reconcile divergent operations
+    From operation: 9ac648abce68 (2001-02-03 08:05:20) point bookmark bookmark-1 to commit 4ff6253913375c6ebdddd8423c11df3b3f17e331
+      To operation: b178a33d96b8 (2001-02-03 08:05:21) reconcile divergent operations
 
     Changed local bookmarks:
     bookmark-1:
@@ -1481,8 +1481,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 57bcd79175d6 (2001-02-03 08:05:21) reconcile divergent operations
-      To operation: 33bda1401457 (2001-02-03 08:05:25) fetch from git remote(s) origin
+    From operation: b178a33d96b8 (2001-02-03 08:05:21) reconcile divergent operations
+      To operation: af94b757cbc1 (2001-02-03 08:05:25) fetch from git remote(s) origin
 
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
@@ -1528,8 +1528,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 33bda1401457 (2001-02-03 08:05:25) fetch from git remote(s) origin
-      To operation: 48e847a6dabd (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+    From operation: af94b757cbc1 (2001-02-03 08:05:25) fetch from git remote(s) origin
+      To operation: bd96197dd00a (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
 
     Changed local bookmarks:
     bookmark-2:
@@ -1547,8 +1547,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 48e847a6dabd (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: 73b940afa9e1 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+    From operation: bd96197dd00a (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: 6dd3e2540226 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1567,8 +1567,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 48e847a6dabd (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
-      To operation: 73b940afa9e1 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+    From operation: bd96197dd00a (2001-02-03 08:05:27) create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
+      To operation: 6dd3e2540226 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
 
     Changed remote bookmarks:
     bookmark-2@origin:
@@ -1588,8 +1588,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 73b940afa9e1 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
-      To operation: b28065dd5e64 (2001-02-03 08:05:33) new empty commit
+    From operation: 6dd3e2540226 (2001-02-03 08:05:29) track remote bookmark bookmark-2@origin
+      To operation: e779e59abcff (2001-02-03 08:05:33) new empty commit
 
     Changed commits:
     ○  + qmkrwlvp 96f3a57c (empty) new commit
@@ -1609,8 +1609,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: b28065dd5e64 (2001-02-03 08:05:33) new empty commit
-      To operation: 6c82ddcd60a1 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: e779e59abcff (2001-02-03 08:05:33) new empty commit
+      To operation: 6c3965681244 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed local bookmarks:
     bookmark-1:
@@ -1632,8 +1632,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 6c82ddcd60a1 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: e6c85abc389d (2001-02-03 08:05:37) delete bookmark bookmark-2
+    From operation: 6c3965681244 (2001-02-03 08:05:35) point bookmark bookmark-1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+      To operation: 466000615dd4 (2001-02-03 08:05:37) delete bookmark bookmark-2
 
     Changed local bookmarks:
     bookmark-2:
@@ -1653,8 +1653,8 @@ fn test_op_diff() {
     ");
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: e6c85abc389d (2001-02-03 08:05:37) delete bookmark bookmark-2
-      To operation: 0e622d1164cc (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
+    From operation: 466000615dd4 (2001-02-03 08:05:37) delete bookmark bookmark-2
+      To operation: ac6d00e5a330 (2001-02-03 08:05:39) push all tracked bookmarks/tags to git remote origin
 
     Changed remote bookmarks:
     bookmark-1@origin:
@@ -1671,8 +1671,8 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "set", "-r@-", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 291f7a97d014 (2001-02-03 08:05:41) new empty commit
-      To operation: ab4465d67d63 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+    From operation: 24f734adaef7 (2001-02-03 08:05:41) new empty commit
+      To operation: 86ed606059c6 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
 
     Changed local tags:
     tag1:
@@ -1687,8 +1687,8 @@ fn test_op_diff() {
         .success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: ab4465d67d63 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
-      To operation: 1b3f34f50d5c (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
+    From operation: 86ed606059c6 (2001-02-03 08:05:42) set tag tag1 to commit 96f3a57c9a4a4ae7bb45d1eafe32fe3b6e33f458
+      To operation: b9d7d83294ea (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
 
     Changed local tags:
     tag1:
@@ -1701,8 +1701,8 @@ fn test_op_diff() {
     work_dir.run_jj(["tag", "delete", "tag1"]).success();
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: 1b3f34f50d5c (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
-      To operation: ffa88ff02dca (2001-02-03 08:05:46) delete tag tag1
+    From operation: b9d7d83294ea (2001-02-03 08:05:44) set tag tag1 to commit 0dee631320b13c6a6542c80bced33b9dd29f6bf0
+      To operation: 50c4130d9818 (2001-02-03 08:05:46) delete tag tag1
 
     Changed local tags:
     tag1:
@@ -1729,8 +1729,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@-", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
-      To operation: 2f45e55601da (2001-02-03 08:05:08) snapshot working copy
+    From operation: e39dc288903d (2001-02-03 08:05:07) add workspace 'default'
+      To operation: f148e2f53b28 (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + qpvuntsm 6b57e33c (no description set)
@@ -1750,8 +1750,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "--op", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: 2f45e55601da (2001-02-03 08:05:08) snapshot working copy
-      To operation: cf0770d7100e (2001-02-03 08:05:08) new empty commit
+    From operation: f148e2f53b28 (2001-02-03 08:05:08) snapshot working copy
+      To operation: 487462262dfc (2001-02-03 08:05:08) new empty commit
 
     Changed commits:
     ○  + rlvkpnrz c1c924b8 (empty) (no description set)
@@ -1773,8 +1773,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: 1411dd0524ab (2001-02-03 08:05:11) snapshot working copy
-      To operation: e6ae6bef0dc4 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+    From operation: 7a92b9c35cdf (2001-02-03 08:05:11) snapshot working copy
+      To operation: f9b785eed068 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
 
     Changed commits:
     ○  + mzvwutvl 6cbd01ae (empty) (no description set)
@@ -1807,8 +1807,8 @@ fn test_op_diff_patch() {
     ");
     let output = work_dir.run_jj(["op", "diff", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    From operation: e6ae6bef0dc4 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
-      To operation: 0b9a2eef07b2 (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
+    From operation: f9b785eed068 (2001-02-03 08:05:11) squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
+      To operation: 345aaf62e45d (2001-02-03 08:05:13) abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
@@ -1831,7 +1831,7 @@ fn test_op_diff_sibling() {
         .run_jj(["op", "log", "--no-graph", r#"-Tid.short() ++ "\n""#])
         .success();
     let base_op_id = output.stdout.raw().lines().next().unwrap();
-    insta::assert_snapshot!(base_op_id, @"90267f31f904");
+    insta::assert_snapshot!(base_op_id, @"e39dc288903d");
 
     // Create merge commit at one operation side. The parent trees will have to
     // be merged when diffing, which requires the commit index of this side.
@@ -1848,28 +1848,28 @@ fn test_op_diff_sibling() {
 
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @    1c4db3c4a594 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @    0571f8166a8a test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj op log
-    ○ │  8276f97c320d test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  62224ab1f2ca test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  new empty commit
     │ │  args: jj new '@-+' -mA
-    ○ │  ff1fbea612d5 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○ │  4fb5ff2413b4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new '@-+' -mA
-    ○ │  bf40689e8204 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  3cccd7ed737f test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.2
-    ○ │  0075fc491372 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○ │  980ecdc182d0 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │ │  snapshot working copy
     │ │  args: jj new 'root()' -mA.2
-    ○ │  7adb656f42e2 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  607b11df2cee test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  new empty commit
     │ │  args: jj new 'root()' -mA.1
-    │ ○  1220c0f6978f test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │ ○  d330b16f187a test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     ├─╯  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    │    args: jj describe --at-op 90267f31f904 -mB
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │    args: jj describe --at-op e39dc288903d -mB
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1882,9 +1882,9 @@ fn test_op_diff_sibling() {
         .success();
     let [head_op_id, p1_op_id, _, _, _, _, p2_op_id] =
         output.stdout.raw().lines().next_array().unwrap();
-    insta::assert_snapshot!(head_op_id, @"1c4db3c4a594");
-    insta::assert_snapshot!(p1_op_id, @"8276f97c320d");
-    insta::assert_snapshot!(p2_op_id, @"1220c0f6978f");
+    insta::assert_snapshot!(head_op_id, @"0571f8166a8a");
+    insta::assert_snapshot!(p1_op_id, @"62224ab1f2ca");
+    insta::assert_snapshot!(p2_op_id, @"d330b16f187a");
 
     // Diff between p1 and p2 operations should work no matter if p2 is chosen
     // as a base operation.
@@ -1900,8 +1900,8 @@ fn test_op_diff_sibling() {
         "--summary",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
-      To operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: 62224ab1f2ca (2001-02-03 08:05:11) new empty commit
+      To operation: d330b16f187a (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
 
     Changed commits:
     ○    - mzvwutvl/0 08c63613 (hidden) (empty) A
@@ -1930,8 +1930,8 @@ fn test_op_diff_sibling() {
         "--summary",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
+    From operation: d330b16f187a (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: 62224ab1f2ca (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     ○  - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
@@ -1962,8 +1962,8 @@ fn test_op_diff_sibling() {
         "--no-graph",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 1220c0f6978f (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-      To operation: 8276f97c320d (2001-02-03 08:05:11) new empty commit
+    From operation: d330b16f187a (2001-02-03 08:05:12) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+      To operation: 62224ab1f2ca (2001-02-03 08:05:11) new empty commit
 
     Changed commits:
     - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
@@ -2033,8 +2033,8 @@ fn test_op_diff_divergent_change() {
         &divergent_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 46c65d1e75d8 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    From operation: a5bc1e206f86 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+      To operation: 00e13cdbe522 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
@@ -2058,8 +2058,8 @@ fn test_op_diff_divergent_change() {
         &resolved_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: c27455b31516 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+    From operation: 00e13cdbe522 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: f686e63324ad (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
@@ -2083,8 +2083,8 @@ fn test_op_diff_divergent_change() {
         &divergent_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 46c65d1e75d8 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
-      To operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    From operation: a5bc1e206f86 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+      To operation: 00e13cdbe522 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
@@ -2133,8 +2133,8 @@ fn test_op_diff_divergent_change() {
         &resolved_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: c27455b31516 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+    From operation: 00e13cdbe522 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: f686e63324ad (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
 
     Changed commits:
     ○  + rlvkpnrz 17d68d92 2ab
@@ -2171,8 +2171,8 @@ fn test_op_diff_divergent_change() {
         &divergent_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: c27455b31516 (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
-      To operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+    From operation: f686e63324ad (2001-02-03 08:05:13) squash commits into c5cad9ab7772714178c158a133a0243908545b48
+      To operation: 00e13cdbe522 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
 
     Changed commits:
     ○  + rlvkpnrz/1 c5cad9ab (divergent) 2b
@@ -2196,8 +2196,8 @@ fn test_op_diff_divergent_change() {
         &initial_op_id,
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 43adb727799e (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
-      To operation: 46c65d1e75d8 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
+    From operation: 00e13cdbe522 (2001-02-03 08:05:11) describe commit 7a72a9ad7f4d8aa8b613a9840313b0ef0632842b
+      To operation: a5bc1e206f86 (2001-02-03 08:05:08) commit 5d86d4b609080a15077fcd723e537582d5ea6559
 
     Changed commits:
     ○  + rlvkpnrz 4f7a567a (empty) (no description set)
@@ -2240,9 +2240,9 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     // FIXME: the diff should be empty
     let output = work_dir.run_jj(["op", "diff"]);
     insta::assert_snapshot!(output, @"
-    From operation: aebc639c7fdb (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
-    From operation: f36a8c8cba9e (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
-      To operation: 8f0e2ab3b7cc (2001-02-03 08:05:11) reconcile divergent operations
+    From operation: 68f983fdc890 (2001-02-03 08:05:09) describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    From operation: b682ca9ba03c (2001-02-03 08:05:10) describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
+      To operation: 64e09790c2a8 (2001-02-03 08:05:11) reconcile divergent operations
 
     Changed commits:
     ○  + rlvkpnrz/1 8f35f6a6 (divergent) (empty) 2b
@@ -2252,7 +2252,7 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    8f0e2ab3b7cc test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    64e09790c2a8 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2260,10 +2260,10 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
 
     let output = work_dir.run_jj(["op", "log", "--op-diff", "--limit=3"]);
     insta::assert_snapshot!(output, @"
-    @    8f0e2ab3b7cc test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    @    64e09790c2a8 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     ├─╮  reconcile divergent operations
     │ │  args: jj log
-    ○ │  aebc639c7fdb test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○ │  68f983fdc890 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │ │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │ │  args: jj describe -r@- -m1
     │ │
@@ -2276,7 +2276,7 @@ fn test_op_diff_at_merge_op_with_rebased_commits() {
     │ │  Changed working copy default@:
     │ │  + rlvkpnrz 7ed5a610 (empty) 2a
     │ │  - rlvkpnrz/1 ab92d1a8 (hidden) (empty) 2a
-    │ ○  f36a8c8cba9e test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │ ○  b682ca9ba03c test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     ├─╯  describe commit ab92d1a87bebb4300165a16a753c5403bd7bc578
     │    args: jj describe '--at-op=@-' -m2b
     │
@@ -2316,8 +2316,8 @@ fn test_op_diff_word_wrap() {
 
     // ui.log-word-wrap option works, and diff stat respects content width
     insta::assert_snapshot!(render(&["op", "diff", "--from=@---", "--stat"], 40, true), @"
-    From operation: f6dad0859f53 (2001-02-03 08:05:07) add git remote origin
-      To operation: 5991a13625d6 (2001-02-03 08:05:08) snapshot working copy
+    From operation: c2d0c49630f8 (2001-02-03 08:05:07) add git remote origin
+      To operation: b2371722afba (2001-02-03 08:05:08) snapshot working copy
 
     Changed commits:
     ○  + sqpuoqvx f6f32c19 (no description
@@ -2384,8 +2384,8 @@ fn test_op_diff_word_wrap() {
     let config = r#"templates.commit_summary='"0 1 2 3 4 5 6 7 8 9"'"#;
     insta::assert_snapshot!(
         render(&["op", "diff", "--from=@---", "--config", config], 10, true), @"
-    From operation: f6dad0859f53 (2001-02-03 08:05:07) add git remote origin
-      To operation: 5991a13625d6 (2001-02-03 08:05:08) snapshot working copy
+    From operation: c2d0c49630f8 (2001-02-03 08:05:07) add git remote origin
+      To operation: b2371722afba (2001-02-03 08:05:08) snapshot working copy
 
     Changed
     commits:
@@ -2496,16 +2496,16 @@ fn test_op_show() {
     // Overview of op log.
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  2f8d408215e9 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  track remote bookmark bookmark-1@origin
     │  args: jj bookmark track bookmark-1
-    ○  80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  82b23649d107 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  fetch from git remote(s) origin
     │  args: jj git fetch
-    ○  ccace750b730 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  ab33a510f80e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  add git remote origin
     │  args: jj git remote add origin ../git-repo
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -2521,7 +2521,7 @@ fn test_op_show() {
     // Showing the latest operation.
     let output = work_dir.run_jj(["op", "show", "@"]);
     insta::assert_snapshot!(output, @"
-    81bc294627f7 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    2f8d408215e9 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     track remote bookmark bookmark-1@origin
     args: jj bookmark track bookmark-1
 
@@ -2543,7 +2543,7 @@ fn test_op_show() {
     // Showing a given operation.
     let output = work_dir.run_jj(["op", "show", "@-"]);
     insta::assert_snapshot!(output, @"
-    80e831767589 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    82b23649d107 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
 
@@ -2603,7 +2603,7 @@ fn test_op_show() {
     // Showing a merge operation is empty.
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    05f1e72786bd test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    755532ad20f8 test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
     reconcile divergent operations
     args: jj log
     [EOF]
@@ -2623,7 +2623,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    4d57f8c435c5 test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
+    12695e2ea673 test-username@host.example.com default@ 2001-02-03 04:05:19.000 +07:00 - 2001-02-03 04:05:19.000 +07:00
     fetch from git remote(s) origin
     args: jj git fetch
 
@@ -2667,7 +2667,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    9919170b2011 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
+    19ee4dd4da75 test-username@host.example.com default@ 2001-02-03 04:05:21.000 +07:00 - 2001-02-03 04:05:21.000 +07:00
     create bookmark bookmark-2 pointing to commit e1a239a57eb15cefc5910198befbbbe2b43c47af
     args: jj bookmark create bookmark-2 -r bookmark-2@origin
 
@@ -2687,7 +2687,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    fb6f3682d196 test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    0f26d7861e0a test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2
 
@@ -2708,7 +2708,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    fb6f3682d196 test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
+    0f26d7861e0a test-username@host.example.com default@ 2001-02-03 04:05:23.000 +07:00 - 2001-02-03 04:05:23.000 +07:00
     track remote bookmark bookmark-2@origin
     args: jj bookmark track bookmark-2
 
@@ -2730,7 +2730,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    0a422359fac3 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
+    0c4b01137220 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
     new empty commit
     args: jj new bookmark-1@origin -m 'new commit'
 
@@ -2753,7 +2753,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    d240a4e0bf5c test-username@host.example.com default@ 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
+    063186f0ab54 test-username@host.example.com default@ 2001-02-03 04:05:29.000 +07:00 - 2001-02-03 04:05:29.000 +07:00
     point bookmark bookmark-1 to commit 8f340dd76dc637e4deac17f30056eef7d8eaf682
     args: jj bookmark set bookmark-1 -r @
 
@@ -2774,7 +2774,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    57051f5b9177 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    dc0cafaf26d5 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     delete bookmark bookmark-2
     args: jj bookmark delete bookmark-2
 
@@ -2796,7 +2796,7 @@ fn test_op_show() {
     ");
     let output = work_dir.run_jj(["op", "show"]);
     insta::assert_snapshot!(output, @"
-    4c467aa621a6 test-username@host.example.com default@ 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
+    aee8032b7c82 test-username@host.example.com default@ 2001-02-03 04:05:33.000 +07:00 - 2001-02-03 04:05:33.000 +07:00
     push all tracked bookmarks/tags to git remote origin
     args: jj git push --tracked --deleted
 
@@ -2812,20 +2812,12 @@ fn test_op_show() {
 
     // Showing a given operation, without graph
     let output = work_dir.run_jj(["op", "show", "--no-graph", "0a422359fac3"]);
-    insta::assert_snapshot!(output, @"
-    0a422359fac3 test-username@host.example.com default@ 2001-02-03 04:05:27.000 +07:00 - 2001-02-03 04:05:27.000 +07:00
-    new empty commit
-    args: jj new bookmark-1@origin -m 'new commit'
-
-    Changed commits:
-    + tlkvzzqu 8f340dd7 (empty) new commit
-    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
-
-    Changed working copy default@:
-    + tlkvzzqu 8f340dd7 (empty) new commit
-    - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: No operation ID matching "0a422359fac3"
     [EOF]
-    ");
+    [exit status: 1]
+    "#);
 }
 
 #[test]
@@ -2845,7 +2837,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "@-", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    2f45e55601da test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    f148e2f53b28 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     snapshot working copy
     args: jj new
 
@@ -2867,7 +2859,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "@", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    cf0770d7100e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    487462262dfc test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     new empty commit
     args: jj new
 
@@ -2891,7 +2883,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    e6ae6bef0dc4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    f9b785eed068 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     args: jj squash
 
@@ -2926,7 +2918,7 @@ fn test_op_show_patch() {
     ");
     let output = work_dir.run_jj(["op", "show", "-p", "--git"]);
     insta::assert_snapshot!(output, @"
-    0b9a2eef07b2 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    345aaf62e45d test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     args: jj abandon
 
@@ -2943,7 +2935,7 @@ fn test_op_show_patch() {
     // Try again with "op log".
     let output = work_dir.run_jj(["op", "log", "--git"]);
     insta::assert_snapshot!(output, @"
-    @  0b9a2eef07b2 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    @  345aaf62e45d test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  abandon commit 6cbd01aefe5ae05a015328311dbd63b7305b8ebe
     │  args: jj abandon
     │
@@ -2954,7 +2946,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + yqosqzyt c97a8573 (empty) (no description set)
     │  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
-    ○  e6ae6bef0dc4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  f9b785eed068 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  squash commits into 6b57e33cc56babbeaa6bcd6e2a296236b52ad93c
     │  args: jj squash
     │
@@ -2974,7 +2966,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + mzvwutvl 6cbd01ae (empty) (no description set)
     │  - rlvkpnrz/0 05a2969e (hidden) (no description set)
-    ○  1411dd0524ab test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  7a92b9c35cdf test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  snapshot working copy
     │  args: jj squash
     │
@@ -2992,7 +2984,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz 05a2969e (no description set)
     │  - rlvkpnrz/1 c1c924b8 (hidden) (empty) (no description set)
-    ○  cf0770d7100e test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  487462262dfc test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  new empty commit
     │  args: jj new
     │
@@ -3002,7 +2994,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + rlvkpnrz c1c924b8 (empty) (no description set)
     │  - qpvuntsm 6b57e33c (no description set)
-    ○  2f45e55601da test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  f148e2f53b28 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj new
     │
@@ -3020,7 +3012,7 @@ fn test_op_show_patch() {
     │  Changed working copy default@:
     │  + qpvuntsm 6b57e33c (no description set)
     │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     │
     │  Changed commits:
@@ -3051,12 +3043,12 @@ fn test_op_show_template() {
         r#"separate(" ", id.short(), description)"#,
         "--no-op-diff",
     ]);
-    insta::assert_snapshot!(output, @"88b1bf13af2b commit 0883ea507656cce545dbba9f23760ff72dff5174[EOF]");
+    insta::assert_snapshot!(output, @"02f1b290fb1f commit 0883ea507656cce545dbba9f23760ff72dff5174[EOF]");
 
     // Test --no-op-diff flag suppresses the diff
     let output = work_dir.run_jj(["op", "show", "--no-op-diff"]);
     insta::assert_snapshot!(output, @"
-    88b1bf13af2b test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    02f1b290fb1f test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     commit 0883ea507656cce545dbba9f23760ff72dff5174
     args: jj commit -m 'first commit'
     [EOF]
@@ -3070,7 +3062,7 @@ fn test_op_show_template() {
         r#"separate(" ", id.short(), description)"#,
     ]);
     insta::assert_snapshot!(output, @"
-    88b1bf13af2b commit 0883ea507656cce545dbba9f23760ff72dff5174
+    02f1b290fb1f commit 0883ea507656cce545dbba9f23760ff72dff5174
     Changed commits:
     ○  + rlvkpnrz e4863b8c (empty) (no description set)
     ○  + qpvuntsm b52b7cb5 first commit
@@ -3098,13 +3090,13 @@ fn test_op_log_parents() {
     let template = r#"id.short() ++ "\nP: " ++ parents.len() ++ " " ++ parents.map(|o| o.id().short()) ++ "\n""#;
     let output = work_dir.run_jj(["op", "log", "-T", template]);
     insta::assert_snapshot!(output, @"
-    @    b991e0d37e4d
-    ├─╮  P: 2 8501e29d2d94 9eb037245431
-    ○ │  8501e29d2d94
-    │ │  P: 1 90267f31f904
-    │ ○  9eb037245431
-    ├─╯  P: 1 90267f31f904
-    ○  90267f31f904
+    @    f4a47cf52d6d
+    ├─╮  P: 2 69e9fab8ce76 a395e6e6a995
+    ○ │  69e9fab8ce76
+    │ │  P: 1 e39dc288903d
+    │ ○  a395e6e6a995
+    ├─╯  P: 1 e39dc288903d
+    ○  e39dc288903d
     │  P: 1 000000000000
     ○  000000000000
        P: 0
@@ -3126,10 +3118,10 @@ fn test_op_log_anonymize() {
 
     let output = work_dir.run_jj(["op", "log", "-Tbuiltin_op_log_redacted"]);
     insta::assert_snapshot!(output, @"
-    @  8501e29d2d94 user-5910 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  69e9fab8ce76 user-5910 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  (redacted)
-    ○  90267f31f904 user-5910 workspace-482a@ 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d user-5910 workspace-482a@ 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -3162,7 +3154,7 @@ fn test_op_immutable_revisions() {
         .run_jj(["abandon", "--ignore-immutable", "::t1 & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    d86e21bb08c0 test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
+    eb0248ec440d test-username@host.example.com default@ 2001-02-03 04:05:16.000 +07:00 - 2001-02-03 04:05:16.000 +07:00
     abandon commit 9c86781f3fe9097ffc530e65fd2ab4aff1e654bd and 5 more
     args: jj abandon --ignore-immutable '::t1 & ~root()'
 
@@ -3175,8 +3167,8 @@ fn test_op_immutable_revisions() {
     // Undo
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    abbb2399227e test-username@host.example.com default@ 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
-    revert operation d86e21bb08c07020add3b8624a72211b087501d2cce3e1fc90ef0e37596385b73b5470b1754dfbaf1ec28df0df5d61dadb6cf338ceb1ae2a1974a3a473ec8230
+    58ade1388288 test-username@host.example.com default@ 2001-02-03 04:05:18.000 +07:00 - 2001-02-03 04:05:18.000 +07:00
+    revert operation eb0248ec440d0bdf7ff8d43113cc8809a526120f1c8857f2e8fb3bc364275a10a7c37f828b52505ffe3c03527143d0be696fd7619c67ec3a8338c06d37054015
     args: jj op revert
 
     Changed commits:
@@ -3207,7 +3199,7 @@ fn test_op_immutable_revisions() {
         .success();
     let op_id_for_diff = work_dir.current_operation_id();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    f33e4de8aa2d test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
@@ -3222,7 +3214,7 @@ fn test_op_immutable_revisions() {
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    cf3d5f839512 test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
+    f33e4de8aa2d test-username@host.example.com default@ 2001-02-03 04:05:31.000 +07:00 - 2001-02-03 04:05:31.000 +07:00
     abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
     args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
 
@@ -3259,7 +3251,7 @@ fn test_op_immutable_revisions() {
         .run_jj(["rebase", "--ignore-immutable", "-s", "bb----", "-d", "ba"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    aeab86c39d0d test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
     rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
@@ -3283,7 +3275,7 @@ fn test_op_immutable_revisions() {
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    5139db3ae21c test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
+    aeab86c39d0d test-username@host.example.com default@ 2001-02-03 04:05:48.000 +07:00 - 2001-02-03 04:05:48.000 +07:00
     rebase commit 6c3a9c2476ba8a8e5bac722f9c0e2ca914b9577d and descendants
     args: jj rebase --ignore-immutable -s bb---- -d ba
 
@@ -3315,7 +3307,7 @@ fn test_op_immutable_revisions() {
         .run_jj(["abandon", "--ignore-immutable", "::ts & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    e660cbda9711 test-username@host.example.com default@ 2001-02-03 04:05:55.000 +07:00 - 2001-02-03 04:05:55.000 +07:00
+    c02348bb9eea test-username@host.example.com default@ 2001-02-03 04:05:55.000 +07:00 - 2001-02-03 04:05:55.000 +07:00
     abandon commit 4ebd4aa1d0bfee524ccd21882606990e3b75fc12 and 1 more
     args: jj abandon --ignore-immutable '::ts & ~root()'
 
@@ -3334,8 +3326,8 @@ fn test_op_immutable_revisions() {
     // Undo to see single addition elision
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
-    revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    00ea08fa4538 test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    revert operation c02348bb9eea32464b19fcb84f1de5195230f21d55bddfb1a862c3e92ff398818e48636ec47a34cf91c4b572bbb82f619e188557b9fe00aefaea79661da2f159
     args: jj op revert
 
     Changed commits:
@@ -3352,8 +3344,8 @@ fn test_op_immutable_revisions() {
 
     // 5. op diff and op log tests
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_id_for_diff]), @"
-    From operation: cf3d5f839512 (2001-02-03 08:05:31) abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
-      To operation: d4f2cba9248e (2001-02-03 08:05:57) revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    From operation: f33e4de8aa2d (2001-02-03 08:05:31) abandon commit 7c60d8fd187f77196d1def564b0d893d477b7e56 and 11 more
+      To operation: 00ea08fa4538 (2001-02-03 08:05:57) revert operation c02348bb9eea32464b19fcb84f1de5195230f21d55bddfb1a862c3e92ff398818e48636ec47a34cf91c4b572bbb82f619e188557b9fe00aefaea79661da2f159
 
     Changed commits:
     ○  + ztnvrxlv 13887367 (empty) (no description set)
@@ -3383,8 +3375,8 @@ fn test_op_immutable_revisions() {
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "1"]), @"
-    @  d4f2cba9248e test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
-    │  revert operation e660cbda9711f6258fca5dffa47b356ace070baff91ee1ff29dee57432d2d44a65cc96375ef6a6e0f0c17171a3a4e209df9f8613790abb28c87acb6fbe107f8d
+    @  00ea08fa4538 test-username@host.example.com default@ 2001-02-03 04:05:57.000 +07:00 - 2001-02-03 04:05:57.000 +07:00
+    │  revert operation c02348bb9eea32464b19fcb84f1de5195230f21d55bddfb1a862c3e92ff398818e48636ec47a34cf91c4b572bbb82f619e188557b9fe00aefaea79661da2f159
     │  args: jj op revert
     │
     │  Changed commits:
@@ -3472,8 +3464,8 @@ fn test_op_immutable_revisions() {
         "all()",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
-      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
+    From operation: edc48eca90ea (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
+      To operation: f8c2543f662a (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
 
     Changed commits:
     ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
@@ -3493,8 +3485,8 @@ fn test_op_immutable_revisions() {
     // of the newly hidden set and elide c1.
     let output = work_dir.run_jj(["op", "diff", "--from", &op_a, "--to", &op_b]);
     insta::assert_snapshot!(output, @"
-    From operation: 6065717c85c3 (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
-      To operation: 15571d49e1b7 (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
+    From operation: edc48eca90ea (2001-02-03 08:06:12) abandon commit 65f87c2d667d5088987ce6bed60f31f783b9e2ba
+      To operation: f8c2543f662a (2001-02-03 08:06:13) abandon commit 7d9fcee9d7dedaa91bee64d976a4252c74750905 and 1 more
 
     Changed commits:
     ○  - quyylypw/0 7d9fcee9 (hidden) (empty) acc-c2
@@ -3561,7 +3553,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 5. Test op show for op_rebase: should show ELISION summary.
     // bookmark_x exists in both states of the rebase.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_rebase]), @"
-    ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    75842f60dc81 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
     rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
     args: jj rebase -s bookmark_x- -d @
 
@@ -3580,7 +3572,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 6. Test op show for op_create: should show WARNING.
     // bookmark_x did not exist in the 'from' state.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create]), @"
-    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    a6739a805d51 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     args: jj bookmark create -r@ bookmark_x
 
@@ -3597,7 +3589,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 7. Test op show for op_create with the flag: should show all changes and NO
     //    WARNING.
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create, "--show-changes-in", "all()"]), @"
-    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    a6739a805d51 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     args: jj bookmark create -r@ bookmark_x
 
@@ -3611,8 +3603,8 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 8. Test op diff from BEFORE creation to op_rebase: should show WARNING.
     let op_before_create = format!("{op_create}-");
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_before_create, "--to", &op_rebase]), @"
-    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
-      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    From operation: 06324bd96409 (2001-02-03 08:05:08) new empty commit
+      To operation: 75842f60dc81 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
 
     Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
        (Use --show-changes-in=all() to see all changes)
@@ -3639,8 +3631,8 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
         "--show-changes-in",
         "all()",
     ]), @"
-    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
-      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    From operation: 06324bd96409 (2001-02-03 08:05:08) new empty commit
+      To operation: 75842f60dc81 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
 
     Changed commits:
     ○  + 3cafca23bb81 stack 2
@@ -3661,7 +3653,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     // 10. Test op log -p: should show BOTH behaviors.
     test_env.add_config(r#"revsets.op-diff-changes-in = "mutable() | bookmark_x""#);
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "6"]), @"
-    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    @  75842f60dc81 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
     │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
     │  args: jj rebase -s bookmark_x- -d @
     │
@@ -3675,7 +3667,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 3cafca23bb81 stack 2
     │  - 5456f1af47ed stack 2
-    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    ○  118a6ee52daa test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  new empty commit
     │  args: jj new 'root()' -m new_base
     │
@@ -3687,7 +3679,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 6b753f7043b4 new_base
     │  - 5456f1af47ed stack 2
-    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    ○  85144a1c6ca9 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
     │  args: jj bookmark set bookmark_x -r@
     │
@@ -3695,7 +3687,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 5456f1af47ed stack 2
     │  - 2308e5a241f7 base
-    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  bcc1579c81d7 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 2'
     │
@@ -3707,7 +3699,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 5456f1af47ed stack 2
     │  - 0f12cf5c679b stack 1
-    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  7e6bd9675d9d test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 1'
     │
@@ -3719,7 +3711,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 0f12cf5c679b stack 1
     │  - 2308e5a241f7 base
-    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  a6739a805d51 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     │  args: jj bookmark create -r@ bookmark_x
     │
@@ -3743,7 +3735,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
         "--show-changes-in",
         "all()",
     ]), @"
-    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    @  75842f60dc81 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
     │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
     │  args: jj rebase -s bookmark_x- -d @
     │
@@ -3757,7 +3749,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 3cafca23bb81 stack 2
     │  - 5456f1af47ed stack 2
-    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    ○  118a6ee52daa test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
     │  new empty commit
     │  args: jj new 'root()' -m new_base
     │
@@ -3769,7 +3761,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 6b753f7043b4 new_base
     │  - 5456f1af47ed stack 2
-    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    ○  85144a1c6ca9 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
     │  args: jj bookmark set bookmark_x -r@
     │
@@ -3777,7 +3769,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  bookmark_x:
     │  + 5456f1af47ed stack 2
     │  - 2308e5a241f7 base
-    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    ○  bcc1579c81d7 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 2'
     │
@@ -3789,7 +3781,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 5456f1af47ed stack 2
     │  - 0f12cf5c679b stack 1
-    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ○  7e6bd9675d9d test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  new empty commit
     │  args: jj new @ -m 'stack 1'
     │
@@ -3801,7 +3793,7 @@ commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
     │  Changed working copy default@:
     │  + 0f12cf5c679b stack 1
     │  - 2308e5a241f7 base
-    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ○  a6739a805d51 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
     │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
     │  args: jj bookmark create -r@ bookmark_x
     │

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -704,7 +704,7 @@ fn test_rebase_revision_onto_descendant() {
     let output = work_dir.run_jj(["op", "restore", &setup_opid]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 445e5af39d91 (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
+    Restored to operation: 945eff3eb457 (2001-02-03 08:05:15) create bookmark merge pointing to commit 08c0951bf69d0362708a5223a78446d664823b50
     Working copy  (@) now at: vruxwmqv 08c0951b merge | merge
     Parent commit (@-)      : royxmykx 6a7081ef b | b
     Parent commit (@-)      : zsuskuln 68fbc443 a | a

--- a/cli/tests/test_split_command.rs
+++ b/cli/tests/test_split_command.rs
@@ -419,16 +419,16 @@ fn test_split_with_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_1, @"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:12 74306e35
     │  Add file1
-    │  -- operation ec53c39a72a8 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation b867816ba998 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
-    │  -- operation 8185a834cefe commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation a5cd7a6de1d8 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation d36e968aa414 snapshot working copy
+    │  -- operation 6d5cd26b7f5d snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
 
@@ -438,16 +438,16 @@ fn test_split_with_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_2, @"
     ○  royxmykx test.user@example.com 2001-02-03 08:05:12 0a37745e
     │  Add file2
-    │  -- operation ec53c39a72a8 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
+    │  -- operation b867816ba998 split commit 1d2499e72cefc8a2b87ebb47569140857b96189f
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 1d2499e7 (hidden)
     │  Add file1 & file2
-    │  -- operation 8185a834cefe commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation a5cd7a6de1d8 commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation d36e968aa414 snapshot working copy
+    │  -- operation 6d5cd26b7f5d snapshot working copy
     ○  qpvuntsm/3 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
     Ok(())
@@ -575,13 +575,13 @@ fn test_split_parallel_no_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_1, @"
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 7bcd474c
     │  TESTED=TODO
-    │  -- operation 90307a87dc57 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 7b9cdc9d8406 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation f07456070284 snapshot working copy
+    │  -- operation 03684cf61546 snapshot working copy
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
 
@@ -591,13 +591,13 @@ fn test_split_parallel_no_descendants() -> TestResult {
     insta::assert_snapshot!(evolog_2, @"
     @  kkmpptxz test.user@example.com 2001-02-03 08:05:09 431886f6
     │  (no description set)
-    │  -- operation 90307a87dc57 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
+    │  -- operation 7b9cdc9d8406 split commit f5700f8ef89e290e4e90ae6adc0908707e0d8c85
     ○  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 f5700f8e (hidden)
     │  (no description set)
-    │  -- operation f07456070284 snapshot working copy
+    │  -- operation 03684cf61546 snapshot working copy
     ○  qpvuntsm/2 test.user@example.com 2001-02-03 08:05:07 e8849ae1 (hidden)
        (empty) (no description set)
-       -- operation 90267f31f904 add workspace 'default'
+       -- operation e39dc288903d add workspace 'default'
     [EOF]
     ");
     Ok(())

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -2124,31 +2124,31 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○    pkstwlsy test.user@example.com 2001-02-03 08:05:35 41510a56
     ├─╮  file 3&4
-    │ │  -- operation 3d6e647dccb7 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 026f4f6709a5 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln/0 test.user@example.com 2001-02-03 08:05:35 a5bc761f (hidden)
     │ │  file4
-    │ │  -- operation 3d6e647dccb7 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │ │  -- operation 026f4f6709a5 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     │ ○  zsuskuln/4 test.user@example.com 2001-02-03 08:05:11 38778966 (hidden)
     │ │  file4
-    │ │  -- operation 9ca0f4771551 commit 89a30a7539466ed176c1ef122a020fd9cb15848e
+    │ │  -- operation 3c3c237dae08 commit 89a30a7539466ed176c1ef122a020fd9cb15848e
     │ ○  zsuskuln/5 test.user@example.com 2001-02-03 08:05:11 89a30a75 (hidden)
     │ │  (no description set)
-    │ │  -- operation 26b29f385618 snapshot working copy
+    │ │  -- operation 8d98ff7c076c snapshot working copy
     │ ○  zsuskuln/6 test.user@example.com 2001-02-03 08:05:10 bbf04d26 (hidden)
     │    (empty) (no description set)
-    │    -- operation fc5403fc3984 commit c23c424826221bc4fdee9487926595324e50ee95
+    │    -- operation 500bbee268a2 commit c23c424826221bc4fdee9487926595324e50ee95
     ○  kkmpptxz/0 test.user@example.com 2001-02-03 08:05:35 ce3b0a58 (hidden)
     │  file3
-    │  -- operation 3d6e647dccb7 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+    │  -- operation 026f4f6709a5 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     ○  kkmpptxz/3 test.user@example.com 2001-02-03 08:05:10 0d254956 (hidden)
     │  file3
-    │  -- operation fc5403fc3984 commit c23c424826221bc4fdee9487926595324e50ee95
+    │  -- operation 500bbee268a2 commit c23c424826221bc4fdee9487926595324e50ee95
     ○  kkmpptxz/4 test.user@example.com 2001-02-03 08:05:10 c23c4248 (hidden)
     │  (no description set)
-    │  -- operation c5043d80534d snapshot working copy
+    │  -- operation 385c607f1340 snapshot working copy
     ○  kkmpptxz/5 test.user@example.com 2001-02-03 08:05:09 c1272e87 (hidden)
        (empty) (no description set)
-       -- operation 4eb3252f7fd7 commit cb58ff1c6f1af92f827661e7275941ceb4d910c5
+       -- operation 1fe18b105580 commit cb58ff1c6f1af92f827661e7275941ceb4d910c5
     [EOF]
     ");
 
@@ -2222,7 +2222,7 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○  nsrwusvy test.user@example.com 2001-02-03 08:05:42 c2183685
        (empty) (no description set)
-       -- operation 29b5af212226 squash 0 commits
+       -- operation 3094a76484ad squash 0 commits
     [EOF]
     ");
 
@@ -2266,7 +2266,7 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○  wtlqussy test.user@example.com 2001-02-03 08:05:46 7eff41c8
        (empty) (no description set)
-       -- operation f5c12bfd0cbc squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
+       -- operation 2dfbda8259b2 squash commit 0d254956d33ed5bb11d93eb795c5e514aadc81b5 and 1 more
     [EOF]
     ");
 
@@ -2313,10 +2313,10 @@ fn test_squash_to_new_commit() -> TestResult {
     insta::assert_snapshot!(output, @"
     ○  pyoswmwk test.user@example.com 2001-02-03 08:05:50 991d0644
     │  (empty) (no description set)
-    │  -- operation 587bcc3abdef squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
+    │  -- operation c4d2417e58a7 squash commit f5e47d019271a392eb7f92a6b2e9f8cf41d97049
     ○  szrrkvty/0 test.user@example.com 2001-02-03 08:05:50 f5e47d01 (hidden)
        (empty) (no description set)
-       -- operation 4096cc584a23 new empty commit
+       -- operation dcf228dfaf3f new empty commit
     [EOF]
     ");
 

--- a/cli/tests/test_undo_redo_commands.rs
+++ b/cli/tests/test_undo_redo_commands.rs
@@ -23,7 +23,7 @@ fn test_undo_root_operation() {
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
+    Undid operation: e39dc288903d (2001-02-03 08:05:07) add workspace 'default'
     Restored to operation: 000000000000 root()
     Warning: The current workspace 'default' no longer exists after this operation. The working copy was left untouched.
     Hint: Restore to an operation that contains the workspace (e.g. `jj undo` or `jj redo`).
@@ -78,8 +78,8 @@ fn test_undo_push_operation() {
     ------- stderr -------
     Warning: Undoing a push operation often leads to conflicted bookmarks.
     Hint: To avoid this, run `jj redo` now.
-    Undid operation: 161aca25fa92 (2001-02-03 08:05:10) push bookmark push-rlvkpnrzqnoo to git remote origin
-    Restored to operation: ac6334185db7 (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
+    Undid operation: 60148e16fc4f (2001-02-03 08:05:10) push bookmark push-rlvkpnrzqnoo to git remote origin
+    Restored to operation: 2b68c607533a (2001-02-03 08:05:09) commit 3850397cf31988d0657948307ad5bbe873d76a38
     [EOF]
     ");
 }

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -114,8 +114,8 @@ fn test_gc_operation_log() {
     ------- stderr -------
     Internal error: Failed to load an operation
     Caused by:
-    1: Object 8eda7af9cb0a21f1e2663b153d168ae65ee8508fdcff832e6ea53bd7285f5304bc6d05d3ce4096d5d0ac4c16159c02a864defafd1f2908af190e02f27d6d28ed of type operation not found
-    2: Cannot access $TEST_ENV/repo/.jj/repo/op_store/operations/8eda7af9cb0a21f1e2663b153d168ae65ee8508fdcff832e6ea53bd7285f5304bc6d05d3ce4096d5d0ac4c16159c02a864defafd1f2908af190e02f27d6d28ed
+    1: Object 20988788f1129348a666f9257a44c0aa66a721ceee139798af6b1b5189882c81071a11bd39d143f9332b87fc49f96e61f629f8a4f4bb42f9364dc84f93d10811 of type operation not found
+    2: Cannot access $TEST_ENV/repo/.jj/repo/op_store/operations/20988788f1129348a666f9257a44c0aa66a721ceee139798af6b1b5189882c81071a11bd39d143f9332b87fc49f96e61f629f8a4f4bb42f9364dc84f93d10811
     [EOF]
     [exit status: 255]
     ");

--- a/cli/tests/test_working_copy.rs
+++ b/cli/tests/test_working_copy.rs
@@ -361,7 +361,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // Working copy should contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("072342f0123bbb53824fe316de828240ec981d9d11608e8a31c12253e99cd504d5a0fae3851f6a83941863a85b68954c90b7d6ad2fd4f7da469b7d8a6482c003")
+    Current operation: OperationId("03fde379ea4a6c7267f99f342c6ceb0a33479432ac84cf561ec672b223e27d8deb3ba598665e7f0a50c757fc15a9900e6973b99a7cd3df0c5ac6cb5ccd9adbf7")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("f56b8223da0dab22b03b8323ced4946329aeb4e0")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           313 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -424,7 +424,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // Working copy should still contain conflict marker length
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("19bcba55afcdec47b31cf0217b2a4b20dd9d90fe7dd7b4cdf0c52b74735c5407a8fddd1d3b43f37c09223b8b8053289f49bcba58c0af68869f891f582460ad4a")
+    Current operation: OperationId("27be51e35a02b5b526684006790fcef67a631d40e94a2d7adc5cdb09ae83d48f9eb6d1b93d36452c09196e2026d2f7337d32cac42e0767b5a866bd2d90bc204c")
     Current tree: MergedTree { tree_ids: Conflicted([TreeId("381273b50cf73f8c81b3f1502ee89e9bbd6c1518"), TreeId("771f3d31c4588ea40a8864b2a981749888e596c2"), TreeId("3329c18c95f7b7a55c278c2259e9c4ce711fae59")]), labels: Labeled(["rlvkpnrz ccf9527c \"side-a\"", "qpvuntsm 2205b3ac \"base\"", "zsuskuln d7acaf48 \"side-b\""]), .. }
     Normal { exec_bit: ExecBit(false) }           274 <timestamp> Some(MaterializedConflictData { conflict_marker_len: 11 }) "file"
     [EOF]
@@ -459,7 +459,7 @@ fn test_conflict_marker_length_stored_in_working_copy() -> TestResult {
     // working copy
     let output = work_dir.run_jj(["debug", "local-working-copy"]);
     insta::assert_snapshot!(output.normalize_stdout_with(redact_output), @r#"
-    Current operation: OperationId("ed741c71397533330b01669ac13c3407ed89ba782a65ef038cefef27f95f3e2a513f0d3b04a2f96e79ac8b9e050ea080b06dd6ad2b10fc4e3f6978100b8ec8c9")
+    Current operation: OperationId("c3508fd3f287d136a73e7eb67f456d4498ce3bbf3382a770213bbfb91661ce6a6ca5149b7bed2b4ed169c85dda985ed3eaf7b5af9438bc4a52f415306715c302")
     Current tree: MergedTree { tree_ids: Resolved(TreeId("6120567b3cb2472d549753ed3e4b84183d52a650")), labels: Unlabeled, .. }
     Normal { exec_bit: ExecBit(false) }           130 <timestamp> None "file"
     [EOF]

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1354,8 +1354,9 @@ fn test_colocated_workspace_update_stale() {
         .run_jj(["bookmark", "set", "-rsubject('old book1')", "book1"])
         .success();
 
+    // Use --no-colocate to keep secondary non-colocated for this test
     main_dir
-        .run_jj(["workspace", "add", "../secondary"])
+        .run_jj(["workspace", "add", "--no-colocate", "../secondary"])
         .success();
 
     // Rewrite the check-out commit from the secondary workspace.

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -649,7 +649,7 @@ fn test_workspace_add_override_path_in_store() {
     let output = main_dir.run_jj(["operation", "restore", "@--"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Restored to operation: 98ef745836d5 (2001-02-03 08:05:08) commit 006bd1130b84e90ab082adeabd7409270d5a86da
+    Restored to operation: c5bfc0be8306 (2001-02-03 08:05:08) commit 006bd1130b84e90ab082adeabd7409270d5a86da
     [EOF]
     ");
 
@@ -738,7 +738,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 112d1427e3d3).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -748,7 +748,7 @@ fn test_workspaces_conflicting_edits() {
     let output = secondary_dir.run_jj(["log"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 112d1427e3d3).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -839,7 +839,7 @@ fn test_workspaces_updated_by_other() {
     let output = secondary_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 58f8ef773e05).
+    Error: The working copy is stale (not updated since operation 112d1427e3d3).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1089,14 +1089,14 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
     ]);
     insta::allow_duplicates! {
         insta::assert_snapshot!(output, @"
-        @  2dea766382 abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
-        ○  0d3faebd8c create initial working-copy commit in workspace secondary
-        ○  200ba564cb add workspace 'secondary'
-        ○  b34eafb924 new empty commit
-        ○  c883929a6b snapshot working copy
-        ○  bd7b1cfa98 new empty commit
-        ○  4509e20d8c snapshot working copy
-        ○  90267f31f9 add workspace 'default'
+        @  999625274f abandon commit de90575a14d8b9198dc0930f9de4a69f846ded36
+        ○  82854b4f68 create initial working-copy commit in workspace secondary
+        ○  5761a0283b add workspace 'secondary'
+        ○  9d91c47f71 new empty commit
+        ○  5d825bd295 snapshot working copy
+        ○  f6770a3428 new empty commit
+        ○  09cf7d1cf3 snapshot working copy
+        ○  e39dc28890 add workspace 'default'
         ○  0000000000
         [EOF]
         ");
@@ -1131,7 +1131,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         Parent commit (@-): rzvqmyuk 891f0006 (empty) (no description set)
         [EOF]
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0d3faebd8cf4f0e39ea3eab47f22c9cdbcdaa54d95e79a86a0dab4ebe3b0377f69e1d64fa4661913c8c6af01dc0ebb5ad7c8b2bfa3d229827b2ba756d729e0bf of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 82854b4f6803b9a5729be4028aa68b075c4c5c2e289ca04146a3a3ce2bcd836556dc5d7db6203777f0a0f059797ba7b689de79e359669d57bb94b91236b58028 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1149,7 +1149,7 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         let output = secondary_dir.run_jj(["workspace", "update-stale"]);
         insta::assert_snapshot!(output, @"
         ------- stderr -------
-        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 0d3faebd8cf4f0e39ea3eab47f22c9cdbcdaa54d95e79a86a0dab4ebe3b0377f69e1d64fa4661913c8c6af01dc0ebb5ad7c8b2bfa3d229827b2ba756d729e0bf of type operation not found
+        Failed to read working copy's current operation; attempting recovery. Error message from read attempt: Object 82854b4f6803b9a5729be4028aa68b075c4c5c2e289ca04146a3a3ce2bcd836556dc5d7db6203777f0a0f059797ba7b689de79e359669d57bb94b91236b58028 of type operation not found
         Created and checked out recovery commit 866928d1e0fd
         [EOF]
         ");
@@ -1200,20 +1200,20 @@ fn test_workspaces_current_op_discarded_by_other(automatic: bool) {
         insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation a35d39d101f4 snapshot working copy
+        │  -- operation 1d9f35c8ff54 snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 754c2986ff83 recovery commit
+           -- operation 64b34ec7908c recovery commit
         [EOF]
         ");
     } else {
         insta::assert_snapshot!(output, @"
         @  kmkuslsw test.user@example.com 2001-02-03 08:05:18 secondary@ 18851b39
         │  RECOVERY COMMIT FROM `jj workspace update-stale`
-        │  -- operation 3ae899f26750 snapshot working copy
+        │  -- operation bb5fe5e623a9 snapshot working copy
         ○  kmkuslsw/1 test.user@example.com 2001-02-03 08:05:18 866928d1 (hidden)
            (empty) RECOVERY COMMIT FROM `jj workspace update-stale`
-           -- operation 754c2986ff83 recovery commit
+           -- operation 64b34ec7908c recovery commit
         [EOF]
         ");
     }
@@ -1271,8 +1271,8 @@ fn test_workspaces_unpublished_operation_same_tree() {
     let output = main_dir.run_jj(["status"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Internal error: The repo was loaded at operation 8627c7508be4, which seems to be a sibling of the working copy's operation eceacbdafd84
-    Hint: Run `jj op integrate eceacbdafd84` to add the working copy's operation to the operation log.
+    Internal error: The repo was loaded at operation 4f9c1f05fdf1, which seems to be a sibling of the working copy's operation 69a858721990
+    Hint: Run `jj op integrate 69a858721990` to add the working copy's operation to the operation log.
     [EOF]
     [exit status: 255]
     ");
@@ -1400,7 +1400,7 @@ fn test_colocated_workspace_update_stale() {
     let output = main_dir.run_jj(["st"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: The working copy is stale (not updated since operation 8ab980a3d398).
+    Error: The working copy is stale (not updated since operation e552d87b13fb).
     Hint: Run `jj workspace update-stale` to update it.
     See https://docs.jj-vcs.dev/latest/working-copy/#stale-working-copy for more information.
     [EOF]
@@ -1607,7 +1607,7 @@ fn test_workspaces_forget_multi_transaction() {
     // the op log should have the multiple valid workspaces forgotten in a single tx
     let output = main_dir.run_jj(["op", "log", "--limit", "1"]);
     insta::assert_snapshot!(output, @"
-    @  90493ae75198 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    @  56637f98c5d4 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
     │  forget workspaces second, third
     │  args: jj workspace forget second third fourth
     [EOF]
@@ -1936,10 +1936,10 @@ fn test_debug_snapshot() {
     work_dir.run_jj(["debug", "snapshot"]).success();
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  a60628738654 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  3c84df1da721 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
@@ -1947,13 +1947,13 @@ fn test_debug_snapshot() {
     work_dir.run_jj(["describe", "-m", "initial"]).success();
     let output = work_dir.run_jj(["op", "log"]);
     insta::assert_snapshot!(output, @"
-    @  e6e34553de88 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    @  afd1de5b1f69 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  describe commit 006bd1130b84e90ab082adeabd7409270d5a86da
     │  args: jj describe -m initial
-    ○  a60628738654 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    ○  3c84df1da721 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  snapshot working copy
     │  args: jj debug snapshot
-    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  e39dc288903d test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]

--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -62,8 +62,15 @@ a comparison with Git, including how workflows are different, see the
 * **Shallow clones: Kind of.** Shallow commits all have the virtual root commit
   as their parent. However, deepening or fully unshallowing a repository is
   currently not yet supported and will cause issues.
-* **git-worktree: No.** However, there's native support for multiple working
-  copies backed by a single repo. See the `jj workspace` family of commands.
+* **git-worktree: Yes, for colocated workspaces.** In a colocated repo,
+  `jj workspace add` automatically registers a matching
+  [Git worktree](https://git-scm.com/docs/git-worktree) for the new workspace, so plain
+  `git` commands work inside it. This is controlled by the `git.auto-register-worktrees`
+  config (default `true`; distinct from `git.colocate`); pass `--colocate` / `--no-colocate`
+  to `jj workspace add` to override per-command. Git HEAD and the index are kept in sync with
+  each workspace's working-copy commit, lazily (a workspace's Git view refreshes on its next
+  `jj` command). jj additionally provides native support for multiple working copies backed by
+  a single repo via the `jj workspace` family of commands.
 * **Sparse checkouts: No.** However, there's native support for sparse
   checkouts. See the `jj sparse` command.
 * **Signed commits: Yes.**

--- a/lib/gen-protos/src/main.rs
+++ b/lib/gen-protos/src/main.rs
@@ -34,6 +34,8 @@ fn main() -> Result<()> {
         .include_file("mod.rs")
         // For old protoc versions. 3.12.4 needs this, but 3.21.12 doesn't.
         .protoc_arg("--experimental_allow_proto3_optional")
+        // Use BTreeMap for deterministic serialization order
+        .btree_map([".simple_op_store.View.workspace_git_heads"])
         .compile_protos(
             &input
                 .into_iter()

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -23,6 +23,7 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::iter;
 use std::num::NonZeroU32;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -1155,28 +1156,35 @@ fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
         .collect()
 }
 
-/// Imports HEAD from the underlying Git repo.
+/// Imports HEAD from the underlying Git repo for a specific workspace.
 ///
 /// Unlike `import_refs()`, the old HEAD branch is not abandoned because HEAD
 /// move doesn't always mean the old HEAD branch has been rewritten.
 ///
 /// Unlike `reset_head()`, this function doesn't move the working-copy commit to
 /// the child of the new HEAD revision.
-pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
+///
+/// Returns `true` if the HEAD changed for this workspace, `false` otherwise.
+pub async fn import_head(
+    mut_repo: &mut MutableRepo,
+    workspace_name: &crate::ref_name::WorkspaceName,
+) -> Result<bool, GitImportError> {
     let store = mut_repo.store().clone();
     let git_backend = get_git_backend(&store)?;
     let git_repo = git_backend.git_repo();
 
-    let old_git_head = mut_repo.view().git_head();
     let new_git_head_id = if let Ok(oid) = git_repo.head_id() {
         Some(CommitId::from_bytes(oid.as_bytes()))
     } else {
         None
     };
-    if old_git_head.as_resolved() == Some(&new_git_head_id) {
-        // Even if the main HEAD hasn't changed, check worktrees
+
+    // Compare against this workspace's stored git_head, not the global one
+    let old_workspace_git_head = mut_repo.get_workspace_git_head(workspace_name);
+    if old_workspace_git_head.as_resolved() == Some(&new_git_head_id) {
+        // HEAD hasn't changed for this workspace; still check other worktrees
         import_worktree_heads(mut_repo, git_backend, &git_repo).await?;
-        return Ok(());
+        return Ok(false);
     }
 
     // Import new head
@@ -1196,12 +1204,17 @@ pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportErro
         mut_repo.add_head(&commit).await?;
     }
 
+    // Update this workspace's git_head
+    let new_target = RefTarget::resolved(new_git_head_id.clone());
+    mut_repo.set_workspace_git_head(workspace_name, new_target.clone());
+
+    // Also update global git_head for backwards compatibility
     mut_repo.set_git_head_target(RefTarget::resolved(new_git_head_id));
 
     // Also import commits from other worktrees' HEADs
     import_worktree_heads(mut_repo, git_backend, &git_repo).await?;
 
-    Ok(())
+    Ok(true)
 }
 
 /// Imports commits from all Git worktrees' HEADs.
@@ -1891,23 +1904,64 @@ impl GitResetHeadError {
 
 /// Sets Git HEAD to the parent of the given working-copy commit and resets
 /// the Git index.
+///
+/// If `workspace_path` is provided and is a colocated workspace (has a `.git`
+/// pointing to the same repo), the git repo will be opened at that path to
+/// support secondary colocated workspaces with their own git worktrees.
 pub async fn reset_head(
     mut_repo: &mut MutableRepo,
     wc_commit: &Commit,
+    workspace_name: &crate::ref_name::WorkspaceName,
 ) -> Result<(), GitResetHeadError> {
-    let git_repo = get_git_repo(mut_repo.store())?;
+    reset_head_at_workspace(mut_repo, wc_commit, workspace_name, None).await
+}
+
+/// Sets Git HEAD to the parent of the given working-copy commit and resets
+/// the Git index at the specified workspace path.
+///
+/// If `workspace_path` is provided and is a colocated workspace (has a `.git`
+/// pointing to the same repo), the git repo will be opened at that path to
+/// support secondary colocated workspaces with their own git worktrees.
+pub async fn reset_head_at_workspace(
+    mut_repo: &mut MutableRepo,
+    wc_commit: &Commit,
+    workspace_name: &crate::ref_name::WorkspaceName,
+    workspace_path: Option<&Path>,
+) -> Result<(), GitResetHeadError> {
+    let store = mut_repo.store();
+    let git_backend = get_git_backend(store)?;
+
+    // If a workspace path is provided and has a .git, try to open it as a worktree
+    let git_repo = if let Some(ws_path) = workspace_path {
+        let git_dir_path = ws_path.join(".git");
+        if git_dir_path.exists() {
+            // Try to open the git repo at the workspace path as a worktree.
+            // Configure committer for reflog updates (required by gix).
+            let open_opts = gix::open::Options::default()
+                .open_path_as_is(true)
+                .config_overrides(["committer.name=jj", "committer.email=jj@example.com"]);
+            match gix::ThreadSafeRepository::open_opts(&git_dir_path, open_opts) {
+                Ok(repo) => repo.to_thread_local(),
+                Err(_) => git_backend.git_repo(),
+            }
+        } else {
+            git_backend.git_repo()
+        }
+    } else {
+        git_backend.git_repo()
+    };
 
     let first_parent_id = &wc_commit.parent_ids()[0];
-    let new_head_target = if first_parent_id != mut_repo.store().root_commit_id() {
+    let new_head_target = if first_parent_id != store.root_commit_id() {
         RefTarget::normal(first_parent_id.clone())
     } else {
         RefTarget::absent()
     };
 
-    // If the first parent of the working copy has changed, reset the Git HEAD.
-    let old_head_target = mut_repo.git_head();
-    if old_head_target != new_head_target {
-        let expected_ref = if let Some(id) = old_head_target.as_normal() {
+    // Compare against this workspace's stored git_head
+    let old_workspace_head = mut_repo.get_workspace_git_head(workspace_name);
+    if old_workspace_head != new_head_target {
+        let expected_ref = if let Some(id) = old_workspace_head.as_normal() {
             // We have to check the actual HEAD state because we don't record a
             // symbolic ref as such.
             let actual_head = git_repo.head().map_err(GitResetHeadError::from_git)?;
@@ -1920,12 +1974,15 @@ pub async fn reset_head(
                 gix::refs::transaction::PreviousValue::MustExist
             }
         } else {
-            // Just overwrite if unborn (or conflict), which is also unusual.
-            gix::refs::transaction::PreviousValue::MustExist
+            // For new workspaces that haven't been tracked yet, allow any current state
+            gix::refs::transaction::PreviousValue::Any
         };
         let new_oid = new_head_target.as_normal().map(owned_oid_from_commit_id);
         update_git_head(&git_repo, expected_ref, new_oid)
             .map_err(|err| GitResetHeadError::UpdateHeadRef(err.into()))?;
+        // Update this workspace's git_head
+        mut_repo.set_workspace_git_head(workspace_name, new_head_target.clone());
+        // Also update global git_head for backwards compatibility
         mut_repo.set_git_head_target(new_head_target);
     }
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -1163,8 +1163,8 @@ fn remotely_pinned_commit_ids(view: &View) -> Vec<CommitId> {
 /// Unlike `reset_head()`, this function doesn't move the working-copy commit to
 /// the child of the new HEAD revision.
 pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportError> {
-    let store = mut_repo.store();
-    let git_backend = get_git_backend(store)?;
+    let store = mut_repo.store().clone();
+    let git_backend = get_git_backend(&store)?;
     let git_repo = git_backend.git_repo();
 
     let old_git_head = mut_repo.view().git_head();
@@ -1174,6 +1174,8 @@ pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportErro
         None
     };
     if old_git_head.as_resolved() == Some(&new_git_head_id) {
+        // Even if the main HEAD hasn't changed, check worktrees
+        import_worktree_heads(mut_repo, git_backend, &git_repo).await?;
         return Ok(());
     }
 
@@ -1195,6 +1197,101 @@ pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportErro
     }
 
     mut_repo.set_git_head_target(RefTarget::resolved(new_git_head_id));
+
+    // Also import commits from other worktrees' HEADs
+    import_worktree_heads(mut_repo, git_backend, &git_repo).await?;
+
+    Ok(())
+}
+
+/// Imports commits from all Git worktrees' HEADs.
+///
+/// This ensures that commits made via git in secondary worktrees are
+/// imported into the jj repo, even when running jj in a different workspace.
+async fn import_worktree_heads(
+    mut_repo: &mut MutableRepo,
+    git_backend: &crate::git_backend::GitBackend,
+    git_repo: &gix::Repository,
+) -> Result<(), GitImportError> {
+    let worktrees = match git_repo.worktrees() {
+        Ok(wts) => wts,
+        Err(err) => {
+            tracing::debug!(?err, "Failed to enumerate git worktrees");
+            return Ok(());
+        }
+    };
+
+    for worktree in worktrees {
+        // Save git_dir for logging before consuming the worktree
+        let worktree_git_dir = worktree.git_dir().to_path_buf();
+
+        // Open the worktree as a repository to access its HEAD.
+        // Use the variant that works even if the worktree directory is inaccessible.
+        let wt_repo = match worktree.into_repo_with_possibly_inaccessible_worktree() {
+            Ok(repo) => repo,
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    ?worktree_git_dir,
+                    "Failed to open worktree as repository"
+                );
+                continue;
+            }
+        };
+
+        let commit_id = match wt_repo.head_id() {
+            Ok(id) => CommitId::from_bytes(id.as_bytes()),
+            Err(err) => {
+                tracing::debug!(?err, ?worktree_git_dir, "Failed to get worktree HEAD");
+                continue;
+            }
+        };
+
+        // Check if already in index
+        match mut_repo.index().has_id(&commit_id) {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    ?worktree_git_dir,
+                    "Failed to check index for worktree HEAD"
+                );
+                continue;
+            }
+        }
+
+        // Import the commit
+        if let Err(err) = git_backend.import_head_commits([&commit_id]) {
+            tracing::debug!(
+                ?err,
+                ?worktree_git_dir,
+                "Failed to import worktree HEAD commit"
+            );
+            continue;
+        }
+
+        // Add to heads
+        match mut_repo.store().get_commit(&commit_id) {
+            Ok(commit) => {
+                if let Err(err) = mut_repo.add_head(&commit).await {
+                    tracing::debug!(
+                        ?err,
+                        ?worktree_git_dir,
+                        "Failed to add worktree HEAD as head"
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    ?worktree_git_dir,
+                    "Failed to get worktree HEAD commit"
+                );
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -949,7 +949,14 @@ fn run_git_gc(program: &OsStr, git_dir: &Path, keep_newer: SystemTime) -> Result
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default(); // underflow
     let mut git = Command::new(program);
+    // Never prune jj-registered Git worktrees (secondary colocated workspaces).
+    // `git gc` auto-runs `git worktree prune` honoring `gc.worktreePruneExpire`
+    // (default 3 months), which would delete a live worktree's admin dir and let
+    // its detached-HEAD commit be garbage-collected. The `-c` override must precede
+    // the `gc` subcommand.
     git.arg("--git-dir=.") // turn off discovery
+        .arg("-c")
+        .arg("gc.worktreePruneExpire=never")
         .arg("gc")
         .arg(format!("--prune=@{} +0000", keep_newer.as_secs()));
     // Don't specify it by GIT_DIR/--git-dir. On Windows, the path could be

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -254,7 +254,20 @@ pub struct View {
     pub remote_views: BTreeMap<RemoteNameBuf, RemoteView>,
     pub git_refs: BTreeMap<GitRefNameBuf, RefTarget>,
     /// The commit the Git HEAD points to.
-    // TODO: Support multiple Git worktrees?
+    ///
+    /// ## Known Limitation: Single git_head for Multiple Workspaces
+    ///
+    /// This field stores a single `git_head`, but when multiple colocated
+    /// workspaces exist (each with its own Git worktree), each worktree has
+    /// an independent HEAD. The value here reflects whichever workspace last
+    /// performed a Git export.
+    ///
+    /// **Impact:** The `git_head()` template may show incorrect values in
+    /// non-default workspaces.
+    ///
+    /// **Workaround:** Export now writes to each worktree's HEAD file
+    /// independently, but this field doesn't track per-workspace state.
+    // TODO: Support multiple Git worktrees by storing per-workspace git_head
     // TODO: Do we want to store the current bookmark name too?
     pub git_head: RefTarget,
     // The commit that *should be* checked out in the workspace. Note that the working copy

--- a/lib/src/op_store.rs
+++ b/lib/src/op_store.rs
@@ -253,23 +253,18 @@ pub struct View {
     pub local_tags: BTreeMap<RefNameBuf, RefTarget>,
     pub remote_views: BTreeMap<RemoteNameBuf, RemoteView>,
     pub git_refs: BTreeMap<GitRefNameBuf, RefTarget>,
-    /// The commit the Git HEAD points to.
+    /// The commit the Git HEAD points to (for the main repository).
     ///
-    /// ## Known Limitation: Single git_head for Multiple Workspaces
-    ///
-    /// This field stores a single `git_head`, but when multiple colocated
-    /// workspaces exist (each with its own Git worktree), each worktree has
-    /// an independent HEAD. The value here reflects whichever workspace last
-    /// performed a Git export.
-    ///
-    /// **Impact:** The `git_head()` template may show incorrect values in
-    /// non-default workspaces.
-    ///
-    /// **Workaround:** Export now writes to each worktree's HEAD file
-    /// independently, but this field doesn't track per-workspace state.
-    // TODO: Support multiple Git worktrees by storing per-workspace git_head
+    /// For backwards compatibility and for workspaces that haven't migrated to
+    /// per-workspace tracking, this still reflects the main repo's HEAD.
     // TODO: Do we want to store the current bookmark name too?
     pub git_head: RefTarget,
+    /// Per-workspace Git HEAD for colocated worktrees.
+    ///
+    /// Each colocated workspace has its own Git worktree with an independent
+    /// HEAD. This map stores the last-known HEAD for each workspace to
+    /// avoid spurious commits when switching between workspaces.
+    pub workspace_git_heads: BTreeMap<WorkspaceNameBuf, RefTarget>,
     // The commit that *should be* checked out in the workspace. Note that the working copy
     // (.jj/working_copy/) has the source of truth about which commit *is* checked out (to be
     // precise: the commit to which we most recently completed an update to).
@@ -286,6 +281,7 @@ impl View {
             remote_views: BTreeMap::new(),
             git_refs: BTreeMap::new(),
             git_head: RefTarget::absent(),
+            workspace_git_heads: BTreeMap::new(),
             wc_commit_ids: BTreeMap::new(),
         }
     }

--- a/lib/src/protos/simple_op_store.proto
+++ b/lib/src/protos/simple_op_store.proto
@@ -104,6 +104,8 @@ message View {
   // TODO: Delete support for the old format.
   bytes git_head_legacy = 7 [deprecated = true];
   RefTarget git_head = 9;
+  // Per-workspace Git HEAD for colocated worktrees. Maps workspace name to HEAD target.
+  map<string, RefTarget> workspace_git_heads = 13;
   // Whether "@git" tags have been migrated to remote_views.
   bool has_git_refs_migrated_to_remote_tags = 12;
   reserved 10;

--- a/lib/src/protos/simple_op_store.rs
+++ b/lib/src/protos/simple_op_store.rs
@@ -136,6 +136,12 @@ pub struct View {
     pub git_head_legacy: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "9")]
     pub git_head: ::core::option::Option<RefTarget>,
+    /// Per-workspace Git HEAD for colocated worktrees. Maps workspace name to HEAD target.
+    #[prost(btree_map = "string, message", tag = "13")]
+    pub workspace_git_heads: ::prost::alloc::collections::BTreeMap<
+        ::prost::alloc::string::String,
+        RefTarget,
+    >,
     /// Whether "@git" tags have been migrated to remote_views.
     #[prost(bool, tag = "12")]
     pub has_git_refs_migrated_to_remote_tags: bool,

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -2006,6 +2006,17 @@ impl MutableRepo {
         self.view_mut().set_git_head_target(target);
     }
 
+    /// Returns the per-workspace Git HEAD target for the given workspace.
+    pub fn get_workspace_git_head(&self, name: &WorkspaceName) -> RefTarget {
+        self.view
+            .with_ref(|v| v.get_workspace_git_head(name).clone())
+    }
+
+    /// Sets the per-workspace Git HEAD target.
+    pub fn set_workspace_git_head(&mut self, name: &WorkspaceName, target: RefTarget) {
+        self.view_mut().set_workspace_git_head(name, target);
+    }
+
     pub fn set_view(&mut self, data: op_store::View) {
         self.view_mut().set_view(data);
         self.view.mark_dirty();
@@ -2098,6 +2109,18 @@ impl MutableRepo {
             other.git_head(),
         )?;
         self.set_git_head_target(new_git_head_target);
+
+        // Merge per-workspace Git HEADs
+        let changed_workspace_git_heads = diff_named_ref_targets(
+            base.workspace_git_heads().iter().map(|(k, v)| (&**k, v)),
+            other.workspace_git_heads().iter().map(|(k, v)| (&**k, v)),
+        );
+        for (name, (base_target, other_target)) in changed_workspace_git_heads {
+            let self_target = self.get_workspace_git_head(name);
+            let new_target =
+                merge_ref_targets(self.index(), &self_target, base_target, other_target)?;
+            self.set_workspace_git_head(name, new_target);
+        }
 
         Ok(())
     }

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -577,6 +577,13 @@ fn view_to_proto(view: &View) -> crate::protos::simple_op_store::View {
 
     let git_head = ref_target_to_proto(&view.git_head);
 
+    let workspace_git_heads = view
+        .workspace_git_heads
+        .iter()
+        .filter(|(_, target)| target.is_present())
+        .map(|(name, target)| (name.into(), ref_target_to_proto(target).unwrap_or_default()))
+        .collect();
+
     #[expect(deprecated)]
     crate::protos::simple_op_store::View {
         head_ids,
@@ -588,6 +595,7 @@ fn view_to_proto(view: &View) -> crate::protos::simple_op_store::View {
         git_refs,
         git_head_legacy: Default::default(),
         git_head,
+        workspace_git_heads,
         // New/loaded view should have been migrated to the latest format
         has_git_refs_migrated_to_remote_tags: true,
     }
@@ -676,6 +684,17 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
         RefTarget::absent()
     };
 
+    let workspace_git_heads = proto
+        .workspace_git_heads
+        .into_iter()
+        .map(|(name, target_proto)| {
+            let name = WorkspaceNameBuf::from(name);
+            let target = ref_target_from_proto(Some(target_proto));
+            (name, target)
+        })
+        .filter(|(_, target)| target.is_present())
+        .collect();
+
     Ok(View {
         head_ids,
         local_bookmarks,
@@ -683,6 +702,7 @@ fn view_from_proto(proto: crate::protos::simple_op_store::View) -> Result<View, 
         remote_views,
         git_refs,
         git_head,
+        workspace_git_heads,
         wc_commit_ids,
     })
 }
@@ -1003,6 +1023,10 @@ mod tests {
                 "refs/heads/feature".into() => git_refs_feature_target,
             },
             git_head: RefTarget::normal(CommitId::from_hex("fff111")),
+            workspace_git_heads: btreemap! {
+                WorkspaceName::DEFAULT.to_owned() => RefTarget::normal(CommitId::from_hex("fff111")),
+                "test".into() => RefTarget::normal(CommitId::from_hex("fff222")),
+            },
             wc_commit_ids: btreemap! {
                 WorkspaceName::DEFAULT.to_owned() => default_wc_commit_id,
                 "test".into() => test_wc_commit_id,
@@ -1058,7 +1082,7 @@ mod tests {
         // Test exact output so we detect regressions in compatibility
         assert_snapshot!(
             ViewId::new(blake2b_hash(&create_view()).to_vec()).hex(),
-            @"2c0b174d117ca85e7faa96f6d997362403105e8eb31e7f82ac9abd3dc48ae62683e9a76ef5d117ebc8a743d17e1945236df9ccefd7574f7e4b5336a63796b967"
+            @"53792bb94ddf46689d833410ef094d1db76e320c0b36136eb855469884f80ccb58b3e8ec63e0fc77376c2a70dc879242c9e09b5c5b5fb611a7e07886e461fc10"
         );
     }
 

--- a/lib/src/view.rs
+++ b/lib/src/view.rs
@@ -101,6 +101,17 @@ impl View {
         &self.data.git_head
     }
 
+    /// Returns the Git HEAD target for the given workspace, or absent if not
+    /// tracked.
+    pub fn get_workspace_git_head(&self, name: &WorkspaceName) -> &RefTarget {
+        self.data.workspace_git_heads.get(name).flatten()
+    }
+
+    /// Returns all per-workspace Git HEAD targets.
+    pub fn workspace_git_heads(&self) -> &BTreeMap<WorkspaceNameBuf, RefTarget> {
+        &self.data.workspace_git_heads
+    }
+
     pub fn set_wc_commit(&mut self, name: WorkspaceNameBuf, commit_id: CommitId) {
         self.data.wc_commit_ids.insert(name, commit_id);
     }
@@ -545,6 +556,18 @@ impl View {
         self.data.git_head = target;
     }
 
+    /// Sets the Git HEAD target for a specific workspace. If the target is
+    /// absent, the workspace entry will be removed.
+    pub fn set_workspace_git_head(&mut self, name: &WorkspaceName, target: RefTarget) {
+        if target.is_present() {
+            self.data
+                .workspace_git_heads
+                .insert(name.to_owned(), target);
+        } else {
+            self.data.workspace_git_heads.remove(name);
+        }
+    }
+
     /// Iterates all commit ids referenced by this view.
     ///
     /// This can include hidden commits referenced by remote bookmarks, previous
@@ -569,6 +592,7 @@ impl View {
             remote_views,
             git_refs,
             git_head,
+            workspace_git_heads,
             wc_commit_ids,
         } = &self.data;
         itertools::chain!(
@@ -582,6 +606,7 @@ impl View {
             }),
             git_refs.values().flat_map(ref_target_ids),
             ref_target_ids(git_head),
+            workspace_git_heads.values().flat_map(ref_target_ids),
             wc_commit_ids.values()
         )
     }

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -280,7 +280,7 @@ fn test_import_refs() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -561,14 +561,14 @@ fn test_import_refs_reimport_git_head_does_not_count() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit);
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
 
     // Delete the bookmark and re-import. The commit should still be there since
     // HEAD points to it
     git_repo.find_reference("refs/heads/main")?.delete()?;
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(&jj_id(commit)));
@@ -591,7 +591,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -604,7 +604,7 @@ fn test_import_refs_reimport_git_head_without_ref() -> TestResult {
     // would be moved by `git checkout` command. This isn't always true because the
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -633,7 +633,7 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -649,13 +649,13 @@ fn test_import_refs_reimport_git_head_with_moved_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD and main, which abandons the old main branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
     // Reimport HEAD and main, which abandons the old main bookmark.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(!tx.repo().view().heads().contains(commit1.id()));
@@ -1340,7 +1340,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -1350,7 +1350,7 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     assert!(tx.repo().view().heads().contains(commit1.id()));
@@ -2473,7 +2473,8 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     git_repo.find_reference("refs/heads/main")?.delete()?;
     testutils::git::set_head_to_id(&git_repo, commit2);
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut()).block_on();
+    let result =
+        git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on();
     assert_matches!(
         result,
         Err(GitImportError::MissingHeadTarget {
@@ -2504,7 +2505,8 @@ fn test_import_refs_missing_git_commit() -> TestResult {
     testutils::git::set_head_to_id(&git_repo, commit1);
     fs::rename(&object_file, &backup_object_file)?;
     let mut tx = repo.start_transaction();
-    let result = git::import_head(tx.repo_mut()).block_on();
+    let result =
+        git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on();
     assert!(result.is_ok());
     Ok(())
 }
@@ -2523,7 +2525,7 @@ fn test_import_refs_detached_head() -> TestResult {
     testutils::git::set_head_to_id(&test_data.git_repo, commit1);
 
     let mut tx = test_data.repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(tx.repo_mut(), &import_options).block_on()?;
     tx.repo_mut().rebase_descendants().block_on()?;
     let repo = tx.commit("test").block_on()?;
@@ -2546,7 +2548,7 @@ fn test_export_refs_no_detach() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2583,7 +2585,7 @@ fn test_export_refs_bookmark_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2636,7 +2638,7 @@ fn test_export_refs_tag_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     let stats = git::import_refs(mut_repo, &import_options).block_on()?;
     assert_eq!(stats.changed_remote_tags.len(), 4);
     mut_repo.rebase_descendants().block_on()?;
@@ -2718,7 +2720,7 @@ fn test_export_refs_current_bookmark_changed() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2771,7 +2773,7 @@ fn test_export_refs_worktree_head_changed() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2814,7 +2816,7 @@ fn test_export_refs_worktree_no_detach() -> TestResult {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
 
@@ -2849,7 +2851,7 @@ fn test_export_refs_current_tag_changed() -> TestResult {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/tags/v1.0");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -2889,7 +2891,7 @@ fn test_export_refs_unborn_git_bookmark(move_placeholder_ref: bool) -> TestResul
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on()?;
+    git::import_head(mut_repo, jj_lib::ref_name::WorkspaceName::DEFAULT).block_on()?;
     git::import_refs(mut_repo, &import_options).block_on()?;
     mut_repo.rebase_descendants().block_on()?;
     let stats = git::export_refs(mut_repo)?;
@@ -3595,7 +3597,12 @@ fn test_reset_head_to_root() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()?;
     assert!(git_repo.head()?.is_detached(), "HEAD is detached");
     assert_eq!(
         tx.repo().git_head(),
@@ -3603,7 +3610,12 @@ fn test_reset_head_to_root() -> TestResult {
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit1,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head().is_absent());
 
@@ -3614,7 +3626,12 @@ fn test_reset_head_to_root() -> TestResult {
         gix::refs::transaction::PreviousValue::MustNotExist,
         "",
     )?;
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()?;
     assert!(git_repo.head_id().is_ok());
     assert_eq!(
         tx.repo().git_head(),
@@ -3623,7 +3640,12 @@ fn test_reset_head_to_root() -> TestResult {
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit1,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()?;
     assert!(git_repo.head()?.is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head().is_absent());
     // The placeholder ref should be deleted
@@ -3658,7 +3680,13 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     let commit5 = write_random_commit(tx.repo_mut());
 
     // unborn -> commit1 (= commit2's parent)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
@@ -3669,7 +3697,13 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
 
     // {expected: commit1, actual: commit5} -> commit1 (= commit3's parent):
     // works because the expected HEAD is unchanged.
-    git::reset_head(tx.repo_mut(), &commit3).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit3,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
@@ -3677,7 +3711,12 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
 
     // {expected: commit1, actual: commit5} -> commit3 (= commit4's parent)
     assert_matches!(
-        git::reset_head(tx.repo_mut(), &commit4).block_on(),
+        git::reset_head(
+            tx.repo_mut(),
+            &commit4,
+            jj_lib::ref_name::WorkspaceName::DEFAULT
+        )
+        .block_on(),
         Err(GitResetHeadError::UpdateHeadRef(_))
     );
     assert_eq!(
@@ -3687,14 +3726,22 @@ fn test_reset_head_detached_out_of_sync() -> TestResult {
     );
 
     // Import the HEAD moved by external process
-    git::import_head(tx.repo_mut()).block_on()?;
+    git::import_head(tx.repo_mut(), jj_lib::ref_name::WorkspaceName::DEFAULT)
+        .block_on()
+        .unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit5.id().clone())
     );
 
     // commit5 -> commit3 (= commit4's parent)
-    git::reset_head(tx.repo_mut(), &commit4).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit4,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit3.id().clone())
@@ -3743,7 +3790,13 @@ fn test_reset_head_with_index() -> TestResult {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 
     // Add "staged changes" to the Git index
@@ -3755,7 +3808,13 @@ fn test_reset_head_with_index() -> TestResult {
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Unconflicted file.txt Mode(FILE)");
 
     // Reset head and the Git index
-    git::reset_head(tx.repo_mut(), &commit2).block_on()?;
+    git::reset_head(
+        tx.repo_mut(),
+        &commit2,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
     Ok(())
 }
@@ -3798,7 +3857,13 @@ fn test_reset_head_with_index_no_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(
+        mut_repo,
+        &wc_commit,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3892,7 +3957,13 @@ fn test_reset_head_with_index_merge_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with merge conflict
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(
+        mut_repo,
+        &wc_commit,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3956,7 +4027,13 @@ fn test_reset_head_with_index_file_directory_conflict() -> TestResult {
         .write_unwrap();
 
     // Reset head to working copy commit with file-directory conflict
-    git::reset_head(mut_repo, &wc_commit).block_on()?;
+    git::reset_head(
+        mut_repo,
+        &wc_commit,
+        jj_lib::ref_name::WorkspaceName::DEFAULT,
+    )
+    .block_on()
+    .unwrap();
 
     // Only the file should be added to the index (the tree should be skipped).
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Theirs test Mode(FILE)");

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -646,15 +646,16 @@ fn test_resolve_op_id() -> TestResult {
         let repo = tx.commit(format!("transaction {i}")).block_on()?;
         operations.push(repo.operation().clone());
     }
-    // "3" and "0" are ambiguous
+    // Snapshot of operation hex ids (changes on rebase; ambiguous prefix depends on
+    // base)
     insta::assert_debug_snapshot!(operations.iter().map(|op| op.id().hex()).collect_vec(), @r#"
     [
-        "3fb99188ad57448697795ade6d59a7fc36c4ba9daa5ce5501ec2e2bb23a027e7358ededd902994b7e9fc319d262c7679af7f079cdf5403ec2784a33f79f17c21",
-        "75f94ddb7d65b220acca16ff4d5a1851945051803d809b66aeb1cd12b77ad8a1cf8973cb531a4524c1948812bf3ccd650bf8988e692d7bd7fa47f08f4c506abd",
-        "de94b57efe85cd747450956e5f8221a277db649e91e643d9ccd524ab0574630abc04dd4fe81108090bfc4e183c62b3ba1b1a3ee077020ea6587a59703990ddc2",
-        "9874219f414e4bba6564c54782ed1016a5ae63d695d6b0e1165983365d527bf10af3016a0e20020c24d2208bf20ef284e2a628c8c99d9742475d51eb6417c867",
-        "380b1e3403ee19d0696441eb38eb9aeac36ac82769012a1bc370825705b745a8dab42f3bbdb1223e0adf860d15290134340842ba2d3e3ec7462a0c8cce54d54c",
-        "08b1bc4a1537ea549fa001dbc29b474f8fd3469facbab331ee2b5e3807eaaf95d04d967e270499ffb7a38098eec0dff97cdb5c7b44ba755f9b71c9924f80c16e",
+        "68ed1e50d1169d6ffdcc66a975a5d4fd44a05dce62a9fbbee0c995878b8680544ee19831fda7a17d414a257410ce6f70375e1746e8d76216866d4df6509166da",
+        "efe8073bf24180446a5f0ddbd2195129c01c112d06fd846c2256d207c9f1264e078107ae8df716a91ed56709aafc198fa0cc5ee8fc508204a16e1808ae2fd60a",
+        "41cd4f03c95558284f5ee478e4289cde576e26ab0304672a0f379ebaff99ac754c5ed228289743f676c61443f99eb590ec835c8b5f9342f4bfbf6816121c8096",
+        "9742cdef1bed927d85f55d602b9ae79ff78082441f2ab7a5fa022c7f09a443b9ff7fb0ac18e8bde6ac6ca447854c489941dfd49609ba250f8b132e2b44dfc6c5",
+        "572e4444063a345ec88a2886dbb2671a3776e939249f5886b79d02a94f44f7cf3e8d5a0d290efc93d7861d7e862bca0bd57c71ec224263ae53c8c4413e081147",
+        "1061688577c51257c8fa58e9c032c1a2f1a332df6ebe8bb3d030d74e193bbdc1022d0de4b9ad442812853dc6159cad5fa5e8fbf5dca312e800699bf176c61c9a",
     ]
     "#);
 
@@ -667,11 +668,11 @@ fn test_resolve_op_id() -> TestResult {
     assert_eq!(resolve(&operations[0].id().hex()[..3])?, operations[0]);
     // Short id, even length
     assert_eq!(resolve(&operations[1].id().hex()[..2])?, operations[1]);
-    // Ambiguous id
+    // Non-existent prefix (no operation starts with '7' with current base)
     assert_matches!(
-        resolve("3"),
+        resolve("7"),
         Err(OpsetEvaluationError::OpsetResolution(
-            OpsetResolutionError::AmbiguousIdPrefix(_)
+            OpsetResolutionError::NoSuchOperation(_)
         ))
     );
     // Empty id
@@ -690,15 +691,12 @@ fn test_resolve_op_id() -> TestResult {
     );
     // Virtual root id
     let root_operation = loader.root_operation().block_on();
-    assert_eq!(resolve(&root_operation.id().hex())?, root_operation);
-    assert_eq!(resolve("00")?, root_operation);
-    assert_eq!(resolve("08")?, operations[5]);
-    assert_matches!(
-        resolve("0"),
-        Err(OpsetEvaluationError::OpsetResolution(
-            OpsetResolutionError::AmbiguousIdPrefix(_)
-        ))
-    );
+    assert_eq!(resolve(&root_operation.id().hex()).unwrap(), root_operation);
+    assert_eq!(resolve("00").unwrap(), root_operation);
+    // operations[4] starts with "57"
+    assert_eq!(resolve("57").unwrap(), operations[4]);
+    // "0" now uniquely matches root (no operations start with "0")
+    assert_eq!(resolve("0").unwrap(), root_operation);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

This PR adds CLI support for colocated workspaces, building on #8667 (backend support).

### Changes

- `workspace add --colocate`: Create Git worktree for colocated workspace
- `git import`: Check all worktrees' HEAD for external changes
- `op_store`: Add per-workspace git_head tracking
- `workspace forget`: Clean up Git worktree when forgetting colocated workspace

### Context

This consolidates PRs #8680, #8681, #8682 into a single reviewable unit.
Part of the colocated workspaces feature tracked in #8052.

**Depends on**: #8667 (base backend support)