### PR TITLE
config: Add `revset-aliases.base(x)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   as `jj simplify-parents` on the rebased commits.
   [#7711](https://github.com/jj-vcs/jj/issues/7711)
 
+* Added new `base([x=@])` revset alias function that refers to the most recent
+  revision on `trunk()` that is also an ancestor of `x` (the "base" of that
+  chain with respect to `trunk()`).
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -1,5 +1,7 @@
 # NOTE: ensure you update docs/revsets.md with documentation when
 # adding/updating any of these aliases
+# Also try to avoid adding non-function revset aliases since they might conflict
+# with bookmarks or other revsets.
 
 [revsets]
 fix = "reachable(@, mutable())"
@@ -26,6 +28,9 @@ latest(
   root()
 )
 '''
+
+'base()' = 'base(@)'
+'base(x)' = 'fork_point(trunk() | x)'
 
 # If immutable_heads() failed to evaluate, many jj commands wouldn't work. Use
 # present(expr) if symbols in expr might not always exist.

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -580,6 +580,11 @@ for a comprehensive list.
   'trunk()' = 'your-bookmark@your-remote'
   ```
 
+* `base([x])`: Resolves to the most recent revision on `trunk()` that is also an
+  ancestor of `x`, which defaults to the working copy `@`. It is the fork point
+  of `trunk()` and `x`, which can be thought of as the "base" of the work in `x`
+  with respect to the history of `trunk()`.
+
 * `builtin_immutable_heads()`: Resolves to `trunk() | tags() |
   untracked_remote_bookmarks()`. It is used as the default definition for
   `immutable_heads()` below. It is not recommended to redefine this


### PR DESCRIPTION
This borrows a concept from Google that refers to the most recent "immutable" / "merged" / "submitted" commit that is an ancestor of the current revision, which is essentially a fork point between `trunk()` and the current revision. Google's definition also excludes the root commit (because that doesn't really count as "submitted" work), but I think it's probably okay to simply use `fork_point()` and not complicate it.

cc @martinvonz for the comment in Google's config; not sure if you had thoughts on the upstream name.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
