### PR TITLE
faq: Add question about how to trigger snapshots

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -599,6 +599,11 @@ export default defineConfig({
 Note: There was a [request](https://github.com/vitejs/vite/issues/20036) to include `.jj`
 in the default ignore list, but manual configuration remains the recommended approach.
 
+### How can I manually trigger (e.g., periodic) snapshots?
+
+See
+[Manually triggering a snapshot](./operation-log.md#manually-triggering-a-snapshot).
+
 ### I want to write a tool which integrates with Jujutsu. Should I use the library or parse the CLI?
 
 There are some trade-offs and there is no definitive answer yet.

--- a/docs/operation-log.md
+++ b/docs/operation-log.md
@@ -25,6 +25,19 @@ The following operators are supported:
 * `x-`: Parents of `x` (e.g. `@-`)
 * `x+`: Children of `x`
 
+## Manually triggering a snapshot
+
+Most `jj` commands will automatically snapshot the working copy at the start of
+the command, and again at the end of the command if the working copy changed
+(for example, running `jj describe --message` or `jj new`). However, if you'd
+like to manually trigger a snapshot for whatever reason, such as for scripting,
+prompt info, or periodic snapshots in parallel with something like a
+[`watch` command](./FAQ.md#can-i-monitor-how-jj-log-evolves), you can run
+`jj util snapshot`. By default this command will print whether a snapshot was
+taken, which you can silence with the global `--quiet` flag. If you would like
+to see the ID of the current operation after this command, you should run
+`jj op log --limit 1` so you can restore to that operation later if needed.
+
 ## Divergent operations
 
 One benefit of the operation log (and the reason for its creation) is that it


### PR DESCRIPTION
Many people commonly ask this question, and `jj debug snapshot` was a popular answer (for some reason people preferred that over something like `jj status &> /dev/null`). After #8860, we can now recommend the shiny new `jj util snapshot` command.

cc @PhilipMetzger 

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
