### PR TITLE
cli: op: Hide non-interesting revisions in operation diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `config()` template function now accepts a `Stringify` expression instead 
   of `LiteralString`. This allows looking up configuration values dynamically.
 
+* `jj op show`, `jj op diff`, `jj op log -p` now only show "interesting"
+  revisions by default (defined by `revsets.op-diff-changes-in`). A new flag,
+  `--show-changes-in`, can be used to override this. [#6083](https://github.com/jj-vcs/jj/issues/6083)
+
 ### Fixed bugs
 
 * `.gitignore` with UTF-8 BOM can now be parsed correctly.

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -34,12 +34,23 @@ use jj_lib::refs::diff_named_ref_targets;
 use jj_lib::refs::diff_named_remote_refs;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo;
+use jj_lib::revset;
+use jj_lib::revset::ResolvedRevsetExpression;
+use jj_lib::revset::RevsetDiagnostics;
 use jj_lib::revset::RevsetExpression;
+use jj_lib::revset::RevsetResolutionError;
+use jj_lib::revset::SymbolResolver;
+use jj_lib::revset::UserRevsetExpression;
+use jj_lib::settings::UserSettings;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
+use crate::cli_util::WorkspaceCommandEnvironment;
 use crate::cli_util::default_ignored_remote_name;
 use crate::command_error::CommandError;
+use crate::command_error::config_error_with_message;
+use crate::command_error::print_parse_diagnostics;
+use crate::command_error::user_error_with_message;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
 use crate::diff_util::DiffRenderer;
@@ -83,6 +94,13 @@ pub struct OperationDiffArgs {
 
     #[command(flatten)]
     diff_format: DiffFormatArgs,
+
+    /// Show only changed revisions matching the given revset expression
+    ///
+    /// If no revisions are specified, this defaults to the
+    /// `revsets.op-diff-changes-in` setting.
+    #[arg(long, value_name = "REVSETS")]
+    show_changes_in: Option<String>,
 }
 
 pub async fn cmd_op_diff(
@@ -133,6 +151,9 @@ pub async fn cmd_op_diff(
             .labeled(["op_diff", "commit"])
     };
 
+    let op_diff_changes_expr =
+        parse_op_diff_changes_in(ui, settings, workspace_env, args.show_changes_in.as_deref())?;
+
     let op_summary_template = workspace_command
         .operation_summary_template()
         .labeled(["op_diff"]);
@@ -150,6 +171,7 @@ pub async fn cmd_op_diff(
 
     show_op_diff(
         ui,
+        workspace_env,
         formatter.as_mut(),
         merged_repo,
         &from_repo,
@@ -158,8 +180,67 @@ pub async fn cmd_op_diff(
         (!args.no_graph).then_some(graph_style),
         &with_content_format,
         diff_renderer.as_ref(),
+        op_diff_changes_expr,
     )
     .await
+}
+
+/// Parses the revset expression used to filter revisions in operation diffs.
+pub fn parse_op_diff_changes_in(
+    ui: &Ui,
+    settings: &UserSettings,
+    workspace_env: &WorkspaceCommandEnvironment,
+    show_changes_in: Option<&str>,
+) -> Result<Arc<UserRevsetExpression>, CommandError> {
+    let (expression_str, is_config) = if let Some(show_changes_in_expr) = show_changes_in {
+        (show_changes_in_expr.to_string(), false)
+    } else {
+        (settings.get("revsets.op-diff-changes-in")?, true)
+    };
+    let mut diagnostics = RevsetDiagnostics::new();
+    let op_diff_changes_expr = revset::parse(
+        &mut diagnostics,
+        &expression_str,
+        &workspace_env.revset_parse_context(),
+    )
+    .map_err(|err| {
+        if is_config {
+            config_error_with_message("Invalid `revsets.op-diff-changes-in`", err)
+        } else {
+            user_error_with_message(
+                format!("Invalid `--show-changes-in` expression: {expression_str}"),
+                err,
+            )
+        }
+    })?;
+    let context_message = if is_config {
+        "In `revsets.op-diff-changes-in`"
+    } else {
+        "In `--show-changes-in`"
+    };
+    print_parse_diagnostics(ui, context_message, &diagnostics)?;
+    Ok(op_diff_changes_expr)
+}
+
+/// Resolves the `op-diff-changes-in` expression for both the "from" and "to"
+/// repositories.
+fn resolve_op_diff_changes_exprs(
+    workspace_env: &WorkspaceCommandEnvironment,
+    op_diff_changes_expr: &UserRevsetExpression,
+    from_repo: &ReadonlyRepo,
+    to_repo: &ReadonlyRepo,
+) -> Result<(Arc<ResolvedRevsetExpression>, Arc<ResolvedRevsetExpression>), RevsetResolutionError> {
+    let extensions = workspace_env
+        .revset_parse_context()
+        .extensions
+        .symbol_resolvers();
+    let from_repo_symbol_resolver = SymbolResolver::new(from_repo, extensions);
+    let to_repo_symbol_resolver = SymbolResolver::new(to_repo, extensions);
+    let from_op_diff_changes_expr =
+        op_diff_changes_expr.resolve_user_expression(from_repo, &from_repo_symbol_resolver)?;
+    let to_op_diff_changes_expr =
+        op_diff_changes_expr.resolve_user_expression(to_repo, &to_repo_symbol_resolver)?;
+    Ok((from_op_diff_changes_expr, to_op_diff_changes_expr))
 }
 
 /// Computes and shows the differences between two operations, using the given
@@ -169,6 +250,7 @@ pub async fn cmd_op_diff(
 #[expect(clippy::too_many_arguments)]
 pub async fn show_op_diff(
     ui: &Ui,
+    workspace_env: &WorkspaceCommandEnvironment,
     formatter: &mut dyn Formatter,
     current_repo: &dyn Repo,
     from_repo: &Arc<ReadonlyRepo>,
@@ -177,11 +259,46 @@ pub async fn show_op_diff(
     graph_style: Option<GraphStyle>,
     with_content_format: &LogContentFormat,
     diff_renderer: Option<&DiffRenderer<'_>>,
+    op_diff_changes_expr: Arc<UserRevsetExpression>,
 ) -> Result<(), CommandError> {
-    let changes = compute_operation_commits_diff(current_repo, from_repo, to_repo).await?;
-    if !changes.is_empty() {
-        let revset =
-            RevsetExpression::commits(changes.keys().cloned().collect()).evaluate(current_repo)?;
+    let op_commits_diff_result = match resolve_op_diff_changes_exprs(
+        workspace_env,
+        &op_diff_changes_expr,
+        from_repo.as_ref(),
+        to_repo.as_ref(),
+    ) {
+        Ok((from_op_diff_changes_expr, to_op_diff_changes_expr)) => {
+            let op_commits_diff = compute_operation_commits_diff(
+                current_repo,
+                from_repo,
+                to_repo,
+                from_op_diff_changes_expr,
+                to_op_diff_changes_expr,
+            )
+            .await?;
+            Some(op_commits_diff)
+        }
+        Err(err) => {
+            writeln!(formatter)?;
+            with_content_format.write(formatter, |formatter| {
+                writeln!(
+                    formatter.labeled("warning"),
+                    "Warning: Could not resolve revset expression for elision: {err}"
+                )?;
+                writeln!(
+                    formatter,
+                    "   (Use --show-changes-in=all() to see all changes)"
+                )
+            })?;
+            None
+        }
+    };
+
+    if let Some(op_commits_diff) = op_commits_diff_result
+        && op_commits_diff.has_changes()
+    {
+        let revset = RevsetExpression::commits(op_commits_diff.changes.keys().cloned().collect())
+            .evaluate(current_repo)?;
         writeln!(formatter)?;
         with_content_format.write(formatter, |formatter| {
             writeln!(formatter, "Changed commits:")
@@ -192,7 +309,7 @@ pub async fn show_op_diff(
             let graph_iter = TopoGroupedGraphIterator::new(revset.iter_graph(), |id| id);
             for node in graph_iter {
                 let (commit_id, mut edges) = node?;
-                let modified_change = changes.get(&commit_id).unwrap();
+                let modified_change = op_commits_diff.changes.get(&commit_id).unwrap();
                 // Omit "missing" edge to keep the graph concise.
                 edges.retain(|edge| !edge.is_missing());
 
@@ -229,7 +346,7 @@ pub async fn show_op_diff(
         } else {
             let mut commit_ids = revset.stream();
             while let Some(commit_id) = commit_ids.try_next().await? {
-                let modified_change = changes.get(&commit_id).unwrap();
+                let modified_change = op_commits_diff.changes.get(&commit_id).unwrap();
                 with_content_format.write(formatter, |formatter| {
                     write_modified_change_summary(
                         formatter,
@@ -243,6 +360,7 @@ pub async fn show_op_diff(
                 }
             }
         }
+        write_elided_commit_counts(formatter, with_content_format, &op_commits_diff)?;
     }
 
     let changed_working_copies = diff_named_commit_ids(
@@ -424,6 +542,39 @@ pub async fn show_op_diff(
     Ok(())
 }
 
+fn write_elided_commit_counts(
+    formatter: &mut dyn Formatter,
+    with_content_format: &LogContentFormat,
+    op_commits_diff: &OperationCommitsDiff,
+) -> Result<(), std::io::Error> {
+    let newly_visible = op_commits_diff.elided_newly_visible_estimate;
+    let newly_hidden = op_commits_diff.elided_newly_hidden_estimate;
+
+    let format_count = |(lower, maybe_upper): (usize, Option<usize>)| match (lower, maybe_upper) {
+        (0, Some(0)) => None,
+        (0, _) => Some("some".to_string()),
+        (lower, Some(upper)) if upper == lower => Some(format!("{lower}")),
+        _ => Some(format!("{lower}+")),
+    };
+
+    let parts: Vec<String> = [
+        (format_count(newly_visible), "added"),
+        (format_count(newly_hidden), "removed"),
+    ]
+    .into_iter()
+    .filter_map(|(count, label)| count.map(|c| format!("{c} newly {label}")))
+    .collect();
+
+    if parts.is_empty() {
+        return Ok(());
+    }
+
+    with_content_format.write(formatter, |formatter| {
+        writeln!(formatter, "   (Elided {} revisions)", parts.join(" and "))
+    })?;
+    Ok(())
+}
+
 /// Writes a summary for the given `ModifiedChange`.
 fn write_modified_change_summary(
     formatter: &mut dyn Formatter,
@@ -524,6 +675,21 @@ impl ModifiedChange {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OperationCommitsDiff {
+    changes: HashMap<CommitId, ModifiedChange>,
+    elided_newly_visible_estimate: (usize, Option<usize>),
+    elided_newly_hidden_estimate: (usize, Option<usize>),
+}
+
+impl OperationCommitsDiff {
+    fn has_changes(&self) -> bool {
+        !self.changes.is_empty()
+            || self.elided_newly_visible_estimate != (0, Some(0))
+            || self.elided_newly_hidden_estimate != (0, Some(0))
+    }
+}
+
 /// Computes created/rewritten/abandoned commits between two operations.
 ///
 /// Returns a map of [`ModifiedChange`]s containing the new and old commits. For
@@ -533,12 +699,16 @@ async fn compute_operation_commits_diff(
     repo: &dyn Repo,
     from_repo: &ReadonlyRepo,
     to_repo: &ReadonlyRepo,
-) -> Result<HashMap<CommitId, ModifiedChange>, CommandError> {
+    from_op_diff_changes_expr: Arc<ResolvedRevsetExpression>,
+    to_op_diff_changes_expr: Arc<ResolvedRevsetExpression>,
+) -> Result<OperationCommitsDiff, CommandError> {
     let store = repo.store();
     let from_heads = from_repo.view().heads().iter().cloned().collect_vec();
     let to_heads = to_repo.view().heads().iter().cloned().collect_vec();
     let from_expr = RevsetExpression::commits(from_heads);
     let to_expr = RevsetExpression::commits(to_heads);
+    let newly_hidden_expr = to_expr.range(&from_expr);
+    let newly_visible_expr = from_expr.range(&to_expr);
 
     let predecessor_commits = accumulate_predecessors(
         slice::from_ref(to_repo.operation()),
@@ -546,10 +716,21 @@ async fn compute_operation_commits_diff(
     )
     .await?;
 
+    let elided_newly_visible_estimate = newly_visible_expr
+        .minus(&to_op_diff_changes_expr)
+        .evaluate(repo)?
+        .count_estimate()?;
+    let elided_newly_hidden_estimate = newly_hidden_expr
+        .minus(&from_op_diff_changes_expr)
+        .evaluate(repo)?
+        .count_estimate()?;
+
     // Collect hidden commits to find abandoned/rewritten changes.
     let mut hidden_commits_by_change: HashMap<ChangeId, CommitId> = HashMap::new();
     let mut abandoned_commits: HashSet<CommitId> = HashSet::new();
-    let newly_hidden = to_expr.range(&from_expr).evaluate(repo)?;
+    let newly_hidden = newly_hidden_expr
+        .intersection(&from_op_diff_changes_expr)
+        .evaluate(repo)?;
     for item in newly_hidden.commit_change_ids() {
         let (commit_id, change_id) = item?;
         // Just pick one if diverged. Divergent commits shouldn't be considered
@@ -562,7 +743,9 @@ async fn compute_operation_commits_diff(
 
     // For each new commit, copy/deduce predecessors based on change id.
     let mut changes: HashMap<CommitId, ModifiedChange> = HashMap::new();
-    let newly_visible = from_expr.range(&to_expr).evaluate(repo)?;
+    let newly_visible = newly_visible_expr
+        .intersection(&to_op_diff_changes_expr)
+        .evaluate(repo)?;
     for item in newly_visible.commit_change_ids() {
         let (commit_id, change_id) = item?;
         let predecessor_ids = if let Some(ids) = predecessor_commits.get(&commit_id) {
@@ -593,7 +776,11 @@ async fn compute_operation_commits_diff(
         changes.insert(commit_id, change);
     }
 
-    Ok(changes)
+    Ok(OperationCommitsDiff {
+        changes,
+        elided_newly_visible_estimate,
+        elided_newly_hidden_estimate,
+    })
 }
 
 /// Displays the diffs of a modified change.

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -26,6 +26,7 @@ use jj_lib::op_walk;
 use jj_lib::operation::Operation;
 use jj_lib::repo::RepoLoader;
 
+use super::diff::parse_op_diff_changes_in;
 use super::diff::show_op_diff;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
@@ -94,6 +95,13 @@ pub struct OperationLogArgs {
 
     #[command(flatten)]
     diff_format: DiffFormatArgs,
+
+    /// Show only changed revisions matching the given revset expression
+    ///
+    /// If no revisions are specified, this defaults to the
+    /// `revsets.op-diff-changes-in` setting.
+    #[arg(long, value_name = "REVSETS")]
+    show_changes_in: Option<String>,
 }
 
 pub async fn cmd_op_log(
@@ -157,6 +165,8 @@ async fn do_op_log(
     let diff_formats = diff_formats_for_log(settings, &args.diff_format, args.patch)?;
     let maybe_show_op_diff = if args.op_diff || !diff_formats.is_empty() {
         let template_text = settings.get_string("templates.commit_summary")?;
+        let op_diff_changes_expr =
+            parse_op_diff_changes_in(ui, settings, workspace_env, args.show_changes_in.as_deref())?;
         let show = async move |ui: &Ui,
                                formatter: &mut dyn Formatter,
                                op: &Operation,
@@ -194,6 +204,7 @@ async fn do_op_log(
             }
             show_op_diff(
                 ui,
+                workspace_env,
                 formatter,
                 repo.as_ref(),
                 &parent_repo,
@@ -202,6 +213,7 @@ async fn do_op_log(
                 (!args.no_graph).then_some(graph_style),
                 with_content_format,
                 diff_renderer.as_ref(),
+                op_diff_changes_expr.clone(),
             )
             .await
         };

--- a/cli/src/commands/operation/show.rs
+++ b/cli/src/commands/operation/show.rs
@@ -16,6 +16,7 @@ use clap_complete::ArgValueCandidates;
 use itertools::Itertools as _;
 use jj_lib::operation::Operation;
 
+use super::diff::parse_op_diff_changes_in;
 use super::diff::show_op_diff;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::LogContentFormat;
@@ -69,6 +70,13 @@ pub struct OperationShowArgs {
 
     #[command(flatten)]
     diff_format: DiffFormatArgs,
+
+    /// Show only changed revisions matching the given revset expression
+    ///
+    /// If no revisions are specified, this defaults to the
+    /// `revsets.op-diff-changes-in` setting.
+    #[arg(long, value_name = "REVSETS")]
+    show_changes_in: Option<String>,
 }
 
 pub async fn cmd_op_show(
@@ -123,6 +131,9 @@ pub async fn cmd_op_show(
             .labeled(["op_show", "operation"])
     };
 
+    let op_diff_changes_expr =
+        parse_op_diff_changes_in(ui, settings, workspace_env, args.show_changes_in.as_deref())?;
+
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     template.format(&op, formatter.as_mut())?;
@@ -135,6 +146,7 @@ pub async fn cmd_op_show(
         }
         show_op_diff(
             ui,
+            workspace_env,
             formatter.as_mut(),
             repo.as_ref(),
             &parent_repo,
@@ -143,6 +155,7 @@ pub async fn cmd_op_show(
             (!args.no_graph).then_some(graph_style),
             &with_content_format,
             diff_renderer.as_ref(),
+            op_diff_changes_expr,
         )
         .await?;
     }

--- a/cli/src/config/revsets.toml
+++ b/cli/src/config/revsets.toml
@@ -12,6 +12,7 @@ log = "present(@) | ancestors(immutable_heads().., 2) | trunk()"
 # Emit the working-copy branch first, which is usually most interesting.
 # This also helps stabilize output order.
 log-graph-prioritize = "present(@)"
+op-diff-changes-in = "mutable() | immutable_heads()"
 sign = "reachable(@, mutable())"
 bookmark-advance-to = "@"
 bookmark-advance-from = "heads(::to & bookmarks())"

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2289,6 +2289,9 @@ Compare changes to the repository between two operations
 * `--context <CONTEXT>` — Number of lines of context to show
 * `--ignore-all-space` — Ignore whitespace when comparing lines
 * `--ignore-space-change` — Ignore changes in amount of whitespace when comparing lines
+* `--show-changes-in <REVSETS>` — Show only changed revisions matching the given revset expression
+
+   If no revisions are specified, this defaults to the `revsets.op-diff-changes-in` setting.
 
 
 
@@ -2352,6 +2355,9 @@ Like other commands, `jj op log` snapshots the current working-copy changes and 
 * `--context <CONTEXT>` — Number of lines of context to show
 * `--ignore-all-space` — Ignore whitespace when comparing lines
 * `--ignore-space-change` — Ignore changes in amount of whitespace when comparing lines
+* `--show-changes-in <REVSETS>` — Show only changed revisions matching the given revset expression
+
+   If no revisions are specified, this defaults to the `revsets.op-diff-changes-in` setting.
 
 
 
@@ -2461,6 +2467,9 @@ Show changes to the repository in an operation
 * `--context <CONTEXT>` — Number of lines of context to show
 * `--ignore-all-space` — Ignore whitespace when comparing lines
 * `--ignore-space-change` — Ignore changes in amount of whitespace when comparing lines
+* `--show-changes-in <REVSETS>` — Show only changed revisions matching the given revset expression
+
+   If no revisions are specified, this defaults to the `revsets.op-diff-changes-in` setting.
 
 
 

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -2320,6 +2320,7 @@ fn test_op_diff_word_wrap() {
         work_dir.run_jj_with(|cmd| {
             cmd.args(args)
                 .arg(format!("--config=ui.log-word-wrap={word_wrap}"))
+                .arg("--config=revset-aliases.'immutable_heads()'='root()'")
                 .env("COLUMNS", columns.to_string())
         })
     };
@@ -3134,6 +3135,713 @@ fn test_op_log_anonymize() {
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
+    ");
+}
+
+#[test]
+fn test_op_immutable_revisions() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "tags() | bookmarks()""#);
+    test_env.add_config(r#"revsets.op-diff-changes-in = "mutable() | immutable_heads()""#);
+
+    // 1. Basic addition and removal elision
+    // Create a stack of 5 commits, all immutable.
+    for i in 1..=5 {
+        work_dir
+            .run_jj(["new", "@", "-m", &format!("commit {i}")])
+            .success();
+    }
+    work_dir.run_jj(["tag", "set", "t1", "-r", "@"]).success();
+
+    // Move working copy away
+    work_dir.run_jj(["new", "root()"]).success();
+
+    // Abandon the immutable stack
+    work_dir
+        .run_jj(["abandon", "--ignore-immutable", "::t1 & ~root()"])
+        .success();
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
+    52517772e194 test-username@host.example.com default@ 2001-02-03 04:05:15.000 +07:00 - 2001-02-03 04:05:15.000 +07:00
+    abandon commit 9c86781f3fe9097ffc530e65fd2ab4aff1e654bd and 5 more
+    args: jj abandon --ignore-immutable '::t1 & ~root()'
+
+    Changed commits:
+    ○  - royxmykx/0 9c86781f (hidden) (empty) commit 5
+       (Elided 5 newly removed revisions)
+    [EOF]
+    ");
+
+    // Undo
+    work_dir.run_jj(["op", "revert"]).success();
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
+    f9e504c0dd85 test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    revert operation 52517772e194b55d56c84c18b868306d9077e768cfe6e33f886ffb621bcc681f8e508e1fd53a8be18470f76c14d8fd00e6a2775c92fab8d6de6553f33a2de4fd
+    args: jj op revert
+
+    Changed commits:
+    ○  + royxmykx 9c86781f (empty) commit 5
+       (Elided 5 newly added revisions)
+    [EOF]
+    ");
+
+    // 2. Multiple branches elision
+    work_dir.run_jj(["new", "t1", "-m", "f1 1"]).success();
+    work_dir.run_jj(["new", "@", "-m", "f1 2"]).success();
+    work_dir.run_jj(["new", "@", "-m", "f1 3"]).success();
+    work_dir.run_jj(["tag", "set", "f1", "-r", "@"]).success();
+
+    work_dir.run_jj(["new", "t1", "-m", "f2 1"]).success();
+    work_dir.run_jj(["new", "@", "-m", "f2 2"]).success();
+    work_dir.run_jj(["new", "@", "-m", "f2 3"]).success();
+    work_dir.run_jj(["tag", "set", "f2", "-r", "@"]).success();
+
+    // Move WC away
+    work_dir.run_jj(["new", "root()"]).success();
+
+    // Abandon both chains
+    work_dir
+        .run_jj(["abandon", "--ignore-immutable", "(::f1 | ::f2) & ~root()"])
+        .success();
+    let op_id_for_diff = work_dir.current_operation_id();
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
+    f90e225dba79 test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
+    abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
+    args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
+
+    Changed commits:
+    ○  - xtnwkqum/0 e7f51c58 (hidden) (empty) f2 3
+    ╷ ○  - kxryzmor/0 c800ddaf (hidden) (empty) f1 3
+    ╭─╯
+    ○  - royxmykx/0 9c86781f (hidden) (empty) commit 5
+       (Elided 9 newly removed revisions)
+    [EOF]
+    ");
+
+    // Use `--show-changes-in none()` to see only elisions
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
+    f90e225dba79 test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
+    abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
+    args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
+
+    Changed commits:
+       (Elided 10+ newly removed revisions)
+    [EOF]
+    ");
+
+    // 3. Case where both added and removed immutable revisions are elided.
+    work_dir.run_jj(["new", "root()", "-m", "mix-a1"]).success();
+    for i in 2..=5 {
+        work_dir
+            .run_jj(["new", "@", "-m", &format!("mix-a{i}")])
+            .success();
+    }
+    work_dir
+        .run_jj(["bookmark", "set", "ba", "-r", "@"])
+        .success();
+
+    work_dir.run_jj(["new", "root()", "-m", "mix-b1"]).success();
+    for i in 2..=5 {
+        work_dir
+            .run_jj(["new", "@", "-m", &format!("mix-b{i}")])
+            .success();
+    }
+    work_dir
+        .run_jj(["bookmark", "set", "bb", "-r", "@"])
+        .success();
+
+    // Rebase bb chain onto ba head.
+    work_dir
+        .run_jj(["rebase", "--ignore-immutable", "-s", "bb----", "-d", "ba"])
+        .success();
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
+    9d3cfa89448a test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
+    rebase commit c09af48da0b4dcbbe6be869823d17bf6cd73a4db and descendants
+    args: jj rebase --ignore-immutable -s bb---- -d ba
+
+    Changed commits:
+    ○  + nsrwusvy caaf0759 (empty) (no description set)
+    │  - nsrwusvy/1 76ebe692 (hidden) (empty) (no description set)
+    ○  + wvmqtotl 44827d4a bb | (empty) mix-b5
+       - wvmqtotl/1 c117dbab (hidden) (empty) mix-b5
+       (Elided 4 newly added and 4 newly removed revisions)
+
+    Changed working copy default@:
+    + nsrwusvy caaf0759 (empty) (no description set)
+    - nsrwusvy/1 76ebe692 (hidden) (empty) (no description set)
+
+    Changed local bookmarks:
+    bb:
+    + wvmqtotl 44827d4a bb | (empty) mix-b5
+    - wvmqtotl/1 c117dbab (hidden) (empty) mix-b5
+    [EOF]
+    ");
+
+    // Use `--show-changes-in none()` to see only elisions
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
+    9d3cfa89448a test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
+    rebase commit c09af48da0b4dcbbe6be869823d17bf6cd73a4db and descendants
+    args: jj rebase --ignore-immutable -s bb---- -d ba
+
+    Changed commits:
+       (Elided 6 newly added and 6 newly removed revisions)
+
+    Changed working copy default@:
+    + nsrwusvy caaf0759 (empty) (no description set)
+    - nsrwusvy/1 76ebe692 (hidden) (empty) (no description set)
+
+    Changed local bookmarks:
+    bb:
+    + wvmqtotl 44827d4a bb | (empty) mix-b5
+    - wvmqtotl/1 c117dbab (hidden) (empty) mix-b5
+    [EOF]
+    ");
+
+    // 4. Case where exactly one immutable revision is elided (singular "revision")
+    work_dir
+        .run_jj(["new", "root()", "-m", "single-1"])
+        .success();
+    work_dir.run_jj(["new", "@", "-m", "single-2"]).success();
+    work_dir
+        .run_jj(["tag", "set", "ts", "-r", "@", "--allow-move"])
+        .success();
+    // Abandon to see single removal elision
+    work_dir
+        .run_jj(["abandon", "--ignore-immutable", "::ts & ~root()"])
+        .success();
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
+    f5a4f77da069 test-username@host.example.com default@ 2001-02-03 04:05:49.000 +07:00 - 2001-02-03 04:05:49.000 +07:00
+    abandon commit 0a2e24c8d8d8010243ed72f9c50ee69b57291eff and 1 more
+    args: jj abandon --ignore-immutable '::ts & ~root()'
+
+    Changed commits:
+    ○  + sryyqqkq 46f2f483 (empty) (no description set)
+       - sryyqqkq/1 d41cf466 (hidden) (empty) (no description set)
+    ○  - ukwxllxp/0 0a2e24c8 (hidden) (empty) single-2
+       (Elided 1 newly removed revisions)
+
+    Changed working copy default@:
+    + sryyqqkq 46f2f483 (empty) (no description set)
+    - sryyqqkq/1 d41cf466 (hidden) (empty) (no description set)
+    [EOF]
+    ");
+
+    // Undo to see single addition elision
+    work_dir.run_jj(["op", "revert"]).success();
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
+    3d2e63a4b374 test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
+    revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    args: jj op revert
+
+    Changed commits:
+    ○  + sryyqqkq d41cf466 (empty) (no description set)
+    │  - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
+    ○  + ukwxllxp 0a2e24c8 (empty) single-2
+       (Elided 1 newly added revisions)
+
+    Changed working copy default@:
+    + sryyqqkq d41cf466 (empty) (no description set)
+    - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
+    [EOF]
+    ");
+
+    // 5. op diff and op log tests
+    insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_id_for_diff]), @"
+    From operation: f90e225dba79 (2001-02-03 08:05:28) abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
+      To operation: 3d2e63a4b374 (2001-02-03 08:05:51) revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+
+    Changed commits:
+    ○  + sryyqqkq d41cf466 (empty) (no description set)
+    ○  + ukwxllxp 0a2e24c8 (empty) single-2
+    ○  + wvmqtotl 44827d4a bb | (empty) mix-b5
+    ○  + pkstwlsy 2e898f29 ba | (empty) mix-a5
+    ○  - tlkvzzqu/0 3f6d698d (hidden) (empty) (no description set)
+       (Elided 9 newly added revisions)
+
+    Changed working copy default@:
+    + sryyqqkq d41cf466 (empty) (no description set)
+    - tlkvzzqu/0 3f6d698d (hidden) (empty) (no description set)
+
+    Changed local bookmarks:
+    ba:
+    + pkstwlsy 2e898f29 ba | (empty) mix-a5
+    - (absent)
+    bb:
+    + wvmqtotl 44827d4a bb | (empty) mix-b5
+    - (absent)
+
+    Changed local tags:
+    ts:
+    + ukwxllxp 0a2e24c8 (empty) single-2
+    - (absent)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "1"]), @"
+    @  3d2e63a4b374 test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
+    │  revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    │  args: jj op revert
+    │
+    │  Changed commits:
+    │  ○  + sryyqqkq d41cf466 (empty) (no description set)
+    │  │  - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
+    │  ○  + ukwxllxp 0a2e24c8 (empty) single-2
+    │     Modified commit description:
+    │             1: single-2
+    │     (Elided 1 newly added revisions)
+    │
+    │  Changed working copy default@:
+    │  + sryyqqkq d41cf466 (empty) (no description set)
+    │  - sryyqqkq/0 46f2f483 (hidden) (empty) (no description set)
+    [EOF]
+    ");
+
+    // 6. Accuracy: Show local heads of affected set even if they have immutable
+    // descendants elsewhere (e.g. already hidden).
+    // root -> c1 -> c2 -> c3 (all immutable)
+    work_dir.run_jj(["new", "root()", "-m", "acc-c1"]).success();
+    let c1_id = work_dir
+        .run_jj(["log", "-T", "commit_id", "-r", "@", "--no-graph"])
+        .stdout
+        .raw()
+        .trim()
+        .to_string();
+    work_dir.run_jj(["new", "@", "-m", "acc-c2"]).success();
+    let c2_id = work_dir
+        .run_jj(["log", "-T", "commit_id", "-r", "@", "--no-graph"])
+        .stdout
+        .raw()
+        .trim()
+        .to_string();
+    work_dir.run_jj(["new", "@", "-m", "acc-c3"]).success();
+    let c3_id = work_dir
+        .run_jj(["log", "-T", "commit_id", "-r", "@", "--no-graph"])
+        .stdout
+        .raw()
+        .trim()
+        .to_string();
+
+    // Use c2_id to ensure the hidden c2 is shown.
+    test_env.add_config(format!(
+        r#"revsets.op-diff-changes-in = "mutable() | (all() & {c2_id})""#,
+    ));
+
+    // Track all with bookmarks.
+    work_dir
+        .run_jj(["bookmark", "create", "ba1", "-r", &c1_id])
+        .success();
+    work_dir
+        .run_jj(["bookmark", "create", "ba2", "-r", &c2_id])
+        .success();
+    work_dir
+        .run_jj(["bookmark", "create", "ba3", "-r", &c3_id])
+        .success();
+    work_dir.run_jj(["new", "root()"]).success();
+
+    // Operation A: Hide acc-c3 by abandoning it. c1 and c2 remain visible via
+    // bookmarks.
+    work_dir
+        .run_jj(["abandon", "--ignore-immutable", "-r", &c3_id])
+        .success();
+    let op_a = work_dir.current_operation_id();
+
+    // Operation B: Abandon c1 and c2. Both become hidden.
+    // newly_hidden = {c1, c2}.
+    // Option 1 (Fix) shows the head (c2) and elides the parent (c1).
+    work_dir
+        .run_jj(["abandon", "--ignore-immutable", "-r", &c1_id, "-r", &c2_id])
+        .success();
+    let op_b = work_dir.current_operation_id();
+
+    // With --show-changes-in all(), the diff should show both c1 and c2 as
+    // newly hidden.
+    let output = work_dir.run_jj([
+        "op",
+        "diff",
+        "--from",
+        &op_a,
+        "--to",
+        &op_b,
+        "--show-changes-in",
+        "all()",
+    ]);
+    insta::assert_snapshot!(output, @"
+    From operation: db293dfe6244 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
+      To operation: 10ca7b3a86f8 (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
+
+    Changed commits:
+    ○  - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
+    ○  - vkywoywq/0 a35cc4a3 (hidden) (empty) acc-c1
+
+    Changed local bookmarks:
+    ba1:
+    + (absent)
+    - vkywoywq/0 a35cc4a3 (hidden) (empty) acc-c1
+    ba2:
+    + (absent)
+    - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
+    [EOF]
+    ");
+
+    // Without --show-changes-in, the diff should show c2 as the head
+    // of the newly hidden set and elide c1.
+    let output = work_dir.run_jj(["op", "diff", "--from", &op_a, "--to", &op_b]);
+    insta::assert_snapshot!(output, @"
+    From operation: db293dfe6244 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
+      To operation: 10ca7b3a86f8 (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
+
+    Changed commits:
+    ○  - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
+       (Elided 1 newly removed revisions)
+
+    Changed local bookmarks:
+    ba1:
+    + (absent)
+    - vkywoywq/0 a35cc4a3 (hidden) (empty) acc-c1
+    ba2:
+    + (absent)
+    - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_op_show_revset_expression_resolution() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    test_env.add_config(
+        r#"
+[templates]
+commit_summary = 'commit_id.short() ++ " " ++ description.first_line()'
+[template-aliases]
+'format_short_id(id)' = 'id.substr(0, 12)'
+'format_short_change_id_with_change_offset(commit)' = 'commit.change_id().short()'
+"#,
+    );
+
+    // 1. Initial commits.
+    work_dir.run_jj(["new", "root()", "-m", "base"]).success();
+
+    // 2. Create bookmark_x (op_create).
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "bookmark_x"])
+        .success();
+    let op_create = work_dir.current_operation_id();
+
+    // 3. Create a stack of 2 commits.
+    for i in 1..=2 {
+        work_dir
+            .run_jj(["new", "@", "-m", &format!("stack {i}")])
+            .success();
+    }
+    work_dir
+        .run_jj(["bookmark", "set", "bookmark_x", "-r@"])
+        .success();
+
+    // 4. Rebase the stack (op_rebase).
+    work_dir
+        .run_jj(["new", "root()", "-m", "new_base"])
+        .success();
+    let new_base = "@";
+    work_dir
+        .run_jj(["rebase", "-s", "bookmark_x-", "-d", new_base])
+        .success();
+    let op_rebase = work_dir.current_operation_id();
+
+    // Configure op-diff-changes-in to require 'bookmark_x'.
+    test_env.add_config(r#"revsets.op-diff-changes-in = "bookmark_x""#);
+
+    // 5. Test op show for op_rebase: should show ELISION summary.
+    // bookmark_x exists in both states of the rebase.
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_rebase]), @"
+    ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    args: jj rebase -s bookmark_x- -d @
+
+    Changed commits:
+    ○  + 3cafca23bb81 stack 2
+       - 5456f1af47ed stack 2
+       (Elided 1 newly added and 1 newly removed revisions)
+
+    Changed local bookmarks:
+    bookmark_x:
+    + 3cafca23bb81 stack 2
+    - 5456f1af47ed stack 2
+    [EOF]
+    ");
+
+    // 6. Test op show for op_create: should show WARNING.
+    // bookmark_x did not exist in the 'from' state.
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create]), @"
+    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    args: jj bookmark create -r@ bookmark_x
+
+    Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
+       (Use --show-changes-in=all() to see all changes)
+
+    Changed local bookmarks:
+    bookmark_x:
+    + 2308e5a241f7 base
+    - (absent)
+    [EOF]
+    ");
+
+    // 7. Test op show for op_create with the flag: should show all changes and NO
+    //    WARNING.
+    insta::assert_snapshot!(work_dir.run_jj(["op", "show", &op_create, "--show-changes-in", "all()"]), @"
+    d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    args: jj bookmark create -r@ bookmark_x
+
+    Changed local bookmarks:
+    bookmark_x:
+    + 2308e5a241f7 base
+    - (absent)
+    [EOF]
+    ");
+
+    // 8. Test op diff from BEFORE creation to op_rebase: should show WARNING.
+    let op_before_create = format!("{op_create}-");
+    insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_before_create, "--to", &op_rebase]), @"
+    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
+      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+
+    Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
+       (Use --show-changes-in=all() to see all changes)
+
+    Changed working copy default@:
+    + 6b753f7043b4 new_base
+    - 2308e5a241f7 base
+
+    Changed local bookmarks:
+    bookmark_x:
+    + 3cafca23bb81 stack 2
+    - (absent)
+    [EOF]
+    ");
+
+    // 9. Test op diff with the flag: should show all changes and NO WARNING.
+    insta::assert_snapshot!(work_dir.run_jj([
+        "op",
+        "diff",
+        "--from",
+        &op_before_create,
+        "--to",
+        &op_rebase,
+        "--show-changes-in",
+        "all()",
+    ]), @"
+    From operation: 2bd218a33e22 (2001-02-03 08:05:08) new empty commit
+      To operation: ce91c7903087 (2001-02-03 08:05:14) rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+
+    Changed commits:
+    ○  + 3cafca23bb81 stack 2
+    ○  + e7bd1678832f stack 1
+    ○  + 6b753f7043b4 new_base
+
+    Changed working copy default@:
+    + 6b753f7043b4 new_base
+    - 2308e5a241f7 base
+
+    Changed local bookmarks:
+    bookmark_x:
+    + 3cafca23bb81 stack 2
+    - (absent)
+    [EOF]
+    ");
+
+    // 10. Test op log -p: should show BOTH behaviors.
+    test_env.add_config(r#"revsets.op-diff-changes-in = "mutable() | bookmark_x""#);
+    insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "6"]), @"
+    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    │  args: jj rebase -s bookmark_x- -d @
+    │
+    │  Changed commits:
+    │  ○  + 3cafca23bb81 stack 2
+    │  │  - 5456f1af47ed stack 2
+    │  ○  + e7bd1678832f stack 1
+    │     - 0f12cf5c679b stack 1
+    │
+    │  Changed local bookmarks:
+    │  bookmark_x:
+    │  + 3cafca23bb81 stack 2
+    │  - 5456f1af47ed stack 2
+    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    │  new empty commit
+    │  args: jj new 'root()' -m new_base
+    │
+    │  Changed commits:
+    │  ○  + 6b753f7043b4 new_base
+    │     Modified commit description:
+    │             1: new_base
+    │
+    │  Changed working copy default@:
+    │  + 6b753f7043b4 new_base
+    │  - 5456f1af47ed stack 2
+    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
+    │  args: jj bookmark set bookmark_x -r@
+    │
+    │  Changed local bookmarks:
+    │  bookmark_x:
+    │  + 5456f1af47ed stack 2
+    │  - 2308e5a241f7 base
+    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  new empty commit
+    │  args: jj new @ -m 'stack 2'
+    │
+    │  Changed commits:
+    │  ○  + 5456f1af47ed stack 2
+    │     Modified commit description:
+    │             1: stack 2
+    │
+    │  Changed working copy default@:
+    │  + 5456f1af47ed stack 2
+    │  - 0f12cf5c679b stack 1
+    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  new empty commit
+    │  args: jj new @ -m 'stack 1'
+    │
+    │  Changed commits:
+    │  ○  + 0f12cf5c679b stack 1
+    │     Modified commit description:
+    │             1: stack 1
+    │
+    │  Changed working copy default@:
+    │  + 0f12cf5c679b stack 1
+    │  - 2308e5a241f7 base
+    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    │  args: jj bookmark create -r@ bookmark_x
+    │
+    │  Warning: Could not resolve revset expression for elision: Revision `bookmark_x` doesn't exist
+    │     (Use --show-changes-in=all() to see all changes)
+    │
+    │  Changed local bookmarks:
+    │  bookmark_x:
+    │  + 2308e5a241f7 base
+    │  - (absent)
+    [EOF]
+    ");
+
+    // 11. Test op log -p with the flag: should show all changes and NO WARNING.
+    insta::assert_snapshot!(work_dir.run_jj([
+        "op",
+        "log",
+        "-p",
+        "--limit",
+        "6",
+        "--show-changes-in",
+        "all()",
+    ]), @"
+    @  ce91c7903087 test-username@host.example.com default@ 2001-02-03 04:05:14.000 +07:00 - 2001-02-03 04:05:14.000 +07:00
+    │  rebase commit 0f12cf5c679b373cb1ee0fa3e441c2f5030c4dc9 and descendants
+    │  args: jj rebase -s bookmark_x- -d @
+    │
+    │  Changed commits:
+    │  ○  + 3cafca23bb81 stack 2
+    │  │  - 5456f1af47ed stack 2
+    │  ○  + e7bd1678832f stack 1
+    │     - 0f12cf5c679b stack 1
+    │
+    │  Changed local bookmarks:
+    │  bookmark_x:
+    │  + 3cafca23bb81 stack 2
+    │  - 5456f1af47ed stack 2
+    ○  86f2ef744e62 test-username@host.example.com default@ 2001-02-03 04:05:13.000 +07:00 - 2001-02-03 04:05:13.000 +07:00
+    │  new empty commit
+    │  args: jj new 'root()' -m new_base
+    │
+    │  Changed commits:
+    │  ○  + 6b753f7043b4 new_base
+    │     Modified commit description:
+    │             1: new_base
+    │
+    │  Changed working copy default@:
+    │  + 6b753f7043b4 new_base
+    │  - 5456f1af47ed stack 2
+    ○  460a7cedc5a7 test-username@host.example.com default@ 2001-02-03 04:05:12.000 +07:00 - 2001-02-03 04:05:12.000 +07:00
+    │  point bookmark bookmark_x to commit 5456f1af47edb52cfd73d582364cc4dd6ddb08cf
+    │  args: jj bookmark set bookmark_x -r@
+    │
+    │  Changed local bookmarks:
+    │  bookmark_x:
+    │  + 5456f1af47ed stack 2
+    │  - 2308e5a241f7 base
+    ○  f64dfa7b064f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  new empty commit
+    │  args: jj new @ -m 'stack 2'
+    │
+    │  Changed commits:
+    │  ○  + 5456f1af47ed stack 2
+    │     Modified commit description:
+    │             1: stack 2
+    │
+    │  Changed working copy default@:
+    │  + 5456f1af47ed stack 2
+    │  - 0f12cf5c679b stack 1
+    ○  a6bc21ea52ed test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    │  new empty commit
+    │  args: jj new @ -m 'stack 1'
+    │
+    │  Changed commits:
+    │  ○  + 0f12cf5c679b stack 1
+    │     Modified commit description:
+    │             1: stack 1
+    │
+    │  Changed working copy default@:
+    │  + 0f12cf5c679b stack 1
+    │  - 2308e5a241f7 base
+    ○  d3ffb3ae407a test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    │  create bookmark bookmark_x pointing to commit 2308e5a241f7a47f186b0686ffb17aa613a727d7
+    │  args: jj bookmark create -r@ bookmark_x
+    │
+    │  Changed local bookmarks:
+    │  bookmark_x:
+    │  + 2308e5a241f7 base
+    │  - (absent)
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_op_diff_invalid_revset() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Invalid flag value
+    insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--show-changes-in", "invalid("]), @"
+    ------- stderr -------
+    Error: Invalid `--show-changes-in` expression: invalid(
+    Caused by:  --> 1:9
+      |
+    1 | invalid(
+      |         ^---
+      |
+      = expected <strict_identifier> or <expression>
+    [EOF]
+    [exit status: 1]
+    ");
+
+    // Invalid config value
+    test_env.add_config(r#"revsets.op-diff-changes-in = "invalid(""#);
+    insta::assert_snapshot!(work_dir.run_jj(["op", "diff"]), @"
+    ------- stderr -------
+    Config error: Invalid `revsets.op-diff-changes-in`
+    Caused by:  --> 1:9
+      |
+    1 | invalid(
+      |         ^---
+      |
+      = expected <strict_identifier> or <expression>
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
+    [EOF]
+    [exit status: 1]
     ");
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -592,6 +592,22 @@ log = "main@origin.."
 The default value for `revsets.log` is
 `'present(@) | ancestors(immutable_heads().., 2) | trunk()'`.
 
+### Default revisions for operation diffs
+
+You can configure the set of revisions that are considered "interesting" when
+showing the difference between two operations (e.g. in `jj op show`,
+`jj op diff`, or `jj op log -p`). Revisions that are not in this set are
+elided into a summary count.
+
+```toml
+[revsets]
+# Only show mutable revisions and the trunk
+op-diff-changes-in = "mutable() | trunk()"
+```
+
+The default value for `revsets.op-diff-changes-in` is
+`'mutable() | immutable_heads()'`.
+
 ### Prioritize Revsets in the Log over @
 
 In some situations the default graph can be hard to read, for example when working with big merges.


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Details

This change introduces elision of "non-salient" revisions in `jj op show`,
`jj op diff`, and `jj op log -p`. This helps keep the output focused on
meaningful changes (like mutable commits) while summarizing less relevant
changes (like large sets of immutable revisions being added or removed).

A new configuration setting `revsets.op-diff-changes-in` defines which revisions
should be shown. It defaults to `mutable() | immutable_heads()`.

A new `--show-changes-in` flag is added to these commands to allow overriding
the default elision behavior for a single invocation (e.g., `--show-changes-in=all()`).

Summary of changes:
- Added `revsets.op-diff-changes-in` config with default `mutable() | immutable_heads()`.
- Implemented filtering and elision logic in `compute_operation_commits_diff`.
- Updated `op show`, `op diff`, and `op log -p` to honor the new elision behavior.
- Added elision summaries to the output (e.g., "Elided X newly removed revisions").
- Updated documentation in `docs/config.md`.
- Added comprehensive integration tests in `cli/tests/test_operations.rs`.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes


Fixes https://github.com/jj-vcs/jj/issues/6083