### PR TITLE
docs: simplify example graphs in docs/revsets.md (operators, functions)

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -111,15 +111,13 @@ y) | z` or `x & (y | z)`.
 
     Given this history:
     ```
-    o D
+    D
     |\
-    | o C
-    | |
-    o | B
+    B C
     |/
-    o A
+    A
     |
-    o root()
+    root()
     ```
 
     **Operator** `x-`
@@ -435,17 +433,14 @@ revsets (expressions) as arguments.
 
     Given this history:
     ```
-    o E
-    |
-    | o D
+    E
+    | D
     |/|
-    | o C
-    | |
-    o | B
+    B C
     |/
-    o A
+    A
     |
-    o root()
+    root()
     ```
 
     **function** `reachable()`


### PR DESCRIPTION
Simplify the example graphs for the operators and functions sections by removing the node symbols and using the labels as the nodes.

This helps the reader grok the graph quicker while consulting the example scenarios.

This notation is also consistent with the graph examples in the sub-commands.

Closes #8855

# Checklist

If applicable:

- [N/A] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [N/A] I have updated the config schema (`cli/src/config-schema.json`)
- [ N/A] I have added/updated tests to cover my changes
