### PR TITLE
cli: Add `jj util snapshot` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
+* `jj debug snapshot` is deprecated in favor of `jj util snapshot`. Although
+  this was an undocumented command in the first place, it will be removed after
+  6 months (v0.45.0) to give people time to migrate away.
+
 ### New features
 
 * Templates now support `first()`, `last()`, `get(index)`, `reverse()`,
@@ -47,6 +51,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New template function `Timestamp::since(ts)` that returns the `TimestampRange`
   between two timestamps. It can be used in conjunction with `.duration()` in
   order to obtain a human-friendly duration between two `Timestamp`s.
+
+* Added new `jj util snapshot` command to manually or programmatically trigger a
+  snapshot. This introduces an official alternative to the
+  previously-undocumented `jj debug snapshot` command. The Watchman integration
+  has also been updated to use this command instead.
 
 ### Fixed bugs
 

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1192,15 +1192,19 @@ impl WorkspaceCommandHelper {
         Ok(stats)
     }
 
-    /// Snapshot the working copy if allowed, and import Git refs if the working
-    /// copy is collocated with Git.
+    /// Snapshots the working copy if allowed, and imports Git refs if the
+    /// working copy is collocated with Git.
+    ///
+    /// Returns whether a snapshot was taken.
     #[instrument(skip_all)]
-    pub fn maybe_snapshot(&mut self, ui: &Ui) -> Result<(), CommandError> {
+    pub fn maybe_snapshot(&mut self, ui: &Ui) -> Result<bool, CommandError> {
+        let op_id_before = self.repo().op_id().clone();
         let stats = self
             .maybe_snapshot_impl(ui)
             .map_err(|err| err.into_command_error())?;
         print_snapshot_stats(ui, &stats, self.env().path_converter())?;
-        Ok(())
+        let op_id_after = self.repo().op_id();
+        Ok(op_id_before != *op_id_after)
     }
 
     /// Imports new HEAD from the colocated Git repo.

--- a/cli/src/commands/debug/snapshot.rs
+++ b/cli/src/commands/debug/snapshot.rs
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Delete in jj 0.45.0+
+
 use std::fmt::Debug;
 
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
 
-/// Trigger a snapshot in the op log
+/// [DEPRECATED] Trigger a snapshot in the op log
+///
+/// This command is deprecated; use `jj util snapshot` instead.
 #[derive(clap::Args, Clone, Debug)]
+#[command(hide = true)]
 pub struct DebugSnapshotArgs {}
 
 pub fn cmd_debug_snapshot(
@@ -27,6 +32,10 @@ pub fn cmd_debug_snapshot(
     command: &CommandHelper,
     _args: &DebugSnapshotArgs,
 ) -> Result<(), CommandError> {
+    writeln!(
+        ui.warning_default(),
+        "`jj debug snapshot` is deprecated; use `jj util snapshot` instead"
+    )?;
     // workspace helper will snapshot as needed
     command.workspace_helper(ui)?;
     Ok(())

--- a/cli/src/commands/util/mod.rs
+++ b/cli/src/commands/util/mod.rs
@@ -18,6 +18,7 @@ mod exec;
 mod gc;
 mod install_man_pages;
 mod markdown_help;
+mod snapshot;
 
 use clap::Subcommand;
 use tracing::instrument;
@@ -34,6 +35,8 @@ use self::install_man_pages::UtilInstallManPagesArgs;
 use self::install_man_pages::cmd_util_install_man_pages;
 use self::markdown_help::UtilMarkdownHelp;
 use self::markdown_help::cmd_util_markdown_help;
+use self::snapshot::UtilSnapshotArgs;
+use self::snapshot::cmd_util_snapshot;
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
@@ -47,6 +50,7 @@ pub(crate) enum UtilCommand {
     Gc(UtilGcArgs),
     InstallManPages(UtilInstallManPagesArgs),
     MarkdownHelp(UtilMarkdownHelp),
+    Snapshot(UtilSnapshotArgs),
 }
 
 #[instrument(skip_all)]
@@ -62,5 +66,6 @@ pub(crate) fn cmd_util(
         UtilCommand::Gc(args) => cmd_util_gc(ui, command, args),
         UtilCommand::InstallManPages(args) => cmd_util_install_man_pages(ui, command, args),
         UtilCommand::MarkdownHelp(args) => cmd_util_markdown_help(ui, command, args),
+        UtilCommand::Snapshot(args) => cmd_util_snapshot(ui, command, args),
     }
 }

--- a/cli/src/commands/util/snapshot.rs
+++ b/cli/src/commands/util/snapshot.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::ui::Ui;
+
+/// Snapshot the working copy if needed
+///
+/// Snapshots the working copy and updates the working-copy commit if the
+/// working copy has changed since the last snapshot. Since almost every command
+/// snapshots the working copy, there is very little reason to run this command
+/// as a human; it is mostly meant for scripts.
+///
+/// If you want to see the ID of the current operation after this command, run
+/// `jj operation log --limit 1`. However, since that command also snapshots the
+/// working copy, there would be no need to run `jj util snapshot` first.
+#[derive(clap::Args, Clone, Debug)]
+pub struct UtilSnapshotArgs {}
+
+pub fn cmd_util_snapshot(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    _args: &UtilSnapshotArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper_no_snapshot(ui)?;
+
+    // Trigger the snapshot if needed.
+    let was_snapshot_taken = workspace_command.maybe_snapshot(ui)?;
+    if was_snapshot_taken {
+        writeln!(ui.status(), "Snapshot complete.")?;
+    } else {
+        writeln!(ui.status(), "No snapshot needed.")?;
+    }
+
+    Ok(())
+}

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -114,6 +114,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj util gc`↴](#jj-util-gc)
 * [`jj util install-man-pages`↴](#jj-util-install-man-pages)
 * [`jj util markdown-help`↴](#jj-util-markdown-help)
+* [`jj util snapshot`↴](#jj-util-snapshot)
 * [`jj version`↴](#jj-version)
 * [`jj workspace`↴](#jj-workspace)
 * [`jj workspace add`↴](#jj-workspace-add)
@@ -3255,6 +3256,7 @@ Infrequently used commands such as for generating shell completions
 * `gc` — Run backend-dependent garbage collection
 * `install-man-pages` — Install Jujutsu's manpages to the provided path
 * `markdown-help` — Print the CLI help for all subcommands in Markdown
+* `snapshot` — Snapshot the working copy if needed
 
 
 
@@ -3394,6 +3396,18 @@ Install Jujutsu's manpages to the provided path
 Print the CLI help for all subcommands in Markdown
 
 **Usage:** `jj util markdown-help`
+
+
+
+## `jj util snapshot`
+
+Snapshot the working copy if needed
+
+Snapshots the working copy and updates the working-copy commit if the working copy has changed since the last snapshot. Since almost every command snapshots the working copy, there is very little reason to run this command as a human; it is mostly meant for scripts.
+
+If you want to see the ID of the current operation after this command, run `jj operation log --limit 1`. However, since that command also snapshots the working copy, there would be no need to run `jj util snapshot` first.
+
+**Usage:** `jj util snapshot`
 
 
 

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -261,3 +261,33 @@ fn test_install_man_pages() {
     assert!(man_dir.is_dir());
     assert!(fs::read_dir(man_dir).unwrap().next().is_some());
 }
+
+#[test]
+fn test_util_snapshot() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("foo", "foo");
+
+    let output = work_dir.run_jj(["util", "snapshot"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Snapshot complete.
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_util_snapshot_nothing_changed() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["util", "snapshot"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    No snapshot needed.
+    [EOF]
+    ");
+}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -599,6 +599,22 @@ export default defineConfig({
 Note: There was a [request](https://github.com/vitejs/vite/issues/20036) to include `.jj`
 in the default ignore list, but manual configuration remains the recommended approach.
 
+### How can I manually trigger (e.g., periodic) snapshots?
+
+Most `jj` commands will automatically snapshot the working copy at the start of
+the command if needed. However, if you'd like to manually trigger a snapshot for
+whatever reason, such as for scripting, prompt info, or periodic snapshots in
+parallel with something like a
+[`watch` command](#can-i-monitor-how-jj-log-evolves), you can run
+`jj util snapshot`. By default this command will print whether a snapshot was
+taken, which you can silence with the global `--quiet` flag. This command is
+likely most useful for scripting rather than for running on the command line by
+a human.
+
+If you want to see the ID of the current operation after this command, it would
+be simpler to run `jj operation log --limit 1` directly, since that command also
+takes a snapshot if needed.
+
 ### I want to write a tool which integrates with Jujutsu. Should I use the library or parse the CLI?
 
 There are some trade-offs and there is no definitive answer yet.

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -287,7 +287,8 @@ pub mod watchman {
                         name: "jj-background-monitor".to_string(),
                         command: vec![
                             "jj".to_string(),
-                            "debug".to_string(),
+                            "--quiet".to_string(),
+                            "util".to_string(),
                             "snapshot".to_string(),
                         ],
                         expression: Some(self.build_exclude_expr()),


### PR DESCRIPTION
This essentially does the same thing as `jj debug snapshot`, but is actually officially documented and thus "supported". We've added it to the `util` subcommand because that seems more intuitive for the end user, despite other `util` commands not usually needing the repo at all.

Suggested in https://github.com/jj-vcs/jj/pull/8842#discussion_r2791120598

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
