### PR TITLE
rebase: Print message for empty input revset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [#7711](https://github.com/jj-vcs/jj/issues/7711)
 
 * `jj rebase --branch` and `jj rebase --source` will no longer return an error
-  if the given argument resolves to an empty revision set.
-  `jj rebase --revisions` already behaved this way.
+  if the given argument resolves to an empty revision set
+  (`jj rebase --revisions` already behaved this way). Instead, a message will be
+  printed to inform the user why nothing has changed.
 
 * Changed Git representation of conflicted commits to include files from the
   first side of the conflict. This should prevent unchanged files from being

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -382,6 +382,7 @@ pub(crate) fn cmd_rebase(
         simplify_ancestor_merge: args.simplify_parents,
     };
     let mut workspace_command = command.workspace_helper(ui)?;
+
     let loc = if !args.revisions.is_empty() {
         plan_rebase_revisions(ui, &workspace_command, &args.revisions, &args.destination)?
     } else if !args.source.is_empty() {
@@ -389,6 +390,15 @@ pub(crate) fn cmd_rebase(
     } else {
         plan_rebase_branch(ui, &workspace_command, &args.branch, &args.destination)?
     };
+
+    let target_ids = match &loc.target {
+        MoveCommitsTarget::Commits(ids) => ids,
+        MoveCommitsTarget::Roots(ids) => ids,
+    };
+    if target_ids.is_empty() {
+        writeln!(ui.status(), "No revisions to rebase.")?;
+        return Ok(());
+    }
 
     let mut tx = workspace_command.start_transaction();
     let mut computed_move = compute_move_commits(tx.repo(), &loc)?;

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -142,26 +142,26 @@ fn test_rebase_empty_sets() {
     let output = work_dir.run_jj(["rebase", "-r=none()", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Nothing changed.
+    No revisions to rebase.
     [EOF]
     ");
     let output = work_dir.run_jj(["rebase", "-s=none()", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Nothing changed.
+    No revisions to rebase.
     [EOF]
     ");
     let output = work_dir.run_jj(["rebase", "-b=none()", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Nothing changed.
+    No revisions to rebase.
     [EOF]
     ");
     // Empty because "b..a" is empty
     let output = work_dir.run_jj(["rebase", "-b=a", "-o=b"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Nothing changed.
+    No revisions to rebase.
     [EOF]
     ");
 }


### PR DESCRIPTION
Follow up to #8828.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
