### PR TITLE
watchman: explicitly supress stdout/stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   previously-undocumented `jj debug snapshot` command. The Watchman integration
   has also been updated to use this command instead.
 
+* Changed background snapshotting to suppress stdout and stderr to avoid long
+  hangs.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/lib/src/fsmonitor.rs
+++ b/lib/src/fsmonitor.rs
@@ -280,6 +280,7 @@ pub mod watchman {
         #[instrument(skip(self))]
         async fn register_trigger(&self) -> Result<(), Error> {
             info!("Registering Watchman trigger...");
+            let null = if cfg!(windows) { ">NUL" } else { ">/dev/null" };
             self.client
                 .register_trigger(
                     &self.resolved_root,
@@ -292,6 +293,8 @@ pub mod watchman {
                             "snapshot".to_string(),
                         ],
                         expression: Some(self.build_exclude_expr()),
+                        stderr: Some(null.into()),
+                        stdout: Some(null.into()),
                         ..Default::default()
                     },
                 )


### PR DESCRIPTION
Based on conversation in #8240 and personal experience this prevents hangs associated with background snapshotting.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
