### PR TITLE
debug object: include value in errors about bad hex id

### DIFF
--- a/cli/src/commands/debug/object.rs
+++ b/cli/src/commands/debug/object.rs
@@ -106,13 +106,13 @@ pub fn cmd_debug_object(
     match args {
         DebugObjectArgs::Commit(args) => {
             let id = CommitId::try_from_hex(&args.id)
-                .ok_or_else(|| user_error("Invalid hex commit id"))?;
+                .ok_or_else(|| user_error(format!(r#"Invalid hex commit id: "{}""#, args.id)))?;
             let commit = repo_loader.store().get_commit(&id)?;
             writeln!(ui.stdout(), "{:#?}", commit.store_commit())?;
         }
         DebugObjectArgs::File(args) => {
-            let id =
-                FileId::try_from_hex(&args.id).ok_or_else(|| user_error("Invalid hex file id"))?;
+            let id = FileId::try_from_hex(&args.id)
+                .ok_or_else(|| user_error(format!(r#"Invalid hex file id: "{}""#, args.id)))?;
             let path = RepoPathBuf::from_internal_string(&args.path).map_err(user_error)?;
             let mut contents = repo_loader.store().read_file(&path, &id).block_on()?;
             let mut buf = vec![];
@@ -121,13 +121,13 @@ pub fn cmd_debug_object(
         }
         DebugObjectArgs::Operation(args) => {
             let id = OperationId::try_from_hex(&args.id)
-                .ok_or_else(|| user_error("Invalid hex operation id"))?;
+                .ok_or_else(|| user_error(format!(r#"Invalid hex operation id: "{}""#, args.id)))?;
             let operation = repo_loader.op_store().read_operation(&id).block_on()?;
             writeln!(ui.stdout(), "{operation:#?}")?;
         }
         DebugObjectArgs::Symlink(args) => {
             let id = SymlinkId::try_from_hex(&args.id)
-                .ok_or_else(|| user_error("Invalid hex symlink id"))?;
+                .ok_or_else(|| user_error(format!(r#"Invalid hex symlink id: "{}""#, args.id)))?;
             let path = RepoPathBuf::from_internal_string(&args.path).map_err(user_error)?;
             let target = repo_loader.store().read_symlink(&path, &id).block_on()?;
             writeln!(ui.stdout(), "{target}")?;
@@ -144,8 +144,9 @@ pub fn cmd_debug_object(
                     return Err(user_error("The path is not a single tree in the commit"));
                 }
             } else {
-                TreeId::try_from_hex(args.id.as_ref().unwrap())
-                    .ok_or_else(|| user_error("Invalid hex tree id"))?
+                let tree_id = args.id.as_ref().unwrap();
+                TreeId::try_from_hex(tree_id)
+                    .ok_or_else(|| user_error(format!(r#"Invalid hex tree id: "{tree_id}""#)))?
             };
             let tree = repo_loader.store().get_tree(dir, &id)?;
             writeln!(ui.stdout(), "{:#?}", tree.data())?;
@@ -156,8 +157,9 @@ pub fn cmd_debug_object(
                 let op = workspace_command.resolve_single_op(op_string)?;
                 op.view_id().clone()
             } else {
-                ViewId::try_from_hex(args.id.as_ref().unwrap())
-                    .ok_or_else(|| user_error("Invalid hex view id"))?
+                let view_id = args.id.as_ref().unwrap();
+                ViewId::try_from_hex(view_id)
+                    .ok_or_else(|| user_error(format!(r#"Invalid hex view id: "{view_id}""#)))?
             };
             let view = repo_loader.op_store().read_view(&id).block_on()?;
             writeln!(ui.stdout(), "{view:#?}")?;


### PR DESCRIPTION
`jj debug object tree abc123 dir` currently fails with `Error: Invalid hex tree id`. It's not clear that the bad value is `dir`. This patch improve the message by making it `Error: Invalid hex tree id: "dir"`.

This is extra confusing because the `jj debug object tree --help` synopsis lists `<DIR>` last, presumably because the `target` argument group involves a named argument and clap prefers to put those first.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
