### PR TITLE
tests: avoid dumping core when fake utilities are instructed to crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "jsonschema",
  "libc",
  "maplit",
+ "nix 0.31.1",
  "once_cell",
  "pest",
  "pest_derive",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -113,6 +113,7 @@ whoami = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
+nix = { workspace = true, features = [ "signal" ] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/cli/testing/fake-formatter.rs
+++ b/cli/testing/fake-formatter.rs
@@ -21,6 +21,8 @@ use std::process::ExitCode;
 use bstr::ByteSlice as _;
 use clap::Parser;
 use itertools::Itertools as _;
+#[cfg(unix)]
+use nix::sys::signal;
 
 /// A fake code formatter, useful for testing
 ///
@@ -158,6 +160,10 @@ fn main() -> ExitCode {
         write!(file, "{stdout}").unwrap();
     }
     if args.abort {
+        // Coredump generation varies by UNIX and is irrelevant to tests
+        // Prefer raising SIGTERM to crash without dumping core
+        #[cfg(unix)]
+        let _ = signal::raise(signal::Signal::SIGTERM);
         std::process::abort()
     } else if args.fail {
         ExitCode::FAILURE

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -205,11 +205,9 @@ fn test_util_exec_crash() {
     );
 
     if cfg!(unix) {
-        // abort produces SIGABRT; strip any "(core dumped)" string
-        let output = output.normalize_stderr_with(|s| s.replacen(" (core dumped)", "", 1));
         insta::assert_snapshot!(output, @r"
         ------- stderr -------
-        Error: External command was terminated by signal: 6 (SIGABRT)
+        Error: External command was terminated by signal: 15 (SIGTERM)
         [EOF]
         [exit status: 1]
         ");


### PR DESCRIPTION
The CI systems used by jj disable coredumps (or place them somewhere else), but others generate coredumps in the working directory, where they can be snapshotted and cause unwanted errors. Raise SIGTERM on UNIX platforms to avoid this situation.

Supercedes #8689.
Closes #8819.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
