### PR TITLE
new: evaluate new_description template for new commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* `jj new` now evaluates the `new_description` template to populate the
+  initial commit description when no `-m` message is provided.
+
 * Templates now support `first()`, `last()`, `get(index)`, `reverse()`,
   `skip(count)`, and `take(count)` methods on list types for more flexible
   list manipulation.

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -17,6 +17,7 @@ config_list = 'builtin_config_list'
 draft_commit_description = 'builtin_draft_commit_description'
 
 duplicate_description = 'description'
+new_description = ''
 
 commit_trailers = ''
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -233,6 +233,31 @@ concat(
 Note that `description` usually ends with a `\n` if it is not blank. Use
 `.trim_end()` to remove the `\n`.
 
+### New commit description
+
+When `jj new` creates a commit without an explicit `-m` message, it evaluates
+the `new_description` template to populate the description. By default, this
+template is empty.
+
+You can customize this to automatically generate descriptions for new commits.
+For example, to auto-generate merge commit messages:
+
+```toml
+[templates]
+new_description = '''
+if(parents.len() > 1,
+  "Merge " ++ parents.skip(1).map(|p| coalesce(
+    p.bookmarks().first().name(),
+    p.change_id().shortest(8)
+  )).join(", ") ++ " into " ++ coalesce(
+    parents.first().bookmarks().first().name(),
+    parents.first().change_id().shortest(8)
+  ) ++ "\n",
+  ""
+)
+'''
+```
+
 ### Bookmark/tag listing order
 
 By default, `jj bookmark list` and `jj tag list` display bookmarks and tags


### PR DESCRIPTION
Hello!

When `jj new` creates a commit without an explicit `-m` message, it now
evaluates the `new_description` template, which is empty. If the
template produces non-empty output, that becomes the commit's description.

Related to https://github.com/jj-vcs/jj/issues/7575#issuecomment-2518988509


Thanks!
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] ~I have updated the documentation (`README.md`, `docs/`, `demos/`)~
- [x] ~I have updated the config schema (`cli/src/config-schema.json`)~
- [x] I have added/updated tests to cover my changes
