### PR TITLE
Native Windows file locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,6 +2511,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "watchman_client",
+ "windows-sys 0.61.2",
  "winreg",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
 unicode-width = "0.2.2"
 watchman_client = "0.9.0"
 whoami = "2.1.0"
+windows-sys = { version = "0.61.2", default-features = false }
 winreg = "0.55"
 
 # put all inter-workspace libraries, i.e. those that use 'path = ...' here in

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -75,6 +75,7 @@ rustix = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 same-file = { workspace = true }
 winreg = { workspace = true }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem", "Win32_System_IO"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,7 +16,6 @@
 
 #![warn(missing_docs)]
 #![deny(unused_must_use)]
-#![forbid(unsafe_code)]
 
 // Needed so that proc macros can be used inside jj_lib and by external crates
 // that depend on it.

--- a/lib/src/lock/mod.rs
+++ b/lib/src/lock/mod.rs
@@ -14,19 +14,24 @@
 
 #![expect(missing_docs)]
 
+#[cfg(not(windows))]
 mod fallback;
 #[cfg(unix)]
 mod unix;
+#[cfg(windows)]
+mod windows;
 
 use std::io;
 use std::path::PathBuf;
 
 use thiserror::Error;
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 pub use self::fallback::FileLock;
 #[cfg(unix)]
 pub use self::unix::FileLock;
+#[cfg(windows)]
+pub use self::windows::FileLock;
 
 #[derive(Debug, Error)]
 #[error("{message}: {path}")]

--- a/lib/src/lock/windows.rs
+++ b/lib/src/lock/windows.rs
@@ -1,0 +1,94 @@
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::FromRawHandle;
+use std::os::windows::io::OwnedHandle;
+use std::path::PathBuf;
+use std::ptr;
+use std::time::Duration;
+
+use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
+use windows_sys::Win32::Foundation::GENERIC_READ;
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+use windows_sys::Win32::Storage::FileSystem::CreateFileW;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_NORMAL;
+use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_DELETE_ON_CLOSE;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_DELETE;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+use windows_sys::Win32::Storage::FileSystem::LOCKFILE_EXCLUSIVE_LOCK;
+use windows_sys::Win32::Storage::FileSystem::LockFileEx;
+use windows_sys::Win32::Storage::FileSystem::OPEN_ALWAYS;
+use windows_sys::Win32::System::IO::OVERLAPPED;
+
+use crate::lock::FileLockError;
+
+pub struct FileLock {
+    _handle: OwnedHandle,
+}
+
+impl FileLock {
+    pub fn lock(path: PathBuf) -> Result<Self, FileLockError> {
+        let mut path_wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        path_wide.push(0);
+        unsafe {
+            let mut handle;
+            let mut attempts = 0;
+            loop {
+                // Safety: `path_wide` is a valid, null-terminated wide string
+                handle = CreateFileW(
+                    path_wide.as_ptr(),
+                    // `LockFileEx` requires read or write access
+                    GENERIC_READ,
+                    // Allow concurrent access attempts to open the lockfile so they can wait on it
+                    FILE_SHARE_READ | FILE_SHARE_DELETE,
+                    ptr::null(),
+                    // Open an existing file or create a new one if none exists
+                    OPEN_ALWAYS,
+                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
+                    ptr::null_mut(),
+                );
+                if handle != INVALID_HANDLE_VALUE {
+                    break;
+                }
+                let err = io::Error::last_os_error();
+                if err.raw_os_error() == Some(ERROR_ACCESS_DENIED as _) && attempts < 10 {
+                    // For unfathomable reasons, deletes aren't atomic and we may have raced with
+                    // one. Try again later.
+                    std::thread::sleep(Duration::from_millis(100));
+                    attempts += 1;
+                    continue;
+                }
+                return Err(FileLockError {
+                    message: "Failed to open lock file",
+                    path: path,
+                    err,
+                });
+            }
+            // Safety: `CreateFileW` is guaranteed to return either INVALID_HANDLE_VALUE or
+            // a valid handle, and we excluded the invalid case above.
+            let handle = OwnedHandle::from_raw_handle(handle);
+            // We use an explicit `LockFileEx` call, rather than playing games with share
+            // mode in `CreateFileW`, so that we can block.
+            //
+            // Safety: `handle` is valid
+            let locked = LockFileEx(
+                handle.as_raw_handle(),
+                LOCKFILE_EXCLUSIVE_LOCK,
+                0,
+                // We must pass some consistent nonempty byte range to get any actual locking
+                1,
+                0,
+                // Zeroed `OVERLAPPED` structure means we wait synchronously
+                &mut OVERLAPPED::default(),
+            );
+            if locked == 0 {
+                return Err(FileLockError {
+                    message: "Failed to lock lock file",
+                    path: path,
+                    err: io::Error::last_os_error(),
+                });
+            }
+            Ok(Self { _handle: handle })
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/jj-vcs/jj/issues/99.

Using raw Windows OS APIs requires `unsafe`, and therefore requires us to remove `#![forbid(unsafe_code)]` from `lib`. The higher-level `windows` crate is still unsafe. We could split out a micro-crate for file locking instead, but that seems of dubious value to me.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
