### PR TITLE
cli: add global option to not commit transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* A new global flag `--no-integrate-operation` lets you run a command without
+  impacting the repo state or the working copy.
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -129,6 +129,7 @@ use jj_lib::str_util::StringExpression;
 use jj_lib::str_util::StringMatcher;
 use jj_lib::str_util::StringPattern;
 use jj_lib::transaction::Transaction;
+use jj_lib::transaction::TransactionCommitError;
 use jj_lib::working_copy;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
@@ -415,6 +416,23 @@ impl CommandHelper {
             template_builder::parse(language, &mut diagnostics, template_text, &aliases)?;
         print_parse_diagnostics(ui, "In template expression", &diagnostics)?;
         Ok(template)
+    }
+
+    pub fn should_commit_transaction(&self) -> bool {
+        !self.global_args().no_integrate_operation
+    }
+
+    async fn maybe_commit_transaction(
+        &self,
+        tx: Transaction,
+        description: impl Into<String>,
+    ) -> Result<Arc<ReadonlyRepo>, TransactionCommitError> {
+        let unpublished_op = tx.write(description).await?;
+        if self.should_commit_transaction() {
+            unpublished_op.publish().await
+        } else {
+            Ok(unpublished_op.leave_unpublished())
+        }
     }
 
     pub fn workspace_loader(&self) -> Result<&dyn WorkspaceLoader, CommandError> {
@@ -1088,6 +1106,7 @@ pub struct WorkspaceCommandHelper {
     // TODO: Parsed template can be cached if it doesn't capture 'repo lifetime
     commit_summary_template_text: String,
     op_summary_template_text: String,
+    may_snapshot_working_copy: bool,
     may_update_working_copy: bool,
     working_copy_shared_with_git: bool,
 }
@@ -1125,8 +1144,10 @@ impl WorkspaceCommandHelper {
         let settings = workspace.settings();
         let commit_summary_template_text = settings.get_string("templates.commit_summary")?;
         let op_summary_template_text = settings.get_string("templates.op_summary")?;
-        let may_update_working_copy =
+        let may_snapshot_working_copy =
             loaded_at_head && !env.command.global_args().ignore_working_copy;
+        let may_update_working_copy =
+            may_snapshot_working_copy && env.command.should_commit_transaction();
         let working_copy_shared_with_git =
             crate::git_util::is_colocated_git_workspace(&workspace, &repo);
 
@@ -1136,6 +1157,7 @@ impl WorkspaceCommandHelper {
             env,
             commit_summary_template_text,
             op_summary_template_text,
+            may_snapshot_working_copy,
             may_update_working_copy,
             working_copy_shared_with_git,
         };
@@ -1158,6 +1180,8 @@ impl WorkspaceCommandHelper {
         } else {
             let hint = if self.env.command.global_args().ignore_working_copy {
                 "Don't use --ignore-working-copy."
+            } else if self.env.command.global_args().no_integrate_operation {
+                "Don't use --no-integrate-operation."
             } else {
                 "Don't use --at-op."
             };
@@ -1189,7 +1213,7 @@ impl WorkspaceCommandHelper {
         &mut self,
         ui: &Ui,
     ) -> Result<SnapshotStats, SnapshotWorkingCopyError> {
-        if !self.may_update_working_copy {
+        if !self.may_snapshot_working_copy {
             return Ok(SnapshotStats::default());
         }
 
@@ -1276,7 +1300,7 @@ impl WorkspaceCommandHelper {
         ui: &Ui,
         git_import_export_lock: &GitImportExportLock,
     ) -> Result<(), CommandError> {
-        assert!(self.may_update_working_copy);
+        assert!(self.may_snapshot_working_copy);
         let mut tx = self.start_transaction();
         jj_lib::git::import_head(tx.repo_mut()).await?;
         if !tx.repo().has_changes() {
@@ -1299,7 +1323,12 @@ impl WorkspaceCommandHelper {
             // state to it without updating working copy files.
             locked_ws.locked_wc().reset(&wc_commit).await?;
             tx.repo_mut().rebase_descendants().await?;
-            self.user_repo = ReadonlyUserRepo::new(tx.commit("import git head").await?);
+            self.user_repo = ReadonlyUserRepo::new(
+                self.env
+                    .command
+                    .maybe_commit_transaction(tx, "import git head")
+                    .await?,
+            );
             locked_ws
                 .finish(self.user_repo.repo.op_id().clone())
                 .await?;
@@ -2033,7 +2062,7 @@ to the current parents may contain changes from multiple commits.
             }
 
             #[cfg(feature = "git")]
-            if self.working_copy_shared_with_git {
+            if self.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
                 let old_tree = wc_commit.tree();
                 let new_tree = commit.tree();
                 export_working_copy_changes_to_git(ui, mut_repo, &old_tree, &new_tree)
@@ -2041,8 +2070,10 @@ to the current parents may contain changes from multiple commits.
                     .map_err(snapshot_command_error)?;
             }
 
-            let repo = tx
-                .commit("snapshot working copy")
+            let repo = self
+                .env
+                .command
+                .maybe_commit_transaction(tx, "snapshot working copy")
                 .await
                 .map_err(snapshot_command_error)?;
             self.user_repo = ReadonlyUserRepo::new(repo);
@@ -2077,10 +2108,12 @@ to the current parents may contain changes from multiple commits.
             .map_err(snapshot_command_error)?;
         }
 
-        locked_ws
-            .finish(self.user_repo.repo.op_id().clone())
-            .await
-            .map_err(snapshot_command_error)?;
+        if self.env.command.should_commit_transaction() {
+            locked_ws
+                .finish(self.user_repo.repo.op_id().clone())
+                .await
+                .map_err(snapshot_command_error)?;
+        }
         Ok(stats)
     }
 
@@ -2222,7 +2255,7 @@ to the current parents may contain changes from multiple commits.
             .transpose()?;
 
         #[cfg(feature = "git")]
-        if self.working_copy_shared_with_git {
+        if self.working_copy_shared_with_git && self.env.command.should_commit_transaction() {
             use std::error::Error as _;
             if let Some(wc_commit) = &maybe_new_wc_commit {
                 // Export Git HEAD while holding the git-head lock to prevent races:
@@ -2244,7 +2277,12 @@ to the current parents may contain changes from multiple commits.
             crate::git_util::print_git_export_stats(ui, &stats)?;
         }
 
-        self.user_repo = ReadonlyUserRepo::new(tx.commit(description).await?);
+        self.user_repo = ReadonlyUserRepo::new(
+            self.env
+                .command
+                .maybe_commit_transaction(tx, description)
+                .await?,
+        );
 
         // Update working copy before reporting repo changes, so that
         // potential errors while reporting changes (broken pipe, etc)
@@ -2260,6 +2298,14 @@ to the current parents may contain changes from multiple commits.
         }
 
         self.report_repo_changes(ui, &old_repo).await?;
+
+        if !self.env.command.should_commit_transaction() {
+            writeln!(
+                ui.status(),
+                "Operation left uncommitted because --no-integrate-operation was requested: {}",
+                short_operation_hash(self.repo().op_id())
+            )?;
+        }
 
         let settings = self.settings();
         let missing_user_name = settings.user_name().is_empty();
@@ -3531,6 +3577,23 @@ pub struct GlobalArgs {
     /// implies `--ignore-working-copy`.
     #[arg(long, global = true)]
     pub ignore_working_copy: bool,
+
+    /// Run the command as usual but don't integrate any operations
+    ///
+    /// When this option is given, the operations will still be created as usual
+    /// but they will not be integrated to the operation log. The working copy
+    /// will also not be updated.
+    ///
+    /// The command will print the resulting operation ID. You can pass that to
+    /// e.g. `jj --at-op` to inspect the resulting repo state, or you can pass
+    /// it to `jj op restore` to restore the repo to that state. You can also
+    /// pass the ID to `jj op integrate` to integrate the operation.
+    ///
+    /// Note that this does *not* prevent side effects outside the repo. For
+    /// example, `jj git push --no-integrate-operation` will still perform the
+    /// push.
+    #[arg(long, global = true)]
+    pub no_integrate_operation: bool,
 
     /// Allow rewriting immutable commits
     ///

--- a/cli/src/commands/debug/init_simple.rs
+++ b/cli/src/commands/debug/init_simple.rs
@@ -45,6 +45,9 @@ pub(crate) async fn cmd_debug_init_simple(
     command: &CommandHelper,
     args: &DebugInitSimpleArgs,
 ) -> Result<(), CommandError> {
+    if command.global_args().no_integrate_operation {
+        return Err(cli_error("--no-integrate-operation is not respected"));
+    }
     if command.global_args().ignore_working_copy {
         return Err(cli_error("--ignore-working-copy is not respected"));
     }

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -108,6 +108,9 @@ pub async fn cmd_git_init(
     command: &CommandHelper,
     args: &GitInitArgs,
 ) -> Result<(), CommandError> {
+    if command.global_args().no_integrate_operation {
+        return Err(cli_error("--no-integrate-operation is not respected"));
+    }
     if command.global_args().ignore_working_copy {
         return Err(cli_error("--ignore-working-copy is not respected"));
     }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -198,6 +198,13 @@ To get started, see the tutorial [`jj help -k tutorial`].
    By default, Jujutsu snapshots the working copy at the beginning of every command. The working copy is also updated at the end of the command, if the command modified the working-copy commit (`@`). If you want to avoid snapshotting the working copy and instead see a possibly stale working-copy commit, you can use `--ignore-working-copy`. This may be useful e.g. in a command prompt, especially if you have another process that commits the working copy.
 
    Loading the repository at a specific operation with `--at-operation` implies `--ignore-working-copy`.
+* `--no-integrate-operation` — Run the command as usual but don't integrate any operations
+
+   When this option is given, the operations will still be created as usual but they will not be integrated to the operation log. The working copy will also not be updated.
+
+   The command will print the resulting operation ID. You can pass that to e.g. `jj --at-op` to inspect the resulting repo state, or you can pass it to `jj op restore` to restore the repo to that state. You can also pass the ID to `jj op integrate` to integrate the operation.
+
+   Note that this does *not* prevent side effects outside the repo. For example, `jj git push --no-integrate-operation` will still perform the push.
 * `--ignore-immutable` — Allow rewriting immutable commits
 
    By default, Jujutsu prevents rewriting commits in the configured set of immutable commits. This option disables that check and lets you rewrite any commit but the root commit.

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -228,6 +228,7 @@ fn test_bookmark_names() {
     --help	Print help (see more with '--help')
     --repository	Path to repository to operate on
     --ignore-working-copy	Don't snapshot the working copy, and don't update it
+    --no-integrate-operation	Run the command as usual but don't integrate any operations
     --ignore-immutable	Allow rewriting immutable commits
     --at-operation	Operation to load the repo at
     --debug	Enable debug logging
@@ -719,6 +720,7 @@ fn test_command_completion_short_name() {
     unset	Update a config file to unset the given option
     --repository	Path to repository to operate on
     --ignore-working-copy	Don't snapshot the working copy, and don't update it
+    --no-integrate-operation	Run the command as usual but don't integrate any operations
     --ignore-immutable	Allow rewriting immutable commits
     --at-operation	Operation to load the repo at
     --debug	Enable debug logging

--- a/cli/tests/test_debug_init_simple_command.rs
+++ b/cli/tests/test_debug_init_simple_command.rs
@@ -41,6 +41,17 @@ fn test_init_local() {
 
     let output = test_env.run_jj_in(
         ".",
+        ["debug", "init-simple", "--no-integrate-operation", "repo2"],
+    );
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: --no-integrate-operation is not respected
+    [EOF]
+    [exit status: 2]
+    ");
+
+    let output = test_env.run_jj_in(
+        ".",
         ["debug", "init-simple", "--ignore-working-copy", "repo2"],
     );
     insta::assert_snapshot!(output, @"

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -115,6 +115,24 @@ fn test_git_init_internal_preexisting_git_repo() {
 }
 
 #[test]
+fn test_git_init_internal_no_integrate_operation() {
+    let test_env = TestEnvironment::default();
+    let workspace_root = test_env.env_root().join("repo");
+    std::fs::create_dir(&workspace_root).unwrap();
+
+    let output = test_env.run_jj_in(
+        &workspace_root,
+        &["git", "init", "--no-integrate-operation"],
+    );
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Error: --no-integrate-operation is not respected
+    [EOF]
+    [exit status: 2]
+    ");
+}
+
+#[test]
 fn test_git_init_ignore_working_copy() {
     let test_env = TestEnvironment::default();
     test_env.add_config("git.colocate = true");

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -228,6 +228,142 @@ fn test_ignore_working_copy() {
 }
 
 #[test]
+fn test_no_integrate_operation() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(test_env.env_root(), &["git", "init", "repo"])
+        .success();
+
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "initial").unwrap();
+    test_env
+        .run_jj_in(&repo_path, &["commit", "-m=initial"])
+        .success();
+    let op_log_output = test_env.run_jj_in(&repo_path, &["op", "log"]);
+    let working_copy_output = test_env.run_jj_in(&repo_path, &["debug", "working-copy"]);
+
+    // Modify the working copy and run a mutating operation. With
+    // --no-integrate-operation, the working copy gets snapshotted and the operation
+    // gets created, but there's no new operation in the operation log, and the
+    // working copy state is not updated.
+    std::fs::write(repo_path.join("file2"), "initial").unwrap();
+    let output = test_env.run_jj_in(&repo_path, &["squash", "--no-integrate-operation"]);
+    insta::assert_snapshot!(output.stdout, @"");
+    insta::assert_snapshot!(output.stderr, @"
+    Operation left uncommitted because --no-integrate-operation was requested: a028de7aa4f4
+    [EOF]
+    ");
+    let stderr = output.stderr.into_raw();
+    let first_line = stderr.split('\n').next().unwrap();
+    let op_id_hex = first_line[first_line.len() - 12..].to_string();
+    let output = test_env.run_jj_in(&repo_path, &["op", "log", "--ignore-working-copy"]);
+    assert_eq!(output.stdout, op_log_output.stdout);
+    let output = test_env.run_jj_in(&repo_path, &["debug", "working-copy"]);
+    assert_eq!(output.stdout, working_copy_output.stdout);
+
+    // We can see the resulting log and op log with --at-op
+    let stdout = test_env.run_jj_in(&repo_path, &["log", "-s", "--at-op", op_id_hex.as_str()]);
+    insta::assert_snapshot!(stdout, @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 10644da4
+    │  (empty) (no description set)
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:11 599772f7
+    │  initial
+    │  A file1
+    │  A file2
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+    let stdout = test_env.run_jj_in(&repo_path, &["op", "log", "--at-op", op_id_hex.as_str()]);
+    insta::assert_snapshot!(stdout, @"
+    @  a028de7aa4f4 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  squash commits into e6fc2362ee5fdd5eb879befc0ae556a2f57b94a0
+    │  args: jj squash --no-integrate-operation
+    ○  13357990b38a test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  snapshot working copy
+    │  args: jj squash --no-integrate-operation
+    ○  e167310e1125 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  commit 289d54a4554ed0d7df9c47d566480a6b773ee431
+    │  args: jj commit '-m=initial'
+    ○  55b88fdb1890 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  snapshot working copy
+    │  args: jj commit '-m=initial'
+    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │  add workspace 'default'
+    ○  000000000000 root()
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_no_integrate_operation_colocated() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(test_env.env_root(), &["git", "init", "--colocate", "repo"])
+        .success();
+
+    let repo_path = test_env.env_root().join("repo");
+
+    std::fs::write(repo_path.join("file1"), "initial").unwrap();
+    test_env
+        .run_jj_in(&repo_path, &["commit", "-m=initial"])
+        .success();
+    let op_log_output = test_env.run_jj_in(&repo_path, &["op", "log"]);
+    let working_copy_output = test_env.run_jj_in(&repo_path, &["debug", "working-copy"]);
+
+    // Modify the working copy and run a mutating operation. With
+    // --no-integrate-operation, the working copy gets snapshotted and the operation
+    // gets created, but there's no new operation in the operation log, and the
+    // working copy state is not updated.
+    std::fs::write(repo_path.join("file2"), "initial").unwrap();
+    let output = test_env.run_jj_in(&repo_path, &["squash", "--no-integrate-operation"]);
+    insta::assert_snapshot!(output.stdout, @"");
+    insta::assert_snapshot!(output.stderr, @"
+    Operation left uncommitted because --no-integrate-operation was requested: 0eccbf94f56f
+    [EOF]
+    ");
+    let stderr = output.stderr.into_raw();
+    let first_line = stderr.split('\n').next().unwrap();
+    let op_id_hex = first_line[first_line.len() - 12..].to_string();
+    let output = test_env.run_jj_in(&repo_path, &["op", "log", "--ignore-working-copy"]);
+    assert_eq!(output.stdout, op_log_output.stdout);
+    let output = test_env.run_jj_in(&repo_path, &["debug", "working-copy"]);
+    assert_eq!(output.stdout, working_copy_output.stdout);
+
+    // We can see the resulting log and op log with --at-op
+    let stdout = test_env.run_jj_in(&repo_path, &["log", "-s", "--at-op", op_id_hex.as_str()]);
+    insta::assert_snapshot!(stdout, @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:11 10644da4
+    │  (empty) (no description set)
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:11 599772f7
+    │  initial
+    │  A file1
+    │  A file2
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+    let stdout = test_env.run_jj_in(&repo_path, &["op", "log", "--at-op", op_id_hex.as_str()]);
+    insta::assert_snapshot!(stdout, @"
+    @  0eccbf94f56f test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  squash commits into e6fc2362ee5fdd5eb879befc0ae556a2f57b94a0
+    │  args: jj squash --no-integrate-operation
+    ○  f9d2255ff5a3 test-username@host.example.com default@ 2001-02-03 04:05:11.000 +07:00 - 2001-02-03 04:05:11.000 +07:00
+    │  snapshot working copy
+    │  args: jj squash --no-integrate-operation
+    ○  30e6a62058cc test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  commit 289d54a4554ed0d7df9c47d566480a6b773ee431
+    │  args: jj commit '-m=initial'
+    ○  55b88fdb1890 test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  snapshot working copy
+    │  args: jj commit '-m=initial'
+    ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    │  add workspace 'default'
+    ○  000000000000 root()
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_repo_arg_with_git_init() {
     let test_env = TestEnvironment::default();
     let output = test_env.run_jj_in(".", ["git", "init", "-R=.", "repo"]);
@@ -1152,6 +1288,7 @@ fn test_help() {
     Global Options:
       -R, --repository <REPOSITORY>      Path to repository to operate on
           --ignore-working-copy          Don't snapshot the working copy, and don't update it
+          --no-integrate-operation       Run the command as usual but don't integrate any operations
           --ignore-immutable             Allow rewriting immutable commits
           --at-operation <AT_OPERATION>  Operation to load the repo at [aliases: --at-op]
           --debug                        Enable debug logging

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -303,6 +303,30 @@ fn test_workspaces_add_ignore_working_copy() {
     "#);
 }
 
+/// Test that --no-integrate-operation is respected
+#[test]
+fn test_workspaces_add_no_integrate_operation() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+
+    // TODO: maybe better to error out early?
+    let output = main_dir.run_jj([
+        "workspace",
+        "add",
+        "--no-integrate-operation",
+        "../secondary",
+    ]);
+    insta::assert_snapshot!(output.normalize_backslash(), @r#"
+    ------- stderr -------
+    Created workspace in "../secondary"
+    Error: This command must be able to update the working copy.
+    Hint: Don't use --no-integrate-operation.
+    [EOF]
+    [exit status: 1]
+    "#);
+}
+
 /// Test that --at-op is respected
 #[test]
 fn test_workspaces_add_at_operation() {

--- a/docs/paid_contributors.md
+++ b/docs/paid_contributors.md
@@ -18,7 +18,7 @@ See [contribution docs](contributing.md#code-reviews) for details on this policy
 * steveklabnik
 * thoughtpolice
 
-## Google
+## Alphabet/Google
 
 * 06393993
 * 2079884FDavid
@@ -52,6 +52,7 @@ See [contribution docs](contributing.md#code-reviews) for details on this policy
 * qfel
 * Ralith
 * rdamazio
+* sbarfurth
 * solson
 * spectral54
 * steadmon


### PR DESCRIPTION
This patch adds a global `--no-integrate-operation` flag that prevents
integration/publishing of most operations, including the ones created by
`snapshot_working_copy()` and `finish_transaction()`. The operations
are still created as usual.

We provide `jj op integrate` to manually reintegrate operations created by
commands with this flag enabled.

Closes https://github.com/jj-vcs/jj/issues/2562

Co-authored-by: Martin von Zweigbergk <martinvonz@google.com>

---

> [!NOTE]
> My Rust and `jj` codebase knowledge is limited. I made some changes on top of the original, but I lack deep knowledge of the code and therefore struggle to understand whether the change is complete. I'm happy to make adjustments as needed. Tests are passing and the functionality seems to be working overall.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
