### PR TITLE
nix: move build definition to `default.nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  gitRev ? null,
+  git,
+  gnupg,
+  installShellFiles,
+  mold,
+  openssh,
+}: let
+  packageVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+  filterSrc = src: regexes:
+    lib.cleanSourceWith {
+      inherit src;
+      filter = path: type: let
+        relPath = lib.removePrefix (toString src + "/") (toString path);
+      in
+        lib.all (re: builtins.match re relPath == null) regexes;
+    };
+in
+  rustPlatform.buildRustPackage {
+    pname = "jujutsu";
+    version = "${packageVersion}-unstable-${
+      if gitRev != null
+      then gitRev
+      else "dirty"
+    }";
+
+    cargoBuildFlags = ["--bin" "jj"]; # don't build and install the fake editors
+    useNextest = true;
+    cargoTestFlags = ["--profile" "ci"];
+    src = filterSrc ./. [
+      ".*\\.nix$"
+      "^.jj/"
+      "^flake\\.lock$"
+      "^target/"
+    ];
+
+    cargoLock.lockFile = ./Cargo.lock;
+    nativeBuildInputs =
+      [
+        installShellFiles
+      ]
+      ++ lib.optionals stdenv.isLinux [
+        mold
+      ];
+    buildInputs = [];
+    nativeCheckInputs = [
+      # for signing tests
+      gnupg
+      openssh
+
+      # for git subprocess test
+      git
+    ];
+
+    env = {
+      RUST_BACKTRACE = 1;
+      CARGO_INCREMENTAL = "0"; # https://github.com/rust-lang/rust/issues/139110
+      RUSTFLAGS = lib.optionalString stdenv.isLinux "-C link-arg=-fuse-ld=mold";
+      NIX_JJ_GIT_HASH = gitRev;
+    };
+
+    postInstall = ''
+      $out/bin/jj util install-man-pages man
+      installManPage ./man/man1/*
+
+      installShellCompletion --cmd jj \
+        --bash <(COMPLETE=bash $out/bin/jj) \
+        --fish <(COMPLETE=fish $out/bin/jj) \
+        --zsh <(COMPLETE=zsh $out/bin/jj)
+    '';
+
+    meta = {
+      description = "Git-compatible DVCS that is both simple and powerful";
+      homepage = "https://github.com/jj-vcs/jj";
+      license = lib.licenses.asl20;
+      mainProgram = "jj";
+    };
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -31,17 +31,6 @@
         ];
       };
 
-      packageVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
-
-      filterSrc = src: regexes:
-        pkgs.lib.cleanSourceWith {
-          inherit src;
-          filter = path: type: let
-            relPath = pkgs.lib.removePrefix (toString src + "/") (toString path);
-          in
-            pkgs.lib.all (re: builtins.match re relPath == null) regexes;
-        };
-
       # When we're running in the shell, we want to use rustc with a bunch
       # of extra junk to ensure that rust-analyzer works, clippy etc are all
       # installed.
@@ -61,73 +50,13 @@
       rustMinimalPlatform =
         let platform = pkgs.rust-bin.selectLatestNightlyWith (t: t.minimal);
         in pkgs.makeRustPlatform { rustc = platform; cargo = platform; };
-
-      nativeBuildInputs = with pkgs;
-        [ ]
-        ++ lib.optionals stdenv.isLinux [
-          mold
-        ];
-
-      buildInputs = [ ];
-
-      nativeCheckInputs = with pkgs; [
-        # for signing tests
-        gnupg
-        openssh
-
-        # for git subprocess test
-        git
-      ];
-
-      env = {
-        RUST_BACKTRACE = 1;
-        CARGO_INCREMENTAL = "0"; # https://github.com/rust-lang/rust/issues/139110
-      };
     in {
       formatter = pkgs.alejandra;
 
       packages = {
-        jujutsu = rustMinimalPlatform.buildRustPackage {
-          pname = "jujutsu";
-          version = "${packageVersion}-unstable-${self.shortRev or "dirty"}";
-
-          cargoBuildFlags = ["--bin" "jj"]; # don't build and install the fake editors
-          useNextest = true;
-          cargoTestFlags = ["--profile" "ci"];
-          src = filterSrc ./. [
-            ".*\\.nix$"
-            "^.jj/"
-            "^flake\\.lock$"
-            "^target/"
-          ];
-
-          cargoLock.lockFile = ./Cargo.lock;
-          nativeBuildInputs = nativeBuildInputs ++ [pkgs.installShellFiles];
-          inherit buildInputs nativeCheckInputs;
-
-          env =
-            env
-            // {
-              RUSTFLAGS = pkgs.lib.optionalString pkgs.stdenv.isLinux "-C link-arg=-fuse-ld=mold";
-              NIX_JJ_GIT_HASH = self.rev or "";
-            };
-
-          postInstall = ''
-            $out/bin/jj util install-man-pages man
-            installManPage ./man/man1/*
-
-            installShellCompletion --cmd jj \
-              --bash <(COMPLETE=bash $out/bin/jj) \
-              --fish <(COMPLETE=fish $out/bin/jj) \
-              --zsh <(COMPLETE=zsh $out/bin/jj)
-          '';
-
-          meta = {
-            description = "Git-compatible DVCS that is both simple and powerful";
-            homepage = "https://github.com/jj-vcs/jj";
-            license = pkgs.lib.licenses.asl20;
-            mainProgram = "jj";
-          };
+        jujutsu = pkgs.callPackage ./default.nix {
+          rustPlatform = rustMinimalPlatform;
+          gitRev = self.rev or self.dirtyRev or null;
         };
         default = self.packages.${system}.jujutsu;
       };
@@ -197,11 +126,13 @@
         shellHook = ''
           export RUSTFLAGS="-Zthreads=0 ${rustLinkFlagsString}"
         '';
+
+        jujutsu = self.packages.${system}.jujutsu;
       in
         pkgs.mkShell {
           name = "jujutsu";
-          packages = packages ++ nativeBuildInputs ++ buildInputs ++ nativeCheckInputs;
-          inherit env shellHook;
+          packages = packages ++ jujutsu.nativeBuildInputs ++ jujutsu.buildInputs;
+          inherit shellHook;
         };
     }));
 }


### PR DESCRIPTION
Previously, if you fetched the source with `pkgs.fetchgit` (or similar), you could not build it, since the build was defined entirely in the flake.

Now, the environment is defined by the flake, but the build is defined in `default.nix`. This allows building with both the old and new nix commands.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
