### PR TITLE
templates: Support Serialize for List.map and if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `revsets.bookmark-advance-from` and `revsets.bookmark-advance-to`.
   The command is heavily inspired by the longstanding community alias `jj tug`.
 
-* Templates now support `Serialize` operations on the result of `map()`, when
-  supported by the underlying type.
+* Templates now support `Serialize` operations on the result of `map()` and
+  `if()`, when supported by the underlying type.
 
 ### Fixed bugs
 

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -494,6 +494,10 @@ impl<'repo> CoreTemplatePropertyVar<'repo> for CommitTemplatePropertyKind<'repo>
         Self::Core(CoreTemplatePropertyKind::wrap_template(template))
     }
 
+    fn wrap_any(property: BoxedAnyProperty<'repo>) -> Self {
+        Self::Core(CoreTemplatePropertyKind::wrap_any(property))
+    }
+
     fn wrap_any_list(property: BoxedAnyProperty<'repo>) -> Self {
         Self::Core(CoreTemplatePropertyKind::wrap_any_list(property))
     }

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -176,6 +176,10 @@ where
         Self::Core(CoreTemplatePropertyKind::wrap_template(template))
     }
 
+    fn wrap_any(property: BoxedAnyProperty<'a>) -> Self {
+        Self::Core(CoreTemplatePropertyKind::wrap_any(property))
+    }
+
     fn wrap_any_list(property: BoxedAnyProperty<'a>) -> Self {
         Self::Core(CoreTemplatePropertyKind::wrap_any_list(property))
     }

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -294,6 +294,10 @@ impl CoreTemplatePropertyVar<'static> for OperationTemplateLanguagePropertyKind 
         Self::Core(CoreTemplatePropertyKind::wrap_template(template))
     }
 
+    fn wrap_any(property: BoxedAnyProperty<'static>) -> Self {
+        Self::Core(CoreTemplatePropertyKind::wrap_any(property))
+    }
+
     fn wrap_any_list(property: BoxedAnyProperty<'static>) -> Self {
         Self::Core(CoreTemplatePropertyKind::wrap_any_list(property))
     }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -105,8 +105,8 @@ The following functions are defined.
 * `stringify(content: Stringify) -> String`: Format `content` to string. This
   effectively removes color labels.
 * `json(value: Serialize) -> String`: Serialize `value` in JSON format.
-* `if(condition: Boolean, then: Template, [else: Template]) -> Template`:
-  Conditionally evaluate `then`/`else` template content.
+* `if(condition: Boolean, then: Any, [else: Any]) -> Any`:
+  Conditionally evaluates to `then`/`else` content.
 * `coalesce(content: Template...) -> Template`: Returns the first **non-empty**
   content.
 * `concat(content: Template...) -> Template`:
@@ -137,6 +137,12 @@ The following methods are defined.
 * `.original_line_number() -> Integer`: 1-based line number in the original commit.
 * `.first_line_in_hunk() -> Boolean`: False when the directly preceding line
   references the same commit.
+
+### `Any` type
+
+_Conversion: `Boolean`: no, `Serialize`: maybe, `Template`: maybe_
+
+All types can be implicitly converted to `Any`. No methods are defined.
 
 ### `AnyList` type
 


### PR DESCRIPTION
Adjusts the return types of `List.map` and `if(...)` to make them more adaptive. The new return types (`AnyList` and `Any`) retain the `Template` and `Serialize` implementations of the wrapped values. This allows using non-`Template` types in these expressions, and serializing the results of these expressions with `json`.

Currently only `Template` and `Serialize` conversions are supported, though this could be easily extended to any of the type conversions in the `CoreTemplatePropertyVar` trait.

Fixes #8888

<details>
<summary>Original PR Message</summary>
Allows the result of `List.map` to be used by the json function within the template language, so long as each element supports `Serialize`. This is done by introducing a series of new traits to delay the call to `try_into_template` or `try_into_serialize` on the template sub-expression until that method is called on the call's result object.

As part of these changes, the `ListTemplate` template language type was renamed to `MapResult`, reflecting that it is no longer necessarily a `Template`.

Fixes #8888

---

This is roughly an implementation of my proposed alternative-approach 3 from #8888. The renaming of `ListTemplate` to `MapResult` is optional, and can easily be reverted.

Some parts of this feel a bit hacky, especially around the `TemplateValue<'a>` trait and the extra lifetime bounds which that requires, but I didn't come up with a better approach. I'm also worried about a reduction in error quality. As we no longer check the type implements `Template`/`Serialize` eagerly, the check is instead happening on the outer `MapResult`, which I believe will lead to errors like "Expected Serialize, got MapResult" or "Expected Template, got MapResult", which could be confusing.

The testing is also a bit lacklustre. I updated the one existing test, but haven't put the effort in to writing more yet. Error handling in particular should probably be tested.
</details>

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
