### PR TITLE
MergedTreeBuilder: make write_tree() async

### DIFF
--- a/cli/src/commands/file/chmod.rs
+++ b/cli/src/commands/file/chmod.rs
@@ -115,7 +115,7 @@ pub(crate) fn cmd_file_chmod(
         tree_builder.set_or_remove(repo_path, tree_value);
     }
 
-    let new_tree = tree_builder.write_tree()?;
+    let new_tree = tree_builder.write_tree().block_on()?;
     tx.repo_mut()
         .rewrite_commit(&commit)
         .set_tree(new_tree)

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -65,7 +65,7 @@ pub(crate) fn cmd_file_untrack(
     for (path, _value) in wc_tree.entries_matching(matcher.as_ref()) {
         tree_builder.set_or_remove(path, Merge::absent());
     }
-    let new_tree = tree_builder.write_tree()?;
+    let new_tree = tree_builder.write_tree().block_on()?;
     let new_commit = tx
         .repo_mut()
         .rewrite_commit(&wc_commit)

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -460,7 +460,7 @@ fn apply_diff_builtin(
             Ok(new_value)
         },
     )?;
-    tree_builder.write_tree()
+    tree_builder.write_tree().block_on()
 }
 
 fn apply_changes(
@@ -755,7 +755,7 @@ fn apply_merge_builtin(
             }))
         },
     )?;
-    tree_builder.write_tree()
+    tree_builder.write_tree().block_on()
 }
 
 #[cfg(test)]

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -371,7 +371,7 @@ pub fn run_mergetool_external(
             }
         }
     }
-    let new_tree = tree_builder.write_tree()?;
+    let new_tree = tree_builder.write_tree().block_on()?;
     Ok((new_tree, partial_resolution_error))
 }
 

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -481,7 +481,7 @@ fn pick_conflict_side(
         }));
         tree_builder.set_or_remove(merge_tool_file.repo_path.clone(), new_tree_value);
     }
-    tree_builder.write_tree()
+    tree_builder.write_tree().block_on()
 }
 
 #[cfg(test)]

--- a/lib/src/absorb.rs
+++ b/lib/src/absorb.rs
@@ -323,7 +323,7 @@ pub fn absorb_hunks(
             return Ok(());
         };
         // Merge hunks between source parent tree and selected tree
-        let selected_tree = tree_builder.write_tree()?;
+        let selected_tree = tree_builder.write_tree().await?;
         let destination_label = rewriter.old_commit().conflict_label();
         let commit_builder = rewriter.rebase().await?;
         let destination_tree = commit_builder.tree();

--- a/lib/src/fix.rs
+++ b/lib/src/fix.rs
@@ -312,7 +312,7 @@ pub async fn fix_files(
         summary.num_checked_commits += 1;
         if has_changes {
             summary.num_fixed_commits += 1;
-            let new_tree = tree_builder.write_tree()?;
+            let new_tree = tree_builder.write_tree().await?;
             let builder = rewriter.reparent();
             let new_commit = builder.set_tree(new_tree).write().await?;
             summary

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1353,12 +1353,14 @@ impl TreeState {
             self.file_states
                 .merge_in(changed_file_states, &deleted_files);
         });
-        trace_span!("write tree").in_scope(|| -> Result<(), BackendError> {
-            let new_tree = tree_builder.write_tree()?;
-            is_dirty |= new_tree.tree_ids_and_labels() != self.tree.tree_ids_and_labels();
-            self.tree = new_tree.clone();
-            Ok(())
-        })?;
+        trace_span!("write tree")
+            .in_scope(async || -> Result<(), BackendError> {
+                let new_tree = tree_builder.write_tree().await?;
+                is_dirty |= new_tree.tree_ids_and_labels() != self.tree.tree_ids_and_labels();
+                self.tree = new_tree.clone();
+                Ok(())
+            })
+            .await?;
         if cfg!(debug_assertions) {
             let tree_paths: HashSet<_> = self
                 .tree

--- a/lib/src/merged_tree_builder.rs
+++ b/lib/src/merged_tree_builder.rs
@@ -18,7 +18,6 @@ use std::collections::BTreeMap;
 use std::iter::zip;
 
 use itertools::Itertools as _;
-use pollster::FutureExt as _;
 
 use crate::backend::BackendResult;
 use crate::backend::TreeId;
@@ -59,7 +58,7 @@ impl MergedTreeBuilder {
     }
 
     /// Create new tree(s) from the base tree(s) and overrides.
-    pub fn write_tree(self) -> BackendResult<MergedTree> {
+    pub async fn write_tree(self) -> BackendResult<MergedTree> {
         let store = self.base_tree.store().clone();
         let labels = self.base_tree.labels().clone();
         let new_tree_ids = self.write_merged_trees()?;
@@ -77,7 +76,7 @@ impl MergedTreeBuilder {
             Ok(single_tree_id) => Ok(MergedTree::resolved(store, single_tree_id)),
             Err(tree_ids) => {
                 let tree = MergedTree::new(store, tree_ids, labels);
-                tree.resolve().block_on()
+                tree.resolve().await
             }
         }
     }

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -128,7 +128,7 @@ pub async fn restore_tree(
     }
 
     let select_matching =
-        |tree: &MergedTree, labels: ConflictLabels| -> BackendResult<MergedTree> {
+        async |tree: &MergedTree, labels: ConflictLabels| -> BackendResult<MergedTree> {
             let empty_tree_ids = Merge::repeated(
                 tree.store().empty_tree_id().clone(),
                 tree.tree_ids().num_sides(),
@@ -142,7 +142,7 @@ pub async fn restore_tree(
                 // to expand resolved conflicts into `Merge::repeated(value, num_sides)`.
                 builder.set_or_remove(path, value?);
             }
-            builder.write_tree()
+            builder.write_tree().await
         };
 
     const RESTORE_BASE_LABEL: &str = "base files for restore";
@@ -174,11 +174,11 @@ pub async fn restore_tree(
             format!("{destination_label} (restore destination)"),
         ),
         (
-            select_matching(destination, base_labels)?,
+            select_matching(destination, base_labels).await?,
             format!("{RESTORE_BASE_LABEL} (from {destination_label})"),
         ),
         (
-            select_matching(source, source.labels().clone())?,
+            select_matching(source, source.labels().clone()).await?,
             format!("restored files (from {source_label})"),
         ),
     ]))

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -301,8 +301,8 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
             files.push((*left_kind, *right_kind, path.clone()));
         }
     }
-    let left_tree = left_tree_builder.write_tree().unwrap();
-    let right_tree = right_tree_builder.write_tree().unwrap();
+    let left_tree = left_tree_builder.write_tree().block_on().unwrap();
+    let right_tree = right_tree_builder.write_tree().block_on().unwrap();
     let left_commit = commit_with_tree(&store, left_tree);
     let right_commit = commit_with_tree(&store, right_tree.clone());
 
@@ -1767,7 +1767,7 @@ fn test_git_submodule(gitignore_content: &str) {
         Merge::normal(TreeValue::GitSubmodule(submodule_id1)),
     );
 
-    let tree_id1 = tree_builder.write_tree().unwrap();
+    let tree_id1 = tree_builder.write_tree().block_on().unwrap();
     let commit1 = commit_with_tree(repo.store(), tree_id1.clone());
 
     let mut tree_builder = MergedTreeBuilder::new(tree_id1.clone());
@@ -1776,7 +1776,7 @@ fn test_git_submodule(gitignore_content: &str) {
         submodule_path.to_owned(),
         Merge::normal(TreeValue::GitSubmodule(submodule_id2)),
     );
-    let tree_id2 = tree_builder.write_tree().unwrap();
+    let tree_id2 = tree_builder.write_tree().block_on().unwrap();
     let commit2 = commit_with_tree(repo.store(), tree_id2.clone());
 
     let ws = &mut test_workspace.workspace;

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -91,7 +91,7 @@ fn test_merged_tree_builder_resolves_conflict() {
         ConflictLabels::from_vec(vec!["tree 2".into(), "tree 1".into(), "tree 3".into()]),
     );
     let tree_builder = MergedTreeBuilder::new(base_tree);
-    let tree = tree_builder.write_tree().unwrap();
+    let tree = tree_builder.write_tree().block_on().unwrap();
     assert_eq!(*tree.tree_ids(), Merge::resolved(tree2.id().clone()));
 }
 


### PR DESCRIPTION
`MergedTreeBuilder::write_tree()` already makes one call to an async function, so it should be async. I hope to reimplement it to be fully async soon.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
