### PR TITLE
gerrit: Create default revisions for `jj gerrit upload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   diff in the commit description editor, making it easier to review changes
   while writing commit messages.
 
+* `jj gerrit upload` no longer requires the `-r` flag, and will default to
+  uploading what you're currently working on.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1375,6 +1375,8 @@ Note: this command takes 1-or-more revsets arguments, each of which can resolve 
 * `-r`, `--revisions <REVISIONS>` — The revset, selecting which revisions are sent in to Gerrit
 
    This can be any arbitrary set of commits. Note that when you push a commit at the head of a stack, all ancestors are pushed too. This means that `jj gerrit upload -r foo` is equivalent to `jj gerrit upload -r 'mutable()::foo`.
+
+   If this is not provided, it will check whether @ has a description. * If it does, it will upload @ * Otherwise, it will upload @-
 * `-b`, `--remote-branch <REMOTE_BRANCH>` — The location where your changes are intended to land
 
    This should be a branch on the remote. Can be configured with the `gerrit.default-remote-branch` repository option.

--- a/docs/gerrit.md
+++ b/docs/gerrit.md
@@ -53,9 +53,11 @@ commit description in JJ.
 > set.
 
 ### Upload a single change
-
 ```shell
-# upload the previous commit (@-) for review to main
+# Upload @ if it has a description, otherwise uploads @-
+$ jj gerrit upload
+
+# Or explicitly specify a revision to upload.
 $ jj gerrit upload -r @-
 ```
 


### PR DESCRIPTION
At google, our `jj piper upload` script automatically selects the revision to upload if you don't specify it. It's extremely convenient. So I've done a similar thing for `jj gerrit upload`

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
