### PR TITLE
templates: add builtin_draft_commit_description_with_diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   trailer `Link`, and will generate a `Link: <review-url>/id/<change-id>` trailer
   if `gerrit.review-url` option is set.
 
+* New `builtin_draft_commit_description_with_diff` template that includes the
+  diff in the commit description editor, making it easier to review changes
+  while writing commit messages.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -112,6 +112,14 @@ concat(
 )
 '''
 
+builtin_draft_commit_description_with_diff = '''
+concat(
+  builtin_draft_commit_description,
+  "\nJJ: ignore-rest\n",
+  diff.git(),
+)
+'''
+
 builtin_evolog_compact = '''
 concat(
   builtin_log_compact(commit),

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -1487,6 +1487,7 @@ fn test_template_alias() {
     builtin_config_list
     builtin_config_list_detailed
     builtin_draft_commit_description
+    builtin_draft_commit_description_with_diff
     builtin_evolog_compact
     builtin_log_comfortable
     builtin_log_compact

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -589,6 +589,7 @@ fn test_evolog_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_with_diff
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -48,6 +48,7 @@ fn test_log_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_with_diff
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -193,6 +193,7 @@ fn test_op_log_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_with_diff
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -336,6 +336,7 @@ fn test_show_with_no_template() {
     - builtin_config_list
     - builtin_config_list_detailed
     - builtin_draft_commit_description
+    - builtin_draft_commit_description_with_diff
     - builtin_evolog_compact
     - builtin_log_comfortable
     - builtin_log_compact

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -147,7 +147,7 @@ fn test_templater_parse_error() {
       | ^-----^
       |
       = Keyword `builtin` doesn't exist
-    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`?
+    Hint: Did you mean `builtin_config_list`, `builtin_config_list_detailed`, `builtin_draft_commit_description`, `builtin_draft_commit_description_with_diff`, `builtin_evolog_compact`, `builtin_log_comfortable`, `builtin_log_compact`, `builtin_log_compact_full_description`, `builtin_log_detailed`, `builtin_log_node`, `builtin_log_node_ascii`, `builtin_log_oneline`, `builtin_log_redacted`, `builtin_op_log_comfortable`, `builtin_op_log_compact`, `builtin_op_log_node`, `builtin_op_log_node_ascii`, `builtin_op_log_oneline`, `builtin_op_log_redacted`?
     [EOF]
     [exit status: 1]
     ");

--- a/web/docs/src/content/docs/config.md
+++ b/web/docs/src/content/docs/config.md
@@ -185,18 +185,11 @@ default-command = ["log", "--reversed"]
 ### Default description
 
 The editor content of a commit description can be populated by the
-`draft_commit_description` template. `self` is a [`Commit`
-object](templates.md#commit-type).
+`draft_commit_description` template.
 
 ```toml
 [templates]
-draft_commit_description = '''
-concat(
-  builtin_draft_commit_description,
-  "\nJJ: ignore-rest\n",
-  diff.git(),
-)
-'''
+draft_commit_description = 'builtin_draft_commit_description_with_diff'
 ```
 
 You can override only the `default_commit_description` value if you like, e.g.:


### PR DESCRIPTION
It seems fairly common to want to include the diff in the draft commit description, instead of everyone having to specify this in their own configs lets just add it as a builtin.

Thanks!

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
