### PR TITLE
mise: fix cargo-insta required version

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -5,7 +5,7 @@
 
 [vars]
 bacon_version = "3.16.0"
-cargo_insta_version = "1.43.3"
+cargo_insta_version = "1.46.3"
 cargo_nextest_version = "0.9.113"
 rust_version = "1.89"
 uv_version = "0.8.13"


### PR DESCRIPTION
cargo-insta 1.43.3 doesn't exist, using the last version 1.46.3

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
