### PR TITLE
cli: bookmark rename: add `--overwrite-existing` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates now support `Serialize` operations on the result of `map()` and
   `if()`, when supported by the underlying type.
 
+* `jj bookmark rename` now supports `--overwrite-existing` to allow renaming a
+  bookmark even if the new name already exists, effectively replacing the
+  existing bookmark.
+
 ### Fixed bugs
 
 ## [0.38.0] - 2026-02-04

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -576,7 +576,7 @@ Rename `old` bookmark name to `new` bookmark name
 
 The new bookmark name points at the same commit as the old bookmark name.
 
-**Usage:** `jj bookmark rename <OLD> <NEW>`
+**Usage:** `jj bookmark rename [OPTIONS] <OLD> <NEW>`
 
 **Command Alias:** `r`
 
@@ -584,6 +584,10 @@ The new bookmark name points at the same commit as the old bookmark name.
 
 * `<OLD>` — The old name of the bookmark
 * `<NEW>` — The new name of the bookmark
+
+###### **Options:**
+
+* `--overwrite-existing` — Allow renaming even if the new bookmark name already exists
 
 
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -224,6 +224,8 @@ fn test_bookmark_names() {
     aaa-tracked	x
     bbb-local	x
     bbb-tracked	x
+    --overwrite-existing	Allow renaming even if the new bookmark name already exists
+    --help	Print help (see more with '--help')
     --repository	Path to repository to operate on
     --ignore-working-copy	Don't snapshot the working copy, and don't update it
     --ignore-immutable	Allow rewriting immutable commits
@@ -234,7 +236,6 @@ fn test_bookmark_names() {
     --no-pager	Disable the pager
     --config	Additional configuration options (can be repeated)
     --config-file	Additional configuration files (can be repeated)
-    --help	Print help (see more with '--help')
     [EOF]
     ");
 


### PR DESCRIPTION
I tried to use `jj bookmark rename [--force] old new` today as a shortcut for `jj bookmark delete` followed by `jj bookmark move` only to discover it wasn't implemented.

Add `--overwrite-existing` to `jj bookmark rename` as a convenient way to delete/move in one step.