### PR TITLE
cli: replace "bright black" colors with dim for better terminal color scheme compatibility

### DIFF
--- a/cli/src/config/colors.toml
+++ b/cli/src/config/colors.toml
@@ -16,7 +16,7 @@
 
 # Unique prefixes and the rest for change & commit ids
 "prefix" = { bold = true }
-"rest" = "bright black"
+"rest" = { dim = true }
 "change_offset" = { bold = true }
 "hidden prefix" = "default"
 
@@ -42,8 +42,8 @@
 "placeholder" = "red"
 "description placeholder" = "yellow"
 "empty description placeholder" = "green"
-"separator" = "bright black"
-"elided" = "bright black"
+"separator" = { dim = true }
+"elided" = { dim = true }
 "root" = "green"
 
 "working_copy" = { bold = true }
@@ -76,11 +76,11 @@
 "config_list value" = "yellow"
 "config_list source" = "blue"
 "config_list path" = "magenta"
-"config_list overridden" = "bright black"
-"config_list overridden name" = "bright black"
-"config_list overridden value" = "bright black"
-"config_list overridden source" = "bright black"
-"config_list overridden path" = "bright black"
+"config_list overridden" = { dim = true }
+"config_list overridden name" = { dim = true }
+"config_list overridden value" = { dim = true }
+"config_list overridden source" = { dim = true }
+"config_list overridden path" = { dim = true }
 
 "diff header" = "yellow"
 "diff empty" = "cyan"
@@ -107,7 +107,7 @@
 "operation current_operation time" = "bright cyan"
 "operation current_operation tags" = "bright magenta"
 
-"node elided" = { fg = "bright black" }
+"node elided" = { dim = true }
 "node working_copy" = { fg = "green", bold = true }
 "node current_operation" = { fg = "green", bold = true }
 "node immutable" = { fg = "bright cyan", bold = true }

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1826,16 +1826,16 @@ fn test_bookmark_list() {
 
     let output = local_dir.run_jj(["bookmark", "list", "--all-remotes", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [38;5;5mabsent-tracked[39m: [1m[38;5;13mw[38;5;8mqnwkozp[39m [38;5;12m03[38;5;8m53dd35[39m [38;5;10m(empty)[39m local-only[0m
+    [38;5;5mabsent-tracked[39m: [1m[38;5;13mw[2mqnwkozp[0m[1m [38;5;12m03[2m53dd35[0m[1m [38;5;10m(empty)[39m local-only[0m
       [38;5;5m@origin[39m (not created yet)
-    [38;5;5mlocal-only[39m: [1m[38;5;13mw[38;5;8mqnwkozp[39m [38;5;12m03[38;5;8m53dd35[39m [38;5;10m(empty)[39m local-only[0m
+    [38;5;5mlocal-only[39m: [1m[38;5;13mw[2mqnwkozp[0m[1m [38;5;12m03[2m53dd35[0m[1m [38;5;10m(empty)[39m local-only[0m
     [38;5;5mremote-delete[39m (deleted)
-      [38;5;5m@origin[39m: [1m[38;5;5mv[0m[38;5;8mruxwmqv[39m [1m[38;5;4mb[0m[38;5;8m32031cf[39m [38;5;2m(empty)[39m remote-delete
-    [38;5;5mremote-sync[39m: [1m[38;5;5mr[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m7[0m[38;5;8ma07dbee[39m [38;5;2m(empty)[39m remote-sync
-      [38;5;5m@origin[39m: [1m[38;5;5mr[0m[38;5;8mlvkpnrz[39m [1m[38;5;4m7[0m[38;5;8ma07dbee[39m [38;5;2m(empty)[39m remote-sync
-    [38;5;5mremote-unsync[39m: [1m[38;5;13mw[38;5;8mqnwkozp[39m [38;5;12m03[38;5;8m53dd35[39m [38;5;10m(empty)[39m local-only[0m
-      [38;5;5m@origin[39m (ahead by 1 commits, behind by 1 commits): [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m5[0m[38;5;8m53203ba[39m [38;5;2m(empty)[39m remote-unsync
-    [38;5;5mremote-untrack@origin[39m: [1m[38;5;5mro[0m[38;5;8myxmykx[39m [1m[38;5;4m1[0m[38;5;8m49bc756[39m [38;5;2m(empty)[39m remote-untrack
+      [38;5;5m@origin[39m: [1m[38;5;5mv[0m[2m[38;5;5mruxwmqv[0m [1m[38;5;4mb[0m[2m[38;5;4m32031cf[0m [38;5;2m(empty)[39m remote-delete
+    [38;5;5mremote-sync[39m: [1m[38;5;5mr[0m[2m[38;5;5mlvkpnrz[0m [1m[38;5;4m7[0m[2m[38;5;4ma07dbee[0m [38;5;2m(empty)[39m remote-sync
+      [38;5;5m@origin[39m: [1m[38;5;5mr[0m[2m[38;5;5mlvkpnrz[0m [1m[38;5;4m7[0m[2m[38;5;4ma07dbee[0m [38;5;2m(empty)[39m remote-sync
+    [38;5;5mremote-unsync[39m: [1m[38;5;13mw[2mqnwkozp[0m[1m [38;5;12m03[2m53dd35[0m[1m [38;5;10m(empty)[39m local-only[0m
+      [38;5;5m@origin[39m (ahead by 1 commits, behind by 1 commits): [1m[38;5;5mzs[0m[2m[38;5;5muskuln[0m [1m[38;5;4m5[0m[2m[38;5;4m53203ba[0m [38;5;2m(empty)[39m remote-unsync
+    [38;5;5mremote-untrack@origin[39m: [1m[38;5;5mro[0m[2m[38;5;5myxmykx[0m [1m[38;5;4m1[0m[2m[38;5;4m49bc756[0m [38;5;2m(empty)[39m remote-untrack
     [EOF]
     ------- stderr -------
     [1m[38;5;6mHint: [0m[39mBookmarks marked as deleted can be *deleted permanently* on the remote by running `jj git push --deleted`. Use `jj bookmark forget` if you don't want that.[39m

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -60,7 +60,7 @@ fn test_log_parents() {
     let template = r#"parents.map(|c| c.commit_id().shortest(4))"#;
     let output = work_dir.run_jj(["log", "-T", template, "-r@", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;4m1[0m[38;5;8mc1c[39m [1m[38;5;4me[0m[38;5;8m884[39m
+    [1m[38;5;2m@[0m  [1m[38;5;4m1[0m[2m[38;5;4mc1c[0m [1m[38;5;4me[0m[2m[38;5;4m884[0m
     │
     ~
     [EOF]
@@ -287,22 +287,22 @@ fn test_log_default() {
     // Color
     let output = work_dir.run_jj(["log", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mc[38;5;8m938c088[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mk[2mkmpptxz[0m[1m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mc[2m938c088[0m[1m[0m
     │  [1m[38;5;10m(empty)[39m description 1[0m
-    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m007[0m[38;5;8m859d3[39m
+    ○  [1m[38;5;5mq[0m[2m[38;5;5mpvuntsm[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m007[0m[2m[38;5;4m859d3[0m
     │  add a file
-    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m000[0m[38;5;8m00000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[2m[38;5;5mzzzzzzz[0m [38;5;2mroot()[39m [1m[38;5;4m000[0m[2m[38;5;4m00000[0m
     [EOF]
     ");
 
     // Color without graph
     let output = work_dir.run_jj(["log", "--color=always", "--no-graph"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;13mk[38;5;8mkmpptxz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mc[38;5;8m938c088[39m[0m
+    [1m[38;5;13mk[2mkmpptxz[0m[1m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;13mmy-bookmark[39m [38;5;12mc[2m938c088[0m[1m[0m
     [1m[38;5;10m(empty)[39m description 1[0m
-    [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m007[0m[38;5;8m859d3[39m
+    [1m[38;5;5mq[0m[2m[38;5;5mpvuntsm[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4m007[0m[2m[38;5;4m859d3[0m
     add a file
-    [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m000[0m[38;5;8m00000[39m
+    [1m[38;5;5mz[0m[2m[38;5;5mzzzzzzz[0m [38;5;2mroot()[39m [1m[38;5;4m000[0m[2m[38;5;4m00000[0m
     [EOF]
     ");
 }
@@ -406,29 +406,29 @@ fn test_log_builtin_templates_colored() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8mec3ec96[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[2mlvkpnrz[0m[1m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[2mec3ec96[0m[1m [38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
+    ○  [1m[38;5;5mq[0m[2m[38;5;5mpvuntsm[0m [38;5;3mtest.user[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[2m[38;5;5mzzzzzzz[0m [38;5;2mroot()[39m [1m[38;5;4m0[0m[2m[38;5;4m0000000[0m
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8mec3ec96[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[2mlvkpnrz[0m[1m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[2mec3ec96[0m[1m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
-    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m
+    ○  [1m[38;5;5mq[0m[2m[38;5;5mpvuntsm[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[2m[38;5;5mzzzzzzz[0m [38;5;2mroot()[39m [1m[38;5;4m0[0m[2m[38;5;4m0000000[0m
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[38;5;8mec3ec96[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[2mlvkpnrz[0m[1m [38;5;9m(no email set)[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;13mmy-bookmark[39m [38;5;12ma[2mec3ec96[0m[1m[0m
     │  [1m[38;5;10m(empty)[39m [38;5;10m(no description set)[39m[0m
     │
-    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m
+    ○  [1m[38;5;5mq[0m[2m[38;5;5mpvuntsm[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     │
-    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[2m[38;5;5mzzzzzzz[0m [38;5;2mroot()[39m [1m[38;5;4m0[0m[2m[38;5;4m0000000[0m
 
     [EOF]
     ");
@@ -475,29 +475,29 @@ fn test_log_builtin_templates_colored_debug() {
         .success();
 
     insta::assert_snapshot!(render(r#"builtin_log_oneline"#), @"
-    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
-    <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[38;5;8m<<log commit mutable change_id shortest rest::pvuntsm>>[39m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[38;5;8m<<log commit mutable commit_id shortest rest::8849ae1>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty::(empty)>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty description placeholder::(no description set)>>[39m<<log commit mutable::>>
-    [1m[38;5;14m<<log commit node immutable::◆>>[0m  [1m[38;5;5m<<log commit immutable change_id shortest prefix::z>>[0m[38;5;8m<<log commit immutable change_id shortest rest::zzzzzzz>>[39m<<log commit immutable:: >>[38;5;2m<<log commit immutable root::root()>>[39m<<log commit immutable:: >>[1m[38;5;4m<<log commit immutable commit_id shortest prefix::0>>[0m[38;5;8m<<log commit immutable commit_id shortest rest::0000000>>[39m<<log commit immutable::>>
+    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[2m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[0m[1m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[2m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[0m[1m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
+    <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[2m[38;5;5m<<log commit mutable change_id shortest rest::pvuntsm>>[0m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[2m[38;5;4m<<log commit mutable commit_id shortest rest::8849ae1>>[0m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty::(empty)>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty description placeholder::(no description set)>>[39m<<log commit mutable::>>
+    [1m[38;5;14m<<log commit node immutable::◆>>[0m  [1m[38;5;5m<<log commit immutable change_id shortest prefix::z>>[0m[2m[38;5;5m<<log commit immutable change_id shortest rest::zzzzzzz>>[0m<<log commit immutable:: >>[38;5;2m<<log commit immutable root::root()>>[39m<<log commit immutable:: >>[1m[38;5;4m<<log commit immutable commit_id shortest prefix::0>>[0m[2m[38;5;4m<<log commit immutable commit_id shortest rest::0000000>>[0m<<log commit immutable::>>
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_compact"#), @"
-    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[39m<<log commit working_copy mutable::>>[0m
+    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[2m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[0m[1m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[2m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[0m[1m<<log commit working_copy mutable::>>[0m
     │  [1m[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
-    <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[38;5;8m<<log commit mutable change_id shortest rest::pvuntsm>>[39m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>><<log commit mutable author email::@>><<log commit mutable author email domain::example.com>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[38;5;8m<<log commit mutable commit_id shortest rest::8849ae1>>[39m<<log commit mutable::>>
+    <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[2m[38;5;5m<<log commit mutable change_id shortest rest::pvuntsm>>[0m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>><<log commit mutable author email::@>><<log commit mutable author email domain::example.com>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[2m[38;5;4m<<log commit mutable commit_id shortest rest::8849ae1>>[0m<<log commit mutable::>>
     │  [38;5;2m<<log commit mutable empty::(empty)>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty description placeholder::(no description set)>>[39m<<log commit mutable::>>
-    [1m[38;5;14m<<log commit node immutable::◆>>[0m  [1m[38;5;5m<<log commit immutable change_id shortest prefix::z>>[0m[38;5;8m<<log commit immutable change_id shortest rest::zzzzzzz>>[39m<<log commit immutable:: >>[38;5;2m<<log commit immutable root::root()>>[39m<<log commit immutable:: >>[1m[38;5;4m<<log commit immutable commit_id shortest prefix::0>>[0m[38;5;8m<<log commit immutable commit_id shortest rest::0000000>>[39m<<log commit immutable::>>
+    [1m[38;5;14m<<log commit node immutable::◆>>[0m  [1m[38;5;5m<<log commit immutable change_id shortest prefix::z>>[0m[2m[38;5;5m<<log commit immutable change_id shortest rest::zzzzzzz>>[0m<<log commit immutable:: >>[38;5;2m<<log commit immutable root::root()>>[39m<<log commit immutable:: >>[1m[38;5;4m<<log commit immutable commit_id shortest prefix::0>>[0m[2m[38;5;4m<<log commit immutable commit_id shortest rest::0000000>>[0m<<log commit immutable::>>
     [EOF]
     ");
 
     insta::assert_snapshot!(render(r#"builtin_log_comfortable"#), @"
-    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[38;5;8m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[39m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[38;5;8m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[39m<<log commit working_copy mutable::>>[0m
+    [1m[38;5;2m<<log commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<log commit working_copy mutable change_id shortest prefix::r>>[2m<<log commit working_copy mutable change_id shortest rest::lvkpnrz>>[0m[1m<<log commit working_copy mutable:: >>[38;5;9m<<log commit working_copy mutable email placeholder::(no email set)>>[39m<<log commit working_copy mutable:: >>[38;5;14m<<log commit working_copy mutable committer timestamp local format::2001-02-03 08:05:08>>[39m<<log commit working_copy mutable:: >>[38;5;13m<<log commit working_copy mutable bookmarks name::my-bookmark>>[39m<<log commit working_copy mutable:: >>[38;5;12m<<log commit working_copy mutable commit_id shortest prefix::a>>[2m<<log commit working_copy mutable commit_id shortest rest::ec3ec96>>[0m[1m<<log commit working_copy mutable::>>[0m
     │  [1m[38;5;10m<<log commit working_copy mutable empty::(empty)>>[39m<<log commit working_copy mutable:: >>[38;5;10m<<log commit working_copy mutable empty description placeholder::(no description set)>>[39m<<log commit working_copy mutable::>>[0m
     │  <<log commit::>>
-    <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[38;5;8m<<log commit mutable change_id shortest rest::pvuntsm>>[39m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>><<log commit mutable author email::@>><<log commit mutable author email domain::example.com>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[38;5;8m<<log commit mutable commit_id shortest rest::8849ae1>>[39m<<log commit mutable::>>
+    <<log commit node mutable::○>>  [1m[38;5;5m<<log commit mutable change_id shortest prefix::q>>[0m[2m[38;5;5m<<log commit mutable change_id shortest rest::pvuntsm>>[0m<<log commit mutable:: >>[38;5;3m<<log commit mutable author email local::test.user>><<log commit mutable author email::@>><<log commit mutable author email domain::example.com>>[39m<<log commit mutable:: >>[38;5;6m<<log commit mutable committer timestamp local format::2001-02-03 08:05:07>>[39m<<log commit mutable:: >>[1m[38;5;4m<<log commit mutable commit_id shortest prefix::e>>[0m[2m[38;5;4m<<log commit mutable commit_id shortest rest::8849ae1>>[0m<<log commit mutable::>>
     │  [38;5;2m<<log commit mutable empty::(empty)>>[39m<<log commit mutable:: >>[38;5;2m<<log commit mutable empty description placeholder::(no description set)>>[39m<<log commit mutable::>>
     │  <<log commit::>>
-    [1m[38;5;14m<<log commit node immutable::◆>>[0m  [1m[38;5;5m<<log commit immutable change_id shortest prefix::z>>[0m[38;5;8m<<log commit immutable change_id shortest rest::zzzzzzz>>[39m<<log commit immutable:: >>[38;5;2m<<log commit immutable root::root()>>[39m<<log commit immutable:: >>[1m[38;5;4m<<log commit immutable commit_id shortest prefix::0>>[0m[38;5;8m<<log commit immutable commit_id shortest rest::0000000>>[39m<<log commit immutable::>>
+    [1m[38;5;14m<<log commit node immutable::◆>>[0m  [1m[38;5;5m<<log commit immutable change_id shortest prefix::z>>[0m[2m[38;5;5m<<log commit immutable change_id shortest rest::zzzzzzz>>[0m<<log commit immutable:: >>[38;5;2m<<log commit immutable root::root()>>[39m<<log commit immutable:: >>[1m[38;5;4m<<log commit immutable commit_id shortest prefix::0>>[0m[2m[38;5;4m<<log commit immutable commit_id shortest rest::0000000>>[0m<<log commit immutable::>>
        <<log commit::>>
     [EOF]
     ");
@@ -568,11 +568,11 @@ fn test_log_evolog_divergence() {
     // Color
     let output = work_dir.run_jj(["log", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m [38;5;9m(divergent)[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;9mq[2mpvuntsm[0m[1m[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[2m6daeb7[0m[1m [38;5;9m(divergent)[39m[0m
     │  [1mdescription 1[0m
-    │ ○  [1m[38;5;1mq[0m[38;5;8mpvuntsm[1m[38;5;1m/0[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m5c[0m[38;5;8mea51a1[39m [38;5;1m(divergent)[39m
+    │ ○  [1m[38;5;1mq[0m[2m[38;5;1mpvuntsm[0m[1m[38;5;1m/0[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:10[39m [1m[38;5;4m5c[0m[2m[38;5;4mea51a1[0m [38;5;1m(divergent)[39m
     ├─╯  description 2
-    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[2m[38;5;5mzzzzzzz[0m [38;5;2mroot()[39m [1m[38;5;4m0[0m[2m[38;5;4m0000000[0m
     [EOF]
     ");
 
@@ -594,15 +594,15 @@ fn test_log_evolog_divergence() {
     // Colored evolog
     let output = work_dir.run_jj(["evolog", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;9mq[38;5;8mpvuntsm[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[38;5;8m6daeb7[39m [38;5;9m(divergent)[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;9mq[2mpvuntsm[0m[1m[38;5;9m/1[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:08[39m [38;5;12m55[2m6daeb7[0m[1m [38;5;9m(divergent)[39m[0m
     │  [1mdescription 1[0m
-    │  [38;5;8m--[39m operation [38;5;4mfec5a045b947[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
-    ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4md[0m[38;5;8m0c049cd[39m (hidden)
+    │  [2m--[0m operation [38;5;4mfec5a045b947[39m describe commit d0c049cd993a8d3a2e69ba6df98788e264ea9fa1
+    ○  [1m[39mq[0m[2m[38;5;5mpvuntsm[0m[1m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4md[0m[2m[38;5;4m0c049cd[0m (hidden)
     │  [38;5;3m(no description set)[39m
-    │  [38;5;8m--[39m operation [38;5;4m911e64a1b666[39m snapshot working copy
-    ○  [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden)
+    │  [2m--[0m operation [38;5;4m911e64a1b666[39m snapshot working copy
+    ○  [1m[39mq[0m[2m[38;5;5mpvuntsm[0m[1m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m (hidden)
        [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-       [38;5;8m--[39m operation [38;5;4m8f47435a3990[39m add workspace 'default'
+       [2m--[0m operation [38;5;4m8f47435a3990[39m add workspace 'default'
     [EOF]
     ");
 }
@@ -806,11 +806,11 @@ fn test_log_git_head() {
 
     let output = work_dir.run_jj(["log", "--color=always"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m6[38;5;8m87fadfd[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[2mlvkpnrz[0m[1m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:09[39m [38;5;12m6[2m87fadfd[0m[1m[0m
     │  [1minitial[0m
-    ○  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m
+    ○  [1m[38;5;5mq[0m[2m[38;5;5mpvuntsm[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:07[39m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m
     │  [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
-    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [38;5;2mroot()[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m
+    [1m[38;5;14m◆[0m  [1m[38;5;5mz[0m[2m[38;5;5mzzzzzzz[0m [38;5;2mroot()[39m [1m[38;5;4m0[0m[2m[38;5;4m0000000[0m
     [EOF]
     ");
 }

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -362,7 +362,7 @@ fn test_config_list_origin() {
         "test-key",
     ]);
     insta::assert_snapshot!(output, @r#"
-    [38;5;8m<<config_list overridden name::# test-key>><<config_list overridden:: = >><<config_list overridden value::"test-val">><<config_list overridden:: # >><<config_list overridden source::user>><<config_list overridden:: >><<config_list overridden path::$TEST_ENV/config/config.toml>><<config_list overridden::>>[39m
+    [2m[38;5;2m<<config_list overridden name::# test-key>>[39m<<config_list overridden:: = >>[38;5;3m<<config_list overridden value::"test-val">>[39m<<config_list overridden:: # >>[38;5;4m<<config_list overridden source::user>>[39m<<config_list overridden:: >>[38;5;5m<<config_list overridden path::$TEST_ENV/config/config.toml>>[39m<<config_list overridden::>>[0m
     [38;5;2m<<config_list name::test-key>>[39m<<config_list:: = >>[38;5;3m<<config_list value::"test-cli-val">>[39m<<config_list:: # >>[38;5;4m<<config_list source::cli>>[39m<<config_list::>>
     [EOF]
     "#);
@@ -461,7 +461,7 @@ fn test_config_layer_override_default() {
         "--include-overridden",
     ]);
     insta::assert_snapshot!(output, @r#"
-    [38;5;8m# merge-tools.vimdiff.program = "user"[39m
+    [2m[38;5;2m# merge-tools.vimdiff.program[39m = [38;5;3m"user"[39m[0m
     [38;5;2mmerge-tools.vimdiff.program[39m = [38;5;3m"repo"[39m
     [EOF]
     "#);

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -50,18 +50,18 @@ fn test_evolog_with_or_without_diff() {
     // Color
     let output = work_dir.run_jj(["--color=always", "evolog"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mr[38;5;8mlvkpnrz[39m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[38;5;8m3c10ace[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mr[2mlvkpnrz[0m[1m [38;5;3mtest.user@example.com[39m [38;5;14m2001-02-03 08:05:10[39m [38;5;12m3[2m3c10ace[0m[1m[0m
     │  [1mmy description[0m
-    │  [38;5;8m--[39m operation [38;5;4m6db8cd4108b4[39m snapshot working copy
-    [1m[38;5;1m×[0m  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mcd[0m[38;5;8mf175ef[39m (hidden) [38;5;1m(conflict)[39m
+    │  [2m--[0m operation [38;5;4m6db8cd4108b4[39m snapshot working copy
+    [1m[38;5;1m×[0m  [1m[39mr[0m[2m[38;5;5mlvkpnrz[0m[1m/1[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4mcd[0m[2m[38;5;4mf175ef[0m (hidden) [38;5;1m(conflict)[39m
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m631cc2c28fbc[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
-    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[38;5;8m1e08f95[39m (hidden)
+    │  [2m--[0m operation [38;5;4m631cc2c28fbc[39m rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
+    ○  [1m[39mr[0m[2m[38;5;5mlvkpnrz[0m[1m/2[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:09[39m [1m[38;5;4m5[0m[2m[38;5;4m1e08f95[0m (hidden)
     │  my description
-    │  [38;5;8m--[39m operation [38;5;4m826347115e2d[39m snapshot working copy
-    ○  [1m[39mr[0m[38;5;8mlvkpnrz[1m[39m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[38;5;8m955b72e[39m (hidden)
+    │  [2m--[0m operation [38;5;4m826347115e2d[39m snapshot working copy
+    ○  [1m[39mr[0m[2m[38;5;5mlvkpnrz[0m[1m/3[0m [38;5;3mtest.user@example.com[39m [38;5;6m2001-02-03 08:05:08[39m [1m[38;5;4mb[0m[2m[38;5;4m955b72e[0m (hidden)
        [38;5;2m(empty)[39m my description
-       [38;5;8m--[39m operation [38;5;4me0f8e58b3800[39m new empty commit
+       [2m--[0m operation [38;5;4me0f8e58b3800[39m new empty commit
     [EOF]
     ");
 
@@ -233,9 +233,9 @@ fn test_evolog_template() {
     ");
     let output = work_dir.run_jj(["evolog", "-r@", "--color=debug"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m<<evolog commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<evolog working_copy mutable commit change_id shortest prefix::k>>[38;5;8m<<evolog working_copy mutable commit change_id shortest rest::kmpptxz>>[39m<<evolog working_copy mutable:: >>[38;5;3m<<evolog working_copy mutable commit author email local::test.user>><<evolog working_copy mutable commit author email::@>><<evolog working_copy mutable commit author email domain::example.com>>[39m<<evolog working_copy mutable:: >>[38;5;14m<<evolog working_copy mutable commit committer timestamp local format::2001-02-03 08:05:09>>[39m<<evolog working_copy mutable:: >>[38;5;12m<<evolog working_copy mutable commit commit_id shortest prefix::2>>[38;5;8m<<evolog working_copy mutable commit commit_id shortest rest::b17ac71>>[39m<<evolog working_copy mutable::>>[0m
+    [1m[38;5;2m<<evolog commit node working_copy mutable::@>>[0m  [1m[38;5;13m<<evolog working_copy mutable commit change_id shortest prefix::k>>[2m<<evolog working_copy mutable commit change_id shortest rest::kmpptxz>>[0m[1m<<evolog working_copy mutable:: >>[38;5;3m<<evolog working_copy mutable commit author email local::test.user>><<evolog working_copy mutable commit author email::@>><<evolog working_copy mutable commit author email domain::example.com>>[39m<<evolog working_copy mutable:: >>[38;5;14m<<evolog working_copy mutable commit committer timestamp local format::2001-02-03 08:05:09>>[39m<<evolog working_copy mutable:: >>[38;5;12m<<evolog working_copy mutable commit commit_id shortest prefix::2>>[2m<<evolog working_copy mutable commit commit_id shortest rest::b17ac71>>[0m[1m<<evolog working_copy mutable::>>[0m
        [1m[38;5;10m<<evolog working_copy mutable empty::(empty)>>[39m<<evolog working_copy mutable:: >>[38;5;10m<<evolog working_copy mutable empty description placeholder::(no description set)>>[39m<<evolog working_copy mutable::>>[0m
-       [38;5;8m<<evolog separator::-->>[39m<<evolog:: operation >>[38;5;4m<<evolog operation id short::2931515731a6>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
+       [2m<<evolog separator::-->>[0m<<evolog:: operation >>[38;5;4m<<evolog operation id short::2931515731a6>>[39m<<evolog:: >><<evolog operation description first_line::add workspace 'default'>><<evolog::>>
     [EOF]
     ");
 
@@ -248,7 +248,7 @@ fn test_evolog_template() {
     ");
     let output = work_dir.run_jj(["evolog", "-rmain@origin", "--color=debug"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;14m<<evolog commit node immutable::◆>>[0m  [1m[38;5;5m<<evolog immutable commit change_id shortest prefix::q>>[0m[38;5;8m<<evolog immutable commit change_id shortest rest::pvuntsm>>[39m<<evolog immutable:: >>[38;5;3m<<evolog immutable commit author email local::test.user>><<evolog immutable commit author email::@>><<evolog immutable commit author email domain::example.com>>[39m<<evolog immutable:: >>[38;5;6m<<evolog immutable commit committer timestamp local format::2001-02-03 08:05:07>>[39m<<evolog immutable:: >>[38;5;5m<<evolog immutable commit bookmarks name::main>><<evolog immutable commit bookmarks::@>><<evolog immutable commit bookmarks remote::origin>>[39m<<evolog immutable:: >>[1m[38;5;4m<<evolog immutable commit commit_id shortest prefix::e>>[0m[38;5;8m<<evolog immutable commit commit_id shortest rest::8849ae1>>[39m<<evolog immutable::>>
+    [1m[38;5;14m<<evolog commit node immutable::◆>>[0m  [1m[38;5;5m<<evolog immutable commit change_id shortest prefix::q>>[0m[2m[38;5;5m<<evolog immutable commit change_id shortest rest::pvuntsm>>[0m<<evolog immutable:: >>[38;5;3m<<evolog immutable commit author email local::test.user>><<evolog immutable commit author email::@>><<evolog immutable commit author email domain::example.com>>[39m<<evolog immutable:: >>[38;5;6m<<evolog immutable commit committer timestamp local format::2001-02-03 08:05:07>>[39m<<evolog immutable:: >>[38;5;5m<<evolog immutable commit bookmarks name::main>><<evolog immutable commit bookmarks::@>><<evolog immutable commit bookmarks remote::origin>>[39m<<evolog immutable:: >>[1m[38;5;4m<<evolog immutable commit commit_id shortest prefix::e>>[0m[2m[38;5;4m<<evolog immutable commit commit_id shortest rest::8849ae1>>[0m<<evolog immutable::>>
        [38;5;2m<<evolog immutable empty::(empty)>>[39m<<evolog immutable:: >>[38;5;2m<<evolog immutable empty description placeholder::(no description set)>>[39m<<evolog immutable::>>
     [EOF]
     ");
@@ -261,7 +261,7 @@ fn test_evolog_template() {
     ");
     let output = work_dir.run_jj(["evolog", "-rroot()", "--color=debug"]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;14m<<evolog commit node immutable::◆>>[0m  [1m[38;5;5m<<evolog immutable commit change_id shortest prefix::z>>[0m[38;5;8m<<evolog immutable commit change_id shortest rest::zzzzzzz>>[39m<<evolog immutable:: >>[38;5;2m<<evolog immutable root::root()>>[39m<<evolog immutable:: >>[1m[38;5;4m<<evolog immutable commit commit_id shortest prefix::0>>[0m[38;5;8m<<evolog immutable commit commit_id shortest rest::0000000>>[39m<<evolog immutable::>>
+    [1m[38;5;14m<<evolog commit node immutable::◆>>[0m  [1m[38;5;5m<<evolog immutable commit change_id shortest prefix::z>>[0m[2m[38;5;5m<<evolog immutable commit change_id shortest rest::zzzzzzz>>[0m<<evolog immutable:: >>[38;5;2m<<evolog immutable root::root()>>[39m<<evolog immutable:: >>[1m[38;5;4m<<evolog immutable commit commit_id shortest prefix::0>>[0m[2m[38;5;4m<<evolog immutable commit commit_id shortest rest::0000000>>[0m<<evolog immutable::>>
     [EOF]
     ");
 

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -639,7 +639,7 @@ fn test_color_ui_messages() {
     ]);
     insta::assert_snapshot!(output, @"
     [38;5;4m8afc18ff677d32e40043e1bc8c1683c2f9c2e916[39m
-    [1m[39m<[38;5;1mError: [39mNo Commit available>[0m  [38;5;8m(elided revisions)[39m
+    [1m[39m<[38;5;1mError: [39mNo Commit available>[0m  [2m(elided revisions)[0m
     [38;5;4m0000000000000000000000000000000000000000[39m
     [EOF]
     ");
@@ -650,8 +650,8 @@ fn test_color_ui_messages() {
     ------- stderr -------
     [1m[38;5;1mError: [39mRevset `..` resolved to more than one revision[0m
     [1m[38;5;6mHint: [0m[39mThe revset `..` resolved to these revisions:[39m
-    [39m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;12m8[38;5;8mafc18ff[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m[39m[39m
-    [39m  [1m[38;5;5mq[0m[38;5;8mpvuntsm[39m [1m[38;5;4me[0m[38;5;8m8849ae1[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
+    [39m  [1m[38;5;13mm[2mzvwutvl[0m[1m[39m [38;5;12m8[2mafc18ff[0m[1m[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m[39m[39m
+    [39m  [1m[38;5;5mq[0m[2m[38;5;5mpvuntsm[0m[39m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m[39m
     [EOF]
     [exit status: 1]
     ");
@@ -660,8 +660,8 @@ fn test_color_ui_messages() {
     let output = work_dir.run_jj(["st", "--color", "debug"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : [1m[38;5;13m<<commit working_copy change_id shortest prefix::m>>[38;5;8m<<commit working_copy change_id shortest rest::zvwutvl>>[39m<<commit working_copy:: >>[38;5;12m<<commit working_copy commit_id shortest prefix::8>>[38;5;8m<<commit working_copy commit_id shortest rest::afc18ff>>[39m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty::(empty)>>[39m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty description placeholder::(no description set)>>[0m
-    Parent commit (@-): [1m[38;5;5m<<commit change_id shortest prefix::q>>[0m[38;5;8m<<commit change_id shortest rest::pvuntsm>>[39m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::e>>[0m[38;5;8m<<commit commit_id shortest rest::8849ae1>>[39m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >>[38;5;2m<<commit empty description placeholder::(no description set)>>[39m
+    Working copy  (@) : [1m[38;5;13m<<commit working_copy change_id shortest prefix::m>>[2m<<commit working_copy change_id shortest rest::zvwutvl>>[0m[1m<<commit working_copy:: >>[38;5;12m<<commit working_copy commit_id shortest prefix::8>>[2m<<commit working_copy commit_id shortest rest::afc18ff>>[0m[1m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty::(empty)>>[39m<<commit working_copy:: >>[38;5;10m<<commit working_copy empty description placeholder::(no description set)>>[0m
+    Parent commit (@-): [1m[38;5;5m<<commit change_id shortest prefix::q>>[0m[2m[38;5;5m<<commit change_id shortest rest::pvuntsm>>[0m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::e>>[0m[2m[38;5;4m<<commit commit_id shortest rest::8849ae1>>[0m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >>[38;5;2m<<commit empty description placeholder::(no description set)>>[39m
     [EOF]
     ");
 
@@ -670,7 +670,7 @@ fn test_color_ui_messages() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      [1m[38;5;5m<<commit change_id shortest prefix::y>>[0m[38;5;8m<<commit change_id shortest rest::ostqsxw>>[39m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::8b>>[0m[38;5;8m<<commit commit_id shortest rest::f82eec>>[39m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >><<commit description first_line::Revert "">>
+      [1m[38;5;5m<<commit change_id shortest prefix::y>>[0m[2m[38;5;5m<<commit change_id shortest rest::ostqsxw>>[0m<<commit:: >>[1m[38;5;4m<<commit commit_id shortest prefix::8b>>[0m[2m[38;5;4m<<commit commit_id shortest rest::f82eec>>[0m<<commit:: >>[38;5;2m<<commit empty::(empty)>>[39m<<commit:: >><<commit description first_line::Revert "">>
     [EOF]
     "#);
 }

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -685,17 +685,17 @@ fn test_log_prefix_highlight_styled() {
         &prefix_format(Some(12)),
     ]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mnwkozpkust[39m commit9 [1m[38;5;4mc2[0m[38;5;8mb4c0bb3362[39m
-    ○  Change [1m[38;5;5mkm[0m[38;5;8mkuslswpqwq[39m commit8 [1m[38;5;4m74[0m[38;5;8mfcd50c0643[39m
-    ○  Change [1m[38;5;5mkp[0m[38;5;8mqxywonksrl[39m commit7 [1m[38;5;4m97[0m[38;5;8mdcaada9b8d[39m
-    ○  Change [1m[38;5;5mzn[0m[38;5;8mkkpsqqskkl[39m commit6 [1m[38;5;4m78[0m[38;5;8mc03ab2235b[39m
-    ○  Change [1m[38;5;5myo[0m[38;5;8mstqsxwqrlt[39m commit5 [1m[38;5;4m40[0m[38;5;8m1119280761[39m
-    ○  Change [1m[38;5;5mvr[0m[38;5;8muxwmqvtpmx[39m commit4 [1m[38;5;4mbc9[0m[38;5;8me8942b459[39m
-    ○  Change [1m[38;5;5myq[0m[38;5;8mosqzytrlsw[39m commit3 [1m[38;5;4m28[0m[38;5;8medbc9658ef[39m
-    ○  Change [1m[38;5;5mro[0m[38;5;8myxmykxtrkr[39m commit2 [1m[38;5;4maf[0m[38;5;8m3e6a27a1d0[39m
-    ○  Change [1m[38;5;5mmz[0m[38;5;8mvwutvlkqwt[39m commit1 [1m[38;5;4m04[0m[38;5;8m6c6a1df762[39m
-    ○  Change [1m[38;5;5mqpv[0m[38;5;8muntsmwlqt[39m initial [1m[38;5;4m82[0m[38;5;8m16f646c36d[39m [38;5;5moriginal[39m
-    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m[38;5;8mzzzzzzzzz[39m [1m[38;5;4m00[0m[38;5;8m0000000000[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[2m[38;5;5mnwkozpkust[0m commit9 [1m[38;5;4mc2[0m[2m[38;5;4mb4c0bb3362[0m
+    ○  Change [1m[38;5;5mkm[0m[2m[38;5;5mkuslswpqwq[0m commit8 [1m[38;5;4m74[0m[2m[38;5;4mfcd50c0643[0m
+    ○  Change [1m[38;5;5mkp[0m[2m[38;5;5mqxywonksrl[0m commit7 [1m[38;5;4m97[0m[2m[38;5;4mdcaada9b8d[0m
+    ○  Change [1m[38;5;5mzn[0m[2m[38;5;5mkkpsqqskkl[0m commit6 [1m[38;5;4m78[0m[2m[38;5;4mc03ab2235b[0m
+    ○  Change [1m[38;5;5myo[0m[2m[38;5;5mstqsxwqrlt[0m commit5 [1m[38;5;4m40[0m[2m[38;5;4m1119280761[0m
+    ○  Change [1m[38;5;5mvr[0m[2m[38;5;5muxwmqvtpmx[0m commit4 [1m[38;5;4mbc9[0m[2m[38;5;4me8942b459[0m
+    ○  Change [1m[38;5;5myq[0m[2m[38;5;5mosqzytrlsw[0m commit3 [1m[38;5;4m28[0m[2m[38;5;4medbc9658ef[0m
+    ○  Change [1m[38;5;5mro[0m[2m[38;5;5myxmykxtrkr[0m commit2 [1m[38;5;4maf[0m[2m[38;5;4m3e6a27a1d0[0m
+    ○  Change [1m[38;5;5mmz[0m[2m[38;5;5mvwutvlkqwt[0m commit1 [1m[38;5;4m04[0m[2m[38;5;4m6c6a1df762[0m
+    ○  Change [1m[38;5;5mqpv[0m[2m[38;5;5muntsmwlqt[0m initial [1m[38;5;4m82[0m[2m[38;5;4m16f646c36d[0m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m[2m[38;5;5mzzzzzzzzz[0m [1m[38;5;4m00[0m[2m[38;5;4m0000000000[0m
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -707,17 +707,17 @@ fn test_log_prefix_highlight_styled() {
         &prefix_format(Some(3)),
     ]);
     insta::assert_snapshot!(output, @"
-    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[38;5;8mn[39m commit9 [1m[38;5;4mc2[0m[38;5;8mb[39m
-    ○  Change [1m[38;5;5mkm[0m[38;5;8mk[39m commit8 [1m[38;5;4m74[0m[38;5;8mf[39m
-    ○  Change [1m[38;5;5mkp[0m[38;5;8mq[39m commit7 [1m[38;5;4m97[0m[38;5;8md[39m
-    ○  Change [1m[38;5;5mzn[0m[38;5;8mk[39m commit6 [1m[38;5;4m78[0m[38;5;8mc[39m
-    ○  Change [1m[38;5;5myo[0m[38;5;8ms[39m commit5 [1m[38;5;4m40[0m[38;5;8m1[39m
-    ○  Change [1m[38;5;5mvr[0m[38;5;8mu[39m commit4 [1m[38;5;4mbc9[0m
-    ○  Change [1m[38;5;5myq[0m[38;5;8mo[39m commit3 [1m[38;5;4m28[0m[38;5;8me[39m
-    ○  Change [1m[38;5;5mro[0m[38;5;8my[39m commit2 [1m[38;5;4maf[0m[38;5;8m3[39m
-    ○  Change [1m[38;5;5mmz[0m[38;5;8mv[39m commit1 [1m[38;5;4m04[0m[38;5;8m6[39m
-    ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4m82[0m[38;5;8m1[39m [38;5;5moriginal[39m
-    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[38;5;8m0[39m
+    [1m[38;5;2m@[0m  Change [1m[38;5;5mwq[0m[2m[38;5;5mn[0m commit9 [1m[38;5;4mc2[0m[2m[38;5;4mb[0m
+    ○  Change [1m[38;5;5mkm[0m[2m[38;5;5mk[0m commit8 [1m[38;5;4m74[0m[2m[38;5;4mf[0m
+    ○  Change [1m[38;5;5mkp[0m[2m[38;5;5mq[0m commit7 [1m[38;5;4m97[0m[2m[38;5;4md[0m
+    ○  Change [1m[38;5;5mzn[0m[2m[38;5;5mk[0m commit6 [1m[38;5;4m78[0m[2m[38;5;4mc[0m
+    ○  Change [1m[38;5;5myo[0m[2m[38;5;5ms[0m commit5 [1m[38;5;4m40[0m[2m[38;5;4m1[0m
+    ○  Change [1m[38;5;5mvr[0m[2m[38;5;5mu[0m commit4 [1m[38;5;4mbc9[0m
+    ○  Change [1m[38;5;5myq[0m[2m[38;5;5mo[0m commit3 [1m[38;5;4m28[0m[2m[38;5;4me[0m
+    ○  Change [1m[38;5;5mro[0m[2m[38;5;5my[0m commit2 [1m[38;5;4maf[0m[2m[38;5;4m3[0m
+    ○  Change [1m[38;5;5mmz[0m[2m[38;5;5mv[0m commit1 [1m[38;5;4m04[0m[2m[38;5;4m6[0m
+    ○  Change [1m[38;5;5mqpv[0m initial [1m[38;5;4m82[0m[2m[38;5;4m1[0m [38;5;5moriginal[39m
+    [1m[38;5;14m◆[0m  Change [1m[38;5;5mzzz[0m [1m[38;5;4m00[0m[2m[38;5;4m0[0m
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -1471,8 +1471,8 @@ fn test_log_word_wrap() {
 
     // Color labels should be preserved
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @"
-    [1m[38;5;2m@[0m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
-    │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12mb[38;5;8mafb1ee5[39m[0m
+    [1m[38;5;2m@[0m  [1m[38;5;13mm[2mzvwutvl[0m[1m [38;5;3mtest.user@example.com[39m[0m
+    │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12mb[2mafb1ee5[0m[1m[0m
     ~  [1m[38;5;10m(empty)[39m merge[0m
     [EOF]
     ");

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -112,20 +112,20 @@ fn test_op_log() {
     │  [1m[38;5;13margs: jj describe -m 'description 0'[39m[0m
     │
     │  Changed commits:
-    │  ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
-    │     [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    │  ○  [38;5;2m+[39m [1m[38;5;13mq[2mpvuntsm[0m[1m [38;5;12m3[2mae22e7f[0m[1m [38;5;10m(empty)[39m description 0[0m
+    │     [38;5;1m-[39m [1m[39mq[0m[2m[38;5;5mpvuntsm[0m[1m/1[0m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     │
     │  Changed working copy [38;5;2mdefault@[39m:
-    │  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m3[38;5;8mae22e7f[39m [38;5;10m(empty)[39m description 0[0m
-    │  [38;5;1m-[39m [1m[39mq[0m[38;5;8mpvuntsm[1m[39m/1[0m [1m[38;5;4me[0m[38;5;8m8849ae1[39m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    │  [38;5;2m+[39m [1m[38;5;13mq[2mpvuntsm[0m[1m [38;5;12m3[2mae22e7f[0m[1m [38;5;10m(empty)[39m description 0[0m
+    │  [38;5;1m-[39m [1m[39mq[0m[2m[38;5;5mpvuntsm[0m[1m/1[0m [1m[38;5;4me[0m[2m[38;5;4m8849ae1[0m (hidden) [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
     ○  [38;5;4m8f47435a3990[39m [38;5;3mtest-username@host.example.com[39m [38;5;6m2001-02-03 04:05:07.000 +07:00[39m - [38;5;6m2001-02-03 04:05:07.000 +07:00[39m
     │  add workspace 'default'
     │
     │  Changed commits:
-    │  ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
+    │  ○  [38;5;2m+[39m [1m[38;5;13mq[2mpvuntsm[0m[1m [38;5;12me[2m8849ae1[0m[1m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
     │
     │  Changed working copy [38;5;2mdefault@[39m:
-    │  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
+    │  [38;5;2m+[39m [1m[38;5;13mq[2mpvuntsm[0m[1m [38;5;12me[2m8849ae1[0m[1m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
     │  [38;5;1m-[39m (absent)
     ○  [38;5;4m000000000000[39m [38;5;2mroot()[39m
     [EOF]
@@ -1153,10 +1153,10 @@ fn test_op_summary_diff_template() {
       To operation: [38;5;4mad76b56af140[39m ([38;5;6m2001-02-03 08:05:09[39m) revert operation 8c2682708d2e786e9c489d18b4cfc68c675d0d49b9be85de9540a973b775c7ef715c0a37c760fe74ee6a31e50487f6d64e392944124a1d288ca31493bf9e36f2
 
     Changed commits:
-    ○  [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
+    ○  [38;5;2m+[39m [1m[38;5;13mq[2mpvuntsm[0m[1m [38;5;12me[2m8849ae1[0m[1m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
 
     Changed working copy [38;5;2mdefault@[39m:
-    [38;5;2m+[39m [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12me[38;5;8m8849ae1[39m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
+    [38;5;2m+[39m [1m[38;5;13mq[2mpvuntsm[0m[1m [38;5;12me[2m8849ae1[0m[1m [38;5;10m(empty)[39m [38;5;10m(no description set)[0m
     [38;5;1m-[39m (absent)
     [EOF]
     ");
@@ -1185,10 +1185,10 @@ fn test_op_summary_diff_template() {
       To operation: [38;5;4m<<op_diff operation id short::f8b6a7ee554b>>[39m<<op_diff operation:: (>>[38;5;6m<<op_diff operation time end local format::2001-02-03 08:05:12>>[39m<<op_diff operation::) >><<op_diff operation description first_line::revert operation c5c76cab7d34a454ae4edcf362f6cc7387c87cb20b328e6d50cbcb6c893c6ea9bf76ff792c34e75f1259a33b066fed38df2561e880661d2b35db1bd65e95b877>>
 
     Changed commits:
-    ○  [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[38;5;8m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[39m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[38;5;8m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
+    ○  [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[2m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[0m[1m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[2m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[0m[1m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
 
     Changed working copy [38;5;2m<<working_copies::default@>>[39m:
-    [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[38;5;8m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[39m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[38;5;8m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
+    [38;5;2m<<diff added::+>>[39m [1m[38;5;13m<<op_diff commit working_copy change_id shortest prefix::q>>[2m<<op_diff commit working_copy change_id shortest rest::pvuntsm>>[0m[1m<<op_diff commit working_copy:: >>[38;5;12m<<op_diff commit working_copy commit_id shortest prefix::e>>[2m<<op_diff commit working_copy commit_id shortest rest::8849ae1>>[0m[1m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty::(empty)>>[39m<<op_diff commit working_copy:: >>[38;5;10m<<op_diff commit working_copy empty description placeholder::(no description set)>>[0m
     [38;5;1m<<diff removed::->>[39m (absent)
     [EOF]
     ");

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -298,14 +298,14 @@ fn test_status_display_relevant_working_commit_conflict_hints() {
     let output = work_dir.run_jj(["status", "--color=always"]);
     insta::assert_snapshot!(output, @"
     The working copy has no changes.
-    Working copy  (@) : [1m[38;5;13my[38;5;8mqosqzyt[39m [38;5;12m06[38;5;8mb8a9dd[39m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
-    Parent commit (@-): [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4mf[0m[38;5;8mc966143[39m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
+    Working copy  (@) : [1m[38;5;13my[2mqosqzyt[0m[1m [38;5;12m06[2mb8a9dd[0m[1m [38;5;9m(conflict)[39m [38;5;10m(empty)[39m boom-cont-2[0m
+    Parent commit (@-): [1m[38;5;5mr[0m[2m[38;5;5moyxmykx[0m [1m[38;5;4mf[0m[2m[38;5;4mc966143[0m [38;5;1m(conflict)[39m [38;5;2m(empty)[39m boom-cont
     [1m[38;5;3mWarning: [39mThere are unresolved conflicts at these paths:[0m
     conflicted1.txt    [38;5;3m2-sided conflict[39m
     conflicted2.txt    [38;5;3m2-sided conflict[39m
     [1m[38;5;6mHint: [0m[39mTo resolve the conflicts, start by creating a commit on top of[39m
     [39mthe first conflicted commit:[39m
-    [39m  jj new [1m[38;5;5mm[0m[38;5;8mzvwutvl[39m[39m
+    [39m  jj new [1m[38;5;5mm[0m[2m[38;5;5mzvwutvl[0m[39m[39m
     [39mThen use `jj resolve`, or edit the conflict markers in the file directly.[39m
     [39mOnce the conflicts are resolved, you can inspect the result with `jj diff`.[39m
     [39mThen run `jj squash` to move the resolution into the conflicted commit.[39m

--- a/cli/tests/test_tag_command.rs
+++ b/cli/tests/test_tag_command.rs
@@ -278,11 +278,11 @@ fn test_tag_list() {
 
     insta::assert_snapshot!(work_dir.run_jj(["tag", "list", "--color=always"]), @"
     [38;5;5mconflicted_tag[39m [38;5;1m(conflicted)[39m:
-      - [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
-      + [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
-      + [1m[38;5;5mr[0m[38;5;8moyxmykx[39m [1m[38;5;4m1[0m[38;5;8m3c4e819[39m [38;5;2m(empty)[39m commit3
-    [38;5;5mtest_tag[39m: [1m[38;5;5mrl[0m[38;5;8mvkpnrz[39m [1m[38;5;4m8[0m[38;5;8m93e67dc[39m [38;5;2m(empty)[39m commit1
-    [38;5;5mtest_tag2[39m: [1m[38;5;5mzs[0m[38;5;8muskuln[39m [1m[38;5;4m7[0m[38;5;8m6abdd20[39m [38;5;2m(empty)[39m commit2
+      - [1m[38;5;5mrl[0m[2m[38;5;5mvkpnrz[0m [1m[38;5;4m8[0m[2m[38;5;4m93e67dc[0m [38;5;2m(empty)[39m commit1
+      + [1m[38;5;5mzs[0m[2m[38;5;5muskuln[0m [1m[38;5;4m7[0m[2m[38;5;4m6abdd20[0m [38;5;2m(empty)[39m commit2
+      + [1m[38;5;5mr[0m[2m[38;5;5moyxmykx[0m [1m[38;5;4m1[0m[2m[38;5;4m3c4e819[0m [38;5;2m(empty)[39m commit3
+    [38;5;5mtest_tag[39m: [1m[38;5;5mrl[0m[2m[38;5;5mvkpnrz[0m [1m[38;5;4m8[0m[2m[38;5;4m93e67dc[0m [38;5;2m(empty)[39m commit1
+    [38;5;5mtest_tag2[39m: [1m[38;5;5mzs[0m[2m[38;5;5muskuln[0m [1m[38;5;4m7[0m[2m[38;5;4m6abdd20[0m [38;5;2m(empty)[39m commit2
     [EOF]
     ");
 

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -199,7 +199,7 @@ fn test_templater_upper_lower() {
 
     insta::assert_snapshot!(
         render(r#"change_id.shortest(4).upper() ++ change_id.shortest(4).upper().lower()"#),
-        @"[1m[38;5;5mZ[0m[38;5;8mZZZ[1m[38;5;5mz[0m[38;5;8mzzz[39m[EOF]");
+        @"[1m[38;5;5mZ[0m[2m[38;5;5mZZZ[0m[1m[38;5;5mz[0m[2m[38;5;5mzzz[0m[EOF]");
     insta::assert_snapshot!(
         render(r#""Hello".upper() ++ "Hello".lower()"#), @"HELLOhello[EOF]");
 }


### PR DESCRIPTION
Using dim will dim the current foreground color, which is more amenable to such color schemes.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
