### PR TITLE
cli: remove example from `bookmark move` help text

### DIFF
--- a/cli/src/commands/bookmark/move.rs
+++ b/cli/src/commands/bookmark/move.rs
@@ -41,10 +41,6 @@ use crate::ui::Ui;
 /// If `--from` options are given, bookmarks currently pointing to the
 /// specified revisions will be updated. The bookmarks can also be filtered by
 /// names.
-///
-/// Example: pull up the nearest bookmarks to the working-copy parent
-///
-/// $ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(clap::ArgGroup::new("source").multiple(true).required(true)))]
 pub struct BookmarkMoveArgs {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -532,10 +532,6 @@ If bookmark names are given, the specified bookmarks will be updated to point to
 
 If `--from` options are given, bookmarks currently pointing to the specified revisions will be updated. The bookmarks can also be filtered by names.
 
-Example: pull up the nearest bookmarks to the working-copy parent
-
-$ jj bookmark move --from 'heads(::@- & bookmarks())' --to @-
-
 **Usage:** `jj bookmark move [OPTIONS] <NAMES|--from <REVSETS>>`
 
 **Command Alias:** `m`


### PR DESCRIPTION
Now that this can be done with `jj bookmark advance --to @-`, I don't think it makes sense to include this as an example anymore.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
