### PR TITLE
tests: exercise gerrit upload with no workspace

### DIFF
--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -135,6 +135,16 @@ fn test_gerrit_upload_default_revision() {
     [EOF]
     [exit status: 1]
     ");
+
+    work_dir.run_jj(["workspace", "forget"]).success();
+    let output = work_dir.run_jj(["gerrit", "upload", "--dry-run"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: No revision provided
+    Hint: Explicitly specify a revision to upload with `-r`
+    [EOF]
+    [exit status: 1]
+    ");
 }
 
 #[test]


### PR DESCRIPTION
I found a single missing coverage test case for #8918 

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
