### PR TITLE
Fix #3099: count number of elided revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Templates now support `Serialize` operations on the result of `map()` and
   `if()`, when supported by the underlying type.
 
+* `jj log` now shows the exact number of elided revisions in the synthetic
+  "(N elided revisions)" graph nodes, instead of always showing a placeholder.
+  [#3099](https://github.com/jj-vcs/jj/issues/3099)
+
 * New `diff_lines_added()` and `diff_lines_removed()` revset functions for
   matching content on only one side of a diff.
 

--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -44,7 +44,7 @@ pub struct SaplingGraphLog<'writer, R> {
 fn convert_graph_edge_into_ancestor<K: Clone>(e: &GraphEdge<K>) -> Ancestor<K> {
     match e.edge_type {
         GraphEdgeType::Direct => Ancestor::Parent(e.target.clone()),
-        GraphEdgeType::Indirect => Ancestor::Ancestor(e.target.clone()),
+        GraphEdgeType::Indirect(_) => Ancestor::Ancestor(e.target.clone()),
         GraphEdgeType::Missing => Ancestor::Anonymous,
     }
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1973,7 +1973,7 @@ Renders a graphical view of the project's history, ordered with children before 
 
 [`jj help -k revsets`]: https://docs.jj-vcs.dev/latest/revsets/
 
-Spans of revisions that are not included in the graph per `--revisions` are rendered as a synthetic node labeled "(elided revisions)".
+Spans of revisions that are not included in the graph per `--revisions` are rendered as a synthetic node labeled "(N elided revisions)".
 
 The working-copy commit is indicated by a `@` symbol in the graph. [Immutable revisions] have a `◆` symbol. Other commits have a `○` symbol. All of these symbols can be [customized].
 

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -2546,7 +2546,7 @@ fn test_git_push_sign_on_push() {
     ○  pre-signed commit
     │  Signature: test-display, Status: good, Key: impeccable
     ◆  commit which should not be signed 1
-    ~  (elided revisions)
+    ~  (3 elided revisions)
     │ ○  description 1
     ├─╯
     ◆
@@ -2570,7 +2570,7 @@ fn test_git_push_sign_on_push() {
     ○  pre-signed commit
     │  Signature: test-display, Status: good, Key: impeccable
     ◆  commit which should not be signed 1
-    ~  (elided revisions)
+    ~  (3 elided revisions)
     │ ○  description 1
     ├─╯
     ◆

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -639,7 +639,7 @@ fn test_color_ui_messages() {
     ]);
     insta::assert_snapshot!(output, @"
     [38;5;4m8afc18ff677d32e40043e1bc8c1683c2f9c2e916[39m
-    [1m[39m<[38;5;1mError: [39mNo Commit available>[0m  [38;5;8m(elided revisions)[39m
+    [1m[39m<[38;5;1mError: [39mNo Commit available>[0m  [38;5;8m(1 elided revision)[39m
     [38;5;4m0000000000000000000000000000000000000000[39m
     [EOF]
     ");

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1662,10 +1662,10 @@ fn test_elided() {
     ├─╮
     │ ○  side bookmark 2
     │ │
-    │ ~  (elided revisions)
+    │ ~  (1 elided revision)
     ○ │  main bookmark 2
     │ │
-    ~ │  (elided revisions)
+    ~ │  (1 elided revision)
     ├─╯
     ○  initial
     │
@@ -1678,10 +1678,10 @@ fn test_elided() {
     insta::assert_snapshot!(get_log("@-- | root()"), @"
     ○  side bookmark 1
     │
-    ~  (elided revisions)
+    ~  (1 elided revision)
     │ ○  main bookmark 1
     │ │
-    │ ~  (elided revisions)
+    │ ~  (1 elided revision)
     ├─╯
     ◆
     [EOF]
@@ -1720,10 +1720,10 @@ fn test_log_with_custom_symbols() {
     ├─╮
     │ ┝  side bookmark 2
     │ │
-    │ 🮀  (elided revisions)
+    │ 🮀  (1 elided revision)
     ┝ │  main bookmark 2
     │ │
-    🮀 │  (elided revisions)
+    🮀 │  (1 elided revision)
     ├─╯
     ┝  initial
     │
@@ -1744,10 +1744,10 @@ fn test_log_with_custom_symbols() {
     |\
     | *  side bookmark 2
     | |
-    | :  (elided revisions)
+    | :  (1 elided revision)
     * |  main bookmark 2
     | |
-    : |  (elided revisions)
+    : |  (1 elided revision)
     |/
     *  initial
     |

--- a/lib/src/default_index/revset_graph_iterator.rs
+++ b/lib/src/default_index/revset_graph_iterator.rs
@@ -29,6 +29,7 @@ use super::rev_walk::RevWalk;
 use super::revset_engine::BoxedRevWalk;
 use crate::backend::CommitId;
 use crate::graph::GraphEdge;
+use crate::graph::GraphEdgeType;
 use crate::graph::GraphNode;
 use crate::revset::RevsetEvaluationError;
 
@@ -165,32 +166,53 @@ impl<'a> RevsetGraphWalk<'a> {
             if self.look_ahead.binary_search(&parent_position).is_ok() {
                 Ok([CommitGraphEdge::direct(parent_position)].into())
             } else {
-                let parent_edges = self.edges_from_external_commit(index, parent)?;
+                let parent_edges = self.edges_from_external_commit(index, parent)?.clone();
                 if parent_edges.iter().all(|edge| edge.is_missing()) {
                     Ok([CommitGraphEdge::missing(parent_position)].into())
                 } else {
-                    Ok(parent_edges.clone())
+                    let counts = self.count_hidden_to_visible(index, &[parent_position]);
+                    let edges: Vec<CommitGraphEdge> = parent_edges
+                        .iter()
+                        .map(|edge| match edge.edge_type {
+                            GraphEdgeType::Indirect(_) => CommitGraphEdge {
+                                target: edge.target,
+                                edge_type: GraphEdgeType::Indirect(
+                                    counts.get(&edge.target).copied().unwrap_or(0),
+                                ),
+                            },
+                            _ => *edge,
+                        })
+                        .collect();
+                    Ok(edges.into())
                 }
             }
         } else {
             let mut edges = Vec::new();
             let mut known_ancestors = PositionsBitSet::with_max_pos(index_entry.position());
+            let mut hidden_entry_points: Vec<GlobalCommitPosition> = Vec::new();
             for parent in parent_entries {
                 let parent_position = parent.position();
                 self.consume_to(index, parent_position)?;
                 if self.look_ahead.binary_search(&parent_position).is_ok() {
                     edges.push(CommitGraphEdge::direct(parent_position));
                 } else {
-                    let parent_edges = self.edges_from_external_commit(index, parent)?;
+                    let parent_edges = self.edges_from_external_commit(index, parent)?.clone();
                     if parent_edges.iter().all(|edge| edge.is_missing()) {
                         edges.push(CommitGraphEdge::missing(parent_position));
                     } else {
-                        edges.extend(
-                            parent_edges
-                                .iter()
-                                .filter(|edge| !known_ancestors.get_set(edge.target)),
-                        );
+                        hidden_entry_points.push(parent_position);
+                        for edge in parent_edges.iter() {
+                            if !known_ancestors.get_set(edge.target) {
+                                edges.push(*edge);
+                            }
+                        }
                     }
+                }
+            }
+            let counts = self.count_hidden_to_visible(index, &hidden_entry_points);
+            for edge in edges.iter_mut() {
+                if let GraphEdgeType::Indirect(count) = &mut edge.edge_type {
+                    *count = counts.get(&edge.target).copied().unwrap_or(0);
                 }
             }
             if self.skip_transitive_edges {
@@ -206,79 +228,147 @@ impl<'a> RevsetGraphWalk<'a> {
         index_entry: CommitIndexEntry<'_>,
     ) -> Result<&Rc<[CommitGraphEdge]>, RevsetEvaluationError> {
         let position = index_entry.position();
-        let mut stack = vec![index_entry];
-        while let Some(entry) = stack.last() {
-            let position = entry.position();
-            if self.edges.contains_key(&position) {
-                stack.pop().unwrap();
-                continue;
+        if self.edges.contains_key(&position) {
+            return Ok(self.edges.get(&position).unwrap());
+        }
+
+        // If position is below min_position, the input set is exhausted above this
+        // point — treat as missing. The caller already called consume_to(position).
+        if position < self.min_position {
+            let edges: Rc<[CommitGraphEdge]> = [CommitGraphEdge::missing(position)].into();
+            self.edges.insert(position, edges);
+            return Ok(self.edges.get(&position).unwrap());
+        }
+
+        // Phase 1: Collect all external positions reachable from `position`
+        // that are not yet cached. We just gather positions here without
+        // computing edges, so the traversal order doesn't matter.
+        let mut to_process: Vec<GlobalCommitPosition> = Vec::new();
+        let mut visited = PositionsBitSet::with_max_pos(position);
+        let mut work: Vec<GlobalCommitPosition> = vec![position];
+        while let Some(pos) = work.pop() {
+            if visited.get_set(pos) {
+                continue; // Already visited
             }
-            let mut parent_entries = entry.parents();
-            let complete_parent_edges = if parent_entries.len() == 1 {
-                let parent = parent_entries.next().unwrap();
-                let parent_position = parent.position();
-                self.consume_to(index, parent_position)?;
-                if self.look_ahead.binary_search(&parent_position).is_ok() {
-                    // We have found a path back into the input set
-                    Some([CommitGraphEdge::indirect(parent_position)].into())
-                } else if let Some(parent_edges) = self.edges.get(&parent_position) {
-                    if parent_edges.iter().all(|edge| edge.is_missing()) {
-                        Some([CommitGraphEdge::missing(parent_position)].into())
-                    } else {
-                        Some(parent_edges.clone())
-                    }
-                } else if parent_position < self.min_position {
-                    // The parent is not in the input set
-                    Some([CommitGraphEdge::missing(parent_position)].into())
-                } else {
-                    // The parent is not in the input set but it's somewhere in the range
-                    // where we have commits in the input set, so continue searching.
-                    stack.push(parent);
-                    None
-                }
-            } else {
-                let mut edges = Vec::new();
-                let mut known_ancestors = PositionsBitSet::with_max_pos(position);
-                let mut parents_complete = true;
-                for parent in parent_entries {
-                    let parent_position = parent.position();
-                    self.consume_to(index, parent_position)?;
-                    if self.look_ahead.binary_search(&parent_position).is_ok() {
-                        // We have found a path back into the input set
-                        edges.push(CommitGraphEdge::indirect(parent_position));
-                    } else if let Some(parent_edges) = self.edges.get(&parent_position) {
-                        if parent_edges.iter().all(|edge| edge.is_missing()) {
-                            edges.push(CommitGraphEdge::missing(parent_position));
-                        } else {
-                            edges.extend(
-                                parent_edges
-                                    .iter()
-                                    .filter(|edge| !known_ancestors.get_set(edge.target)),
-                            );
-                        }
-                    } else if parent_position < self.min_position {
-                        // The parent is not in the input set
-                        edges.push(CommitGraphEdge::missing(parent_position));
-                    } else {
-                        // The parent is not in the input set but it's somewhere in the range
-                        // where we have commits in the input set, so continue searching.
-                        stack.push(parent);
-                        parents_complete = false;
-                    }
-                }
-                parents_complete.then(|| {
-                    if self.skip_transitive_edges {
-                        self.remove_transitive_edges(index.commits(), &mut edges);
-                    }
-                    edges.into()
-                })
-            };
-            if let Some(edges) = complete_parent_edges {
-                stack.pop().unwrap();
-                self.edges.insert(position, edges);
+            if self.edges.contains_key(&pos) {
+                continue; // Already cached
+            }
+            self.consume_to(index, pos)?;
+            if self.look_ahead.binary_search(&pos).is_ok() || pos < self.min_position {
+                continue; // Visible or outside the search range
+            }
+            to_process.push(pos);
+            let entry = index.commits().entry_by_pos(pos);
+            for parent_pos in entry.parent_positions() {
+                work.push(parent_pos);
             }
         }
+
+        // Phase 2: Process positions in ascending order (parents before children).
+        // Because GlobalCommitPosition is topologically sorted (lower = older =
+        // ancestor), ascending order guarantees every parent is processed
+        // before its children. This pass only records structural reachability —
+        // which visible targets a hidden commit can reach. Counts are left as 0
+        // and filled in later by count_hidden_to_visible at the visible-commit
+        // level, where a BFS deduplicates shared ancestors correctly.
+        to_process.sort_unstable();
+        for &pos in &to_process {
+            let entry = index.commits().entry_by_pos(pos);
+            let parent_positions = entry.parent_positions();
+            let mut edges: Vec<CommitGraphEdge> = Vec::new();
+            let mut known = PositionsBitSet::with_max_pos(pos);
+            for parent_pos in parent_positions {
+                if self.look_ahead.binary_search(&parent_pos).is_ok() {
+                    // Parent is visible: record reachability; count filled in later.
+                    if !known.get_set(parent_pos) {
+                        edges.push(CommitGraphEdge {
+                            target: parent_pos,
+                            edge_type: GraphEdgeType::Indirect(0),
+                        });
+                    }
+                } else if let Some(parent_edges) = self.edges.get(&parent_pos).cloned() {
+                    if parent_edges.iter().all(|e| e.is_missing()) {
+                        // Parent's entire reachable subgraph is outside the input set.
+                        if !known.get_set(parent_pos) {
+                            edges.push(CommitGraphEdge::missing(parent_pos));
+                        }
+                    } else {
+                        // Propagate parent's reachable targets (dedup only, no counting).
+                        for edge in parent_edges.iter() {
+                            match edge.edge_type {
+                                GraphEdgeType::Indirect(_) => {
+                                    if !known.get_set(edge.target) {
+                                        edges.push(CommitGraphEdge {
+                                            target: edge.target,
+                                            edge_type: GraphEdgeType::Indirect(0),
+                                        });
+                                    }
+                                }
+                                GraphEdgeType::Missing => {
+                                    if !known.get_set(edge.target) {
+                                        edges.push(*edge);
+                                    }
+                                }
+                                GraphEdgeType::Direct => {
+                                    unreachable!("external commit cache never holds Direct edges")
+                                }
+                            }
+                        }
+                    }
+                } else if parent_pos < self.min_position {
+                    // Parent is below the search range.
+                    if !known.get_set(parent_pos) {
+                        edges.push(CommitGraphEdge::missing(parent_pos));
+                    }
+                }
+                // else: parent_pos is in the range but not cached and not
+                // visible. This can't happen because we sorted
+                // to_process ascending and parents always have
+                // lower positions than their children.
+            }
+            if self.skip_transitive_edges {
+                self.remove_transitive_edges(index.commits(), &mut edges);
+            }
+            self.edges.insert(pos, edges.into());
+        }
+
         Ok(self.edges.get(&position).unwrap())
+    }
+
+    /// Counts distinct hidden commits reachable from `entry_points` that can
+    /// reach each visible target. The BFS visits each hidden commit exactly
+    /// once, so shared ancestors in crossed-ancestry patterns are counted once
+    /// regardless of how many paths lead to them.
+    fn count_hidden_to_visible(
+        &self,
+        index: &CompositeIndex,
+        entry_points: &[GlobalCommitPosition],
+    ) -> BTreeMap<GlobalCommitPosition, usize> {
+        let mut counts = BTreeMap::new();
+        let Some(&max_pos) = entry_points.iter().max() else {
+            return counts;
+        };
+        let mut visited = PositionsBitSet::with_max_pos(max_pos);
+        let mut work: Vec<GlobalCommitPosition> = entry_points.to_vec();
+        while let Some(pos) = work.pop() {
+            if visited.get_set(pos) {
+                continue;
+            }
+            if let Some(edges) = self.edges.get(&pos) {
+                for edge in edges.iter() {
+                    if matches!(edge.edge_type, GraphEdgeType::Indirect(_)) {
+                        *counts.entry(edge.target).or_insert(0) += 1;
+                    }
+                }
+                let entry = index.commits().entry_by_pos(pos);
+                for parent_pos in entry.parent_positions() {
+                    if self.edges.contains_key(&parent_pos) {
+                        work.push(parent_pos);
+                    }
+                }
+            }
+        }
+        counts
     }
 
     fn remove_transitive_edges(

--- a/lib/src/graph.rs
+++ b/lib/src/graph.rs
@@ -49,7 +49,7 @@ impl<N> GraphEdge<N> {
     pub fn indirect(target: N) -> Self {
         Self {
             target,
-            edge_type: GraphEdgeType::Indirect,
+            edge_type: GraphEdgeType::Indirect(0),
         }
     }
 
@@ -69,7 +69,7 @@ impl<N> GraphEdge<N> {
     }
 
     pub fn is_indirect(&self) -> bool {
-        self.edge_type == GraphEdgeType::Indirect
+        matches!(self.edge_type, GraphEdgeType::Indirect(_))
     }
 }
 
@@ -77,7 +77,11 @@ impl<N> GraphEdge<N> {
 pub enum GraphEdgeType {
     Missing,
     Direct,
-    Indirect,
+    /// Total number of elided (not-in-revset) commits between the source and
+    /// this target, summed across all paths. Multiple hidden branches that
+    /// converge on the same visible ancestor each contribute their own hidden
+    /// commits to the count.
+    Indirect(usize),
 }
 
 fn reachable_targets<N>(edges: &[GraphEdge<N>]) -> impl DoubleEndedIterator<Item = &N> {
@@ -381,7 +385,7 @@ mod tests {
         match edge.edge_type {
             GraphEdgeType::Missing => format!("missing({c})"),
             GraphEdgeType::Direct => format!("direct({c})"),
-            GraphEdgeType::Indirect => format!("indirect({c})"),
+            GraphEdgeType::Indirect(_) => format!("indirect({c})"),
         }
     }
 
@@ -406,7 +410,7 @@ mod tests {
                     .map(|edge| match edge.edge_type {
                         GraphEdgeType::Missing => Ancestor::Anonymous,
                         GraphEdgeType::Direct => Ancestor::Parent(edge.target),
-                        GraphEdgeType::Indirect => Ancestor::Ancestor(edge.target),
+                        GraphEdgeType::Indirect(_) => Ancestor::Ancestor(edge.target),
                     })
                     .collect();
                 renderer.next_row(id, parents, glyph, message)

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -18,6 +18,7 @@ use jj_lib::commit::Commit;
 use jj_lib::default_index::DefaultReadonlyIndex;
 use jj_lib::default_index::DefaultReadonlyIndexRevset;
 use jj_lib::graph::GraphEdge;
+use jj_lib::graph::GraphEdgeType;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
 use jj_lib::revset::ResolvedExpression;
@@ -40,12 +41,15 @@ fn direct(commit: &Commit) -> GraphEdge<CommitId> {
     GraphEdge::direct(commit.id().clone())
 }
 
-fn indirect(commit: &Commit) -> GraphEdge<CommitId> {
-    GraphEdge::indirect(commit.id().clone())
-}
-
 fn missing(commit: &Commit) -> GraphEdge<CommitId> {
     GraphEdge::missing(commit.id().clone())
+}
+
+fn indirect_n(commit: &Commit, n: usize) -> GraphEdge<CommitId> {
+    GraphEdge {
+        target: commit.id().clone(),
+        edge_type: GraphEdgeType::Indirect(n),
+    }
 }
 
 #[test_case(false, 0; "keep transitive edges")]
@@ -83,7 +87,8 @@ fn test_graph_iterator_linearized(skip_transitive_edges: bool, padding: u32) {
     assert_eq!(commits.len(), 2);
     assert_eq!(commits[0].0, *commit_d.id());
     assert_eq!(commits[1].0, *commit_a.id());
-    assert_eq!(commits[0].1, vec![indirect(&commit_a)]);
+    // 2 hidden commits between D and A: b and c.
+    assert_eq!(commits[0].1, vec![indirect_n(&commit_a, 2)]);
     assert_eq!(commits[1].1, vec![missing(&root_commit)]);
 }
 
@@ -128,12 +133,15 @@ fn test_graph_iterator_virtual_octopus(skip_transitive_edges: bool, padding: u32
     assert_eq!(commits[1].0, *commit_c.id());
     assert_eq!(commits[2].0, *commit_b.id());
     assert_eq!(commits[3].0, *commit_a.id());
+    // F→d→A: 1 hidden (d).
+    // F→d+e→B: 2 hidden (d and e both connect to B).
+    // F→e→C: 1 hidden (e).
     assert_eq!(
         commits[0].1,
         vec![
-            indirect(&commit_a),
-            indirect(&commit_b),
-            indirect(&commit_c),
+            indirect_n(&commit_a, 1),
+            indirect_n(&commit_b, 2),
+            indirect_n(&commit_c, 1),
         ]
     );
     assert_eq!(commits[1].1, vec![missing(&root_commit)]);
@@ -181,8 +189,10 @@ fn test_graph_iterator_simple_fork(skip_transitive_edges: bool, padding: u32) {
     assert_eq!(commits[0].0, *commit_e.id());
     assert_eq!(commits[1].0, *commit_c.id());
     assert_eq!(commits[2].0, *commit_a.id());
-    assert_eq!(commits[0].1, vec![indirect(&commit_a)]);
-    assert_eq!(commits[1].1, vec![indirect(&commit_a)]);
+    // E→d→b→A: 2 hidden (d and b).
+    assert_eq!(commits[0].1, vec![indirect_n(&commit_a, 2)]);
+    // C→b→A: 1 hidden (b).
+    assert_eq!(commits[1].1, vec![indirect_n(&commit_a, 1)]);
     assert_eq!(commits[2].1, vec![missing(&root_commit)]);
 }
 
@@ -224,9 +234,14 @@ fn test_graph_iterator_multiple_missing(skip_transitive_edges: bool, padding: u3
     assert_eq!(commits.len(), 2);
     assert_eq!(commits[0].0, *commit_f.id());
     assert_eq!(commits[1].0, *commit_b.id());
+    // F→d+e→B: 2 hidden (d and e both connect to B).
     assert_eq!(
         commits[0].1,
-        vec![missing(&commit_a), indirect(&commit_b), missing(&commit_c)]
+        vec![
+            missing(&commit_a),
+            indirect_n(&commit_b, 2),
+            missing(&commit_c)
+        ]
     );
     assert_eq!(commits[1].1, vec![missing(&root_commit)]);
 }
@@ -275,7 +290,11 @@ fn test_graph_iterator_edge_to_ancestor(skip_transitive_edges: bool, padding: u3
     if skip_transitive_edges {
         assert_eq!(commits[0].1, vec![direct(&commit_d)]);
     } else {
-        assert_eq!(commits[0].1, vec![direct(&commit_d), indirect(&commit_c),]);
+        // F→e→C: 1 hidden (e).
+        assert_eq!(
+            commits[0].1,
+            vec![direct(&commit_d), indirect_n(&commit_c, 1)]
+        );
     }
     assert_eq!(commits[1].1, vec![missing(&commit_b), direct(&commit_c)]);
     assert_eq!(commits[2].1, vec![missing(&commit_a)]);
@@ -337,16 +356,89 @@ fn test_graph_iterator_edge_escapes_from_(skip_transitive_edges: bool, padding: 
     assert_eq!(commits[3].0, *commit_d.id());
     assert_eq!(commits[4].0, *commit_a.id());
     if skip_transitive_edges {
-        assert_eq!(commits[0].1, vec![direct(&commit_g), indirect(&commit_h)]);
-        assert_eq!(commits[1].1, vec![indirect(&commit_d)]);
+        // J→i→H: 1 hidden (i).
+        assert_eq!(
+            commits[0].1,
+            vec![direct(&commit_g), indirect_n(&commit_h, 1)]
+        );
+        // H→f→D: 1 hidden (f).
+        assert_eq!(commits[1].1, vec![indirect_n(&commit_d, 1)]);
     } else {
         assert_eq!(
             commits[0].1,
-            vec![direct(&commit_g), indirect(&commit_d), indirect(&commit_h)]
+            vec![
+                direct(&commit_g),
+                indirect_n(&commit_d, 2), // J→i→e→D: 2 hidden (i and e).
+                indirect_n(&commit_h, 1), // J→i→H: 1 hidden (i).
+            ]
         );
-        assert_eq!(commits[1].1, vec![indirect(&commit_d), indirect(&commit_a)]);
+        assert_eq!(
+            commits[1].1,
+            vec![
+                indirect_n(&commit_d, 1), // H→f→D: 1 hidden (f).
+                indirect_n(&commit_a, 2), // H→f→c→A: 2 hidden (f and c).
+            ]
+        );
     }
-    assert_eq!(commits[2].1, vec![indirect(&commit_a)]);
-    assert_eq!(commits[3].1, vec![indirect(&commit_a)]);
+    // G→b→A: 1 hidden (b).
+    assert_eq!(commits[2].1, vec![indirect_n(&commit_a, 1)]);
+    // D→b→A: 1 hidden (b).
+    assert_eq!(commits[3].1, vec![indirect_n(&commit_a, 1)]);
     assert_eq!(commits[4].1, vec![missing(&root_commit)]);
+}
+
+#[test_case(false; "keep transitive edges")]
+#[test_case(true; "skip transitive edges")]
+fn test_graph_iterator_crossed_ancestry(skip_transitive_edges: bool) {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    // Tests that the elided count is not inflated when a hidden commit is
+    // reachable via multiple distinct hidden paths to the same visible ancestor.
+    //
+    // b1 is a parent of both c1 and c3, so d reaches a via three paths:
+    //   f→e1→d→c1→b1→a
+    //   f→e1→d→c1→b2→a
+    //   f→e1→d→c3→b1→a
+    //
+    //   f                f
+    //   |                |
+    //   e1               :
+    //   |           =>   :  (6 hidden: e1, d, c1, c3, b1, b2)
+    //   d                :
+    //  / \               :
+    // c1  c3             a
+    // |\ /               ~
+    // b2 b1
+    //  \/
+    //   a
+    //   |
+    //  root
+    let mut tx = repo.start_transaction();
+    let commit_a = write_random_commit(tx.repo_mut());
+    let commit_b1 = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
+    let commit_b2 = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
+    let commit_c1 =
+        write_random_commit_with_parents(tx.repo_mut(), &[&commit_b1, &commit_b2]);
+    let commit_c3 = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b1]);
+    let commit_d =
+        write_random_commit_with_parents(tx.repo_mut(), &[&commit_c1, &commit_c3]);
+    let commit_e1 = write_random_commit_with_parents(tx.repo_mut(), &[&commit_d]);
+    let commit_f = write_random_commit_with_parents(tx.repo_mut(), &[&commit_e1]);
+    let repo = tx.commit("test").block_on().unwrap();
+    let root_commit = repo.store().root_commit();
+
+    let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_f]);
+    let commits: Vec<_> = revset
+        .iter_graph_impl(skip_transitive_edges)
+        .try_collect()
+        .unwrap();
+    assert_eq!(commits.len(), 2);
+    assert_eq!(commits[0].0, *commit_f.id());
+    assert_eq!(commits[1].0, *commit_a.id());
+    // 6 distinct hidden commits between f and a: e1, d, c1, c3, b1, b2.
+    // b1 appears on two hidden paths (via c1 and via c3); it must be
+    // counted once, not once per path.
+    assert_eq!(commits[0].1, vec![indirect_n(&commit_a, 6)]);
+    assert_eq!(commits[1].1, vec![missing(&root_commit)]);
 }

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -31,6 +31,7 @@ use jj_lib::fileset::FilesetAliasesMap;
 use jj_lib::fileset::FilesetExpression;
 use jj_lib::git;
 use jj_lib::graph::GraphEdge;
+use jj_lib::graph::GraphEdgeType;
 use jj_lib::graph::reverse_graph;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::merge::Merge;
@@ -5188,7 +5189,10 @@ fn test_reverse_graph() {
     assert_eq!(commits[4].0, *commit_f.id());
     assert_eq!(
         commits[0].1,
-        vec![GraphEdge::indirect(commit_c.id().clone())]
+        vec![GraphEdge {
+            target: commit_c.id().clone(),
+            edge_type: GraphEdgeType::Indirect(1),
+        }]
     );
     assert_eq!(
         commits[1].1,


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

My attempt to address #3099

## Notes

This PR serves as a research point to address counting elided revisions, it's currently focuses on being *correct*, more than being *fast*, because there's edge cases difficult to count, as anticipated by reviewers.

### ⚠️ Significant regressions

Using benches from https://github.com/jj-vcs/jj/pull/9025 (against e2ea896b5621c388b142580e7bff99f7988da8a7)

### linear_chain

| Input size | Time (mean) ; lower is better | Change vs. baseline ; lower is better |
| ---------- | ------------------------------ | -------------------------------------- |
| 100 | 18.856 µs | **+168.78%** |
| 1000 | 198.26 µs | **+157.01%** |

### diamond_staircase

| Variant | Time (mean) ; lower is better | Change vs. baseline ; lower is better |
| ------- | ------------------------------ | -------------------------------------- |
| d200_w2 | 126.35 µs | **+73.06%** |
| d100_w4 | 107.31 µs | **+102.83%** |
| d40_w10 | 96.755 µs | **+131.74%** |

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
