### PR TITLE
bisect: show remaining revisions and estimated steps during `bisect run`

### DIFF
--- a/cli/src/commands/bisect/run.rs
+++ b/cli/src/commands/bisect/run.rs
@@ -132,7 +132,13 @@ pub(crate) fn cmd_bisect_run(
                 {
                     let mut formatter = ui.stdout_formatter();
                     // TODO: Show a graph of the current range instead?
-                    // TODO: Say how many commits are left and estimate the number of iterations.
+                    let remaining = bisector.remaining_count()?;
+                    let steps = ((remaining + 1) as f64).log2().ceil() as usize;
+                    writeln!(
+                        formatter,
+                        "Bisecting: {remaining} revisions left to test after this (roughly \
+                         {steps} steps)"
+                    )?;
                     let commit_template = workspace_command.commit_summary_template();
                     write!(formatter, "Now evaluating: ")?;
                     commit_template.format(&commit, formatter.as_mut())?;

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -68,11 +68,13 @@ fn test_bisect_run() {
     create_commit(&work_dir, "f", &["e"]);
 
     std::fs::write(&bisection_script, ["fail"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
     The revision is bad.
 
+    Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is bad.
@@ -145,11 +147,13 @@ fn test_bisect_run_find_first_good() {
     create_commit(&work_dir, "e", &["d"]);
     create_commit(&work_dir, "f", &["e"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", &bisector_path]), @r"
+    Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
     The revision is good.
 
+    Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is good.
@@ -196,7 +200,8 @@ fn test_bisect_run_missing_bisector() {
 
     let output = work_dir.run_jj(["bisect", "run", "--range=..", "nonexistent"]);
     if cfg!(unix) {
-        insta::assert_snapshot!(output, @"
+        insta::assert_snapshot!(output, @r"
+        Bisecting: 5 revisions left to test after this (roughly 3 steps)
         Now evaluating: royxmykx dffaa0d4 c | c
         [EOF]
         ------- stderr -------
@@ -210,6 +215,7 @@ fn test_bisect_run_missing_bisector() {
         ");
     } else if cfg!(windows) {
         insta::assert_snapshot!(output, @"
+        Bisecting: 5 revisions left to test after this (roughly 3 steps)
         Now evaluating: royxmykx dffaa0d4 c | c
         [EOF]
         ------- stderr -------
@@ -239,15 +245,18 @@ fn test_bisect_run_with_args() {
     create_commit(&work_dir, "e", &["d"]);
     create_commit(&work_dir, "f", &["e"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--", &bisector_path, "--require-file=c"]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", "--find-good", "--", &bisector_path, "--require-file=c"]), @r"
+    Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
     The revision is good.
 
+    Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is bad.
 
+    Bisecting: 1 revisions left to test after this (roughly 1 steps)
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
     The revision is bad.
@@ -299,11 +308,13 @@ fn test_bisect_run_crash() {
 
     // bisector crash is equivalent to a failure
     std::fs::write(&bisection_script, ["crash"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    Bisecting: 5 revisions left to test after this (roughly 3 steps)
     Now evaluating: royxmykx dffaa0d4 c | c
     fake-bisector testing commit dffaa0d4daccf6cee70bac3498fae3b3fd5d6b5b
     The revision is bad.
 
+    Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is bad.
@@ -337,7 +348,8 @@ fn test_bisect_run_abort() {
 
     // stop immediately on failure
     std::fs::write(&bisection_script, ["abort"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     Evaluation command returned 127 (command not found) - aborting bisection.
@@ -368,7 +380,8 @@ fn test_bisect_run_skip() {
     create_commit(&work_dir, "b", &["a"]);
 
     std::fs::write(&bisection_script, ["skip"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    Bisecting: 1 revisions left to test after this (roughly 1 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     It could not be determined if the revision is good or bad.
@@ -399,11 +412,13 @@ fn test_bisect_run_multiple_results() {
     create_commit(&work_dir, "c", &["a"]);
     create_commit(&work_dir, "d", &["c"]);
 
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=a|b|c|d", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=a|b|c|d", &bisector_path]), @r"
+    Bisecting: 2 revisions left to test after this (roughly 2 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is good.
 
+    Bisecting: 1 revisions left to test after this (roughly 1 steps)
     Now evaluating: royxmykx 991a7501 c | c
     fake-bisector testing commit 991a7501d660abb6a80e8b00f77c651d76d845d7
     The revision is good.
@@ -444,11 +459,13 @@ fn test_bisect_run_write_file() {
         ["write new-file\nsome contents", "fail"].join("\0"),
     )
     .unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    Bisecting: 4 revisions left to test after this (roughly 3 steps)
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
     The revision is bad.
 
+    Bisecting: 1 revisions left to test after this (roughly 1 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is bad.
@@ -507,11 +524,13 @@ fn test_bisect_run_jj_command() {
     create_commit(&work_dir, "e", &["d"]);
 
     std::fs::write(&bisection_script, ["jj new -mtesting", "fail"].join("\0")).unwrap();
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
+    Bisecting: 4 revisions left to test after this (roughly 3 steps)
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
     The revision is bad.
 
+    Bisecting: 1 revisions left to test after this (roughly 1 steps)
     Now evaluating: rlvkpnrz 7d980be7 a | a
     fake-bisector testing commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
     The revision is bad.

--- a/lib/src/bisect.rs
+++ b/lib/src/bisect.rs
@@ -177,27 +177,34 @@ impl<'repo> Bisector<'repo> {
         &self.skipped_commits
     }
 
+    fn candidates(&self) -> Arc<ResolvedRevsetExpression> {
+        let good_expr = RevsetExpression::commits(self.good_commits.iter().cloned().collect());
+        let bad_expr = RevsetExpression::commits(self.bad_commits.iter().cloned().collect());
+        let skipped_expr =
+            RevsetExpression::commits(self.skipped_commits.iter().cloned().collect());
+
+        self.input_range
+            .intersection(&good_expr.heads().range(&bad_expr.roots()))
+            .minus(&bad_expr)
+            .minus(&skipped_expr)
+    }
+
+    /// Returns the number of remaining candidate commits to evaluate.
+    pub fn remaining_count(&self) -> Result<usize, BisectionError> {
+        Ok(self.candidates().evaluate(self.repo)?.iter().count())
+    }
+
     /// Find the next commit to evaluate, or determine that there are no more
     /// steps.
     pub fn next_step(&mut self) -> Result<NextStep, BisectionError> {
         if self.aborted {
             return Ok(NextStep::Done(BisectionResult::Abort));
         }
-        let good_expr = RevsetExpression::commits(self.good_commits.iter().cloned().collect());
-        let bad_expr = RevsetExpression::commits(self.bad_commits.iter().cloned().collect());
-        let skipped_expr =
-            RevsetExpression::commits(self.skipped_commits.iter().cloned().collect());
         // Intersect the input range with the current bad range and then bisect it to
         // find the next commit to evaluate.
         // Skipped revisions are simply subtracted from the set.
         // TODO: Handle long ranges of skipped revisions better
-        let to_evaluate_expr = self
-            .input_range
-            .intersection(&good_expr.heads().range(&bad_expr.roots()))
-            .minus(&bad_expr)
-            .minus(&skipped_expr)
-            .bisect()
-            .latest(1);
+        let to_evaluate_expr = self.candidates().bisect().latest(1);
         let to_evaluate_set = to_evaluate_expr.evaluate(self.repo)?;
         if let Some(commit) = to_evaluate_set
             .iter()
@@ -207,6 +214,7 @@ impl<'repo> Bisector<'repo> {
         {
             Ok(NextStep::Evaluate(commit))
         } else {
+            let bad_expr = RevsetExpression::commits(self.bad_commits.iter().cloned().collect());
             let bad_roots = bad_expr.roots().evaluate(self.repo)?;
             let bad_commits: Vec<_> = bad_roots.iter().commits(self.repo.store()).try_collect()?;
             if bad_commits.is_empty() {


### PR DESCRIPTION
Fixes #8664

This diff prints a progress line before each evaluation during `bisect run`, showing how many candidate revisions remain and an estimate of how many steps are left, e.g. "Bisecting: 5 revisions left to test after this (roughly 3 steps)". 