### PR TITLE
Detach HEAD of git worktrees if they refer to a moved or deleted branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   creation, fixing issues with "pending delete" semantics leaving lock files
   stuck.
 
+* `jj` now safely detaches the `HEAD` of alternate Git worktrees if their
+  checked-out branch is moved or deleted during Git export.
+
 ## [0.38.0] - 2026-02-04
 
 ### Release highlights


### PR DESCRIPTION
This avoids leaving git worktrees in a somewhat broken state when performing jj operations within the primary git repository.

Assisted-by: Gemini 3.1 Pro via Google Antigravity