### PR TITLE
docs: demystify a little bit change IDs when using the git backend

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -241,9 +241,12 @@ as well as the `.jjconflict-*/` directories, making it look like they
 were added to your working copy. You will probably want to run
 `jj abandon` to get back to the state with the unresolved conflicts.
 
-Change IDs are stored in git commit headers as reverse hex encodings. This is
+When creating or rewriting git commits, change IDs are stored in git commit
+headers as reverse hex encodings. This is
 a non-standard header and is not preserved by all `git` tooling. For example,
 the header is preserved by a `git commit --amend`, but is not preserved through
 a rebase operation. GitHub and other major forges seem to preserve them for the
 most part. This functionality is currently behind a `git.write-change-id-header`
-flag.
+flag. Change IDs of other git commits never touched by `jj` are generated
+deterministically: they match across clones even without any forge or git
+cooperation.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -53,6 +53,8 @@ A change ID is a unique identifier for a [change](#change). They are typically
 16 bytes long and are often randomly generated. By default, `jj log` presents
 them as a sequence of 12 letters in the k-z range, at the beginning of a line.
 These are actually hexadecimal numbers that use "digits" z-k instead of 0-9a-f.
+Change IDs are generally not random when using the git backend, see [git
+compatibility](git-compatibility.md#format-mapping-details) for more details.
 
 ## Change offset
 


### PR DESCRIPTION
glossary.md says that change IDs are "often randomly generated". So I didn't expect to be hit by so much "divergence" when I started to fetch across three different git clones.

FAQ.md warns that interleaving git and jj commands "... may create divergent changes" but I was sticking to `jj git fetch ...` and not using git directly!

jj's ability to preserve change IDs across clones felt annoyingly "magical". I searched an explanation in docs/ but couldn't find one. I also tried to break the magic by using git directly but that failed too. It's only when a search engine found commit 0b6d0a7a753e that things started to make sense.

Add a couple lines in glossary.md and git-compatibility.md to elaborate on top of that commit and clarify the change ID magic for hopefully more users.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
