### PR TITLE
tests: improve formatter coverage

### DIFF
--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -1108,6 +1108,7 @@ mod tests {
             [colors]
             not_bold = { fg = 'red', bg = 'blue', italic = true, underline = true }
             bold_font = { bold = true }
+            stop_bold = { bold = false }
         "});
         let mut output: Vec<u8> = vec![];
         let mut formatter = ColorFormatter::for_config(&mut output, &config, false).unwrap();
@@ -1115,13 +1116,17 @@ mod tests {
         write!(formatter, " not bold ").unwrap();
         formatter.push_label("bold_font");
         write!(formatter, " bold ").unwrap();
+        formatter.push_label("stop_bold");
+        write!(formatter, " stop bold ").unwrap();
+        formatter.pop_label();
+        write!(formatter, " bold again ").unwrap();
         formatter.pop_label();
         write!(formatter, " not bold again ").unwrap();
         formatter.pop_label();
         drop(formatter);
         insta::assert_snapshot!(
             to_snapshot_string(output),
-            @"[3m[4m[38;5;1m[48;5;4m not bold [1m bold [0m[3m[4m[38;5;1m[48;5;4m not bold again [23m[24m[39m[49m[EOF]");
+            @"[3m[4m[38;5;1m[48;5;4m not bold [1m bold [0m[3m[4m[38;5;1m[48;5;4m stop bold [1m bold again [0m[3m[4m[38;5;1m[48;5;4m not bold again [23m[24m[39m[49m[EOF]");
     }
 
     #[test]
@@ -1131,6 +1136,7 @@ mod tests {
             [colors]
             not_dim = { fg = 'red', bg = 'blue', italic = true, underline = true }
             dim_font = { dim = true }
+            stop_dim = { dim = false }
         "});
         let mut output: Vec<u8> = vec![];
         let mut formatter = ColorFormatter::for_config(&mut output, &config, false).unwrap();
@@ -1138,13 +1144,17 @@ mod tests {
         write!(formatter, " not dim ").unwrap();
         formatter.push_label("dim_font");
         write!(formatter, " dim ").unwrap();
+        formatter.push_label("stop_dim");
+        write!(formatter, " stop dim ").unwrap();
+        formatter.pop_label();
+        write!(formatter, " dim again ").unwrap();
         formatter.pop_label();
         write!(formatter, " not dim again ").unwrap();
         formatter.pop_label();
         drop(formatter);
         insta::assert_snapshot!(
             to_snapshot_string(output),
-            @"[3m[4m[38;5;1m[48;5;4m not dim [2m dim [0m[3m[4m[38;5;1m[48;5;4m not dim again [23m[24m[39m[49m[EOF]");
+            @"[3m[4m[38;5;1m[48;5;4m not dim [2m dim [0m[3m[4m[38;5;1m[48;5;4m stop dim [2m dim again [0m[3m[4m[38;5;1m[48;5;4m not dim again [23m[24m[39m[49m[EOF]");
     }
 
     #[test]
@@ -1509,9 +1519,17 @@ mod tests {
         write!(formatter, " inside ").unwrap();
         formatter.pop_label();
         formatter.pop_label();
+        // Matching debug styles are not separated.
+        formatter.push_label("outer");
+        formatter.push_label("inner");
+        write!(formatter, " inside two ").unwrap();
+        formatter.pop_label();
+        formatter.pop_label();
         drop(formatter);
         insta::assert_snapshot!(
-            to_snapshot_string(output), @"[38;5;2m<<outer inner:: inside >>[39m[EOF]");
+            to_snapshot_string(output),
+            @"[38;5;2m<<outer inner:: inside  inside two >>[39m[EOF]",
+        );
     }
 
     #[test]


### PR DESCRIPTION
As discovered by `cargo +nightly llvm-cov --branch --open nextest -p jj-cli formatter::tests::`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
