### PR TITLE
clippy: enable warning for stack frame size, and reduce some of them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,23 @@ jobs:
           components: clippy
       - run: cargo +stable clippy --all-features --workspace --all-targets -- -D warnings
 
+  # TODO: Enable the large-stack-frames lint in Cargo.toml and remove this job
+  # once https://github.com/rust-lang/rust-clippy/pull/16347 is in stable.
+  check-clippy-large-stack-frames:
+    name: check (clippy large stack frames)
+    permissions:
+      checks: write
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: nightly
+          components: clippy
+      - run: cargo +nightly clippy --all-features --workspace --all-targets -- -D clippy::large_stack_frames
+
   check-cargo-deny:
     runs-on: ubuntu-24.04
     strategy:

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -3286,6 +3286,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::large_stack_frames)]
     fn test_list_method() {
         let mut env = TestTemplateEnv::new();
         env.add_keyword("empty", || literal(true));
@@ -3529,6 +3530,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::large_stack_frames)]
     fn test_string_method() {
         let mut env = TestTemplateEnv::new();
         env.add_keyword("description", || literal("description 1".to_owned()));

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_stack_frames)]
+
 use std::path::PathBuf;
 
 mod common;

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+stack-size-threshold = 40000

--- a/lib/src/commit_builder.rs
+++ b/lib/src/commit_builder.rs
@@ -390,7 +390,11 @@ impl DetachedCommitBuilder {
     }
 
     /// Writes new commit and makes it visible in the `mut_repo`.
-    pub async fn write(mut self, mut_repo: &mut MutableRepo) -> BackendResult<Commit> {
+    pub async fn write(self, mut_repo: &mut MutableRepo) -> BackendResult<Commit> {
+        Box::pin(self.write_impl(mut_repo)).await
+    }
+
+    async fn write_impl(mut self, mut_repo: &mut MutableRepo) -> BackendResult<Commit> {
         if self.record_predecessors_in_commit {
             self.commit.predecessors = self.predecessors.clone();
         }

--- a/lib/src/eol.rs
+++ b/lib/src/eol.rs
@@ -200,6 +200,8 @@ mod tests {
 
     use super::*;
 
+    const LONG_BINARY_CONTENT: &[u8] = &[0; 20 << 10];
+
     #[tokio::main(flavor = "current_thread")]
     #[test_case(b"a\n", TargetEol::PassThrough, b"a\n"; "LF text with no EOL conversion")]
     #[test_case(b"a\r\n", TargetEol::PassThrough, b"a\r\n"; "CRLF text with no EOL conversion")]
@@ -313,7 +315,7 @@ mod tests {
       }, b"\r\r\n", b"\r\r\n"; "input output settings binary input with lone CR")]
     #[test_case(TargetEolStrategy {
           eol_conversion_mode: EolConversionMode::Input,
-      }, &[0; 20 << 10], &[0; 20 << 10]; "input settings long binary input")]
+      }, LONG_BINARY_CONTENT, LONG_BINARY_CONTENT; "input settings long binary input")]
     #[test_case(TargetEolStrategy {
           eol_conversion_mode: EolConversionMode::Input,
       }, &test_probe_limit_input_crlf(), &test_probe_limit_input_lf(); "input settings with CRLF on probe boundary")]
@@ -348,7 +350,7 @@ mod tests {
       }, b"\0\n", b"\0\n"; "input output settings binary input")]
     #[test_case(TargetEolStrategy {
           eol_conversion_mode: EolConversionMode::Input,
-      }, &[0; 20 << 10], &[0; 20 << 10]; "input output settings long binary input")]
+      }, LONG_BINARY_CONTENT, LONG_BINARY_CONTENT; "input output settings long binary input")]
     async fn test_eol_strategy_convert_eol_for_update(
         strategy: TargetEolStrategy,
         contents: &[u8],

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_stack_frames)]
+
 use std::path::PathBuf;
 
 #[test]


### PR DESCRIPTION
Without the code changes, the `transform_descendants()` callback in `absorb.rs` was just over 60KB on my architecture. After the changes, it's under 40KB (the limit set in `clippy.toml`). We probably want to try to reduce the limit further, but this is at least a start.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
