### PR TITLE
templater: add 'root' to WorkspecRef template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* `WorkspaceRef` templates now provide a `.root()` method to show the absolute
+  path to each workspace root.
+
 ### Release highlights
 
 ### Breaking changes

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -81,6 +81,10 @@ use jj_lib::signing::Verification;
 use jj_lib::store::Store;
 use jj_lib::trailer;
 use jj_lib::trailer::Trailer;
+use jj_lib::workspace::DefaultWorkspaceLoaderFactory;
+use jj_lib::workspace::WorkspaceLoaderFactory as _;
+use jj_lib::workspace_store::SimpleWorkspaceStore;
+use jj_lib::workspace_store::WorkspaceStore as _;
 use once_cell::unsync::OnceCell;
 use pollster::FutureExt as _;
 use serde::Serialize as _;
@@ -1772,6 +1776,42 @@ impl WorkspaceRef {
     pub fn target(&self) -> &Commit {
         &self.target
     }
+
+    /// Returns the root path of the workspace.
+    fn root(&self, path_converter: &RepoPathUiConverter) -> Result<String, TemplatePropertyError> {
+        let RepoPathUiConverter::Fs { cwd: _, base } = path_converter;
+        // TODO: Stop reconstructing the workspace loader here once we've
+        // decided which object should own the workspace store.
+        let workspace_loader = DefaultWorkspaceLoaderFactory.create(base)?;
+        let repo_path = workspace_loader.repo_path().to_owned();
+        let workspace_store = SimpleWorkspaceStore::load(&repo_path)?;
+        let workspace_path = workspace_store
+            .get_workspace_path(self.name())?
+            .ok_or_else(|| {
+                TemplatePropertyError(
+                    format!(
+                        "Workspace has no recorded path: {}",
+                        self.name().as_symbol()
+                    )
+                    .into(),
+                )
+            })?;
+        let full_path = repo_path.join(workspace_path);
+        let path = dunce::canonicalize(&full_path).map_err(|err| {
+            TemplatePropertyError(
+                format!(
+                    "Failed to resolve workspace root: {}: {}: {err}",
+                    self.name().as_symbol(),
+                    full_path.display()
+                )
+                .into(),
+            )
+        })?;
+        // TODO: Return PathBuf once the templater has a filesystem path type.
+        path.into_os_string()
+            .into_string()
+            .map_err(|_| TemplatePropertyError("Invalid UTF-8 sequence in path".into()))
+    }
 }
 
 impl Template for WorkspaceRef {
@@ -1801,6 +1841,15 @@ fn builtin_workspace_ref_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'rep
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|ws_ref| ws_ref.target);
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
+    map.insert(
+        "root",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let path_converter = language.path_converter;
+            let out_property = self_property.and_then(move |ws_ref| ws_ref.root(path_converter));
             Ok(out_property.into_dyn_wrapped())
         },
     );

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -1605,6 +1605,53 @@ fn test_list_workspaces_template() {
     ");
 }
 
+#[test]
+fn test_list_workspaces_template_root() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir
+        .run_jj(["workspace", "add", "--name", "second", "../secondary"])
+        .success();
+
+    let template = r#"name ++ ": " ++ root ++ "\n""#;
+    let output = main_dir.run_jj(["workspace", "list", "-T", template]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    default: $TEST_ENV/main
+    second: $TEST_ENV/secondary
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_list_workspaces_template_root_unavailable() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "main"]).success();
+    let main_dir = test_env.work_dir("main");
+
+    main_dir
+        .run_jj(["workspace", "add", "--name", "second", "../secondary"])
+        .success();
+    std::fs::remove_dir_all(test_env.env_root().join("secondary")).unwrap();
+
+    let template = r#"name ++ ": " ++ root ++ "\n""#;
+    let output = main_dir
+        .run_jj(["workspace", "list", "-T", template])
+        .normalize_backslash()
+        .normalize_stdout_with(|s| {
+            s.replace(
+                "The system cannot find the file specified.",
+                "No such file or directory",
+            )
+        });
+    insta::assert_snapshot!(output, @"
+    default: $TEST_ENV/main
+    second: <Error: Failed to resolve workspace root: second: $TEST_ENV/main/.jj/repo/../../../secondary: No such file or directory (os error 2)>
+    [EOF]
+    ");
+}
+
 /// Test getting the workspace root from primary and secondary workspaces
 #[test]
 fn test_workspaces_root() {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -699,6 +699,7 @@ The following methods are defined.
 
 * `.name() -> RefSymbol`: Returns the workspace name as a symbol.
 * `.target() -> Commit`: Returns the working-copy commit of this workspace.
+* `.root() -> Template`: Returns the absolute path to the workspace root.
 
 ## Color labels
 


### PR DESCRIPTION
This adds "root" to the WorkspaceRef template type - which returns the absolute path to the workspace root.

I only _barely_ know Rust - so while I wrote all of the code myself, I definitely had some review / debugging assist from my AI buddy.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
