### PR TITLE
cargo: compile all deps in optimized mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,16 +172,12 @@ redundant_imports = "warn"
 # Opt-level 0 tends to run out of stack on Windows when running async code
 opt-level = 1
 
-[profile.dev.package]
-# Insta suggests compiling these packages in opt mode for faster testing.
-# See https://docs.rs/insta/latest/insta/#optional-faster-runs.
-insta.opt-level = 3
-similar.opt-level = 3
-# Proptest suggests compiling itself and its RNG in opt mode as well.
-# See https://proptest-rs.github.io/proptest/proptest/tips-and-best-practices.html#setting-opt-level
-proptest.opt-level = 3
-proptest-state-machine.opt-level = 3
-rand_chacha.opt-level = 3
+[profile.dev.package."*"]
+# Compile all dependencies with opt-level=3 to help speed up tests and
+# debug builds
+codegen-units = 1
+debug = "line-tables-only"
+opt-level = 3
 
 [profile.release]
 strip = "debuginfo"


### PR DESCRIPTION
(Refile of #3447 in light of the changes to set the default `dev` profile to use `opt-level=1`. Now that we don't rely on libgit2, I think compiling in optimized mode by default makes more sense – less need to break out gdb)

---

Only a few of our dependencies are truly performance sensitive for general development iteration, but compiling all of them in optimized mode has a compounding effect. The net result is that when iterating and running the testuite, this change gives me a speedup of 56s -> 41s.

Furthermore, this also removes a lot of debug info from dependencies to help curb growth of the target/ directory and its general tendency to grow infinitely.

It also makes testing my own debug jj builds visibly faster, though I wouldn't call it dramatic.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
