### PR TITLE
cli: make `jj git fetch` documentation clearer

### DIFF
--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -47,8 +47,12 @@ use crate::ui::Ui;
 
 /// Fetch from a Git remote
 ///
-/// If no branches nor tags are specified, the default fetch refspecs are read
-/// from the Git configuration.
+/// If no remotes are specified, fetches the remotes specified by the
+/// `git.fetch` setting. If that is not configured and there are multiple
+/// remotes, the remote named "origin" will be used.
+///
+/// If no branches nor tags are specified, the default fetch refspecs for the
+/// selected remotes are read from the Git configuration.
 ///
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
@@ -100,9 +104,6 @@ pub struct GitFetchArgs {
 
     /// The remote to fetch from (only named remotes are supported, can be
     /// repeated)
-    ///
-    /// This defaults to the `git.fetch` setting. If that is not configured, and
-    /// if there are multiple remotes, the remote named "origin" will be used.
     ///
     /// By default, the specified pattern matches remote names with glob syntax,
     /// e.g. `--remote '*'`. You can also use other [string pattern syntax].

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1623,7 +1623,9 @@ There is no need to run this command if you're in colocated workspace because th
 
 Fetch from a Git remote
 
-If no branches nor tags are specified, the default fetch refspecs are read from the Git configuration.
+If no remotes are specified, fetches the remotes specified by the `git.fetch` setting. If that is not configured and there are multiple remotes, the remote named "origin" will be used.
+
+If no branches nor tags are specified, the default fetch refspecs for the selected remotes are read from the Git configuration.
 
 If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
 
@@ -1642,8 +1644,6 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
    This fetches only bookmarks that are already tracked from the specified remote(s).
 * `--remote <REMOTE>` — The remote to fetch from (only named remotes are supported, can be repeated)
-
-   This defaults to the `git.fetch` setting. If that is not configured, and if there are multiple remotes, the remote named "origin" will be used.
 
    By default, the specified pattern matches remote names with glob syntax, e.g. `--remote '*'`. You can also use other [string pattern syntax].
 


### PR DESCRIPTION
Document the behavior when `--remote` is not specified in the main command documentation, alongside the documentation for the case where `--tag` and `--branch` are not specified. Don't put it in the documentation for the `--remote` flag, since it's not documentation about the behavior of that flag.