### PR TITLE
cli: remove some redundant block_on() calls

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1989,7 +1989,7 @@ to the current parents may contain changes from multiple commits.
             // Rebase descendants
             let num_rebased = mut_repo
                 .rebase_descendants()
-                .block_on()
+                .await
                 .map_err(snapshot_command_error)?;
             if num_rebased > 0 {
                 writeln!(

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -77,7 +77,6 @@ use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::rewrite::rebase_to_dest_parent;
 use jj_lib::settings::UserSettings;
 use jj_lib::store::Store;
-use pollster::FutureExt as _;
 use thiserror::Error;
 use tracing::instrument;
 use unicode_width::UnicodeWidthStr as _;
@@ -488,7 +487,7 @@ impl<'a> DiffRenderer<'a> {
                     let tree_diff = diff_stream();
                     let stats =
                         DiffStats::calculate(store, tree_diff, options, self.conflict_marker_style)
-                            .block_on()?;
+                            .await?;
                     show_diff_stats(formatter, &stats, path_converter, width)?;
                 }
                 DiffFormat::Types => {


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
