### PR TITLE
Revert "revert: allow revisions as positional argument"

### DIFF
--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -45,17 +45,11 @@ use crate::ui::Ui;
 /// `templates.revert_description` config variable.
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(ArgGroup::new("location").args(&["onto", "insert_after", "insert_before"]).multiple(true).required(true)))]
-#[command(group(clap::ArgGroup::new("revisions").multiple(true).required(true)))]
 pub(crate) struct RevertArgs {
     /// The revision(s) to apply the reverse of
-    #[arg(group = "revisions", value_name = "REVSETS")]
+    #[arg(long, short, value_name = "REVSETS", required = true)]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
-    revisions_pos: Vec<RevisionArg>,
-
-    /// The revision(s) to apply the reverse of
-    #[arg(long = "revisions", short, group = "revisions", value_name = "REVSETS")]
-    #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
-    revisions_opt: Vec<RevisionArg>,
+    revisions: Vec<RevisionArg>,
 
     /// The revision(s) to apply the reverse changes on top of
     #[arg(
@@ -101,7 +95,7 @@ pub(crate) async fn cmd_revert(
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper(ui)?;
     let to_revert: Vec<_> = workspace_command
-        .parse_union_revsets(ui, &[&*args.revisions_pos, &*args.revisions_opt].concat())?
+        .parse_union_revsets(ui, &args.revisions)?
         .evaluate_to_commits()?
         .try_collect()?; // in reverse topological order
     if to_revert.is_empty() {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2880,11 +2880,7 @@ The reverse of each of the given revisions is applied sequentially in reverse to
 
 The description of the new revisions can be customized with the `templates.revert_description` config variable.
 
-**Usage:** `jj revert <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>> <REVSETS|--revisions <REVSETS>>`
-
-###### **Arguments:**
-
-* `<REVSETS>` — The revision(s) to apply the reverse of
+**Usage:** `jj revert --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
 
 ###### **Options:**
 

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -50,7 +50,7 @@ fn test_revert() {
     error: the following required arguments were not provided:
       <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
-    Usage: jj revert <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>> <REVSETS|--revisions <REVSETS>>
+    Usage: jj revert --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -236,8 +236,8 @@ fn test_revert_multiple() {
     [EOF]
     ");
 
-    // Revert multiple commits (mix of positional and named revision args)
-    let output = work_dir.run_jj(["revert", "b", "-rc", "e", "-d@"]);
+    // Revert multiple commits
+    let output = work_dir.run_jj(["revert", "-rb", "-rc", "-re", "-d@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 3 commits as follows:


### PR DESCRIPTION
This reverts commit 4dc6323bfd0edf253f5c16e3760fe91dc17323cb.

There's talk about maybe making the command accept paths, so let's revert this at least for now so it's not part of the next release. That way we have more time to think about it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
