### PR TITLE
arrange: use separate templates.arrange config instead of commit_summary

### DIFF
--- a/cli/src/commands/arrange.rs
+++ b/cli/src/commands/arrange.rs
@@ -124,12 +124,14 @@ pub(crate) async fn cmd_arrange(
     let mut state = State::new(commits, external_children);
     state.update_commit_order();
 
-    let result = run_tui(
-        ui,
-        &mut terminal,
-        &workspace_command.commit_summary_template(),
-        state,
-    );
+    let template_string = workspace_command
+        .settings()
+        .get_string("templates.arrange")?;
+    let template = workspace_command
+        .parse_commit_template(ui, &template_string)?
+        .labeled(["commit"]);
+
+    let result = run_tui(ui, &mut terminal, template, state);
 
     // Restore the terminal
     disable_raw_mode()?;
@@ -381,7 +383,7 @@ impl RewritePlan {
 fn run_tui<B: ratatui::backend::Backend>(
     ui: &mut Ui,
     terminal: &mut Terminal<B>,
-    template: &TemplateRenderer<Commit>,
+    template: TemplateRenderer<Commit>,
     mut state: State,
 ) -> Result<Option<State>, CommandError> {
     let help_items = [
@@ -413,7 +415,7 @@ fn run_tui<B: ratatui::backend::Backend>(
                     .split(frame.area());
                 let main_area = layout[0];
                 let help_area = layout[1];
-                render(&state, ui, template, frame, main_area);
+                render(&state, ui, &template, frame, main_area);
                 frame.render_widget(&help_line, help_area);
             })
             .map_err(|e| internal_error(format!("Failed to draw TUI: {e}")))?;

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -49,7 +49,10 @@
                     "default": "diff"
                 },
                 "command": {
-                    "type": ["string", "array"],
+                    "type": [
+                        "string",
+                        "array"
+                    ],
                     "minItems": 1,
                     "items": {
                         "type": "string"
@@ -306,18 +309,21 @@
             "properties": {
                 "backend": {
                     "type": "string",
-                    "enum": ["none", "watchman"],
+                    "enum": [
+                        "none",
+                        "watchman"
+                    ],
                     "default": "none",
                     "description": "Whether to use an external filesystem monitor, useful for large repos"
                 },
                 "watchman": {
                     "type": "object",
                     "properties": {
-                      "register-snapshot-trigger": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Whether to use triggers to monitor for changes in the background."
-                      }
+                        "register-snapshot-trigger": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Whether to use triggers to monitor for changes in the background."
+                        }
                     }
                 }
             }
@@ -356,17 +362,17 @@
                     "pattern": "^#[0-9a-fA-F]{6}$"
                 },
                 "colors": {
-                  "oneOf": [
-                    {
-                        "$ref": "#/properties/colors/definitions/colorNames"
-                    },
-                    {
-                        "$ref": "#/properties/colors/definitions/ansi256Color"
-                    },
-                    {
-                        "$ref": "#/properties/colors/definitions/hexColor"
-                    }
-                  ]
+                    "oneOf": [
+                        {
+                            "$ref": "#/properties/colors/definitions/colorNames"
+                        },
+                        {
+                            "$ref": "#/properties/colors/definitions/ansi256Color"
+                        },
+                        {
+                            "$ref": "#/properties/colors/definitions/hexColor"
+                        }
+                    ]
                 }
             },
             "additionalProperties": {
@@ -596,20 +602,22 @@
                             "type": "integer"
                         },
                         "description": "Array of exit codes that do not indicate tool failure, i.e. [0, 1] for unix diff.",
-                        "default": [0]
+                        "default": [
+                            0
+                        ]
                     },
                     "diff-do-chdir": {
-                      "type": "boolean",
-                      "description": "Invoke the tool in the temporary diff directory. This setting will be removed soon",
-                      "default": true
+                        "type": "boolean",
+                        "description": "Invoke the tool in the temporary diff directory. This setting will be removed soon",
+                        "default": true
                     },
                     "diff-invocation-mode": {
-                      "description": "Invoke the tool with directories or individual files",
-                      "enum": [
-                        "dir",
-                        "file-by-file"
-                      ],
-                      "default": "dir"
+                        "description": "Invoke the tool with directories or individual files",
+                        "enum": [
+                            "dir",
+                            "file-by-file"
+                        ],
+                        "default": "dir"
                     },
                     "edit-args": {
                         "type": "array",
@@ -777,7 +785,12 @@
             "properties": {
                 "backend": {
                     "type": "string",
-                    "enum": ["gpg", "gpgsm", "none", "ssh"],
+                    "enum": [
+                        "gpg",
+                        "gpgsm",
+                        "none",
+                        "ssh"
+                    ],
                     "description": "The backend to use for signing commits. The string `none` disables signing.",
                     "default": "none"
                 },
@@ -787,7 +800,12 @@
                 },
                 "behavior": {
                     "type": "string",
-                    "enum": ["drop", "keep", "own", "force"],
+                    "enum": [
+                        "drop",
+                        "keep",
+                        "own",
+                        "force"
+                    ],
                     "description": "Which commits to sign by default. Values: drop (never sign), keep (preserve existing signatures), own (sign own commits), force (sign all commits)"
                 },
                 "backends": {
@@ -908,6 +926,10 @@
             "type": "object",
             "description": "Definitions for the templates that various jj commands use",
             "properties": {
+                "arrange": {
+                    "type": "string",
+                    "description": "`jj arrange``'s template for commits in the main view"
+                },
                 "bookmark_list": {
                     "type": "string",
                     "description": "`jj bookmark list`'s output"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -2,6 +2,7 @@
 bookmark_list = 'format_commit_ref(self, "bookmark") ++ "\n"'
 
 commit_summary = 'format_commit_summary_with_refs(self, bookmarks)'
+arrange = 'format_commit_summary_with_refs(self, bookmarks)'
 
 file_annotate = '''
 join(" ",


### PR DESCRIPTION
My main motivation for this is
https://github.com/ratatui/ansi-to-tui/issues/82. Until that's fixed, any hyperlinks are invisible, and it seems like the rest of the line is also invisible. We have an overridden `templates.commit_summary` at Google that includes a hyperlink.

I think this is a good change even once that limitation has been fixed in `ansi-to-tui` because it seems reasonable to want to use a different template in the TUI. In particular, perhaps one would prefer to not include the commit ID since they no longer are correct after changes are made in the UI.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
