### PR TITLE
cli: reject private commits in `jj gerrit upload`

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -36,6 +36,7 @@ use jj_lib::trailer::parse_description_trailers;
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
 use crate::cli_util::short_change_hash;
+use crate::cli_util::short_commit_hash;
 use crate::command_error::CommandError;
 use crate::command_error::internal_error;
 use crate::command_error::user_error;
@@ -93,6 +94,11 @@ pub struct UploadArgs {
     /// Do not actually push the changes to Gerrit
     #[arg(long = "dry-run", short = 'n')]
     dry_run: bool,
+
+    /// Allow uploading commits that are configured as private in
+    /// `git.private-commits`
+    #[arg(long)]
+    allow_private: bool,
 
     // The following flags are options Gerrit supports during upload.
     // They are documented at
@@ -447,6 +453,34 @@ pub async fn cmd_gerrit_upload(
         )
         .evaluate_to_commits()?
         .try_collect()?;
+
+    // Check for private commits
+    if !args.allow_private {
+        let settings = workspace_command.settings();
+        let private_revset_str = RevisionArg::from(settings.get_string("git.private-commits")?);
+        let is_private = workspace_command
+            .parse_revset(ui, &private_revset_str)?
+            .evaluate()?
+            .containing_fn();
+
+        for commit in &to_upload {
+            if is_private(commit.id())? {
+                let mut error = user_error(format!(
+                    "Won't upload commit {} since it is private",
+                    short_commit_hash(commit.id())
+                ));
+                error.add_formatted_hint_with(|formatter| {
+                    write!(formatter, "Rejected commit: ")?;
+                    workspace_command.write_commit_summary(formatter, commit)?;
+                    Ok(())
+                });
+                error.add_hint(format!(
+                    "Configured git.private-commits: '{private_revset_str}'",
+                ));
+                return Err(error);
+            }
+        }
+    }
 
     // Note: This transaction is intentionally never finished. This way, the
     // Change-Id is never part of the commit description in jj.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1437,6 +1437,7 @@ Note: this command takes 1-or-more revsets arguments, each of which can resolve 
 
    Can be configured with the `gerrit.default-remote` repository option as well. This is typically a full SSH URL for your Gerrit instance.
 * `-n`, `--dry-run` — Do not actually push the changes to Gerrit
+* `--allow-private` — Allow uploading commits that are configured as private in `git.private-commits`
 * `--reviewer <REVIEWER>` — Add these emails as a reviewer (can be repeated)
 * `--cc <CC>` — CC these emails on the change (can be repeated)
 * `-l`, `--label <LABEL>` — Add the following labels configured by Gerrit (can be repeated)

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -832,3 +832,68 @@ fn test_gerrit_upload_rejected_by_remote() {
     [exit status: 1]
     ");
 }
+
+#[test]
+fn test_gerrit_upload_private_commits_blocked() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "remote"])
+        .success();
+    let remote_dir = test_env.work_dir("remote");
+    create_commit(&remote_dir, "a", &[]);
+    test_env
+        .run_jj_in(".", ["git", "clone", "remote", "local"])
+        .success();
+    test_env.add_config(r#"gerrit.default-remote="origin""#);
+    test_env.add_config(r#"gerrit.default-remote-branch="main""#);
+    let local_dir = test_env.work_dir("local");
+
+    test_env.add_config(r#"git.private-commits = "description('private*')""#);
+    create_commit(&local_dir, "private-stuff", &["a@origin"]);
+
+    let output = local_dir.run_jj(["gerrit", "upload", "-r", "@", "--dry-run"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Won't upload commit 6450da38ac8d since it is private
+    Hint: Rejected commit: mzvwutvl 6450da38 private-stuff | private-stuff
+    Hint: Configured git.private-commits: 'description('private*')'
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_gerrit_upload_allow_private_override() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "remote"])
+        .success();
+    let remote_dir = test_env.work_dir("remote");
+    create_commit(&remote_dir, "a", &[]);
+    test_env
+        .run_jj_in(".", ["git", "clone", "remote", "local"])
+        .success();
+    test_env.add_config(r#"gerrit.default-remote="origin""#);
+    test_env.add_config(r#"gerrit.default-remote-branch="main""#);
+    let local_dir = test_env.work_dir("local");
+
+    test_env.add_config(r#"git.private-commits = "description('private*')""#);
+    create_commit(&local_dir, "private-stuff", &["a@origin"]);
+
+    // With --allow-private, the private commit check should be skipped.
+    // The command may fail later (e.g. during push), but not on the private check.
+    let output = local_dir.run_jj([
+        "gerrit",
+        "upload",
+        "-r",
+        "@",
+        "--dry-run",
+        "--allow-private",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
+    Dry-run: Would push mzvwutvl 6450da38 private-stuff | private-stuff
+    [EOF]
+    ");
+}


### PR DESCRIPTION
Closes https://github.com/jj-vcs/jj/issues/9019

There is a minor hitch with this, though. When I whipped this up, I chose `--allow-private` for an escape hatch flag, taken from `jj git push --allow-private`. But we just added `--private` *for Gerrit* in https://github.com/jj-vcs/jj/pull/8445 which leads to a case like `jj gerrit upload --allow-private --private` or `--allow-private --remove-private`

Which I think is a bit of a mouthful, and really badly worded. but both of these makes sense. What do we think about this? I wonder if perhaps we should not add a new option, but the newly existing `--private` should instead be the escape hatch?

---

**Disclosure**: This change was generated by Claude Code, Opus 4.6. I figured it was a good example of an extremely small change that was directed and would only take it a minute or two. ~~As a result, I have set the `Author` field for Claude, though I think this change is so trivially straightforward there's really nothing special about it.~~ UPDATE: In yet another technical FUBAR from the silly CLA bot, I cannot actually set the author field of the commit as Claude, otherwise it gets pissed off. So let the record here show that I tried to do what I thought was right. :/

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
