### PR TITLE
cli: fix a silly formatting issue in 'jj new'

### DIFF
--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -134,7 +134,7 @@ pub(crate) struct NewArgs {
     /// Example: `jj new --insert-after A --insert-before D`:
     ///
     /// ```text
-    /// 
+    ///
     ///     D            D
     ///     |           / \
     ///     C          |   C


### PR DESCRIPTION
This might be a rust nightly change? I'm not sure. Either way 'cargo fmt' spat this out.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
