### PR TITLE
templates: extract a function for formatting refs

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -1,8 +1,8 @@
 [templates]
 bookmark_list = 'format_commit_ref(self, "bookmark") ++ "\n"'
 
-commit_summary = 'format_commit_summary_with_refs(self, bookmarks)'
-arrange = 'format_commit_summary_with_refs(self, bookmarks)'
+commit_summary = 'format_commit_summary_with_refs(self, format_commit_ref_names(bookmarks))'
+arrange = 'format_commit_summary_with_refs(self, format_commit_ref_names(bookmarks))'
 
 file_annotate = '''
 join(" ",
@@ -48,7 +48,7 @@ workspace_list = '''
 concat(
   name,
   ": ",
-  format_commit_summary_with_refs(target, target.bookmarks()),
+  format_commit_summary_with_refs(target, format_commit_ref_names(target.bookmarks())),
   "\n",
 )
 '''
@@ -371,6 +371,8 @@ label("immutable",
   ) ++ "\n"
 )
 '''
+
+'format_commit_ref_names(refs)' = 'refs'
 
 'format_commit_ref(ref, type)' = '''
 if(ref.remote(),


### PR DESCRIPTION
`format_commit_summary_with_refs(commit, refs)` expects the second argument to be a `Template`. We sometimes pass a `List<CommitRef>` and sometimes `String`, which both can be converted to `Template`. However, that makes it not possible to override `format_commit_summary_with_refs(commit, refs)` and e.g. linkify some bookmarks. This fixes that by doing the formatting outside before calling the function, in a separate new function.

Closes #9017

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
