### PR TITLE
bench: Add benchmarks for revset graph

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,6 +29,10 @@ name = "runner"
 name = "diff_bench"
 harness = false
 
+[[bench]]
+name = "revset_graph_bench"
+harness = false
+
 [dependencies]
 async-trait = { workspace = true }
 blake2 = { workspace = true }
@@ -91,7 +95,7 @@ testutils = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = { workspace = true, features = [ "fs" ] }
+nix = { workspace = true, features = ["fs"] }
 
 [features]
 default = ["git"]

--- a/lib/benches/revset_graph_bench.rs
+++ b/lib/benches/revset_graph_bench.rs
@@ -1,0 +1,126 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Benchmarks for the revset graph iteration pipeline, approximating the cost
+//! of `jj log` (excluding template rendering). Each benchmark iteration covers
+//! revset evaluation and topo-grouped graph traversal — the two phases `jj log`
+//! runs before rendering each commit.
+
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use itertools::Itertools as _;
+use jj_lib::graph::TopoGroupedGraphIterator;
+use jj_lib::revset::RevsetExpression;
+use pollster::FutureExt as _;
+use testutils::TestRepo;
+use testutils::write_random_commit;
+use testutils::write_random_commit_with_parents;
+
+/// Benchmark over a long linear chain of hidden commits.
+///
+/// Graph shape (N = chain length):
+///
+///   tip (visible)
+///    |
+///   [N hidden commits]
+///    |
+///   root (visible)
+///
+/// This exercises `edges_from_external_commit` (two-phase BFS) and
+/// `count_hidden_to_visible` (the elided-count BFS) over a deep linear path.
+fn bench_linear_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("revset_graph/linear_chain");
+    for &n in &[100usize, 1_000] {
+        // Build the repo once outside the measurement loop.
+        let test_repo = TestRepo::init();
+        let mut tx = test_repo.repo.start_transaction();
+        let root_visible = write_random_commit(tx.repo_mut());
+        let mut prev = root_visible.clone();
+        for _ in 0..n {
+            prev = write_random_commit_with_parents(tx.repo_mut(), &[&prev]);
+        }
+        let tip_visible = write_random_commit_with_parents(tx.repo_mut(), &[&prev]);
+        let repo = tx.commit("bench").block_on().unwrap();
+
+        let expression =
+            RevsetExpression::commits(vec![root_visible.id().clone(), tip_visible.id().clone()]);
+
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let revset = expression.clone().evaluate(repo.as_ref()).unwrap();
+                TopoGroupedGraphIterator::new(revset.iter_graph(), |id| id)
+                    .try_collect::<_, Vec<_>, _>()
+                    .unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Benchmark over a staircase of diamond-shaped hidden subgraphs.
+///
+/// Graph shape for D=2 layers, W=3 branches (all intermediate commits hidden):
+///
+///   tip  (visible)
+///    |
+///  merge_1  (hidden)
+///  / | \
+/// b0 b1 b2  (hidden)
+///  \ | /
+///  merge_0  (hidden)
+///  / | \
+/// b0 b1 b2  (hidden)
+///  \ | /
+///   root  (visible)
+///
+/// Parameterized by D (depth = number of diamond layers) and W (width =
+/// branches per layer).
+fn bench_diamond_staircase(c: &mut Criterion) {
+    let mut group = c.benchmark_group("revset_graph/diamond_staircase");
+    // (depth, width): depth = number of diamond layers, width = branches per layer
+    for &(depth, width) in &[(200usize, 2usize), (100, 4), (40, 10)] {
+        let test_repo = TestRepo::init();
+        let mut tx = test_repo.repo.start_transaction();
+        let root_visible = write_random_commit(tx.repo_mut());
+        let mut base = root_visible.clone();
+        for _ in 0..depth {
+            let branches: Vec<_> = (0..width)
+                .map(|_| write_random_commit_with_parents(tx.repo_mut(), &[&base]))
+                .collect();
+            let branch_refs: Vec<&_> = branches.iter().collect();
+            base = write_random_commit_with_parents(tx.repo_mut(), &branch_refs);
+        }
+        let tip_visible = write_random_commit_with_parents(tx.repo_mut(), &[&base]);
+        let repo = tx.commit("bench").block_on().unwrap();
+
+        let expression =
+            RevsetExpression::commits(vec![root_visible.id().clone(), tip_visible.id().clone()]);
+
+        let label = format!("d{depth}_w{width}");
+        group.bench_with_input(BenchmarkId::from_parameter(&label), &label, |b, _| {
+            b.iter(|| {
+                let revset = expression.clone().evaluate(repo.as_ref()).unwrap();
+                TopoGroupedGraphIterator::new(revset.iter_graph(), |id| id)
+                    .try_collect::<_, Vec<_>, _>()
+                    .unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_linear_chain, bench_diamond_staircase);
+criterion_main!(benches);


### PR DESCRIPTION
This adds simple, isolated and reproducible benchmarks for revsets.

## Context

- While working on https://github.com/jj-vcs/jj/pull/8968 ; performance was mentioned, as well as trying impacts on big repositories such as linux.

Cloning a big repository to test performance is cumbersome, difficult to compare baseline for, and not intuitive.

From what I understand, `jj bench log` is what's used right now by jj developers, with https://github.com/jj-vcs/jj/blob/main/cli/testing/bench-revsets-git.txt being a suggestion of revset to pass to. This file is regularly outdated so using it wasn't very fun.

## Details on this PR

- This builds on what exists on this repository, within `lib/benches`. It seems a bit underused/old, but still on the repository so I'm hopeful that the design is still relevant.
- No additional dependencies
- Small by design, I want a baseline performance comparison for future discussions on https://github.com/jj-vcs/jj/pull/8968, or other topics.
- Future possibilities: This is a simpler setup to run on a CI: `cargo bench`

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [x] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
