### PR TITLE
docs: move misplaced changelog entry about diff_lines_*() revsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* New `diff_lines_added()` and `diff_lines_removed()` revset functions for
+  matching content on only one side of a diff.
+
 ### Fixed bugs
 
 ## [0.39.0] - 2026-03-04
@@ -120,9 +123,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Templates now support `Serialize` operations on the result of `map()` and
   `if()`, when supported by the underlying type.
-
-* New `diff_lines_added()` and `diff_lines_removed()` revset functions for
-  matching content on only one side of a diff.
 
 * `jj bookmark rename` now supports `--overwrite-existing` to allow renaming a
   bookmark even if the new name already exists, effectively replacing the


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
