### PR TITLE
templating: Make `end` optional in `substr()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `diff_lines_added()` and `diff_lines_removed()` revset functions for
   matching content on only one side of a diff.
 
+* The `end` parameter in the `String.substr(start, end)` templating method is
+  now optional. If not given, `substr()` returns from `start` to the end of the
+  string.
+
 ### Fixed bugs
 
 ## [0.39.0] - 2026-03-04

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -1080,15 +1080,27 @@ fn builtin_string_methods<'a, L: TemplateLanguage<'a> + ?Sized>()
     map.insert(
         "substr",
         |language, diagnostics, build_ctx, self_property, function| {
-            let [start_idx, end_idx] = function.expect_exact_arguments()?;
+            let ([start_idx], [end_idx]) = function.expect_arguments()?;
             let start_idx_property =
                 expect_isize_expression(language, diagnostics, build_ctx, start_idx)?;
-            let end_idx_property =
-                expect_isize_expression(language, diagnostics, build_ctx, end_idx)?;
+            let end_idx_property = if let Some(end_idx) = end_idx {
+                Some(expect_isize_expression(
+                    language,
+                    diagnostics,
+                    build_ctx,
+                    end_idx,
+                )?)
+            } else {
+                None
+            };
             let out_property = (self_property, start_idx_property, end_idx_property).map(
                 |(s, start_idx, end_idx)| {
                     let start_idx = string_index_to_char_boundary(&s, start_idx);
-                    let end_idx = string_index_to_char_boundary(&s, end_idx);
+                    let end_idx = if let Some(idx) = end_idx {
+                        string_index_to_char_boundary(&s, idx)
+                    } else {
+                        s.len()
+                    };
                     s.get(start_idx..end_idx).unwrap_or_default().to_owned()
                 },
             );
@@ -3659,10 +3671,15 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#""foo".substr(0, 1)"#), @"f");
         insta::assert_snapshot!(env.render_ok(r#""foo".substr(0, 3)"#), @"foo");
         insta::assert_snapshot!(env.render_ok(r#""foo".substr(0, 4)"#), @"foo");
+        insta::assert_snapshot!(env.render_ok(r#""foo".substr(1, 3)"#), @"oo");
+        insta::assert_snapshot!(env.render_ok(r#""foo".substr(1)"#), @"oo");
+        insta::assert_snapshot!(env.render_ok(r#""foo".substr(0)"#), @"foo");
         insta::assert_snapshot!(env.render_ok(r#""abcdef".substr(2, -1)"#), @"cde");
         insta::assert_snapshot!(env.render_ok(r#""abcdef".substr(-3, 99)"#), @"def");
+        insta::assert_snapshot!(env.render_ok(r#""abcdef".substr(-3)"#), @"def");
         insta::assert_snapshot!(env.render_ok(r#""abcdef".substr(-6, 99)"#), @"abcdef");
         insta::assert_snapshot!(env.render_ok(r#""abcdef".substr(-7, 1)"#), @"a");
+        insta::assert_snapshot!(env.render_ok(r#""abcdef".substr(-100)"#), @"abcdef");
 
         // non-ascii characters
         insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(2, -1)"#), @"c💩");
@@ -3676,6 +3693,15 @@ mod tests {
         insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-1, 7)"#), @"");
         insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-3, 7)"#), @"");
         insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-4, 7)"#), @"💩");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(0)"#), @"abc💩");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(1)"#), @"bc💩");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(3)"#), @"💩");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(4)"#), @"💩");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-5)"#), @"c💩");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-4)"#), @"💩");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-3)"#), @"");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-2)"#), @"");
+        insta::assert_snapshot!(env.render_ok(r#""abc💩".substr(-1)"#), @"");
 
         // ranges with end > start are empty
         insta::assert_snapshot!(env.render_ok(r#""abcdef".substr(4, 2)"#), @"");

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -538,12 +538,13 @@ defined.
 * `.trim() -> String`: Removes leading and trailing whitespace
 * `.trim_start() -> String`: Removes leading whitespace
 * `.trim_end() -> String`: Removes trailing whitespace
-* `.substr(start: Integer, end: Integer) -> String`: Extract substring. The
-  `start`/`end` indices should be specified in UTF-8 bytes. Indices are 0-based
-  and `end` is exclusive. Negative values count from the end of the string,
-  with `-1` being the last byte. If the `start` index is in the middle of a UTF-8
-  codepoint, the codepoint is fully part of the result. If the `end` index is in
-  the middle of a UTF-8 codepoint, the codepoint is not part of the result.
+* `.substr(start: Integer, [end: Integer]) -> String`: Extract substring. The
+  `start`/`end` indices should be specified in units of UTF-8 bytes. Indices are
+  0-based and `end` is exclusive. Negative values count from the end of the
+  string, with `-1` being the last byte. If the `start` index is in the middle
+  of a UTF-8 codepoint, the codepoint is fully part of the result. If the `end`
+  index is in the middle of a UTF-8 codepoint, the codepoint is not part of the
+  result. If `end` is not given, returns from `start` to the end of the string.
 * `.escape_json() -> String`: Serializes the string in JSON format. This
   function is useful for making machine-readable templates. For example, you
   can use it in a template like `'{ "foo": ' ++ foo.escape_json() ++ ' }'` to
@@ -724,7 +725,7 @@ Additionally, you can **manually** insert arbitrary labels using the
 `label(label, content)` function. For example,
 
 ```sh
-jj op log -T '"ID: " ++ self.id().short().substr(0, 1) ++ label("id short",  "<redacted>")'
+jj op log -T '"ID: " ++ self.id().short().substr(0, 1) ++ label("id short", "<redacted>")'
 ```
 
 will print "ID:" in the default style, and the string `<redacted>` in the same

--- a/web/docs/src/content/docs/templates.md
+++ b/web/docs/src/content/docs/templates.md
@@ -504,12 +504,13 @@ defined.
 * `.trim() -> String`: Removes leading and trailing whitespace
 * `.trim_start() -> String`: Removes leading whitespace
 * `.trim_end() -> String`: Removes trailing whitespace
-* `.substr(start: Integer, end: Integer) -> String`: Extract substring. The
-  `start`/`end` indices should be specified in UTF-8 bytes. Indices are 0-based
-  and `end` is exclusive. Negative values count from the end of the string,
-  with `-1` being the last byte. If the `start` index is in the middle of a UTF-8
-  codepoint, the codepoint is fully part of the result. If the `end` index is in
-  the middle of a UTF-8 codepoint, the codepoint is not part of the result.
+* `.substr(start: Integer, [end: Integer]) -> String`: Extract substring. The
+  `start`/`end` indices should be specified in units of UTF-8 bytes. Indices are
+  0-based and `end` is exclusive. Negative values count from the end of the
+  string, with `-1` being the last byte. If the `start` index is in the middle
+  of a UTF-8 codepoint, the codepoint is fully part of the result. If the `end`
+  index is in the middle of a UTF-8 codepoint, the codepoint is not part of the
+  result. If `end` is not given, returns from `start` to the end of the string.
 * `.escape_json() -> String`: Serializes the string in JSON format. This
   function is useful for making machine-readable templates. For example, you
   can use it in a template like `'{ "foo": ' ++ foo.escape_json() ++ ' }'` to
@@ -682,7 +683,7 @@ Additionally, you can **manually** insert arbitrary labels using the
 `label(label, content)` function. For example,
 
 ```sh
-jj op log -T '"ID: " ++ self.id().short().substr(0, 1) ++ label("id short",  "<redacted>")'
+jj op log -T '"ID: " ++ self.id().short().substr(0, 1) ++ label("id short", "<redacted>")'
 ```
 
 will print "ID:" in the default style, and the string `<redacted>` in the same


### PR DESCRIPTION
# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
