### PR TITLE
docs: Add config docs for bookmark advance

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -280,6 +280,36 @@ is the most significant.
 
 When the `--sort` option is used, the configuration is ignored.
 
+### Bookmark advance default targets
+
+The `jj bookmark advance` command moves bookmarks forward in the graph. The
+default values for what bookmarks to advance and where to advance them to are:
+
+```toml
+[revsets]
+bookmark-advance-from = 'heads(::to & bookmarks())'  # The closest bookmarks
+bookmark-advance-to = '@'  # To the current working copy
+```
+
+The default `from` is likely to be a good fit for almost everyone. The `from`
+revset has access to `to`, allowing it to find bookmarks relative to the
+destination revision.
+
+The default `to` is largely up to your preference and workflow. One simple
+alternative which fits squash-heavy workflows is `@-`, while a more involved
+and versatile alternative that advances to the closest "pushable" revision is:
+
+```toml
+[revsets]
+bookmark-advance-to = 'closest_pushable(@)'
+
+[revset-aliases]
+# Closest revision that is mutable, described and either non-empty or a merge
+'closest_pushable(to)' = '''
+  heads(::to & mutable() & ~description(exact:"") & (~empty() | merges()))
+'''
+```
+
 ### Commit trailers
 
 You can configure automatic addition of one or more trailers to commit


### PR DESCRIPTION
Quick draft documenting the `jj bookmark advance` config settings. I missed updating these docs when submitting the main PR.

# Checklist

If applicable:

- [ ] ~I have updated `CHANGELOG.md`~
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] ~I have updated the config schema (`cli/src/config-schema.json`)~
- [ ] ~I have added/updated tests to cover my changes~
- [ ] ~I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI~
- [ ] ~For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.~
