### PR TITLE
lib: reduce .block_on().unwrap() calls in tests with extension trait

### DIFF
--- a/cli/src/commands/arrange.rs
+++ b/cli/src/commands/arrange.rs
@@ -564,8 +564,8 @@ fn render(
 #[cfg(test)]
 mod tests {
     use maplit::hashset;
-    use pollster::FutureExt as _;
     use testutils::CommitBuilderExt as _;
+    use testutils::FutureTestExt as _;
     use testutils::TestRepo;
 
     use super::*;
@@ -768,8 +768,8 @@ mod tests {
             vec![store.root_commit_id().clone()];
         plan.rewrites.get_mut(commit_f.id()).unwrap().new_parents = vec![commit_a.id().clone()];
 
-        let rewritten = plan.execute(tx.repo_mut()).block_on().unwrap();
-        tx.repo_mut().rebase_descendants().block_on().unwrap();
+        let rewritten = plan.execute(tx.repo_mut()).block_unwrap();
+        tx.repo_mut().rebase_descendants().block_unwrap();
         assert_eq!(
             rewritten.keys().collect::<HashSet<_>>(),
             hashset![
@@ -830,8 +830,8 @@ mod tests {
             action: RewriteAction::Abandon,
         };
 
-        let rewritten = plan.execute(tx.repo_mut()).block_on().unwrap();
-        tx.repo_mut().rebase_descendants().block_on().unwrap();
+        let rewritten = plan.execute(tx.repo_mut()).block_unwrap();
+        tx.repo_mut().rebase_descendants().block_unwrap();
         assert_eq!(rewritten.keys().sorted().collect_vec(), vec![commit_d.id()]);
         let new_commit_d = rewritten.get(commit_d.id()).unwrap();
         assert_eq!(new_commit_d.parent_ids(), &[commit_a.id().clone()]);

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -292,7 +292,7 @@ async fn visit_collapsed_untracked_files(
 
 #[cfg(test)]
 mod test {
-    use pollster::FutureExt as _;
+    use testutils::FutureTestExt as _;
     use testutils::TestRepo;
     use testutils::TestTreeBuilder;
     use testutils::repo_path;
@@ -314,8 +314,7 @@ mod test {
             result.push('\n');
             Ok(())
         })
-        .block_on()
-        .unwrap();
+        .block_unwrap();
         result
     }
 

--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -773,6 +773,7 @@ mod tests {
     use proptest_state_machine::StateMachineTest;
     use proptest_state_machine::prop_state_machine;
     use test_case::test_matrix;
+    use testutils::FutureTestExt as _;
     use testutils::TestRepo;
     use testutils::assert_tree_eq;
     use testutils::dump_tree;
@@ -805,8 +806,7 @@ mod tests {
             tree_diff,
             ConflictMarkerStyle::Diff,
         )
-        .block_on()
-        .unwrap()
+        .block_unwrap()
     }
 
     fn apply_diff(
@@ -1035,8 +1035,7 @@ mod tests {
 
         let get_actual_executables = |tree: &MergedTree| {
             tree.path_value_async(file_path)
-                .block_on()
-                .unwrap()
+                .block_unwrap()
                 .to_executable_merge()
                 .expect("The path should point to an existing file.")
         };
@@ -1153,16 +1152,15 @@ mod tests {
             }
         }
         let tree = apply_diff(store, &left_tree, &right_tree, &changed_files, &files);
-        let actual_copy_ids =
-            tree.path_value_async(file_path)
-                .block_on()
-                .unwrap()
-                .map(|tree_value| {
-                    let Some(TreeValue::File { copy_id, .. }) = tree_value else {
-                        panic!("The path should point to an existing file.");
-                    };
-                    copy_id.clone()
-                });
+        let actual_copy_ids = tree
+            .path_value_async(file_path)
+            .block_unwrap()
+            .map(|tree_value| {
+                let Some(TreeValue::File { copy_id, .. }) = tree_value else {
+                    panic!("The path should point to an existing file.");
+                };
+                copy_id.clone()
+            });
         assert_eq!(
             actual_copy_ids.resolve_trivial(SameChange::Accept),
             Some(&copy_id),
@@ -1202,16 +1200,15 @@ mod tests {
         let tree =
             apply_merge_builtin(store, &tree, vec![file_path.to_owned()], &[merge_file]).unwrap();
 
-        let actual_copy_ids =
-            tree.path_value_async(file_path)
-                .block_on()
-                .unwrap()
-                .map(|tree_value| {
-                    let Some(TreeValue::File { copy_id, .. }) = tree_value else {
-                        panic!("The path should point to an existing file.");
-                    };
-                    copy_id.clone()
-                });
+        let actual_copy_ids = tree
+            .path_value_async(file_path)
+            .block_unwrap()
+            .map(|tree_value| {
+                let Some(TreeValue::File { copy_id, .. }) = tree_value else {
+                    panic!("The path should point to an existing file.");
+                };
+                copy_id.clone()
+            });
         assert_eq!(
             actual_copy_ids.resolve_trivial(SameChange::Accept),
             Some(&new_copy_id),
@@ -2091,9 +2088,7 @@ mod tests {
             to_file_id(base_tree.path_value(path).unwrap()),
             to_file_id(right_tree.path_value(path).unwrap()),
         ]);
-        let content = extract_as_single_hunk(&merge, store, path)
-            .block_on()
-            .unwrap();
+        let content = extract_as_single_hunk(&merge, store, path).block_unwrap();
         let merge_result = files::merge_hunks(&content, store.merge_options());
         let sections = make_merge_sections(merge_result).unwrap();
         insta::assert_debug_snapshot!(sections, @r#"

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -487,6 +487,7 @@ mod tests {
     use itertools::Itertools as _;
     use pollster::FutureExt as _;
     use test_case::test_case;
+    use testutils::FutureTestExt as _;
 
     use super::*;
     use crate::tests::new_temp_dir;
@@ -697,11 +698,11 @@ mod tests {
         let mut async_reader = BlockingAsyncReader::new(sync_reader);
 
         let mut buf = [0u8; 3];
-        let num_bytes_read = async_reader.read(&mut buf).block_on().unwrap();
+        let num_bytes_read = async_reader.read(&mut buf).block_unwrap();
         assert_eq!(num_bytes_read, 3);
         assert_eq!(&buf, &input[0..3]);
 
-        let num_bytes_read = async_reader.read(&mut buf).block_on().unwrap();
+        let num_bytes_read = async_reader.read(&mut buf).block_unwrap();
         assert_eq!(num_bytes_read, 2);
         assert_eq!(&buf[0..2], &input[3..5]);
     }
@@ -713,7 +714,7 @@ mod tests {
         let mut async_reader = BlockingAsyncReader::new(sync_reader);
 
         let mut buf = vec![];
-        let num_bytes_read = async_reader.read_to_end(&mut buf).block_on().unwrap();
+        let num_bytes_read = async_reader.read_to_end(&mut buf).block_unwrap();
         assert_eq!(num_bytes_read, input.len());
         assert_eq!(&buf, &input);
     }

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1577,6 +1577,7 @@ mod tests {
     use gix::objs::CommitRef;
     use indoc::indoc;
     use pollster::FutureExt as _;
+    use testutils::FutureTestExt as _;
 
     use super::*;
     use crate::config::StackedConfig;
@@ -1706,7 +1707,7 @@ mod tests {
             .collect_vec();
         assert_eq!(git_refs, vec![git_commit_id2]);
 
-        let commit = backend.read_commit(&commit_id).block_on().unwrap();
+        let commit = backend.read_commit(&commit_id).block_unwrap();
         assert_eq!(&commit.change_id, &change_id);
         assert_eq!(commit.parents, vec![CommitId::from_bytes(&[0; 20])]);
         assert_eq!(commit.predecessors, vec![]);
@@ -1735,8 +1736,7 @@ mod tests {
                 RepoPath::root(),
                 &TreeId::from_bytes(root_tree_id.as_bytes()),
             )
-            .block_on()
-            .unwrap();
+            .block_unwrap();
         let mut root_entries = root_tree.entries();
         let dir = root_entries.next().unwrap();
         assert_eq!(root_entries.next(), None);
@@ -1751,8 +1751,7 @@ mod tests {
                 RepoPath::from_internal_string("dir").unwrap(),
                 &TreeId::from_bytes(dir_tree_id.as_bytes()),
             )
-            .block_on()
-            .unwrap();
+            .block_unwrap();
         let mut entries = dir_tree.entries();
         let file = entries.next().unwrap();
         let symlink = entries.next().unwrap();
@@ -1772,7 +1771,7 @@ mod tests {
             &TreeValue::Symlink(SymlinkId::from_bytes(blob2.as_bytes()))
         );
 
-        let commit2 = backend.read_commit(&commit_id2).block_on().unwrap();
+        let commit2 = backend.read_commit(&commit_id2).block_unwrap();
         assert_eq!(commit2.parents, vec![commit_id.clone()]);
         assert_eq!(commit.predecessors, vec![]);
         assert_eq!(
@@ -1870,8 +1869,7 @@ mod tests {
 
         let commit = backend
             .read_commit(&CommitId::from_bytes(git_commit_id.as_bytes()))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
         let sig = commit.secure_sig.expect("failed to read the signature");
 
@@ -1976,9 +1974,8 @@ mod tests {
             secure_sig: None,
         };
 
-        let (initial_commit_id, _init_commit) =
-            backend.write_commit(commit, None).block_on().unwrap();
-        let commit = backend.read_commit(&initial_commit_id).block_on().unwrap();
+        let (initial_commit_id, _init_commit) = backend.write_commit(commit, None).block_unwrap();
+        let commit = backend.read_commit(&initial_commit_id).block_unwrap();
         assert_eq!(
             commit.change_id, original_change_id,
             "The change-id header did not roundtrip"
@@ -1991,8 +1988,7 @@ mod tests {
             GitBackend::init_external(&settings, &empty_store_path, git_repo.path()).unwrap();
         let no_extra_commit = no_extra_backend
             .read_commit(&initial_commit_id)
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
         assert_eq!(
             no_extra_commit.change_id, original_change_id,
@@ -2082,7 +2078,7 @@ mod tests {
         // Only root commit as parent
         commit.parents = vec![backend.root_commit_id().clone()];
         let first_id = write_commit(commit.clone()).unwrap().0;
-        let first_commit = backend.read_commit(&first_id).block_on().unwrap();
+        let first_commit = backend.read_commit(&first_id).block_unwrap();
         assert_eq!(first_commit, commit);
         let first_git_commit = git_repo.find_commit(git_id(&first_id)).unwrap();
         assert!(first_git_commit.parent_ids().collect_vec().is_empty());
@@ -2090,7 +2086,7 @@ mod tests {
         // Only non-root commit as parent
         commit.parents = vec![first_id.clone()];
         let second_id = write_commit(commit.clone()).unwrap().0;
-        let second_commit = backend.read_commit(&second_id).block_on().unwrap();
+        let second_commit = backend.read_commit(&second_id).block_unwrap();
         assert_eq!(second_commit, commit);
         let second_git_commit = git_repo.find_commit(git_id(&second_id)).unwrap();
         assert_eq!(
@@ -2101,7 +2097,7 @@ mod tests {
         // Merge commit
         commit.parents = vec![first_id.clone(), second_id.clone()];
         let merge_id = write_commit(commit.clone()).unwrap().0;
-        let merge_commit = backend.read_commit(&merge_id).block_on().unwrap();
+        let merge_commit = backend.read_commit(&merge_id).block_unwrap();
         assert_eq!(merge_commit, commit);
         let merge_git_commit = git_repo.find_commit(git_id(&merge_id)).unwrap();
         assert_eq!(
@@ -2162,7 +2158,7 @@ mod tests {
         // When writing a tree-level conflict, the root tree on the git side has the
         // individual trees as subtrees.
         let read_commit_id = write_commit(commit.clone()).unwrap().0;
-        let read_commit = backend.read_commit(&read_commit_id).block_on().unwrap();
+        let read_commit = backend.read_commit(&read_commit_id).block_unwrap();
         assert_eq!(read_commit, commit);
         let git_commit = git_repo
             .find_commit(gix::ObjectId::from_bytes_or_panic(
@@ -2224,7 +2220,7 @@ mod tests {
         // regular git tree.
         commit.root_tree = Merge::resolved(create_tree(5));
         let read_commit_id = write_commit(commit.clone()).unwrap().0;
-        let read_commit = backend.read_commit(&read_commit_id).block_on().unwrap();
+        let read_commit = backend.read_commit(&read_commit_id).block_unwrap();
         assert_eq!(read_commit, commit);
         let git_commit = git_repo
             .find_commit(gix::ObjectId::from_bytes_or_panic(
@@ -2262,7 +2258,7 @@ mod tests {
             committer: signature,
             secure_sig: None,
         };
-        let commit_id = backend.write_commit(commit, None).block_on().unwrap().0;
+        let commit_id = backend.write_commit(commit, None).block_unwrap().0;
         let git_refs = git_repo.references().unwrap();
         let git_ref_ids: Vec<_> = git_refs
             .prefixed("refs/jj/keep/")
@@ -2355,7 +2351,7 @@ mod tests {
         let (commit_id2, mut actual_commit2) = write_commit(commit2.clone()).unwrap();
         // The returned matches the ID
         assert_eq!(
-            backend.read_commit(&commit_id2).block_on().unwrap(),
+            backend.read_commit(&commit_id2).block_unwrap(),
             actual_commit2
         );
         assert_ne!(commit_id2, commit_id1);
@@ -2394,8 +2390,7 @@ mod tests {
 
         let (id, commit) = backend
             .write_commit(commit, Some(&mut signer as &mut SigningFn))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
         let git_repo = backend.git_repo();
         let obj = git_repo
@@ -2414,7 +2409,7 @@ mod tests {
 
         let returned_sig = commit.secure_sig.expect("failed to return the signature");
 
-        let commit = backend.read_commit(&id).block_on().unwrap();
+        let commit = backend.read_commit(&id).block_unwrap();
 
         let sig = commit.secure_sig.expect("failed to read the signature");
         assert_eq!(&sig, &returned_sig);

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -505,6 +505,7 @@ fn signature_from_proto(proto: crate::protos::simple_store::commit::Signature) -
 mod tests {
     use assert_matches::assert_matches;
     use pollster::FutureExt as _;
+    use testutils::FutureTestExt as _;
 
     use super::*;
     use crate::merge::Merge;
@@ -543,25 +544,25 @@ mod tests {
         // Only root commit as parent
         commit.parents = vec![backend.root_commit_id().clone()];
         let first_id = write_commit(commit.clone()).unwrap().0;
-        let first_commit = backend.read_commit(&first_id).block_on().unwrap();
+        let first_commit = backend.read_commit(&first_id).block_unwrap();
         assert_eq!(first_commit, commit);
 
         // Only non-root commit as parent
         commit.parents = vec![first_id.clone()];
         let second_id = write_commit(commit.clone()).unwrap().0;
-        let second_commit = backend.read_commit(&second_id).block_on().unwrap();
+        let second_commit = backend.read_commit(&second_id).block_unwrap();
         assert_eq!(second_commit, commit);
 
         // Merge commit
         commit.parents = vec![first_id.clone(), second_id.clone()];
         let merge_id = write_commit(commit.clone()).unwrap().0;
-        let merge_commit = backend.read_commit(&merge_id).block_on().unwrap();
+        let merge_commit = backend.read_commit(&merge_id).block_unwrap();
         assert_eq!(merge_commit, commit);
 
         // Merge commit with root as one parent
         commit.parents = vec![first_id, backend.root_commit_id().clone()];
         let root_merge_id = write_commit(commit.clone()).unwrap().0;
-        let root_merge_commit = backend.read_commit(&root_merge_id).block_on().unwrap();
+        let root_merge_commit = backend.read_commit(&root_merge_id).block_unwrap();
         assert_eq!(root_merge_commit, commit);
     }
 

--- a/lib/src/simple_op_store.rs
+++ b/lib/src/simple_op_store.rs
@@ -942,6 +942,7 @@ mod tests {
     use maplit::btreemap;
     use maplit::hashmap;
     use maplit::hashset;
+    use testutils::FutureTestExt as _;
 
     use super::*;
     use crate::hex_util;
@@ -1071,8 +1072,8 @@ mod tests {
         };
         let store = SimpleOpStore::init(temp_dir.path(), root_data).unwrap();
         let view = create_view();
-        let view_id = store.write_view(&view).block_on().unwrap();
-        let read_view = store.read_view(&view_id).block_on().unwrap();
+        let view_id = store.write_view(&view).block_unwrap();
+        let read_view = store.read_view(&view_id).block_unwrap();
         assert_eq!(read_view, view);
     }
 
@@ -1084,8 +1085,8 @@ mod tests {
         };
         let store = SimpleOpStore::init(temp_dir.path(), root_data).unwrap();
         let operation = create_operation();
-        let op_id = store.write_operation(&operation).block_on().unwrap();
-        let read_operation = store.read_operation(&op_id).block_on().unwrap();
+        let op_id = store.write_operation(&operation).block_unwrap();
+        let read_operation = store.read_operation(&op_id).block_unwrap();
         assert_eq!(read_operation, operation);
     }
 

--- a/lib/tests/test_annotate.rs
+++ b/lib/tests/test_annotate.rs
@@ -30,8 +30,8 @@ use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::revset::ResolvedRevsetExpression;
 use jj_lib::revset::RevsetExpression;
-use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::create_tree;
 use testutils::read_file;
@@ -71,15 +71,13 @@ fn annotate_within(
     domain: &Arc<ResolvedRevsetExpression>,
     file_path: &RepoPath,
 ) -> String {
-    let mut annotator = FileAnnotator::from_commit(commit, file_path)
-        .block_on()
-        .unwrap();
-    annotator.compute(repo, domain).block_on().unwrap();
+    let mut annotator = FileAnnotator::from_commit(commit, file_path).block_unwrap();
+    annotator.compute(repo, domain).block_unwrap();
     format_annotation(repo, &annotator.to_annotation())
 }
 
 fn annotate_parent_tree(repo: &dyn Repo, commit: &Commit, file_path: &RepoPath) -> String {
-    let tree = commit.parent_tree(repo).block_on().unwrap();
+    let tree = commit.parent_tree(repo).block_unwrap();
     let text = match tree.path_value(file_path).unwrap().into_resolved().unwrap() {
         Some(TreeValue::File { id, .. }) => read_file(repo.store(), file_path, &id),
         value => panic!("unexpected path value: {value:?}"),
@@ -87,8 +85,7 @@ fn annotate_parent_tree(repo: &dyn Repo, commit: &Commit, file_path: &RepoPath) 
     let mut annotator = FileAnnotator::with_file_content(commit.id(), file_path, text);
     annotator
         .compute(repo, &RevsetExpression::all())
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     format_annotation(repo, &annotator.to_annotation())
 }
 
@@ -216,9 +213,7 @@ fn test_annotate_merge_simple() {
     ");
 
     // Calculate incrementally
-    let mut annotator = FileAnnotator::from_commit(&commit4, file_path)
-        .block_on()
-        .unwrap();
+    let mut annotator = FileAnnotator::from_commit(&commit4, file_path).block_unwrap();
     assert_eq!(annotator.pending_commits().collect_vec(), [commit4.id()]);
     insta::assert_snapshot!(format_annotation(tx.repo(), &annotator.to_annotation()), @"
     commit4:1*: 2
@@ -234,8 +229,7 @@ fn test_annotate_merge_simple() {
                 commit2.id().clone(),
             ]),
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(annotator.pending_commits().collect_vec(), [commit1.id()]);
     insta::assert_snapshot!(format_annotation(tx.repo(), &annotator.to_annotation()), @"
     commit2:1 : 2
@@ -247,8 +241,7 @@ fn test_annotate_merge_simple() {
             tx.repo(),
             &RevsetExpression::commits(vec![commit1.id().clone()]),
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert!(annotator.pending_commits().next().is_none());
     insta::assert_snapshot!(format_annotation(tx.repo(), &annotator.to_annotation()), @"
     commit2:1 : 2

--- a/lib/tests/test_bad_locking.rs
+++ b/lib/tests/test_bad_locking.rs
@@ -19,8 +19,8 @@ use jj_lib::repo::Repo as _;
 use jj_lib::repo::StoreFactories;
 use jj_lib::workspace::Workspace;
 use jj_lib::workspace::default_working_copy_factories;
-use pollster::FutureExt as _;
 use test_case::test_case;
+use testutils::FutureTestExt as _;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
 use testutils::write_random_commit;
@@ -113,7 +113,7 @@ fn test_bad_locking_children(backend: TestRepoBackend) {
 
     let mut tx = repo.start_transaction();
     let initial = write_random_commit(tx.repo_mut());
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     // Simulate a write of a commit that happens on one machine
     let machine1_root = test_workspace.root_dir().join("machine1");
@@ -128,11 +128,10 @@ fn test_bad_locking_children(backend: TestRepoBackend) {
     let machine1_repo = machine1_workspace
         .repo_loader()
         .load_at_head()
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let mut machine1_tx = machine1_repo.start_transaction();
     let child1 = write_random_commit_with_parents(machine1_tx.repo_mut(), &[&initial]);
-    machine1_tx.commit("test").block_on().unwrap();
+    machine1_tx.commit("test").block_unwrap();
 
     // Simulate a write of a commit that happens on another machine
     let machine2_root = test_workspace.root_dir().join("machine2");
@@ -147,11 +146,10 @@ fn test_bad_locking_children(backend: TestRepoBackend) {
     let machine2_repo = machine2_workspace
         .repo_loader()
         .load_at_head()
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let mut machine2_tx = machine2_repo.start_transaction();
     let child2 = write_random_commit_with_parents(machine2_tx.repo_mut(), &[&initial]);
-    machine2_tx.commit("test").block_on().unwrap();
+    machine2_tx.commit("test").block_unwrap();
 
     // Simulate that the distributed file system now has received the changes from
     // both machines
@@ -164,19 +162,11 @@ fn test_bad_locking_children(backend: TestRepoBackend) {
         &default_working_copy_factories(),
     )
     .unwrap();
-    let merged_repo = merged_workspace
-        .repo_loader()
-        .load_at_head()
-        .block_on()
-        .unwrap();
+    let merged_repo = merged_workspace.repo_loader().load_at_head().block_unwrap();
     assert!(merged_repo.view().heads().contains(child1.id()));
     assert!(merged_repo.view().heads().contains(child2.id()));
     let op_id = merged_repo.op_id().clone();
-    let op = merged_repo
-        .op_store()
-        .read_operation(&op_id)
-        .block_on()
-        .unwrap();
+    let op = merged_repo.op_store().read_operation(&op_id).block_unwrap();
     assert_eq!(op.parents.len(), 2);
 }
 
@@ -193,7 +183,7 @@ fn test_bad_locking_interrupted(backend: TestRepoBackend) {
 
     let mut tx = repo.start_transaction();
     let initial = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Simulate a crash that resulted in the old op-head left in place. We simulate
     // it somewhat hackily by copying the .jj/op_heads/ directory before the
@@ -204,13 +194,7 @@ fn test_bad_locking_interrupted(backend: TestRepoBackend) {
     copy_directory(&op_heads_dir, &backup_path);
     let mut tx = repo.start_transaction();
     write_random_commit_with_parents(tx.repo_mut(), &[&initial]);
-    let op_id = tx
-        .commit("test")
-        .block_on()
-        .unwrap()
-        .operation()
-        .id()
-        .clone();
+    let op_id = tx.commit("test").block_unwrap().operation().id().clone();
 
     copy_directory(&backup_path, &op_heads_dir);
     // Reload the repo and check that only the new head is present.

--- a/lib/tests/test_commit_builder.rs
+++ b/lib/tests/test_commit_builder.rs
@@ -33,6 +33,7 @@ use jj_lib::settings::UserSettings;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::TestRepoBackend;
 use testutils::assert_rebased_onto;
@@ -117,9 +118,9 @@ fn test_initial(backend: TestRepoBackend) {
     assert_eq!(builder.author(), &author_signature);
     assert_eq!(builder.committer(), &committer_signature);
     let commit = builder.write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
-    let parents = commit.parents().block_on().unwrap();
+    let parents = commit.parents().block_unwrap();
     assert_eq!(parents, vec![store.root_commit()]);
     assert!(commit.store_commit().predecessors.is_empty());
     assert_eq!(commit.description(), "description");
@@ -159,7 +160,7 @@ fn test_rewrite(backend: TestRepoBackend) {
         .repo_mut()
         .new_commit(vec![store.root_commit_id().clone()], initial_tree)
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let rewritten_tree = create_tree(
         &repo,
@@ -194,9 +195,9 @@ fn test_rewrite(backend: TestRepoBackend) {
         .rewrite_commit(&initial_commit)
         .set_tree(rewritten_tree)
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
-    let parents = rewritten_commit.parents().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
+    let parents = rewritten_commit.parents().block_unwrap();
     assert_eq!(parents, vec![store.root_commit()]);
     assert_eq!(
         rewritten_commit.store_commit().predecessors,
@@ -252,7 +253,7 @@ fn test_rewrite_update_missing_user(backend: TestRepoBackend) {
     assert_eq!(initial_commit.author().email, "");
     assert_eq!(initial_commit.committer().name, "");
     assert_eq!(initial_commit.committer().email, "");
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let mut config = StackedConfig::with_defaults();
     config.add_layer(
@@ -302,7 +303,7 @@ fn test_rewrite_resets_author_timestamp(backend: TestRepoBackend) {
             repo.store().empty_merged_tree(),
         )
         .write_unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let initial_timestamp =
         Timestamp::from_datetime(chrono::DateTime::parse_from_rfc3339(initial_timestamp).unwrap());
@@ -321,8 +322,8 @@ fn test_rewrite_resets_author_timestamp(backend: TestRepoBackend) {
         .rewrite_commit(&initial_commit)
         .set_description("No longer discardable")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    tx.commit("test").block_unwrap();
 
     let new_timestamp_1 =
         Timestamp::from_datetime(chrono::DateTime::parse_from_rfc3339(new_timestamp_1).unwrap());
@@ -344,8 +345,8 @@ fn test_rewrite_resets_author_timestamp(backend: TestRepoBackend) {
         .rewrite_commit(&rewritten_commit_1)
         .set_description("New description")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    tx.commit("test").block_unwrap();
 
     let new_timestamp_2 =
         Timestamp::from_datetime(chrono::DateTime::parse_from_rfc3339(new_timestamp_2).unwrap());
@@ -372,21 +373,21 @@ fn test_rewrite_to_identical_commit(backend: TestRepoBackend) {
             store.empty_merged_tree(),
         )
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Create commit identical to the original
     let mut tx = repo.start_transaction();
     let mut builder = tx.repo_mut().rewrite_commit(&commit1).detach();
     builder.set_predecessors(vec![]);
     // Writing to the store should work
-    let commit2 = builder.write_hidden().block_on().unwrap();
+    let commit2 = builder.write_hidden().block_unwrap();
     assert_eq!(commit1, commit2);
     // Writing to the repo shouldn't work, which would create cycle in
     // predecessors/parent mappings
     let result = builder.write(tx.repo_mut()).block_on();
     assert_matches!(result, Err(BackendError::Other(_)));
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    tx.commit("test").block_unwrap();
 
     // Create two rewritten commits of the same content and metadata
     let mut tx = repo.start_transaction();
@@ -401,8 +402,8 @@ fn test_rewrite_to_identical_commit(backend: TestRepoBackend) {
         .write()
         .block_on();
     assert_matches!(result, Err(BackendError::Other(_)));
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    tx.commit("test").block_unwrap();
 }
 
 #[test_case(TestRepoBackend::Simple ; "simple backend")]
@@ -416,7 +417,7 @@ fn test_commit_builder_descendants(backend: TestRepoBackend) {
     let commit1 = write_random_commit(tx.repo_mut());
     let commit2 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
     let commit3 = write_random_commit_with_parents(tx.repo_mut(), &[&commit2]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Test with for_new_commit()
     let mut tx = repo.start_transaction();

--- a/lib/tests/test_commit_concurrent.rs
+++ b/lib/tests/test_commit_concurrent.rs
@@ -19,8 +19,8 @@ use std::thread;
 use jj_lib::dag_walk;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
-use pollster::FutureExt as _;
 use test_case::test_case;
+use testutils::FutureTestExt as _;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
 use testutils::write_random_commit;
@@ -33,9 +33,9 @@ fn count_non_merge_operations(repo: &Arc<ReadonlyRepo>) -> usize {
     for op_id in dag_walk::dfs(
         vec![op_id],
         |op_id| op_id.clone(),
-        |op_id| op_store.read_operation(op_id).block_on().unwrap().parents,
+        |op_id| op_store.read_operation(op_id).block_unwrap().parents,
     ) {
-        let op = op_store.read_operation(&op_id).block_on().unwrap();
+        let op = op_store.read_operation(&op_id).block_unwrap();
         if op.parents.len() <= 1 {
             num_ops += 1;
         }
@@ -59,11 +59,11 @@ fn test_commit_parallel(backend: TestRepoBackend) {
             s.spawn(move || {
                 let mut tx = repo.start_transaction();
                 write_random_commit(tx.repo_mut());
-                tx.commit("test").block_on().unwrap();
+                tx.commit("test").block_unwrap();
             });
         }
     });
-    let repo = repo.reload_at_head().block_on().unwrap();
+    let repo = repo.reload_at_head().block_unwrap();
     // One commit per thread plus the commit from the initial working-copy on top of
     // the root commit
     assert_eq!(repo.view().heads().len(), num_threads + 1);
@@ -90,7 +90,7 @@ fn test_commit_parallel_instances(backend: TestRepoBackend) {
             s.spawn(move || {
                 let mut tx = repo.start_transaction();
                 write_random_commit(tx.repo_mut());
-                tx.commit("test").block_on().unwrap();
+                tx.commit("test").block_unwrap();
             });
         }
     });

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -31,8 +31,8 @@ use jj_lib::repo::Repo as _;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::store::Store;
 use jj_lib::tree_merge::MergeOptions;
-use pollster::FutureExt as _;
 use test_case::test_case;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::read_file;
 use testutils::repo_path;
@@ -634,8 +634,7 @@ fn test_materialize_update_roundtrip(style: ConflictMarkerStyle) {
         materialized.as_bytes(),
         MIN_CONFLICT_MARKER_LEN,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     assert_eq!(parsed, conflict);
 }
@@ -1769,9 +1768,7 @@ fn test_update_conflict_from_content() {
     let materialized =
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     let parse = |content| {
-        update_from_content(&conflict, store, path, content, MIN_CONFLICT_MARKER_LEN)
-            .block_on()
-            .unwrap()
+        update_from_content(&conflict, store, path, content, MIN_CONFLICT_MARKER_LEN).block_unwrap()
     };
     assert_eq!(parse(materialized.as_bytes()), conflict);
 
@@ -1819,9 +1816,7 @@ fn test_update_conflict_from_content_modify_delete() {
     let materialized =
         materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
     let parse = |content| {
-        update_from_content(&conflict, store, path, content, MIN_CONFLICT_MARKER_LEN)
-            .block_on()
-            .unwrap()
+        update_from_content(&conflict, store, path, content, MIN_CONFLICT_MARKER_LEN).block_unwrap()
     };
     assert_eq!(parse(materialized.as_bytes()), conflict);
 
@@ -1872,9 +1867,7 @@ fn test_update_conflict_from_content_simplified_conflict() {
     let materialized =
         materialize_conflict_string(store, path, &simplified_conflict, ConflictMarkerStyle::Diff);
     let parse = |content| {
-        update_from_content(&conflict, store, path, content, MIN_CONFLICT_MARKER_LEN)
-            .block_on()
-            .unwrap()
+        update_from_content(&conflict, store, path, content, MIN_CONFLICT_MARKER_LEN).block_unwrap()
     };
     insta::assert_snapshot!(
         materialized,
@@ -1981,9 +1974,7 @@ fn test_update_conflict_from_content_with_long_markers() {
 
     // The conflict should be materialized using long conflict markers
     let materialized_marker_len = choose_materialized_conflict_marker_len(
-        &extract_as_single_hunk(&conflict, store, path)
-            .block_on()
-            .unwrap(),
+        &extract_as_single_hunk(&conflict, store, path).block_unwrap(),
     );
     assert!(materialized_marker_len > MIN_CONFLICT_MARKER_LEN);
     let materialized =
@@ -2010,9 +2001,7 @@ fn test_update_conflict_from_content_with_long_markers() {
     );
 
     let parse = |conflict, content| {
-        update_from_content(conflict, store, path, content, materialized_marker_len)
-            .block_on()
-            .unwrap()
+        update_from_content(conflict, store, path, content, materialized_marker_len).block_unwrap()
     };
     assert_eq!(parse(&conflict, materialized.as_bytes()), conflict);
 
@@ -2154,8 +2143,7 @@ fn test_update_conflict_from_content_no_eol() {
             materialized.as_bytes(),
             MIN_CONFLICT_MARKER_LEN,
         )
-        .block_on()
-        .unwrap(),
+        .block_unwrap(),
         conflict
     );
 
@@ -2193,8 +2181,7 @@ fn test_update_conflict_from_content_no_eol() {
             materialized.as_bytes(),
             MIN_CONFLICT_MARKER_LEN,
         )
-        .block_on()
-        .unwrap(),
+        .block_unwrap(),
         conflict
     );
 
@@ -2230,8 +2217,7 @@ fn test_update_conflict_from_content_no_eol() {
             materialized.as_bytes(),
             MIN_CONFLICT_MARKER_LEN,
         )
-        .block_on()
-        .unwrap(),
+        .block_unwrap(),
         conflict
     );
 }
@@ -2309,8 +2295,7 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() {
             materialized.as_bytes(),
             MIN_CONFLICT_MARKER_LEN,
         )
-        .block_on()
-        .unwrap(),
+        .block_unwrap(),
         conflict
     );
 }
@@ -2353,8 +2338,7 @@ fn test_update_conflict_from_content_only_no_eol_change() {
             materialized.as_bytes(),
             MIN_CONFLICT_MARKER_LEN,
         )
-        .block_on()
-        .unwrap(),
+        .block_unwrap(),
         conflict
     );
 }
@@ -2405,9 +2389,7 @@ fn test_update_from_content_malformed_conflict() {
 
     // The conflict should be materialized with normal markers
     let materialized_marker_len = choose_materialized_conflict_marker_len(
-        &extract_as_single_hunk(&conflict, store, path)
-            .block_on()
-            .unwrap(),
+        &extract_as_single_hunk(&conflict, store, path).block_unwrap(),
     );
     assert!(materialized_marker_len == MIN_CONFLICT_MARKER_LEN);
 
@@ -2437,9 +2419,7 @@ fn test_update_from_content_malformed_conflict() {
     );
 
     let parse = |conflict, content| {
-        update_from_content(conflict, store, path, content, materialized_marker_len)
-            .block_on()
-            .unwrap()
+        update_from_content(conflict, store, path, content, materialized_marker_len).block_unwrap()
     };
     assert_eq!(parse(&conflict, materialized.as_bytes()), conflict);
 
@@ -2538,9 +2518,7 @@ fn materialize_conflict_string_with_labels(
     conflict_labels: &ConflictLabels,
     marker_style: ConflictMarkerStyle,
 ) -> String {
-    let contents = extract_as_single_hunk(conflict, store, path)
-        .block_on()
-        .unwrap();
+    let contents = extract_as_single_hunk(conflict, store, path).block_unwrap();
     let options = ConflictMaterializeOptions {
         marker_style,
         marker_len: None,

--- a/lib/tests/test_default_revset_graph_iterator.rs
+++ b/lib/tests/test_default_revset_graph_iterator.rs
@@ -21,8 +21,8 @@ use jj_lib::graph::GraphEdge;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
 use jj_lib::revset::ResolvedExpression;
-use pollster::FutureExt as _;
 use test_case::test_case;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
@@ -72,7 +72,7 @@ fn test_graph_iterator_linearized(skip_transitive_edges: bool, padding: u32) {
     let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
     let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
     let commit_d = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b, &commit_c]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_d]);
@@ -115,7 +115,7 @@ fn test_graph_iterator_virtual_octopus(skip_transitive_edges: bool, padding: u32
     let commit_d = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a, &commit_b]);
     let commit_e = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b, &commit_c]);
     let commit_f = write_random_commit_with_parents(tx.repo_mut(), &[&commit_d, &commit_e]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_b, &commit_c, &commit_f]);
@@ -169,7 +169,7 @@ fn test_graph_iterator_simple_fork(skip_transitive_edges: bool, padding: u32) {
     let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b]);
     let commit_d = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b]);
     let commit_e = write_random_commit_with_parents(tx.repo_mut(), &[&commit_d]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_a, &commit_c, &commit_e]);
@@ -213,7 +213,7 @@ fn test_graph_iterator_multiple_missing(skip_transitive_edges: bool, padding: u3
     let commit_d = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a, &commit_b]);
     let commit_e = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b, &commit_c]);
     let commit_f = write_random_commit_with_parents(tx.repo_mut(), &[&commit_d, &commit_e]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_b, &commit_f]);
@@ -261,7 +261,7 @@ fn test_graph_iterator_edge_to_ancestor(skip_transitive_edges: bool, padding: u3
     let commit_d = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b, &commit_c]);
     let commit_e = write_random_commit_with_parents(tx.repo_mut(), &[&commit_c]);
     let commit_f = write_random_commit_with_parents(tx.repo_mut(), &[&commit_d, &commit_e]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_c, &commit_d, &commit_f]);
     let commits: Vec<_> = revset
@@ -319,7 +319,7 @@ fn test_graph_iterator_edge_escapes_from_(skip_transitive_edges: bool, padding: 
     let commit_h = write_random_commit_with_parents(tx.repo_mut(), &[&commit_f]);
     let commit_i = write_random_commit_with_parents(tx.repo_mut(), &[&commit_e, &commit_h]);
     let commit_j = write_random_commit_with_parents(tx.repo_mut(), &[&commit_g, &commit_i]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let root_commit = repo.store().root_commit();
 
     let revset = revset_for_commits(

--- a/lib/tests/test_eol.rs
+++ b/lib/tests/test_eol.rs
@@ -24,9 +24,9 @@ use jj_lib::rewrite::merge_commit_trees;
 use jj_lib::settings::UserSettings;
 use jj_lib::workspace::Workspace;
 use jj_lib::workspace::default_working_copy_factories;
-use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
 use testutils::assert_tree_eq;
@@ -144,8 +144,7 @@ fn test_eol_conversion_snapshot(
             None,
             &file_removed_commit,
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert!(!file_disk_path.exists());
 
     let user_settings =
@@ -172,8 +171,7 @@ fn test_eol_conversion_snapshot(
             None,
             &file_added_commit,
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert!(file_disk_path.exists());
     let new_tree = test_workspace.snapshot().unwrap();
     assert_tree_eq!(
@@ -221,13 +219,12 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
         .repo_mut()
         .new_commit(vec![root_commit.id().clone()], tree)
         .write_unwrap();
-    tx.commit("commit parent1").block_on().unwrap();
+    tx.commit("commit parent1").block_unwrap();
 
     test_workspace
         .workspace
         .check_out(test_workspace.repo.op_id().clone(), None, &root_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     testutils::write_working_copy_file(
         test_workspace.workspace.workspace_root(),
         file_repo_path,
@@ -239,22 +236,20 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
         .repo_mut()
         .new_commit(vec![root_commit.id().clone()], tree)
         .write_unwrap();
-    tx.commit("commit parent2").block_on().unwrap();
+    tx.commit("commit parent2").block_unwrap();
 
     // Reload the repo to pick up the new commits.
-    test_workspace.repo = test_workspace.repo.reload_at_head().block_on().unwrap();
+    test_workspace.repo = test_workspace.repo.reload_at_head().block_unwrap();
     // Create the merge commit.
-    let tree = merge_commit_trees(&*test_workspace.repo, &[parent1_commit, parent2_commit])
-        .block_on()
-        .unwrap();
+    let tree =
+        merge_commit_trees(&*test_workspace.repo, &[parent1_commit, parent2_commit]).block_unwrap();
     let merge_commit = commit_with_tree(test_workspace.repo.store(), tree);
     // Append new texts to the file with conflicts to make sure the last line is not
     // conflict markers.
     test_workspace
         .workspace
         .check_out(test_workspace.repo.op_id().clone(), None, &merge_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let mut file = File::options().append(true).open(&file_disk_path).unwrap();
     file.write_all(b"c\r\n").unwrap();
     drop(file);
@@ -293,8 +288,7 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
             None,
             &test_workspace.workspace.repo_loader().store().root_commit(),
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     // We have to query the Commit again. The Workspace is backed by a different
     // Store from the original Commit.
     let merge_commit = test_workspace
@@ -306,8 +300,7 @@ fn create_conflict_snapshot_and_read(extra_setting: &str) -> Vec<u8> {
     test_workspace
         .workspace
         .check_out(test_workspace.repo.op_id().clone(), None, &merge_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     assert!(std::fs::exists(&file_disk_path).unwrap());
     std::fs::read(&file_disk_path).unwrap()
@@ -426,22 +419,20 @@ fn test_eol_conversion_update_conflicts(
         .repo_mut()
         .new_commit(vec![root_commit.id().clone()], tree)
         .write_unwrap();
-    tx.commit("commit parent 2").block_on().unwrap();
+    tx.commit("commit parent 2").block_unwrap();
 
     // Reload the repo to pick up the new commits.
-    test_workspace.repo = test_workspace.repo.reload_at_head().block_on().unwrap();
+    test_workspace.repo = test_workspace.repo.reload_at_head().block_unwrap();
     // Create the merge commit.
-    let tree = merge_commit_trees(&*test_workspace.repo, &[parent1_commit, parent2_commit])
-        .block_on()
-        .unwrap();
+    let tree =
+        merge_commit_trees(&*test_workspace.repo, &[parent1_commit, parent2_commit]).block_unwrap();
     let merge_commit = commit_with_tree(test_workspace.repo.store(), tree);
 
     // Checkout the merge commit.
     test_workspace
         .workspace
         .check_out(test_workspace.repo.op_id().clone(), None, &merge_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let contents = std::fs::read(&file_disk_path).unwrap();
     for line in contents.lines_with_terminator() {
         assert!(
@@ -549,8 +540,7 @@ fn test_eol_conversion_checkout(
             None,
             &test_workspace.workspace.repo_loader().store().root_commit(),
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert!(!std::fs::exists(&file_disk_path).unwrap());
 
     let extra_setting = format!("{extra_setting}\n");
@@ -577,8 +567,7 @@ fn test_eol_conversion_checkout(
     test_workspace
         .workspace
         .check_out(test_workspace.repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // When we take a snapshot now, the tree may not be clean, because the EOL our
     // snapshot creates may not align with what is currently used in store. e.g.

--- a/lib/tests/test_evolution_predecessors.rs
+++ b/lib/tests/test_evolution_predecessors.rs
@@ -29,8 +29,8 @@ use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
 use jj_lib::settings::UserSettings;
 use maplit::btreemap;
-use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::commit_transactions;
 use testutils::write_random_commit;
@@ -49,7 +49,7 @@ fn test_walk_predecessors_basic() {
 
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit2 = tx
@@ -57,8 +57,8 @@ fn test_walk_predecessors_basic() {
         .rewrite_commit(&commit1)
         .set_description("rewritten")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     // The root commit has no associated operation because it isn't "created" at
     // the root operation.
@@ -92,7 +92,7 @@ fn test_walk_predecessors_basic_legacy_op() {
 
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit2 = tx
@@ -100,8 +100,8 @@ fn test_walk_predecessors_basic_legacy_op() {
         .rewrite_commit(&commit1)
         .set_description("rewritten")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     // Save operation without the predecessors as old jj would do. We only need
     // to rewrite the head operation since walk_predecessors() will fall back to
@@ -109,9 +109,9 @@ fn test_walk_predecessors_basic_legacy_op() {
     let repo2 = {
         let mut data = repo2.operation().store_operation().clone();
         data.commit_predecessors = None;
-        let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
-        let op = loader.load_operation(&op_id).block_on().unwrap();
-        loader.load_at(&op).block_on().unwrap()
+        let op_id = loader.op_store().write_operation(&data).block_unwrap();
+        let op = loader.load_operation(&op_id).block_unwrap();
+        loader.load_at(&op).block_unwrap()
     };
 
     let entries = collect_predecessors(&repo2, commit2.id());
@@ -131,7 +131,7 @@ fn test_walk_predecessors_concurrent_ops() {
 
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx2 = repo1.start_transaction();
     let commit2 = tx2
@@ -139,14 +139,14 @@ fn test_walk_predecessors_concurrent_ops() {
         .rewrite_commit(&commit1)
         .set_description("rewritten 2")
         .write_unwrap();
-    tx2.repo_mut().rebase_descendants().block_on().unwrap();
+    tx2.repo_mut().rebase_descendants().block_unwrap();
     let mut tx3 = repo1.start_transaction();
     let commit3 = tx3
         .repo_mut()
         .rewrite_commit(&commit1)
         .set_description("rewritten 3")
         .write_unwrap();
-    tx3.repo_mut().rebase_descendants().block_on().unwrap();
+    tx3.repo_mut().rebase_descendants().block_unwrap();
     let repo4 = commit_transactions(vec![tx2, tx3]);
     let [op2, op3] = repo4
         .operation()
@@ -166,8 +166,8 @@ fn test_walk_predecessors_concurrent_ops() {
         .rewrite_commit(&commit3)
         .set_description("rewritten 5")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo5 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo5 = tx.commit("test").block_unwrap();
 
     let entries = collect_predecessors(&repo5, commit4.id());
     assert_eq!(entries.len(), 3);
@@ -201,11 +201,11 @@ fn test_walk_predecessors_multiple_predecessors_across_ops() {
 
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit2 = write_random_commit(tx.repo_mut());
-    let repo2 = tx.commit("test").block_on().unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     let mut tx = repo2.start_transaction();
     let commit3 = tx
@@ -214,8 +214,8 @@ fn test_walk_predecessors_multiple_predecessors_across_ops() {
         .set_predecessors(vec![commit2.id().clone(), commit1.id().clone()])
         .set_description("rewritten")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo3 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo3 = tx.commit("test").block_unwrap();
 
     // Predecessor commits are emitted in chronological (operation) order.
     let entries = collect_predecessors(&repo3, commit3.id());
@@ -242,7 +242,7 @@ fn test_walk_predecessors_multiple_predecessors_within_op() {
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
     let commit2 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit3 = tx
@@ -251,8 +251,8 @@ fn test_walk_predecessors_multiple_predecessors_within_op() {
         .set_predecessors(vec![commit1.id().clone(), commit2.id().clone()])
         .set_description("rewritten")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     let entries = collect_predecessors(&repo2, commit3.id());
     assert_eq!(entries.len(), 3);
@@ -277,7 +277,7 @@ fn test_walk_predecessors_transitive() {
 
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit2 = tx
@@ -290,8 +290,8 @@ fn test_walk_predecessors_transitive() {
         .rewrite_commit(&commit2)
         .set_description("rewritten 3")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     let entries = collect_predecessors(&repo2, commit3.id());
     assert_eq!(entries.len(), 3);
@@ -336,8 +336,8 @@ fn test_walk_predecessors_transitive_graph_order() {
         .rewrite_commit(&commit1)
         .set_description("rewritten 4")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo1 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit5 = tx
@@ -346,8 +346,8 @@ fn test_walk_predecessors_transitive_graph_order() {
         .set_predecessors(vec![commit4.id().clone(), commit3.id().clone()])
         .set_description("rewritten 5")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     let entries = collect_predecessors(&repo2, commit5.id());
     assert_eq!(entries.len(), 5);
@@ -384,7 +384,7 @@ fn test_walk_predecessors_unsimplified() {
 
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit2 = tx
@@ -392,8 +392,8 @@ fn test_walk_predecessors_unsimplified() {
         .rewrite_commit(&commit1)
         .set_description("rewritten 2")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     let mut tx = repo2.start_transaction();
     let commit3 = tx
@@ -402,8 +402,8 @@ fn test_walk_predecessors_unsimplified() {
         .set_predecessors(vec![commit1.id().clone(), commit2.id().clone()])
         .set_description("rewritten 3")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo3 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo3 = tx.commit("test").block_unwrap();
 
     let entries = collect_predecessors(&repo3, commit3.id());
     assert_eq!(entries.len(), 3);
@@ -429,16 +429,16 @@ fn test_walk_predecessors_direct_cycle_within_op() {
 
     let mut tx = repo0.start_transaction();
     let commit1 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let repo1 = {
         let mut data = repo1.operation().store_operation().clone();
         data.commit_predecessors = Some(btreemap! {
             commit1.id().clone() => vec![commit1.id().clone()],
         });
-        let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
-        let op = loader.load_operation(&op_id).block_on().unwrap();
-        loader.load_at(&op).block_on().unwrap()
+        let op_id = loader.op_store().write_operation(&data).block_unwrap();
+        let op = loader.load_operation(&op_id).block_unwrap();
+        loader.load_at(&op).block_unwrap()
     };
     assert_matches!(
         walk_predecessors(&repo1, slice::from_ref(commit1.id())).next(),
@@ -456,7 +456,7 @@ fn test_walk_predecessors_indirect_cycle_within_op() {
     let commit1 = write_random_commit(tx.repo_mut());
     let commit2 = write_random_commit(tx.repo_mut());
     let commit3 = write_random_commit(tx.repo_mut());
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let repo1 = {
         let mut data = repo1.operation().store_operation().clone();
@@ -465,9 +465,9 @@ fn test_walk_predecessors_indirect_cycle_within_op() {
             commit2.id().clone() => vec![commit1.id().clone()],
             commit3.id().clone() => vec![commit2.id().clone()],
         });
-        let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
-        let op = loader.load_operation(&op_id).block_on().unwrap();
-        loader.load_at(&op).block_on().unwrap()
+        let op_id = loader.op_store().write_operation(&data).block_unwrap();
+        let op = loader.load_operation(&op_id).block_unwrap();
+        loader.load_at(&op).block_unwrap()
     };
     assert_matches!(
         walk_predecessors(&repo1, slice::from_ref(commit3.id())).next(),
@@ -519,26 +519,26 @@ fn test_accumulate_predecessors() {
     let commit_a1 = new_commit(tx.repo_mut(), "a1");
     let commit_a2 = new_commit(tx.repo_mut(), "a2");
     let commit_a3 = new_commit(tx.repo_mut(), "a3");
-    let repo_a = tx.commit("a").block_on().unwrap();
+    let repo_a = tx.commit("a").block_unwrap();
 
     let mut tx = repo_a.start_transaction();
     let commit_b1 = rewrite_commit(tx.repo_mut(), &[&commit_a1], "b1");
     let commit_b2 = rewrite_commit(tx.repo_mut(), &[&commit_a2, &commit_a3], "b2");
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo_b = tx.commit("b").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo_b = tx.commit("b").block_unwrap();
 
     let mut tx = repo_b.start_transaction();
     let commit_c1 = rewrite_commit(tx.repo_mut(), &[&commit_b1], "c1");
     let commit_c2 = rewrite_commit(tx.repo_mut(), &[&commit_b2, &commit_a3], "c2");
     let commit_c3 = rewrite_commit(tx.repo_mut(), &[&commit_c2], "c3");
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo_c = tx.commit("c").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo_c = tx.commit("c").block_unwrap();
 
     let mut tx = repo_a.start_transaction();
     let commit_d1 = rewrite_commit(tx.repo_mut(), &[&commit_a1], "d1");
     let commit_d2 = rewrite_commit(tx.repo_mut(), &[&commit_a2], "d2");
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo_d = tx.commit("d").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo_d = tx.commit("d").block_unwrap();
 
     // Empty old/new ops
     let predecessors = accumulate_predecessors(&[], slice::from_ref(repo_c.operation())).unwrap();

--- a/lib/tests/test_fix.rs
+++ b/lib/tests/test_fix.rs
@@ -29,6 +29,7 @@ use jj_lib::store::Store;
 use jj_lib::transaction::Transaction;
 use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::assert_tree_eq;
 use testutils::create_tree;
@@ -82,8 +83,7 @@ fn fix_file(store: &Store, file_to_fix: &FileToFix) -> Result<Option<FileId>, Fi
         let new_content = rest.to_ascii_uppercase();
         let new_file_id = store
             .write_file(&file_to_fix.repo_path, &mut new_content.as_slice())
-            .block_on()
-            .unwrap();
+            .block_unwrap();
         Ok(Some(new_file_id))
     } else if let Some(rest) = old_content.strip_prefix(b"error:") {
         Err(make_fix_content_error(str::from_utf8(rest).unwrap()))
@@ -121,8 +121,7 @@ fn test_fix_one_file() {
         tx.repo_mut(),
         &mut file_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     let expected_tree_a = create_tree(repo, &[(path1, "CONTENT")]);
     assert_eq!(summary.rewrites.len(), 1);
@@ -158,8 +157,7 @@ fn test_fixer_does_not_change_content() {
         tx.repo_mut(),
         &mut file_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     assert!(summary.rewrites.is_empty());
     assert_eq!(summary.num_checked_commits, 1);
@@ -186,8 +184,7 @@ fn test_empty_commit() {
         tx.repo_mut(),
         &mut file_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     assert!(summary.rewrites.is_empty());
     assert_eq!(summary.num_checked_commits, 1);
@@ -245,8 +242,7 @@ fn test_unchanged_file_is_not_fixed() {
         tx.repo_mut(),
         &mut file_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     assert!(summary.rewrites.is_empty());
     assert_eq!(summary.num_checked_commits, 1);
@@ -276,8 +272,7 @@ fn test_unchanged_file_is_fixed() {
         tx.repo_mut(),
         &mut file_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     let expected_tree_b = create_tree(repo, &[(path1, "CONTENT")]);
     assert_eq!(summary.rewrites.len(), 1);
@@ -317,8 +312,7 @@ fn test_already_fixed_descendant() {
         tx.repo_mut(),
         &mut file_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     assert_eq!(summary.rewrites.len(), 2);
     assert!(summary.rewrites.contains_key(&commit_a));
@@ -359,8 +353,7 @@ fn test_parallel_fixer_basic() {
         tx.repo_mut(),
         &mut parallel_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     let expected_tree_a = create_tree(repo, &[(path1, "CONTENT")]);
     assert_eq!(summary.rewrites.len(), 1);
@@ -399,8 +392,7 @@ fn test_parallel_fixer_fixes_files() {
         tx.repo_mut(),
         &mut parallel_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     let expected_tree_a = create_tree_with(repo, |builder| {
         for i in 0..100 {
@@ -444,8 +436,7 @@ fn test_parallel_fixer_does_not_change_content() {
         tx.repo_mut(),
         &mut parallel_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     assert!(summary.rewrites.is_empty());
     assert_eq!(summary.num_checked_commits, 1);
@@ -527,8 +518,7 @@ fn test_fix_multiple_revisions() {
         tx.repo_mut(),
         &mut file_fixer,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     let expected_tree_a = create_tree(repo, &[(path1, "XYZ")]);
 

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -92,6 +92,7 @@ use pollster::FutureExt as _;
 use tempfile::TempDir;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::TestRepoBackend;
 use testutils::base_user_config;
@@ -183,7 +184,7 @@ fn fetch_import_all(mut_repo: &mut MutableRepo, remote: &RemoteName) -> GitImpor
     )
     .unwrap();
     fetch_all_with(&mut fetcher, remote).unwrap();
-    fetcher.import_refs().block_on().unwrap()
+    fetcher.import_refs().block_unwrap()
 }
 
 /// Fetches all refs without importing.
@@ -239,12 +240,10 @@ fn test_import_refs() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    let stats = git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
 
     assert!(stats.abandoned_commits.is_empty());
@@ -384,11 +383,9 @@ fn test_import_refs_reimport() {
         .unwrap();
 
     let mut tx = repo.start_transaction();
-    let stats = git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     assert!(stats.abandoned_commits.is_empty());
     let expected_heads = hashset! {
@@ -410,14 +407,12 @@ fn test_import_refs_reimport() {
         .write_unwrap();
     tx.repo_mut()
         .set_local_bookmark_target("feature2".as_ref(), RefTarget::normal(commit6.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
-    let stats = git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     assert_eq!(
         // The order is unstable just because we import heads from Git repo.
@@ -499,20 +494,16 @@ fn test_import_refs_reimport_head_removed() {
 
     let commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     let commit_id = jj_id(commit);
     // Test the setup
     assert!(tx.repo().view().heads().contains(&commit_id));
 
     // Remove the head and re-import
     tx.repo_mut().remove_head(&commit_id);
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(!tx.repo().view().heads().contains(&commit_id));
 }
 
@@ -529,11 +520,9 @@ fn test_import_refs_reimport_git_head_does_not_count() {
     testutils::git::set_head_to_id(&git_repo, commit);
 
     let mut tx = repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
 
     // Delete the bookmark and re-import. The commit should still be there since
     // HEAD points to it
@@ -542,11 +531,9 @@ fn test_import_refs_reimport_git_head_does_not_count() {
         .unwrap()
         .delete()
         .unwrap();
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(!tx.repo().view().heads().contains(&jj_id(commit)));
 }
 
@@ -566,11 +553,9 @@ fn test_import_refs_reimport_git_head_without_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD.
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
 
@@ -581,11 +566,9 @@ fn test_import_refs_reimport_git_head_without_ref() {
     // would be moved by `git checkout` command. This isn't always true because the
     // detached HEAD commit could be rewritten by e.g. `git commit --amend` command,
     // but it should be safer than abandoning old checkout branch.
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
 }
@@ -613,11 +596,9 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
 
@@ -633,19 +614,15 @@ fn test_import_refs_reimport_git_head_with_moved_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD and main, which abandons the old main branch.
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(!tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
     // Reimport HEAD and main, which abandons the old main bookmark.
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(!tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
 }
@@ -676,11 +653,9 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
     );
 
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let expected_heads = hashset! {
             jj_id(commit_main),
@@ -735,11 +710,9 @@ fn test_import_refs_reimport_with_deleted_remote_ref() {
     delete_git_ref(&git_repo, "refs/remotes/origin/feature-remote-and-local");
 
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let view = repo.view();
     // The local bookmarks were indeed deleted
@@ -805,11 +778,9 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
     );
 
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let expected_heads = hashset! {
             jj_id(commit_main),
@@ -874,11 +845,9 @@ fn test_import_refs_reimport_with_moved_remote_ref() {
     );
 
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let view = repo.view();
     assert_eq!(view.bookmarks().count(), 3);
@@ -940,11 +909,9 @@ fn test_import_refs_reimport_with_moved_untracked_remote_ref() {
     let commit_base = empty_git_commit(&git_repo, remote_ref_name, &[]);
     let commit_remote_t0 = empty_git_commit(&git_repo, remote_ref_name, &[commit_base]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
 
     assert_eq!(*view.heads(), hashset! { jj_id(commit_remote_t0) });
@@ -962,11 +929,9 @@ fn test_import_refs_reimport_with_moved_untracked_remote_ref() {
     delete_git_ref(&git_repo, remote_ref_name);
     let commit_remote_t1 = empty_git_commit(&git_repo, remote_ref_name, &[commit_base]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
 
     // commit_remote_t0 should be abandoned, but commit_base shouldn't because
@@ -998,11 +963,9 @@ fn test_import_refs_reimport_with_deleted_untracked_intermediate_remote_ref() {
     let commit_remote_a = empty_git_commit(&git_repo, remote_ref_name_a, &[]);
     let commit_remote_b = empty_git_commit(&git_repo, remote_ref_name_b, &[commit_remote_a]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
 
     assert_eq!(*view.heads(), hashset! { jj_id(commit_remote_b) });
@@ -1026,11 +989,9 @@ fn test_import_refs_reimport_with_deleted_untracked_intermediate_remote_ref() {
     // Delete feature-a remotely and fetch the changes.
     delete_git_ref(&git_repo, remote_ref_name_a);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
 
     // No commits should be abandoned because feature-a is pinned by feature-b.
@@ -1063,11 +1024,9 @@ fn test_import_refs_reimport_with_deleted_abandoned_untracked_remote_ref() {
     let commit_remote_a = empty_git_commit(&git_repo, remote_ref_name_a, &[]);
     let commit_remote_b = empty_git_commit(&git_repo, remote_ref_name_b, &[commit_remote_a]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
 
     assert_eq!(*view.heads(), hashset! { jj_id(commit_remote_b) });
@@ -1098,8 +1057,8 @@ fn test_import_refs_reimport_with_deleted_abandoned_untracked_remote_ref() {
         .get_commit(&jj_id(commit_remote_b))
         .unwrap();
     tx.repo_mut().record_abandoned_commit(&jj_commit_remote_b);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
     assert_eq!(*view.heads(), hashset! { jj_id(commit_remote_a) });
     assert_eq!(view.local_bookmarks().count(), 0);
@@ -1108,11 +1067,9 @@ fn test_import_refs_reimport_with_deleted_abandoned_untracked_remote_ref() {
     // Delete feature-a remotely and fetch the changes.
     delete_git_ref(&git_repo, remote_ref_name_a);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let view = repo.view();
 
     // The feature-a commit should be abandoned. Since feature-b has already
@@ -1153,14 +1110,12 @@ fn test_import_refs_reimport_absent_tracked_remote_bookmarks() {
         .set_remote_bookmark(remote_symbol("foo", "origin"), absent_tracked_ref.clone());
     tx.repo_mut()
         .set_remote_bookmark(remote_symbol("foo", "upstream"), absent_tracked_ref.clone());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Import with no change.
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Absent tracked remote refs shouldn't be deleted.
     assert_eq!(
@@ -1182,10 +1137,8 @@ fn test_import_refs_reimport_absent_tracked_remote_bookmarks() {
         )
         .unwrap();
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Tracked refs should be merged and their state should be preserved.
     assert_eq!(
@@ -1231,14 +1184,12 @@ fn test_import_refs_reimport_absent_tracked_remote_tags() {
         .set_remote_tag(remote_symbol("bar", "git"), absent_tracked_ref.clone());
     tx.repo_mut()
         .set_remote_tag(remote_symbol("foo", "git"), absent_tracked_ref.clone());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Import with no change.
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Absent tracked remote refs shouldn't be deleted.
     assert_eq!(
@@ -1260,10 +1211,8 @@ fn test_import_refs_reimport_absent_tracked_remote_tags() {
         )
         .unwrap();
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Tracked refs should be merged and their state should be preserved.
     assert_eq!(
@@ -1307,15 +1256,13 @@ fn test_import_refs_reimport_remote_tags_deleted() {
         .set_remote_tag(remote_symbol("tag1", "git"), remote_ref1.clone());
     tx.repo_mut()
         .set_remote_tag(remote_symbol("tag1", "origin"), remote_ref1.clone());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Import "deleted" tags from Git repo.
     let mut tx = repo.start_transaction();
-    let stats = git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(stats.changed_remote_tags.len(), 1);
     assert_eq!(stats.changed_remote_tags[0].0, remote_symbol("tag1", "git"));
 
@@ -1356,11 +1303,9 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit1));
 
     // Import HEAD and main.
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
 
@@ -1368,11 +1313,9 @@ fn test_import_refs_reimport_git_head_with_fixed_ref() {
     testutils::git::set_head_to_id(&git_repo, git_id(&commit2));
 
     // Reimport HEAD, which shouldn't abandon the old HEAD branch.
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(tx.repo().view().heads().contains(commit1.id()));
     assert!(tx.repo().view().heads().contains(commit2.id()));
 }
@@ -1388,10 +1331,8 @@ fn test_import_refs_reimport_all_from_root_removed() {
 
     let commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     // Test the setup
     assert!(tx.repo().view().heads().contains(&jj_id(commit)));
 
@@ -1401,10 +1342,8 @@ fn test_import_refs_reimport_all_from_root_removed() {
         .unwrap()
         .delete()
         .unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(!tx.repo().view().heads().contains(&jj_id(commit)));
 }
 
@@ -1422,10 +1361,8 @@ fn test_import_refs_reimport_abandoning_disabled() {
     let commit1 = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let commit2 = empty_git_commit(&git_repo, "refs/heads/delete-me", &[commit1]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     // Test the setup
     assert!(tx.repo().view().heads().contains(&jj_id(commit2)));
 
@@ -1435,10 +1372,8 @@ fn test_import_refs_reimport_abandoning_disabled() {
         .unwrap()
         .delete()
         .unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert!(tx.repo().view().heads().contains(&jj_id(commit2)));
 }
 
@@ -1452,16 +1387,12 @@ fn test_import_refs_reimport_conflicted_remote_bookmark() {
     let commit1 = empty_git_commit(&git_repo, "refs/heads/commit1", &[]);
     git_ref(&git_repo, "refs/remotes/origin/main", commit1);
     let mut tx1 = repo.start_transaction();
-    git::import_refs(tx1.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(tx1.repo_mut(), &import_options).block_unwrap();
 
     let commit2 = empty_git_commit(&git_repo, "refs/heads/commit2", &[]);
     git_ref(&git_repo, "refs/remotes/origin/main", commit2);
     let mut tx2 = repo.start_transaction();
-    git::import_refs(tx2.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(tx2.repo_mut(), &import_options).block_unwrap();
 
     // Remote bookmark can diverge by divergent operations (like `jj git fetch`)
     let repo = commit_transactions(vec![tx1, tx2]);
@@ -1480,10 +1411,8 @@ fn test_import_refs_reimport_conflicted_remote_bookmark() {
 
     // The conflict can be resolved by importing the current Git state
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(
         repo.view().get_git_ref("refs/remotes/origin/main".as_ref()),
         &RefTarget::normal(jj_id(commit2)),
@@ -1509,9 +1438,7 @@ fn test_import_refs_reserved_remote_name() {
     empty_git_commit(&git_repo, "refs/remotes/gita/main", &[]);
 
     let mut tx = repo.start_transaction();
-    let stats = git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
     assert_eq!(stats.failed_ref_names, ["refs/remotes/git/main"]);
     let view = tx.repo().view();
     assert_eq!(
@@ -1547,10 +1474,9 @@ fn test_import_some_refs() {
             && symbol.remote == "origin"
             && symbol.name.as_str().starts_with("feature")
     })
-    .block_on()
-    .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    .block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // There are two heads, feature2 and feature4.
     let view = repo.view();
@@ -1641,10 +1567,9 @@ fn test_import_some_refs() {
     git::import_some_refs(tx.repo_mut(), &import_options, |kind, symbol| {
         kind == GitRefKind::Bookmark && symbol.remote == "origin" && symbol.name == "feature2"
     })
-    .block_on()
-    .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    .block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // feature2 and feature4 will still be heads, and all four bookmarks should be
     // present.
@@ -1658,11 +1583,10 @@ fn test_import_some_refs() {
     git::import_some_refs(tx.repo_mut(), &import_options, |kind, symbol| {
         kind == GitRefKind::Bookmark && symbol.remote == "origin" && symbol.name == "feature1"
     })
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     // No descendant should be rewritten.
-    assert_eq!(tx.repo_mut().rebase_descendants().block_on().unwrap(), 0);
-    let repo = tx.commit("test").block_on().unwrap();
+    assert_eq!(tx.repo_mut().rebase_descendants().block_unwrap(), 0);
+    let repo = tx.commit("test").block_unwrap();
 
     // feature2 and feature4 should still be the heads, and all three bookmarks
     // feature2, feature3, and feature3 should exist.
@@ -1676,11 +1600,10 @@ fn test_import_some_refs() {
     git::import_some_refs(tx.repo_mut(), &import_options, |kind, symbol| {
         kind == GitRefKind::Bookmark && symbol.remote == "origin" && symbol.name == "feature3"
     })
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.repo_mut().rebase_descendants().block_on().unwrap(), 0);
-    let repo = tx.commit("test").block_on().unwrap();
+    assert_eq!(tx.repo_mut().rebase_descendants().block_unwrap(), 0);
+    let repo = tx.commit("test").block_unwrap();
 
     // feature2 and feature4 should still be the heads, and both bookmarks
     // should exist.
@@ -1693,11 +1616,10 @@ fn test_import_some_refs() {
     git::import_some_refs(tx.repo_mut(), &import_options, |kind, symbol| {
         kind == GitRefKind::Bookmark && symbol.remote == "origin" && symbol.name == "feature4"
     })
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     // No descendant should be rewritten
-    assert_eq!(tx.repo_mut().rebase_descendants().block_on().unwrap(), 0);
-    let repo = tx.commit("test").block_on().unwrap();
+    assert_eq!(tx.repo_mut().rebase_descendants().block_unwrap(), 0);
+    let repo = tx.commit("test").block_unwrap();
 
     // feature2 should now be the only head and only bookmark.
     let view = repo.view();
@@ -1752,8 +1674,7 @@ impl GitRepoData {
             ReadonlyRepo::default_index_store_initializer(),
             ReadonlyRepo::default_submodule_store_initializer(),
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
         Self {
             _temp_dir: temp_dir,
             origin_repo,
@@ -1769,11 +1690,9 @@ fn test_import_refs_empty_git_repo() {
     let import_options = default_import_options();
     let heads_before = test_data.repo.view().heads().clone();
     let mut tx = test_data.repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(*repo.view().heads(), heads_before);
     assert_eq!(repo.view().bookmarks().count(), 0);
     assert_eq!(repo.view().local_tags().count(), 0);
@@ -1875,12 +1794,10 @@ fn test_import_refs_detached_head() {
     testutils::git::set_head_to_id(&test_data.git_repo, commit1);
 
     let mut tx = test_data.repo.start_transaction();
-    git::import_head(tx.repo_mut()).block_on().unwrap();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let expected_heads = hashset! { jj_id(commit1) };
     assert_eq!(*repo.view().heads(), expected_heads);
@@ -1899,11 +1816,9 @@ fn test_export_refs_no_detach() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
 
     // Do an initial export to make sure `main` is considered
     let stats = git::export_refs(mut_repo).unwrap();
@@ -1946,11 +1861,9 @@ fn test_export_refs_bookmark_changed() {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
     assert!(stats.failed_bookmarks.is_empty());
     assert!(stats.failed_tags.is_empty());
@@ -2006,12 +1919,10 @@ fn test_export_refs_tag_changed() {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    let stats = git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    let stats = git::import_refs(mut_repo, &import_options).block_unwrap();
     assert_eq!(stats.changed_remote_tags.len(), 4);
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
     assert!(stats.failed_bookmarks.is_empty());
     assert!(stats.failed_tags.is_empty());
@@ -2097,11 +2008,9 @@ fn test_export_refs_current_bookmark_changed() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
     assert!(stats.failed_bookmarks.is_empty());
     assert!(stats.failed_tags.is_empty());
@@ -2153,11 +2062,9 @@ fn test_export_refs_worktree_head_changed() {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
 
     let new_commit = create_random_commit(mut_repo)
         .set_parents(vec![jj_id(commit1)])
@@ -2197,11 +2104,9 @@ fn test_export_refs_worktree_no_detach() {
 
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
 
     let new_commit = create_random_commit(mut_repo)
         .set_parents(vec![jj_id(commit1)])
@@ -2233,11 +2138,9 @@ fn test_export_refs_current_tag_changed() {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/tags/v1.0");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
     assert!(stats.failed_bookmarks.is_empty());
     assert!(stats.failed_tags.is_empty());
@@ -2276,11 +2179,9 @@ fn test_export_refs_unborn_git_bookmark(move_placeholder_ref: bool) {
     testutils::git::set_symbolic_reference(&git_repo, "HEAD", "refs/heads/main");
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    git::import_head(mut_repo).block_on().unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    git::import_head(mut_repo).block_unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     let stats = git::export_refs(mut_repo).unwrap();
     assert!(stats.failed_bookmarks.is_empty());
     assert!(stats.failed_tags.is_empty());
@@ -2343,9 +2244,7 @@ fn test_export_import_sequence() {
             "test",
         )
         .unwrap();
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
         RefTarget::normal(commit_a.id().clone())
@@ -2374,9 +2273,7 @@ fn test_export_import_sequence() {
         .unwrap();
 
     // Import from git
-    git::import_refs(mut_repo, &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(mut_repo, &import_options).block_unwrap();
     assert_eq!(
         mut_repo.get_git_ref("refs/heads/main".as_ref()),
         RefTarget::normal(commit_c.id().clone())
@@ -2398,9 +2295,7 @@ fn test_import_export_non_tracking_bookmark() {
     let mut tx = test_data.repo.start_transaction();
     let mut_repo = tx.repo_mut();
 
-    git::import_refs(mut_repo, &default_import_options())
-        .block_on()
-        .unwrap();
+    git::import_refs(mut_repo, &default_import_options()).block_unwrap();
 
     assert!(
         mut_repo
@@ -2435,9 +2330,7 @@ fn test_import_export_non_tracking_bookmark() {
     // for the known bookmark "main".
     let commit_main_t1 = empty_git_commit(&git_repo, "refs/remotes/origin/main", &[commit_main_t0]);
     let commit_feat_t1 = empty_git_commit(&git_repo, "refs/remotes/origin/feat", &[]);
-    git::import_refs(mut_repo, &auto_track_import_options())
-        .block_on()
-        .unwrap();
+    git::import_refs(mut_repo, &auto_track_import_options()).block_unwrap();
     assert!(
         mut_repo
             .view()
@@ -2470,9 +2363,7 @@ fn test_import_export_non_tracking_bookmark() {
     // Reimport with auto-track-bookmarks off. Tracking bookmark should be imported.
     let commit_main_t2 = empty_git_commit(&git_repo, "refs/remotes/origin/main", &[commit_main_t1]);
     let commit_feat_t2 = empty_git_commit(&git_repo, "refs/remotes/origin/feat", &[commit_feat_t1]);
-    git::import_refs(mut_repo, &default_import_options())
-        .block_on()
-        .unwrap();
+    git::import_refs(mut_repo, &default_import_options()).block_unwrap();
     assert!(
         mut_repo
             .view()
@@ -3023,8 +2914,7 @@ fn test_reset_head_to_root() {
     let git_repo = testutils::git::init(&workspace_root);
     let (_workspace, repo) =
         Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -3039,7 +2929,7 @@ fn test_reset_head_to_root() {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).block_unwrap();
     assert!(git_repo.head().unwrap().is_detached(), "HEAD is detached");
     assert_eq!(
         tx.repo().git_head(),
@@ -3047,7 +2937,7 @@ fn test_reset_head_to_root() {
     );
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit1).block_unwrap();
     assert!(git_repo.head().unwrap().is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head().is_absent());
 
@@ -3060,7 +2950,7 @@ fn test_reset_head_to_root() {
             "",
         )
         .unwrap();
-    git::reset_head(tx.repo_mut(), &commit2).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).block_unwrap();
     assert!(git_repo.head_id().is_ok());
     assert_eq!(
         tx.repo().git_head(),
@@ -3069,7 +2959,7 @@ fn test_reset_head_to_root() {
     assert!(git_repo.find_reference("refs/jj/root").is_ok());
 
     // Set Git HEAD back to root
-    git::reset_head(tx.repo_mut(), &commit1).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit1).block_unwrap();
     assert!(git_repo.head().unwrap().is_unborn(), "HEAD is unborn");
     assert!(tx.repo().git_head().is_absent());
     // The placeholder ref should be deleted
@@ -3085,8 +2975,7 @@ fn test_reset_head_detached_out_of_sync() {
     let git_repo = testutils::git::init(&workspace_root);
     let (_workspace, repo) =
         Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
     let mut tx = repo.start_transaction();
 
@@ -3104,7 +2993,7 @@ fn test_reset_head_detached_out_of_sync() {
     let commit5 = write_random_commit(tx.repo_mut());
 
     // unborn -> commit1 (= commit2's parent)
-    git::reset_head(tx.repo_mut(), &commit2).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).block_unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
@@ -3118,7 +3007,7 @@ fn test_reset_head_detached_out_of_sync() {
 
     // {expected: commit1, actual: commit5} -> commit1 (= commit3's parent):
     // works because the expected HEAD is unchanged.
-    git::reset_head(tx.repo_mut(), &commit3).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit3).block_unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit1.id().clone())
@@ -3136,14 +3025,14 @@ fn test_reset_head_detached_out_of_sync() {
     );
 
     // Import the HEAD moved by external process
-    git::import_head(tx.repo_mut()).block_on().unwrap();
+    git::import_head(tx.repo_mut()).block_unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit5.id().clone())
     );
 
     // commit5 -> commit3 (= commit4's parent)
-    git::reset_head(tx.repo_mut(), &commit4).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit4).block_unwrap();
     assert_eq!(
         tx.repo().git_head(),
         RefTarget::normal(commit3.id().clone())
@@ -3176,8 +3065,7 @@ fn test_reset_head_with_index() {
     let git_repo = testutils::git::init(&workspace_root);
     let (_workspace, repo) =
         Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -3192,7 +3080,7 @@ fn test_reset_head_with_index() {
         .write_unwrap();
 
     // Set Git HEAD to commit2's parent (i.e. commit1)
-    git::reset_head(tx.repo_mut(), &commit2).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).block_unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 
     // Add "staged changes" to the Git index
@@ -3204,7 +3092,7 @@ fn test_reset_head_with_index() {
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Unconflicted file.txt Mode(FILE)");
 
     // Reset head and the Git index
-    git::reset_head(tx.repo_mut(), &commit2).block_on().unwrap();
+    git::reset_head(tx.repo_mut(), &commit2).block_unwrap();
     insta::assert_snapshot!(get_index_state(&workspace_root), @"");
 }
 
@@ -3217,8 +3105,7 @@ fn test_reset_head_with_index_no_conflict() {
     gix::init(&workspace_root).unwrap();
     let (_workspace, repo) =
         Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -3247,7 +3134,7 @@ fn test_reset_head_with_index_no_conflict() {
         .write_unwrap();
 
     // Reset head to working copy commit
-    git::reset_head(mut_repo, &wc_commit).block_on().unwrap();
+    git::reset_head(mut_repo, &wc_commit).block_unwrap();
 
     // Git index should contain all files from the tree.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3268,8 +3155,7 @@ fn test_reset_head_with_index_merge_conflict() {
     gix::init(&workspace_root).unwrap();
     let (_workspace, repo) =
         Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -3341,7 +3227,7 @@ fn test_reset_head_with_index_merge_conflict() {
         .write_unwrap();
 
     // Reset head to working copy commit with merge conflict
-    git::reset_head(mut_repo, &wc_commit).block_on().unwrap();
+    git::reset_head(mut_repo, &wc_commit).block_unwrap();
 
     // Index should contain conflicted files from merge of parent commits.
     // `Mode(DIR | SYMLINK)` actually means `MODE(COMMIT)`, as in a git submodule.
@@ -3370,8 +3256,7 @@ fn test_reset_head_with_index_file_directory_conflict() {
     gix::init(&workspace_root).unwrap();
     let (_workspace, repo) =
         Workspace::init_external_git(&settings, &workspace_root, &workspace_root.join(".git"))
-            .block_on()
-            .unwrap();
+            .block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -3405,7 +3290,7 @@ fn test_reset_head_with_index_file_directory_conflict() {
         .write_unwrap();
 
     // Reset head to working copy commit with file-directory conflict
-    git::reset_head(mut_repo, &wc_commit).block_on().unwrap();
+    git::reset_head(mut_repo, &wc_commit).block_unwrap();
 
     // Only the file should be added to the index (the tree should be skipped).
     insta::assert_snapshot!(get_index_state(&workspace_root), @"Theirs test Mode(FILE)");
@@ -3436,8 +3321,7 @@ fn test_init() {
         ReadonlyRepo::default_index_store_initializer(),
         ReadonlyRepo::default_submodule_store_initializer(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     // The refs were *not* imported -- it's the caller's responsibility to import
     // any refs they care about.
     assert!(!repo.view().heads().contains(&jj_id(initial_git_commit)));
@@ -3454,7 +3338,7 @@ fn test_fetch_empty_repo() {
     let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options).unwrap();
     fetch_all_with(&mut fetcher, "origin".as_ref()).unwrap();
     let default_branch = fetcher.get_default_branch("origin".as_ref()).unwrap();
-    let stats = fetcher.import_refs().block_on().unwrap();
+    let stats = fetcher.import_refs().block_unwrap();
     // No default bookmark and no refs
     assert_eq!(default_branch, None);
     assert!(stats.abandoned_commits.is_empty());
@@ -3474,11 +3358,11 @@ fn test_fetch_initial_commit_head_is_not_set() {
     let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options).unwrap();
     fetch_all_with(&mut fetcher, "origin".as_ref()).unwrap();
     let default_branch = fetcher.get_default_branch("origin".as_ref()).unwrap();
-    let stats = fetcher.import_refs().block_on().unwrap();
+    let stats = fetcher.import_refs().block_unwrap();
     // No default bookmark because the origin repo's HEAD wasn't set
     assert_eq!(default_branch, None);
     assert!(stats.abandoned_commits.is_empty());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     // The initial commit is visible after git_fetch().
     let view = repo.view();
     assert!(view.heads().contains(&jj_id(initial_git_commit)));
@@ -3533,7 +3417,7 @@ fn test_fetch_initial_commit_head_is_set() {
     let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options).unwrap();
     fetch_all_with(&mut fetcher, "origin".as_ref()).unwrap();
     let default_branch = fetcher.get_default_branch("origin".as_ref()).unwrap();
-    let stats = fetcher.import_refs().block_on().unwrap();
+    let stats = fetcher.import_refs().block_unwrap();
 
     assert_eq!(default_branch, Some("main".into()));
     assert!(stats.abandoned_commits.is_empty());
@@ -3551,8 +3435,8 @@ fn test_fetch_success() {
     let mut fetcher =
         GitFetch::new(tx.repo_mut(), subprocess_options.clone(), &import_options).unwrap();
     fetch_all_with(&mut fetcher, "origin".as_ref()).unwrap();
-    fetcher.import_refs().block_on().unwrap();
-    test_data.repo = tx.commit("test").block_on().unwrap();
+    fetcher.import_refs().block_unwrap();
+    test_data.repo = tx.commit("test").block_unwrap();
 
     testutils::git::set_symbolic_reference(&test_data.origin_repo, "HEAD", "refs/heads/main");
     let new_git_commit = empty_git_commit(
@@ -3574,11 +3458,11 @@ fn test_fetch_success() {
     let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options).unwrap();
     fetch_all_with(&mut fetcher, "origin".as_ref()).unwrap();
     let default_branch = fetcher.get_default_branch("origin".as_ref()).unwrap();
-    let stats = fetcher.import_refs().block_on().unwrap();
+    let stats = fetcher.import_refs().block_unwrap();
     // The default bookmark is "main"
     assert_eq!(default_branch, Some("main".into()));
     assert!(stats.abandoned_commits.is_empty());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     // The new commit is visible after we fetch again
     let view = repo.view();
     assert!(view.heads().contains(&jj_id(new_git_commit)));
@@ -3662,7 +3546,7 @@ fn test_fetch_no_default_branch() {
     let mut fetcher =
         GitFetch::new(tx.repo_mut(), subprocess_options.clone(), &import_options).unwrap();
     fetch_all_with(&mut fetcher, "origin".as_ref()).unwrap();
-    fetcher.import_refs().block_on().unwrap();
+    fetcher.import_refs().block_unwrap();
 
     empty_git_commit(
         &test_data.origin_repo,
@@ -3677,7 +3561,7 @@ fn test_fetch_no_default_branch() {
     let mut fetcher = GitFetch::new(tx.repo_mut(), subprocess_options, &import_options).unwrap();
     fetch_all_with(&mut fetcher, "origin".as_ref()).unwrap();
     let default_branch = fetcher.get_default_branch("origin".as_ref()).unwrap();
-    fetcher.import_refs().block_on().unwrap();
+    fetcher.import_refs().block_unwrap();
     // There is no default bookmark
     assert_eq!(default_branch, None);
 }
@@ -3698,16 +3582,14 @@ fn test_fetch_empty_refspecs() {
         tag: StringExpression::none(),
     };
     fetch_with(&mut fetcher, "origin".as_ref(), ref_expr).unwrap();
-    fetcher.import_refs().block_on().unwrap();
+    fetcher.import_refs().block_unwrap();
     assert_eq!(
         tx.repo_mut()
             .get_remote_bookmark(remote_symbol("main", "origin")),
         RemoteRef::absent()
     );
     // No remote refs should have been fetched
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
     assert_eq!(
         tx.repo_mut()
             .get_remote_bookmark(remote_symbol("main", "origin")),
@@ -3999,7 +3881,7 @@ fn test_fetch_multiple_branches() {
         tag: StringExpression::none(),
     };
     fetch_with(&mut fetcher, "origin".as_ref(), ref_expr).unwrap();
-    let stats = fetcher.import_refs().block_on().unwrap();
+    let stats = fetcher.import_refs().block_unwrap();
 
     assert_eq!(
         stats
@@ -4034,7 +3916,7 @@ fn test_fetch_local_remote_conflicts() {
         fetcher
             .fetch(remote, refspecs, &mut NullCallback, depth, fetch_tags)
             .unwrap();
-        fetcher.import_refs().block_on().unwrap()
+        fetcher.import_refs().block_unwrap()
     };
 
     // Create bookmark and tag at remote.
@@ -4054,7 +3936,7 @@ fn test_fetch_local_remote_conflicts() {
 
     // Fetch and track bookmark and tag.
     let stats = fetch_import(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(stats.changed_remote_bookmarks.len(), 1);
     assert_eq!(stats.changed_remote_tags.len(), 1);
 
@@ -4105,13 +3987,13 @@ fn test_fetch_with_tag_changes() {
         .set_remote_tag(remote_symbol("tag2", "git"), remote_ref2.clone());
     tx.repo_mut()
         .set_remote_tag(remote_symbol("tag2", "origin"), remote_ref2.clone());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Fetch and import refs.
     let mut tx = repo.start_transaction();
     let stats = fetch_import_all(tx.repo_mut(), "origin".as_ref());
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(stats.changed_remote_tags.len(), 2);
     assert_eq!(stats.changed_remote_tags[0].0, remote_symbol("tag1", "git"));
     assert_eq!(stats.changed_remote_tags[1].0, remote_symbol("tag2", "git"));
@@ -4159,7 +4041,7 @@ fn test_fetch_with_explicit_tag_patterns() {
         fetcher
             .fetch(remote, refspecs, &mut NullCallback, depth, fetch_tags)
             .unwrap();
-        fetcher.import_refs().block_on().unwrap()
+        fetcher.import_refs().block_unwrap()
     };
 
     // Create tagged commit at remote: tag1 could be fetched implicitly by
@@ -4181,7 +4063,7 @@ fn test_fetch_with_explicit_tag_patterns() {
     // Fetch "tag2". "tag1" shouldn't be fetched implicitly.
     let mut tx = test_data.repo.start_transaction();
     let stats = fetch_import(tx.repo_mut(), StringExpression::exact("tag2"));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(stats.changed_remote_tags.len(), 1);
     assert_eq!(
         stats.changed_remote_tags[0].0,
@@ -4203,7 +4085,7 @@ fn test_fetch_with_explicit_tag_patterns() {
     // Fetch "tag1". "tag2" should be unchanged.
     let mut tx = repo.start_transaction();
     let stats = fetch_import(tx.repo_mut(), StringExpression::exact("tag1"));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(stats.changed_remote_tags.len(), 1);
     assert_eq!(
         stats.changed_remote_tags[0].0,
@@ -4247,7 +4129,7 @@ fn test_fetch_export_annotated_tags() {
         fetcher
             .fetch(remote, refspecs, &mut NullCallback, depth, fetch_tags)
             .unwrap();
-        fetcher.import_refs().block_on().unwrap()
+        fetcher.import_refs().block_unwrap()
     };
 
     // Create tags at remote
@@ -4290,7 +4172,7 @@ fn test_fetch_export_annotated_tags() {
     tx.repo_mut()
         .set_local_tag_target("tag3.4".as_ref(), target4.clone());
     git::export_refs(tx.repo_mut()).unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     assert_eq!(repo.view().get_local_tag("tag1".as_ref()), &target1);
     assert_eq!(
@@ -4384,7 +4266,7 @@ fn test_fetch_with_fetch_tags_override() {
             fetcher
                 .fetch(remote, refspecs, &mut NullCallback, depth, fetch_tags)
                 .unwrap();
-            fetcher.import_refs().block_on().unwrap()
+            fetcher.import_refs().block_unwrap()
         };
     let changed_tags = |stats: &GitImportStats| {
         stats
@@ -4416,7 +4298,7 @@ fn test_fetch_with_fetch_tags_override() {
         &StringExpression::all(),
     )
     .unwrap();
-    let _repo = tx.commit("test").block_on().unwrap();
+    let _repo = tx.commit("test").block_unwrap();
     // Reload after Git configuration change.
     let repo = &test_repo
         .env
@@ -4447,7 +4329,7 @@ fn test_fetch_with_fetch_tags_override() {
         &StringExpression::all(),
     )
     .unwrap();
-    let _repo = tx.commit("test").block_on().unwrap();
+    let _repo = tx.commit("test").block_unwrap();
     // Reload after Git configuration change.
     let repo = &test_repo
         .env
@@ -4486,7 +4368,7 @@ fn test_fetch_rejected_tag_updates() {
     tx.repo_mut()
         .set_local_tag_target("tag".as_ref(), target2.clone());
     git::export_refs(tx.repo_mut()).unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Tags shouldn't be "force" updated. (#7528)
     let mut tx = repo.start_transaction();
@@ -4558,8 +4440,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
         ReadonlyRepo::default_index_store_initializer(),
         ReadonlyRepo::default_submodule_store_initializer(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     get_git_backend(&jj_repo)
         .import_head_commits(&[jj_id(initial_git_commit)])
         .unwrap();
@@ -4587,7 +4468,7 @@ fn set_up_push_repos(settings: &UserSettings, temp_dir: &TempDir) -> PushTestSet
             state: RemoteRefState::Tracked,
         },
     );
-    let jj_repo = tx.commit("test").block_on().unwrap();
+    let jj_repo = tx.commit("test").block_unwrap();
     PushTestSetup {
         source_repo_dir,
         jj_repo,
@@ -4668,11 +4549,9 @@ fn test_push_bookmarks_success() {
     );
 
     // Check that the repo view reflects the changes in the Git repo
-    setup.jj_repo = tx.commit("test").block_on().unwrap();
+    setup.jj_repo = tx.commit("test").block_unwrap();
     let mut tx = setup.jj_repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
     assert!(!tx.repo().has_changes());
 }
 
@@ -4745,11 +4624,9 @@ fn test_push_bookmarks_deletion() {
     );
 
     // Check that the repo view reflects the changes in the Git repo
-    setup.jj_repo = tx.commit("test").block_on().unwrap();
+    setup.jj_repo = tx.commit("test").block_unwrap();
     let mut tx = setup.jj_repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
     assert!(!tx.repo().has_changes());
 }
 
@@ -4839,11 +4716,9 @@ fn test_push_bookmarks_mixed_deletion_and_addition() {
     );
 
     // Check that the repo view reflects the changes in the Git repo
-    setup.jj_repo = tx.commit("test").block_on().unwrap();
+    setup.jj_repo = tx.commit("test").block_unwrap();
     let mut tx = setup.jj_repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
     assert!(!tx.repo().has_changes());
 }
 
@@ -4990,7 +4865,7 @@ fn test_push_bookmarks_unmapped_refs() {
         &StringExpression::exact("dummy"),
     )
     .unwrap();
-    let repo = tx.commit("set up remote").block_on().unwrap();
+    let repo = tx.commit("set up remote").block_unwrap();
     // Reload after Git configuration change.
     let repo = test_repo
         .env
@@ -5445,11 +5320,9 @@ fn test_bulk_update_extra_on_import_refs() {
     };
     let import_refs = |repo: &Arc<ReadonlyRepo>| {
         let mut tx = repo.start_transaction();
-        git::import_refs(tx.repo_mut(), &import_options)
-            .block_on()
-            .unwrap();
-        tx.repo_mut().rebase_descendants().block_on().unwrap();
-        tx.commit("test").block_on().unwrap()
+        git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+        tx.repo_mut().rebase_descendants().block_unwrap();
+        tx.commit("test").block_unwrap()
     };
 
     // Extra metadata table shouldn't be created per read_commit() call. The number
@@ -5488,11 +5361,9 @@ fn test_rewrite_imported_commit() {
     // Import git commit, which generates change id from the commit id.
     let git_commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let imported_commit = repo.store().get_commit(&jj_id(git_commit)).unwrap();
 
     // Try to create identical commit with different change id.
@@ -5507,7 +5378,7 @@ fn test_rewrite_imported_commit() {
         .set_committer(imported_commit.committer().clone())
         .set_description(imported_commit.description())
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Imported commit shouldn't be reused, and the timestamp of the authored
     // commit should be adjusted to create new commit.
@@ -5555,7 +5426,7 @@ fn test_concurrent_write_commit() {
                 let commit = create_rooted_commit(tx.repo_mut())
                     .set_description("racy commit")
                     .write_unwrap();
-                tx.commit(format!("writer {i}")).block_on().unwrap();
+                tx.commit(format!("writer {i}")).block_unwrap();
                 sender
                     .send((commit.id().clone(), commit.change_id().clone()))
                     .unwrap();
@@ -5576,7 +5447,7 @@ fn test_concurrent_write_commit() {
     assert_eq!(commit_change_ids.len(), num_thread);
 
     // All unique commits should be preserved.
-    let repo = repo.reload_at_head().block_on().unwrap();
+    let repo = repo.reload_at_head().block_unwrap();
     for (commit_id, change_ids) in &commit_change_ids {
         let commit = repo.store().get_commit(commit_id).unwrap();
         assert_eq!(commit.id(), commit_id);
@@ -5644,7 +5515,7 @@ fn test_concurrent_read_write_commit() {
                 let commit = create_rooted_commit(tx.repo_mut())
                     .set_description(format!("commit {i}"))
                     .write_unwrap();
-                tx.commit(format!("writer {i}")).block_on().unwrap();
+                tx.commit(format!("writer {i}")).block_unwrap();
                 assert_eq!(commit.id(), commit_id);
             });
         }
@@ -5663,7 +5534,7 @@ fn test_concurrent_read_write_commit() {
                     if pending_commit_ids.is_empty() {
                         break;
                     }
-                    repo = repo.reload_at_head().block_on().unwrap();
+                    repo = repo.reload_at_head().block_unwrap();
                     let git_backend = get_git_backend(&repo);
                     let mut tx = repo.start_transaction();
                     pending_commit_ids = pending_commit_ids
@@ -5692,7 +5563,7 @@ fn test_concurrent_read_write_commit() {
                         })
                         .collect_vec();
                     if tx.repo().has_changes() {
-                        tx.commit(format!("reader {i}")).block_on().unwrap();
+                        tx.commit(format!("reader {i}")).block_unwrap();
                     }
                     thread::yield_now();
                 }
@@ -5710,7 +5581,7 @@ fn test_concurrent_read_write_commit() {
     });
 
     // The index should be consistent with the store.
-    let repo = repo.reload_at_head().block_on().unwrap();
+    let repo = repo.reload_at_head().block_unwrap();
     for commit_id in &commit_ids {
         assert!(repo.index().has_id(commit_id).unwrap());
         let commit = repo.store().get_commit(commit_id).unwrap();
@@ -5784,10 +5655,8 @@ fn test_shallow_commits_lack_parents() {
     let repo = make_shallow(repo, vec![b, c]);
 
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("import").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    let repo = tx.commit("import").block_unwrap();
     let store = repo.store();
     let root = store.root_commit_id();
 
@@ -5817,10 +5686,8 @@ fn test_shallow_commits_lack_parents() {
     let repo = make_shallow(&repo, vec![a]);
 
     let mut tx = repo.start_transaction();
-    git::import_refs(tx.repo_mut(), &import_options)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("import").block_on().unwrap();
+    git::import_refs(tx.repo_mut(), &import_options).block_unwrap();
+    let repo = tx.commit("import").block_unwrap();
     let store = repo.store();
     let root = store.root_commit_id();
 
@@ -5857,7 +5724,7 @@ fn test_remote_remove_refs() {
         &StringExpression::all(),
     )
     .unwrap();
-    let _repo = tx.commit("test").block_on().unwrap();
+    let _repo = tx.commit("test").block_unwrap();
     // Reload after Git configuration change.
     let repo = &test_repo
         .env
@@ -5872,7 +5739,7 @@ fn test_remote_remove_refs() {
 
     let mut tx = repo.start_transaction();
     git::remove_remote(tx.repo_mut(), "foo".as_ref()).unwrap();
-    let repo = &tx.commit("remove").block_on().unwrap();
+    let repo = &tx.commit("remove").block_unwrap();
 
     let git_repo = get_git_repo(repo);
     // remote bookmarks
@@ -5926,7 +5793,7 @@ fn test_remote_rename_refs() {
         &StringExpression::all(),
     )
     .unwrap();
-    let _repo = tx.commit("test").block_on().unwrap();
+    let _repo = tx.commit("test").block_unwrap();
     // Reload after Git configuration change.
     let repo = &test_repo
         .env
@@ -5941,7 +5808,7 @@ fn test_remote_rename_refs() {
 
     let mut tx = repo.start_transaction();
     git::rename_remote(tx.repo_mut(), "foo".as_ref(), "bar".as_ref()).unwrap();
-    let repo = &tx.commit("rename").block_on().unwrap();
+    let repo = &tx.commit("rename").block_unwrap();
 
     let git_repo = get_git_repo(repo);
     // remote bookmarks
@@ -6026,7 +5893,7 @@ fn test_remote_add_with_tags_specification(fetch_tags: gix::remote::fetch::Tags)
         &StringExpression::all(),
     )
     .unwrap();
-    let _repo = tx.commit("test").block_on().unwrap();
+    let _repo = tx.commit("test").block_unwrap();
 
     // Reload after Git configuration change.
     let repo = &test_repo
@@ -6165,7 +6032,7 @@ fn test_remote_add_with_refspecs() {
         &bookmark_expr,
     )
     .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Reload after Git configuration change.
     let repo = &test_repo

--- a/lib/tests/test_git_backend.rs
+++ b/lib/tests/test_git_backend.rs
@@ -40,8 +40,8 @@ use jj_lib::store::Store;
 use jj_lib::transaction::Transaction;
 use maplit::hashmap;
 use maplit::hashset;
-use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::TestRepoBackend;
 use testutils::assert_tree_eq;
@@ -142,7 +142,7 @@ fn test_gc() {
         .set_parents(vec![commit_f.id().clone()])
         .set_predecessors(vec![commit_d.id().clone()])
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(
         *repo.view().heads(),
         hashset! {
@@ -203,13 +203,13 @@ fn test_gc() {
 
     // G is no longer reachable
     let mut mut_index = base_index.start_modification();
-    mut_index.add_commit(&commit_a).block_on().unwrap();
-    mut_index.add_commit(&commit_b).block_on().unwrap();
-    mut_index.add_commit(&commit_c).block_on().unwrap();
-    mut_index.add_commit(&commit_d).block_on().unwrap();
-    mut_index.add_commit(&commit_e).block_on().unwrap();
-    mut_index.add_commit(&commit_f).block_on().unwrap();
-    mut_index.add_commit(&commit_h).block_on().unwrap();
+    mut_index.add_commit(&commit_a).block_unwrap();
+    mut_index.add_commit(&commit_b).block_unwrap();
+    mut_index.add_commit(&commit_c).block_unwrap();
+    mut_index.add_commit(&commit_d).block_unwrap();
+    mut_index.add_commit(&commit_e).block_unwrap();
+    mut_index.add_commit(&commit_f).block_unwrap();
+    mut_index.add_commit(&commit_h).block_unwrap();
     repo.store().gc(mut_index.as_index(), now()).unwrap();
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
@@ -222,10 +222,10 @@ fn test_gc() {
 
     // D|E|H are no longer reachable
     let mut mut_index = base_index.start_modification();
-    mut_index.add_commit(&commit_a).block_on().unwrap();
-    mut_index.add_commit(&commit_b).block_on().unwrap();
-    mut_index.add_commit(&commit_c).block_on().unwrap();
-    mut_index.add_commit(&commit_f).block_on().unwrap();
+    mut_index.add_commit(&commit_a).block_unwrap();
+    mut_index.add_commit(&commit_b).block_unwrap();
+    mut_index.add_commit(&commit_c).block_unwrap();
+    mut_index.add_commit(&commit_f).block_unwrap();
     repo.store().gc(mut_index.as_index(), now()).unwrap();
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
@@ -237,7 +237,7 @@ fn test_gc() {
 
     // B|C|F are no longer reachable
     let mut mut_index = base_index.start_modification();
-    mut_index.add_commit(&commit_a).block_on().unwrap();
+    mut_index.add_commit(&commit_a).block_unwrap();
     repo.store().gc(mut_index.as_index(), now()).unwrap();
     assert_eq!(
         collect_no_gc_refs(git_repo_path),
@@ -289,7 +289,7 @@ fn test_gc_extra_table() {
     for _ in 0..4 {
         write_random_commit(tx.repo_mut());
     }
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
     // The first 3 will be squashed into one table segment
     assert_eq!(collect_extra_segment_num_entries(), [3, 1]);
     assert_eq!(list_dir(&extra_path).len(), 5 + 1);

--- a/lib/tests/test_id_prefix.rs
+++ b/lib/tests/test_id_prefix.rs
@@ -33,8 +33,8 @@ use jj_lib::repo::MutableRepo;
 use jj_lib::repo::Repo as _;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::settings::UserSettings;
-use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::TestRepoBackend;
 
@@ -75,7 +75,7 @@ fn test_id_prefix() {
     for _ in 0..25 {
         commits.push(create_commit(commits.last().unwrap().id()));
     }
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Print the commit IDs and change IDs for reference
     let commit_prefixes = commits
@@ -290,7 +290,7 @@ fn test_id_prefix_divergent() {
         second_commit.clone(),
         third_commit_divergent_with_second.clone(),
     ];
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Print the commit IDs and change IDs for reference
     let change_prefixes = commits
@@ -461,8 +461,8 @@ fn test_id_prefix_hidden() {
 
     let hidden_commit = &commits[8];
     tx.repo_mut().record_abandoned_commit(hidden_commit);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let prefix = |x: &str| HexPrefix::try_from_hex(x).unwrap();
     let shortest_commit_prefix_len = |index: &IdPrefixIndex, commit_id| {

--- a/lib/tests/test_index.rs
+++ b/lib/tests/test_index.rs
@@ -45,6 +45,7 @@ use jj_lib::revset::ResolvedExpression;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::assert_tree_eq;
 use testutils::commit_transactions;
@@ -70,9 +71,8 @@ fn enable_changed_path_index(repo: &ReadonlyRepo) -> Arc<ReadonlyRepo> {
     let default_index_store: &DefaultIndexStore = repo.index_store().downcast_ref().unwrap();
     default_index_store
         .build_changed_path_index_at_operation(repo.op_id(), repo.store(), 0, |_| ())
-        .block_on()
-        .unwrap();
-    repo.reload_at(repo.operation()).block_on().unwrap()
+        .block_unwrap();
+    repo.reload_at(repo.operation()).block_unwrap()
 }
 
 fn collect_changed_paths(repo: &ReadonlyRepo, commit_id: &CommitId) -> Option<Vec<RepoPathBuf>> {
@@ -141,7 +141,7 @@ fn test_index_commits_standard_cases() {
     let commit_f = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b, &commit_e]);
     let commit_g = write_random_commit_with_parents(tx.repo_mut(), &[&commit_f]);
     let commit_h = write_random_commit_with_parents(tx.repo_mut(), &[&commit_e]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let index = as_readonly_index(&repo);
     // There should be the root commit, plus 8 more
@@ -208,7 +208,7 @@ fn test_index_commits_criss_cross() {
         left_commits.push(new_left);
         right_commits.push(new_right);
     }
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let index = as_readonly_index(&repo);
     // There should the root commit, plus 2 for each generation
@@ -380,11 +380,11 @@ fn test_index_commits_previous_operations() {
     let commit_a = write_random_commit(tx.repo_mut());
     let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
     let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().remove_head(commit_c.id());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Delete index from disk
     let default_index_store: &DefaultIndexStore = repo.index_store().downcast_ref().unwrap();
@@ -435,7 +435,7 @@ fn test_index_commits_hidden_but_referenced() {
         },
     );
 
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     // All commits should be indexed
     assert!(index_has_id(repo.index(), commit_a.id()));
     assert!(index_has_id(repo.index(), commit_b.id()));
@@ -471,7 +471,7 @@ fn test_index_commits_incremental() {
     let root_commit = repo.store().root_commit();
     let mut tx = repo.start_transaction();
     let commit_a = write_random_commit_with_parents(tx.repo_mut(), &[]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let index = as_readonly_index(&repo);
     // There should be the root commit, plus 1 more
@@ -480,7 +480,7 @@ fn test_index_commits_incremental() {
     let mut tx = repo.start_transaction();
     let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
     let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b]);
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let repo = test_env.load_repo_at_head(&settings, test_repo.repo_path());
     let index = as_readonly_index(&repo);
@@ -517,13 +517,13 @@ fn test_index_commits_incremental_empty_transaction() {
     let root_commit = repo.store().root_commit();
     let mut tx = repo.start_transaction();
     let commit_a = write_random_commit_with_parents(tx.repo_mut(), &[]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let index = as_readonly_index(&repo);
     // There should be the root commit, plus 1 more
     assert_eq!(index.num_commits(), 1 + 1);
 
-    repo.start_transaction().commit("test").block_on().unwrap();
+    repo.start_transaction().commit("test").block_unwrap();
 
     let repo = test_env.load_repo_at_head(&settings, test_repo.repo_path());
     let index = as_readonly_index(&repo);
@@ -555,7 +555,7 @@ fn test_index_commits_incremental_already_indexed() {
 
     let mut tx = repo.start_transaction();
     let commit_a = write_random_commit_with_parents(tx.repo_mut(), &[]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     assert!(index_has_id(repo.index(), commit_a.id()));
     assert_eq!(as_readonly_index(&repo).num_commits(), 1 + 1);
@@ -571,7 +571,7 @@ fn create_n_commits(repo: &Arc<ReadonlyRepo>, num_commits: i32) -> Arc<ReadonlyR
     for _ in 0..num_commits {
         write_random_commit(tx.repo_mut());
     }
-    tx.commit("test").block_on().unwrap()
+    tx.commit("test").block_unwrap()
 }
 
 fn as_readonly_index(repo: &Arc<ReadonlyRepo>) -> &DefaultReadonlyIndex {
@@ -661,7 +661,7 @@ fn test_reindex_no_segments_dir() {
 
     let mut tx = repo.start_transaction();
     let commit_a = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert!(index_has_id(repo.index(), commit_a.id()));
 
     // jj <= 0.14 doesn't have "segments" directory
@@ -682,7 +682,7 @@ fn test_reindex_corrupt_segment_files() {
 
     let mut tx = repo.start_transaction();
     let commit_a = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert!(index_has_id(repo.index(), commit_a.id()));
 
     // Corrupt the index files
@@ -719,7 +719,7 @@ fn test_reindex_from_merged_operation() {
     for _ in 0..2 {
         let mut tx = repo.start_transaction();
         let commit = write_random_commit(tx.repo_mut());
-        let repo = tx.commit("test").block_on().unwrap();
+        let repo = tx.commit("test").block_unwrap();
         let mut tx = repo.start_transaction();
         tx.repo_mut().remove_head(commit.id());
         txs.push(tx);
@@ -729,7 +729,7 @@ fn test_reindex_from_merged_operation() {
     op_ids_to_delete.push(repo.op_id());
     let mut tx = repo.start_transaction();
     write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     op_ids_to_delete.push(repo.op_id());
     let operation_to_reload = repo.operation();
 
@@ -745,7 +745,7 @@ fn test_reindex_from_merged_operation() {
     // When re-indexing, one of the merge parent operations will be selected as
     // the parent index segment. The commits in the other side should still be
     // reachable.
-    let repo = repo.reload_at(operation_to_reload).block_on().unwrap();
+    let repo = repo.reload_at(operation_to_reload).block_unwrap();
     let index = as_readonly_index(&repo);
     assert_eq!(index.num_commits(), 4);
 }
@@ -759,12 +759,12 @@ fn test_reindex_missing_commit() {
 
     let mut tx = repo.start_transaction();
     let missing_commit = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let bad_op_id = repo.op_id();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().remove_head(missing_commit.id());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Remove historical head commit to simulate bad GC.
     let test_backend: &TestBackend = repo.store().backend_impl().unwrap();
@@ -828,7 +828,7 @@ fn test_changed_path_segments() {
         .repo_mut()
         .new_commit(vec![root_commit_id.clone()], tree1)
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let stats = as_readonly_index(&repo).stats();
     assert_eq!(count_segment_files(), 1);
     assert_eq!(stats.changed_path_commits_range, Some(1..2));
@@ -848,7 +848,7 @@ fn test_changed_path_segments() {
         .repo_mut()
         .new_commit(vec![root_commit_id.clone()], tree2)
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let stats = as_readonly_index(&repo).stats();
     assert_eq!(count_segment_files(), 2);
     assert_eq!(stats.changed_path_commits_range, Some(1..3));
@@ -881,14 +881,13 @@ fn test_build_changed_path_segments() {
             .new_commit(vec![root_commit_id.clone()], tree)
             .write_unwrap();
     }
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Index the last 4 commits
     default_index_store
         .build_changed_path_index_at_operation(repo.op_id(), repo.store(), 4, |_| ())
-        .block_on()
-        .unwrap();
-    let repo = repo.reload_at(repo.operation()).block_on().unwrap();
+        .block_unwrap();
+    let repo = repo.reload_at(repo.operation()).block_unwrap();
     let stats = as_readonly_index(&repo).stats();
     assert_eq!(stats.changed_path_commits_range, Some(6..10));
     assert_eq!(stats.changed_path_levels.len(), 1);
@@ -899,9 +898,8 @@ fn test_build_changed_path_segments() {
     // Index remainders
     default_index_store
         .build_changed_path_index_at_operation(repo.op_id(), repo.store(), u32::MAX, |_| ())
-        .block_on()
-        .unwrap();
-    let repo = repo.reload_at(repo.operation()).block_on().unwrap();
+        .block_unwrap();
+    let repo = repo.reload_at(repo.operation()).block_unwrap();
     let stats = as_readonly_index(&repo).stats();
     assert_eq!(stats.changed_path_commits_range, Some(0..10));
     assert_eq!(stats.changed_path_levels.len(), 2);
@@ -929,7 +927,7 @@ fn test_build_changed_path_segments_partially_enabled() {
                 .new_commit(vec![root_commit_id.clone()], tree)
                 .write_unwrap();
         }
-        let repo = tx.commit("test").block_on().unwrap();
+        let repo = tx.commit("test").block_unwrap();
         let repo = enable_changed_path_index(&repo);
         let mut tx = repo.start_transaction();
         let tree = create_tree(&repo, &[(repo_path("5"), "")]);
@@ -957,9 +955,8 @@ fn test_build_changed_path_segments_partially_enabled() {
     // Index later commits from the mid point
     default_index_store
         .build_changed_path_index_at_operation(repo.op_id(), repo.store(), 2, |_| ())
-        .block_on()
-        .unwrap();
-    let repo = repo.reload_at(repo.operation()).block_on().unwrap();
+        .block_unwrap();
+    let repo = repo.reload_at(repo.operation()).block_unwrap();
     let stats = as_readonly_index(&repo).stats();
     assert_eq!(stats.changed_path_commits_range, Some(5..8));
     assert_eq!(stats.changed_path_levels.len(), 1);
@@ -970,9 +967,8 @@ fn test_build_changed_path_segments_partially_enabled() {
     // Index later and earlier commits from the mid point
     default_index_store
         .build_changed_path_index_at_operation(repo.op_id(), repo.store(), 3, |_| ())
-        .block_on()
-        .unwrap();
-    let repo = repo.reload_at(repo.operation()).block_on().unwrap();
+        .block_unwrap();
+    let repo = repo.reload_at(repo.operation()).block_unwrap();
     let stats = as_readonly_index(&repo).stats();
     assert_eq!(stats.changed_path_commits_range, Some(4..10));
     assert_eq!(stats.changed_path_levels.len(), 1);
@@ -996,7 +992,7 @@ fn test_merge_changed_path_segments_both_enabled() {
     tx.repo_mut()
         .new_commit(vec![root_commit_id.clone()], tree1)
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Merge concurrent index segments without the common base segment
     let mut tx1 = repo.start_transaction();
@@ -1033,7 +1029,7 @@ fn test_merge_changed_path_segments_enabled_and_disabled() {
         tx.repo_mut()
             .new_commit(vec![root_commit_id.clone()], tree1)
             .write_unwrap();
-        let repo = tx.commit("test").block_on().unwrap();
+        let repo = tx.commit("test").block_unwrap();
         let repo = enable_changed_path_index(&repo);
         let mut tx = repo.start_transaction();
         tx.repo_mut()
@@ -1057,7 +1053,7 @@ fn test_merge_changed_path_segments_enabled_and_disabled() {
     // Changed paths in new commit can no longer be indexed
     let mut tx = repo.start_transaction();
     write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let stats = as_readonly_index(&repo).stats();
     assert_eq!(stats.num_commits, 5);
     assert_eq!(stats.changed_path_commits_range, Some(2..3));
@@ -1103,7 +1099,7 @@ fn test_commit_is_empty(indexed: bool) {
             tree4.clone(),
         )
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Sanity check
     let stats = as_readonly_index(&repo).stats();
@@ -1113,27 +1109,15 @@ fn test_commit_is_empty(indexed: bool) {
         assert_eq!(stats.changed_path_commits_range, None);
     }
 
-    assert!(commit1.is_empty(repo.as_ref()).block_on().unwrap());
-    assert!(!commit2.is_empty(repo.as_ref()).block_on().unwrap());
-    assert!(!commit3.is_empty(repo.as_ref()).block_on().unwrap());
-    assert!(commit4.is_empty(repo.as_ref()).block_on().unwrap());
+    assert!(commit1.is_empty(repo.as_ref()).block_unwrap());
+    assert!(!commit2.is_empty(repo.as_ref()).block_unwrap());
+    assert!(!commit3.is_empty(repo.as_ref()).block_unwrap());
+    assert!(commit4.is_empty(repo.as_ref()).block_unwrap());
 
-    assert_tree_eq!(
-        commit1.parent_tree(repo.as_ref()).block_on().unwrap(),
-        root_tree
-    );
-    assert_tree_eq!(
-        commit2.parent_tree(repo.as_ref()).block_on().unwrap(),
-        root_tree
-    );
-    assert_tree_eq!(
-        commit3.parent_tree(repo.as_ref()).block_on().unwrap(),
-        root_tree
-    );
-    assert_tree_eq!(
-        commit4.parent_tree(repo.as_ref()).block_on().unwrap(),
-        tree4
-    );
+    assert_tree_eq!(commit1.parent_tree(repo.as_ref()).block_unwrap(), root_tree);
+    assert_tree_eq!(commit2.parent_tree(repo.as_ref()).block_unwrap(), root_tree);
+    assert_tree_eq!(commit3.parent_tree(repo.as_ref()).block_unwrap(), root_tree);
+    assert_tree_eq!(commit4.parent_tree(repo.as_ref()).block_unwrap(), tree4);
 }
 
 #[test]

--- a/lib/tests/test_init.rs
+++ b/lib/tests/test_init.rs
@@ -22,8 +22,8 @@ use jj_lib::ref_name::WorkspaceName;
 use jj_lib::repo::Repo as _;
 use jj_lib::settings::UserSettings;
 use jj_lib::workspace::Workspace;
-use pollster::FutureExt as _;
 use test_case::test_case;
+use testutils::FutureTestExt as _;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
 use testutils::assert_tree_eq;
@@ -41,9 +41,7 @@ fn test_init_local() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
-    let (workspace, repo) = Workspace::init_simple(&settings, &uncanonical)
-        .block_on()
-        .unwrap();
+    let (workspace, repo) = Workspace::init_simple(&settings, &uncanonical).block_unwrap();
     assert!(repo.store().backend_impl::<GitBackend>().is_none());
     assert_eq!(workspace.workspace_root(), &canonical);
 
@@ -57,9 +55,7 @@ fn test_init_internal_git() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
-    let (workspace, repo) = Workspace::init_internal_git(&settings, &uncanonical)
-        .block_on()
-        .unwrap();
+    let (workspace, repo) = Workspace::init_internal_git(&settings, &uncanonical).block_unwrap();
     let git_backend: &GitBackend = repo.store().backend_impl().unwrap();
     let repo_path = canonical.join(".jj").join("repo");
     assert_eq!(workspace.workspace_root(), &canonical);
@@ -83,9 +79,7 @@ fn test_init_colocated_git() {
     let settings = testutils::user_settings();
     let temp_dir = testutils::new_temp_dir();
     let (canonical, uncanonical) = canonicalize(temp_dir.path());
-    let (workspace, repo) = Workspace::init_colocated_git(&settings, &uncanonical)
-        .block_on()
-        .unwrap();
+    let (workspace, repo) = Workspace::init_colocated_git(&settings, &uncanonical).block_unwrap();
     let git_backend: &GitBackend = repo.store().backend_impl().unwrap();
     let repo_path = canonical.join(".jj").join("repo");
     assert_eq!(workspace.workspace_root(), &canonical);
@@ -114,8 +108,7 @@ fn test_init_external_git() {
         &uncanonical.join("jj"),
         &git_repo_path.join(".git"),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let git_backend: &GitBackend = repo.store().backend_impl().unwrap();
     assert_eq!(workspace.workspace_root(), &canonical.join("jj"));
     assert_eq!(
@@ -186,7 +179,6 @@ fn test_init_load_non_utf8_path() {
     use std::os::unix::ffi::OsStrExt as _;
 
     use jj_lib::workspace::default_working_copy_factories;
-    use pollster::FutureExt as _;
     use testutils::TestEnvironment;
 
     let settings = testutils::user_settings();
@@ -209,8 +201,7 @@ fn test_init_load_non_utf8_path() {
     let workspace_root = test_env.root().join(OsStr::from_bytes(b"jj\xe0"));
     std::fs::create_dir(&workspace_root).unwrap();
     Workspace::init_external_git(&settings, &workspace_root, &git_repo_path.join(".git"))
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Workspace can be loaded
     let workspace = Workspace::load(
@@ -222,7 +213,7 @@ fn test_init_load_non_utf8_path() {
     .unwrap();
 
     // Just test that we can write a commit to the store
-    let repo = workspace.repo_loader().load_at_head().block_on().unwrap();
+    let repo = workspace.repo_loader().load_at_head().block_unwrap();
     let mut tx = repo.start_transaction();
     write_random_commit(tx.repo_mut());
 }

--- a/lib/tests/test_load_repo.rs
+++ b/lib/tests/test_load_repo.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use jj_lib::repo::RepoLoader;
-use pollster::FutureExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::write_random_commit;
 
@@ -25,11 +25,11 @@ fn test_load_at_operation() {
 
     let mut tx = repo.start_transaction();
     let commit = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("add commit").block_on().unwrap();
+    let repo = tx.commit("add commit").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().remove_head(commit.id());
-    tx.commit("remove commit").block_on().unwrap();
+    tx.commit("remove commit").block_unwrap();
 
     // If we load the repo at head, we should not see the commit since it was
     // removed
@@ -39,7 +39,7 @@ fn test_load_at_operation() {
         &test_repo.env.default_store_factories(),
     )
     .unwrap();
-    let head_repo = loader.load_at_head().block_on().unwrap();
+    let head_repo = loader.load_at_head().block_unwrap();
     assert!(!head_repo.view().heads().contains(commit.id()));
 
     // If we load the repo at the previous operation, we should see the commit since
@@ -50,6 +50,6 @@ fn test_load_at_operation() {
         &test_repo.env.default_store_factories(),
     )
     .unwrap();
-    let old_repo = loader.load_at(repo.operation()).block_on().unwrap();
+    let old_repo = loader.load_at(repo.operation()).block_unwrap();
     assert!(old_repo.view().heads().contains(commit.id()));
 }

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -70,6 +70,7 @@ use jj_lib::workspace::default_working_copy_factories;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
@@ -253,7 +254,7 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
                 )
             }
             Kind::Symlink => {
-                let id = store.write_symlink(path, "target").block_on().unwrap();
+                let id = store.write_symlink(path, "target").block_unwrap();
                 Merge::normal(TreeValue::Symlink(id))
             }
             Kind::Tree => {
@@ -270,7 +271,7 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
             Kind::GitSubmodule => {
                 let mut tx = repo.start_transaction();
                 let id = write_random_commit(tx.repo_mut()).id().clone();
-                tx.commit("test").block_on().unwrap();
+                tx.commit("test").block_unwrap();
                 Merge::normal(TreeValue::GitSubmodule(id))
             }
         };
@@ -301,18 +302,16 @@ fn test_checkout_file_transitions(backend: TestRepoBackend) {
             files.push((*left_kind, *right_kind, path.clone()));
         }
     }
-    let left_tree = left_tree_builder.write_tree().block_on().unwrap();
-    let right_tree = right_tree_builder.write_tree().block_on().unwrap();
+    let left_tree = left_tree_builder.write_tree().block_unwrap();
+    let right_tree = right_tree_builder.write_tree().block_unwrap();
     let left_commit = commit_with_tree(&store, left_tree);
     let right_commit = commit_with_tree(&store, right_tree.clone());
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &left_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     ws.check_out(repo.op_id().clone(), None, &right_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Check that the working copy is clean.
     let new_tree = test_workspace.snapshot().unwrap();
@@ -407,8 +406,7 @@ fn test_checkout_no_op() {
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Test the setup: the file should exist on in the tree state.
     let wc: &LocalWorkingCopy = ws.working_copy().downcast_ref().unwrap();
@@ -418,8 +416,7 @@ fn test_checkout_no_op() {
     let new_op_id = OperationId::from_bytes(b"whatever");
     let stats = ws
         .check_out(new_op_id.clone(), None, &commit2)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(stats, CheckoutStats::default());
 
     // The tree state is unchanged but the recorded operation id is updated.
@@ -444,17 +441,14 @@ fn test_conflict_subdirectory() {
         (empty_tree, "empty".into()),
         (tree2, "tree 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let merged_commit = commit_with_tree(repo.store(), merged_tree);
     let repo = &test_workspace.repo;
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     ws.check_out(repo.op_id().clone(), None, &merged_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 }
 
 #[test]
@@ -500,17 +494,12 @@ fn test_acl() {
     )
     .unwrap();
     // Reload commits from the store associated with the workspace
-    let repo = ws
-        .repo_loader()
-        .load_at(repo.operation())
-        .block_on()
-        .unwrap();
+    let repo = ws.repo_loader().load_at(repo.operation()).block_unwrap();
     let commit1 = repo.store().get_commit(commit1.id()).unwrap();
     let commit2 = repo.store().get_commit(commit2.id()).unwrap();
 
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert!(
         !secret_modified_path
             .to_fs_path_unchecked(&workspace_root)
@@ -537,8 +526,7 @@ fn test_acl() {
             .is_file()
     );
     ws.check_out(repo.op_id().clone(), None, &commit2)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert!(
         !secret_modified_path
             .to_fs_path_unchecked(&workspace_root)
@@ -580,8 +568,7 @@ fn test_tree_builder_file_directory_transition() {
             MergedTree::resolved(repo.store().clone(), tree.id().clone()),
         );
         ws.check_out(repo.op_id().clone(), None, &commit)
-            .block_on()
-            .unwrap();
+            .block_unwrap();
     };
 
     let parent_path = repo_path("foo/bar");
@@ -597,7 +584,7 @@ fn test_tree_builder_file_directory_transition() {
             copy_id: CopyId::placeholder(),
         },
     );
-    let tree_id = tree_builder.write_tree().block_on().unwrap();
+    let tree_id = tree_builder.write_tree().block_unwrap();
     check_out_tree(&tree_id);
     assert!(parent_path.to_fs_path_unchecked(&workspace_root).is_file());
     assert!(!child_path.to_fs_path_unchecked(&workspace_root).exists());
@@ -613,7 +600,7 @@ fn test_tree_builder_file_directory_transition() {
             copy_id: CopyId::placeholder(),
         },
     );
-    let tree_id = tree_builder.write_tree().block_on().unwrap();
+    let tree_id = tree_builder.write_tree().block_unwrap();
     check_out_tree(&tree_id);
     assert!(parent_path.to_fs_path_unchecked(&workspace_root).is_dir());
     assert!(child_path.to_fs_path_unchecked(&workspace_root).is_file());
@@ -629,7 +616,7 @@ fn test_tree_builder_file_directory_transition() {
             copy_id: CopyId::placeholder(),
         },
     );
-    let tree_id = tree_builder.write_tree().block_on().unwrap();
+    let tree_id = tree_builder.write_tree().block_unwrap();
     check_out_tree(&tree_id);
     assert!(parent_path.to_fs_path_unchecked(&workspace_root).is_file());
     assert!(!child_path.to_fs_path_unchecked(&workspace_root).exists());
@@ -682,8 +669,7 @@ fn test_conflicting_changes_on_disk() {
 
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(
         stats,
         CheckoutStats {
@@ -734,8 +720,7 @@ fn test_reset() {
     let ws = &mut test_workspace.workspace;
     let commit = commit_with_tree(repo.store(), tree_with_file.clone());
     ws.check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Test the setup: the file should exist on disk and in the tree state.
     assert!(ignored_path.to_fs_path_unchecked(&workspace_root).is_file());
@@ -749,9 +734,8 @@ fn test_reset() {
     locked_ws
         .locked_wc()
         .reset(&commit_without_file)
-        .block_on()
-        .unwrap();
-    locked_ws.finish(op_id.clone()).block_on().unwrap();
+        .block_unwrap();
+    locked_ws.finish(op_id.clone()).block_unwrap();
     assert!(ignored_path.to_fs_path_unchecked(&workspace_root).is_file());
     let wc: &LocalWorkingCopy = ws.working_copy().downcast_ref().unwrap();
     assert!(!wc.file_states().unwrap().contains_path(ignored_path));
@@ -765,9 +749,8 @@ fn test_reset() {
     locked_ws
         .locked_wc()
         .reset(&commit_with_file)
-        .block_on()
-        .unwrap();
-    locked_ws.finish(op_id.clone()).block_on().unwrap();
+        .block_unwrap();
+    locked_ws.finish(op_id.clone()).block_unwrap();
     assert!(ignored_path.to_fs_path_unchecked(&workspace_root).is_file());
     let wc: &LocalWorkingCopy = ws.working_copy().downcast_ref().unwrap();
     assert!(wc.file_states().unwrap().contains_path(ignored_path));
@@ -795,8 +778,7 @@ fn test_checkout_discard() {
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let wc: &LocalWorkingCopy = ws.working_copy().downcast_ref().unwrap();
     let state_path = wc.state_path().to_path_buf();
 
@@ -807,11 +789,7 @@ fn test_checkout_discard() {
 
     // Start a checkout
     let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-    locked_ws
-        .locked_wc()
-        .check_out(&commit2)
-        .block_on()
-        .unwrap();
+    locked_ws.locked_wc().check_out(&commit2).block_unwrap();
     // The change should be reflected in the working copy but not saved
     assert!(!file1_path.to_fs_path_unchecked(&workspace_root).is_file());
     assert!(file2_path.to_fs_path_unchecked(&workspace_root).is_file());
@@ -858,8 +836,7 @@ fn test_snapshot_file_directory_transition() {
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // file -> directory
     std::fs::remove_file(to_ws_path(file1p_path)).unwrap();
@@ -873,8 +850,7 @@ fn test_snapshot_file_directory_transition() {
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit2)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // directory -> file
     std::fs::remove_file(to_ws_path(file1_path)).unwrap();
@@ -912,14 +888,12 @@ fn test_materialize_snapshot_conflicted_files() {
         (base2_tree, "base 2".into()),
         (side3_tree, "side 3".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let commit = commit_with_tree(repo.store(), merged_tree.clone());
 
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(
         stats,
         CheckoutStats {
@@ -1049,15 +1023,13 @@ fn test_materialize_snapshot_unchanged_conflicts() {
         (base_tree, "base".into()),
         (right_tree, "right".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let commit = commit_with_tree(repo.store(), merged_tree.clone());
 
     test_workspace
         .workspace
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // "line 5" should be deleted from the checked-out content.
     let disk_path = file_path.to_fs_path_unchecked(&workspace_root);
@@ -1094,8 +1066,7 @@ fn test_materialize_snapshot_unchanged_conflicts() {
     let stats = test_workspace
         .workspace
         .check_out(repo.op_id().clone(), None, &commit_with_labels)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(
         stats,
         CheckoutStats {
@@ -1358,20 +1329,18 @@ fn test_snapshot_modified_materialized_conflict(
         .new_commit(vec![base_commit.id().clone()], tree)
         .write_unwrap();
     // Update the repo to pick up the new commits.
-    test_workspace.repo = tx.commit("create parent commits").block_on().unwrap();
+    test_workspace.repo = tx.commit("create parent commits").block_unwrap();
 
     // Create the merge commit.
-    let tree = merge_commit_trees(&*test_workspace.repo, &[parent1_commit, parent2_commit])
-        .block_on()
-        .unwrap();
+    let tree =
+        merge_commit_trees(&*test_workspace.repo, &[parent1_commit, parent2_commit]).block_unwrap();
     let merge_commit = commit_with_tree(test_workspace.repo.store(), tree);
 
     // Checkout the merge commit.
     test_workspace
         .workspace
         .check_out(test_workspace.repo.op_id().clone(), None, &merge_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let contents = std::fs::read(&file_disk_path).unwrap();
     let hunks =
         jj_lib::conflicts::parse_conflict(&contents, 2, jj_lib::conflicts::MIN_CONFLICT_MARKER_LEN)
@@ -1400,8 +1369,7 @@ fn test_snapshot_modified_materialized_conflict(
     let tree = test_workspace.snapshot().unwrap();
     let actual_file_contents = tree
         .path_value_async(file_repo_path)
-        .block_on()
-        .unwrap()
+        .block_unwrap()
         .try_map_async(async |tree_value| {
             let Some(tree_value) = tree_value else {
                 return Ok::<_, Infallible>(None);
@@ -1421,8 +1389,7 @@ fn test_snapshot_modified_materialized_conflict(
                 .unwrap();
             Ok::<_, Infallible>(Some(String::from_utf8(contents).unwrap()))
         })
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let expected_file_contents =
         expected_file_contents.map(|contents| contents.as_deref().map(str::to_string));
     assert_eq!(actual_file_contents, expected_file_contents);
@@ -1447,8 +1414,7 @@ fn test_snapshot_racy_timestamps() {
         let (new_tree, _stats) = locked_ws
             .locked_wc()
             .snapshot(&empty_snapshot_options())
-            .block_on()
-            .unwrap();
+            .block_unwrap();
         assert_ne!(new_tree.tree_ids(), previous_tree.tree_ids());
         previous_tree = new_tree;
     }
@@ -1480,12 +1446,10 @@ fn test_snapshot_special_file() {
     let (tree, _stats) = locked_ws
         .locked_wc()
         .snapshot(&empty_snapshot_options())
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     locked_ws
         .finish(OperationId::from_hex("abc123"))
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     // Only the regular files should be in the tree
     assert_eq!(
         tree.entries().map(|(path, _value)| path).collect_vec(),
@@ -1588,9 +1552,7 @@ fn test_gitignores_in_ignored_dir() {
     let tree1 = create_tree(&test_workspace.repo, &[(gitignore_path, "ignored\n")]);
     let commit1 = commit_with_tree(test_workspace.repo.store(), tree1.clone());
     let ws = &mut test_workspace.workspace;
-    ws.check_out(op_id.clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+    ws.check_out(op_id.clone(), None, &commit1).block_unwrap();
 
     testutils::write_working_copy_file(&workspace_root, nested_gitignore_path, "!file\n");
     testutils::write_working_copy_file(&workspace_root, ignored_path, "contents");
@@ -1611,11 +1573,10 @@ fn test_gitignores_in_ignored_dir() {
         .workspace
         .start_working_copy_mutation()
         .unwrap();
-    locked_ws.locked_wc().reset(&commit2).block_on().unwrap();
+    locked_ws.locked_wc().reset(&commit2).block_unwrap();
     locked_ws
         .finish(OperationId::from_hex("abc123"))
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     let new_tree = test_workspace.snapshot().unwrap();
     assert_tree_eq!(new_tree, tree2);
@@ -1698,8 +1659,7 @@ fn test_gitignores_ignored_directory_already_tracked() {
     // Check out the tree with the files in `ignored/`
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Make some changes inside the ignored directory and check that they are
     // detected when we snapshot. The files that are still there should not be
@@ -1818,7 +1778,7 @@ fn test_git_submodule(gitignore_content: &str) {
         Merge::normal(TreeValue::GitSubmodule(submodule_id1)),
     );
 
-    let tree_id1 = tree_builder.write_tree().block_on().unwrap();
+    let tree_id1 = tree_builder.write_tree().block_unwrap();
     let commit1 = commit_with_tree(repo.store(), tree_id1.clone());
 
     let mut tree_builder = MergedTreeBuilder::new(tree_id1.clone());
@@ -1827,13 +1787,12 @@ fn test_git_submodule(gitignore_content: &str) {
         submodule_path.to_owned(),
         Merge::normal(TreeValue::GitSubmodule(submodule_id2)),
     );
-    let tree_id2 = tree_builder.write_tree().block_on().unwrap();
+    let tree_id2 = tree_builder.write_tree().block_unwrap();
     let commit2 = commit_with_tree(repo.store(), tree_id2.clone());
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     std::fs::create_dir(submodule_path.to_fs_path_unchecked(&workspace_root)).unwrap();
 
@@ -1861,8 +1820,7 @@ fn test_git_submodule(gitignore_content: &str) {
     // of existing submodule files
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit2)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Check that the files in the submodule are not deleted
     let file_in_submodule_path = added_submodule_path.to_fs_path_unchecked(&workspace_root);
@@ -1882,8 +1840,7 @@ fn test_git_submodule(gitignore_content: &str) {
     let ws = &mut test_workspace.workspace;
     let stats = ws
         .check_out(repo.op_id().clone(), None, &store.root_commit())
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(stats.skipped_files, 1);
 }
 
@@ -1901,8 +1858,7 @@ fn test_check_out_existing_file_cannot_be_removed() {
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Make the parent directory readonly.
     let writable_dir_perm = workspace_root.symlink_metadata().unwrap().permissions();
@@ -1938,8 +1894,7 @@ fn test_check_out_existing_file_replaced_with_directory() {
 
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     std::fs::remove_file(file_path.to_fs_path_unchecked(&workspace_root)).unwrap();
     std::fs::create_dir(file_path.to_fs_path_unchecked(&workspace_root)).unwrap();
@@ -1947,8 +1902,7 @@ fn test_check_out_existing_file_replaced_with_directory() {
     // Checkout doesn't fail, but the file should be skipped.
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit2)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(stats.skipped_files, 1);
     assert!(file_path.to_fs_path_unchecked(&workspace_root).is_dir());
 }
@@ -1981,8 +1935,7 @@ fn test_check_out_existing_directory_symlink() {
     let ws = &mut test_workspace.workspace;
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(stats.skipped_files, 2);
 
     // Therefore, "../escaped*" paths shouldn't be created.
@@ -2015,8 +1968,7 @@ fn test_check_out_existing_directory_symlink_icase_fs() {
     let ws = &mut test_workspace.workspace;
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     if is_icase_fs {
         assert_eq!(stats.skipped_files, 2);
     } else {
@@ -2062,8 +2014,7 @@ fn test_check_out_existing_file_symlink_icase_fs(victim_exists: bool) {
     let ws = &mut test_workspace.workspace;
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     if is_icase_fs {
         assert_eq!(stats.skipped_files, 1);
     } else {
@@ -2098,8 +2049,7 @@ fn test_check_out_file_removal_over_existing_directory_symlink() {
     // Check out "parent/escaped".
     let ws = &mut test_workspace.workspace;
     ws.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Pretend that "parent" was a symlink, which might be created by
     // e.g. checking out "PARENT" on case-insensitive fs. The file
@@ -2114,8 +2064,7 @@ fn test_check_out_file_removal_over_existing_directory_symlink() {
     // Check out empty tree, which tries to remove "parent/escaped".
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit2)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(stats.skipped_files, 1);
 
     // "../escaped" shouldn't be removed.
@@ -2151,8 +2100,7 @@ fn test_check_out_symlink_unusual_target(link_target: &str) {
     let ws = &mut test_workspace.workspace;
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(stats.added_files, 1);
 
     // Symlink should be created
@@ -2164,8 +2112,7 @@ fn test_check_out_symlink_unusual_target(link_target: &str) {
     // Check out empty tree
     let stats = ws
         .check_out(repo.op_id().clone(), None, &commit2)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(stats.removed_files, 1);
 
     // Symlink should be deleted
@@ -2262,8 +2209,8 @@ fn test_check_out_reserved_file_path(file_path_str: &str) {
 
     // Pretend that the checkout somehow succeeded.
     let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-    locked_ws.locked_wc().reset(&commit1).block_on().unwrap();
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+    locked_ws.locked_wc().reset(&commit1).block_unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
     if ![".git", ".jj"].contains(&file_path_str) {
         std::fs::create_dir_all(disk_path.parent().unwrap()).unwrap();
         std::fs::write(&disk_path, "").unwrap();
@@ -2321,8 +2268,8 @@ fn test_check_out_reserved_file_path_icase_fs(file_path_str: &str) {
 
     // Pretend that the checkout somehow succeeded.
     let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-    locked_ws.locked_wc().reset(&commit1).block_on().unwrap();
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+    locked_ws.locked_wc().reset(&commit1).block_unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
     std::fs::create_dir_all(disk_path.parent().unwrap()).unwrap();
     std::fs::write(&disk_path, "").unwrap();
 
@@ -2386,8 +2333,8 @@ fn test_check_out_reserved_file_path_hfs_plus(file_path_str: &str) {
 
     // Pretend that the checkout somehow succeeded.
     let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-    locked_ws.locked_wc().reset(&commit1).block_on().unwrap();
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+    locked_ws.locked_wc().reset(&commit1).block_unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
     std::fs::create_dir_all(disk_path.parent().unwrap()).unwrap();
     std::fs::write(&disk_path, "").unwrap();
 
@@ -2456,8 +2403,8 @@ fn test_check_out_reserved_file_path_vfat(vfat_path_str: &str, file_path_strs: &
 
     // Pretend that the checkout somehow succeeded.
     let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-    locked_ws.locked_wc().reset(&commit1).block_on().unwrap();
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+    locked_ws.locked_wc().reset(&commit1).block_unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
     if is_vfat {
         std::fs::create_dir_all(vfat_disk_path.parent().unwrap()).unwrap();
         std::fs::write(&vfat_disk_path, "").unwrap();
@@ -2518,8 +2465,8 @@ fn test_check_out_reserved_file_path_dot_git_symlink(file_path_str: &str) {
 
     // Pretend that the checkout somehow succeeded.
     let mut locked_ws = ws.start_working_copy_mutation().unwrap();
-    locked_ws.locked_wc().reset(&commit1).block_on().unwrap();
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+    locked_ws.locked_wc().reset(&commit1).block_unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
     if file_path_str != ".git" {
         std::fs::write(&disk_path, "").unwrap();
     }
@@ -2581,8 +2528,7 @@ fn test_fsmonitor() {
         .unwrap();
         tree_state
             .snapshot(&empty_snapshot_options())
-            .block_on()
-            .unwrap();
+            .block_unwrap();
         tree_state
     };
 
@@ -2670,7 +2616,7 @@ fn track_ignored_with_flag_and_fsmonitor() {
         if let Some(matcher) = matcher {
             options.force_tracking_matcher = matcher;
         }
-        tree_state.snapshot(&options).block_on().unwrap();
+        tree_state.snapshot(&options).block_unwrap();
         tree_state.save().unwrap();
         tree_state
     };
@@ -2729,8 +2675,7 @@ fn fsmonitor_gitignore_rescan_subtree() {
         .unwrap();
         tree_state
             .snapshot(&empty_snapshot_options())
-            .block_on()
-            .unwrap();
+            .block_unwrap();
         tree_state.save().unwrap();
         tree_state
     };
@@ -2865,8 +2810,7 @@ fn test_snapshot_symlink_use_forward_slash() {
         .repo
         .store()
         .read_symlink(link, &symlink_id)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     assert!(
         !actual_link_contents.contains('\\'),
@@ -2963,15 +2907,10 @@ fn test_snapshot_and_update_valid_symlink(get_link_target: impl FnOnce(&Path, &P
         .start_working_copy_mutation()
         .unwrap();
     let root_commit = test_workspace.repo.store().root_commit();
-    locked_ws
-        .locked_wc()
-        .check_out(&root_commit)
-        .block_on()
-        .unwrap();
+    locked_ws.locked_wc().check_out(&root_commit).block_unwrap();
     locked_ws
         .finish(test_workspace.repo.op_id().clone())
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     assert!(!std::fs::exists(&link_path).unwrap());
     assert!(std::fs::read_link(&link_path).is_err());
@@ -2981,11 +2920,10 @@ fn test_snapshot_and_update_valid_symlink(get_link_target: impl FnOnce(&Path, &P
         .workspace
         .start_working_copy_mutation()
         .unwrap();
-    locked_ws.locked_wc().check_out(&commit).block_on().unwrap();
+    locked_ws.locked_wc().check_out(&commit).block_unwrap();
     locked_ws
         .finish(test_workspace.repo.op_id().clone())
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     let actual_target = std::fs::read_link(&link_path).expect("The symlink itself should exist.");
     let actual_contents = std::fs::read(&link_path).unwrap_or_else(|e| {

--- a/lib/tests/test_local_working_copy_concurrent.rs
+++ b/lib/tests/test_local_working_copy_concurrent.rs
@@ -21,6 +21,7 @@ use jj_lib::working_copy::CheckoutError;
 use jj_lib::workspace::Workspace;
 use jj_lib::workspace::default_working_copy_factories;
 use pollster::FutureExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestWorkspace;
 use testutils::assert_tree_eq;
 use testutils::commit_with_tree;
@@ -50,8 +51,7 @@ fn test_concurrent_checkout() {
     let ws1 = &mut test_workspace1.workspace;
     // The operation ID is not correct, but that doesn't matter for this test
     ws1.check_out(repo.op_id().clone(), None, &commit1)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Check out tree2 from another process (simulated by another workspace
     // instance)
@@ -64,15 +64,10 @@ fn test_concurrent_checkout() {
         )
         .unwrap();
         // Reload commit from the store associated with the workspace
-        let repo = ws2
-            .repo_loader()
-            .load_at(repo.operation())
-            .block_on()
-            .unwrap();
+        let repo = ws2.repo_loader().load_at(repo.operation()).block_unwrap();
         let commit2 = repo.store().get_commit(commit2.id()).unwrap();
         ws2.check_out(repo.op_id().clone(), Some(&tree1), &commit2)
-            .block_on()
-            .unwrap();
+            .block_unwrap();
     }
 
     // Checking out another tree (via the first workspace instance) should now fail.
@@ -117,8 +112,7 @@ fn test_checkout_parallel() {
     test_workspace
         .workspace
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     thread::scope(|s| {
         for tree in &trees {
@@ -140,14 +134,10 @@ fn test_checkout_parallel() {
                 let repo = workspace
                     .repo_loader()
                     .load_at(repo.operation())
-                    .block_on()
-                    .unwrap();
+                    .block_unwrap();
                 let commit = repo.store().get_commit(commit.id()).unwrap();
                 // The operation ID is not correct, but that doesn't matter for this test
-                let stats = workspace
-                    .check_out(op_id, None, &commit)
-                    .block_on()
-                    .unwrap();
+                let stats = workspace.check_out(op_id, None, &commit).block_unwrap();
                 assert_eq!(stats.updated_files, 0);
                 assert_eq!(stats.added_files, 1);
                 assert_eq!(stats.removed_files, 1);
@@ -159,8 +149,7 @@ fn test_checkout_parallel() {
                 let (new_tree, _stats) = locked_ws
                     .locked_wc()
                     .snapshot(&empty_snapshot_options())
-                    .block_on()
-                    .unwrap();
+                    .block_unwrap();
                 assert!(
                     trees
                         .iter()
@@ -185,9 +174,7 @@ fn test_racy_checkout() {
     let mut num_matches = 0;
     for _ in 0..100 {
         let ws = &mut test_workspace.workspace;
-        ws.check_out(op_id.clone(), None, &commit)
-            .block_on()
-            .unwrap();
+        ws.check_out(op_id.clone(), None, &commit).block_unwrap();
         assert_eq!(
             std::fs::read(path.to_fs_path_unchecked(&workspace_root)).unwrap(),
             b"1".to_vec()

--- a/lib/tests/test_local_working_copy_executable_bit.rs
+++ b/lib/tests/test_local_working_copy_executable_bit.rs
@@ -25,7 +25,7 @@ use jj_lib::merged_tree::MergedTree;
 use jj_lib::repo::Repo as _;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::store::Store;
-use pollster::FutureExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestTreeBuilder;
 use testutils::TestWorkspace;
 use testutils::repo_path;
@@ -98,10 +98,7 @@ fn test_exec_bit_checkout() {
     let mut checkout_exec_commit = |executable| {
         let commit = if executable { &exec } else { &no_exec };
         let op_id = ws.repo.op_id().clone();
-        ws.workspace
-            .check_out(op_id, None, commit)
-            .block_on()
-            .unwrap();
+        ws.workspace.check_out(op_id, None, commit).block_unwrap();
     };
 
     // Checkout commits and ensure the filesystem is updated correctly.

--- a/lib/tests/test_local_working_copy_sparse.rs
+++ b/lib/tests/test_local_working_copy_sparse.rs
@@ -22,6 +22,7 @@ use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::WorkingCopy as _;
 use pollster::FutureExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestWorkspace;
 use testutils::commit_with_tree;
 use testutils::create_tree;
@@ -63,8 +64,7 @@ fn test_sparse_checkout() {
     test_workspace
         .workspace
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let ws = &mut test_workspace.workspace;
 
     // Set sparse patterns to only dir1/
@@ -73,8 +73,7 @@ fn test_sparse_checkout() {
     let stats = locked_ws
         .locked_wc()
         .set_sparse_patterns(sparse_patterns.clone())
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(
         stats,
         CheckoutStats {
@@ -120,7 +119,7 @@ fn test_sparse_checkout() {
     );
 
     // Write the new state to disk
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
     let wc: &LocalWorkingCopy = ws.working_copy().downcast_ref().unwrap();
     assert_eq!(
         wc.file_states().unwrap().paths().collect_vec(),
@@ -147,8 +146,7 @@ fn test_sparse_checkout() {
     let sparse_patterns = to_owned_path_vec(&[root_file1_path, dir1_subdir1_path, dir2_path]);
     let stats = locked_wc
         .set_sparse_patterns(sparse_patterns.clone())
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(
         stats,
         CheckoutStats {
@@ -189,7 +187,7 @@ fn test_sparse_checkout() {
             .to_fs_path_unchecked(&working_copy_path)
             .exists()
     );
-    let wc = locked_wc.finish(repo.op_id().clone()).block_on().unwrap();
+    let wc = locked_wc.finish(repo.op_id().clone()).block_unwrap();
     let wc: &LocalWorkingCopy = wc.downcast_ref().unwrap();
     assert_eq!(
         wc.file_states().unwrap().paths().collect_vec(),
@@ -224,8 +222,7 @@ fn test_sparse_commit() {
     test_workspace
         .workspace
         .check_out(repo.op_id().clone(), None, &commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
     // Set sparse patterns to only dir1/
     let mut locked_ws = test_workspace
@@ -236,9 +233,8 @@ fn test_sparse_commit() {
     locked_ws
         .locked_wc()
         .set_sparse_patterns(sparse_patterns)
-        .block_on()
-        .unwrap();
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+        .block_unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
 
     // Write modified version of all files, including files that are not in the
     // sparse patterns.
@@ -278,9 +274,8 @@ fn test_sparse_commit() {
     locked_ws
         .locked_wc()
         .set_sparse_patterns(sparse_patterns)
-        .block_on()
-        .unwrap();
-    locked_ws.finish(op_id).block_on().unwrap();
+        .block_unwrap();
+    locked_ws.finish(op_id).block_unwrap();
 
     // Create a tree from the working copy. Only dir1/file1 and dir2/file1 should be
     // updated in the tree.
@@ -314,9 +309,8 @@ fn test_sparse_commit_gitignore() {
     locked_ws
         .locked_wc()
         .set_sparse_patterns(sparse_patterns)
-        .block_on()
-        .unwrap();
-    locked_ws.finish(repo.op_id().clone()).block_on().unwrap();
+        .block_unwrap();
+    locked_ws.finish(repo.op_id().clone()).block_unwrap();
 
     // Write dir1/file1 and dir1/file2 and a .gitignore saying to ignore dir1/file1
     std::fs::write(working_copy_path.join(".gitignore"), "dir1/file1").unwrap();

--- a/lib/tests/test_merge_trees.rs
+++ b/lib/tests/test_merge_trees.rs
@@ -20,9 +20,9 @@ use jj_lib::merge::SameChange;
 use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::rebase_commit;
 use jj_lib::settings::UserSettings;
-use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::assert_tree_eq;
 use testutils::create_tree;
@@ -68,12 +68,10 @@ fn test_simplify_conflict_after_resolving_parent() {
         .new_commit(vec![commit_a.id().clone()], tree_d)
         .write_unwrap();
 
-    let commit_b2 = rebase_commit(tx.repo_mut(), commit_b, vec![commit_d.id().clone()])
-        .block_on()
-        .unwrap();
-    let commit_c2 = rebase_commit(tx.repo_mut(), commit_c, vec![commit_b2.id().clone()])
-        .block_on()
-        .unwrap();
+    let commit_b2 =
+        rebase_commit(tx.repo_mut(), commit_b, vec![commit_d.id().clone()]).block_unwrap();
+    let commit_c2 =
+        rebase_commit(tx.repo_mut(), commit_c, vec![commit_b2.id().clone()]).block_unwrap();
 
     // Test the setup: Both B and C should have conflicts.
     let tree_b2 = commit_b2.tree();
@@ -88,11 +86,10 @@ fn test_simplify_conflict_after_resolving_parent() {
         .rewrite_commit(&commit_b2)
         .set_tree(tree_b3)
         .write_unwrap();
-    let commit_c3 = rebase_commit(tx.repo_mut(), commit_c2, vec![commit_b3.id().clone()])
-        .block_on()
-        .unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let commit_c3 =
+        rebase_commit(tx.repo_mut(), commit_c2, vec![commit_b3.id().clone()]).block_unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // The conflict should now be resolved.
     let tree_c2 = commit_c3.tree();
@@ -160,13 +157,11 @@ fn test_rebase_linearize_lossy_merge(same_change: SameChange) {
         .write_unwrap();
 
     match same_change {
-        SameChange::Keep => assert!(!commit_d.is_empty(repo_mut).block_on().unwrap()),
-        SameChange::Accept => assert!(commit_d.is_empty(repo_mut).block_on().unwrap()),
+        SameChange::Keep => assert!(!commit_d.is_empty(repo_mut).block_unwrap()),
+        SameChange::Accept => assert!(commit_d.is_empty(repo_mut).block_unwrap()),
     }
 
-    let commit_d2 = rebase_commit(repo_mut, commit_d, vec![commit_b.id().clone()])
-        .block_on()
-        .unwrap();
+    let commit_d2 = rebase_commit(repo_mut, commit_d, vec![commit_b.id().clone()]).block_unwrap();
 
     match same_change {
         SameChange::Keep => assert_tree_eq!(commit_d2.tree(), tree_1),
@@ -219,8 +214,8 @@ fn test_rebase_on_lossy_merge(same_change: SameChange) {
         .write_unwrap();
 
     match same_change {
-        SameChange::Keep => assert!(!commit_d.is_empty(repo_mut).block_on().unwrap()),
-        SameChange::Accept => assert!(commit_d.is_empty(repo_mut).block_on().unwrap()),
+        SameChange::Keep => assert!(!commit_d.is_empty(repo_mut).block_unwrap()),
+        SameChange::Accept => assert!(commit_d.is_empty(repo_mut).block_unwrap()),
     }
 
     let commit_c2 = repo_mut
@@ -231,8 +226,7 @@ fn test_rebase_on_lossy_merge(same_change: SameChange) {
         commit_d,
         vec![commit_b.id().clone(), commit_c2.id().clone()],
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     match same_change {
         SameChange::Keep => assert_tree_eq!(commit_d2.tree(), tree_3),

--- a/lib/tests/test_merged_tree.rs
+++ b/lib/tests/test_merged_tree.rs
@@ -42,6 +42,7 @@ use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
 use pollster::FutureExt as _;
 use pretty_assertions::assert_eq;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::assert_tree_eq;
 use testutils::create_single_tree;
@@ -91,7 +92,7 @@ fn test_merged_tree_builder_resolves_conflict() {
         ConflictLabels::from_vec(vec!["tree 2".into(), "tree 1".into(), "tree 3".into()]),
     );
     let tree_builder = MergedTreeBuilder::new(base_tree);
-    let tree = tree_builder.write_tree().block_on().unwrap();
+    let tree = tree_builder.write_tree().block_unwrap();
     assert_eq!(*tree.tree_ids(), Merge::resolved(tree2.id().clone()));
 }
 
@@ -159,12 +160,12 @@ fn test_path_value_and_entries() {
     // Get file path without conflict
     assert_eq!(
         merged_tree.path_value(resolved_file_path).unwrap(),
-        Merge::resolved(tree1.path_value(resolved_file_path).block_on().unwrap()),
+        Merge::resolved(tree1.path_value(resolved_file_path).block_unwrap()),
     );
     // Get directory path without conflict
     assert_eq!(
         merged_tree.path_value(resolved_dir_path).unwrap(),
-        Merge::resolved(tree1.path_value(resolved_dir_path).block_on().unwrap()),
+        Merge::resolved(tree1.path_value(resolved_dir_path).block_unwrap()),
     );
     // Get missing path
     assert_eq!(
@@ -175,21 +176,18 @@ fn test_path_value_and_entries() {
     assert_eq!(
         merged_tree.path_value(modify_delete_path).unwrap(),
         Merge::from_removes_adds(
-            vec![tree1.path_value(modify_delete_path).block_on().unwrap()],
-            vec![
-                tree2.path_value(modify_delete_path).block_on().unwrap(),
-                None
-            ]
+            vec![tree1.path_value(modify_delete_path).block_unwrap()],
+            vec![tree2.path_value(modify_delete_path).block_unwrap(), None]
         ),
     );
     // Get file/dir conflict path
     assert_eq!(
         merged_tree.path_value(file_dir_conflict_path).unwrap(),
         Merge::from_removes_adds(
-            vec![tree1.path_value(file_dir_conflict_path).block_on().unwrap()],
+            vec![tree1.path_value(file_dir_conflict_path).block_unwrap()],
             vec![
-                tree2.path_value(file_dir_conflict_path).block_on().unwrap(),
-                tree3.path_value(file_dir_conflict_path).block_on().unwrap()
+                tree2.path_value(file_dir_conflict_path).block_unwrap(),
+                tree3.path_value(file_dir_conflict_path).block_unwrap()
             ]
         ),
     );
@@ -301,7 +299,7 @@ fn test_resolve_success() {
         ]),
         ConflictLabels::from_vec(vec!["left".into(), "base".into(), "right".into()]),
     );
-    let resolved_tree = tree.resolve().block_on().unwrap();
+    let resolved_tree = tree.resolve().block_unwrap();
     assert!(resolved_tree.tree_ids().is_resolved());
     assert_tree_eq!(resolved_tree, expected);
 }
@@ -327,7 +325,7 @@ fn test_resolve_root_becomes_empty() {
         ]),
         ConflictLabels::from_vec(vec!["side 1".into(), "base 1".into(), "side 2".into()]),
     );
-    let resolved = tree.resolve().block_on().unwrap();
+    let resolved = tree.resolve().block_unwrap();
     assert_tree_eq!(resolved, store.empty_merged_tree());
 }
 
@@ -373,7 +371,7 @@ fn test_resolve_with_conflict() {
             "side 3".into(),
         ]),
     );
-    let resolved_tree = tree.resolve().block_on().unwrap();
+    let resolved_tree = tree.resolve().block_unwrap();
     assert_tree_eq!(
         resolved_tree,
         MergedTree::new(
@@ -409,7 +407,7 @@ fn test_resolve_with_conflict_containing_empty_subtree() {
         ]),
         ConflictLabels::from_vec(vec!["left".into(), "base".into(), "right".into()]),
     );
-    let resolved_tree = tree.clone().resolve().block_on().unwrap();
+    let resolved_tree = tree.clone().resolve().block_unwrap();
     assert_tree_eq!(resolved_tree, tree);
 }
 
@@ -495,10 +493,10 @@ fn test_conflict_iterator() {
         .collect_vec();
     let conflict_at = |path: &RepoPath| {
         Merge::from_removes_adds(
-            vec![base1.path_value(path).block_on().unwrap()],
+            vec![base1.path_value(path).block_unwrap()],
             vec![
-                side1.path_value(path).block_on().unwrap(),
-                side2.path_value(path).block_on().unwrap(),
+                side1.path_value(path).block_unwrap(),
+                side2.path_value(path).block_unwrap(),
             ],
         )
     };
@@ -541,7 +539,7 @@ fn test_conflict_iterator() {
     );
 
     // After we resolve conflicts, there are only non-trivial conflicts left
-    let tree = tree.resolve().block_on().unwrap();
+    let tree = tree.resolve().block_unwrap();
     let conflicts = tree
         .conflicts()
         .map(|(path, conflict)| (path, conflict.unwrap()))
@@ -618,13 +616,13 @@ fn test_conflict_iterator_higher_arity() {
     let conflict_at = |path: &RepoPath| {
         Merge::from_removes_adds(
             vec![
-                base1.path_value(path).block_on().unwrap(),
-                base2.path_value(path).block_on().unwrap(),
+                base1.path_value(path).block_unwrap(),
+                base2.path_value(path).block_unwrap(),
             ],
             vec![
-                side1.path_value(path).block_on().unwrap(),
-                side2.path_value(path).block_on().unwrap(),
-                side3.path_value(path).block_on().unwrap(),
+                side1.path_value(path).block_unwrap(),
+                side2.path_value(path).block_unwrap(),
+                side3.path_value(path).block_unwrap(),
             ],
         )
     };
@@ -678,8 +676,8 @@ fn test_diff_resolved() {
         (
             modified_path.to_owned(),
             (
-                Merge::resolved(before.path_value(modified_path).block_on().unwrap()),
-                Merge::resolved(after.path_value(modified_path).block_on().unwrap())
+                Merge::resolved(before.path_value(modified_path).block_unwrap()),
+                Merge::resolved(after.path_value(modified_path).block_unwrap())
             ),
         )
     );
@@ -688,7 +686,7 @@ fn test_diff_resolved() {
         (
             removed_path.to_owned(),
             (
-                Merge::resolved(before.path_value(removed_path).block_on().unwrap()),
+                Merge::resolved(before.path_value(removed_path).block_unwrap()),
                 Merge::absent()
             ),
         )
@@ -699,7 +697,7 @@ fn test_diff_resolved() {
             added_path.to_owned(),
             (
                 Merge::absent(),
-                Merge::resolved(after.path_value(added_path).block_on().unwrap())
+                Merge::resolved(after.path_value(added_path).block_unwrap())
             ),
         )
     );
@@ -770,8 +768,8 @@ fn test_diff_copy_tracing() {
                 target: modified_path.to_owned()
             },
             Diff::new(
-                Merge::resolved(before.path_value(modified_path).block_on().unwrap()),
-                Merge::resolved(after.path_value(modified_path).block_on().unwrap())
+                Merge::resolved(before.path_value(modified_path).block_unwrap()),
+                Merge::resolved(after.path_value(modified_path).block_unwrap())
             ),
         )
     );
@@ -783,8 +781,8 @@ fn test_diff_copy_tracing() {
                 target: copied_path.to_owned(),
             },
             Diff::new(
-                Merge::resolved(before.path_value(modified_path).block_on().unwrap()),
-                Merge::resolved(after.path_value(copied_path).block_on().unwrap()),
+                Merge::resolved(before.path_value(modified_path).block_unwrap()),
+                Merge::resolved(after.path_value(copied_path).block_unwrap()),
             ),
         )
     );
@@ -796,8 +794,8 @@ fn test_diff_copy_tracing() {
                 target: added_path.to_owned(),
             },
             Diff::new(
-                Merge::resolved(before.path_value(removed_path).block_on().unwrap()),
-                Merge::resolved(after.path_value(added_path).block_on().unwrap())
+                Merge::resolved(before.path_value(removed_path).block_unwrap()),
+                Merge::resolved(after.path_value(added_path).block_unwrap())
             ),
         )
     );
@@ -1307,8 +1305,7 @@ fn test_merge_simple() {
         (base1_merged, "base 1".into()),
         (side2_merged, "side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(merged, expected_merged);
 }
 
@@ -1345,8 +1342,7 @@ fn test_merge_partial_resolution() {
         (base1_merged, "base 1".into()),
         (side2_merged, "side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(merged, expected_merged);
 }
 
@@ -1398,8 +1394,7 @@ fn test_merge_simplify_only() {
         (base1_merged, "base 1".into()),
         (side2_merged, "side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(merged, expected_merged);
 }
 
@@ -1460,8 +1455,7 @@ fn test_merge_simplify_result() {
         (base1_merged, "base 1".into()),
         (side2_merged, "side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(merged, expected_merged);
 }
 
@@ -1516,8 +1510,7 @@ fn test_merge_simplify_result_with_resolved_labels() {
         (base1_merged, "".into()),
         (side2_merged, "side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(merged, expected_merged);
 }
 
@@ -1648,8 +1641,7 @@ fn test_merge_simplify_file_conflict() {
         (parent_merged, "parent".into()),
         (child2_merged, "child 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(merged, expected_merged);
 
     // Also test the setup by checking that the unsimplified content conflict cannot
@@ -1713,8 +1705,7 @@ fn test_merge_simplify_file_conflict_with_absent() {
         (parent_merged, "parent".into()),
         (child2_merged, "child 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(merged, expected_merged);
 }
 

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -27,8 +27,8 @@ use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::RebaseOptions;
 use maplit::hashset;
-use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::assert_rebased_onto;
 use testutils::create_random_commit;
@@ -60,15 +60,14 @@ fn test_edit() {
 
     let mut tx = repo.start_transaction();
     let wc_commit = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     tx.repo_mut()
         .edit(ws_name.clone(), &wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(repo.view().get_wc_commit_id(&ws_name), Some(wc_commit.id()));
 }
 
@@ -80,19 +79,18 @@ fn test_checkout() {
 
     let mut tx = repo.start_transaction();
     let wc_commit_parent = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     let wc_commit = tx
         .repo_mut()
         .check_out(ws_name.clone(), &wc_commit_parent)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(wc_commit.tree_ids(), wc_commit_parent.tree_ids());
     assert_eq!(wc_commit.parent_ids().len(), 1);
     assert_eq!(&wc_commit.parent_ids()[0], wc_commit_parent.id());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(repo.view().get_wc_commit_id(&ws_name), Some(wc_commit.id()));
 }
 
@@ -109,15 +107,14 @@ fn test_edit_previous_not_empty() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let new_wc_commit = write_random_commit(mut_repo);
-    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.edit(ws_name, &new_wc_commit).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -139,15 +136,14 @@ fn test_edit_previous_empty() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let new_wc_commit = write_random_commit(mut_repo);
-    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.edit(ws_name, &new_wc_commit).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(!mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -168,8 +164,7 @@ fn test_edit_previous_empty_merge() {
         (empty_tree, "empty".into()),
         (old_parent2.tree(), "old parent 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let old_wc_commit = mut_repo
         .new_commit(
             vec![old_parent1.id().clone(), old_parent2.id().clone()],
@@ -180,15 +175,14 @@ fn test_edit_previous_empty_merge() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let new_wc_commit = write_random_commit(mut_repo);
-    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.edit(ws_name, &new_wc_commit).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(!mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -211,15 +205,14 @@ fn test_edit_previous_empty_with_description() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let new_wc_commit = write_random_commit(mut_repo);
-    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.edit(ws_name, &new_wc_commit).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -242,15 +235,14 @@ fn test_edit_previous_empty_with_local_bookmark() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let new_wc_commit = write_random_commit(mut_repo);
-    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.edit(ws_name, &new_wc_commit).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -272,20 +264,18 @@ fn test_edit_previous_empty_with_other_workspace() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     let other_ws_name = WorkspaceNameBuf::from("other");
     mut_repo
         .edit(other_ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let new_wc_commit = write_random_commit(mut_repo);
-    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.edit(ws_name, &new_wc_commit).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -310,15 +300,14 @@ fn test_edit_previous_empty_non_head() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
     let new_wc_commit = write_random_commit(mut_repo);
-    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.edit(ws_name, &new_wc_commit).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert_eq!(
         *mut_repo.view().heads(),
         hashset! {old_child.id().clone(), new_wc_commit.id().clone()}
@@ -334,15 +323,14 @@ fn test_edit_initial() {
 
     let mut tx = repo.start_transaction();
     let wc_commit = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let ws_name = WorkspaceNameBuf::from("new-workspace");
     tx.repo_mut()
         .edit(ws_name.clone(), &wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(repo.view().get_wc_commit_id(&ws_name), Some(wc_commit.id()));
 }
 
@@ -363,9 +351,8 @@ fn test_edit_hidden_commit() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     tx.repo_mut()
         .edit(ws_name.clone(), &wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(repo.view().get_wc_commit_id(&ws_name), Some(wc_commit.id()));
     assert_eq!(*repo.view().heads(), hashset! {wc_commit.id().clone()});
 }
@@ -391,7 +378,7 @@ fn test_add_head_success() {
     mut_repo.add_head(&new_commit).unwrap();
     assert!(mut_repo.view().heads().contains(new_commit.id()));
     assert!(index_has_id(mut_repo.index(), new_commit.id()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert!(repo.view().heads().contains(new_commit.id()));
     assert!(index_has_id(repo.index(), new_commit.id()));
 }
@@ -407,7 +394,7 @@ fn test_add_head_ancestor() {
     let commit1 = write_random_commit(tx.repo_mut());
     let commit2 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
     let commit3 = write_random_commit_with_parents(tx.repo_mut(), &[&commit2]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     assert_eq!(repo.view().heads(), &hashset! {commit3.id().clone()});
     let mut tx = repo.start_transaction();
@@ -425,7 +412,7 @@ fn test_add_head_not_immediate_child() {
 
     let mut tx = repo.start_transaction();
     let initial = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Create some commits outside of the repo by using a temporary transaction.
     // Then add one of them as a head.
@@ -462,7 +449,7 @@ fn test_remove_head() {
     let commit1 = write_random_commit(tx.repo_mut());
     let commit2 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
     let commit3 = write_random_commit_with_parents(tx.repo_mut(), &[&commit2]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -475,7 +462,7 @@ fn test_remove_head() {
     assert!(index_has_id(mut_repo.index(), commit1.id()));
     assert!(index_has_id(mut_repo.index(), commit2.id()));
     assert!(index_has_id(mut_repo.index(), commit3.id()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let heads = repo.view().heads().clone();
     assert!(!heads.contains(commit3.id()));
     assert!(!heads.contains(commit2.id()));
@@ -511,7 +498,7 @@ fn test_has_changed() {
         remote_symbol("main", "origin"),
         normal_remote_ref(commit1.id()),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     // Test the setup
     assert_eq!(repo.view().heads(), &hashset! {commit1.id().clone()});
 
@@ -578,7 +565,7 @@ fn test_rebase_descendants_simple() {
     let commit3 = write_random_commit_with_parents(tx.repo_mut(), &[&commit2]);
     let commit4 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
     let commit5 = write_random_commit_with_parents(tx.repo_mut(), &[&commit4]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -611,7 +598,7 @@ fn test_rebase_descendants_divergent_rewrite() {
     let commit1 = write_random_commit(tx.repo_mut());
     let commit2 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
     let _commit3 = write_random_commit_with_parents(tx.repo_mut(), &[&commit2]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -664,14 +651,13 @@ fn test_remove_wc_commit_previous_not_discardable() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    mut_repo.remove_wc_commit(&ws_name).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.remove_wc_commit(&ws_name).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -693,14 +679,13 @@ fn test_remove_wc_commit_previous_discardable() {
     let ws_name = WorkspaceName::DEFAULT.to_owned();
     mut_repo
         .edit(ws_name.clone(), &old_wc_commit)
-        .block_on()
-        .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+        .block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
-    mut_repo.remove_wc_commit(&ws_name).block_on().unwrap();
-    mut_repo.rebase_descendants().block_on().unwrap();
+    mut_repo.remove_wc_commit(&ws_name).block_unwrap();
+    mut_repo.rebase_descendants().block_unwrap();
     assert!(!mut_repo.view().heads().contains(old_wc_commit.id()));
 }
 
@@ -730,7 +715,7 @@ fn test_reparent_descendants() {
         mut_repo
             .set_local_bookmark_target(bookmark.as_ref(), RefTarget::normal(commit.id().clone()));
     }
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Rewrite "commit_a".
     let mut tx = repo.start_transaction();
@@ -739,11 +724,11 @@ fn test_reparent_descendants() {
         .rewrite_commit(&commit_a)
         .set_tree(create_random_tree(&repo))
         .write_unwrap();
-    let reparented = mut_repo.reparent_descendants().block_on().unwrap();
+    let reparented = mut_repo.reparent_descendants().block_unwrap();
     // "child_a_b", "grandchild_a_b" and "child_a" (3 commits) must have been
     // reparented.
     assert_eq!(reparented, 3);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     for (bookmark, commit) in [
         ("b", &commit_b),
@@ -786,13 +771,13 @@ fn test_bookmark_hidden_commit() {
     let mut tx = repo.start_transaction();
     let commit = write_random_commit(tx.repo_mut());
     tx.repo_mut().remove_head(commit.id());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     // Test the setup
     assert_eq!(*repo.view().heads(), hashset! {root_commit.id().clone()});
 
     let mut tx = repo.start_transaction();
     tx.repo_mut()
         .set_local_bookmark_target("b".as_ref(), RefTarget::normal(commit.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     assert_eq!(*repo.view().heads(), hashset! {commit.id().clone()});
 }

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -37,6 +37,7 @@ use jj_lib::settings::UserSettings;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
@@ -75,11 +76,11 @@ fn test_unpublished_operation() {
 
     let mut tx1 = repo.start_transaction();
     write_random_commit(tx1.repo_mut());
-    let unpublished_op = tx1.write("transaction 1").block_on().unwrap();
+    let unpublished_op = tx1.write("transaction 1").block_unwrap();
     let op_id1 = unpublished_op.operation().id().clone();
     assert_ne!(op_id1, op_id0);
     assert_eq!(list_dir(&op_heads_dir), vec![op_id0.hex()]);
-    unpublished_op.publish().block_on().unwrap();
+    unpublished_op.publish().block_unwrap();
     assert_eq!(list_dir(&op_heads_dir), vec![op_id1.hex()]);
 }
 
@@ -98,21 +99,19 @@ fn test_consecutive_operations() {
     write_random_commit(tx1.repo_mut());
     let op_id1 = tx1
         .commit("transaction 1")
-        .block_on()
-        .unwrap()
+        .block_unwrap()
         .operation()
         .id()
         .clone();
     assert_ne!(op_id1, op_id0);
     assert_eq!(list_dir(&op_heads_dir), vec![op_id1.hex()]);
 
-    let repo = repo.reload_at_head().block_on().unwrap();
+    let repo = repo.reload_at_head().block_unwrap();
     let mut tx2 = repo.start_transaction();
     write_random_commit(tx2.repo_mut());
     let op_id2 = tx2
         .commit("transaction 2")
-        .block_on()
-        .unwrap()
+        .block_unwrap()
         .operation()
         .id()
         .clone();
@@ -122,7 +121,7 @@ fn test_consecutive_operations() {
 
     // Reloading the repo makes no difference (there are no conflicting operations
     // to resolve).
-    let _repo = repo.reload_at_head().block_on().unwrap();
+    let _repo = repo.reload_at_head().block_unwrap();
     assert_eq!(list_dir(&op_heads_dir), vec![op_id2.hex()]);
 }
 
@@ -141,8 +140,7 @@ fn test_concurrent_operations() {
     write_random_commit(tx1.repo_mut());
     let op_id1 = tx1
         .commit("transaction 1")
-        .block_on()
-        .unwrap()
+        .block_unwrap()
         .operation()
         .id()
         .clone();
@@ -155,8 +153,7 @@ fn test_concurrent_operations() {
     write_random_commit(tx2.repo_mut());
     let op_id2 = tx2
         .commit("transaction 2")
-        .block_on()
-        .unwrap()
+        .block_unwrap()
         .operation()
         .id()
         .clone();
@@ -169,7 +166,7 @@ fn test_concurrent_operations() {
     assert_eq!(actual_heads_on_disk, expected_heads_on_disk);
 
     // Reloading the repo causes the operations to be merged
-    let repo = repo.reload_at_head().block_on().unwrap();
+    let repo = repo.reload_at_head().block_unwrap();
     let merged_op_id = repo.op_id().clone();
     assert_ne!(merged_op_id, op_id0);
     assert_ne!(merged_op_id, op_id1);
@@ -190,7 +187,7 @@ fn test_isolation() {
 
     let mut tx = repo.start_transaction();
     let initial = write_random_commit_with_parents(tx.repo_mut(), &[]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let mut_repo1 = tx1.repo_mut();
@@ -205,12 +202,12 @@ fn test_isolation() {
         .rewrite_commit(&initial)
         .set_description("rewrite1")
         .write_unwrap();
-    mut_repo1.rebase_descendants().block_on().unwrap();
+    mut_repo1.rebase_descendants().block_unwrap();
     let rewrite2 = mut_repo2
         .rewrite_commit(&initial)
         .set_description("rewrite2")
         .write_unwrap();
-    mut_repo2.rebase_descendants().block_on().unwrap();
+    mut_repo2.rebase_descendants().block_unwrap();
 
     // Neither transaction has committed yet, so each transaction sees its own
     // commit.
@@ -219,15 +216,15 @@ fn test_isolation() {
     assert_heads(mut_repo2, vec![rewrite2.id()]);
 
     // The base repo and tx2 don't see the commits from tx1.
-    tx1.commit("transaction 1").block_on().unwrap();
+    tx1.commit("transaction 1").block_unwrap();
     assert_heads(repo.as_ref(), vec![initial.id()]);
     assert_heads(mut_repo2, vec![rewrite2.id()]);
 
     // The base repo still doesn't see the commits after both transactions commit.
-    tx2.commit("transaction 2").block_on().unwrap();
+    tx2.commit("transaction 2").block_unwrap();
     assert_heads(repo.as_ref(), vec![initial.id()]);
     // After reload, the base repo sees both rewrites.
-    let repo = repo.reload_at_head().block_on().unwrap();
+    let repo = repo.reload_at_head().block_unwrap();
     assert_heads(repo.as_ref(), vec![rewrite1.id(), rewrite2.id()]);
 }
 
@@ -244,11 +241,11 @@ fn test_stored_commit_predecessors() {
         .rewrite_commit(&commit1)
         .set_description("rewritten")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Reload operation from disk.
-    let op = loader.load_operation(repo.op_id()).block_on().unwrap();
+    let op = loader.load_operation(repo.op_id()).block_unwrap();
     assert!(op.stores_commit_predecessors());
     assert_matches!(op.predecessors_for_commit(commit1.id()), Some([]));
     assert_matches!(op.predecessors_for_commit(commit2.id()), Some([id]) if id == commit1.id());
@@ -256,9 +253,9 @@ fn test_stored_commit_predecessors() {
     // Save operation without the predecessors as old jj would do.
     let mut data = op.store_operation().clone();
     data.commit_predecessors = None;
-    let op_id = loader.op_store().write_operation(&data).block_on().unwrap();
+    let op_id = loader.op_store().write_operation(&data).block_unwrap();
     assert_ne!(&op_id, op.id());
-    let op = loader.load_operation(&op_id).block_on().unwrap();
+    let op = loader.load_operation(&op_id).block_unwrap();
     assert!(!op.stores_commit_predecessors());
 }
 
@@ -269,7 +266,7 @@ fn test_reparent_range_linear() {
     let loader = repo_0.loader();
     let op_store = repo_0.op_store();
 
-    let read_op = |id| loader.load_operation(id).block_on().unwrap();
+    let read_op = |id| loader.load_operation(id).block_unwrap();
 
     fn op_parents<const N: usize>(op: &Operation) -> [Operation; N] {
         let parents: Vec<_> = op.parents().try_collect().unwrap();
@@ -287,10 +284,10 @@ fn test_reparent_range_linear() {
         write_random_commit(tx.repo_mut());
         tx
     };
-    let repo_a = random_tx(&repo_0).commit("op A").block_on().unwrap();
-    let repo_b = random_tx(&repo_a).commit("op B").block_on().unwrap();
-    let repo_c = random_tx(&repo_b).commit("op C").block_on().unwrap();
-    let repo_d = random_tx(&repo_c).commit("op D").block_on().unwrap();
+    let repo_a = random_tx(&repo_0).commit("op A").block_unwrap();
+    let repo_b = random_tx(&repo_a).commit("op B").block_unwrap();
+    let repo_c = random_tx(&repo_b).commit("op C").block_unwrap();
+    let repo_d = random_tx(&repo_c).commit("op D").block_unwrap();
 
     // Reparent B..D (=C|D) onto A:
     // D'
@@ -303,8 +300,7 @@ fn test_reparent_range_linear() {
         slice::from_ref(repo_d.operation()),
         repo_a.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 2);
     assert_eq!(stats.unreachable_count, 1);
@@ -323,8 +319,7 @@ fn test_reparent_range_linear() {
         slice::from_ref(repo_d.operation()),
         repo_a.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids, vec![repo_a.op_id().clone()]);
     assert_eq!(stats.rewritten_count, 0);
     assert_eq!(stats.unreachable_count, 3);
@@ -337,7 +332,7 @@ fn test_reparent_range_branchy() {
     let loader = repo_0.loader();
     let op_store = repo_0.op_store();
 
-    let read_op = |id| loader.load_operation(id).block_on().unwrap();
+    let read_op = |id| loader.load_operation(id).block_unwrap();
 
     fn op_parents<const N: usize>(op: &Operation) -> [Operation; N] {
         let parents: Vec<_> = op.parents().try_collect().unwrap();
@@ -360,10 +355,10 @@ fn test_reparent_range_branchy() {
         write_random_commit(tx.repo_mut());
         tx
     };
-    let repo_a = random_tx(&repo_0).commit("op A").block_on().unwrap();
-    let repo_b = random_tx(&repo_a).commit("op B").block_on().unwrap();
-    let repo_c = random_tx(&repo_b).commit("op C").block_on().unwrap();
-    let repo_d = random_tx(&repo_c).commit("op D").block_on().unwrap();
+    let repo_a = random_tx(&repo_0).commit("op A").block_unwrap();
+    let repo_b = random_tx(&repo_a).commit("op B").block_unwrap();
+    let repo_c = random_tx(&repo_b).commit("op C").block_unwrap();
+    let repo_d = random_tx(&repo_c).commit("op D").block_unwrap();
     let tx_e = random_tx(&repo_d);
     let tx_f = random_tx(&repo_c);
     let repo_g = testutils::commit_transactions(vec![tx_e, tx_f]);
@@ -384,8 +379,7 @@ fn test_reparent_range_branchy() {
         slice::from_ref(repo_g.operation()),
         repo_b.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 3);
     assert_eq!(stats.unreachable_count, 2);
@@ -412,8 +406,7 @@ fn test_reparent_range_branchy() {
         slice::from_ref(repo_g.operation()),
         repo_a.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 5);
     assert_eq!(stats.unreachable_count, 1);
@@ -439,8 +432,7 @@ fn test_reparent_range_branchy() {
         slice::from_ref(repo_g.operation()),
         repo_d.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 1);
     assert_eq!(stats.unreachable_count, 2);
@@ -462,8 +454,7 @@ fn test_reparent_range_branchy() {
         slice::from_ref(&op_f),
         repo_d.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 1);
     assert_eq!(stats.unreachable_count, 0);
@@ -482,8 +473,8 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
     let op_store = repo_0.op_store();
 
     let repo_at = |id: &OperationId| {
-        let op = loader.load_operation(id).block_on().unwrap();
-        loader.load_at(&op).block_on().unwrap()
+        let op = loader.load_operation(id).block_unwrap();
+        loader.load_at(&op).block_unwrap()
     };
     let head_commits = |repo: &dyn Repo| {
         repo.view()
@@ -502,7 +493,7 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
     let mut tx = repo_0.start_transaction();
     let commit_a0 = write_random_commit(tx.repo_mut());
     let commit_b0 = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a0]);
-    let repo_1 = tx.commit("op1").block_on().unwrap();
+    let repo_1 = tx.commit("op1").block_unwrap();
 
     let mut tx = repo_1.start_transaction();
     let commit_a1 = tx
@@ -510,15 +501,15 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
         .rewrite_commit(&commit_a0)
         .set_description("a1")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     let [commit_b1] = head_commits(tx.repo()).try_into().unwrap();
     tx.repo_mut().add_head(&commit_b0).unwrap(); // resurrect rewritten commits
-    let repo_2 = tx.commit("op2").block_on().unwrap();
+    let repo_2 = tx.commit("op2").block_unwrap();
 
     let mut tx = repo_2.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_b0);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo_3 = tx.commit("op3").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo_3 = tx.commit("op3").block_unwrap();
 
     let mut tx = repo_3.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_a0);
@@ -528,8 +519,8 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
         .rewrite_commit(&commit_a1)
         .set_description("a2")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo_4 = tx.commit("op4").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo_4 = tx.commit("op4").block_unwrap();
 
     let repo_4 = if op_stores_commit_predecessors {
         repo_4
@@ -539,7 +530,7 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
         // fall back to the legacy code path immediately.
         let mut data = repo_4.operation().store_operation().clone();
         data.commit_predecessors = None;
-        let op_id = op_store.write_operation(&data).block_on().unwrap();
+        let op_id = op_store.write_operation(&data).block_unwrap();
         repo_at(&op_id)
     };
 
@@ -573,8 +564,7 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
         slice::from_ref(repo_4.operation()),
         repo_0.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 3);
     assert_eq!(stats.unreachable_count, 1);
@@ -600,8 +590,7 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
         slice::from_ref(repo_4.operation()),
         repo_0.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 2);
     assert_eq!(stats.unreachable_count, 2);
@@ -635,8 +624,7 @@ fn test_reparent_discarding_predecessors(op_stores_commit_predecessors: bool) {
         slice::from_ref(repo_4.operation()),
         repo_0.operation(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(stats.new_head_ids.len(), 1);
     assert_eq!(stats.rewritten_count, 1);
     assert_eq!(stats.unreachable_count, 3);
@@ -676,7 +664,7 @@ fn test_resolve_op_id() {
     // up with hashes with ambiguous prefixes.
     for i in (1..5).chain([9, 27]) {
         let tx = repo.start_transaction();
-        let repo = tx.commit(format!("transaction {i}")).block_on().unwrap();
+        let repo = tx.commit(format!("transaction {i}")).block_unwrap();
         operations.push(repo.operation().clone());
     }
     // "6" and "0" are ambiguous
@@ -747,9 +735,7 @@ fn test_resolve_current_op() {
     let repo = test_repo.repo;
 
     assert_eq!(
-        op_walk::resolve_op_with_repo(&repo, "@")
-            .block_on()
-            .unwrap(),
+        op_walk::resolve_op_with_repo(&repo, "@").block_unwrap(),
         *repo.operation()
     );
 }
@@ -764,7 +750,7 @@ fn test_resolve_op_parents_children() {
     let mut repos = Vec::new();
     for _ in 0..3 {
         let tx = repo.start_transaction();
-        repos.push(tx.commit("test").block_on().unwrap());
+        repos.push(tx.commit("test").block_unwrap());
         repo = repos.last().unwrap();
     }
     let operations = repos.iter().map(|repo| repo.operation()).collect_vec();
@@ -772,15 +758,11 @@ fn test_resolve_op_parents_children() {
     // Parent
     let op2_id_hex = operations[2].id().hex();
     assert_eq!(
-        op_walk::resolve_op_with_repo(repo, &format!("{op2_id_hex}-"))
-            .block_on()
-            .unwrap(),
+        op_walk::resolve_op_with_repo(repo, &format!("{op2_id_hex}-")).block_unwrap(),
         *operations[1]
     );
     assert_eq!(
-        op_walk::resolve_op_with_repo(repo, &format!("{op2_id_hex}--"))
-            .block_on()
-            .unwrap(),
+        op_walk::resolve_op_with_repo(repo, &format!("{op2_id_hex}--")).block_unwrap(),
         *operations[0]
     );
     // "{op2_id_hex}----" is the root operation
@@ -794,15 +776,11 @@ fn test_resolve_op_parents_children() {
     // Child
     let op0_id_hex = operations[0].id().hex();
     assert_eq!(
-        op_walk::resolve_op_with_repo(repo, &format!("{op0_id_hex}+"))
-            .block_on()
-            .unwrap(),
+        op_walk::resolve_op_with_repo(repo, &format!("{op0_id_hex}+")).block_unwrap(),
         *operations[1]
     );
     assert_eq!(
-        op_walk::resolve_op_with_repo(repo, &format!("{op0_id_hex}++"))
-            .block_on()
-            .unwrap(),
+        op_walk::resolve_op_with_repo(repo, &format!("{op0_id_hex}++")).block_unwrap(),
         *operations[2]
     );
     assert_matches!(
@@ -814,17 +792,13 @@ fn test_resolve_op_parents_children() {
 
     // Child of parent
     assert_eq!(
-        op_walk::resolve_op_with_repo(repo, &format!("{op2_id_hex}--+"))
-            .block_on()
-            .unwrap(),
+        op_walk::resolve_op_with_repo(repo, &format!("{op2_id_hex}--+")).block_unwrap(),
         *operations[1]
     );
 
     // Child at old repo: new operations shouldn't be visible
     assert_eq!(
-        op_walk::resolve_op_with_repo(&repos[1], &format!("{op0_id_hex}+"))
-            .block_on()
-            .unwrap(),
+        op_walk::resolve_op_with_repo(&repos[1], &format!("{op0_id_hex}+")).block_unwrap(),
         *operations[1]
     );
     assert_matches!(
@@ -893,15 +867,13 @@ fn test_walk_ancestors() {
     fn collect_ancestors(head_ops: &[Operation]) -> Vec<Operation> {
         op_walk::walk_ancestors(head_ops)
             .try_collect()
-            .block_on()
-            .unwrap()
+            .block_unwrap()
     }
 
     fn collect_ancestors_range(head_ops: &[Operation], root_ops: &[Operation]) -> Vec<Operation> {
         op_walk::walk_ancestors_range(head_ops, root_ops)
             .try_collect()
-            .block_on()
-            .unwrap()
+            .block_unwrap()
     }
 
     // Set up operation graph:
@@ -917,36 +889,19 @@ fn test_walk_ancestors() {
     // A |
     // |/
     // 0 (initial)
-    let repo_a = repo_0
-        .start_transaction()
-        .commit("op A")
-        .block_on()
-        .unwrap();
+    let repo_a = repo_0.start_transaction().commit("op A").block_unwrap();
     let repo_b = repo_0
         .start_transaction()
         .write("op B")
-        .block_on()
-        .unwrap()
+        .block_unwrap()
         .leave_unpublished();
-    let repo_c = repo_a
-        .start_transaction()
-        .commit("op C")
-        .block_on()
-        .unwrap();
-    let repo_d = repo_c
-        .start_transaction()
-        .commit("op D")
-        .block_on()
-        .unwrap();
+    let repo_c = repo_a.start_transaction().commit("op C").block_unwrap();
+    let repo_d = repo_c.start_transaction().commit("op D").block_unwrap();
     let tx_e = repo_d.start_transaction();
     let tx_f = repo_c.start_transaction();
     let repo_g = testutils::commit_transactions(vec![tx_e, tx_f]);
     let [op_e, op_f] = op_parents(repo_g.operation());
-    let repo_h = repo_g
-        .start_transaction()
-        .commit("op H")
-        .block_on()
-        .unwrap();
+    let repo_h = repo_g.start_transaction().commit("op H").block_unwrap();
 
     // At merge, parents are visited in forward order, which isn't important.
     assert_eq!(
@@ -1055,12 +1010,12 @@ fn test_gc() {
         write_random_commit(tx.repo_mut());
         tx
     };
-    let repo_a = random_tx(&repo_0).commit("op A").block_on().unwrap();
-    let repo_b = random_tx(&repo_a).commit("op B").block_on().unwrap();
-    let repo_c = random_tx(&repo_b).commit("op C").block_on().unwrap();
-    let repo_d = random_tx(&repo_c).commit("op D").block_on().unwrap();
-    let repo_e = empty_tx(&repo_b).commit("op E").block_on().unwrap();
-    let repo_f = random_tx(&repo_e).commit("op F").block_on().unwrap();
+    let repo_a = random_tx(&repo_0).commit("op A").block_unwrap();
+    let repo_b = random_tx(&repo_a).commit("op B").block_unwrap();
+    let repo_c = random_tx(&repo_b).commit("op C").block_unwrap();
+    let repo_d = random_tx(&repo_c).commit("op D").block_unwrap();
+    let repo_e = empty_tx(&repo_b).commit("op E").block_unwrap();
+    let repo_f = random_tx(&repo_e).commit("op F").block_unwrap();
 
     // Sanity check for the original state
     let mut expected_op_entries = list_dir(&op_dir);
@@ -1069,22 +1024,21 @@ fn test_gc() {
     assert_eq!(expected_view_entries.len(), 5);
 
     // No heads, but all kept by file modification time
-    op_store.gc(&[], SystemTime::UNIX_EPOCH).block_on().unwrap();
+    op_store.gc(&[], SystemTime::UNIX_EPOCH).block_unwrap();
     assert_eq!(list_dir(&op_dir), expected_op_entries);
     assert_eq!(list_dir(&view_dir), expected_view_entries);
 
     // All reachable from heads
     let now = SystemTime::now();
     let head_ids = [repo_d.op_id().clone(), repo_f.op_id().clone()];
-    op_store.gc(&head_ids, now).block_on().unwrap();
+    op_store.gc(&head_ids, now).block_unwrap();
     assert_eq!(list_dir(&op_dir), expected_op_entries);
     assert_eq!(list_dir(&view_dir), expected_view_entries);
 
     // E|F are no longer reachable, but E's view is still reachable
     op_store
         .gc(slice::from_ref(repo_d.op_id()), now)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     expected_op_entries
         .retain(|name| *name != repo_e.op_id().hex() && *name != repo_f.op_id().hex());
     expected_view_entries.retain(|name| *name != repo_f.operation().view_id().hex());
@@ -1094,8 +1048,7 @@ fn test_gc() {
     // B|C|D are no longer reachable
     op_store
         .gc(slice::from_ref(repo_a.op_id()), now)
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     expected_op_entries.retain(|name| {
         *name != repo_b.op_id().hex()
             && *name != repo_c.op_id().hex()

--- a/lib/tests/test_refs.rs
+++ b/lib/tests/test_refs.rs
@@ -16,7 +16,7 @@ use jj_lib::merge::Merge;
 use jj_lib::op_store::RefTarget;
 use jj_lib::refs::merge_ref_targets;
 use jj_lib::repo::Repo as _;
-use pollster::FutureExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestWorkspace;
 use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
@@ -42,7 +42,7 @@ fn test_merge_ref_targets() {
     let commit5 = write_random_commit_with_parents(tx.repo_mut(), &[&commit1]);
     let commit6 = write_random_commit_with_parents(tx.repo_mut(), &[&commit5]);
     let commit7 = write_random_commit_with_parents(tx.repo_mut(), &[&commit5]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let target1 = RefTarget::normal(commit1.id().clone());
     let target2 = RefTarget::normal(commit2.id().clone());

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -69,6 +69,7 @@ use jj_lib::workspace::Workspace;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
@@ -134,9 +135,8 @@ fn build_changed_path_index(repo: &ReadonlyRepo) -> Arc<ReadonlyRepo> {
     let default_index_store: &DefaultIndexStore = repo.index_store().downcast_ref().unwrap();
     default_index_store
         .build_changed_path_index_at_operation(repo.op_id(), repo.store(), u32::MAX, |_| ())
-        .block_on()
-        .unwrap();
-    repo.reload_at(repo.operation()).block_on().unwrap()
+        .block_unwrap();
+    repo.reload_at(repo.operation()).block_unwrap()
 }
 
 #[test]
@@ -183,7 +183,7 @@ fn test_resolve_symbol_commit_id() {
             .write_unwrap();
         commits.push(commit);
     }
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Test the test setup
     insta::assert_snapshot!(commits.iter().map(|c| c.id().hex()).join("\n"), @"
@@ -340,7 +340,7 @@ fn test_resolve_symbol_change_id(readonly: bool) {
 
     let _readonly_repo;
     let repo: &dyn Repo = if readonly {
-        _readonly_repo = tx.commit("test").block_on().unwrap();
+        _readonly_repo = tx.commit("test").block_unwrap();
         _readonly_repo.as_ref()
     } else {
         tx.repo_mut()
@@ -467,8 +467,8 @@ fn test_resolve_symbol_hidden_change_id() {
         .rewrite_commit(&commit1)
         .set_description("updated commit")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("rewrite commit").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("rewrite commit").block_unwrap();
 
     let change_id = commit1.change_id();
     assert_eq!(
@@ -495,8 +495,8 @@ fn test_resolve_symbol_hidden_change_id() {
     // Abandon the new commit as well so that there are only hidden commits.
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit2);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("abandon commit").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("abandon commit").block_unwrap();
 
     assert_matches!(
         resolve_symbol(repo.as_ref(), &format!("{change_id}")),
@@ -532,12 +532,12 @@ fn test_resolve_symbol_in_different_disambiguation_context() {
     for _ in 0..50 {
         write_random_commit(tx.repo_mut());
     }
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit2 = tx.repo_mut().rewrite_commit(&commit1).write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     // Set up disambiguation index which only contains the commit2.id().
     let id_prefix_context = IdPrefixContext::new(Arc::new(RevsetExtensions::default()))
@@ -1270,12 +1270,12 @@ fn test_evaluate_expression_with_hidden_revisions() {
     let commit2 = write_random_commit(mut_repo);
     let commit3 = write_random_commit_with_parents(mut_repo, &[&commit1]);
     let commit4 = write_random_commit_with_parents(mut_repo, &[&commit3]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit3);
     tx.repo_mut().record_abandoned_commit(&commit4);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Sanity check
     assert_eq!(
@@ -1338,7 +1338,7 @@ fn test_evaluate_expression_root_and_checkout() {
     let repo = &test_workspace.repo;
 
     let root_operation = repo.loader().root_operation().block_on();
-    let root_repo = repo.reload_at(&root_operation).block_on().unwrap();
+    let root_repo = repo.reload_at(&root_operation).block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -4113,7 +4113,7 @@ fn test_evaluate_expression_at_operation() {
         "commit1_ref".as_ref(),
         RefTarget::normal(commit1_op1.id().clone()),
     );
-    let repo1 = tx.commit("test").block_on().unwrap();
+    let repo1 = tx.commit("test").block_unwrap();
 
     let mut tx = repo1.start_transaction();
     let commit1_op2 = tx
@@ -4124,8 +4124,8 @@ fn test_evaluate_expression_at_operation() {
     let commit3_op2 = create_random_commit(tx.repo_mut())
         .set_description("commit3@op2")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo2 = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo2 = tx.commit("test").block_unwrap();
 
     let mut tx = repo2.start_transaction();
     let _commit4_op3 = create_random_commit(tx.repo_mut())
@@ -4921,8 +4921,7 @@ fn test_evaluate_expression_diff_lines_conflict(indexed: bool) {
         (tree1, "tree 1".into()),
         (tree3, "tree 3".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let commit2 = create_commit(vec![commit1.id().clone()], tree4);
 
     assert_eq!(
@@ -5085,8 +5084,7 @@ fn test_evaluate_expression_conflict() {
         (tree1, "tree 1".into()),
         (tree3, "tree 3".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let commit4 = create_commit(vec![commit3.id().clone()], tree4);
 
     // Only commit4 has a conflict
@@ -5113,7 +5111,7 @@ fn test_evaluate_expression_divergent() {
 
     let change_id = commit1.change_id();
 
-    let repo = tx.commit("Divergent commits").block_on().unwrap();
+    let repo = tx.commit("Divergent commits").block_unwrap();
 
     assert_matches!(
         resolve_symbol(repo.as_ref(), &format!("{change_id}")),
@@ -5128,8 +5126,8 @@ fn test_evaluate_expression_divergent() {
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit1);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("abandon commit").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("abandon commit").block_unwrap();
 
     assert_eq!(resolve_commit_ids(repo.as_ref(), "divergent()"), vec![]);
 
@@ -5173,7 +5171,7 @@ fn test_reverse_graph() {
     let commit_d = write_random_commit_with_parents(mut_repo, &[&commit_c]);
     let commit_e = write_random_commit_with_parents(mut_repo, &[&commit_c]);
     let commit_f = write_random_commit_with_parents(mut_repo, &[&commit_d, &commit_e]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let revset = revset_for_commits(
         repo.as_ref(),
@@ -5237,7 +5235,7 @@ fn test_revset_containing_fn() {
     let commit_b = write_random_commit(mut_repo);
     let commit_c = write_random_commit(mut_repo);
     let commit_d = write_random_commit(mut_repo);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let revset = revset_for_commits(repo.as_ref(), &[&commit_b, &commit_d]);
 

--- a/lib/tests/test_revset_optimized.rs
+++ b/lib/tests/test_revset_optimized.rs
@@ -34,9 +34,9 @@ use jj_lib::revset::RevsetFilterPredicate;
 use jj_lib::rewrite::RebaseOptions;
 use jj_lib::rewrite::RebasedCommit;
 use jj_lib::settings::UserSettings;
-use pollster::FutureExt as _;
 use proptest::prelude::*;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 
 fn stable_settings() -> UserSettings {
@@ -67,8 +67,7 @@ fn rebase_descendants(repo: &mut MutableRepo) -> Vec<Commit> {
         RebasedCommit::Rewritten(commit) => commits.push(commit),
         RebasedCommit::Abandoned { .. } => {}
     })
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     commits
 }
 
@@ -192,7 +191,7 @@ fn test_mostly_linear() {
     let commits = vec![
         commit0, commit1, commit2, commit3, commit4, commit5, commit6, commit7, commit8, commit9,
     ];
-    let repo = tx.commit("a").block_on().unwrap();
+    let repo = tx.commit("a").block_unwrap();
 
     // Commit ids for reference
     insta::assert_snapshot!(
@@ -246,7 +245,7 @@ fn test_weird_merges() {
     let commits = vec![
         commit0, commit1, commit2, commit3, commit4, commit5, commit6, commit7, commit8,
     ];
-    let repo = tx.commit("a").block_on().unwrap();
+    let repo = tx.commit("a").block_unwrap();
 
     // Commit ids for reference
     insta::assert_snapshot!(
@@ -303,18 +302,18 @@ fn test_feature_branches() {
     let commit3 = write_new_commit(tx.repo_mut(), "3", [&commit0]);
     let commit4 = write_new_commit(tx.repo_mut(), "4", [&commit3]);
     let commit5 = write_new_commit(tx.repo_mut(), "5", [&commit4]);
-    let repo = tx.commit("a").block_on().unwrap();
+    let repo = tx.commit("a").block_unwrap();
 
     // Merge branch 2
     let mut tx = repo.start_transaction();
     let commit6 = write_new_commit(tx.repo_mut(), "6", [&commit0, &commit2]);
-    let repo = tx.commit("a").block_on().unwrap();
+    let repo = tx.commit("a").block_unwrap();
 
     // Fetch merged branch 7
     let mut tx = repo.start_transaction();
     let commit7 = write_new_commit(tx.repo_mut(), "7", [&commit6]);
     let commit8 = write_new_commit(tx.repo_mut(), "8", [&commit6, &commit7]);
-    let repo = tx.commit("a").block_on().unwrap();
+    let repo = tx.commit("a").block_unwrap();
 
     // Merge branch 5
     let mut tx = repo.start_transaction();
@@ -322,7 +321,7 @@ fn test_feature_branches() {
     let commits = vec![
         commit0, commit1, commit2, commit3, commit4, commit5, commit6, commit7, commit8, commit9,
     ];
-    let repo = tx.commit("a").block_on().unwrap();
+    let repo = tx.commit("a").block_unwrap();
 
     // Commit ids for reference
     insta::assert_snapshot!(
@@ -374,7 +373,7 @@ fn test_rewritten() {
     let commit4 = write_new_commit(tx.repo_mut(), "4", [&commit1]);
     let commit5 = write_new_commit(tx.repo_mut(), "5", [&commit4, &commit2]);
     let mut commits = vec![commit0, commit1, commit2, commit3, commit4, commit5];
-    let repo = tx.commit("a").block_on().unwrap();
+    let repo = tx.commit("a").block_unwrap();
 
     // Rewrite 2, rebase 3 and 5
     let mut tx = repo.start_transaction();
@@ -385,13 +384,13 @@ fn test_rewritten() {
         .write_unwrap();
     commits.push(commit2b);
     commits.extend(rebase_descendants(tx.repo_mut()));
-    let repo = tx.commit("b").block_on().unwrap();
+    let repo = tx.commit("b").block_unwrap();
 
     // Abandon 4, rebase 5
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commits[4]);
     commits.extend(rebase_descendants(tx.repo_mut()));
-    let repo = tx.commit("c").block_on().unwrap();
+    let repo = tx.commit("c").block_unwrap();
 
     // Commit ids for reference
     insta::assert_snapshot!(

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -45,6 +45,7 @@ use maplit::hashset;
 use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::assert_abandoned_with_parent;
 use testutils::assert_rebased_onto;
@@ -103,9 +104,7 @@ fn test_merge_criss_cross() {
         vec![commit_b.id().clone(), commit_c.id().clone()],
         tree_e,
     );
-    let merged = merge_commit_trees(tx.repo_mut(), &[commit_d, commit_e])
-        .block_on()
-        .unwrap();
+    let merged = merge_commit_trees(tx.repo_mut(), &[commit_d, commit_e]).block_unwrap();
 
     assert_tree_eq!(merged, tree_expected);
 }
@@ -164,8 +163,7 @@ fn test_restore_tree() {
         "right side".into(),
         &EverythingMatcher,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(restored, left);
 
     // Restore everything using FilesMatcher
@@ -176,8 +174,7 @@ fn test_restore_tree() {
         "right side".into(),
         &FilesMatcher::new([&path1, &path2, &path3, &path4]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(restored, left);
 
     // Restore some files
@@ -188,8 +185,7 @@ fn test_restore_tree() {
         "right side".into(),
         &FilesMatcher::new([path1, path2]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let expected = create_tree(repo, &[(path2, "left"), (path3, "right")]);
     assert_tree_eq!(restored, expected);
 }
@@ -216,15 +212,13 @@ fn test_restore_tree_with_conflicts() {
         (left_base1, "left base 1".into()),
         (left_side2, "left side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let right = MergedTree::merge(Merge::from_vec(vec![
         (right_side1.clone(), "right side 1".into()),
         (right_base1.clone(), "right base 1".into()),
         (right_side2.clone(), "right side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     // Restore everything using EverythingMatcher
     let restored = restore_tree(
@@ -234,8 +228,7 @@ fn test_restore_tree_with_conflicts() {
         "right side".into(),
         &EverythingMatcher,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(restored, left);
 
     // Restore a single conflicted file
@@ -246,8 +239,7 @@ fn test_restore_tree_with_conflicts() {
         "right side".into(),
         &FilesMatcher::new([path1]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     // After simplifying, the result should have path 1 from the left side and path
     // 2 from the right side.
@@ -357,15 +349,13 @@ fn test_restore_tree_with_conflicts() {
         (left_base2, "left base 2".into()),
         (left_side3, "left side 3".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let right = MergedTree::merge(Merge::from_vec(vec![
         (right_side1.clone(), "right side 1".into()),
         (right_base1.clone(), "right base 1".into()),
         (right_side2.clone(), "right side 2".into()),
     ]))
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     // Restore everything using EverythingMatcher
     let restored = restore_tree(
@@ -375,8 +365,7 @@ fn test_restore_tree_with_conflicts() {
         "right side".into(),
         &EverythingMatcher,
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_tree_eq!(restored, left);
 
     // Restore a single conflicted file
@@ -387,8 +376,7 @@ fn test_restore_tree_with_conflicts() {
         "right side".into(),
         &FilesMatcher::new([path2]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     // After simplifying, the result should have paths 1 and 3 from the right side
     // and path 2 from the left side.
@@ -436,8 +424,7 @@ fn test_restore_tree_with_conflicts() {
         "right side".into(),
         &FilesMatcher::new([path3]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     // After simplifying, the result should have paths 1 and 2 from the right side
     // and path 3 from the left side.
@@ -1183,8 +1170,8 @@ fn test_rebase_descendants_hidden() {
     let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b]);
     tx.repo_mut().record_abandoned_commit(&commit_b);
     tx.repo_mut().record_abandoned_commit(&commit_c);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
     let mut tx = repo.start_transaction();
 
     let commit_d = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
@@ -1348,11 +1335,11 @@ fn test_rebase_descendants_basic_bookmark_update() {
     let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
     tx.repo_mut()
         .set_local_bookmark_target("main".as_ref(), RefTarget::normal(commit_b.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let commit_b2 = tx.repo_mut().rewrite_commit(&commit_b).write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
         RefTarget::normal(commit_b2.id().clone())
@@ -1382,7 +1369,7 @@ fn test_rebase_descendants_bookmark_move_two_steps() {
     let commit_c = write_random_commit_with_parents(tx.repo_mut(), &[&commit_b]);
     tx.repo_mut()
         .set_local_bookmark_target("main".as_ref(), RefTarget::normal(commit_c.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let commit_b2 = tx
@@ -1395,7 +1382,7 @@ fn test_rebase_descendants_bookmark_move_two_steps() {
         .rewrite_commit(&commit_c)
         .set_description("more different")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     let heads = tx.repo().view().heads();
     assert_eq!(heads.len(), 1);
     let c3_id = heads.iter().next().unwrap().clone();
@@ -1434,11 +1421,11 @@ fn test_rebase_descendants_basic_bookmark_update_with_non_local_bookmark() {
         .set_remote_bookmark(remote_symbol("main", "origin"), commit_b_remote_ref.clone());
     tx.repo_mut()
         .set_local_tag_target("v1".as_ref(), RefTarget::normal(commit_b.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let commit_b2 = tx.repo_mut().rewrite_commit(&commit_b).write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
         RefTarget::normal(commit_b2.id().clone())
@@ -1487,7 +1474,7 @@ fn test_rebase_descendants_update_bookmark_after_abandon(delete_abandoned_bookma
         .set_remote_bookmark(remote_symbol("main", "origin"), commit_b_remote_ref.clone());
     tx.repo_mut()
         .set_local_bookmark_target("other".as_ref(), RefTarget::normal(commit_c.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_b);
@@ -1547,7 +1534,7 @@ fn test_rebase_descendants_update_bookmarks_after_divergent_rewrite() {
         .set_local_bookmark_target("main".as_ref(), RefTarget::normal(commit_b.id().clone()));
     tx.repo_mut()
         .set_local_bookmark_target("other".as_ref(), RefTarget::normal(commit_c.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let commit_b2 = tx.repo_mut().rewrite_commit(&commit_b).write_unwrap();
@@ -1581,7 +1568,7 @@ fn test_rebase_descendants_update_bookmarks_after_divergent_rewrite() {
         commit_b4.id().clone(),
         vec![commit_b41.id().clone(), commit_b42.id().clone()],
     );
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
 
     let main_target = tx.repo().get_local_bookmark("main".as_ref());
     assert!(main_target.has_conflict());
@@ -1636,7 +1623,7 @@ fn test_rebase_descendants_rewrite_updates_bookmark_conflict() {
             [commit_b.id().clone(), commit_c.id().clone()],
         ),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let commit_a2 = tx.repo_mut().rewrite_commit(&commit_a).write_unwrap();
@@ -1661,7 +1648,7 @@ fn test_rebase_descendants_rewrite_updates_bookmark_conflict() {
         commit_b.id().clone(),
         vec![commit_b2.id().clone(), commit_b3.id().clone()],
     );
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
 
     let target = tx.repo().get_local_bookmark("main".as_ref());
     assert!(target.has_conflict());
@@ -1713,7 +1700,7 @@ fn test_rebase_descendants_rewrite_resolves_bookmark_conflict() {
             [commit_b.id().clone(), commit_c.id().clone()],
         ),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let commit_b2 = tx
@@ -1721,7 +1708,7 @@ fn test_rebase_descendants_rewrite_resolves_bookmark_conflict() {
         .rewrite_commit(&commit_b)
         .set_parents(vec![commit_c.id().clone()])
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
     assert_eq!(
         tx.repo().get_local_bookmark("main".as_ref()),
         RefTarget::normal(commit_b2.id().clone())
@@ -1756,7 +1743,7 @@ fn test_rebase_descendants_bookmark_delete_modify_abandon(delete_abandoned_bookm
         "main".as_ref(),
         RefTarget::from_legacy_form([commit_a.id().clone()], [commit_b.id().clone()]),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_b);
@@ -1799,7 +1786,7 @@ fn test_rebase_descendants_bookmark_move_forward_abandon(delete_abandoned_bookma
             Some(commit_c.id().clone()),
         ])),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_b);
@@ -1850,7 +1837,7 @@ fn test_rebase_descendants_bookmark_move_sideways_abandon(delete_abandoned_bookm
             Some(commit_c.id().clone()),
         ])),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_b);
@@ -1905,7 +1892,7 @@ fn test_rebase_descendants_update_checkout() {
     tx.repo_mut()
         .set_wc_commit(ws3_name.clone(), commit_a.id().clone())
         .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let commit_c = tx
@@ -1913,8 +1900,8 @@ fn test_rebase_descendants_update_checkout() {
         .rewrite_commit(&commit_b)
         .set_description("C")
         .write_unwrap();
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Workspaces 1 and 2 had B checked out, so they get updated to C. Workspace 3
     // had A checked out, so it doesn't get updated.
@@ -1949,12 +1936,12 @@ fn test_rebase_descendants_update_checkout_abandoned() {
     tx.repo_mut()
         .set_wc_commit(ws3_name.clone(), commit_a.id().clone())
         .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_b);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // Workspaces 1 and 2 had B checked out, so they get updated to the same new
     // commit on top of C. Workspace 3 had A checked out, so it doesn't get updated.
@@ -1992,12 +1979,12 @@ fn test_rebase_descendants_update_checkout_abandoned_merge() {
     tx.repo_mut()
         .set_wc_commit(ws_name.clone(), commit_d.id().clone())
         .unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     tx.repo_mut().record_abandoned_commit(&commit_d);
-    tx.repo_mut().rebase_descendants().block_on().unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    tx.repo_mut().rebase_descendants().block_unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let new_checkout_id = repo.view().get_wc_commit_id(&ws_name).unwrap();
     let checkout = repo.store().get_commit(new_checkout_id).unwrap();
@@ -2204,9 +2191,7 @@ fn test_rebase_abandoning_empty() {
         simplify_ancestor_merge: true,
     };
     let rewriter = CommitRewriter::new(tx.repo_mut(), commit_b, vec![commit_b2.id().clone()]);
-    rebase_commit_with_options(rewriter, &rebase_options)
-        .block_on()
-        .unwrap();
+    rebase_commit_with_options(rewriter, &rebase_options).block_unwrap();
     let rebase_map = rebase_descendants_with_options_return_map(tx.repo_mut(), &rebase_options);
     assert_eq!(rebase_map.len(), 5);
     let new_commit_c = assert_rebased_onto(tx.repo(), &rebase_map, &commit_c, &[commit_b2.id()]);
@@ -2331,8 +2316,7 @@ fn test_find_duplicate_divergent_commits() {
         &[commit_a2.id().clone()],
         &MoveCommitsTarget::Roots(vec![commit_d.id().clone()]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     // Commits b2 and c2 are duplicates
     assert_eq!(duplicate_commits, &[commit_c2.clone(), commit_b2.clone()]);
 
@@ -2342,8 +2326,7 @@ fn test_find_duplicate_divergent_commits() {
         &[commit_e.id().clone()],
         &MoveCommitsTarget::Roots(vec![commit_b1.id().clone()]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     // Commits b1 and c1 are duplicates. Commit a2 is not a duplicate, because
     // it already had a1 as an ancestor before the rebase.
     assert_eq!(duplicate_commits, &[commit_c1.clone(), commit_b1.clone()]);
@@ -2358,8 +2341,7 @@ fn test_find_duplicate_divergent_commits() {
             commit_e.id().clone(),
         ]),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     // Commit c2 is a duplicate
     assert_eq!(duplicate_commits, std::slice::from_ref(&commit_c2));
 }

--- a/lib/tests/test_rewrite_duplicate.rs
+++ b/lib/tests/test_rewrite_duplicate.rs
@@ -19,8 +19,8 @@ use jj_lib::backend::CommitId;
 use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::duplicate_commits;
 use jj_lib::transaction::Transaction;
-use pollster::FutureExt as _;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::assert_tree_eq;
 use testutils::create_tree;
@@ -67,7 +67,7 @@ fn test_duplicate_linear_contents() {
         .repo_mut()
         .new_commit(vec![commit_d.id().clone()], tree_2.clone())
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let duplicate_in_between = |tx: &mut Transaction,
                                 target_commits: &[&CommitId],
@@ -80,8 +80,7 @@ fn test_duplicate_linear_contents() {
             &parent_commit_ids.iter().copied().cloned().collect_vec(),
             &children_commit_ids.iter().copied().cloned().collect_vec(),
         )
-        .block_on()
-        .unwrap()
+        .block_unwrap()
     };
     let duplicate_onto =
         |tx: &mut Transaction, target_commits: &[&CommitId], parent_commit_ids: &[&CommitId]| {

--- a/lib/tests/test_rewrite_transform.rs
+++ b/lib/tests/test_rewrite_transform.rs
@@ -19,7 +19,7 @@ use jj_lib::repo::Repo as _;
 use jj_lib::rewrite::RewriteRefsOptions;
 use maplit::hashmap;
 use maplit::hashset;
-use pollster::FutureExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::write_random_commit;
 use testutils::write_random_commit_with_parents;
@@ -62,8 +62,7 @@ fn test_transform_descendants_sync() {
             }
             Ok(())
         })
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(rebased.len(), 4);
     let new_commit_b = rebased.get(commit_b.id()).unwrap();
     let new_commit_d = rebased.get(commit_d.id()).unwrap();
@@ -111,8 +110,7 @@ fn test_transform_descendants_sync_linearize_merge() {
             rebased.insert(old_commit_id, new_commit);
             Ok(())
         })
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(rebased.len(), 1);
     let new_commit_c = rebased.get(commit_c.id()).unwrap();
 
@@ -175,8 +173,7 @@ fn test_transform_descendants_new_parents_map() {
                 Ok(())
             },
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
     assert_eq!(rebased.len(), 5);
     let new_commit_b = rebased.get(commit_b.id()).unwrap();
     let new_commit_c = rebased.get(commit_c.id()).unwrap();

--- a/lib/tests/test_signing.rs
+++ b/lib/tests/test_signing.rs
@@ -10,9 +10,9 @@ use jj_lib::signing::SignBehavior;
 use jj_lib::signing::Signer;
 use jj_lib::signing::Verification;
 use jj_lib::test_signing_backend::TestSigningBackend;
-use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepoBackend;
 use testutils::TestWorkspace;
 use testutils::create_random_commit;
@@ -79,7 +79,7 @@ fn manual(backend: TestRepoBackend) {
         .set_sign_behavior(SignBehavior::Own)
         .set_author(someone_else())
         .write_unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let commit1 = repo.store().get_commit(commit1.id()).unwrap();
     assert_eq!(commit1.verification().unwrap(), good_verification());
@@ -102,7 +102,7 @@ fn keep_on_rewrite(backend: TestRepoBackend) {
     let commit = create_random_commit(tx.repo_mut())
         .set_sign_behavior(SignBehavior::Own)
         .write_unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -126,7 +126,7 @@ fn manual_drop_on_rewrite(backend: TestRepoBackend) {
     let commit = create_random_commit(tx.repo_mut())
         .set_sign_behavior(SignBehavior::Own)
         .write_unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let mut tx = repo.start_transaction();
     let mut_repo = tx.repo_mut();
@@ -153,7 +153,7 @@ fn forced(backend: TestRepoBackend) {
     let commit = create_random_commit(tx.repo_mut())
         .set_author(someone_else())
         .write_unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let commit = repo.store().get_commit(commit.id()).unwrap();
     assert_eq!(commit.verification().unwrap(), good_verification());
@@ -171,7 +171,7 @@ fn configured(backend: TestRepoBackend) {
     let repo = repo.clone();
     let mut tx = repo.start_transaction();
     let commit = write_random_commit(tx.repo_mut());
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let commit = repo.store().get_commit(commit.id()).unwrap();
     assert_eq!(commit.verification().unwrap(), good_verification());
@@ -191,7 +191,7 @@ fn drop_behavior(backend: TestRepoBackend) {
     let commit = create_random_commit(tx.repo_mut())
         .set_sign_behavior(SignBehavior::Own)
         .write_unwrap();
-    tx.commit("test").block_on().unwrap();
+    tx.commit("test").block_unwrap();
 
     let original_commit = repo.store().get_commit(commit.id()).unwrap();
     assert_eq!(original_commit.verification().unwrap(), good_verification());

--- a/lib/tests/test_view.rs
+++ b/lib/tests/test_view.rs
@@ -26,9 +26,9 @@ use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::Repo as _;
 use maplit::btreemap;
 use maplit::hashset;
-use pollster::FutureExt as _;
 use test_case::test_case;
 use testutils::CommitBuilderExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestRepo;
 use testutils::commit_transactions;
 use testutils::create_random_commit;
@@ -66,7 +66,7 @@ fn test_heads_fork() {
     let initial = write_random_commit(tx.repo_mut());
     let child1 = write_random_commit_with_parents(tx.repo_mut(), &[&initial]);
     let child2 = write_random_commit_with_parents(tx.repo_mut(), &[&initial]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     assert_eq!(
         *repo.view().heads(),
@@ -87,7 +87,7 @@ fn test_heads_merge() {
     let child1 = write_random_commit_with_parents(tx.repo_mut(), &[&initial]);
     let child2 = write_random_commit_with_parents(tx.repo_mut(), &[&initial]);
     let merge = write_random_commit_with_parents(tx.repo_mut(), &[&child1, &child2]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     assert_eq!(*repo.view().heads(), hashset! {merge.id().clone()});
 }
@@ -103,7 +103,7 @@ fn test_merge_views_heads() {
     let head_unchanged = write_random_commit(mut_repo);
     let head_remove_tx1 = write_random_commit(mut_repo);
     let head_remove_tx2 = write_random_commit(mut_repo);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     tx1.repo_mut().remove_head(head_remove_tx1.id());
@@ -167,7 +167,7 @@ fn test_merge_views_checkout() {
         .repo_mut()
         .set_wc_commit(ws5_name.clone(), commit1.id().clone())
         .unwrap();
-    let repo = initial_tx.commit("test").block_on().unwrap();
+    let repo = initial_tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     tx1.repo_mut()
@@ -176,10 +176,7 @@ fn test_merge_views_checkout() {
     tx1.repo_mut()
         .set_wc_commit(ws2_name.clone(), commit2.id().clone())
         .unwrap();
-    tx1.repo_mut()
-        .remove_wc_commit(&ws4_name)
-        .block_on()
-        .unwrap();
+    tx1.repo_mut().remove_wc_commit(&ws4_name).block_unwrap();
     tx1.repo_mut()
         .set_wc_commit(ws5_name.clone(), commit2.id().clone())
         .unwrap();
@@ -197,10 +194,7 @@ fn test_merge_views_checkout() {
     tx2.repo_mut()
         .set_wc_commit(ws4_name.clone(), commit3.id().clone())
         .unwrap();
-    tx2.repo_mut()
-        .remove_wc_commit(&ws5_name)
-        .block_on()
-        .unwrap();
+    tx2.repo_mut().remove_wc_commit(&ws5_name).block_unwrap();
     tx2.repo_mut()
         .set_wc_commit(ws7_name.clone(), commit3.id().clone())
         .unwrap();
@@ -255,7 +249,7 @@ fn test_merge_views_bookmarks() {
         "feature".as_ref(),
         RefTarget::normal(feature_bookmark_local_tx0.id().clone()),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let main_bookmark_local_tx1 = write_random_commit(tx1.repo_mut());
@@ -329,7 +323,7 @@ fn test_merge_views_tags() {
     mut_repo.set_local_tag_target("v1.0".as_ref(), RefTarget::normal(v1_tx0.id().clone()));
     let v2_tx0 = write_random_commit(mut_repo);
     mut_repo.set_local_tag_target("v2.0".as_ref(), RefTarget::normal(v2_tx0.id().clone()));
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let v1_tx1 = write_random_commit(tx1.repo_mut());
@@ -392,7 +386,7 @@ fn test_merge_views_remote_tags() {
             state: RemoteRefState::Tracked,
         },
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     // v1.0@origin: tx0 (new) -> tx1 (new)
     // v2.0@upstream: tx0 (tracked) -> tx1 (tracked)
@@ -479,7 +473,7 @@ fn test_merge_views_git_refs() {
         "refs/heads/feature".as_ref(),
         RefTarget::normal(feature_bookmark_tx0.id().clone()),
     );
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let main_bookmark_tx1 = write_random_commit(tx1.repo_mut());
@@ -529,7 +523,7 @@ fn test_merge_views_git_heads() {
     let tx0_head = write_random_commit(tx0.repo_mut());
     tx0.repo_mut()
         .set_git_head_target(RefTarget::normal(tx0_head.id().clone()));
-    let repo = tx0.commit("test").block_on().unwrap();
+    let repo = tx0.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let tx1_head = write_random_commit(tx1.repo_mut());
@@ -557,7 +551,7 @@ fn test_merge_views_divergent() {
 
     let mut tx = test_repo.repo.start_transaction();
     let commit_a = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let commit_a2 = tx1
@@ -565,7 +559,7 @@ fn test_merge_views_divergent() {
         .rewrite_commit(&commit_a)
         .set_description("A2")
         .write_unwrap();
-    tx1.repo_mut().rebase_descendants().block_on().unwrap();
+    tx1.repo_mut().rebase_descendants().block_unwrap();
 
     let mut tx2 = repo.start_transaction();
     let commit_a3 = tx2
@@ -573,7 +567,7 @@ fn test_merge_views_divergent() {
         .rewrite_commit(&commit_a)
         .set_description("A3")
         .write_unwrap();
-    tx2.repo_mut().rebase_descendants().block_on().unwrap();
+    tx2.repo_mut().rebase_descendants().block_unwrap();
 
     let repo = commit_transactions(vec![tx1, tx2]);
 
@@ -593,7 +587,7 @@ fn test_merge_views_child_on_rewritten(child_first: bool) {
 
     let mut tx = test_repo.repo.start_transaction();
     let commit_a = write_random_commit(tx.repo_mut());
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let commit_b = write_random_commit_with_parents(tx1.repo_mut(), &[&commit_a]);
@@ -604,7 +598,7 @@ fn test_merge_views_child_on_rewritten(child_first: bool) {
         .rewrite_commit(&commit_a)
         .set_description("A2")
         .write_unwrap();
-    tx2.repo_mut().rebase_descendants().block_on().unwrap();
+    tx2.repo_mut().rebase_descendants().block_unwrap();
 
     let repo = if child_first {
         commit_transactions(vec![tx1, tx2])
@@ -637,7 +631,7 @@ fn test_merge_views_child_on_rewritten_divergent(on_rewritten: bool, child_first
     let commit_a3 = create_random_commit(tx.repo_mut())
         .set_change_id(commit_a2.change_id().clone())
         .write_unwrap();
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let parent = if on_rewritten { &commit_a2 } else { &commit_a3 };
@@ -649,7 +643,7 @@ fn test_merge_views_child_on_rewritten_divergent(on_rewritten: bool, child_first
         .rewrite_commit(&commit_a2)
         .set_description("A4")
         .write_unwrap();
-    tx2.repo_mut().rebase_descendants().block_on().unwrap();
+    tx2.repo_mut().rebase_descendants().block_unwrap();
 
     let repo = if child_first {
         commit_transactions(vec![tx1, tx2])
@@ -685,14 +679,14 @@ fn test_merge_views_child_on_abandoned(child_first: bool) {
     let mut tx = test_repo.repo.start_transaction();
     let commit_a = write_random_commit(tx.repo_mut());
     let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
-    let repo = tx.commit("test").block_on().unwrap();
+    let repo = tx.commit("test").block_unwrap();
 
     let mut tx1 = repo.start_transaction();
     let commit_c = write_random_commit_with_parents(tx1.repo_mut(), &[&commit_b]);
 
     let mut tx2 = repo.start_transaction();
     tx2.repo_mut().record_abandoned_commit(&commit_b);
-    tx2.repo_mut().rebase_descendants().block_on().unwrap();
+    tx2.repo_mut().rebase_descendants().block_unwrap();
 
     let repo = if child_first {
         commit_transactions(vec![tx1, tx2])

--- a/lib/tests/test_workspace.rs
+++ b/lib/tests/test_workspace.rs
@@ -21,7 +21,7 @@ use jj_lib::workspace::Workspace;
 use jj_lib::workspace::WorkspaceLoadError;
 use jj_lib::workspace::default_working_copy_factories;
 use jj_lib::workspace::default_working_copy_factory;
-use pollster::FutureExt as _;
+use testutils::FutureTestExt as _;
 use testutils::TestEnvironment;
 use testutils::TestWorkspace;
 
@@ -59,8 +59,7 @@ fn test_init_additional_workspace() {
         &*default_working_copy_factory(),
         ws2_name.clone(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     let wc_commit_id = repo.view().get_wc_commit_id(&ws2_name);
     assert_ne!(wc_commit_id, None);
     let wc_commit_id = wc_commit_id.unwrap();
@@ -116,8 +115,7 @@ fn test_init_additional_workspace_absolute_path_compat() {
         &*default_working_copy_factory(),
         ws2_name.clone(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
 
     let repo_file_path = ws2_root.join(".jj").join("repo");
     let abs_repo_path = dunce::canonicalize(workspace.repo_path()).unwrap();
@@ -160,9 +158,7 @@ fn test_init_additional_workspace_non_utf8_path() {
 
     let ws1_root = test_env.root().join(OsStr::from_bytes(b"ws1_root\xe0"));
     std::fs::create_dir(&ws1_root).unwrap();
-    let (ws1, repo) = Workspace::init_simple(&settings, &ws1_root)
-        .block_on()
-        .unwrap();
+    let (ws1, repo) = Workspace::init_simple(&settings, &ws1_root).block_unwrap();
 
     let ws2_name = WorkspaceNameBuf::from("ws2");
     let ws2_root = test_env.root().join(OsStr::from_bytes(b"ws2_root\xe0"));
@@ -174,8 +170,7 @@ fn test_init_additional_workspace_non_utf8_path() {
         &*default_working_copy_factory(),
         ws2_name.clone(),
     )
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     assert_eq!(ws2.workspace_name(), &ws2_name);
     assert_eq!(
         *ws2.repo_path(),

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -82,6 +82,40 @@ pub mod git;
 pub mod proptest;
 pub mod test_backend;
 
+pub trait TestUnwrap {
+    type Output;
+    #[track_caller]
+    fn test_unwrap(self) -> Self::Output;
+}
+
+impl<T, E: std::fmt::Debug> TestUnwrap for Result<T, E> {
+    type Output = T;
+    #[track_caller]
+    fn test_unwrap(self) -> T {
+        self.unwrap()
+    }
+}
+
+impl<T> TestUnwrap for Option<T> {
+    type Output = T;
+    #[track_caller]
+    fn test_unwrap(self) -> T {
+        self.unwrap()
+    }
+}
+
+pub trait FutureTestExt: std::future::Future + Sized {
+    #[track_caller]
+    fn block_unwrap(self) -> <Self::Output as TestUnwrap>::Output
+    where
+        Self::Output: TestUnwrap,
+    {
+        self.block_on().test_unwrap()
+    }
+}
+
+impl<F: std::future::Future + Sized> FutureTestExt for F {}
+
 pub const HERMETIC_GIT_CONFIGS: &[(&str, &str)] = &[
     // gitoxide uses "main" as the default branch name, whereas git uses "master". This also
     // prevents git CLI from issuing the initial branch name advice.
@@ -216,8 +250,7 @@ impl TestEnvironment {
         RepoLoader::init_from_file_system(settings, repo_path, &self.default_store_factories())
             .unwrap()
             .load_at_head()
-            .block_on()
-            .unwrap()
+            .block_unwrap()
     }
 }
 
@@ -281,8 +314,7 @@ impl TestRepo {
             ReadonlyRepo::default_index_store_initializer(),
             ReadonlyRepo::default_submodule_store_initializer(),
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
         Self {
             env,
@@ -339,8 +371,7 @@ impl TestWorkspace {
             &|settings, store_path| backend.init_backend(&env, settings, store_path),
             signer,
         )
-        .block_on()
-        .unwrap();
+        .block_unwrap();
 
         Self {
             env,
@@ -367,10 +398,7 @@ impl TestWorkspace {
         let mut locked_ws = self.workspace.start_working_copy_mutation().unwrap();
         let (tree, stats) = locked_ws.locked_wc().snapshot(options).block_on()?;
         // arbitrary operation id
-        locked_ws
-            .finish(self.repo.op_id().clone())
-            .block_on()
-            .unwrap();
+        locked_ws.finish(self.repo.op_id().clone()).block_unwrap();
         Ok((tree, stats))
     }
 
@@ -385,10 +413,10 @@ pub fn commit_transactions(txs: Vec<Transaction>) -> Arc<ReadonlyRepo> {
     let repo_loader = txs[0].base_repo().loader().clone();
     let mut op_ids = vec![];
     for tx in txs {
-        op_ids.push(tx.commit("test").block_on().unwrap().op_id().clone());
+        op_ids.push(tx.commit("test").block_unwrap().op_id().clone());
         std::thread::sleep(std::time::Duration::from_millis(1));
     }
-    let repo = repo_loader.load_at_head().block_on().unwrap();
+    let repo = repo_loader.load_at_head().block_unwrap();
     // Test the setup. The assumption here is that the parent order matches the
     // order in which they were merged (which currently matches the transaction
     // commit order), so we want to know make sure they appear in a certain
@@ -411,17 +439,16 @@ pub fn repo_path_buf(value: impl Into<String>) -> RepoPathBuf {
 }
 
 pub fn read_file(store: &Store, path: &RepoPath, id: &FileId) -> Vec<u8> {
-    let mut reader = store.read_file(path, id).block_on().unwrap();
+    let mut reader = store.read_file(path, id).block_unwrap();
     let mut content = vec![];
-    reader.read_to_end(&mut content).block_on().unwrap();
+    reader.read_to_end(&mut content).block_unwrap();
     content
 }
 
 pub fn write_file(store: &Store, path: &RepoPath, contents: &str) -> FileId {
     store
         .write_file(path, &mut contents.as_bytes())
-        .block_on()
-        .unwrap()
+        .block_unwrap()
 }
 
 pub struct TestTreeBuilder {
@@ -453,7 +480,7 @@ impl TestTreeBuilder {
     }
 
     pub fn symlink(&mut self, path: &RepoPath, target: &str) {
-        let id = self.store.write_symlink(path, target).block_on().unwrap();
+        let id = self.store.write_symlink(path, target).block_unwrap();
         self.tree_builder
             .set(path.to_owned(), TreeValue::Symlink(id));
     }
@@ -464,12 +491,12 @@ impl TestTreeBuilder {
     }
 
     pub fn write_single_tree(self) -> Tree {
-        let id = self.tree_builder.write_tree().block_on().unwrap();
+        let id = self.tree_builder.write_tree().block_unwrap();
         self.store.get_tree(RepoPathBuf::root(), &id).unwrap()
     }
 
     pub fn write_merged_tree(self) -> MergedTree {
-        let id = self.tree_builder.write_tree().block_on().unwrap();
+        let id = self.tree_builder.write_tree().block_unwrap();
         MergedTree::resolved(self.store, id)
     }
 }
@@ -500,8 +527,7 @@ impl Drop for TestTreeFileEntryBuilder<'_> {
             .tree_builder
             .store()
             .write_file(&self.path, &mut self.contents.as_slice())
-            .block_on()
-            .unwrap();
+            .block_unwrap();
         let path = std::mem::replace(&mut self.path, RepoPathBuf::root());
         self.tree_builder.set(
             path,
@@ -630,14 +656,14 @@ pub fn commit_with_tree(store: &Arc<Store>, tree: MergedTree) -> Commit {
         committer: signature,
         secure_sig: None,
     };
-    store.write_commit(commit, None).block_on().unwrap()
+    store.write_commit(commit, None).block_unwrap()
 }
 
 pub fn dump_tree(merged_tree: &MergedTree) -> String {
     use std::fmt::Write as _;
     let store = merged_tree.store();
     let mut buf = String::new();
-    let trees = merged_tree.trees().block_on().unwrap();
+    let trees = merged_tree.trees().block_unwrap();
     writeln!(&mut buf, "merged tree (sides: {})", trees.num_sides()).unwrap();
     for tree in &trees {
         writeln!(&mut buf, "  tree {}", tree.id()).unwrap();
@@ -730,8 +756,7 @@ pub fn rebase_descendants_with_options_return_map(
         };
         rebased.insert(old_commit_id, new_commit_id);
     })
-    .block_on()
-    .unwrap();
+    .block_unwrap();
     rebased
 }
 
@@ -852,7 +877,7 @@ pub trait CommitBuilderExt {
 
 impl CommitBuilderExt for CommitBuilder<'_> {
     fn write_unwrap(self) -> Commit {
-        self.write().block_on().unwrap()
+        self.write().block_unwrap()
     }
 }
 

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -433,6 +433,7 @@ mod tests {
     use pollster::FutureExt as _;
 
     use super::*;
+    use crate::FutureTestExt as _;
     use crate::repo_path_buf;
 
     fn copy_history(path: &str, parents: &[CopyId]) -> CopyHistory {
@@ -449,11 +450,11 @@ mod tests {
 
         // Test with a single chain so the resulting order is deterministic
         let copy1 = copy_history("foo1", &[]);
-        let copy1_id = backend.write_copy(&copy1).block_on().unwrap();
+        let copy1_id = backend.write_copy(&copy1).block_unwrap();
         let copy2 = copy_history("foo2", std::slice::from_ref(&copy1_id));
-        let copy2_id = backend.write_copy(&copy2).block_on().unwrap();
+        let copy2_id = backend.write_copy(&copy2).block_unwrap();
         let copy3 = copy_history("foo3", std::slice::from_ref(&copy2_id));
-        let copy3_id = backend.write_copy(&copy3).block_on().unwrap();
+        let copy3_id = backend.write_copy(&copy3).block_unwrap();
 
         // Error when looking up by non-existent id
         assert!(
@@ -465,9 +466,9 @@ mod tests {
 
         // Looking up by any id returns the related copies in the same order (children
         // before parents)
-        let related = backend.get_related_copies(&copy1_id).block_on().unwrap();
+        let related = backend.get_related_copies(&copy1_id).block_unwrap();
         assert_eq!(related, vec![copy3.clone(), copy2.clone(), copy1.clone()]);
-        let related: Vec<CopyHistory> = backend.get_related_copies(&copy3_id).block_on().unwrap();
+        let related: Vec<CopyHistory> = backend.get_related_copies(&copy3_id).block_unwrap();
         assert_eq!(related, vec![copy3.clone(), copy2.clone(), copy1.clone()]);
     }
 }


### PR DESCRIPTION
This was all written by Gemini CLI. I'm happy to drop it if people don't like it.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
