### PR TITLE
nix: flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772615108,
-        "narHash": "sha256-lC0KbklwgeSqS+sTkaYpnSYr/HDeVMzYUZqV/dT31Lo=",
+        "lastModified": 1772736753,
+        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c39f3b5a9a234421d4ad43ab9c7cf64840172d0",
+        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772593411,
-        "narHash": "sha256-47WOnCSyOL6AghZiMIJaTLWM359DHe3be9R1cNCdGUE=",
+        "lastModified": 1772939270,
+        "narHash": "sha256-HbxD5DJAKxzo0G8on5wdY+OZNiUWt3FTvGmXmVEmg7g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a741b36b77440f5db15fcf2ab6d7d592d2f9ee8f",
+        "rev": "bb93f191a07c0165992ed6d0b4197ee5c7e6e641",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Running `cargo fmt` using the Nix shell on macOS was causing the following error:

```
dyld[41989]: Library not loaded: @rpath/librustc_driver-7ab42a0fdacc12d4.dylib
  Referenced from: <0D40FF1D-6F51-3AD7-937E-5D52A0C4D2A5> /nix/store/sp9hj1jbrg9fas976w73jzg0pwdiv6i7-rustfmt-preview-1.96.0-nightly-2026-03-04-aarch64-apple-darwin/bin/rustfmt
  Reason: tried: '/nix/store/sp9hj1jbrg9fas976w73jzg0pwdiv6i7-rustfmt-preview-1.96.0-nightly-2026-03-04-aarch64-apple-darwin/bin/../lib/librustc_driver-7ab42a0fdacc12d4.dylib' (no such file), '/nix/store/sp9hj1jbrg9fas976w73jzg0pwdiv6i7-rustfmt-preview-1.96.0-nightly-2026-03-04-aarch64-apple-darwin/bin/../lib/librustc_driver-7ab42a0fdacc12d4.dylib' (no such file)
```

This was fixed in https://github.com/oxalica/rust-overlay/pull/251.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
