### PR TITLE
cli: consistently use singular in flag names

### DIFF
--- a/cli/src/commands/bookmark/list.rs
+++ b/cli/src/commands/bookmark/list.rs
@@ -92,7 +92,7 @@ pub struct BookmarkListArgs {
     ///
     /// Note that `-r deleted_bookmark` will not work since `deleted_bookmark`
     /// wouldn't have a local target.
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     revisions: Option<Vec<RevisionArg>>,
 
     /// Render each bookmark using the given template

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -74,7 +74,7 @@ pub struct UploadArgs {
     /// If this is not provided, it will check whether @ has a description.
     /// * If it does, it will upload @
     /// * Otherwise, it will upload @-
-    #[arg(long, short = 'r')]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     revisions: Vec<RevisionArg>,
 
     /// The location where your changes are intended to land

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -177,7 +177,7 @@ pub struct GitPushArgs {
     allow_private: bool,
 
     /// Push bookmarks pointing to these commits (can be repeated)
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     // While `-r` will often be used with mutable revisions, immutable revisions
     // can be useful as parts of revsets or to push special-purpose branches.
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -73,7 +73,7 @@ pub(crate) struct LogArgs {
     ///
     /// If no paths nor revisions are specified, this defaults to the
     /// `revsets.log` setting.
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
     revisions: Vec<RevisionArg>,
 

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -296,7 +296,7 @@ pub(crate) struct RebaseArgs {
     /// descendant of `A`.
     ///
     /// If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     revisions: Vec<RevisionArg>,
 

--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -48,7 +48,13 @@ use crate::ui::Ui;
 #[command(group(ArgGroup::new("location").args(&["onto", "insert_after", "insert_before"]).multiple(true).required(true)))]
 pub(crate) struct RevertArgs {
     /// The revision(s) to apply the reverse of
-    #[arg(long, short, value_name = "REVSETS", required = true)]
+    #[arg(
+        long = "revision",
+        short,
+        value_name = "REVSETS",
+        required = true,
+        alias = "revisions"
+    )]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
     revisions: Vec<RevisionArg>,
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -41,7 +41,13 @@ pub struct RunArgs {
     shell_command: String,
 
     /// The revisions to change.
-    #[arg(long, short, default_value = "@", value_name = "REVSETS")]
+    #[arg(
+        long = "revision",
+        short,
+        default_value = "@",
+        value_name = "REVSETS",
+        alias = "revisions"
+    )]
     revisions: Vec<RevisionArg>,
 
     /// A no-op option to match the interface of `git rebase -x`.

--- a/cli/src/commands/sign.rs
+++ b/cli/src/commands/sign.rs
@@ -53,7 +53,7 @@ pub struct SignArgs {
     ///
     /// [#5786]:
     ///     https://github.com/jj-vcs/jj/issues/5786
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     revisions: Vec<RevisionArg>,
 

--- a/cli/src/commands/simplify_parents.rs
+++ b/cli/src/commands/simplify_parents.rs
@@ -32,7 +32,7 @@ pub(crate) struct SimplifyParentsArgs {
     /// If both `--source` and `--revisions` are not provided, this defaults to
     /// the `revsets.simplify-parents` setting, or `reachable(@, mutable())`
     /// if it is not set.
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     revisions: Vec<RevisionArg>,
 }

--- a/cli/src/commands/tag/list.rs
+++ b/cli/src/commands/tag/list.rs
@@ -87,7 +87,7 @@ pub struct TagListArgs {
     ///
     /// Note that `-r deleted_tag` will not work since `deleted_tag` wouldn't
     /// have a local target.
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     revisions: Option<Vec<RevisionArg>>,
 
     /// Render each tag using the given template

--- a/cli/src/commands/unsign.rs
+++ b/cli/src/commands/unsign.rs
@@ -38,7 +38,7 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub struct UnsignArgs {
     /// What revision(s) to unsign
-    #[arg(long, short, value_name = "REVSETS")]
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     revisions: Vec<RevisionArg>,
 }

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -73,8 +73,8 @@ pub struct WorkspaceAddArgs {
     /// the new working-copy commit will be created with all these revisions as
     /// parents, i.e. the working-copy commit will exist as if you had run `jj
     /// new r1 r2 r3 ...`.
-    #[arg(long, short, value_name = "REVSETS")]
-    revision: Vec<RevisionArg>,
+    #[arg(long = "revision", short, value_name = "REVSETS", alias = "revisions")]
+    revisions: Vec<RevisionArg>,
 
     /// The change description to use
     #[arg(long = "message", short, value_name = "MESSAGE")]
@@ -178,7 +178,7 @@ pub async fn cmd_workspace_add(
 
     // If no parent revisions are specified, create a working-copy commit based
     // on the parent of the current working-copy commit.
-    let parents = if args.revision.is_empty() {
+    let parents = if args.revisions.is_empty() {
         // Check out parents of the current workspace's working-copy commit, or the
         // root if there is no working-copy commit in the current workspace.
         if let Some(old_wc_commit_id) = tx
@@ -196,7 +196,7 @@ pub async fn cmd_workspace_add(
         }
     } else {
         old_workspace_command
-            .resolve_some_revsets(ui, &args.revision)
+            .resolve_some_revsets(ui, &args.revisions)
             .await?
             .iter()
             .map(|id| tx.repo().store().get_commit(id))

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -517,7 +517,7 @@ See [`jj help -k bookmarks`] for more information.
 
    This omits local Git-tracking bookmarks by default.
 * `-c`, `--conflicted` — Show conflicted bookmarks only
-* `-r`, `--revisions <REVSETS>` — Show bookmarks whose local targets are in the given revisions
+* `-r`, `--revision <REVSETS>` — Show bookmarks whose local targets are in the given revisions
 
    Note that `-r deleted_bookmark` will not work since `deleted_bookmark` wouldn't have a local target.
 * `-T`, `--template <TEMPLATE>` — Render each bookmark using the given template
@@ -1426,7 +1426,7 @@ Note: this command takes 1-or-more revsets arguments, each of which can resolve 
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVISIONS>` — The revset, selecting which revisions are sent in to Gerrit
+* `-r`, `--revision <REVSETS>` — The revset, selecting which revisions are sent in to Gerrit
 
    This can be any arbitrary set of commits. Note that when you push a commit at the head of a stack, all ancestors are pushed too. This means that `jj gerrit upload -r foo` is equivalent to `jj gerrit upload -r 'mutable()::foo`.
 
@@ -1755,7 +1755,7 @@ Before the command actually moves, creates, or deletes a remote bookmark, it mak
 * `--allow-private` — Allow pushing commits that are private
 
    The set of private commits can be configured by the `git.private-commits` setting. The default is `none()`, meaning all commits are eligible to be pushed.
-* `-r`, `--revisions <REVSETS>` — Push bookmarks pointing to these commits (can be repeated)
+* `-r`, `--revision <REVSETS>` — Push bookmarks pointing to these commits (can be repeated)
 * `-c`, `--change <REVSETS>` — Push this commit by creating a bookmark (can be repeated)
 
    The created bookmark will be tracked automatically. Use the `templates.git_push_bookmark` setting to customize the generated bookmark name. The default is `"push-" ++ change_id.short()`.
@@ -1989,7 +1989,7 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVSETS>` — Which revisions to show
+* `-r`, `--revision <REVSETS>` — Which revisions to show
 
    If no paths nor revisions are specified, this defaults to the `revsets.log` setting.
 * `-n`, `--limit <LIMIT>` — Limit number of revisions to show
@@ -2785,7 +2785,7 @@ J           J
    Each specified revision will become a direct child of the destination revision(s), even if some of the source revisions are descendants of others.
 
    If none of `-b`, `-s`, or `-r` is provided, then the default is `-b @`.
-* `-r`, `--revisions <REVSETS>` — Rebase the given revisions, rebasing descendants onto this revision's parent(s)
+* `-r`, `--revision <REVSETS>` — Rebase the given revisions, rebasing descendants onto this revision's parent(s)
 
    Unlike `-s` or `-b`, you may `jj rebase -r` a revision `A` onto a descendant of `A`.
 
@@ -2880,11 +2880,11 @@ The reverse of each of the given revisions is applied sequentially in reverse to
 
 The description of the new revisions can be customized with the `templates.revert_description` config variable.
 
-**Usage:** `jj revert --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
+**Usage:** `jj revert --revision <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVSETS>` — The revision(s) to apply the reverse of
+* `-r`, `--revision <REVSETS>` — The revision(s) to apply the reverse of
 * `-o`, `--onto <REVSETS>` [alias: `destination`] — The revision(s) to apply the reverse changes on top of
 * `-A`, `--insert-after <REVSETS>` [alias: `after`] — The revision(s) to insert the reverse changes after (can be repeated to create a merge commit)
 * `-B`, `--insert-before <REVSETS>` [alias: `before`] — The revision(s) to insert the reverse changes before (can be repeated to create a merge commit)
@@ -2950,7 +2950,7 @@ This command requires configuring a [commit signing] backend.
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVSETS>` — What revision(s) to sign
+* `-r`, `--revision <REVSETS>` — What revision(s) to sign
 
    If no revisions are specified, this defaults to the `revsets.sign` setting.
 
@@ -2976,7 +2976,7 @@ In other words, for all (A, B, C) where A has (B, C) as parents and C is an ance
 ###### **Options:**
 
 * `-s`, `--source <REVSETS>` — Simplify specified revision(s) together with their trees of descendants (can be repeated)
-* `-r`, `--revisions <REVSETS>` — Simplify specified revision(s) (can be repeated)
+* `-r`, `--revision <REVSETS>` — Simplify specified revision(s) (can be repeated)
 
    If both `--source` and `--revisions` are not provided, this defaults to the `revsets.simplify-parents` setting, or `reachable(@, mutable())` if it is not set.
 
@@ -3259,7 +3259,7 @@ By default, a tracked remote tag will be included only if its target is differen
 
 * `-a`, `--all-remotes` — Show all tracked and untracked remote tags including the ones whose targets are synchronized with the local tags
 * `-c`, `--conflicted` — Show conflicted tags only
-* `-r`, `--revisions <REVSETS>` — Show tags whose local targets are in the given revisions
+* `-r`, `--revision <REVSETS>` — Show tags whose local targets are in the given revisions
 
    Note that `-r deleted_tag` will not work since `deleted_tag` wouldn't have a local target.
 * `-T`, `--template <TEMPLATE>` — Render each tag using the given template
@@ -3327,7 +3327,7 @@ See also [commit signing] docs.
 
 ###### **Options:**
 
-* `-r`, `--revisions <REVSETS>` — What revision(s) to unsign
+* `-r`, `--revision <REVSETS>` — What revision(s) to unsign
 
 
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -430,19 +430,19 @@ fn test_aliases_are_resolved(shell: Shell) {
     match shell {
         Shell::Bash => {
             insta::assert_snapshot!(output, @"
-            --revisions
+            --revision
             --reversed[EOF]
             ");
         }
         Shell::Zsh => {
             insta::assert_snapshot!(output, @"
-            --revisions:Which revisions to show
+            --revision:Which revisions to show
             --reversed:Show revisions in the opposite order (older revisions first)[EOF]
             ");
         }
         Shell::Fish => {
             insta::assert_snapshot!(output, @"
-            --revisions	Which revisions to show
+            --revision	Which revisions to show
             --reversed	Show revisions in the opposite order (older revisions first)
             [EOF]
             ");
@@ -519,21 +519,21 @@ fn test_default_command_is_resolved(shell: Shell) {
     match shell {
         Shell::Bash => {
             insta::assert_snapshot!(output, @"
-            --revisions
+            --revision
             --limit
             [EOF]
             ");
         }
         Shell::Zsh => {
             insta::assert_snapshot!(output, @"
-            --revisions:Which revisions to show
+            --revision:Which revisions to show
             --limit:Limit number of revisions to show
             [EOF]
             ");
         }
         Shell::Fish => {
             insta::assert_snapshot!(output, @"
-            --revisions	Which revisions to show
+            --revision	Which revisions to show
             --limit	Limit number of revisions to show
             [EOF]
             ");

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -24,7 +24,7 @@ fn test_log_with_empty_revision() {
     let output = work_dir.run_jj(["log", "-r="]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    error: a value is required for '--revisions <REVSETS>' but none was supplied
+    error: a value is required for '--revision <REVSETS>' but none was supplied
 
     For more information, try '--help'.
     [EOF]

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -45,9 +45,9 @@ fn test_rebase_invalid() {
     let output = work_dir.run_jj(["rebase", "-r", "a", "-s", "a", "-o", "b"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    error: the argument '--revisions <REVSETS>' cannot be used with '--source <REVSETS>'
+    error: the argument '--revision <REVSETS>' cannot be used with '--source <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revision <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -73,7 +73,7 @@ fn test_rebase_invalid() {
     ------- stderr -------
     error: the argument '--onto <REVSETS>' cannot be used with '--insert-after <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revision <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]
@@ -86,7 +86,7 @@ fn test_rebase_invalid() {
     ------- stderr -------
     error: the argument '--onto <REVSETS>' cannot be used with '--insert-before <REVSETS>'
 
-    Usage: jj rebase --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj rebase --revision <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -50,7 +50,7 @@ fn test_revert() {
     error: the following required arguments were not provided:
       <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
-    Usage: jj revert --revisions <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
+    Usage: jj revert --revision <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
 
     For more information, try '--help'.
     [EOF]


### PR DESCRIPTION
I run into this every once in a while. `--revision` sometimes makes sense and some commands support the alias already. So, using it with a command that doesn't is an unpleasant speed bump.

- [n/a] I have updated `CHANGELOG.md`
- [n/a] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [n/a] I have updated the config schema (`cli/src/config-schema.json`)
- [n/a] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [x] I did not use LLMs to create these changes.
