### PR TITLE
revert: default location arguments to -B @

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
    order is guaranteed: each revision begins execution only after the previous
    one has started, even with `--jobs` higher than 1.
 
+* `jj revert` now inserts the reverted revision before the working copy (@) by
+  default.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/cli/src/commands/revert.rs
+++ b/cli/src/commands/revert.rs
@@ -15,7 +15,6 @@
 use std::collections::HashSet;
 
 use bstr::ByteVec as _;
-use clap::ArgGroup;
 use clap_complete::ArgValueCompleter;
 use futures::TryStreamExt as _;
 use futures::future::try_join_all;
@@ -43,10 +42,12 @@ use crate::ui::Ui;
 /// The reverse of each of the given revisions is applied sequentially in
 /// reverse topological order at the given location.
 ///
+/// By default the reverted revision is inserted before the working-copy
+/// (--insert-before @).
+///
 /// The description of the new revisions can be customized with the
 /// `templates.revert_description` config variable.
 #[derive(clap::Args, Clone, Debug)]
-#[command(group(ArgGroup::new("location").args(&["onto", "insert_after", "insert_before"]).multiple(true).required(true)))]
 pub(crate) struct RevertArgs {
     /// The revision(s) to apply the reverse of
     #[arg(
@@ -101,6 +102,12 @@ pub(crate) async fn cmd_revert(
     command: &CommandHelper,
     args: &RevertArgs,
 ) -> Result<(), CommandError> {
+    let insert_before =
+        if args.onto.is_none() && args.insert_after.is_none() && args.insert_before.is_none() {
+            Some(vec![RevisionArg::from("@".to_string())])
+        } else {
+            args.insert_before.clone()
+        };
     let mut workspace_command = command.workspace_helper(ui).await?;
     let to_revert: Vec<_> = workspace_command
         .parse_union_revsets(ui, &args.revisions)?
@@ -116,7 +123,7 @@ pub(crate) async fn cmd_revert(
         &workspace_command,
         args.onto.as_deref(),
         args.insert_after.as_deref(),
-        args.insert_before.as_deref(),
+        insert_before.as_deref(),
         "reverted commits",
     )
     .await?;

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2934,9 +2934,11 @@ Apply the reverse of the given revision(s)
 
 The reverse of each of the given revisions is applied sequentially in reverse topological order at the given location.
 
+By default the reverted revision is inserted before the working-copy (--insert-before @).
+
 The description of the new revisions can be customized with the `templates.revert_description` config variable.
 
-**Usage:** `jj revert --revision <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>`
+**Usage:** `jj revert [OPTIONS] --revision <REVSETS>`
 
 ###### **Options:**
 

--- a/cli/tests/test_revert_command.rs
+++ b/cli/tests/test_revert_command.rs
@@ -43,30 +43,30 @@ fn test_revert() {
     ");
     let setup_opid = work_dir.current_operation_id();
 
-    // Reverting without a location is an error
+    // Reverting without a location insert the commit before @
     let output = work_dir.run_jj(["revert", "-ra"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    error: the following required arguments were not provided:
-      <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
-
-    Usage: jj revert --revision <REVSETS> <--onto <REVSETS>|--insert-after <REVSETS>|--insert-before <REVSETS>>
-
-    For more information, try '--help'.
+    Reverted 1 commits as follows:
+      kmkuslsw 286c8c66 Revert "a"
+    Rebased 1 descendant commits.
+    Working copy  (@) now at: vruxwmqv 2afa6413 d | (empty) d
+    Parent commit (@-)      : kmkuslsw 286c8c66 Revert "a"
+    Added 0 files, modified 0 files, removed 1 files
     [EOF]
-    [exit status: 2]
-    ");
+    "#);
+    work_dir.run_jj(["op", "restore", &setup_opid]).success();
 
     // Revert the commit with `--onto`
     let output = work_dir.run_jj(["revert", "-ra", "-d@"]);
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      wqnwkozp 64910788 Revert "a"
+      lylxulpl bd658e04 Revert "a"
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ○  64910788f8a5 Revert "a"
+    ○  bd658e0413c5 Revert "a"
     │
     │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
     @  98fb6151f954 d
@@ -87,14 +87,14 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      nkmrtpmo 90d12316 Revert "Revert "a""
+      uyznsvlq fee69440 Revert "Revert "a""
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    ○  90d123162199 Revert "Revert "a""
+    ○  fee69440c3d9 Revert "Revert "a""
     │
-    │  This reverts commit 64910788f8a5d322739e1e38ef35f7d06ea4b38d.
-    ○  64910788f8a5 Revert "a"
+    │  This reverts commit bd658e0413c590b93dcbabec38fc5d15258469a1.
+    ○  bd658e0413c5 Revert "a"
     │
     │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
     @  98fb6151f954 d
@@ -116,17 +116,17 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      nmzmmopx 9e7b8585 Revert "a"
+      tlkvzzqu ccdc971f Revert "a"
     Rebased 2 descendant commits.
-    Working copy  (@) now at: vruxwmqv b1885396 d | (empty) d
-    Parent commit (@-)      : royxmykx efc4bd83 c | (empty) c
+    Working copy  (@) now at: vruxwmqv c114bcab d | (empty) d
+    Parent commit (@-)      : royxmykx 59e91fd2 c | (empty) c
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    @  b18853966f79 d
-    ○  efc4bd83159f c
-    ○  9e7b85853718 Revert "a"
+    @  c114bcabdf5e d
+    ○  59e91fd21873 c
+    ○  ccdc971f590b Revert "a"
     │
     │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
     ○  58aaf278bf58 b
@@ -146,16 +146,16 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      pzsxstzt d51ea564 Revert "a"
+      xlzxqlsl afc1d158 Revert "a"
     Rebased 1 descendant commits.
-    Working copy  (@) now at: vruxwmqv 5c5d60a6 d | (empty) d
-    Parent commit (@-)      : pzsxstzt d51ea564 Revert "a"
+    Working copy  (@) now at: vruxwmqv cdc45e62 d | (empty) d
+    Parent commit (@-)      : xlzxqlsl afc1d158 Revert "a"
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    @  5c5d60a69afd d
-    ○  d51ea56444ce Revert "a"
+    @  cdc45e62ac5b d
+    ○  afc1d15825d2 Revert "a"
     │
     │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
     ○  96ff42270bbc c
@@ -176,18 +176,18 @@ fn test_revert() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Reverted 1 commits as follows:
-      oupztwtk d311a8f0 Revert "a"
+      pkstwlsy 6c118c03 Revert "a"
     Rebased 1 descendant commits.
-    Working copy  (@) now at: vruxwmqv 5b97d572 d | (empty) d
+    Working copy  (@) now at: vruxwmqv 3f3fb2f9 d | (empty) d
     Parent commit (@-)      : royxmykx 96ff4227 c | (empty) c
-    Parent commit (@-)      : oupztwtk d311a8f0 Revert "a"
+    Parent commit (@-)      : pkstwlsy 6c118c03 Revert "a"
     Added 0 files, modified 0 files, removed 1 files
     [EOF]
     "#);
     insta::assert_snapshot!(get_log_output(&work_dir), @r#"
-    @    5b97d572e457 d
+    @    3f3fb2f905d3 d
     ├─╮
-    │ ○  d311a8f0c13f Revert "a"
+    │ ○  6c118c03ae97 Revert "a"
     │ │
     │ │  This reverts commit 7d980be7a1d499e4d316ab4c01242885032f7eaf.
     ○ │  96ff42270bbc c


### PR DESCRIPTION
Make the location arguments (--onto, --insert-after, --insert-before) optional for revert. This change introduces a default destination of -B @ when no specific location is provided.

Inserting the revert before the current working copy aligns with the common workflow of wanting to immediately build upon or examine the reverted state.

Because this only provides a fallback for previously "missing" arguments, it does not break or change the behavior of existing usages that already provide explicit location flags.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
