### PR TITLE
build: set opt-level to 1 only in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
     - name: Test
       run: >-
         cargo nextest run
+        --cargo-profile ci-test
         --config .cargo/config-ci.toml
         --workspace
         --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,10 +168,6 @@ while_let_loop = "warn"
 let_underscore_drop = "warn"
 redundant_imports = "warn"
 
-[profile.dev]
-# Opt-level 0 tends to run out of stack on Windows when running async code
-opt-level = 1
-
 [profile.dev.package."*"]
 # Compile all dependencies with opt-level=3 to help speed up tests and
 # debug builds
@@ -182,3 +178,8 @@ opt-level = 3
 [profile.release]
 strip = "debuginfo"
 codegen-units = 1
+
+[profile.ci-test]
+inherits = "test"
+# Opt-level 0 tends to run out of stack on Windows when running async code
+opt-level = 1


### PR DESCRIPTION
Incremental builds have gotten painfully slow since I set `opt-level=1` in cb81f0e99483. They take around 3 minutes for me on a pretty fast machine. Let's go back to using the default opt-level of 0 in the dev profile and use an opt-level of 1 only in CI tests.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by AI
- [ ] For any prose generated by AI, I have proof-read and copy-edited with an
      eye towards deleting anything that is irrelevant, clarifying anything that
      is confusing, and adding details that are relevant. This includes, for
      example, commit descriptions, PR descriptions, and code comments.
