### PR TITLE
git_backend: Revert "Revert "git_backend: stop writing tree ids to pr…

### DIFF
--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -738,12 +738,6 @@ fn serialize_extras(commit: &Commit) -> Vec<u8> {
         ..Default::default()
     };
     proto.uses_tree_conflict_format = true;
-    if !commit.root_tree.is_resolved() {
-        // This is done for the sake of jj versions <0.28 (before commit
-        // f7b14be) being able to read the repo. At some point in the
-        // future, we can stop doing it.
-        proto.root_tree = commit.root_tree.iter().map(|r| r.to_bytes()).collect();
-    }
     for predecessor in &commit.predecessors {
         proto.predecessors.push(predecessor.to_bytes());
     }


### PR DESCRIPTION
…oto""

This reverts commit bb902b69b57e7d68ec19e323833f8d60e4d52b49.

Now that well over twelve months have passed this should be fine to land, since everyone had time to update the tools beyond such a version.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
