### PR TITLE
git-lfs: ignore filtered files in .gitattributes during snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ None
   revisions by default (defined by `revsets.op-diff-changes-in`). A new flag,
   `--show-changes-in`, can be used to override this. [#6083](https://github.com/jj-vcs/jj/issues/6083)
 
+* Added `git.ignore-filters` setting to specify what filtered files in
+  `.gitattributes` are ignored by `jj`. Defaults to `["lfs"]`.
+
 ### Fixed bugs
 
 * `.gitignore` with UTF-8 BOM can now be parsed correctly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -115,7 +115,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -840,7 +840,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -935,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b5d9f7e55a0f9a936a877fa4f9758692a308550a39a45684286941a20a8e5c0"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
 dependencies = [
  "bstr",
  "fastrand",
@@ -2482,7 +2482,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2598,6 +2598,7 @@ dependencies = [
  "eyre",
  "futures 0.3.32",
  "gix",
+ "gix-attributes",
  "gix-ignore",
  "globset",
  "hashbrown 0.17.0",
@@ -2993,7 +2994,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3906,7 +3907,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4208,7 +4209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4299,7 +4300,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4309,7 +4310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5170,7 +5171,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5410,7 +5411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ gix = { version = "0.83.0", default-features = false, features = [
     "zlib-rs",
 ] }
 gix-ignore = { version = "0.21.0" }
+gix-attributes = "0.33.0"
 globset = "0.4.18"
 hashbrown = { version = "0.17.0", default-features = false, features = ["inline-more"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
@@ -115,7 +116,7 @@ test-case = "3.3.1"
 textwrap = "0.16.2"
 thiserror = "2.0.17"
 timeago = { version = "0.6.0", default-features = false }
-tokio = { version = "1.52.1", features = ["io-util"] }
+tokio = { version = "1.52.1", features = ["io-util", "sync"] }
 toml = "1.1.0"
 toml_edit = { version = "0.25.8", features = ["serde"] }
 tracing = "0.1.44"

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -34,6 +34,7 @@ use jj_lib::fileset::FilePatternParseError;
 use jj_lib::fileset::FilesetParseError;
 use jj_lib::fileset::FilesetParseErrorKind;
 use jj_lib::fix::FixError;
+use jj_lib::gitattributes::GitAttributesError;
 use jj_lib::gitignore::GitIgnoreError;
 use jj_lib::index::IndexError;
 use jj_lib::op_heads_store::OpHeadResolutionError;
@@ -722,6 +723,12 @@ impl From<WorkingCopyStateError> for CommandError {
 impl From<GitIgnoreError> for CommandError {
     fn from(err: GitIgnoreError) -> Self {
         user_error_with_message("Failed to process .gitignore.", err)
+    }
+}
+
+impl From<GitAttributesError> for CommandError {
+    fn from(err: GitAttributesError) -> Self {
+        user_error_with_message("Failed to process .gitattributes.", err)
     }
 }
 

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -522,6 +522,14 @@
                     "type": "boolean",
                     "description": "Whether to colocate the working copy with the git repository",
                     "default": true
+                },
+                "ignore-filters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Names of `.gitattributes` filter attributes whose matching files should be excluded from snapshots",
+                    "default": ["lfs"]
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -26,6 +26,7 @@ disabled-branches = []
 
 [git]
 colocate = true
+ignore-filters = ["lfs"]
 private-commits = "none()"
 push-new-bookmarks = false
 sign-on-push = false

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io;
 use std::io::Write as _;
@@ -156,6 +157,7 @@ pub(crate) async fn check_out_trees(
             eol_conversion_mode: EolConversionMode::None,
             exec_change_setting: ExecChangeSetting::Auto,
             fsmonitor_settings: FsmonitorSettings::None,
+            ignore_filters: HashSet::new(),
         };
         let mut state = TreeState::init(store.clone(), wc_path, state_dir, &tree_state_settings)?;
         state.set_sparse_patterns(changed_files.clone())?;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -42,6 +42,7 @@ etcetera = { workspace = true }
 futures = { workspace = true }
 gix = { workspace = true, optional = true }
 gix-ignore = { workspace = true }
+gix-attributes = { workspace = true }
 globset = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -99,6 +99,7 @@ pub struct GitSettings {
     pub abandon_unreachable_commits: bool,
     pub executable_path: PathBuf,
     pub write_change_id_header: bool,
+    pub ignore_filters: Vec<String>,
 }
 
 impl GitSettings {
@@ -108,6 +109,10 @@ impl GitSettings {
             abandon_unreachable_commits: settings.get_bool("git.abandon-unreachable-commits")?,
             executable_path: settings.get("git.executable-path")?,
             write_change_id_header: settings.get("git.write-change-id-header")?,
+            ignore_filters: settings
+                .get("git.ignore-filters")
+                .optional()?
+                .unwrap_or_else(|| vec!["lfs".to_string()]),
         })
     }
 

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -40,6 +40,7 @@ use crate::backend::CommitId;
 use crate::backend::TreeValue;
 use crate::commit::Commit;
 use crate::config::ConfigGetError;
+use crate::config::ConfigGetResultExt as _;
 use crate::file_util::IoResultExt as _;
 use crate::file_util::PathError;
 use crate::git_backend::GitBackend;

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -1,0 +1,704 @@
+// Copyright 2025 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![expect(missing_docs)]
+#![allow(unused)]
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use gix_attributes::Search;
+use gix_attributes::State;
+use gix_attributes::glob::pattern::Case;
+use gix_attributes::search::MetadataCollection;
+use gix_attributes::search::Outcome;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt as _;
+use tokio::sync::OnceCell;
+
+use crate::backend::TreeValue;
+use crate::file_util::BlockingAsyncReader;
+use crate::merge::SameChange;
+use crate::merged_tree::MergedTree;
+use crate::repo_path::RepoPath;
+use crate::repo_path::RepoPathBuf;
+use crate::repo_path::RepoPathComponent;
+
+/// Git Attributes instance
+///
+/// This struct handles accessing .gitattributes files
+/// and maintains a cache to prevent loading the same file twice.
+///
+/// It's lazy loaded so .gitattributes files are only accessed
+/// if you search for attributes for a given path.
+pub(crate) struct GitAttributes {
+    disk_file_loader: Arc<dyn FileLoader>,
+    store_file_loader: Arc<dyn FileLoader>,
+    node_cache: Mutex<HashMap<RepoPathBuf, Arc<GitAttributesNode>>>,
+}
+
+#[async_trait::async_trait]
+pub(crate) trait FileLoader: Send + Sync {
+    /// Loads a file in a given `path`
+    ///
+    /// Returns Some(..) if the file was found and None if not
+    async fn load(
+        &self,
+        path: &RepoPath,
+    ) -> Result<Option<Box<dyn AsyncRead + Send + Unpin>>, GitAttributesError>;
+}
+
+pub(crate) struct TreeFileLoader {
+    tree: MergedTree,
+}
+impl TreeFileLoader {
+    pub fn new(tree: MergedTree) -> Self {
+        Self { tree }
+    }
+}
+
+#[async_trait::async_trait]
+impl FileLoader for TreeFileLoader {
+    async fn load(
+        &self,
+        path: &RepoPath,
+    ) -> Result<Option<Box<dyn AsyncRead + Send + Unpin>>, GitAttributesError> {
+        let merged_tree_value =
+            self.tree
+                .path_value(path)
+                .await
+                .map_err(|err| GitAttributesError {
+                    message: "Could not retrieve the value from path".to_string(),
+                    source: err.into(),
+                })?;
+        let maybe_file_merge = merged_tree_value.to_file_merge();
+        // try to resolve the file
+        let id = match maybe_file_merge
+            .as_ref()
+            .and_then(|files| files.resolve_trivial(SameChange::Accept))
+        {
+            Some(Some(id)) => id,
+            Some(None) => return Ok(None),
+            None => {
+                // conflict path
+                let Some(id) = merged_tree_value.iter().find_map(|tree_value| {
+                    let Some(TreeValue::File { id, .. }) = tree_value else {
+                        return None;
+                    };
+                    Some(id)
+                }) else {
+                    return Ok(None);
+                };
+                id
+            }
+        };
+
+        let result =
+            self.tree
+                .store()
+                .read_file(path, id)
+                .await
+                .map_err(|err| GitAttributesError {
+                    message: "Could not retrieve the value from path".to_string(),
+                    source: err.into(),
+                })?;
+        Ok(Some(Box::new(result)))
+    }
+}
+
+pub(crate) struct DiskFileLoader {
+    repo_root: PathBuf,
+}
+
+impl DiskFileLoader {
+    pub fn new(repo_root: PathBuf) -> Self {
+        Self { repo_root }
+    }
+}
+
+#[async_trait::async_trait]
+impl FileLoader for DiskFileLoader {
+    async fn load(
+        &self,
+        path: &RepoPath,
+    ) -> Result<Option<Box<dyn AsyncRead + Send + Unpin>>, GitAttributesError> {
+        let path = path
+            .to_fs_path(&self.repo_root)
+            .map_err(|err| GitAttributesError {
+                message: "Could not convert path into fs path".to_string(),
+                source: err.into(),
+            })?;
+
+        // we use symlink_metadata to not follow symlinks to follow Git's behavior.
+        let metadata = match path.symlink_metadata() {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => {
+                return Err(GitAttributesError {
+                    message: format!("Failed to obtain the file metadata of {}", path.display()),
+                    source: err.into(),
+                });
+            }
+        };
+        if !metadata.is_file() {
+            return Ok(None);
+        }
+
+        let file = match File::open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(err) => {
+                return Err(GitAttributesError {
+                    message: format!("Failed to open the file at {}", path.display()),
+                    source: err.into(),
+                });
+            }
+        };
+        Ok(Some(Box::new(BlockingAsyncReader::new(file))))
+    }
+}
+
+struct SearchAndCollection {
+    search: Search,
+    collection: MetadataCollection,
+}
+
+struct GitAttributesNode {
+    disk_first: OnceCell<Arc<SearchAndCollection>>,
+    store_first: OnceCell<Arc<SearchAndCollection>>,
+    disk_file_loader: Arc<dyn FileLoader>,
+    store_file_loader: Arc<dyn FileLoader>,
+    parent: Option<Arc<Self>>,
+    path: RepoPathBuf,
+}
+
+impl GitAttributesNode {
+    async fn get_disk_first(&self) -> Result<Arc<SearchAndCollection>, GitAttributesError> {
+        self.primary_then_secondary(SearchPriority::Disk).await
+    }
+    async fn get_store_first(&self) -> Result<Arc<SearchAndCollection>, GitAttributesError> {
+        self.primary_then_secondary(SearchPriority::Store).await
+    }
+
+    fn store(&self, priority: SearchPriority) -> &OnceCell<Arc<SearchAndCollection>> {
+        match priority {
+            SearchPriority::Store => &self.store_first,
+            SearchPriority::Disk => &self.disk_first,
+        }
+    }
+
+    fn primary_loader(&self, priority: SearchPriority) -> &Arc<dyn FileLoader> {
+        match priority {
+            SearchPriority::Store => &self.store_file_loader,
+            SearchPriority::Disk => &self.disk_file_loader,
+        }
+    }
+
+    fn secondary_loader(&self, priority: SearchPriority) -> &Arc<dyn FileLoader> {
+        match priority {
+            SearchPriority::Store => &self.disk_file_loader,
+            SearchPriority::Disk => &self.store_file_loader,
+        }
+    }
+
+    async fn primary_then_secondary(
+        &self,
+        priority: SearchPriority,
+    ) -> Result<Arc<SearchAndCollection>, GitAttributesError> {
+        self.store(priority)
+            .get_or_try_init(async || {
+                let parent_metadata = match &self.parent {
+                    // we use pin because this is a recursive call
+                    Some(parent) => Box::pin(parent.primary_then_secondary(priority)).await?,
+                    None => {
+                        let mut search = Search::default();
+                        let mut collection = MetadataCollection::default();
+                        // initialize search
+                        search.add_patterns_buffer(
+                            b"[attr]binary -diff -merge -text",
+                            "[builtin]".into(),
+                            None,
+                            &mut collection,
+                            true, /* allow macros */
+                        );
+                        Arc::new(SearchAndCollection { search, collection })
+                    }
+                };
+                let git_attributes_path =
+                    self.path
+                        .join(RepoPathComponent::new(".gitattributes").map_err(|err| {
+                            GitAttributesError {
+                                message: "Could not join path with .gitattributes".to_string(),
+                                source: err.into(),
+                            }
+                        })?);
+                let mut async_reader = match self
+                    .primary_loader(priority)
+                    .load(&git_attributes_path)
+                    .await?
+                {
+                    Some(reader) => reader,
+                    None => {
+                        // fallback to the secondary loader
+                        match self
+                            .secondary_loader(priority)
+                            .load(&git_attributes_path)
+                            .await?
+                        {
+                            Some(reader) => reader,
+                            None => return Ok(parent_metadata),
+                        }
+                    }
+                };
+                let mut bytes = Vec::new();
+                async_reader
+                    .read_to_end(&mut bytes)
+                    .await
+                    .map_err(|err| GitAttributesError {
+                        source: err.into(),
+                        message: "Could not read .gitattributes file".into(),
+                    })?;
+                let mut search = parent_metadata.search.clone();
+                let mut collection = parent_metadata.collection.clone();
+
+                search.add_patterns_buffer(
+                    &bytes,
+                    git_attributes_path
+                        .to_fs_path(&PathBuf::new())
+                        .map_err(|err| GitAttributesError {
+                            message: "Could not convert gitattributes path into PathBuf"
+                                .to_string(),
+                            source: err.into(),
+                        })?,
+                    Some(&PathBuf::new()),
+                    &mut collection,
+                    // Macros can only be defined in top-level gitattributes:
+                    // https://git-scm.com/docs/gitattributes#_defining_macro_attributes
+                    self.parent.is_none(), /* allow macros */
+                );
+
+                Ok(Arc::new(SearchAndCollection { search, collection }))
+            })
+            .await
+            .cloned()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SearchPriority {
+    Store,
+    Disk,
+}
+
+impl GitAttributes {
+    /// Creates a new instance by receiving a Store File Loader, a Disk File
+    /// Loader and a list of filters to be ignored.
+    pub fn new(
+        store_file_loader: impl FileLoader + 'static,
+        disk_file_loader: impl FileLoader + 'static,
+    ) -> Self {
+        Self {
+            store_file_loader: Arc::new(store_file_loader),
+            disk_file_loader: Arc::new(disk_file_loader),
+            node_cache: Default::default(),
+        }
+    }
+
+    pub(crate) async fn search(
+        &self,
+        path: &RepoPath,
+        attribute_names: impl AsRef<[&str]>,
+        priority: SearchPriority,
+    ) -> Result<HashMap<String, State>, GitAttributesError> {
+        let attributes = self.get_git_attributes_node(path);
+        let store = match priority {
+            SearchPriority::Store => attributes.get_store_first().await?,
+            SearchPriority::Disk => attributes.get_disk_first().await?,
+        };
+        let SearchAndCollection { search, collection } = &*store;
+
+        let mut out = Outcome::default();
+        out.initialize_with_selection(
+            collection,
+            // From<&str> is implemented for KStringRef
+            attribute_names.as_ref().iter().copied(),
+        );
+        search.pattern_matching_relative_path(
+            path.as_internal_file_string().into(),
+            Case::Sensitive,
+            None,
+            &mut out,
+        );
+
+        let mut map = out
+            .iter_selected()
+            .map(|attr| {
+                let val = attr.assignment.to_owned();
+                (val.name.as_str().to_string(), val.state)
+            })
+            .collect::<HashMap<String, State>>();
+
+        // go over attributes and mark as unspecified if not set
+        for attribute_name in attribute_names.as_ref() {
+            map.entry(attribute_name.to_string())
+                .or_insert(State::Unspecified);
+        }
+
+        Ok(map)
+    }
+
+    fn get_git_attributes_node(&self, path: &RepoPath) -> Arc<GitAttributesNode> {
+        let path = path.parent().unwrap_or(RepoPath::root());
+        let mut val = self.node_cache.lock().expect("Not be poisoned");
+        self.inner(&mut val, path)
+    }
+
+    fn inner(
+        &self,
+        map: &mut HashMap<RepoPathBuf, Arc<GitAttributesNode>>,
+        path: &RepoPath,
+    ) -> Arc<GitAttributesNode> {
+        if let Some(node) = map.get(path) {
+            return node.clone();
+        }
+        let parent = path.parent().map(|parent| self.inner(map, parent));
+        let new_node = Arc::new(GitAttributesNode {
+            disk_first: OnceCell::new(),
+            store_first: OnceCell::new(),
+            disk_file_loader: self.disk_file_loader.clone(),
+            store_file_loader: self.store_file_loader.clone(),
+            parent,
+            path: path.to_owned(),
+        });
+        map.insert(path.to_owned(), new_node.clone());
+        new_node
+    }
+}
+
+/// Errors for GitAttributes
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct GitAttributesError {
+    message: String,
+    #[source]
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::io::Cursor;
+
+    use gix_attributes::state::Value;
+    use indoc::indoc;
+    use pollster::FutureExt as _;
+
+    use super::*;
+
+    type TestStore = HashMap<RepoPathBuf, Result<String, String>>;
+
+    #[async_trait::async_trait]
+    impl FileLoader for TestStore {
+        async fn load(
+            &self,
+            path: &RepoPath,
+        ) -> Result<Option<Box<dyn AsyncRead + Send + Unpin>>, GitAttributesError> {
+            let Some(mocked_result) = self.get(path) else {
+                return Ok(None);
+            };
+            let data = mocked_result.clone();
+            match data {
+                Ok(data) => Ok(Some(Box::new(Cursor::new(Vec::from(data))))),
+                Err(message) => Err(GitAttributesError {
+                    message: message.clone(),
+                    source: message.into(),
+                }),
+            }
+        }
+    }
+
+    fn repo_path(path: &str) -> &RepoPath {
+        RepoPath::from_internal_string(path).unwrap()
+    }
+
+    fn create_git_attributes(files: &[(&'static str, &'static str)]) -> GitAttributes {
+        let data: TestStore = files
+            .iter()
+            .map(|(key, value)| (repo_path(key).to_owned(), Ok(value.to_string())))
+            .collect();
+
+        GitAttributes::new(HashMap::new(), data)
+    }
+
+    fn assert_search_output(
+        git_attributes: &GitAttributes,
+        file: &str,
+        attribute: &str,
+        expected: State,
+    ) {
+        assert_search_output_with_priority(
+            git_attributes,
+            file,
+            attribute,
+            expected,
+            SearchPriority::Disk,
+        );
+    }
+
+    fn assert_search_output_with_priority(
+        git_attributes: &GitAttributes,
+        file: &str,
+        attribute: &str,
+        expected: State,
+        search: SearchPriority,
+    ) {
+        let map = git_attributes
+            .search(repo_path(file), &[attribute], search)
+            .block_on()
+            .unwrap();
+        assert_eq!(map.len(), 1);
+        assert_eq!(*map.get(attribute).unwrap(), expected);
+    }
+
+    fn assert_attribute_output(
+        git_attributes_content: &'static str,
+        file: &str,
+        attribute: &str,
+        expected: State,
+    ) {
+        let git_attributes = create_git_attributes(&[(".gitattributes", git_attributes_content)]);
+        assert_search_output(&git_attributes, file, attribute, expected);
+    }
+
+    #[test]
+    fn test_search_state_set() {
+        assert_attribute_output("abc foo", "abc", "foo", State::Set);
+    }
+
+    #[test]
+    fn test_search_state_eol_lf() {
+        assert_attribute_output("foo eol=lf", "foo", "eol", State::Value(Value::from("lf")));
+    }
+
+    #[test]
+    fn test_search_unset() {
+        assert_attribute_output("foo -text", "foo", "text", State::Unset);
+    }
+
+    #[test]
+    fn test_search_unspecified() {
+        assert_attribute_output("foo !text", "foo", "text", State::Unspecified);
+    }
+
+    #[test]
+    fn test_search_unspecified_no_pattern() {
+        assert_attribute_output("foo elo=lf", "bar", "text", State::Unspecified);
+        assert_attribute_output("foo elo=lf", "bar", "elo", State::Unspecified);
+    }
+
+    #[test]
+    fn test_path_and_pattern_matching() {
+        // Using https://git-scm.com/docs/gitattributes#_examples as example
+        // It's not 1:1 because we don't support $GIT_DIR/info/.gitattributes
+        // that would override in-tree settings.
+        let git_attributes = create_git_attributes(&[
+            (".gitattributes", "abc	foo bar baz"),
+            (
+                "t/.gitattributes",
+                indoc! {"
+                    ab*	merge=filfre
+                    abc	-foo -bar
+                    *.c	frotz
+                "},
+            ),
+        ]);
+
+        assert_search_output(&git_attributes, "t/abc", "foo", State::Unset);
+        assert_search_output(&git_attributes, "t/abc", "bar", State::Unset);
+        assert_search_output(&git_attributes, "t/abc", "baz", State::Set);
+        assert_search_output(
+            &git_attributes,
+            "t/abc",
+            "merge",
+            State::Value(Value::from("filfre")),
+        );
+        assert_search_output(&git_attributes, "t/abc", "frotz", State::Unspecified);
+    }
+
+    #[test]
+    fn test_glob_matching() {
+        assert_attribute_output("*.txt text", "bar.txt", "text", State::Set);
+        assert_attribute_output("foo/ text", "foo/bar.txt", "text", State::Unspecified);
+        assert_attribute_output("**/bar.rs text", "baz/bar.rs", "text", State::Set);
+    }
+
+    #[test]
+    fn test_case_sensitive_attr() {
+        assert_attribute_output(
+            indoc! {"
+                foo text
+                FOO -text
+            "},
+            "foo",
+            "text",
+            State::Set,
+        );
+        assert_attribute_output(
+            indoc! {"
+                foo text
+                FOO -text
+            "},
+            "FOO",
+            "text",
+            State::Unset,
+        );
+    }
+
+    #[test]
+    fn test_subdirectory_override() {
+        let git_attributes = create_git_attributes(&[
+            (".gitattributes", "abc	!baz"),
+            ("t/.gitattributes", "abc baz"),
+        ]);
+        assert_search_output(&git_attributes, "t/abc", "baz", State::Set);
+    }
+
+    #[test]
+    fn test_subdirectory_root_match() {
+        assert_attribute_output("baz/foo text", "baz/foo", "text", State::Set);
+    }
+
+    #[test]
+    fn test_directory_shouldnt_match() {
+        assert_attribute_output("foo text", "foo/bar.txt", "text", State::Unspecified);
+    }
+
+    #[test]
+    fn test_subdirectory_attribute() {
+        let git_attributes = create_git_attributes(&[("foo/.gitattributes", "bar.txt text")]);
+        assert_search_output(&git_attributes, "foo/bar.txt", "text", State::Set);
+    }
+
+    #[test]
+    fn test_macro_definition() {
+        let git_attributes = create_git_attributes(&[
+            (
+                ".gitattributes",
+                indoc! {"
+                    [attr]base_macro a
+                    [attr]override_macro b
+                "},
+            ),
+            (
+                "foo1/.gitattributes",
+                indoc! {"
+                    # this macro definition shouldn't take effect.
+                    [attr]override_macro c
+                    # this macro definition shouldn't take effect.
+                    [attr]new_macro e
+                    bar base_macro override_macro new_macro 
+                "},
+            ),
+            (
+                "foo2/.gitattributes",
+                indoc! {"
+                    # this macro definition shouldn't take effect.
+                    [attr]override_macro d
+                    # this macro definition shouldn't take effect.
+                    [attr]new_macro e
+                    bar base_macro override_macro new_macro
+                "},
+            ),
+        ]);
+        assert_search_output(&git_attributes, "foo1/bar", "a", State::Set);
+        assert_search_output(&git_attributes, "foo1/bar", "b", State::Set);
+        assert_search_output(&git_attributes, "foo1/bar", "c", State::Unspecified);
+        assert_search_output(&git_attributes, "foo1/bar", "d", State::Unspecified);
+        assert_search_output(&git_attributes, "foo1/bar", "e", State::Unspecified);
+        assert_search_output(&git_attributes, "foo1/bar", "new_macro", State::Set);
+
+        assert_search_output(&git_attributes, "foo2/bar", "a", State::Set);
+        assert_search_output(&git_attributes, "foo2/bar", "b", State::Set);
+        assert_search_output(&git_attributes, "foo2/bar", "c", State::Unspecified);
+        assert_search_output(&git_attributes, "foo2/bar", "d", State::Unspecified);
+        assert_search_output(&git_attributes, "foo2/bar", "e", State::Unspecified);
+        assert_search_output(&git_attributes, "foo2/bar", "new_macro", State::Set);
+    }
+
+    #[test]
+    fn test_search_priority_and_fallback() {
+        let disk = TestStore::from([(
+            repo_path("foo/.gitattributes").to_owned(),
+            Ok("*.txt text".to_string()),
+        )]);
+
+        let store = TestStore::from([(
+            repo_path("bar/.gitattributes").to_owned(),
+            Ok("*.txt text".to_string()),
+        )]);
+
+        let git_attributes = GitAttributes::new(store, disk);
+        assert_search_output_with_priority(
+            &git_attributes,
+            "foo/bar.txt",
+            "text",
+            State::Set,
+            SearchPriority::Disk,
+        );
+        assert_search_output_with_priority(
+            &git_attributes,
+            "foo/bar.txt",
+            "text",
+            State::Set,
+            SearchPriority::Store,
+        );
+        assert_search_output_with_priority(
+            &git_attributes,
+            "bar/bar.txt",
+            "text",
+            State::Set,
+            SearchPriority::Store,
+        );
+        assert_search_output_with_priority(
+            &git_attributes,
+            "bar/bar.txt",
+            "text",
+            State::Set,
+            SearchPriority::Disk,
+        );
+    }
+
+    #[test]
+    fn test_file_loader_io_error() {
+        let store: TestStore = TestStore::from([(
+            repo_path(".gitattributes").to_owned(),
+            Err("There was an IO error".to_string()),
+        )]);
+
+        let git_attributes = GitAttributes::new(store, HashMap::new());
+        let result = &git_attributes
+            .search(repo_path("foo/bar.txt"), &["text"], SearchPriority::Disk)
+            .block_on();
+        assert!(result.is_err());
+        assert_eq!(
+            &result.as_ref().unwrap_err().message,
+            "There was an IO error",
+        );
+    }
+}

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![expect(missing_docs)]
-#![allow(unused)]
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/lib/src/gitattributes.rs
+++ b/lib/src/gitattributes.rs
@@ -391,6 +391,27 @@ impl GitAttributes {
     }
 }
 
+impl GitAttributes {
+    /// Returns whether the given `path` has a `filter` attribute in
+    /// .gitattributes whose value is contained in `ignore_filters`.
+    pub(crate) async fn filter_matches(
+        &self,
+        path: &RepoPath,
+        ignore_filters: &HashSet<String>,
+        priority: SearchPriority,
+    ) -> bool {
+        let Ok(result) = self.search(path, ["filter"], priority).await else {
+            return false;
+        };
+
+        let Some(State::Value(value)) = result.get("filter") else {
+            return false;
+        };
+        let value = value.as_ref().as_bstr();
+        ignore_filters.iter().any(|state| value == state.as_str())
+    }
+}
+
 /// Errors for GitAttributes
 #[derive(Debug, thiserror::Error)]
 #[error("{message}")]
@@ -699,6 +720,160 @@ mod tests {
         assert_eq!(
             &result.as_ref().unwrap_err().message,
             "There was an IO error",
+        );
+    }
+
+    fn matches(input: &str, path: &str) -> bool {
+        let data = TestStore::from([(
+            RepoPathBuf::from_internal_string(".gitattributes").unwrap(),
+            Ok(input.to_string()),
+        )]);
+        let attributes = GitAttributes::new(HashMap::new(), data);
+
+        attributes
+            .filter_matches(
+                repo_path(path),
+                &HashSet::from(["lfs".to_string()]),
+                SearchPriority::Disk,
+            )
+            .block_on()
+    }
+
+    #[test]
+    fn test_gitattributes_empty_file() {
+        assert!(!matches("", "foo"));
+    }
+
+    #[test]
+    fn test_gitattributes_simple_match() {
+        assert!(matches("*.bin filter=lfs\n", "file.bin"));
+        assert!(!matches("*.bin filter=lfs\n", "file.txt"));
+        assert!(!matches("*.bin filter=other\n", "file.bin"));
+        assert!(!matches("*.bin filter=other\n", "path/to/file.bin"));
+    }
+
+    #[test]
+    fn test_gitattributes_directory_match() {
+        // patterns that match a directory do not recursively match paths inside that
+        // directory (so using the trailing-slash path/ syntax is pointless in
+        // an attributes file; use path/** instead)
+        // https://git-scm.com/docs/gitattributes#_description
+        assert!(!matches("dir/ filter=lfs\n", "dir/file.txt"));
+        assert!(!matches("dir/ filter=lfs\n", "other/file.txt"));
+        assert!(!matches("dir/ filter=lfs\n", "dir"));
+    }
+
+    #[test]
+    fn test_gitattributes_path_match() {
+        assert!(matches("path/to/file.bin filter=lfs\n", "path/to/file.bin"));
+        assert!(!matches("path/to/file.bin filter=lfs\n", "path/file.bin"));
+    }
+
+    #[test]
+    fn test_gitattributes_wildcard_match() {
+        assert!(matches("*.bin filter=lfs\n", "file.bin"));
+        assert!(matches("file.* filter=lfs\n", "file.bin"));
+        assert!(matches("**/file.bin filter=lfs\n", "path/to/file.bin"));
+    }
+
+    #[test]
+    fn test_gitattributes_multiple_attributes() {
+        let input = "*.bin filter=lfs diff=binary\n";
+        assert!(matches(input, "file.bin"));
+        assert!(!matches("*.bin diff=binary\n", "file.bin")); // Only testing filter=lfs
+    }
+
+    #[test]
+    fn test_gitattributes_chained_files() {
+        let data = TestStore::from([
+            (
+                repo_path(".gitattributes").to_owned(),
+                Ok("*.bin filter=lfs\n".to_string()),
+            ),
+            (
+                repo_path("subdir/.gitattributes").to_owned(),
+                Ok("*.txt filter=text\n".to_string()),
+            ),
+        ]);
+        let attributes = GitAttributes::new(HashMap::new(), data);
+
+        let filters = &HashSet::from(["lfs".to_string(), "text".to_string()]);
+        assert!(
+            attributes
+                .filter_matches(repo_path("file.bin"), filters, SearchPriority::Disk)
+                .block_on()
+        );
+        assert!(
+            attributes
+                .filter_matches(repo_path("subdir/file.txt"), filters, SearchPriority::Disk)
+                .block_on()
+        );
+        assert!(
+            !attributes
+                .filter_matches(repo_path("file.txt"), filters, SearchPriority::Disk)
+                .block_on()
+        ); // Not in subdir
+    }
+
+    #[test]
+    fn test_gitattributes_negated_pattern() {
+        let input = "*.bin filter=lfs\n!important.bin filter=lfs\n";
+        assert!(matches(input, "file.bin"));
+        // negative patterns are forbidden
+        // https://git-scm.com/docs/gitattributes#_description
+        assert!(matches(input, "important.bin"));
+    }
+
+    #[test]
+    fn test_gitattributes_multiple_filters() {
+        let data = TestStore::from([
+            (
+                repo_path(".gitattributes").to_owned(),
+                Ok(indoc! {"
+                    *.bin filter=lfs
+                    *.secret filter=git-crypt
+                    *.txt filter=other
+                "}
+                .to_string()),
+            ),
+            (
+                repo_path("subdir/.gitattributes").to_owned(),
+                Ok("*.txt filter=text\n".to_string()),
+            ),
+        ]);
+
+        // Create a GitAttributesFile with both "lfs" and "git-crypt" as ignore filters
+        let attributes = GitAttributes::new(HashMap::new(), data);
+
+        let filters = &HashSet::from(["lfs".to_string(), "git-crypt".to_string()]);
+
+        // Test with lfs filter
+        assert!(
+            attributes
+                .filter_matches(repo_path("file.bin"), filters, SearchPriority::Disk)
+                .block_on()
+        );
+        // Test with git-crypt filter
+        assert!(
+            attributes
+                .filter_matches(
+                    repo_path("credentials.secret"),
+                    filters,
+                    SearchPriority::Disk
+                )
+                .block_on()
+        );
+        // Not In the filter
+        assert!(
+            !attributes
+                .filter_matches(repo_path("file.bin2"), filters, SearchPriority::Disk)
+                .block_on()
+        );
+        // Test that other filters don't match
+        assert!(
+            !attributes
+                .filter_matches(repo_path("file.txt"), filters, SearchPriority::Disk)
+                .block_on()
         );
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -62,6 +62,7 @@ pub mod git;
 pub mod git_backend;
 #[cfg(feature = "git")]
 mod git_subprocess;
+pub mod gitattributes;
 pub mod gitignore;
 pub mod gpg_signing;
 pub mod graph;

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -90,6 +90,12 @@ use crate::fsmonitor::FsmonitorSettings;
 use crate::fsmonitor::WatchmanConfig;
 #[cfg(feature = "watchman")]
 use crate::fsmonitor::watchman;
+#[cfg(feature = "git")]
+use crate::git::GitSettings;
+use crate::gitattributes::DiskFileLoader;
+use crate::gitattributes::GitAttributes;
+use crate::gitattributes::SearchPriority;
+use crate::gitattributes::TreeFileLoader;
 use crate::gitignore::GitIgnoreFile;
 use crate::lock::FileLock;
 use crate::matchers::DifferenceMatcher;
@@ -973,6 +979,10 @@ pub struct TreeStateSettings {
     pub exec_change_setting: ExecChangeSetting,
     /// The fsmonitor (e.g. Watchman) to use, if any.
     pub fsmonitor_settings: FsmonitorSettings,
+
+    /// Names of .gitattributes filters whose matching files should be ignored
+    /// in the working copy.
+    pub ignore_filters: HashSet<String>,
 }
 
 impl TreeStateSettings {
@@ -983,6 +993,19 @@ impl TreeStateSettings {
             eol_conversion_mode: EolConversionMode::try_from_settings(user_settings)?,
             exec_change_setting: user_settings.get("working-copy.exec-bit-change")?,
             fsmonitor_settings: FsmonitorSettings::from_settings(user_settings)?,
+            ignore_filters: {
+                #[cfg(feature = "git")]
+                {
+                    GitSettings::from_settings(user_settings)?
+                        .ignore_filters
+                        .into_iter()
+                        .collect()
+                }
+                #[cfg(not(feature = "git"))]
+                {
+                    HashSet::new()
+                }
+            },
         })
     }
 }
@@ -1007,6 +1030,10 @@ pub struct TreeState {
     exec_policy: ExecChangePolicy,
     fsmonitor_settings: FsmonitorSettings,
     target_eol_strategy: TargetEolStrategy,
+
+    // attributes
+    git_attributes: Arc<GitAttributes>,
+    ignore_filters: HashSet<String>,
 }
 
 #[derive(Debug, Error)]
@@ -1067,14 +1094,21 @@ impl TreeState {
             eol_conversion_mode,
             exec_change_setting,
             fsmonitor_settings,
+            ignore_filters,
         }: &TreeStateSettings,
     ) -> Self {
         let exec_policy = ExecChangePolicy::new(*exec_change_setting, &state_path);
+        let tree = store.empty_merged_tree();
+
+        let store_file_loader = TreeFileLoader::new(tree.clone());
+        let disk_file_loader = DiskFileLoader::new(working_copy_path.clone());
+
+        let git_attributes = Arc::new(GitAttributes::new(store_file_loader, disk_file_loader));
         Self {
             store: store.clone(),
             working_copy_path,
             state_path,
-            tree: store.empty_merged_tree(),
+            tree,
             file_states: FileStatesMap::new(),
             sparse_patterns: vec![RepoPathBuf::root()],
             own_mtime: MillisSinceEpoch(0),
@@ -1084,6 +1118,9 @@ impl TreeState {
             exec_policy,
             fsmonitor_settings: fsmonitor_settings.clone(),
             target_eol_strategy: TargetEolStrategy::new(*eol_conversion_mode),
+            // TODO We should update git_attributes every time TreeState::tree_id is updated
+            git_attributes,
+            ignore_filters: ignore_filters.clone(),
         }
     }
 
@@ -1332,6 +1369,8 @@ impl TreeState {
                 error: OnceLock::new(),
                 progress: *progress,
                 max_new_file_size: *max_new_file_size,
+                git_attributes: self.git_attributes.clone(),
+                ignore_filters: self.ignore_filters.clone(),
             };
             let directory_to_visit = DirectoryToVisit {
                 dir: RepoPathBuf::root(),
@@ -1503,6 +1542,9 @@ struct FileSnapshotter<'a> {
     error: OnceLock<SnapshotError>,
     progress: Option<&'a SnapshotProgress<'a>>,
     max_new_file_size: u64,
+
+    git_attributes: Arc<GitAttributes>,
+    ignore_filters: HashSet<String>,
 }
 
 impl FileSnapshotter<'_> {
@@ -1643,7 +1685,16 @@ impl FileSnapshotter<'_> {
             if let Some(progress) = self.progress {
                 progress(&path);
             }
-            if maybe_current_file_state.is_none()
+            if self
+                .git_attributes
+                .filter_matches(&path, &self.ignore_filters, SearchPriority::Disk)
+                .block_on()
+            {
+                // Skip gitattributes files that we want to ignore - this
+                // would result in them showing up as deleted, but we also
+                // omit them in `emit_deleted_files` to avoid that.
+                Ok(None)
+            } else if maybe_current_file_state.is_none()
                 && (git_ignore.matches_file(&path) && !self.force_tracking_matcher.matches(&path))
             {
                 // If it wasn't already tracked and it matches
@@ -1786,6 +1837,13 @@ impl FileSnapshotter<'_> {
             .flat_map(|(_, chunk)| chunk)
             // Whether or not the entry exists, submodule should be ignored
             .filter(|(_, state)| state.file_type != FileType::GitSubmodule)
+            // Whether or not the entry exists, ignored gitattributes files should be omitted
+            .filter(|(path, _)| {
+                !self
+                    .git_attributes
+                    .filter_matches(path, &self.ignore_filters, SearchPriority::Disk)
+                    .block_on()
+            })
             .filter(|(path, _)| self.matcher.matches(path))
             .try_for_each(|(path, _)| self.deleted_files_tx.send(path.to_owned()))
             .ok();

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -28,6 +28,7 @@ use tracing::instrument;
 use crate::backend::BackendError;
 use crate::commit::Commit;
 use crate::dag_walk_async;
+use crate::gitattributes::GitAttributesError;
 use crate::gitignore::GitIgnoreError;
 use crate::gitignore::GitIgnoreFile;
 use crate::matchers::Matcher;
@@ -190,6 +191,9 @@ pub enum SnapshotError {
     /// Checking path with ignore patterns failed.
     #[error(transparent)]
     GitIgnoreError(#[from] GitIgnoreError),
+    /// Checking path with gitattributes patterns failed.
+    #[error(transparent)]
+    GitAttributesError(#[from] GitAttributesError),
     /// Failed to load the working copy state.
     #[error(transparent)]
     WorkingCopyStateError(#[from] WorkingCopyStateError),


### PR DESCRIPTION
Partially addresses #80 by ignoring files matched by configurable `.gitattributes` filter attributes during snapshot. This lets users work with Git LFS (and git-crypt, etc.) repos in jj by excluding filtered files from tracking, deferring actual file handling to the external tool (e.g. `git lfs pull`).

## History

This work builds on several prior attempts to bring LFS support to jj:

- #5480 — @weiznich's original "Ignore Git LFS files" PR (closed)
- #6036 — @bcspragu's "add support for ignoring Git LFS files" PR (open, draft)
- #7098 — @gusinacio's "Git Lfs" PR, which forked from @kejadlen's branch and added `gix-attributes`-based parsing. Recently closed by the author due to uncertainty about the design direction.
- #7164 — @06393993's "cornerstone for gitattributes features" design proposal
- #8144 — @06393993's "Gitattributes filter design" (WIP)

This PR picks up where #7098 left off, per https://github.com/jj-vcs/jj/pull/7098#issuecomment-3973108127.

## Approach

A new `git.ignore-filters` setting (defaulting to `["lfs"]`) names `.gitattributes` filter attributes whose matching files should be excluded from snapshots. During snapshot, the working copy reads `.gitattributes` files from both disk and the tree store, matches paths against `gix-attributes`, and skips files whose `filter` attribute matches a configured ignore filter. Skipped files are also omitted from the deleted-files check so they don't appear as spuriously removed.

This only affects the snapshot path (disk → store). Checkout (store → disk) is unaffected, which is intentional: files are still checked out normally so that `git lfs pull` works afterward.

### Known limitations

- All `.gitattributes` files in the repo are parsed on every snapshot, regardless of which directories changed.
- Symlinked `.gitattributes` files are followed (matching jj's current `.gitignore` behavior, but diverging from git).
- No checkout-path filtering — this is snapshot-only.

These are acceptable tradeoffs for an initial implementation and can be refined alongside the broader gitattributes design (#7164, #8144).

# Checklist

- [x] I have updated `CHANGELOG.md`
- ~~I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.

(PR summary assisted by Claude Opus 4.6 via pi)