### PR TITLE
repo: don't auto-abandon tagged working-copy revision

### DIFF
--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1562,15 +1562,16 @@ impl MutableRepo {
         workspace_name: &WorkspaceName,
     ) -> Result<(), EditCommitError> {
         let is_commit_referenced = |view: &View, commit_id: &CommitId| -> bool {
-            view.wc_commit_ids()
-                .iter()
-                .filter(|&(name, _)| name != workspace_name)
-                .map(|(_, wc_id)| wc_id)
-                .chain(
-                    view.local_bookmarks()
-                        .flat_map(|(_, target)| target.added_ids()),
-                )
-                .any(|id| id == commit_id)
+            itertools::chain!(
+                view.wc_commit_ids()
+                    .iter()
+                    .filter(|&(name, _)| name != workspace_name)
+                    .map(|(_, wc_id)| wc_id),
+                view.local_bookmarks()
+                    .flat_map(|(_, target)| target.added_ids()),
+                view.local_tags().flat_map(|(_, target)| target.added_ids()),
+            )
+            .any(|id| id == commit_id)
         };
 
         let maybe_wc_commit_id = self
@@ -1589,8 +1590,8 @@ impl MutableRepo {
                 && self.view().heads().contains(wc_commit.id())
             {
                 // Abandon the working-copy commit we're leaving if it's
-                // discardable, not pointed by local bookmark or other working
-                // copies, and a head commit.
+                // discardable, not pointed by local bookmark, tag, or other
+                // working copies, and is a head commit.
                 self.record_abandoned_commit(&wc_commit);
             }
         }

--- a/lib/tests/test_mut_repo.rs
+++ b/lib/tests/test_mut_repo.rs
@@ -255,6 +255,37 @@ fn test_edit_previous_empty_with_local_bookmark() {
 }
 
 #[test]
+fn test_edit_previous_empty_with_local_tag() {
+    // Test that MutableRepo::edit() does not abandon the previous commit if it
+    // is pointed by local tag.
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    let mut tx = repo.start_transaction();
+    let mut_repo = tx.repo_mut();
+    let old_wc_commit = mut_repo
+        .new_commit(
+            vec![repo.store().root_commit_id().clone()],
+            repo.store().empty_merged_tree(),
+        )
+        .write_unwrap();
+    mut_repo.set_local_tag_target("t".as_ref(), RefTarget::normal(old_wc_commit.id().clone()));
+    let ws_name = WorkspaceName::DEFAULT.to_owned();
+    mut_repo
+        .edit(ws_name.clone(), &old_wc_commit)
+        .block_on()
+        .unwrap();
+    let repo = tx.commit("test").block_on().unwrap();
+
+    let mut tx = repo.start_transaction();
+    let mut_repo = tx.repo_mut();
+    let new_wc_commit = write_random_commit(mut_repo);
+    mut_repo.edit(ws_name, &new_wc_commit).block_on().unwrap();
+    mut_repo.rebase_descendants().block_on().unwrap();
+    assert!(mut_repo.view().heads().contains(old_wc_commit.id()));
+}
+
+#[test]
 fn test_edit_previous_empty_with_other_workspace() {
     // Test that MutableRepo::edit() does not abandon the previous commit if it
     // is pointed by another workspace


### PR DESCRIPTION


# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
