### PR TITLE
undo: prevent restoring to root operation

### DIFF
--- a/cli/src/commands/undo.rs
+++ b/cli/src/commands/undo.rs
@@ -151,6 +151,16 @@ pub async fn cmd_undo(
             .await?;
     }
 
+    // Prevent restoring to the root operation, which has no working copy and
+    // would leave the repo in an unusable state (many commands would fail with
+    // "This command requires a working copy").
+    if op_to_restore.parent_ids().is_empty() {
+        return Err(user_error(
+            "Cannot undo: restoring to root operation would leave the repo without a working copy",
+        )
+        .hinted("Use `jj redo` to restore a working state"));
+    }
+
     let mut tx = workspace_command.start_transaction();
     let new_view = view_with_desired_portions_restored(
         op_to_restore.view().await?.store_view(),

--- a/cli/tests/test_undo_redo_commands.rs
+++ b/cli/tests/test_undo_redo_commands.rs
@@ -20,18 +20,33 @@ fn test_undo_root_operation() {
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
 
+    // When there is only one non-root operation in history, undo would restore to
+    // the root operation which has no working copy and would leave the repo
+    // unusable. We prevent this and show a helpful error instead. (Issue #8153)
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Undid operation: 8f47435a3990 (2001-02-03 08:05:07) add workspace 'default'
-    Restored to operation: 000000000000 root()
+    Error: Cannot undo: restoring to root operation would leave the repo without a working copy
+    Hint: Use `jj redo` to restore a working state
     [EOF]
+    [exit status: 1]
     ");
+}
+
+#[test]
+fn test_undo_root_operation_no_colocate() {
+    // Reproduces the exact scenario from issue #8153
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--no-colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
 
     let output = work_dir.run_jj(["undo"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Error: Cannot undo root operation
+    Error: Cannot undo: restoring to root operation would leave the repo without a working copy
+    Hint: Use `jj redo` to restore a working state
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
Fixes #8153

When there is only one non-root operation in history, `jj undo` would restore to the root operation which has no working copy, leaving the repo in an unusable state (many commands fail with "This command requires a working copy").

This prevents `jj undo` from restoring to the root operation and shows a helpful error message with a hint to use `jj redo`.

I read the discussion on the issue @martinvonz suggested warning when the current workspace no longer exists (in `cli_util.rs`). The current implementation takes the simpler approach of blocking undo to root, but happy to rework this to check workspace existence instead if that's preferred.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.

Assisted-by: Cursor
