### PR TITLE
cli: make two functions trivially async

### DIFF
--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -197,7 +197,7 @@ new working-copy commit.
     // to an empty description would break that logic.
     let description = if !description.is_empty() || use_editor {
         commit_builder.set_description(description);
-        add_trailers(ui, &tx, &commit_builder)?
+        add_trailers(ui, &tx, &commit_builder).await?
     } else {
         description
     };

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -228,7 +228,7 @@ pub(crate) async fn cmd_new(
         // can be discarded as soon as it's no longer the working copy. Adding a
         // trailer to an empty description would break that logic.
         commit_builder.set_description(&description);
-        let description = add_trailers(ui, &tx, &commit_builder)?;
+        let description = add_trailers(ui, &tx, &commit_builder).await?;
         commit_builder.set_description(&description);
     }
     let new_commit = commit_builder.write(tx.repo_mut()).await?;

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -308,7 +308,7 @@ pub(crate) async fn cmd_split(
         // logic.
         let description = if !description.is_empty() || use_editor {
             commit_builder.set_description(description);
-            add_trailers(ui, &tx, &commit_builder)?
+            add_trailers(ui, &tx, &commit_builder).await?
         } else {
             description
         };
@@ -375,7 +375,7 @@ pub(crate) async fn cmd_split(
             commit_builder.description().to_owned()
         };
         let description = if show_editor {
-            let new_description = add_trailers(ui, &tx, &commit_builder)?;
+            let new_description = add_trailers(ui, &tx, &commit_builder).await?;
             commit_builder.set_description(new_description);
             let temp_commit = commit_builder.write_hidden().await?;
             let intro = "Enter a description for the remaining changes.";

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -344,7 +344,7 @@ pub(crate) async fn cmd_squash(
                 description
             } else {
                 commit_builder.set_description(&description);
-                let description_with_trailers = add_trailers(ui, &tx, &commit_builder)?;
+                let description_with_trailers = add_trailers(ui, &tx, &commit_builder).await?;
                 if args.editor {
                     commit_builder.set_description(&description_with_trailers);
                     let temp_commit = commit_builder.write_hidden().await?;
@@ -364,7 +364,8 @@ pub(crate) async fn cmd_squash(
                 abandoned_commits,
                 (!insert_destination_commit).then_some(&destination),
                 &commit_builder,
-            )?;
+            )
+            .await?;
             // It's weird that commit.description() contains "JJ: " lines, but works.
             commit_builder.set_description(combined);
             let temp_commit = commit_builder.write_hidden().await?;

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -212,7 +212,7 @@ pub async fn cmd_workspace_add(
         // can be discarded as soon as it's no longer the working copy. Adding a
         // trailer to an empty description would break that logic.
         commit_builder.set_description(description);
-        description = add_trailers(ui, &tx, &commit_builder)?;
+        description = add_trailers(ui, &tx, &commit_builder).await?;
     }
     commit_builder.set_description(&description);
     let new_wc_commit = commit_builder.write(tx.repo_mut()).await?;

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -21,7 +21,6 @@ use jj_lib::file_util::PathError;
 use jj_lib::settings::UserSettings;
 use jj_lib::trailer::parse_description_trailers;
 use jj_lib::trailer::parse_trailers;
-use pollster::FutureExt as _;
 use thiserror::Error;
 
 use crate::cli_util::WorkspaceCommandTransaction;
@@ -321,9 +320,9 @@ pub fn try_combine_messages(sources: &[Commit], destination: &Commit) -> Option<
 ///
 /// This includes empty descriptins too, so the user doesn't have to wonder why
 /// they only see 2 descriptions when they combined 3 commits.
-pub fn combine_messages_for_editing(
+pub async fn combine_messages_for_editing(
     ui: &Ui,
-    tx: &WorkspaceCommandTransaction,
+    tx: &WorkspaceCommandTransaction<'_>,
     sources: &[Commit],
     destination: Option<&Commit>,
     commit_builder: &DetachedCommitBuilder,
@@ -345,7 +344,7 @@ pub fn combine_messages_for_editing(
             .chain(destination)
             .flat_map(|commit| parse_description_trailers(commit.description()))
             .collect();
-        let commit = commit_builder.write_hidden().block_on()?;
+        let commit = commit_builder.write_hidden().await?;
         let trailer_lines = template
             .format_plain_text(&commit)
             .into_string()
@@ -427,13 +426,13 @@ pub fn add_trailers_with_template(
 /// the description
 ///
 /// It just lets the description untouched if the trailers are already there.
-pub fn add_trailers(
+pub async fn add_trailers(
     ui: &Ui,
-    tx: &WorkspaceCommandTransaction,
+    tx: &WorkspaceCommandTransaction<'_>,
     commit_builder: &DetachedCommitBuilder,
 ) -> Result<String, CommandError> {
     if let Some(renderer) = parse_trailers_template(ui, tx)? {
-        let commit = commit_builder.write_hidden().block_on()?;
+        let commit = commit_builder.write_hidden().await?;
         add_trailers_with_template(&renderer, &commit)
     } else {
         Ok(commit_builder.description().to_owned())


### PR DESCRIPTION
Assisted-by: Opus 4.6 via Claude Code

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
