### PR TITLE
lib: make a few more functions async

### DIFF
--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -177,7 +177,7 @@ pub async fn show_op_diff(
     with_content_format: &LogContentFormat,
     diff_renderer: Option<&DiffRenderer<'_>>,
 ) -> Result<(), CommandError> {
-    let changes = compute_operation_commits_diff(current_repo, from_repo, to_repo)?;
+    let changes = compute_operation_commits_diff(current_repo, from_repo, to_repo).await?;
     if !changes.is_empty() {
         let revset =
             RevsetExpression::commits(changes.keys().cloned().collect()).evaluate(current_repo)?;
@@ -528,7 +528,7 @@ impl ModifiedChange {
 /// Returns a map of [`ModifiedChange`]s containing the new and old commits. For
 /// created/rewritten commits, the map entries are indexed by new ids. For
 /// abandoned commits, the entries are indexed by old ids.
-fn compute_operation_commits_diff(
+async fn compute_operation_commits_diff(
     repo: &dyn Repo,
     from_repo: &ReadonlyRepo,
     to_repo: &ReadonlyRepo,
@@ -542,7 +542,8 @@ fn compute_operation_commits_diff(
     let predecessor_commits = accumulate_predecessors(
         slice::from_ref(to_repo.operation()),
         slice::from_ref(from_repo.operation()),
-    )?;
+    )
+    .await?;
 
     // Collect hidden commits to find abandoned/rewritten changes.
     let mut hidden_commits_by_change: HashMap<ChangeId, CommitId> = HashMap::new();

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -77,6 +77,7 @@ use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::rewrite::rebase_to_dest_parent;
 use jj_lib::settings::UserSettings;
 use jj_lib::store::Store;
+use pollster::FutureExt as _;
 use thiserror::Error;
 use tracing::instrument;
 use unicode_width::UnicodeWidthStr as _;
@@ -1311,7 +1312,7 @@ fn diff_content_with<T>(
             contents: map_resolved(format!("Access denied: {err}").into()),
         }),
         MaterializedTreeValue::File(mut file) => {
-            file_content_for_diff(path, &mut file, map_resolved)
+            file_content_for_diff(path, &mut file, map_resolved).block_on()
         }
         MaterializedTreeValue::Symlink { id: _, target } => Ok(FileContent {
             // Unix file paths can't contain null bytes.
@@ -1719,8 +1720,8 @@ pub async fn show_git_diff(
         let right_path_string = right_path.as_internal_file_string();
         let values = values?;
 
-        let left_part = git_diff_part(left_path, values.before, &materialize_options)?;
-        let right_part = git_diff_part(right_path, values.after, &materialize_options)?;
+        let left_part = git_diff_part(left_path, values.before, &materialize_options).await?;
+        let right_part = git_diff_part(right_path, values.after, &materialize_options).await?;
 
         {
             let mut formatter = formatter.labeled("file_header");

--- a/lib/src/diff_presentation/mod.rs
+++ b/lib/src/diff_presentation/mod.rs
@@ -21,7 +21,6 @@ use std::mem;
 
 use bstr::BString;
 use itertools::Itertools as _;
-use pollster::FutureExt as _;
 
 use crate::backend::BackendResult;
 use crate::conflicts::MaterializedFileValue;
@@ -54,7 +53,7 @@ pub struct FileContent<T> {
     pub contents: T,
 }
 
-pub fn file_content_for_diff<T>(
+pub async fn file_content_for_diff<T>(
     path: &RepoPath,
     file: &mut MaterializedFileValue,
     map_resolved: impl FnOnce(BString) -> T,
@@ -66,7 +65,7 @@ pub fn file_content_for_diff<T>(
     // TODO: currently we look at the whole file, even though for binary files we
     // only need to know the file size. To change that we'd have to extend all
     // the data backends to support getting the length.
-    let contents = BString::new(file.read_all(path).block_on()?);
+    let contents = BString::new(file.read_all(path).await?);
     let start = &contents[..PEEK_SIZE.min(contents.len())];
     Ok(FileContent {
         is_binary: start.contains(&b'\0'),

--- a/lib/src/diff_presentation/unified.rs
+++ b/lib/src/diff_presentation/unified.rs
@@ -56,7 +56,7 @@ pub enum UnifiedDiffError {
     },
 }
 
-pub fn git_diff_part(
+pub async fn git_diff_part(
     path: &RepoPath,
     value: MaterializedTreeValue,
     materialize_options: &ConflictMaterializeOptions,
@@ -85,7 +85,7 @@ pub fn git_diff_part(
         MaterializedTreeValue::File(mut file) => {
             mode = if file.executable { "100755" } else { "100644" };
             hash = file.id.hex();
-            content = file_content_for_diff(path, &mut file, |content| content)?;
+            content = file_content_for_diff(path, &mut file, |content| content).await?;
         }
         MaterializedTreeValue::Symlink { id, target } => {
             mode = "120000";

--- a/lib/src/evolution.rs
+++ b/lib/src/evolution.rs
@@ -264,7 +264,7 @@ where
 /// between `old_ops` and `new_ops`. If `old_ops` and `new_ops` have ancestors
 /// and descendants each other, or if criss-crossed merges exist between these
 /// operations, the returned mapping would be lossy.
-pub fn accumulate_predecessors(
+pub async fn accumulate_predecessors(
     new_ops: &[Operation],
     old_ops: &[Operation],
 ) -> Result<BTreeMap<CommitId, Vec<CommitId>>, WalkPredecessorsError> {
@@ -287,13 +287,13 @@ pub fn accumulate_predecessors(
     // BTreeMap to stabilize order of the reversed edges.
     let mut accumulated = BTreeMap::new();
     let reverse_ops = op_walk::walk_ancestors_range(old_ops, new_ops);
-    if !try_collect_predecessors_into(&mut accumulated, reverse_ops)? {
+    if !try_collect_predecessors_into(&mut accumulated, reverse_ops).await? {
         return Ok(BTreeMap::new());
     }
     let mut accumulated = reverse_edges(accumulated);
     // Follow forward edges from new_ops to the common ancestor.
     let forward_ops = op_walk::walk_ancestors_range(new_ops, old_ops);
-    if !try_collect_predecessors_into(&mut accumulated, forward_ops)? {
+    if !try_collect_predecessors_into(&mut accumulated, forward_ops).await? {
         return Ok(BTreeMap::new());
     }
     let new_commit_ids = new_ops
@@ -304,12 +304,12 @@ pub fn accumulate_predecessors(
         .map_err(|id| WalkPredecessorsError::CycleDetected(id.clone()))
 }
 
-fn try_collect_predecessors_into(
+async fn try_collect_predecessors_into(
     collected: &mut BTreeMap<CommitId, Vec<CommitId>>,
     ops: impl Stream<Item = OpStoreResult<Operation>>,
 ) -> OpStoreResult<bool> {
     let mut ops = pin!(ops);
-    while let Some(op) = ops.next().block_on() {
+    while let Some(op) = ops.next().await {
         let op = op?;
         let Some(map) = &op.store_operation().commit_predecessors else {
             return Ok(false);

--- a/lib/tests/test_evolution_predecessors.rs
+++ b/lib/tests/test_evolution_predecessors.rs
@@ -541,9 +541,13 @@ fn test_accumulate_predecessors() {
     let repo_d = tx.commit("d").block_on().unwrap();
 
     // Empty old/new ops
-    let predecessors = accumulate_predecessors(&[], slice::from_ref(repo_c.operation())).unwrap();
+    let predecessors = accumulate_predecessors(&[], slice::from_ref(repo_c.operation()))
+        .block_on()
+        .unwrap();
     assert!(predecessors.is_empty());
-    let predecessors = accumulate_predecessors(slice::from_ref(repo_c.operation()), &[]).unwrap();
+    let predecessors = accumulate_predecessors(slice::from_ref(repo_c.operation()), &[])
+        .block_on()
+        .unwrap();
     assert!(predecessors.is_empty());
 
     // Empty range
@@ -551,6 +555,7 @@ fn test_accumulate_predecessors() {
         slice::from_ref(repo_c.operation()),
         slice::from_ref(repo_c.operation()),
     )
+    .block_on()
     .unwrap();
     assert!(predecessors.is_empty());
 
@@ -559,6 +564,7 @@ fn test_accumulate_predecessors() {
         slice::from_ref(repo_c.operation()),
         slice::from_ref(repo_b.operation()),
     )
+    .block_on()
     .unwrap();
     assert_eq!(
         predecessors,
@@ -574,6 +580,7 @@ fn test_accumulate_predecessors() {
         slice::from_ref(repo_c.operation()),
         slice::from_ref(repo_a.operation()),
     )
+    .block_on()
     .unwrap();
     assert_eq!(
         predecessors,
@@ -591,6 +598,7 @@ fn test_accumulate_predecessors() {
         slice::from_ref(repo_a.operation()),
         slice::from_ref(repo_c.operation()),
     )
+    .block_on()
     .unwrap();
     assert_eq!(
         predecessors,
@@ -609,6 +617,7 @@ fn test_accumulate_predecessors() {
         slice::from_ref(repo_d.operation()),
         slice::from_ref(repo_c.operation()),
     )
+    .block_on()
     .unwrap();
     assert_eq!(
         predecessors,


### PR DESCRIPTION
This allows us to get rid of two more `block_on()` calls.

Assisted-by: Opus 4.6 via Claude Code

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
