### PR TITLE
template: add `env()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   changes/conflicts are propagated accordingly, e.g., `jj run -- cargo check
   --all-features` or `jj run -- cargo fix` behaves as one might expect.
 
+* Add `env(name)` template function that looks up the value of a given
+  environment variable.
+
 ### Fixed bugs
 
 * `jj` now creates a new working-copy revision during snapshotting if the

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1066,6 +1066,7 @@ impl WorkspaceCommandEnvironment {
             repo,
             &self.path_converter,
             &self.workspace_name,
+            self.env_vars(),
             self.revset_parse_context(),
             id_prefix_context,
             self.immutable_expression(),
@@ -1076,6 +1077,10 @@ impl WorkspaceCommandEnvironment {
 
     pub fn operation_template_extensions(&self) -> &[Arc<dyn OperationTemplateLanguageExtension>] {
         &self.command.data.operation_template_extensions
+    }
+
+    pub(crate) fn env_vars(&self) -> &HashMap<String, String> {
+        self.command.config_env().env_vars()
     }
 }
 
@@ -1884,6 +1889,7 @@ to the current parents may contain changes from multiple commits.
         OperationTemplateLanguage::new(
             self.workspace.repo_loader(),
             Some(self.repo().op_id()),
+            self.env.env_vars(),
             self.env.operation_template_extensions(),
         )
     }

--- a/cli/src/commands/config/list.rs
+++ b/cli/src/commands/config/list.rs
@@ -15,7 +15,6 @@
 use clap_complete::ArgValueCandidates;
 use jj_lib::config::ConfigNamePathBuf;
 use jj_lib::config::ConfigSource;
-use jj_lib::settings::UserSettings;
 use tracing::instrument;
 
 use super::ConfigLevelArgs;
@@ -81,7 +80,7 @@ pub async fn cmd_config_list(
     args: &ConfigListArgs,
 ) -> Result<(), CommandError> {
     let template: TemplateRenderer<AnnotatedValue> = {
-        let language = config_template_language(command.settings());
+        let language = config_template_language(command);
         let text = match &args.template {
             Some(value) => value.to_owned(),
             None => command.settings().get_string("templates.config_list")?,
@@ -128,8 +127,9 @@ generic_templater::impl_self_property_wrapper!(AnnotatedValue);
 
 // AnnotatedValue will be cloned internally in the templater. If the cloning
 // cost matters, wrap it with Rc.
-fn config_template_language(settings: &UserSettings) -> ConfigTemplateLanguage {
-    let mut language = ConfigTemplateLanguage::new(settings);
+fn config_template_language(command: &CommandHelper) -> ConfigTemplateLanguage {
+    let mut language =
+        ConfigTemplateLanguage::new(command.config_env().env_vars(), command.settings());
     language.add_keyword("name", |self_property| {
         let out_property = self_property.map(|annotated| annotated.name.to_string());
         Ok(out_property.into_dyn_wrapped())

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -143,6 +143,7 @@ async fn do_op_log(
         let language = OperationTemplateLanguage::new(
             repo_loader,
             Some(current_op.id()),
+            workspace_env.env_vars(),
             workspace_env.operation_template_extensions(),
         );
         let text = match &args.template {

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -138,6 +138,7 @@ pub struct CommitTemplateLanguage<'repo> {
     repo: &'repo dyn Repo,
     path_converter: &'repo RepoPathUiConverter,
     workspace_name: WorkspaceNameBuf,
+    env_vars: &'repo HashMap<String, String>,
     // RevsetParseContext doesn't borrow a repo, but we'll need 'repo lifetime
     // anyway to capture it to evaluate dynamically-constructed user expression
     // such as `revset("ancestors(" ++ commit_id ++ ")")`.
@@ -162,6 +163,7 @@ impl<'repo> CommitTemplateLanguage<'repo> {
         repo: &'repo dyn Repo,
         path_converter: &'repo RepoPathUiConverter,
         workspace_name: &WorkspaceName,
+        env_vars: &'repo HashMap<String, String>,
         revset_parse_context: RevsetParseContext<'repo>,
         id_prefix_context: &'repo IdPrefixContext,
         immutable_expression: Arc<UserRevsetExpression>,
@@ -182,6 +184,7 @@ impl<'repo> CommitTemplateLanguage<'repo> {
             repo,
             path_converter,
             workspace_name: workspace_name.to_owned(),
+            env_vars,
             revset_parse_context,
             id_prefix_context,
             immutable_expression,
@@ -202,6 +205,10 @@ impl<'repo> CommitTemplateLanguage<'repo> {
 
 impl<'repo> TemplateLanguage<'repo> for CommitTemplateLanguage<'repo> {
     type Property = CommitTemplatePropertyKind<'repo>;
+
+    fn env_vars(&self) -> &HashMap<String, String> {
+        self.env_vars
+    }
 
     fn settings(&self) -> &UserSettings {
         self.repo.base_repo().settings()
@@ -3048,6 +3055,7 @@ mod tests {
         revset_aliases_map: RevsetAliasesMap,
         template_aliases_map: TemplateAliasesMap,
         immutable_expression: Arc<UserRevsetExpression>,
+        env_vars: HashMap<String, String>,
         extra_functions: HashMap<&'static str, BuildFunctionFn>,
     }
 
@@ -3072,6 +3080,7 @@ mod tests {
                 revset_aliases_map: RevsetAliasesMap::new(),
                 template_aliases_map: TemplateAliasesMap::new(),
                 immutable_expression: RevsetExpression::none(),
+                env_vars: HashMap::new(),
                 extra_functions: HashMap::new(),
             }
         }
@@ -3105,6 +3114,7 @@ mod tests {
                 self.test_workspace.repo.as_ref(),
                 &self.path_converter,
                 self.test_workspace.workspace.workspace_name(),
+                &self.env_vars,
                 revset_parse_context,
                 &self.id_prefix_context,
                 self.immutable_expression.clone(),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -444,6 +444,10 @@ impl ConfigEnv {
             .map(ConfigPath::as_path)
     }
 
+    pub fn env_vars(&self) -> &HashMap<String, String> {
+        &self.environment
+    }
+
     fn load_secure_config(
         &self,
         ui: &Ui,

--- a/cli/src/generic_templater.rs
+++ b/cli/src/generic_templater.rs
@@ -43,6 +43,7 @@ use crate::templater::TemplatePropertyExt as _;
 /// registered to extract properties from the self object.
 pub struct GenericTemplateLanguage<'a, C> {
     settings: UserSettings,
+    env_vars: HashMap<String, String>,
     build_fn_table: GenericTemplateBuildFnTable<'a, C>,
 }
 
@@ -53,18 +54,20 @@ where
     /// Sets up environment with no keywords.
     ///
     /// New keyword functions can be registered by `add_keyword()`.
-    pub fn new(settings: &UserSettings) -> Self {
-        Self::with_keywords(HashMap::new(), settings)
+    pub fn new(env_vars: &HashMap<String, String>, settings: &UserSettings) -> Self {
+        Self::with_keywords(HashMap::new(), env_vars, settings)
     }
 
     /// Sets up environment with the given `keywords` table.
     pub fn with_keywords(
         keywords: GenericTemplateBuildKeywordFnMap<'a, C>,
+        env_vars: &HashMap<String, String>,
         settings: &UserSettings,
     ) -> Self {
         Self {
             // Clone settings to keep lifetime simple. It's cheap.
             settings: settings.clone(),
+            env_vars: env_vars.clone(),
             build_fn_table: GenericTemplateBuildFnTable {
                 core: CoreTemplateBuildFnTable::builtin(),
                 keywords,
@@ -100,6 +103,10 @@ where
     C: serde::Serialize + 'a,
 {
     type Property = GenericTemplatePropertyKind<'a, C>;
+
+    fn env_vars(&self) -> &HashMap<String, String> {
+        &self.env_vars
+    }
 
     fn settings(&self) -> &UserSettings {
         &self.settings

--- a/cli/src/operation_templater.rs
+++ b/cli/src/operation_templater.rs
@@ -67,6 +67,7 @@ pub trait OperationTemplateEnvironment {
 pub struct OperationTemplateLanguage {
     repo_loader: RepoLoader,
     current_op_id: Option<OperationId>,
+    env_vars: HashMap<String, String>,
     build_fn_table: OperationTemplateLanguageBuildFnTable,
     cache_extensions: ExtensionsMap,
 }
@@ -77,6 +78,7 @@ impl OperationTemplateLanguage {
     pub fn new(
         repo_loader: &RepoLoader,
         current_op_id: Option<&OperationId>,
+        env_vars: &HashMap<String, String>,
         extensions: &[impl AsRef<dyn OperationTemplateLanguageExtension>],
     ) -> Self {
         let mut build_fn_table = OperationTemplateLanguageBuildFnTable::builtin();
@@ -93,6 +95,7 @@ impl OperationTemplateLanguage {
             // Clone these to keep lifetime simple
             repo_loader: repo_loader.clone(),
             current_op_id: current_op_id.cloned(),
+            env_vars: env_vars.clone(),
             build_fn_table,
             cache_extensions,
         }
@@ -101,6 +104,10 @@ impl OperationTemplateLanguage {
 
 impl TemplateLanguage<'static> for OperationTemplateLanguage {
     type Property = OperationTemplateLanguagePropertyKind;
+
+    fn env_vars(&self) -> &HashMap<String, String> {
+        &self.env_vars
+    }
 
     fn settings(&self) -> &UserSettings {
         self.repo_loader.settings()

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -2602,6 +2602,14 @@ fn builtin_functions<'a, L: TemplateLanguage<'a> + ?Sized>() -> TemplateBuildFun
             Ok(out_property.into_dyn_wrapped())
         }
     });
+    map.insert("env", |language, diagnostics, _build_ctx, function| {
+        let [name_node] = function.expect_exact_arguments()?;
+        let name = template_parser::catch_aliases(diagnostics, name_node, |_diagnostics, node| {
+            template_parser::expect_string_literal(node)
+        })?;
+        let out_property = language.env_vars().get(name).cloned().unwrap_or_default();
+        Ok(Literal(out_property).into_dyn_wrapped())
+    });
     map
 }
 
@@ -5663,6 +5671,24 @@ mod tests {
         // dynamic lookup where name expression itself fails at runtime
         env.add_keyword("bad_string", || new_error_property::<String>("Bad"));
         insta::assert_snapshot!(env.render_ok(r#"config(bad_string)"#), @"<Error: Bad>");
+    }
+
+    #[test]
+    fn test_env_function() {
+        let env_vars = HashMap::from([
+            ("JJ_TEMPLATE_ENV".to_owned(), "template-value".to_owned()),
+            ("JJ_EMPTY_ENV".to_owned(), "".to_owned()),
+        ]);
+        let env =
+            TestTemplateEnv::with_config_and_env_vars(StackedConfig::with_defaults(), env_vars);
+
+        insta::assert_snapshot!(env.render_ok(r#"env("JJ_TEMPLATE_ENV")"#), @"template-value");
+        insta::assert_snapshot!(env.render_ok(r#"env("JJ_EMPTY_ENV")"#), @"");
+        insta::assert_snapshot!(env.render_ok(r#"env("JJ_MISSING_ENV")"#), @"");
+        insta::assert_snapshot!(
+            env.render_ok(r#"if(env("JJ_EMPTY_ENV"), "yes", "no")"#),
+            @"no"
+        );
     }
 
     #[test]

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -89,6 +89,8 @@ use crate::time_util;
 pub trait TemplateLanguage<'a> {
     type Property: CoreTemplatePropertyVar<'a> + 'a;
 
+    fn env_vars(&self) -> &HashMap<String, String>;
+
     fn settings(&self) -> &UserSettings;
 
     /// Translates the given global `function` call to a property.
@@ -3036,6 +3038,8 @@ mod tests {
     /// Helper to set up template evaluation environment.
     struct TestTemplateEnv {
         language: TestTemplateLanguage,
+        #[allow(unused)]
+        env_vars: HashMap<String, String>,
         aliases_map: TemplateAliasesMap,
         color_rules: Vec<(Vec<String>, formatter::Style)>,
     }
@@ -3046,9 +3050,17 @@ mod tests {
         }
 
         fn with_config(config: StackedConfig) -> Self {
+            Self::with_config_and_env_vars(config, HashMap::new())
+        }
+
+        fn with_config_and_env_vars(
+            config: StackedConfig,
+            env_vars: HashMap<String, String>,
+        ) -> Self {
             let settings = UserSettings::from_config(config).unwrap();
             Self {
-                language: TestTemplateLanguage::new(&settings),
+                language: TestTemplateLanguage::new(&env_vars, &settings),
+                env_vars,
                 aliases_map: TemplateAliasesMap::new(),
                 color_rules: Vec::new(),
             }

--- a/cli/tests/test_templater.rs
+++ b/cli/tests/test_templater.rs
@@ -511,6 +511,28 @@ fn test_templater_config_function() {
     insta::assert_snapshot!(render("config('unknown')"), @"");
 }
 
+#[test]
+fn test_templater_env_function() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let render = |template| get_template_output(&work_dir, "@-", template);
+    insta::assert_snapshot!(render("env('JJ_TEMPLATE_ENV')"), @"");
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "log",
+            "--no-graph",
+            "-r",
+            "@-",
+            "-T",
+            "env('JJ_TEMPLATE_ENV')",
+        ])
+        .env("JJ_TEMPLATE_ENV", "template-env-value")
+    });
+    insta::assert_snapshot!(output, @"template-env-value[EOF]");
+}
+
 #[must_use]
 fn get_template_output(work_dir: &TestWorkDir, rev: &str, template: &str) -> CommandOutput {
     work_dir.run_jj(["log", "--no-graph", "-r", rev, "-T", template])

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -134,6 +134,8 @@ The following functions are defined.
 * `git_web_url([remote: String]) -> String`: Best-effort conversion of a git
   remote URL to an HTTPS web URL. Defaults to the "origin" remote. Returns an
   empty string on failure. SSH host alias resolution is currently unsupported.
+* `env(name: StringLiteral) -> String`:
+  Look up the value of a given environment variable by `name`.
 
 ## Types
 


### PR DESCRIPTION
Relates to #5571

**STATUS** (Jun 2026): The core functionality of this PR is complete, but there is an unresolved issue regarding the introduction of `Option<String>`, see comments below. Given that `env()` is not an urgent feature, further progress is currently on hold pending additional discussion.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
