### PR TITLE
tests: improve coverage for `jj bookmark rename --overwrite-existing`

### DIFF
--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -639,25 +639,6 @@ fn test_bookmark_rename() {
     [exit status: 1]
     ");
 
-    // Rename to the same name with --overwrite-existing is a noop
-    let output = work_dir.run_jj([
-        "bookmark",
-        "rename",
-        "--overwrite-existing",
-        "blocal1",
-        "blocal1",
-    ]);
-    insta::assert_snapshot!(output, @"");
-
-    let output = work_dir.run_jj([
-        "bookmark",
-        "rename",
-        "--overwrite-existing",
-        "blocal1",
-        "bexist",
-    ]);
-    insta::assert_snapshot!(output, @"");
-
     work_dir.run_jj(["new"]).success();
     work_dir.run_jj(["describe", "-m=commit-2"]).success();
     work_dir
@@ -689,7 +670,7 @@ fn test_bookmark_rename() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Changes to push to origin:
-      Add bookmark bremote2 to 79b00f5a00d0
+      Add bookmark bremote2 to 1e76d54fcfce
     [EOF]
     ");
     work_dir
@@ -708,80 +689,7 @@ fn test_bookmark_rename() {
     [EOF]
     ");
 
-    // overwrite-existing where the overwritten bookmark has a present+tracked
-    // remote: the tracked state should be dropped and local should move.
-    work_dir
-        .run_jj(["op", "restore", &op_id_after_rename])
-        .success();
-    work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["describe", "-m=commit-3"]).success();
-    work_dir
-        .run_jj(["bookmark", "create", "boverwrite"])
-        .success();
-    work_dir
-        .run_jj(["git", "push", "--allow-new", "-b=boverwrite"])
-        .success();
-    // Now rename bremote2 -> boverwrite with --overwrite-existing.
-    // boverwrite@origin was tracked; after overwrite it should be untracked
-    // and the local should point to bremote2's target (commit-2).
-    let output = work_dir.run_jj([
-        "bookmark",
-        "rename",
-        "--overwrite-existing",
-        "bremote2",
-        "boverwrite",
-    ]);
-    insta::assert_snapshot!(output, @"
-    ------- stderr -------
-    Warning: The renamed bookmark already exists on the remote 'origin', tracking state was dropped.
-    Hint: To track the existing remote bookmark, run `jj bookmark track boverwrite --remote=origin`
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: qwyusntz f5374493 (empty) (no description set)
-    Parent commit (@-)      : uuuvxpvw 95cd2f9e boverwrite@origin | (empty) commit-3
-    [EOF]
-    ");
-    let output = work_dir.run_jj(["bookmark", "list", "--all", "boverwrite"]);
-    insta::assert_snapshot!(output, @"
-    boverwrite: lylxulpl 79b00f5a (empty) commit-2
-    boverwrite@origin: uuuvxpvw 95cd2f9e (empty) commit-3
-    [EOF]
-    ");
-
-    // overwrite-existing where old bookmark has no tracked remote on the same
-    // remote as the overwritten bookmark: should warn about dropped tracking.
-    work_dir
-        .run_jj(["op", "restore", &op_id_after_rename])
-        .success();
-    work_dir.run_jj(["new"]).success();
-    work_dir.run_jj(["describe", "-m=commit-3"]).success();
-    work_dir.run_jj(["bookmark", "create", "bpushed"]).success();
-    work_dir
-        .run_jj(["git", "push", "--allow-new", "-b=bpushed"])
-        .success();
-    // blocal1 was renamed from blocal and has no tracked remotes.
-    // Renaming blocal1 -> bpushed should warn that bpushed@origin tracking was
-    // dropped since blocal1 wasn't tracked on origin.
-    let output = work_dir.run_jj([
-        "bookmark",
-        "rename",
-        "--overwrite-existing",
-        "bexist",
-        "bpushed",
-    ]);
-    insta::assert_snapshot!(output, @"
-    ------- stderr -------
-    Warning: Tracking of remote bookmark bpushed@origin was dropped.
-    Hint: Use `jj bookmark track` to re-track if needed.
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: zkyosouw b7492c1d (empty) (no description set)
-    Parent commit (@-)      : soqnvnyz 0e52e7ce bpushed@origin | (empty) commit-3
-    [EOF]
-    ");
-
     // rename an untracked bookmark
-    work_dir
-        .run_jj(["op", "restore", &op_id_after_rename])
-        .success();
     work_dir
         .run_jj(["bookmark", "untrack", "buntracked"])
         .success();


### PR DESCRIPTION
Coverage indicated some missing cases with the new `jj bookmark rename --overwrite-existing` flag introduced with #8938.

The only way I could really convince myself it was all working correctly was to reproduce [this table](https://github.com/jj-vcs/jj/pull/8938#issuecomment-3940877602).  Turns out I also needed to differentiate between present and absent old bookmarks to get full coverage.

With a separate comprehensive test in place, I partially reverted the `--overwrite-existing` tests added with #8938.

Suggestions welcome.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
