### PR TITLE
merge: use `Merge::into_map` in more places to avoid clones

### DIFF
--- a/cli/src/merge_tools/builtin.rs
+++ b/cli/src/merge_tools/builtin.rs
@@ -1211,16 +1211,16 @@ mod tests {
             .block_on()
             .unwrap();
 
-        let actual_copy_ids = tree
-            .path_value(file_path)
-            .block_on()
-            .unwrap()
-            .map(|tree_value| {
-                let Some(TreeValue::File { copy_id, .. }) = tree_value else {
-                    panic!("The path should point to an existing file.");
-                };
-                copy_id.clone()
-            });
+        let actual_copy_ids =
+            tree.path_value(file_path)
+                .block_on()
+                .unwrap()
+                .into_map(|tree_value| {
+                    let Some(TreeValue::File { copy_id, .. }) = tree_value else {
+                        panic!("The path should point to an existing file.");
+                    };
+                    copy_id
+                });
         assert_eq!(
             actual_copy_ids.resolve_trivial(SameChange::Accept),
             Some(&new_copy_id),

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -363,10 +363,7 @@ impl MergedTree {
                 .map(|&label| label.to_owned()),
         );
         let flattened_tree_ids: Merge<TreeId> = merge
-            .into_iter()
-            .map(|(tree, _label)| tree.into_tree_ids())
-            .collect::<MergeBuilder<_>>()
-            .build()
+            .into_map(|(tree, _label)| tree.into_tree_ids())
             .flatten();
 
         let (labels, tree_ids) = flattened_labels.simplify_with(&flattened_tree_ids);

--- a/lib/src/merged_tree_builder.rs
+++ b/lib/src/merged_tree_builder.rs
@@ -92,7 +92,7 @@ impl MergedTreeBuilder {
         base_tree_ids.pad_to(num_sides, store.empty_tree_id());
         // Create a single-tree builder for each base tree
         let mut tree_builders =
-            base_tree_ids.map(|base_tree_id| TreeBuilder::new(store.clone(), base_tree_id.clone()));
+            base_tree_ids.into_map(|base_tree_id| TreeBuilder::new(store.clone(), base_tree_id));
         for (path, values) in self.overrides {
             match values.into_resolved() {
                 Ok(value) => {


### PR DESCRIPTION
Previously, it was necessary to use `into_iter()` and `MergeBuilder` to avoid clones when mapping, but the new `into_map()` function makes that unnecessary, so we can avoid clones in more places.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
