### PR TITLE
revset: remove unneeded lifetime bounds from RevsetIteratorExt

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3484,14 +3484,14 @@ pub trait RevsetIteratorExt {
     fn commits(
         self,
         store: &Arc<Store>,
-    ) -> impl Iterator<Item = Result<Commit, RevsetEvaluationError>> + use<'_, Self>;
+    ) -> impl Iterator<Item = Result<Commit, RevsetEvaluationError>> + use<Self>;
 }
 
 impl<I: Iterator<Item = Result<CommitId, RevsetEvaluationError>>> RevsetIteratorExt for I {
     fn commits(
         self,
         store: &Arc<Store>,
-    ) -> impl Iterator<Item = Result<Commit, RevsetEvaluationError>> + use<'_, I> {
+    ) -> impl Iterator<Item = Result<Commit, RevsetEvaluationError>> + use<I> {
         let store = store.clone();
         self.map(move |result| {
             let commit_id = result?;


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
