### PR TITLE
proc-macros: use re-exported DigestUpdate in ContentHash derive output

### DIFF
--- a/lib/proc-macros/src/lib.rs
+++ b/lib/proc-macros/src/lib.rs
@@ -29,7 +29,7 @@ pub fn derive_content_hash(input: proc_macro::TokenStream) -> proc_macro::TokenS
         #[automatically_derived]
         impl #impl_generics ::jj_lib::content_hash::ContentHash for #name #ty_generics
         #where_clause {
-            fn hash(&self, state: &mut impl digest::Update) {
+            fn hash(&self, state: &mut impl ::jj_lib::content_hash::DigestUpdate) {
                 #hash_impl
             }
         }


### PR DESCRIPTION
Before this commit, external crates trying to use
`#[derive(ContentHash)]` need to explicitly depend on the `digest` crate
because the proc-macro refers to `digest::Update`.

https://github.com/jj-vcs/jj/commit/965d6ce4e40e5b2cd47cac99b7c55e79902c3ee6 intended to prevent this inconvenience by introducing a
`jj_lib::content_hash::DigestUpdate` re-export, and it correctly used it
in the macro output. However, https://github.com/jj-vcs/jj/commit/8e1a6c708f07df77626cb8dcf870334f0d911465 ("Add support for generics to
#[derive(ContentHash)]") accidentally reverted it back to
`digest::Update` when rewriting the `quote!` block.

This is the fixup to https://github.com/jj-vcs/jj/commit/8e1a6c708f07df77626cb8dcf870334f0d911465 to make things work as originally
intended. Now, with just a `jj-lib` dependency, the following should
work:

```rust
use jj_lib::content_hash::ContentHash;

#[derive(ContentHash)]
struct Foo {
    x: u32,
    y: String,
}
```

-----

### Thoughts I'd leave outside the scope of this PR

We could have a regression test for this by creating a dummy crate that needs to compile. I can't decide whether it's worth it.

**Update:** Or we could import `digest` under a name like `digest-use-only-via-jj-lib-content-hash-reimport`, and change all users to use `::jj_lib::content_hash::digest`. Then, accidentally using `digest::Update` would become an error. (But probably not in this PR)

But this could be overkill, since nobody seemed to notice the problem for a year, and this proc-macro seems unlikely to be frequently updated. Cc @emesterhazy if you have thoughts.

# Checklist

If applicable:

- (n/a) I have updated `CHANGELOG.md`
- (n/a) I have updated the documentation (`README.md`, `docs/`, `demos/`)
- n/a I have updated the config schema (`cli/src/config-schema.json`)
- [??] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
