### PR TITLE
cli: add `snapshot.derive-tracked-from-ignores` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,9 @@ None
   revisions by default (defined by `revsets.op-diff-changes-in`). A new flag,
   `--show-changes-in`, can be used to override this. [#6083](https://github.com/jj-vcs/jj/issues/6083)
 
+* New `snapshot.derive-tracked-from-ignores` option to treat ignoring/unignoring files
+  as deletes/adds, respectively.
+
 ### Fixed bugs
 
 * `.gitignore` with UTF-8 BOM can now be parsed correctly.

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1558,6 +1558,9 @@ to the current parents may contain changes from multiple commits.
             start_tracking_matcher,
             force_tracking_matcher: &NothingMatcher,
             max_new_file_size,
+            derive_tracked_from_ignores: self
+                .settings()
+                .get_bool("snapshot.derive-tracked-from-ignores")?,
         })
     }
 
@@ -3353,6 +3356,7 @@ impl DiffSelector {
         tree_labels: Diff<String>,
         matcher: &dyn Matcher,
         format_instructions: impl FnOnce() -> String,
+        derive_tracked_from_ignores: bool,
     ) -> Result<MergedTree, CommandError> {
         let selected_tree = restore_tree(
             trees.after,
@@ -3377,6 +3381,7 @@ impl DiffSelector {
                             Diff::new(trees.before, &selected_tree),
                             matcher,
                             format_instructions,
+                            derive_tracked_from_ignores,
                         )
                         .await?)
                 }

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -103,6 +103,9 @@ pub(crate) async fn cmd_commit(
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let text_editor = workspace_command.text_editor()?;
+    let derive_tracked_from_ignores = workspace_command
+        .settings()
+        .get_bool("snapshot.derive-tracked-from-ignores")?;
     let mut tx = workspace_command.start_transaction();
     let base_tree = commit.parent_tree(tx.repo()).await?;
     let format_instructions = || {
@@ -127,6 +130,7 @@ new working-copy commit.
             ),
             matcher.as_ref(),
             format_instructions,
+            derive_tracked_from_ignores,
         )
         .await?;
     if !args.paths.is_empty() && tree.tree_ids() == base_tree.tree_ids() {

--- a/cli/src/commands/diffedit.rs
+++ b/cli/src/commands/diffedit.rs
@@ -124,6 +124,9 @@ pub(crate) async fn cmd_diffedit(
         .await?;
 
     let diff_editor = workspace_command.diff_editor(ui, args.tool.as_deref())?;
+    let derive_tracked_from_ignores = workspace_command
+        .settings()
+        .get_bool("snapshot.derive-tracked-from-ignores")?;
     let mut tx = workspace_command.start_transaction();
     let format_instructions = || {
         format!(
@@ -140,7 +143,12 @@ don't make any changes, then the operation will be aborted.",
     let base_tree = merge_commit_trees(tx.repo(), base_commits.as_slice()).await?;
     let tree = target_commit.tree();
     let edited_tree = diff_editor
-        .edit(Diff::new(&base_tree, &tree), &matcher, format_instructions)
+        .edit(
+            Diff::new(&base_tree, &tree),
+            &matcher,
+            format_instructions,
+            derive_tracked_from_ignores,
+        )
         .await?;
     if edited_tree.tree_ids() == target_commit.tree_ids() {
         writeln!(ui.status(), "Nothing changed.")?;

--- a/cli/src/commands/file/track.rs
+++ b/cli/src/commands/file/track.rs
@@ -24,6 +24,7 @@ use crate::cli_util::CommandHelper;
 use crate::cli_util::print_large_file_hint;
 use crate::cli_util::print_untracked_files;
 use crate::command_error::CommandError;
+use crate::command_error::cli_error;
 use crate::ui::Ui;
 
 /// Start tracking specified paths in the working copy
@@ -63,6 +64,16 @@ pub(crate) async fn cmd_file_track(
         .to_matcher();
 
     let mut options = workspace_command.snapshot_options_with_start_tracking_matcher(&matcher)?;
+    if options.derive_tracked_from_ignores {
+        let mut err =
+            cli_error("Explicit track not allowed when `derive-tracked-from-ignores` is true");
+        err.extend_hints(Some(
+            "Edit `.gitignore` to not ignore the selected paths and they will be automatically \
+             tracked"
+                .to_string(),
+        ));
+        return Err(err);
+    }
     if args.include_ignored {
         options.force_tracking_matcher = &matcher;
     }

--- a/cli/src/commands/file/untrack.rs
+++ b/cli/src/commands/file/untrack.rs
@@ -25,6 +25,7 @@ use crate::cli_util::export_working_copy_changes_to_git;
 use crate::cli_util::print_snapshot_stats;
 use crate::cli_util::print_unmatched_explicit_paths;
 use crate::command_error::CommandError;
+use crate::command_error::cli_error;
 use crate::command_error::user_error;
 use crate::complete;
 use crate::ui::Ui;
@@ -53,7 +54,16 @@ pub(crate) async fn cmd_file_untrack(
     let auto_tracking_matcher = workspace_command.auto_tracking_matcher(ui)?;
     let options =
         workspace_command.snapshot_options_with_start_tracking_matcher(&auto_tracking_matcher)?;
-
+    if options.derive_tracked_from_ignores {
+        let mut err =
+            cli_error("Explicit untrack not allowed when `derive-tracked-from-ignores` is true");
+        err.extend_hints(Some(
+            "Edit `.gitignore` to ignore the selected paths and they will be automatically \
+             untracked"
+                .to_string(),
+        ));
+        return Err(err);
+    }
     let working_copy_shared_with_git = workspace_command.working_copy_shared_with_git();
 
     let mut tx = workspace_command.start_transaction().into_inner();

--- a/cli/src/commands/restore.rs
+++ b/cli/src/commands/restore.rs
@@ -158,6 +158,9 @@ pub(crate) async fn cmd_restore(
             to_commit = workspace_command.format_commit_summary(&to_commit),
         }
     };
+    let derive_tracked_from_ignores = workspace_command
+        .settings()
+        .get_bool("snapshot.derive-tracked-from-ignores")?;
     let new_tree = diff_selector
         .select(
             ui,
@@ -168,6 +171,7 @@ pub(crate) async fn cmd_restore(
             ),
             &matcher,
             format_instructions,
+            derive_tracked_from_ignores,
         )
         .await?;
 

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -287,10 +287,21 @@ pub(crate) async fn cmd_split(
         new_child_ids,
     } = args.resolve(ui, &workspace_command).await?;
     let text_editor = workspace_command.text_editor()?;
+    let derive_tracked_from_ignores = workspace_command
+        .settings()
+        .get_bool("snapshot.derive-tracked-from-ignores")?;
     let mut tx = workspace_command.start_transaction();
 
     // Prompt the user to select the changes they want for the first commit.
-    let target = select_diff(ui, &tx, &target_commit, &matcher, &diff_selector).await?;
+    let target = select_diff(
+        ui,
+        &tx,
+        &target_commit,
+        &matcher,
+        &diff_selector,
+        derive_tracked_from_ignores,
+    )
+    .await?;
 
     // Create the first commit, which includes the changes selected by the user.
     let first_commit = {
@@ -551,6 +562,7 @@ async fn select_diff(
     target_commit: &Commit,
     matcher: &dyn Matcher,
     diff_selector: &DiffSelector,
+    derive_tracked_from_ignores: bool,
 ) -> Result<CommitWithSelection, CommandError> {
     let format_instructions = || {
         format!(
@@ -577,6 +589,7 @@ The changes that are not selected will replace the original commit.
             ),
             matcher,
             format_instructions,
+            derive_tracked_from_ignores,
         )
         .await?;
     let selection = CommitWithSelection {

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -233,6 +233,9 @@ pub(crate) async fn cmd_squash(
     workspace_command
         .check_rewritable(sources.iter().chain(&pre_existing_destination).ids())
         .await?;
+    let derive_tracked_from_ignores = workspace_command
+        .settings()
+        .get_bool("snapshot.derive-tracked-from-ignores")?;
 
     // prepare the tx description before possibly rebasing the source commits
     let source_ids: Vec<_> = sources.iter().ids().collect();
@@ -317,8 +320,16 @@ pub(crate) async fn cmd_squash(
     let text_editor = tx.base_workspace_helper().text_editor()?;
     let squashed_description = SquashedDescription::from_args(args);
 
-    let source_commits =
-        select_diff(ui, &tx, &sources, &destination, &matcher, &diff_selector).await?;
+    let source_commits = select_diff(
+        ui,
+        &tx,
+        &sources,
+        &destination,
+        &matcher,
+        &diff_selector,
+        derive_tracked_from_ignores,
+    )
+    .await?;
 
     print_unmatched_explicit_paths(
         ui,
@@ -470,6 +481,7 @@ async fn select_diff(
     destination: &Commit,
     matcher: &dyn Matcher,
     diff_selector: &DiffSelector,
+    derive_tracked_from_ignores: bool,
 ) -> Result<Vec<CommitWithSelection>, CommandError> {
     let mut source_commits = vec![];
     for source in sources {
@@ -502,6 +514,7 @@ async fn select_diff(
                 ),
                 matcher,
                 format_instructions,
+                derive_tracked_from_ignores,
             )
             .await?;
         source_commits.push(CommitWithSelection {

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -857,6 +857,11 @@
                     ],
                     "description": "New files with a size in bytes above this threshold are not snapshotted, unless the threshold is 0",
                     "default": "1MiB"
+                },
+                "derive-tracked-from-ignores": {
+                    "type": "boolean",
+                    "description": "Track a file if and only if it is not ignored. If a file was previously tracked and then it gets ignored, this will cause the snapshot to see it as a delete.",
+                    "default": false
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -59,6 +59,7 @@ show-ruler = true
 max-new-file-size = "1MiB"
 auto-track = "all()"
 auto-update-stale = false
+derive-tracked-from-ignores = false
 
 # TODO: https://github.com/jj-vcs/jj/issues/3419 - Remove when fully deprecated.
 # The behavior when this flag is set to false is experimental and may be changed

--- a/cli/src/merge_tools/diff_working_copies.rs
+++ b/cli/src/merge_tools/diff_working_copies.rs
@@ -297,6 +297,7 @@ diff editing in mind and be a little inaccurate.
     pub async fn snapshot_results(
         self,
         base_ignores: Arc<GitIgnoreFile>,
+        derive_tracked_from_ignores: bool,
     ) -> Result<MergedTree, DiffEditError> {
         if let Some(path) = self.instructions_path_to_cleanup {
             std::fs::remove_file(path).ok();
@@ -312,6 +313,7 @@ diff editing in mind and be a little inaccurate.
                 start_tracking_matcher: &EverythingMatcher,
                 force_tracking_matcher: &NothingMatcher,
                 max_new_file_size: u64::MAX,
+                derive_tracked_from_ignores,
             })
             .await?;
         Ok(output_tree_state.current_tree().clone())

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -387,6 +387,7 @@ pub async fn edit_diff_external(
     instructions: Option<&str>,
     base_ignores: Arc<GitIgnoreFile>,
     default_conflict_marker_style: ConflictMarkerStyle,
+    derive_tracked_from_ignores: bool,
 ) -> Result<MergedTree, DiffEditError> {
     let conflict_marker_style = editor
         .conflict_marker_style
@@ -439,7 +440,9 @@ pub async fn edit_diff_external(
         }
     }
 
-    diffedit_wc.snapshot_results(base_ignores).await
+    diffedit_wc
+        .snapshot_results(base_ignores, derive_tracked_from_ignores)
+        .await
 }
 
 /// Generates textual diff by the specified `tool` and writes into `writer`.

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -297,6 +297,7 @@ impl DiffEditor {
         trees: Diff<&MergedTree>,
         matcher: &dyn Matcher,
         format_instructions: impl FnOnce() -> String,
+        derive_tracked_from_ignores: bool,
     ) -> Result<MergedTree, DiffEditError> {
         match &self.tool {
             DiffEditTool::Builtin => {
@@ -315,6 +316,7 @@ impl DiffEditor {
                     instructions.as_deref(),
                     self.base_ignores.clone(),
                     self.conflict_marker_style,
+                    derive_tracked_from_ignores,
                 )
                 .await
             }

--- a/cli/tests/test_file_track_untrack_commands.rs
+++ b/cli/tests/test_file_track_untrack_commands.rs
@@ -389,3 +389,69 @@ fn test_track_ignored_directory() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_derive_tracked_from_ignores() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config(r#"snapshot.derive-tracked-from-ignores = true"#);
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1.txt", "content1");
+    work_dir.write_file("file2.txt", "content2");
+
+    // No ignores, all files tracked
+    let output = work_dir.run_jj(["file", "list"]);
+    insta::assert_snapshot!(output, @"
+    file1.txt
+    file2.txt
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output, @"
+    Working copy changes:
+    A file1.txt
+    A file2.txt
+    Working copy  (@) : qpvuntsm 376a8fab (no description set)
+    Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ");
+
+    // If a file is ignored, it gets untracked
+    work_dir.write_file(".gitignore", "file1.txt\n");
+    let output = work_dir.run_jj(["file", "list"]);
+    insta::assert_snapshot!(output, @"
+    .gitignore
+    file2.txt
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output, @"
+    Working copy changes:
+    A .gitignore
+    A file2.txt
+    Working copy  (@) : qpvuntsm 7b2ed7a2 (no description set)
+    Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ");
+
+    // If a file is unignored, it gets tracked
+    work_dir.write_file(".gitignore", "\n");
+    let output = work_dir.run_jj(["file", "list"]);
+    insta::assert_snapshot!(output, @"
+    .gitignore
+    file1.txt
+    file2.txt
+    [EOF]
+    ");
+    let output = work_dir.run_jj(["status"]);
+    insta::assert_snapshot!(output, @"
+    Working copy changes:
+    A .gitignore
+    A file1.txt
+    A file2.txt
+    Working copy  (@) : qpvuntsm ee9547bd (no description set)
+    Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ");
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -2034,6 +2034,23 @@ copy. However, first [ignore](working-copy.md#ignored-files) them or remove them
 from the `snapshot.auto-track` patterns; otherwise they will be immediately
 tracked again.
 
+If you set `snapshot.derive-tracked-from-ignores`, ignored files will be treated
+as if they don't exist:
+- A file that was previously in the repo but then added to `.gitignore` will
+  show up as deleted in subsequent snapshots. This is different than the
+  behavior when `snapshot.derive-tracked-from-ignores = false`, for which
+  adding a tracked file to `.gitignore` will _not_ remove it from the snapshot.
+- Removing a file from `.gitignore` will make it show up as added (assuming it
+  isn't filtered out another way, e.g. because of `snapshot.auto-track` or
+  `snapshot.max-new-file-size`).
+Using this option opts out of the tracking/untracking system for files,
+treating `.gitignore` as the source of truth for what should be snapshotted.
+Because of this, `jj file track` and `jj file untrack` will error and tell you
+to update `.gitignore` instead.
+Note that files are still filtered by `snapshot.auto-track`, so if you use
+`snapshot.derive-tracked-from-ignores`, you probably want to leave the former
+set to `all()` (the default).
+
 ### Maximum size for new files
 
 By default, as an anti-footgun measure, `jj` will refuse to add new files to the

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1285,6 +1285,7 @@ impl TreeState {
             start_tracking_matcher,
             force_tracking_matcher,
             max_new_file_size,
+            derive_tracked_from_ignores,
         } = options;
 
         let sparse_matcher = self.sparse_matcher();
@@ -1332,6 +1333,7 @@ impl TreeState {
                 error: OnceLock::new(),
                 progress: *progress,
                 max_new_file_size: *max_new_file_size,
+                derive_tracked_from_ignores: *derive_tracked_from_ignores,
             };
             let directory_to_visit = DirectoryToVisit {
                 dir: RepoPathBuf::root(),
@@ -1503,6 +1505,7 @@ struct FileSnapshotter<'a> {
     error: OnceLock<SnapshotError>,
     progress: Option<&'a SnapshotProgress<'a>>,
     max_new_file_size: u64,
+    derive_tracked_from_ignores: bool,
 }
 
 impl FileSnapshotter<'_> {
@@ -1613,10 +1616,13 @@ impl FileSnapshotter<'_> {
                     return Ok(None);
                 }
             }
+            
+            let is_ignored = git_ignore.matches_dir(&path);
+            if is_ignored && self.derive_tracked_from_ignores {
+                return Ok(None);
+            }
 
-            if git_ignore.matches_dir(&path)
-                && self.force_tracking_matcher.visit(&path).is_nothing()
-            {
+            if is_ignored && self.force_tracking_matcher.visit(&path).is_nothing() {
                 // If the whole directory is ignored by .gitignore, visit only
                 // paths we're already tracking. This is because .gitignore in
                 // ignored directory must be ignored. It's also more efficient.
@@ -1643,8 +1649,13 @@ impl FileSnapshotter<'_> {
             if let Some(progress) = self.progress {
                 progress(&path);
             }
+            let is_ignored = git_ignore.matches_file(&path);
+            if is_ignored && self.derive_tracked_from_ignores {
+                return Ok(None);
+            }
+
             if maybe_current_file_state.is_none()
-                && (git_ignore.matches_file(&path) && !self.force_tracking_matcher.matches(&path))
+                && (is_ignored && !self.force_tracking_matcher.matches(&path))
             {
                 // If it wasn't already tracked and it matches
                 // the ignored paths, then ignore it.

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -229,6 +229,10 @@ pub struct SnapshotOptions<'a> {
     /// (depending on implementation)
     /// return `SnapshotError::NewFileTooLarge`.
     pub max_new_file_size: u64,
+    /// Track a file if and only if it is not ignored.
+    /// If a file was previously tracked and then it gets ignored,
+    /// this will cause the snapshot to see it as a delete.
+    pub derive_tracked_from_ignores: bool,
 }
 
 /// A callback for getting progress updates.

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -157,6 +157,7 @@ pub fn empty_snapshot_options() -> SnapshotOptions<'static> {
         start_tracking_matcher: &EverythingMatcher,
         force_tracking_matcher: &NothingMatcher,
         max_new_file_size: u64::MAX,
+        derive_tracked_from_ignores: false,
     }
 }
 


### PR DESCRIPTION
This is a proposal for a new feature (opt-in via config) to alleviate the issue mentioned in #323. I skimmed the ~200 comments and didn't see this _exact_ idea discussed there, though some were similar, particularly https://github.com/jj-vcs/jj/issues/323#issuecomment-2405081307 ("There should be one source of truth for ignored or not. I assume this to be the ignore file." by @joyously is a nice way of putting it). In a sense this PR is the opposite of #8628. Also, this PR would touch on #6157.

This PR adds config `snapshot.derive-tracked-from-ignores` (tentative name), which if `true`, treats the ignores as the "source of truth" for what should be tracked, or rather, what should _not_ be tracked:
- if a file is currently tracked, adding it to ignores should have the same effect as deleting it: `jj status` should show it as deleted
- if a file is not currently tracked but in the ignores, removing it from ignores should have the same effect adding that file to a repo that didn't have it: `jj status` should show it as added

The new test `test_derive_tracked_from_ignores` checks exactly this.

Additionally, if `snapshot.derive-tracked-from-ignores` is set, I also made `jj {un,}track` error, because that conflicts with ignores being the source of truth.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
