### PR TITLE
docs: use real world biome example

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1345,12 +1345,8 @@ path to such a program:
 
 ```toml
 [fix.tools.biome]
-
-# Linux and macOS
-command = ["$root/node_modules/@biomejs/cli-linux-x64/biome"]
-
-# Windows
-command = ["$root\\node_modules\\@biomejs\\cli-win32-x64\\biome.exe"]
+command = ["$root/node_modules/@biomejs/biome/bin/biome", "format", "--stdin-file-path=$path"]
+patterns = ["glob:'**/*.ts'", "glob:'**/*.tsx'"]
 ```
 
 ### Execution order of tools

--- a/web/docs/src/content/docs/config.md
+++ b/web/docs/src/content/docs/config.md
@@ -1268,12 +1268,8 @@ path to such a program:
 
 ```toml
 [fix.tools.biome]
-
-# Linux and macOS
-command = ["$root/node_modules/@biomejs/cli-linux-x64/biome"]
-
-# Windows
-command = ["$root\\node_modules\\@biomejs\\cli-win32-x64\\biome.exe"]
+command = ["$root/node_modules/@biomejs/biome/bin/biome", "format", "--stdin-file-path=$path"]
+patterns = ["glob:'**/*.ts'", "glob:'**/*.tsx'"]
 ```
 
 ### Execution order of tools


### PR DESCRIPTION
The previous biome example in the docs was
not using a valid command and resulted in
the biome "--help" output being written to every file.

I also removed the windows version as there
seems to be a OS-agnostic binary now.

---
I was unsure why there is `docs` and `web/docs` … is one generated? anyway because this is a tiny change i just edited both.