### PR TITLE
revset: make commits() methods buffered

### DIFF
--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3516,7 +3516,7 @@ impl<S: Stream<Item = Result<CommitId, RevsetEvaluationError>>> RevsetStreamExt 
         self,
         store: &Arc<Store>,
     ) -> impl Stream<Item = Result<Commit, RevsetEvaluationError>> + use<'_, S> {
-        self.then(async move |result| {
+        self.map(async move |result| {
             let commit_id = result?;
             let commit = store
                 .get_commit_async(&commit_id)
@@ -3524,6 +3524,7 @@ impl<S: Stream<Item = Result<CommitId, RevsetEvaluationError>>> RevsetStreamExt 
                 .map_err(RevsetEvaluationError::Backend)?;
             Ok(commit)
         })
+        .buffered(store.concurrency())
     }
 }
 


### PR DESCRIPTION
This should make it so commits are read concurrently (depending on `Backend::concurrency()`). All current callers of `commits()` immediately do `try_collect()`, so this patch should help them all.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
