### PR TITLE
cleanup: use BoxStream and .boxed() more

### DIFF
--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
 use std::slice;
 
 use clap_complete::ArgValueCandidates;
-use futures::Stream;
 use futures::StreamExt as _;
 use futures::stream;
+use futures::stream::BoxStream;
 use itertools::Itertools as _;
 use jj_lib::graph::GraphEdge;
 use jj_lib::graph::reverse_graph;
@@ -225,14 +224,15 @@ async fn do_op_log(
             let edges = ids.iter().cloned().map(GraphEdge::direct).collect();
             Ok((op, edges))
         });
-        let mut stream_nodes: Pin<Box<dyn Stream<Item = _>>> = if args.reversed {
-            Box::pin(stream::iter(
+        let mut stream_nodes: BoxStream<'_, _> = if args.reversed {
+            stream::iter(
                 reverse_graph(stream.collect::<Vec<_>>().await.into_iter(), Operation::id)?
                     .into_iter()
                     .map(Ok),
-            ))
+            )
+            .boxed()
         } else {
-            Box::pin(stream)
+            stream.boxed()
         };
         while let Some(node) = stream_nodes.next().await {
             let (op, edges) = node?;
@@ -254,12 +254,10 @@ async fn do_op_log(
             )?;
         }
     } else {
-        let mut stream: Pin<Box<dyn Stream<Item = _>>> = if args.reversed {
-            Box::pin(stream::iter(
-                stream.collect::<Vec<_>>().await.into_iter().rev(),
-            ))
+        let mut stream: BoxStream<'_, _> = if args.reversed {
+            stream::iter(stream.collect::<Vec<_>>().await.into_iter().rev()).boxed()
         } else {
-            Box::pin(stream)
+            stream.boxed()
         };
         while let Some(op) = stream.next().await {
             let op = op?;

--- a/lib/src/default_index/revset_engine.rs
+++ b/lib/src/default_index/revset_engine.rs
@@ -21,13 +21,12 @@ use std::convert::Infallible;
 use std::fmt;
 use std::iter;
 use std::ops::Range;
-use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use bstr::BString;
-use futures::Stream;
 use futures::StreamExt as _;
+use futures::stream::LocalBoxStream;
 use itertools::Itertools as _;
 use pollster::FutureExt as _;
 
@@ -164,13 +163,11 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
         Box::new(iter::from_fn(move || walk.next(index.as_composite())))
     }
 
-    fn stream<'a>(
-        &self,
-    ) -> Pin<Box<dyn Stream<Item = Result<CommitId, RevsetEvaluationError>> + 'a>>
+    fn stream<'a>(&self) -> LocalBoxStream<'a, Result<CommitId, RevsetEvaluationError>>
     where
         Self: 'a,
     {
-        Box::pin(futures::stream::iter(self.iter()))
+        futures::stream::iter(self.iter()).boxed_local()
     }
 
     fn commit_change_ids<'a>(
@@ -199,11 +196,11 @@ impl<I: AsCompositeIndex + Clone> Revset for RevsetImpl<I> {
 
     fn stream_graph<'a>(
         &self,
-    ) -> Pin<Box<dyn Stream<Item = Result<GraphNode<CommitId>, RevsetEvaluationError>> + 'a>>
+    ) -> LocalBoxStream<'a, Result<GraphNode<CommitId>, RevsetEvaluationError>>
     where
         Self: 'a,
     {
-        Box::pin(futures::stream::iter(self.iter_graph()))
+        futures::stream::iter(self.iter_graph()).boxed_local()
     }
 
     fn is_empty(&self) -> bool {

--- a/lib/src/evolution.rs
+++ b/lib/src/evolution.rs
@@ -88,7 +88,7 @@ pub fn walk_predecessors<'repo>(
     repo: &'repo ReadonlyRepo,
     start_commits: &[CommitId],
 ) -> impl Iterator<Item = Result<CommitEvolutionEntry, WalkPredecessorsError>> + use<'repo> {
-    let op_ancestors = Box::pin(op_walk::walk_ancestors(slice::from_ref(repo.operation())));
+    let op_ancestors = op_walk::walk_ancestors(slice::from_ref(repo.operation())).boxed();
     WalkPredecessors {
         repo,
         op_ancestors,

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -34,6 +34,7 @@ use std::sync::MutexGuard;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use futures::StreamExt as _;
 use futures::stream::BoxStream;
 use gix::bstr::BString;
 use gix::objs::CommitRefIter;
@@ -1459,7 +1460,7 @@ impl Backend for GitBackend {
                 },
             )
             .map_err(|err| BackendError::Other(err.into()))?;
-        Ok(Box::pin(futures::stream::iter(records)))
+        Ok(futures::stream::iter(records).boxed())
     }
 
     #[tracing::instrument(skip(self, index))]

--- a/lib/src/merged_tree.rs
+++ b/lib/src/merged_tree.rs
@@ -273,11 +273,9 @@ impl MergedTree {
     ) -> TreeDiffStream<'matcher> {
         let concurrency = self.store().concurrency();
         if concurrency <= 1 {
-            Box::pin(futures::stream::iter(TreeDiffIterator::new(
-                self, other, matcher,
-            )))
+            futures::stream::iter(TreeDiffIterator::new(self, other, matcher)).boxed()
         } else {
-            Box::pin(TreeDiffStreamImpl::new(self, other, matcher, concurrency))
+            TreeDiffStreamImpl::new(self, other, matcher, concurrency).boxed()
         }
     }
 
@@ -306,9 +304,7 @@ impl MergedTree {
         other: &Self,
         matcher: &'matcher dyn Matcher,
     ) -> TreeDiffStream<'matcher> {
-        Box::pin(DiffStreamForFileSystem::new(
-            self.diff_stream_internal(other, matcher),
-        ))
+        DiffStreamForFileSystem::new(self.diff_stream_internal(other, matcher)).boxed()
     }
 
     /// Like `diff_stream()` but takes the given copy records into account.
@@ -319,12 +315,7 @@ impl MergedTree {
         copy_records: &'a CopyRecords,
     ) -> BoxStream<'a, CopiesTreeDiffEntry> {
         let stream = self.diff_stream(other, matcher);
-        Box::pin(CopiesTreeDiffStream::new(
-            stream,
-            self.clone(),
-            other.clone(),
-            copy_records,
-        ))
+        CopiesTreeDiffStream::new(stream, self.clone(), other.clone(), copy_records).boxed()
     }
 
     /// Like `diff_stream()` but takes CopyHistory into account.
@@ -334,7 +325,7 @@ impl MergedTree {
         matcher: &'a dyn Matcher,
     ) -> BoxStream<'a, CopyHistoryTreeDiffEntry> {
         let stream = self.diff_stream(other, matcher);
-        Box::pin(CopyHistoryDiffStream::new(stream, self, other))
+        CopyHistoryDiffStream::new(stream, self, other).boxed()
     }
 
     /// Merges the provided trees into a single `MergedTree`. Any conflicts will
@@ -926,22 +917,24 @@ impl Stream for TreeDiffStreamImpl<'_> {
 }
 
 fn stream_without_trees(stream: TreeDiffStream) -> TreeDiffStream {
-    Box::pin(stream.filter_map(|mut entry| async move {
-        let skip_tree = |merge: MergedTreeValue| {
-            if merge.is_tree() {
-                Merge::absent()
-            } else {
-                merge
-            }
-        };
-        entry.values = entry.values.map(|diff| diff.map(skip_tree));
+    stream
+        .filter_map(|mut entry| async move {
+            let skip_tree = |merge: MergedTreeValue| {
+                if merge.is_tree() {
+                    Merge::absent()
+                } else {
+                    merge
+                }
+            };
+            entry.values = entry.values.map(|diff| diff.map(skip_tree));
 
-        // Filter out entries where neither side is present.
-        let any_present = entry.values.as_ref().map_or(true, |diff| {
-            diff.before.is_present() || diff.after.is_present()
-        });
-        any_present.then_some(entry)
-    }))
+            // Filter out entries where neither side is present.
+            let any_present = entry.values.as_ref().map_or(true, |diff| {
+                diff.before.is_present() || diff.after.is_present()
+            });
+            any_present.then_some(entry)
+        })
+        .boxed()
 }
 
 /// Adapts a `TreeDiffStream` to emit a added file at a given path after a

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -21,12 +21,12 @@ use std::convert::Infallible;
 use std::fmt;
 use std::ops::ControlFlow;
 use std::ops::Range;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::LazyLock;
 
 use futures::Stream;
 use futures::StreamExt as _;
+use futures::stream::LocalBoxStream;
 use itertools::Itertools as _;
 use pollster::FutureExt as _;
 use thiserror::Error;
@@ -3429,9 +3429,8 @@ pub trait Revset: fmt::Debug {
         Self: 'a;
 
     /// Streams in topological order with children before parents.
-    fn stream<'a>(
-        &self,
-    ) -> Pin<Box<dyn Stream<Item = Result<CommitId, RevsetEvaluationError>> + 'a>>
+    // TODO: Relax to BoxStream?
+    fn stream<'a>(&self) -> LocalBoxStream<'a, Result<CommitId, RevsetEvaluationError>>
     where
         Self: 'a;
 
@@ -3454,7 +3453,7 @@ pub trait Revset: fmt::Debug {
     /// children before parents.
     fn stream_graph<'a>(
         &self,
-    ) -> Pin<Box<dyn Stream<Item = Result<GraphNode<CommitId>, RevsetEvaluationError>> + 'a>>
+    ) -> LocalBoxStream<'a, Result<GraphNode<CommitId>, RevsetEvaluationError>>
     where
         Self: 'a;
 

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -28,6 +28,7 @@ use std::time::SystemTime;
 use async_trait::async_trait;
 use blake2::Blake2b512;
 use blake2::Digest as _;
+use futures::StreamExt as _;
 use futures::stream;
 use futures::stream::BoxStream;
 use pollster::FutureExt as _;
@@ -343,7 +344,7 @@ impl Backend for SimpleBackend {
         _root: &CommitId,
         _head: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
-        Ok(Box::pin(stream::empty()))
+        Ok(stream::empty().boxed())
     }
 
     fn gc(&self, _index: &dyn Index, _keep_newer: SystemTime) -> BackendResult<()> {

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -26,6 +26,7 @@ use std::sync::MutexGuard;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use futures::StreamExt as _;
 use futures::stream;
 use futures::stream::BoxStream;
 use jj_lib::backend::Backend;
@@ -423,7 +424,7 @@ impl Backend for TestBackend {
         _root: &CommitId,
         _head: &CommitId,
     ) -> BackendResult<BoxStream<'_, BackendResult<CopyRecord>>> {
-        Ok(Box::pin(stream::empty()))
+        Ok(stream::empty().boxed())
     }
 
     fn gc(&self, _index: &dyn Index, _keep_newer: SystemTime) -> BackendResult<()> {


### PR DESCRIPTION
This was mainly to reduce type complexity by using `BoxStream`. The documentation for that type says that's its often created by calling `.boxed()`, so I did that too.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
