### PR TITLE
proc-macros: simplistic regression test for cd960361

### DIFF
--- a/lib/proc-macros/tests/test_hygiene.rs
+++ b/lib/proc-macros/tests/test_hygiene.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn no_direct_digest_references_in_macro_output() {
+    for (filename, source) in [
+        ("lib.rs", include_str!("../src/lib.rs")),
+        ("content_hash.rs", include_str!("../src/content_hash.rs")),
+    ] {
+        // The proc-macro output must not reference `digest::` directly, as
+        // that would
+        // 1) require downstream crates to add `digest` as a direct dependency
+        // 2) cause compilation errors if downstream crates use a *different version* of
+        //    `digest` than jj-lib.
+        assert!(
+            !source.contains("digest::"),
+            "{filename} references `digest::` directly; use \
+             `::jj_lib::content_hash::DigestUpdate` instead"
+        );
+    }
+}


### PR DESCRIPTION
String-based check that people don't use `digest::` inside the proc-macros crate, so that other crates using jj-lib can use `#[derive(ContentHash)]`.

Follows up on cd960361.

-----

Example failure: https://github.com/jj-vcs/jj/actions/runs/23173922046/job/67331847132?pr=9126

Cc @emesterhazy since I cc-ed the previous pr to you, but no worries if you're doing other things.

# Checklist

If applicable:

- n/a I have updated `CHANGELOG.md`
- n/a I have updated the documentation (`README.md`, `docs/`, `demos/`)
- n/a I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
