### PR TITLE
docs: note Git 2.41.0+ requirement, and make error message clearer

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -185,6 +185,11 @@ via scoop:
 scoop install main/jj
 ```
 
+## Runtime Requirements
+
+You will need git 2.41.0 or above. On older systems (e.g. Debian 11, Ubuntu
+22.04) you will need to [upgrade Git](https://git-scm.com/install/).
+
 ## Initial configuration
 
 You may want to configure your name and email so commits are made in your name.

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -44,6 +44,7 @@ use crate::ref_name::RemoteName;
 // * 2.29.0 introduced `git fetch --no-write-fetch-head`
 // * 2.40 still receives security patches (latest one was in Jan/2025)
 // * 2.41.0 introduced `git fetch --porcelain`
+// If bumped, please update ../../docs/install-and-setup.md
 const MINIMUM_GIT_VERSION: &str = "2.41.0";
 
 /// Error originating by a Git subprocess
@@ -66,7 +67,7 @@ pub enum GitSubprocessError {
     #[error("Failed to wait for the git process")]
     Wait(std::io::Error),
     #[error(
-        "Git does not recognize required option: {0} (note: supported version is \
+        "Git does not recognize required option: {0} (note: Jujutsu requires git >= \
          {MINIMUM_GIT_VERSION})"
     )]
     UnsupportedGitOption(String),


### PR DESCRIPTION
Emit a more actionable error message when the error was likely caused by a too-old Git:

before: "note: supported version is .."
after: "note: Jujutsu requires Git >= .."

Also note Git requirement in the docs, and add a comment reminding maintainers to keep this updated.

Fixes #9128