### PR TITLE
docs: clarify `fork_point` is `merge-base`

### DIFF
--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -349,6 +349,10 @@ revsets (expressions) as arguments.
   the revset `heads(::x_1 & ::x_2 & ... & ::x_N)`, where `x_{1..N}` are commits
   in `x`. If `x` resolves to a single commit, `fork_point(x)` resolves to `x`.
 
+  `fork_point(x | y)` is what `git merge-base x y` calculates (but unlike `git
+  merge-base --fork-point`, the `fork_point()` function does *not* take a
+  bookmark's history into account).
+
 * `merge_point(x)`: The merge point of all commits in `x`. Similar to the fork
   point, the merge point is the common descendant(s) of all commits in `x` which
   do not have any ancestors that are also common descendants of all commits in


### PR DESCRIPTION
I was a bit surprised that there wasn't a `merge_base` function, and more surprised that searching this page for "merge-base" didn't find anything.

Let's add a note here.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
