### PR TITLE
template: allow dynamic config value lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj op log` now includes the name of the workspace the operation was created
   from.
 
+* The `config()` template function now accepts a `Stringify` expression instead 
+  of `LiteralString`. This allows looking up configuration values dynamically.
+
 ### Fixed bugs
 
 * `.gitignore` with UTF-8 BOM can now be parsed correctly.

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -2116,28 +2116,34 @@ fn builtin_functions<'a, L: TemplateLanguage<'a> + ?Sized>() -> TemplateBuildFun
         });
         Ok(L::Property::wrap_template(Box::new(template)))
     });
-    map.insert("config", |language, diagnostics, _build_ctx, function| {
-        // Dynamic lookup can be implemented if needed. The name is literal
-        // string for now so the error can be reported early.
+    map.insert("config", |language, diagnostics, build_ctx, function| {
         let [name_node] = function.expect_exact_arguments()?;
-        let name: ConfigNamePathBuf =
-            template_parser::catch_aliases(diagnostics, name_node, |_diagnostics, node| {
-                let name = template_parser::expect_string_literal(node)?;
-                name.parse().map_err(|err| {
-                    TemplateParseError::expression("Failed to parse config name", node.span)
-                        .with_source(err)
-                })
-            })?;
-        let value = language
-            .settings()
-            .get_value(&name)
-            .optional()
-            .map_err(|err| {
-                TemplateParseError::expression("Failed to get config value", function.name_span)
+        let name_expression =
+            expect_stringify_expression(language, diagnostics, build_ctx, name_node)?;
+        if let Ok(name) = name_expression.extract() {
+            let config_path: ConfigNamePathBuf = name.parse().map_err(|err| {
+                TemplateParseError::expression("Failed to parse config name", name_node.span)
                     .with_source(err)
             })?;
-        // .decorated("", "") to trim leading/trailing whitespace
-        Ok(Literal(value.map(|v| v.decorated("", ""))).into_dyn_wrapped())
+            let value = language
+                .settings()
+                .get_value(config_path)
+                .optional()
+                .map_err(|err| {
+                    TemplateParseError::expression("Failed to get config value", function.name_span)
+                        .with_source(err)
+                })?;
+            // .decorated("", "") to trim leading/trailing whitespace
+            Ok(Literal(value.map(|v| v.decorated("", ""))).into_dyn_wrapped())
+        } else {
+            let settings = language.settings().clone();
+            let out_property = name_expression.and_then(move |name| {
+                let config_path: ConfigNamePathBuf = name.parse()?;
+                let value = settings.get_value(config_path).optional()?;
+                Ok(value.map(|v| v.decorated("", "")))
+            });
+            Ok(out_property.into_dyn_wrapped())
+        }
     });
     map
 }
@@ -2528,6 +2534,20 @@ mod tests {
             F: Fn() -> TestTemplatePropertyKind + 'static,
         {
             self.language.add_keyword(name, move |_| Ok(build()));
+        }
+
+        /// Like `add_keyword`, but the value depends on the `self` context
+        /// property, making it not statically extractable.
+        fn add_dynamic_keyword<O, F>(&mut self, name: &'static str, build: F)
+        where
+            O: 'static,
+            F: Fn() -> O + Clone + 'static,
+            TestTemplatePropertyKind: WrapTemplateProperty<'static, O>,
+        {
+            self.language.add_keyword(name, move |self_property| {
+                let build = build.clone();
+                Ok(self_property.map(move |_| build()).into_dyn_wrapped())
+            });
         }
 
         fn add_alias(&mut self, decl: impl AsRef<str>, defn: impl Into<String>) {
@@ -4818,7 +4838,7 @@ mod tests {
             ConfigLayer::parse(ConfigSource::User, "user.email = 'test@example.com'").unwrap(),
         );
 
-        let env = TestTemplateEnv::with_config(config);
+        let mut env = TestTemplateEnv::with_config(config);
 
         // valid config path
         insta::assert_snapshot!(env.render_ok(r#"config("user.name")"#), @"'Test User'");
@@ -4846,6 +4866,68 @@ mod tests {
           |     ^
         invalid unquoted key, expected letters, numbers, `-`, `_`
         ");
+
+        // lookup at parse time
+        env.add_alias("config_key", r#""name""#);
+        insta::assert_snapshot!(env.render_ok(r#"config("user." ++ "name")"#), @"'Test User'");
+        insta::assert_snapshot!(env.render_ok(r#"config("us" ++ "er")"#), @"{ email = 'test@example.com', name = 'Test User' }");
+        insta::assert_snapshot!(env.render_ok(r#"config("user." ++ config_key)"#), @"'Test User'");
+
+        // invalid expression
+        insta::assert_snapshot!(env.parse_err(r#"config("user." ++)"#), @r#"
+         --> 1:18
+          |
+        1 | config("user." ++)
+          |                  ^---
+          |
+          = expected <expression>
+        "#);
+        insta::assert_snapshot!(env.parse_err(r#"config("user|" ++ "name")"#), @r#"
+         --> 1:8
+          |
+        1 | config("user|" ++ "name")
+          |        ^---------------^
+          |
+          = Failed to parse config name
+        TOML parse error at line 1, column 5
+          |
+        1 | user|name
+          |     ^
+        invalid unquoted key, expected letters, numbers, `-`, `_`
+        "#);
+        insta::assert_snapshot!(env.parse_err(r#"config(invalid)"#), @"
+         --> 1:8
+          |
+        1 | config(invalid)
+          |        ^-----^
+          |
+          = Keyword `invalid` doesn't exist
+        ");
+
+        // dynamic lookup using a keyword that depends on runtime context
+        env.add_dynamic_keyword("dyn_config_name", || "user.name".to_owned());
+        insta::assert_snapshot!(
+            env.render_ok(r#"config(dyn_config_name)"#), @"'Test User'"
+        );
+
+        // dynamic lookup with nonexistent path
+        env.add_dynamic_keyword("dyn_missing", || "non.existent".to_owned());
+        insta::assert_snapshot!(env.render_ok(r#"config(dyn_missing)"#), @"");
+
+        // dynamic lookup with invalid config path at runtime
+        env.add_dynamic_keyword("dyn_bad_path", || "user|name".to_owned());
+        insta::assert_snapshot!(env.render_ok(r#"config(dyn_bad_path)"#), @r"
+        <Error: TOML parse error at line 1, column 5
+          |
+        1 | user|name
+          |     ^
+        invalid unquoted key, expected letters, numbers, `-`, `_`
+        >
+        ");
+
+        // dynamic lookup where name expression itself fails at runtime
+        env.add_keyword("bad_string", || new_error_property::<String>("Bad"));
+        insta::assert_snapshot!(env.render_ok(r#"config(bad_string)"#), @"<Error: Bad>");
     }
 
     #[test]

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -117,7 +117,7 @@ The following functions are defined.
   `separator` between **non-empty** `content`s.
 * `surround(prefix: Template, suffix: Template, content: Template) -> Template`:
   Surround **non-empty** content with texts such as parentheses.
-* `config(name: StringLiteral) -> Option<ConfigValue>`: Look up configuration
+* `config(name: Stringify) -> Option<ConfigValue>`: Look up configuration
    value by `name`.
 * `git_web_url([remote: String]) -> String`: Best-effort conversion of a git
   remote URL to an HTTPS web URL. Defaults to the "origin" remote. Returns an

--- a/web/docs/src/content/docs/templates.md
+++ b/web/docs/src/content/docs/templates.md
@@ -97,7 +97,7 @@ The following functions are defined.
   `separator` between **non-empty** `content`s.
 * `surround(prefix: Template, suffix: Template, content: Template) -> Template`:
   Surround **non-empty** content with texts such as parentheses.
-* `config(name: StringLiteral) -> ConfigValue`: Look up configuration value by `name`.
+* `config(name: Stringify) -> ConfigValue`: Look up configuration value by `name`.
 * `git_web_url([remote: String]) -> String`: Best-effort conversion of a git
   remote URL to an HTTPS web URL. Defaults to the "origin" remote. Returns an
   empty string on failure. SSH host alias resolution is currently unsupported.


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Fix: #9144

It looks like there is a comment talking about allowing dynamic configuration lookup for this function already. This PR implements that.

I would like to be able to show GitHub PR numbers that I store in my JJ configs. This allows me to write templates for `jj log` that shows PR numbers.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
