### PR TITLE
log: properly render elided roots in reversed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   remote's fetch URL or effective push URL.
   [#413](https://github.com/jj-vcs/jj/issues/413)
 
+* `jj log --reversed` now correctly shows elided nodes.
+
 ## [0.42.0] - 2026-06-04
 
 ### Release highlights
@@ -101,6 +103,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   launched once per changed file, making it possible to use per-file tools like
   `vimdiff` for editing.
 
+* The final `~` shown in `jj log` now respects `ui.log-synthetic-elided-nodes`
+  and uses the `log_node` template.
+
 ### Fixed bugs
 
 * `jj git remote add` now reports an error instead of panicking when the
@@ -117,28 +122,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * The `builtin_log_redacted` template now also redacts workspace names.
 
-### Contributors
-
-Thanks to the people who made this release happen!
-
-* Alex Jaspersen (@ajaspers)
-* Archer (@archer-321)
-* ase (@adamse)
-* Austin Seipp (@thoughtpolice)
-* David Rieber (@drieber)
-* Eyüp Can Akman (@eyupcanakman)
-* Jakub Stasiak (@jstasiak)
-* James Dixon (@lemonase)
-* Joseph Lou (@josephlou5)
-* Laurynas Keturakis (@laulauland)
-* Luna Schwalbe (@lunagl)
-* Martin von Zweigbergk (@martinvonz)
-* Niko Savola (@nikosavola)
-* OlshaMB (@OlshaMB)
-* Sergey Kasmy (@SergeyKasmy)
-* truffle (@truffle-dev)
-* Vincent Ging Ho Yim (@cenviity)
-* Yuya Nishihara (@yuja)
 
 ## [0.41.0] - 2026-05-06
 

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -25,6 +25,7 @@ use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
 use jj_lib::graph::GraphEdge;
 use jj_lib::graph::GraphEdgeType;
+use jj_lib::graph::GraphNode;
 use jj_lib::graph::TopoGroupedGraph;
 use jj_lib::graph::reverse_graph;
 use jj_lib::repo::Repo as _;
@@ -233,87 +234,60 @@ pub(crate) async fn cmd_log(
                 // The input to TopoGroupedGraph shouldn't be truncated because the prioritized
                 // commit must exist in the input set.
                 let forward_stream = forward_stream.take(args.limit.unwrap_or(usize::MAX));
+
+                let display_stream =
+                    edges_to_display(forward_stream.boxed_local(), use_elided_nodes)
+                        .map(|r| r.map_err(CommandError::from));
+
                 if args.reversed {
-                    let nodes: Vec<_> = forward_stream.collect().await;
-                    let nodes = reverse_graph(nodes.into_iter(), |id: &CommitId| id)?;
+                    let nodes: Vec<_> = display_stream.collect().await;
+                    let nodes = reverse_graph(nodes.into_iter(), |id| id)?;
                     stream::iter(nodes.into_iter().map(Ok)).boxed_local()
                 } else {
-                    forward_stream.boxed_local()
+                    display_stream.boxed_local()
                 }
             };
-            while let Some((commit_id, edges)) = stream.try_next().await? {
-                // The graph is keyed by (CommitId, is_synthetic)
-                let mut graphlog_edges = vec![];
-                // TODO: Should we update revset.stream_graph() to yield a `has_missing` flag
-                // instead of all the missing edges since we don't care about
-                // where they point here anyway?
-                let mut missing_edge_id = None;
-                let mut elided_targets = vec![];
-                for edge in edges {
-                    match edge.edge_type {
-                        GraphEdgeType::Missing => {
-                            missing_edge_id = Some(edge.target);
-                        }
-                        GraphEdgeType::Direct => {
-                            graphlog_edges.push(GraphEdge::direct((edge.target, false)));
-                        }
-                        GraphEdgeType::Indirect => {
-                            if use_elided_nodes {
-                                elided_targets.push(edge.target.clone());
-                                graphlog_edges.push(GraphEdge::direct((edge.target, true)));
-                            } else {
-                                graphlog_edges.push(GraphEdge::indirect((edge.target, false)));
-                            }
-                        }
-                    }
-                }
-                if let Some(missing_edge_id) = missing_edge_id {
-                    graphlog_edges.push(GraphEdge::missing((missing_edge_id, false)));
-                }
-                let mut buffer = vec![];
-                let key = (commit_id, false);
-                let commit = store.get_commit_async(&key.0).await?;
-                let within_graph =
-                    with_content_format.sub_width(graph.width(&key, &graphlog_edges));
-                within_graph
-                    .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
-                        template.format(&commit, formatter)
-                    })
-                    .await?;
-                if let Some(renderer) = &diff_renderer {
-                    let mut formatter = ui.new_formatter(&mut buffer);
-                    renderer
-                        .show_patch(
-                            ui,
-                            formatter.as_mut(),
-                            &commit,
-                            matcher.as_ref(),
-                            within_graph.width(),
-                        )
+            while let Some((key, edges)) = stream.try_next().await? {
+                if !key.1 {
+                    let mut buffer = vec![];
+                    let commit = store.get_commit_async(&key.0).await?;
+                    let within_graph = with_content_format.sub_width(graph.width(&key, &edges));
+                    within_graph
+                        .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
+                            template.format(&commit, formatter)
+                        })
                         .await?;
-                }
+                    if let Some(renderer) = &diff_renderer {
+                        let mut formatter = ui.new_formatter(&mut buffer);
+                        renderer
+                            .show_patch(
+                                ui,
+                                formatter.as_mut(),
+                                &commit,
+                                matcher.as_ref(),
+                                within_graph.width(),
+                            )
+                            .await?;
+                    }
 
-                let commit = Some(commit);
-                let node_symbol = format_template(ui, &commit, &node_template);
-                graph.add_node(
-                    &key,
-                    &graphlog_edges,
-                    &node_symbol,
-                    &String::from_utf8_lossy(&buffer),
-                )?;
+                    let commit = Some(commit);
+                    let node_symbol = format_template(ui, &commit, &node_template);
+                    graph.add_node(
+                        &key,
+                        &edges,
+                        &node_symbol,
+                        &String::from_utf8_lossy(&buffer),
+                    )?;
 
-                let tree = commit.map(|c| c.tree()).unwrap();
-                // TODO: propagate errors
-                explicit_paths
-                    .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
-
-                for elided_target in elided_targets {
-                    let elided_key = (elided_target, true);
-                    let real_key = (elided_key.0.clone(), false);
+                    let tree = commit.map(|c| c.tree()).unwrap();
+                    // TODO: propagate errors
+                    explicit_paths
+                        .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
+                } else {
+                    let real_key = (key.0.clone(), false);
                     let edges = [GraphEdge::direct(real_key)];
                     let mut buffer = vec![];
-                    let within_graph =
-                        with_content_format.sub_width(graph.width(&elided_key, &edges));
+                    let within_graph = with_content_format.sub_width(graph.width(&key, &edges));
                     within_graph
                         .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
                             writeln!(formatter.labeled("elided"), "(elided revisions)")
@@ -321,7 +295,7 @@ pub(crate) async fn cmd_log(
                         .await?;
                     let node_symbol = format_template(ui, &None, &node_template);
                     graph.add_node(
-                        &elided_key,
+                        &key,
                         &edges,
                         &node_symbol,
                         &String::from_utf8_lossy(&buffer),
@@ -396,4 +370,61 @@ pub(crate) async fn cmd_log(
     }
 
     Ok(())
+}
+
+type MaybeSyntheticCommit = (CommitId, bool);
+
+/// Convert a revision graph into a display-suitable format.
+///
+/// This method creates synthetic nodes to allow clearly differentiating elided
+/// revisions and showing elided roots (otherwise not possible in reversed mode
+/// due to limitations of sapling-renderdag).
+fn edges_to_display<'a, E: 'a>(
+    input: impl stream::Stream<Item = Result<GraphNode<CommitId, CommitId>, E>> + 'a,
+    use_elided_nodes: bool,
+) -> impl stream::Stream<Item = Result<GraphNode<MaybeSyntheticCommit, MaybeSyntheticCommit>, E>> {
+    stream::unfold(
+        (
+            std::collections::VecDeque::<(CommitId, bool)>::new(),
+            Box::pin(input.fuse()),
+        ),
+        move |(mut pending, mut input)| async move {
+            if let Some(node) = pending.pop_front() {
+                return Some((Ok((node, vec![])), (pending, input)));
+            }
+            let item = input.next().await?;
+            let (node, edges) = match item {
+                Ok(v) => v,
+                Err(e) => return Some((Err(e), (pending, input))),
+            };
+            // The graph is keyed by (CommitId, is_synthetic)
+            let mut graphlog_edges = vec![];
+            // TODO: Should we update revset.stream_graph() to yield a `has_missing` flag
+            // instead of all the missing edges since we don't care about
+            // where they point here anyway?
+            let mut missing_edge_id = None;
+            for edge in edges {
+                match edge.edge_type {
+                    GraphEdgeType::Missing => {
+                        missing_edge_id = Some(edge.target);
+                    }
+                    GraphEdgeType::Direct => {
+                        graphlog_edges.push(GraphEdge::direct((edge.target, false)));
+                    }
+                    GraphEdgeType::Indirect => {
+                        if use_elided_nodes {
+                            pending.push_back((edge.target.clone(), true));
+                            graphlog_edges.push(GraphEdge::direct((edge.target, true)));
+                        } else {
+                            graphlog_edges.push(GraphEdge::indirect((edge.target, false)));
+                        }
+                    }
+                }
+            }
+            if let Some(missing_edge_id) = missing_edge_id {
+                graphlog_edges.push(GraphEdge::missing((missing_edge_id, false)));
+            }
+            Some((Ok(((node, false), graphlog_edges)), (pending, input)))
+        },
+    )
 }

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -247,60 +247,63 @@ pub(crate) async fn cmd_log(
                     display_stream.boxed_local()
                 }
             };
-            while let Some((key, edges)) = stream.try_next().await? {
-                if !key.1 {
-                    let mut buffer = vec![];
-                    let commit = store.get_commit_async(&key.0).await?;
-                    let within_graph = with_content_format.sub_width(graph.width(&key, &edges));
-                    within_graph
-                        .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
-                            template.format(&commit, formatter)
-                        })
-                        .await?;
-                    if let Some(renderer) = &diff_renderer {
-                        let mut formatter = ui.new_formatter(&mut buffer);
-                        renderer
-                            .show_patch(
-                                ui,
-                                formatter.as_mut(),
-                                &commit,
-                                matcher.as_ref(),
-                                within_graph.width(),
+            while let Some((node, edges)) = stream.try_next().await? {
+                let mut label_buffer = vec![];
+                let commit = match &node {
+                    DisplayNode::Present(commit_id) => {
+                        let commit = store.get_commit_async(commit_id).await?;
+                        let within_graph =
+                            with_content_format.sub_width(graph.width(&node, &edges));
+                        within_graph
+                            .write(
+                                ui.new_formatter(&mut label_buffer).as_mut(),
+                                async |formatter| template.format(&commit, formatter),
                             )
                             .await?;
+                        if let Some(renderer) = &diff_renderer {
+                            let mut formatter = ui.new_formatter(&mut label_buffer);
+                            renderer
+                                .show_patch(
+                                    ui,
+                                    formatter.as_mut(),
+                                    &commit,
+                                    matcher.as_ref(),
+                                    within_graph.width(),
+                                )
+                                .await?;
+                        }
+
+                        let tree = commit.tree();
+                        // TODO: propagate errors
+                        explicit_paths
+                            .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
+
+                        Some(commit)
                     }
+                    DisplayNode::IndirectPath { .. } => {
+                        // Give the (elided revisions) label only for intermediate missing nodes
+                        let within_graph =
+                            with_content_format.sub_width(graph.width(&node, &edges));
+                        within_graph
+                            .write(
+                                ui.new_formatter(&mut label_buffer).as_mut(),
+                                async |formatter| {
+                                    writeln!(formatter.labeled("elided"), "(elided revisions)")
+                                },
+                            )
+                            .await?;
+                        None
+                    }
+                    DisplayNode::MissingParentsOf(..) => None,
+                };
 
-                    let commit = Some(commit);
-                    let node_symbol = format_template(ui, &commit, &node_template);
-                    graph.add_node(
-                        &key,
-                        &edges,
-                        &node_symbol,
-                        &String::from_utf8_lossy(&buffer),
-                    )?;
-
-                    let tree = commit.map(|c| c.tree()).unwrap();
-                    // TODO: propagate errors
-                    explicit_paths
-                        .retain(|&path| tree.path_value(path).block_on().unwrap().is_absent());
-                } else {
-                    let real_key = (key.0.clone(), false);
-                    let edges = [GraphEdge::direct(real_key)];
-                    let mut buffer = vec![];
-                    let within_graph = with_content_format.sub_width(graph.width(&key, &edges));
-                    within_graph
-                        .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
-                            writeln!(formatter.labeled("elided"), "(elided revisions)")
-                        })
-                        .await?;
-                    let node_symbol = format_template(ui, &None, &node_template);
-                    graph.add_node(
-                        &key,
-                        &edges,
-                        &node_symbol,
-                        &String::from_utf8_lossy(&buffer),
-                    )?;
-                }
+                let node_symbol = format_template(ui, &commit, &node_template);
+                graph.add_node(
+                    &node,
+                    &edges,
+                    &node_symbol,
+                    &String::from_utf8_lossy(&label_buffer),
+                )?;
             }
         } else {
             let id_stream: LocalBoxStream<Result<CommitId, RevsetEvaluationError>> = {
@@ -372,7 +375,16 @@ pub(crate) async fn cmd_log(
     Ok(())
 }
 
-type MaybeSyntheticCommit = (CommitId, bool);
+/// Indicates how the graph node should be displayed.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum DisplayNode {
+    /// Prints the commit normally
+    Present(CommitId),
+    /// Prints the "(elided revisions)" between child and (present) ancestor
+    IndirectPath { child: CommitId, ancestor: CommitId },
+    /// Prints the representation of all elided parents of the commit
+    MissingParentsOf(CommitId),
+}
 
 /// Convert a revision graph into a display-suitable format.
 ///
@@ -382,49 +394,61 @@ type MaybeSyntheticCommit = (CommitId, bool);
 fn edges_to_display<'a, E: 'a>(
     input: impl stream::Stream<Item = Result<GraphNode<CommitId, CommitId>, E>> + 'a,
     use_elided_nodes: bool,
-) -> impl stream::Stream<Item = Result<GraphNode<MaybeSyntheticCommit, MaybeSyntheticCommit>, E>> {
+) -> impl stream::Stream<Item = Result<GraphNode<DisplayNode, DisplayNode>, E>> + 'a {
     stream::unfold(
         (
-            std::collections::VecDeque::<(CommitId, bool)>::new(),
+            std::collections::VecDeque::<GraphNode<DisplayNode, DisplayNode>>::new(),
             Box::pin(input.fuse()),
         ),
         move |(mut pending, mut input)| async move {
             if let Some(node) = pending.pop_front() {
-                return Some((Ok((node, vec![])), (pending, input)));
+                return Some((Ok(node), (pending, input)));
             }
             let item = input.next().await?;
             let (node, edges) = match item {
                 Ok(v) => v,
                 Err(e) => return Some((Err(e), (pending, input))),
             };
-            // The graph is keyed by (CommitId, is_synthetic)
-            let mut graphlog_edges = vec![];
-            // TODO: Should we update revset.stream_graph() to yield a `has_missing` flag
-            // instead of all the missing edges since we don't care about
-            // where they point here anyway?
-            let mut missing_edge_id = None;
+            let mut has_missing_parents = false;
+            let mut new_edges = Vec::with_capacity(edges.len());
             for edge in edges {
                 match edge.edge_type {
-                    GraphEdgeType::Missing => {
-                        missing_edge_id = Some(edge.target);
-                    }
                     GraphEdgeType::Direct => {
-                        graphlog_edges.push(GraphEdge::direct((edge.target, false)));
+                        new_edges.push(GraphEdge::direct(DisplayNode::Present(edge.target)));
                     }
                     GraphEdgeType::Indirect => {
-                        if use_elided_nodes {
-                            pending.push_back((edge.target.clone(), true));
-                            graphlog_edges.push(GraphEdge::direct((edge.target, true)));
+                        if !use_elided_nodes {
+                            // print the elided nodes using a dashed line
+                            new_edges.push(GraphEdge::indirect(DisplayNode::Present(edge.target)));
                         } else {
-                            graphlog_edges.push(GraphEdge::indirect((edge.target, false)));
+                            // create a synthetic elided nodes, use direct edges
+                            let synthetic_node = DisplayNode::IndirectPath {
+                                child: node.clone(),
+                                ancestor: edge.target.clone(),
+                            };
+                            let real_target = DisplayNode::Present(edge.target);
+                            pending.push_back((
+                                synthetic_node.clone(),
+                                vec![GraphEdge::direct(real_target)],
+                            ));
+                            new_edges.push(GraphEdge::direct(synthetic_node));
+                        }
+                    }
+                    GraphEdgeType::Missing => {
+                        if use_elided_nodes && !has_missing_parents {
+                            // print missing parents as a single elided node
+                            has_missing_parents = true;
+                            let node = DisplayNode::MissingParentsOf(node.clone());
+                            pending.push_back((node.clone(), vec![]));
+                            new_edges.push(GraphEdge::direct(node));
                         }
                     }
                 }
             }
-            if let Some(missing_edge_id) = missing_edge_id {
-                graphlog_edges.push(GraphEdge::missing((missing_edge_id, false)));
-            }
-            Some((Ok(((node, false), graphlog_edges)), (pending, input)))
+            Some((
+                Ok((DisplayNode::Present(node), new_edges)),
+                (pending, input),
+            ))
         },
     )
 }

--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -51,7 +51,7 @@ fn convert_graph_edge_into_ancestor<K: Clone>(e: &GraphEdge<K>) -> Ancestor<K> {
     match e.edge_type {
         GraphEdgeType::Direct => Ancestor::Parent(e.target.clone()),
         GraphEdgeType::Indirect => Ancestor::Ancestor(e.target.clone()),
-        GraphEdgeType::Missing => Ancestor::Anonymous,
+        _ => unreachable!("all edges should be converted to direct with synthetic nodes"),
     }
 }
 

--- a/cli/src/graphlog.rs
+++ b/cli/src/graphlog.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::hash::Hash;
 use std::io;
 use std::io::Write;
@@ -36,9 +37,14 @@ pub trait GraphLog<K: Clone + Eq + Hash> {
     fn width(&self, id: &K, edges: &[GraphEdge<K>]) -> usize;
 }
 
-pub struct SaplingGraphLog<'writer, R> {
+pub struct SaplingGraphLog<'writer, K, R> {
     renderer: R,
     writer: &'writer mut dyn Write,
+    /// IDs we expect to see as future nodes (targets of edges from
+    /// already-emitted nodes). Used for component boundary detection.
+    expected_ids: HashSet<K>,
+    /// Whether we have emitted at least one node.
+    has_emitted: bool,
 }
 
 fn convert_graph_edge_into_ancestor<K: Clone>(e: &GraphEdge<K>) -> Ancestor<K> {
@@ -49,7 +55,7 @@ fn convert_graph_edge_into_ancestor<K: Clone>(e: &GraphEdge<K>) -> Ancestor<K> {
     }
 }
 
-impl<K, R> GraphLog<K> for SaplingGraphLog<'_, R>
+impl<K, R> GraphLog<K> for SaplingGraphLog<'_, K, R>
 where
     K: Clone + Eq + Hash,
     R: Renderer<K, Output = String>,
@@ -61,6 +67,20 @@ where
         node_symbol: &str,
         text: &str,
     ) -> io::Result<()> {
+        // Detect component boundaries: if all pending edges from previous
+        // nodes have been drained, this node starts a new disconnected
+        // component. Insert a blank line to visually separate them.
+        if self.has_emitted && self.expected_ids.is_empty() {
+            writeln!(self.writer)?;
+        }
+        self.has_emitted = true;
+        self.expected_ids.remove(id);
+
+        // Track edge targets as expected future nodes.
+        for edge in edges {
+            self.expected_ids.insert(edge.target.clone());
+        }
+
         let row = self.renderer.next_row(
             id.clone(),
             edges.iter().map(convert_graph_edge_into_ancestor).collect(),
@@ -78,11 +98,8 @@ where
     }
 }
 
-impl<'writer, R> SaplingGraphLog<'writer, R> {
-    pub fn create<K>(
-        renderer: R,
-        formatter: &'writer mut dyn Write,
-    ) -> Box<dyn GraphLog<K> + 'writer>
+impl<'writer, K, R> SaplingGraphLog<'writer, K, R> {
+    pub fn create(renderer: R, formatter: &'writer mut dyn Write) -> Box<dyn GraphLog<K> + 'writer>
     where
         K: Clone + Eq + Hash + 'writer,
         R: Renderer<K, Output = String> + 'writer,
@@ -90,6 +107,8 @@ impl<'writer, R> SaplingGraphLog<'writer, R> {
         Box::new(SaplingGraphLog {
             renderer,
             writer: formatter,
+            expected_ids: HashSet::new(),
+            has_emitted: false,
         })
     }
 }

--- a/cli/tests/test_absorb_command.rs
+++ b/cli/tests/test_absorb_command.rs
@@ -122,8 +122,9 @@ fn test_absorb_simple() {
     │  +1b
     ○  qpvuntsm 6a446874 0
     │  diff --git a/file1 b/file1
-    ~  new file mode 100644
-       index 0000000000..e69de29bb2
+    │  new file mode 100644
+    │  index 0000000000..e69de29bb2
+    ~
     [EOF]
     ");
     insta::assert_snapshot!(get_evolog(&work_dir, "subject(1)"), @"
@@ -212,22 +213,23 @@ fn test_absorb_replace_single_line_hunk() {
     │  ->>>>>>> conflict 1 of 1 ends
     ×  qpvuntsm 125fba68 (conflict) 1
     │  diff --git a/file1 b/file1
-    ~  new file mode 100644
-       index 0000000000..0000000000
-       --- /dev/null
-       +++ b/file1
-       @@ -0,0 +1,11 @@
-       +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from: kkmpptxz 9d700628 "2" (parents of absorbed revision)
-       +\\\\\\\        to: qpvuntsm aa6cb9bc "1" (absorb destination)
-       +-2a
-       + 1a
-       +-2b
-       ++++++++ absorbed changes (from zsuskuln 5d926f12)
-       +2a
-       +1A
-       +2b
-       +>>>>>>> conflict 1 of 1 ends
+    │  new file mode 100644
+    │  index 0000000000..0000000000
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,11 @@
+    │  +<<<<<<< conflict 1 of 1
+    │  +%%%%%%% diff from: kkmpptxz 9d700628 "2" (parents of absorbed revision)
+    │  +\\\\\\\        to: qpvuntsm aa6cb9bc "1" (absorb destination)
+    │  +-2a
+    │  + 1a
+    │  +-2b
+    │  ++++++++ absorbed changes (from zsuskuln 5d926f12)
+    │  +2a
+    │  +1A
+    │  +2b
+    │  +>>>>>>> conflict 1 of 1 ends
+    ~
     [EOF]
     "#);
 }
@@ -318,12 +320,13 @@ fn test_absorb_merge() {
     │     0a
     ○  qpvuntsm d4f07be5 0
     │  diff --git a/file1 b/file1
-    ~  new file mode 100644
-       index 0000000000..eb6e8821f1
-       --- /dev/null
-       +++ b/file1
-       @@ -0,0 +1,1 @@
-       +0a
+    │  new file mode 100644
+    │  index 0000000000..eb6e8821f1
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,1 @@
+    │  +0a
+    ~
     [EOF]
     ");
 }
@@ -401,12 +404,13 @@ fn test_absorb_discardable_merge_with_descendant() {
     │     0a
     ○  qpvuntsm d4f07be5 0
     │  diff --git a/file1 b/file1
-    ~  new file mode 100644
-       index 0000000000..eb6e8821f1
-       --- /dev/null
-       +++ b/file1
-       @@ -0,0 +1,1 @@
-       +0a
+    │  new file mode 100644
+    │  index 0000000000..eb6e8821f1
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,1 @@
+    │  +0a
+    ~
     [EOF]
     ");
 }
@@ -514,11 +518,12 @@ fn test_absorb_deleted_file() {
     │  index e69de29bb2..0000000000
     ○  qpvuntsm 38af7fd3 1
     │  diff --git a/file2 b/file2
-    ~  new file mode 100644
-       index 0000000000..e69de29bb2
-       diff --git a/file3 b/file3
-       new file mode 100644
-       index 0000000000..e69de29bb2
+    │  new file mode 100644
+    │  index 0000000000..e69de29bb2
+    │  diff --git a/file3 b/file3
+    │  new file mode 100644
+    │  index 0000000000..e69de29bb2
+    ~
     [EOF]
     ");
 }
@@ -620,32 +625,33 @@ fn test_absorb_deleted_file_with_multiple_hunks() {
     │   >>>>>>> conflict 1 of 1 ends
     ×  qpvuntsm c49bcdd3 (conflict) 1
     │  diff --git a/file1 b/file1
-    ~  new file mode 100644
-       index 0000000000..0000000000
-       --- /dev/null
-       +++ b/file1
-       @@ -0,0 +1,7 @@
-       +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
-       +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
-       + 1a
-       ++1b
-       ++++++++ absorbed changes (from zsuskuln d6492c8f)
-       +>>>>>>> conflict 1 of 1 ends
-       diff --git a/file2 b/file2
-       new file mode 100644
-       index 0000000000..0000000000
-       --- /dev/null
-       +++ b/file2
-       @@ -0,0 +1,8 @@
-       +<<<<<<< conflict 1 of 1
-       +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
-       +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
-       + 1a
-       +-1b
-       ++++++++ absorbed changes (from zsuskuln d6492c8f)
-       +1b
-       +>>>>>>> conflict 1 of 1 ends
+    │  new file mode 100644
+    │  index 0000000000..0000000000
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,7 @@
+    │  +<<<<<<< conflict 1 of 1
+    │  +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
+    │  +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
+    │  + 1a
+    │  ++1b
+    │  ++++++++ absorbed changes (from zsuskuln d6492c8f)
+    │  +>>>>>>> conflict 1 of 1 ends
+    │  diff --git a/file2 b/file2
+    │  new file mode 100644
+    │  index 0000000000..0000000000
+    │  --- /dev/null
+    │  +++ b/file2
+    │  @@ -0,0 +1,8 @@
+    │  +<<<<<<< conflict 1 of 1
+    │  +%%%%%%% diff from: kkmpptxz 33662096 "2" (parents of absorbed revision)
+    │  +\\\\\\\        to: qpvuntsm 66b2ce5b "1" (absorb destination)
+    │  + 1a
+    │  +-1b
+    │  ++++++++ absorbed changes (from zsuskuln d6492c8f)
+    │  +1b
+    │  +>>>>>>> conflict 1 of 1 ends
+    ~
     [EOF]
     "#);
 }
@@ -686,12 +692,13 @@ fn test_absorb_file_mode() {
     │  new mode 100644
     ○  qpvuntsm 2a0c7f1d 1
     │  diff --git a/file1 b/file1
-    ~  new file mode 100755
-       index 0000000000..268de3f3ec
-       --- /dev/null
-       +++ b/file1
-       @@ -0,0 +1,1 @@
-       +1A
+    │  new file mode 100755
+    │  index 0000000000..268de3f3ec
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,1 @@
+    │  +1A
+    ~
     [EOF]
     ");
 }
@@ -741,17 +748,18 @@ fn test_absorb_from_into() {
     │   Z
     ○  kkmpptxz cae507ef 2
     │  diff --git a/file1 b/file1
-    ~  index 352e9b3794..faf62af049 100644
-       --- a/file1
-       +++ b/file1
-       @@ -1,3 +1,7 @@
-        1a
-       +X
-       +2a
-        1b
-        1c
-       +2b
-       +Z
+    │  index 352e9b3794..faf62af049 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -1,3 +1,7 @@
+    │   1a
+    │  +X
+    │  +2a
+    │   1b
+    │   1c
+    │  +2b
+    │  +Z
+    ~
     [EOF]
     ");
 
@@ -798,7 +806,6 @@ fn test_absorb_from_into() {
     │  +2b
     │  +Z
     ○  qpvuntsm e8849ae1 (empty) (no description set)
-    │
     ~
     [EOF]
     ");
@@ -851,19 +858,20 @@ fn test_absorb_paths() {
     │  +1A
     ○  qpvuntsm ca07fabe 1
     │  diff --git a/file1 b/file1
-    ~  new file mode 100644
-       index 0000000000..268de3f3ec
-       --- /dev/null
-       +++ b/file1
-       @@ -0,0 +1,1 @@
-       +1A
-       diff --git a/file2 b/file2
-       new file mode 100644
-       index 0000000000..a8994dc188
-       --- /dev/null
-       +++ b/file2
-       @@ -0,0 +1,1 @@
-       +1a
+    │  new file mode 100644
+    │  index 0000000000..268de3f3ec
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,1 @@
+    │  +1A
+    │  diff --git a/file2 b/file2
+    │  new file mode 100644
+    │  index 0000000000..a8994dc188
+    │  --- /dev/null
+    │  +++ b/file2
+    │  @@ -0,0 +1,1 @@
+    │  +1a
+    ~
     [EOF]
     ");
 }
@@ -940,13 +948,14 @@ fn test_absorb_immutable() {
     │  +2B
     ◆  qpvuntsm e35bcaff 1
     │  diff --git a/file1 b/file1
-    ~  new file mode 100644
-       index 0000000000..8c5268f893
-       --- /dev/null
-       +++ b/file1
-       @@ -0,0 +1,2 @@
-       +1a
-       +1b
+    │  new file mode 100644
+    │  index 0000000000..8c5268f893
+    │  --- /dev/null
+    │  +++ b/file1
+    │  @@ -0,0 +1,2 @@
+    │  +1a
+    │  +1b
+    ~
     [EOF]
     ");
 }

--- a/cli/tests/test_alias.rs
+++ b/cli/tests/test_alias.rs
@@ -27,7 +27,6 @@ fn test_alias_basic() {
     let output = work_dir.run_jj(["bk"]);
     insta::assert_snapshot!(output, @"
     @  my-bookmark
-    │
     ~
     [EOF]
     ");

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -61,8 +61,7 @@ fn test_log_parents() {
     let output = work_dir.run_jj(["log", "-T", template, "-r@", "--color=always"]);
     insta::assert_snapshot!(output, @"
     [1m[38;5;2m@[0m  [1m[38;5;4m1[0m[38;5;8mc1c[39m [1m[38;5;4me[0m[38;5;8m884[39m
-    │
-    ~
+    [38;5;8m~[39m
     [EOF]
     ");
 
@@ -1648,7 +1647,6 @@ fn test_signature_templates() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user 2001-02-03 08:05:09 eb0e9b58 [✓︎] (empty) signed
     ○  qpvuntsm test.user 2001-02-03 08:05:08 0604e056 (empty) unsigned
-    │
     ~
     [EOF]
     ");
@@ -1675,12 +1673,13 @@ fn test_signature_templates() {
     │
     ○  Commit ID: 0604e056feaf8ee553fae4e06d4bfc57cdd319d6
     │  Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
-    ~  Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
-       Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
-       Signature: (no signature)
-
-           unsigned
-
+    │  Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
+    │  Signature: (no signature)
+    │
+    │      unsigned
+    │
+    ~
     [EOF]
     ");
 
@@ -1694,7 +1693,6 @@ fn test_signature_templates() {
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user 2001-02-03 08:05:09 eb0e9b58 status: good (empty) signed
     ○  qpvuntsm test.user 2001-02-03 08:05:08 0604e056 status: <Error: No CryptographicSignature available> (empty) unsigned
-    │
     ~
     [EOF]
     ");

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -116,6 +116,7 @@ fn test_evolog_with_or_without_diff() {
     ○  rlvkpnrz/3 test.user@example.com 2001-02-03 08:05:08 b955b72e (hidden)
        (empty) my description
        -- operation c5d06fd4ff51 new empty commit
+
     ○  qpvuntsm test.user@example.com 2001-02-03 08:05:08 c664a51b
     │  (no description set)
     │  -- operation b243f4039fc9 snapshot working copy

--- a/cli/tests/test_fileset_output.rs
+++ b/cli/tests/test_fileset_output.rs
@@ -148,14 +148,14 @@ fn test_alias_in_revset_or_template() {
     insta::assert_snapshot!(output, @"
     @  qpvuntsm test.user@example.com 2001-02-03 08:05:08 093c3c96
     │  (no description set)
-    ~  A file1
+    │  A file1
+    ~
     [EOF]
     ");
 
     let output = work_dir.run_jj(["log", "-r@", "-Tself.diff('star').summary()"]);
     insta::assert_snapshot!(output, @"
     @  A file1
-    │
     ~
     [EOF]
     ");

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -1066,7 +1066,6 @@ fn test_git_clone_conditional_config() {
     @  new-repo@example.org
     ○  new-repo@example.org
     ◆  someone@example.org message
-    │
     ~
     [EOF]
     ");

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2124,6 +2124,7 @@ fn test_git_fetch_remotely_rewritten() {
     │  -- operation 747e22d526e2 fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
        (empty) bookmarked
+
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
     │  -- operation 747e22d526e2 fetch from git remote(s) origin
@@ -2165,6 +2166,7 @@ fn test_git_fetch_remotely_rewritten() {
     │  -- operation 747e22d526e2 fetch from git remote(s) origin
     ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 eedc2709 (hidden)
        (empty) bookmarked
+
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
     │  (empty) modified
     │  -- operation 747e22d526e2 fetch from git remote(s) origin
@@ -2236,6 +2238,7 @@ fn test_git_fetch_remotely_rewritten_no_synthetic_predecessors() {
     insta::assert_snapshot!(output, @"
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:14 book@origin 3ee37bc8
        (empty) bookmarked
+
     ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:14 f30445f7
        (empty) modified
     [EOF]

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -847,7 +847,6 @@ fn test_git_remote_named_git() {
     let output = work_dir.run_jj(["log", "-rmain@git", "-Tbookmarks"]);
     insta::assert_snapshot!(output, @"
     @  main
-    │
     ~
     [EOF]
     ");
@@ -890,7 +889,6 @@ fn test_git_remote_named_git() {
     let output = work_dir.run_jj(["log", "-rmain@git", "-Tbookmarks"]);
     insta::assert_snapshot!(output, @"
     ○  main
-    │
     ~
     [EOF]
     ");
@@ -965,7 +963,6 @@ fn test_git_remote_with_slashes() {
     let output = work_dir.run_jj(["log", "-rmain@git", "-Tbookmarks"]);
     insta::assert_snapshot!(output, @"
     ○  main
-    │
     ~
     [EOF]
     ");

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -332,9 +332,7 @@ fn test_rewrite_immutable_commands() {
     │  (no description set)
     │ ◆  mzvwutvl test.user@example.com 2001-02-03 08:05:12 main 1ca17106 (conflict)
     ╭─┤  merge
-    │ │
     │ ~
-    │
     ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:10 9d190342
     │  b
     ~

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -897,6 +897,61 @@ fn test_log_reversed() {
 }
 
 #[test]
+fn test_log_reversed_disconnected_components() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Create a linear chain: root <- A <- B <- C
+    // plus a branch off A:  A <- D (working copy)
+    //
+    //   C  D (@)
+    //   |  |
+    //   B  |
+    //   |/
+    //   A
+    //   |
+    //  root
+    work_dir.run_jj(["new", "root()", "-m", "A"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "a", "-r", "@"])
+        .success();
+    work_dir.run_jj(["new", "-m", "B"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "b", "-r", "@"])
+        .success();
+    work_dir.run_jj(["new", "-m", "C"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "c", "-r", "@"])
+        .success();
+    work_dir.run_jj(["new", "a", "-m", "D"]).success();
+
+    // Forward: two disconnected components
+    let output = work_dir.run_jj(["log", "-r", ".. ~ a", "-T", "description"]);
+    insta::assert_snapshot!(output, @r"
+    @  D
+    │
+    ~
+
+    ○  C
+    ○  B
+    │
+    ~
+    [EOF]
+    ");
+
+    // Reversed: two disconnected components, order flipped
+    let output = work_dir.run_jj(["log", "-r", ".. ~ a", "-T", "description", "--reversed"]);
+    insta::assert_snapshot!(output, @r"
+    ○  B
+    ○  C
+
+    @  D
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_log_filtered_by_path() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -368,12 +368,13 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  a new commit
     │  diff --git a/file1 b/file1
-    ~  index 257cc5642c..3bd1f0e297 100644
-       --- a/file1
-       +++ b/file1
-       @@ -1,1 +1,2 @@
-        foo
-       +bar
+    │  index 257cc5642c..3bd1f0e297 100644
+    │  --- a/file1
+    │  +++ b/file1
+    │  @@ -1,1 +1,2 @@
+    │   foo
+    │  +bar
+    ~
     [EOF]
     ");
     let output = work_dir.run_jj(["log", "-T", "description", "-r", "@", "--no-graph", "--git"]);
@@ -394,8 +395,9 @@ fn test_log_with_or_without_diff() {
     insta::assert_snapshot!(output, @"
     @  a new commit
     │  Modified regular file file1:
-    ~     1    1: foo
-               2: bar
+    │     1    1: foo
+    │          2: bar
+    ~
     [EOF]
     ");
     let output = work_dir.run_jj([
@@ -652,7 +654,6 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(
         work_dir.run_jj(["log", "-r", "original", "-T", &prefix_format(Some(12))]), @"
     @  Change qpvuntsmwlqt initial 8216f646c36d original
-    │
     ~
     [EOF]
     ");
@@ -672,7 +673,6 @@ fn test_log_prefix_highlight_styled() {
     insta::assert_snapshot!(
         work_dir.run_jj(["log", "-r", "original", "-T", &prefix_format(Some(12))]), @"
     ○  Change qpvuntsmwlqt initial 8216f646c36d original
-    │
     ~
     [EOF]
     ");
@@ -802,7 +802,6 @@ fn test_log_prefix_highlight_counts_hidden_commits() {
     ");
     insta::assert_snapshot!(work_dir.run_jj(["log", "-r", "88", "-T", prefix_format]), @"
     @  Change wq[nwkozpkust] 88[e8407a4f0a]
-    │
     ~
     [EOF]
     ");
@@ -930,12 +929,10 @@ fn test_log_reversed_disconnected_components() {
     let output = work_dir.run_jj(["log", "-r", ".. ~ a", "-T", "description"]);
     insta::assert_snapshot!(output, @r"
     @  D
-    │
     ~
 
     ○  C
     ○  B
-    │
     ~
     [EOF]
     ");
@@ -943,9 +940,11 @@ fn test_log_reversed_disconnected_components() {
     // Reversed: two disconnected components, order flipped
     let output = work_dir.run_jj(["log", "-r", ".. ~ a", "-T", "description", "--reversed"]);
     insta::assert_snapshot!(output, @r"
+    ~
     ○  B
     ○  C
 
+    ~
     @  D
     [EOF]
     ");
@@ -985,7 +984,6 @@ fn test_log_filtered_by_path() {
     insta::assert_snapshot!(output, @"
     @  second
     ○  first
-    │
     ~
     [EOF]
     ");
@@ -993,7 +991,6 @@ fn test_log_filtered_by_path() {
     let output = work_dir.run_jj(["log", "-T", "description", "file2"]);
     insta::assert_snapshot!(output, @"
     @  second
-    │
     ~
     [EOF]
     ");
@@ -1136,7 +1133,6 @@ fn test_log_limit() {
     let output = work_dir.run_jj(["log", "-T", "description", "--limit=1", "b", "c"]);
     insta::assert_snapshot!(output, @"
     ○  c
-    │
     ~
     [EOF]
     ------- stderr -------
@@ -1157,7 +1153,6 @@ fn test_log_warn_path_might_be_revset() {
     let output = work_dir.run_jj(["log", "file1", "-T", "description"]);
     insta::assert_snapshot!(output, @"
     @
-    │
     ~
     [EOF]
     ");
@@ -1166,7 +1161,6 @@ fn test_log_warn_path_might_be_revset() {
     let output = work_dir.run_jj(["log", ".", "-T", "description"]);
     insta::assert_snapshot!(output, @r#"
     @
-    │
     ~
     [EOF]
     ------- stderr -------
@@ -1233,7 +1227,6 @@ fn test_default_revset() {
     // The default revset is not used if a path is specified
     insta::assert_snapshot!(work_dir.run_jj(["log", "file1", "-T", "description"]), @"
     @  add a file
-    │
     ~
     [EOF]
     ");
@@ -1277,7 +1270,6 @@ fn test_multiple_revsets() {
     insta::assert_snapshot!(
         work_dir.run_jj(["log", "-T", "bookmarks", "-rfoo"]), @"
     ○  foo
-    │
     ~
     [EOF]
     ");
@@ -1286,14 +1278,12 @@ fn test_multiple_revsets() {
     @  baz
     ○  bar
     ○  foo
-    │
     ~
     [EOF]
     ");
     insta::assert_snapshot!(
         work_dir.run_jj(["log", "-T", "bookmarks", "-rfoo", "-rfoo"]), @"
     ○  foo
-    │
     ~
     [EOF]
     ");
@@ -1509,7 +1499,8 @@ fn test_log_word_wrap() {
     insta::assert_snapshot!(render(&["log", "-r@"], 40, true), @"
     @  mzvwutvl test.user@example.com
     │  2001-02-03 08:05:11 bafb1ee5
-    ~  (empty) merge
+    │  (empty) merge
+    ~
     [EOF]
     ");
     insta::assert_snapshot!(render(&["log", "--no-graph", "-r@"], 40, false), @"
@@ -1528,7 +1519,8 @@ fn test_log_word_wrap() {
     insta::assert_snapshot!(render(&["log", "-r@", "--color=always"], 40, true), @"
     [1m[38;5;2m@[0m  [1m[38;5;13mm[38;5;8mzvwutvl[39m [38;5;3mtest.user@example.com[39m[0m
     │  [1m[38;5;14m2001-02-03 08:05:11[39m [38;5;12mb[38;5;8mafb1ee5[39m[0m
-    ~  [1m[38;5;10m(empty)[39m merge[0m
+    │  [1m[38;5;10m(empty)[39m merge[0m
+    [38;5;8m~[39m
     [EOF]
     ");
 
@@ -1560,21 +1552,23 @@ fn test_log_word_wrap() {
     insta::assert_snapshot!(render(&["log", "-r@"], 0, true), @"
     @  mzvwutvl
     │  test.user@example.com
-    ~  2001-02-03
-       08:05:11
-       bafb1ee5
-       (empty)
-       merge
+    │  2001-02-03
+    │  08:05:11
+    │  bafb1ee5
+    │  (empty)
+    │  merge
+    ~
     [EOF]
     ");
     insta::assert_snapshot!(render(&["log", "-r@"], 1, true), @"
     @  mzvwutvl
     │  test.user@example.com
-    ~  2001-02-03
-       08:05:11
-       bafb1ee5
-       (empty)
-       merge
+    │  2001-02-03
+    │  08:05:11
+    │  bafb1ee5
+    │  (empty)
+    │  merge
+    ~
     [EOF]
     ");
 }
@@ -1594,8 +1588,9 @@ fn test_log_word_wrap_with_hyperlinks() {
     insta::assert_snapshot!(output, @r"
     [1m[38;5;2m@[0m  ]8;;http://example.com\long
     │  line to
-    ~  force
-       wrapping]8;;\
+    │  force
+    │  wrapping]8;;\
+    [38;5;8m~[39m
     [EOF]
     ");
 }
@@ -1692,8 +1687,7 @@ fn test_elided() {
     ○ ╷  main bookmark 2
     ├─╯
     ○  initial
-    │
-    ~
+
     [EOF]
     ");
 

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -1280,9 +1280,13 @@ fn test_op_diff() {
 
     Changed commits:
     ○  + skovwzlu 854c38b8 Commit 4
+
     ○  + rnnslrkn 4ff62539 bookmark-2@origin | Commit 2
+
     ○  + rnnkyono 11671e4c bookmark-3@origin | Commit 3
+
     ○  + pukowqtp 0cb7e07e bookmark-1 | Commit 1
+
     ○  + qpvuntsm e8849ae1 (empty) (no description set)
 
     Changed working copy default@:
@@ -1325,9 +1329,13 @@ fn test_op_diff() {
 
     Changed commits:
     ○  - skovwzlu/0 854c38b8 (hidden) Commit 4
+
     ○  - rnnslrkn/0 4ff62539 (hidden) Commit 2
+
     ○  - rnnkyono/0 11671e4c (hidden) Commit 3
+
     ○  - pukowqtp/0 0cb7e07e (hidden) Commit 1
+
     ○  - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
@@ -1488,7 +1496,9 @@ fn test_op_diff() {
 
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
+
     ○  + zkmtkqvo 0dee6313 bookmark-1?? bookmark-1@origin | Commit 4
+
     ○  - rnnkyono/0 11671e4c (hidden) Commit 3
 
     Changed local bookmarks:
@@ -1814,6 +1824,7 @@ fn test_op_diff_patch() {
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
+
     ○  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
 
     Changed working copy default@:
@@ -1912,6 +1923,7 @@ fn test_op_diff_sibling() {
     │    A file1
     ○  - zsuskuln/0 47b9525e (hidden) A.2
        A file2
+
     ○  + qpvuntsm b1ca67e2 (empty) B
        - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
 
@@ -1937,6 +1949,7 @@ fn test_op_diff_sibling() {
 
     Changed commits:
     ○  - qpvuntsm/0 b1ca67e2 (hidden) (empty) B
+
     ○    + mzvwutvl 08c63613 (empty) A
     ├─╮
     │ ○  + kkmpptxz 6c70a4f7 A.1
@@ -2041,6 +2054,7 @@ fn test_op_diff_divergent_change() {
     Changed commits:
     ○  + rlvkpnrz/0 c5cad9ab (divergent) 2b
        - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
+
     ○  + rlvkpnrz/2 f189cafa (divergent) 2a
        - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
 
@@ -2103,6 +2117,7 @@ fn test_op_diff_divergent_change() {
        @@ -1,1 +1,2 @@
         1
        +2b
+
     ○  + rlvkpnrz/2 f189cafa (divergent) 2a
        - rlvkpnrz/4 4f7a567a (hidden) (empty) (no description set)
        diff --git a/JJ-COMMIT-DESCRIPTION b/JJ-COMMIT-DESCRIPTION
@@ -2179,6 +2194,7 @@ fn test_op_diff_divergent_change() {
     Changed commits:
     ○  + rlvkpnrz/1 c5cad9ab (divergent) 2b
        - rlvkpnrz/0 17d68d92 (hidden) 2ab
+
     ○  + rlvkpnrz/3 f189cafa (divergent) 2a
        - rlvkpnrz/0 17d68d92 (hidden) 2ab
 
@@ -2330,17 +2346,21 @@ fn test_op_diff_word_wrap() {
        Commit 1
        some-file | 1 +
        1 file changed, 1 insertion(+), 0 deletions(-)
+
     ○  + skovwzlu 854c38b8 Commit 4
        some-file | 1 +
        1 file changed, 1 insertion(+), 0 deletions(-)
+
     ○  + rnnslrkn 4ff62539 bookmark-2@origin
        | Commit 2
        some-file | 1 +
        1 file changed, 1 insertion(+), 0 deletions(-)
+
     ○  + rnnkyono 11671e4c bookmark-3@origin
        | Commit 3
        some-file | 1 +
        1 file changed, 1 insertion(+), 0 deletions(-)
+
     ○  - qpvuntsm/0 e8849ae1 (hidden)
        (empty) (no description set)
        0 files changed, 0 insertions(+), 0 deletions(-)
@@ -2392,15 +2412,19 @@ fn test_op_diff_word_wrap() {
     ○  + 0 1 2
        3 4 5 6
        7 8 9
+
     ○  + 0 1 2
        3 4 5 6
        7 8 9
+
     ○  + 0 1 2
        3 4 5 6
        7 8 9
+
     ○  + 0 1 2
        3 4 5 6
        7 8 9
+
     ○  - 0 1 2
        3 4 5 6
        7 8 9
@@ -2537,8 +2561,11 @@ fn test_op_show() {
 
     Changed commits:
     ○  + skovwzlu 854c38b8 Commit 4
+
     ○  + rnnslrkn 4ff62539 bookmark-2@origin | Commit 2
+
     ○  + rnnkyono 11671e4c bookmark-3@origin | Commit 3
+
     ○  + pukowqtp 0cb7e07e bookmark-1@origin | Commit 1
 
     Changed local tags:
@@ -2618,7 +2645,9 @@ fn test_op_show() {
 
     Changed commits:
     ○  + kulxwnxm e1a239a5 bookmark-2@origin | Commit 5
+
     ○  + zkmtkqvo 0dee6313 bookmark-1?? bookmark-1@origin | Commit 4
+
     ○  - rnnkyono/0 11671e4c (hidden) Commit 3
 
     Changed local bookmarks:
@@ -2725,6 +2754,7 @@ fn test_op_show() {
 
     Changed commits:
     ○  + tlkvzzqu 8f340dd7 (empty) new commit
+
     ○  - qpvuntsm/0 e8849ae1 (hidden) (empty) (no description set)
 
     Changed working copy default@:
@@ -2921,6 +2951,7 @@ fn test_op_show_patch() {
 
     Changed commits:
     ○  + yqosqzyt c97a8573 (empty) (no description set)
+
     ○  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
 
     Changed working copy default@:
@@ -2938,6 +2969,7 @@ fn test_op_show_patch() {
     │
     │  Changed commits:
     │  ○  + yqosqzyt c97a8573 (empty) (no description set)
+    │
     │  ○  - mzvwutvl/0 6cbd01ae (hidden) (empty) (no description set)
     │
     │  Changed working copy default@:
@@ -3311,6 +3343,7 @@ fn test_op_immutable_revisions() {
     Changed commits:
     ○  + ztnvrxlv 41578768 (empty) (no description set)
        - ztnvrxlv/1 13887367 (hidden) (empty) (no description set)
+
     ○  - wqxolloz/0 4ebd4aa1 (hidden) (empty) single-2
        (Elided 1 newly removed revisions)
 
@@ -3347,8 +3380,10 @@ fn test_op_immutable_revisions() {
     Changed commits:
     ○  + ztnvrxlv 13887367 (empty) (no description set)
     ○  + wqxolloz 4ebd4aa1 (empty) single-2
+
     ○  + xpnwykqz 741a5187 bb | (empty) mix-b5
     ○  + zowrlwsv 5653a1de ba | (empty) mix-a5
+
     ○  - pzsxstzt/0 8192fa83 (hidden) (empty) (no description set)
        (Elided 9 newly added revisions)
 

--- a/cli/tests/test_sign_unsign_commands.rs
+++ b/cli/tests/test_sign_unsign_commands.rs
@@ -172,12 +172,13 @@ key = "some-key"
     │
     ○  Commit ID: eec44cafe0dc853b67cc7e14ca4fe3b80d3687f1
     │  Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
-    ~  Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
-       Committer: Test User <test.user@example.com> (2001-02-03 08:05:11)
-       Signature: good signature by test-display another-key
-
-           one
-
+    │  Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
+    │  Committer: Test User <test.user@example.com> (2001-02-03 08:05:11)
+    │  Signature: good signature by test-display another-key
+    │
+    │      one
+    │
+    ~
     [EOF]
     ");
 }


### PR DESCRIPTION
This is my first contribution to jj. I experimented with several approaches to this problem and this one is the best approach I could come up with.

This properly addresses #9149, which was incorrectly marked as a duplicate of #1092. Although the two issues are related, this does NOT resolve the latter but does fix the correctness issue shown in the former.

Related issues:
- Properly resolves https://github.com/jj-vcs/jj/issues/9149
- Resolves https://github.com/jj-vcs/jj/issues/5937 by no longer using Ancestor::Anonymous nodes
- Related but unfixed https://github.com/jj-vcs/jj/issues/1092 because this is a limitation of sapling renderdag.

Notable changes:
- the vertical line now always goes to the end of a multi-line node before showing the ~
- the extra blank lines that were forced around ~ lines disappear, but disconnected components ALWAYS get a blank line separating them
- merges where multiple parents are elided now show multiple ~ nodes (the number of parents is preserved)
- the final root ~ now respects ui.log-synthetic-elided-nodes, and is rendered using the log_node template

To address potential concerns:
- Why are evolog and op log not affected? These logs never produce disconnected components. It might be nice to use these synthetic elided nodes so that users can customize the log_node template, but not critical to correctness.
- Why not remove the concept of a "missing edge" entirely? That's a hugely invasive change, and doesn't seem worthwhile.
- Why not add proper support for reversed graphs to sapling's renderdag? This is the only approach I can see that will actually resolve the differences shown in #1092, but it's complicated. We walk commits from leafs to root because that's how the database is set up, and this assumption is baked into renderdag, so it can perform online rendering of the graph in O(1) space. 

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
