### PR TITLE
cli: error when inside a git repo inside of a jj repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A new global flag `--no-integrate-operation` lets you run a command without
   impacting the repo state or the working copy.
 
+### Fixed bugs
+
+* `jj` now shows an error when inside of a Git repo nested inside of a JJ repo.
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2730,6 +2730,15 @@ impl WorkspaceCommandTransaction<'_> {
 }
 
 pub fn find_workspace_dir(cwd: &Path) -> &Path {
+    // If the user is inside of a Git repo, there's a fairly good chance
+    // that's the repo they intended to act on.
+    cwd.ancestors()
+        .find(|path| path.join(".jj").is_dir() || path.join(".git").is_dir())
+        .unwrap_or(cwd)
+}
+
+/// Variant of `find_workspace_dir` that only finds JJ repos.
+fn find_workspace_dir_hint(cwd: &Path) -> &Path {
     cwd.ancestors()
         .find(|path| path.join(".jj").is_dir())
         .unwrap_or(cwd)
@@ -2741,16 +2750,26 @@ fn map_workspace_load_error(err: WorkspaceLoadError, user_wc_path: Option<&str>)
             // Prefer user-specified path instead of absolute wc_path if any.
             let short_wc_path = user_wc_path.map_or(wc_path.as_ref(), Path::new);
             let message = format!(r#"There is no jj repo in "{}""#, short_wc_path.display());
+            let mut error = user_error(message);
+
             let git_dir = wc_path.join(".git");
             if git_dir.is_dir() {
-                user_error(message).hinted(
+                error = error.hinted(
                     "It looks like this is a git repo. You can create a jj repo backed by it by \
                      running this:
 jj git init",
-                )
-            } else {
-                user_error(message)
+                );
+
+                let jj_wc_path = find_workspace_dir_hint(&wc_path);
+                if jj_wc_path != wc_path {
+                    error = error.hinted(format!(
+                        r#"Or, you may have intended to run this command inside "{}""#,
+                        jj_wc_path.display()
+                    ));
+                }
             }
+
+            error
         }
         WorkspaceLoadError::RepoDoesNotExist(repo_dir) => user_error(format!(
             "The repository directory at {} is missing. Was it moved?",

--- a/cli/tests/test_root.rs
+++ b/cli/tests/test_root.rs
@@ -48,3 +48,30 @@ fn test_root_outside_a_repo() {
     [exit status: 1]
     "#);
 }
+
+#[test_case(TestRepoBackend::Simple ; "simple backend")]
+#[test_case(TestRepoBackend::Git ; "git backend")]
+fn test_root_inside_a_nested_repo(backend: TestRepoBackend) -> TestResult {
+    let test_env = TestEnvironment::default();
+    let test_workspace = TestWorkspace::init_with_backend(backend);
+    let root = test_workspace.workspace.workspace_root();
+    let subdir = root.join("subdir");
+    std::fs::create_dir_all(subdir.join(".git"))?;
+
+    let mut insta_settings = insta::Settings::clone_current();
+    insta_settings.add_filter(&regex::escape(&root.to_string_lossy()), "<root>");
+    let _guard = insta_settings.bind_to_scope();
+
+    let output = test_env.run_jj_in(&subdir, ["root"]);
+    insta::assert_snapshot!(output, @r#"
+        ------- stderr -------
+        Error: There is no jj repo in "."
+        Hint: It looks like this is a git repo. You can create a jj repo backed by it by running this:
+        jj git init
+        Hint: Or, you may have intended to run this command inside "<root>"
+        [EOF]
+        [exit status: 1]
+    "#);
+
+    Ok(())
+}


### PR DESCRIPTION
When the user is inside a Git repo that is itself inside of a JJ repo, there's a fairly good chance that the user intended to act on the inner repo and didn't realise it wasn't colocated with a JJ repo yet. This change modifies `find_workspace_dir` to also return Git repos and adds a new error hint to be shown in this nested repos situation.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Below is my original description of the issue. Note that this PR does not resolve #8439.

> I've run into a similar case where I'm inside of the nested repo:
> 
> ```sh
> jj git init parent
> cd parent
> git init nested
> cd nested
> jj st
> ```
> 
> Here, JJ operates on the parent repo, but I'm currently inside of a nested Git repo so my intention is to operate on the nested repo. I would appreciate a message to warn me that JJ might not be operating on the repo I expected.
> 
> This case will probably be covered by whatever fix you end up going with, but I think it's worth explicitly testing.
> 
> Edit: I thought it worth mentioning that, in my case, the nested repo is also gitignored. 

 _Originally posted by @Benjamin-Davies in [#8439](https://github.com/jj-vcs/jj/issues/8439#issuecomment-3795482088)_

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] ~~I have updated the documentation (`README.md`, `docs/`, `demos/`)~~
- [ ] ~~I have updated the config schema (`cli/src/config-schema.json`)~~
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
