### PR TITLE
git: reject remote names that are empty or contain whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj git remote add` now reports an error instead of panicking when the
+  remote name is empty or contains whitespace.
+  [#9099](https://github.com/jj-vcs/jj/issues/9099)
+
 * Color-words diffs are now shown as separate before and after lines when color
   output is disabled, making piped or redirected diffs readable.
   [#5894](https://github.com/jj-vcs/jj/issues/5894)

--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -965,3 +965,28 @@ fn test_git_remote_with_global_git_remote_config() {
     	fetch = +refs/heads/*:refs/remotes/origin/*
     "#);
 }
+
+#[test]
+fn test_git_remote_name_validation() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Invalid remote name is rejected (detailed validation tested in jj-lib)
+    let output = work_dir.run_jj([
+        "git",
+        "remote",
+        "add",
+        "my remote",
+        "http://example.com/repo",
+    ]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Invalid Git remote name
+    Caused by:
+    1: remote names must be valid within refspecs for fetching: "my remote"
+    2: Reference name contains invalid byte: " "
+    [EOF]
+    [exit status: 1]
+    "#);
+}

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -150,9 +150,12 @@ pub enum GitRemoteNameError {
     ReservedForLocalGitRepo,
     #[error("Git remotes with slashes are incompatible with jj: {}", .0.as_symbol())]
     WithSlash(RemoteNameBuf),
+    #[error("Invalid Git remote name")]
+    InvalidName(#[from] gix::remote::name::Error),
 }
 
 fn validate_remote_name(name: &RemoteName) -> Result<(), GitRemoteNameError> {
+    gix::remote::name::validated(name.as_str())?;
     if name == REMOTE_NAME_FOR_LOCAL_GIT_REPO {
         Err(GitRemoteNameError::ReservedForLocalGitRepo)
     } else if name.as_str().contains('/') {

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -6848,3 +6848,80 @@ fn test_set_remote_urls() -> TestResult {
     );
     Ok(())
 }
+
+#[test]
+fn test_remote_name_validation() -> TestResult {
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+
+    let try_add_remote = |name: &str| {
+        let mut tx = test_repo.repo.start_transaction();
+        git::add_remote(
+            tx.repo_mut(),
+            name.as_ref(),
+            "https://example.com/",
+            None,
+            gix::remote::fetch::Tags::None,
+        )
+    };
+
+    // Valid remote name
+    try_add_remote("origin")?;
+
+    // Empty remote name
+    assert_matches!(
+        try_add_remote(""),
+        Err(git::GitRemoteManagementError::RemoteName(
+            git::GitRemoteNameError::InvalidName(_)
+        ))
+    );
+
+    // Whitespace in remote name
+    assert_matches!(
+        try_add_remote("my remote"),
+        Err(git::GitRemoteManagementError::RemoteName(
+            git::GitRemoteNameError::InvalidName(_)
+        ))
+    );
+
+    // Tab in remote name
+    assert_matches!(
+        try_add_remote("my\tremote"),
+        Err(git::GitRemoteManagementError::RemoteName(
+            git::GitRemoteNameError::InvalidName(_)
+        ))
+    );
+
+    // Newline in remote name
+    assert_matches!(
+        try_add_remote("my\nremote"),
+        Err(git::GitRemoteManagementError::RemoteName(
+            git::GitRemoteNameError::InvalidName(_)
+        ))
+    );
+
+    // Leading whitespace
+    assert_matches!(
+        try_add_remote(" origin"),
+        Err(git::GitRemoteManagementError::RemoteName(
+            git::GitRemoteNameError::InvalidName(_)
+        ))
+    );
+
+    // Slash in remote name (jj-specific restriction)
+    assert_matches!(
+        try_add_remote("foo/bar"),
+        Err(git::GitRemoteManagementError::RemoteName(
+            git::GitRemoteNameError::WithSlash(_)
+        ))
+    );
+
+    // Reserved name for local git repo
+    assert_matches!(
+        try_add_remote("git"),
+        Err(git::GitRemoteManagementError::RemoteName(
+            git::GitRemoteNameError::ReservedForLocalGitRepo
+        ))
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
A remote name that is empty or contains whitespace (e.g. `jj git remote add "my remote" url`) caused a panic instead of an error. `validate_remote_name` now passes the name through `gix::remote::name::validated()`, which rejects empty and whitespace names (and anything else git itself rejects) before it reaches the refspec parser.

Fixes #9099

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
