### PR TITLE
bisect: use Revset::count_estimate() for remaining count

### DIFF
--- a/cli/src/commands/bisect/run.rs
+++ b/cli/src/commands/bisect/run.rs
@@ -131,14 +131,22 @@ pub(crate) async fn cmd_bisect_run(
             jj_lib::bisect::NextStep::Evaluate(commit) => {
                 {
                     let mut formatter = ui.stdout_formatter();
+                    let (lower, upper) = bisector.remaining_revset().await?.count_estimate()?;
+                    let lower_steps = ((lower + 1) as f64).log2().ceil() as usize;
+                    if upper == Some(lower) {
+                        writeln!(
+                            formatter,
+                            "Bisecting: {lower} revisions left to test after this (roughly \
+                             {lower_steps} steps)"
+                        )?;
+                    } else {
+                        writeln!(
+                            formatter,
+                            "Bisecting: at least {lower} revisions left to test after this (at \
+                             least roughly {lower_steps} steps)"
+                        )?;
+                    }
                     // TODO: Show a graph of the current range instead?
-                    let remaining = bisector.remaining_count().await?;
-                    let steps = ((remaining + 1) as f64).log2().ceil() as usize;
-                    writeln!(
-                        formatter,
-                        "Bisecting: {remaining} revisions left to test after this (roughly \
-                         {steps} steps)"
-                    )?;
                     let commit_template = workspace_command.commit_summary_template();
                     write!(formatter, "Now evaluating: ")?;
                     commit_template.format(&commit, formatter.as_mut())?;

--- a/lib/src/bisect.rs
+++ b/lib/src/bisect.rs
@@ -18,7 +18,6 @@ use std::collections::HashSet;
 use std::pin::pin;
 use std::sync::Arc;
 
-use futures::StreamExt as _;
 use futures::TryStreamExt as _;
 use thiserror::Error;
 
@@ -27,6 +26,7 @@ use crate::backend::CommitId;
 use crate::commit::Commit;
 use crate::repo::Repo;
 use crate::revset::ResolvedRevsetExpression;
+use crate::revset::Revset;
 use crate::revset::RevsetEvaluationError;
 use crate::revset::RevsetExpression;
 use crate::revset::RevsetStreamExt as _;
@@ -200,14 +200,11 @@ impl<'repo> Bisector<'repo> {
             .minus(&skipped_expr)
     }
 
-    /// Returns the number of remaining candidate commits to evaluate.
-    pub async fn remaining_count(&self) -> Result<usize, BisectionError> {
-        Ok(self
-            .candidates()
-            .evaluate(self.repo)?
-            .stream()
-            .count()
-            .await)
+    /// Returns the evaluated revset representing the remaining candidate
+    /// commits. Can be used for getting an estimate of how many commits are
+    /// left to evaluate.
+    pub async fn remaining_revset(&self) -> Result<Box<dyn Revset + 'repo>, BisectionError> {
+        Ok(self.candidates().evaluate(self.repo)?)
     }
 
     /// Find the next commit to evaluate, or determine that there are no more


### PR DESCRIPTION
The remaining commit count and estimated number of steps we added in b31a82a283e0c counts the number of commits by iterating/streaming through the revset. That is very slow at Google where there are commonly millions of commits to bisect and they are streamed from the server. We should instead use the `Revset::count_estimate()` for this purpose, so that's what this patch does. I updated the message to handle all three of cases of "exact count known", "both bounds known", and "only lower bound known".

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
