### PR TITLE
gerrit upload: don't error when unrelated links are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Improving consistency with `git` handling of `.gitignore`, including `/`
   after entries and `\r\r\n` for MacOS files.
 
+* `jj gerrit upload` on commits with unrelated Links can be uploaded again.
+  (broke in v0.39.0)
+
 * `jj status` filters untracked paths by fileset
   [#9287](https://github.com/jj-vcs/jj/issues/9287)
 

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -502,7 +502,10 @@ pub async fn cmd_gerrit_upload(
 
         let change_id_trailers: Vec<&Trailer> = trailers
             .iter()
-            .filter(|trailer| trailer.key == "Change-Id" || trailer.key == "Link")
+            .filter(|trailer| {
+                trailer.key == "Change-Id"
+                    || (trailer.key == "Link" && trailer.value.contains("/id/I"))
+            })
             .collect();
 
         // There shouldn't be multiple change-ID fields. So just error out if

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -693,7 +693,11 @@ fn test_gerrit_upload_bad_change_ids() {
         ])
         .success();
     local_dir
-        .run_jj(["describe", "-rb3", "-m\n\nLink: malformed\n"])
+        .run_jj([
+            "describe",
+            "-rb3",
+            "-m\n\nLink: ignored\nChange-Id: Id39b308212fe7e0b746d16c13355f3a90712d7f9\n",
+        ])
         .success();
     local_dir
         .run_jj([
@@ -767,10 +771,9 @@ fn test_gerrit_upload_bad_change_ids() {
     ------- stderr -------
     Warning: Invalid Change-Id footer in revision mzvwutvlkqwt
     Warning: Invalid Change-Id footer in revision yqosqzytrlsw
-    Warning: Invalid Link footer in revision yostqsxwqrlt
     Warning: Invalid Link footer in revision kpqxywonksrl
     Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
-    Pushing kpqxywon 69536ef3 b4
+    Pushing kpqxywon f155d484 b4
     [EOF]
     ");
 }


### PR DESCRIPTION
jj gerrit upload would error when any link is present, even if they are
not recognized as gerrit links: filter for '/id/I' as per the split_once
check that follows.

This fixes the following error when any Link trailer is present:
> Error: Multiple Change-Id footers in revision yvkyokmoywqk

Fixes: 38fed24 ("gerrit upload: support the alternative `Link` change-id trailer")

--------------

~~Note: happy to drop the trivial commit removing trailing whitespace (or squash), my editor just did it on its own so I'm sending it as an extra flyby.~~ dropped on rebase

Also wasn't sure if I should say which version broke, I find that kind of information helpful but no other changelog entry does say it so happy to remove it.

Oh and thanks for jj!

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] No LLM was used