### PR TITLE
ci: add riscv64 to release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux-x86_64-musl, linux-aarch64-musl, macos-x86_64, macos-aarch64, win-x86_64, win-aarch64]
+        build: [linux-x86_64-musl, linux-aarch64-musl, linux-riscv64-musl, macos-x86_64, macos-aarch64, win-x86_64, win-aarch64]
         include:
         - build: linux-x86_64-musl
           os: ubuntu-24.04
@@ -25,6 +25,9 @@ jobs:
         - build: linux-aarch64-musl
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-musl
+        - build: linux-riscv64-musl
+          os: ubuntu-24.04-riscv
+          target: riscv64gc-unknown-linux-musl
         - build: macos-x86_64
           os: macos-15
           target: x86_64-apple-darwin


### PR DESCRIPTION
Adds `riscv64gc-unknown-linux-musl` to the release matrix, producing `jj-*-riscv64gc-unknown-linux-musl.tar.gz` in each release. Consistent with the existing musl targets for x86_64 and aarch64.

The build runs on `ubuntu-24.04-riscv` runners from the [RISE Project](https://riseproject.dev). Once the [RISE GitHub App](https://github.com/apps/rise-risc-v-runners) is installed on the jj-vcs org, the runner label is picked up automatically.

Build evidence from a native riscv64 runner: https://github.com/gounthar/jj/actions/runs/23513361087

Closes #9183