### PR TITLE
arrange: use log template instead of commit summary template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `jj arrange` TUI now includes immediate parents and children. They are not
   selectable and are dimmed by default.
 
+* `jj arrange` uses the default log template (`builtin_log_compact`) instead of
+   the shorter commit summary style.
+
 * [Diff colors](docs/config.md#diff-colors-and-styles) can now be configured
   differently for each format.
 
 * `jj op log` now includes the name of the workspace the operation was created
   from.
 
-* The `config()` template function now accepts a `Stringify` expression instead 
+* The `config()` template function now accepts a `Stringify` expression instead
   of `LiteralString`. This allows looking up configuration values dynamically.
 
 * `jj op show`, `jj op diff`, `jj op log -p` now only show "interesting"

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -2,7 +2,7 @@
 bookmark_list = 'format_commit_ref(self, "bookmark") ++ "\n"'
 
 commit_summary = 'format_commit_summary_with_refs(self, format_commit_ref_names(bookmarks))'
-arrange = 'format_commit_summary_with_refs(self, format_commit_ref_names(bookmarks))'
+arrange = 'builtin_log_compact'
 
 file_annotate = '''
 join(" ",


### PR DESCRIPTION
I think I just used the commit summary template to look similar to `hg histedit`, but since `jj arrange` actually shows the log and has two lines per commit, I think it makes more sense to use the log template.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
