### PR TITLE
cli: add partial clone hint on object-not-found errors

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -158,6 +158,7 @@ use crate::command_error::config_error_with_message;
 use crate::command_error::handle_command_result;
 use crate::command_error::internal_error;
 use crate::command_error::internal_error_with_message;
+use crate::command_error::maybe_add_partial_clone_hint;
 use crate::command_error::print_error_sources;
 use crate::command_error::print_parse_diagnostics;
 use crate::command_error::user_error;
@@ -2853,10 +2854,10 @@ async fn update_stale_working_copy(
         .check_out(new_commit)
         .await
         .map_err(|err| {
-            internal_error_with_message(
+            maybe_add_partial_clone_hint(internal_error_with_message(
                 format!("Failed to check out commit {}", new_commit.id().hex()),
                 err,
-            )
+            ))
         })?;
     locked_ws.finish(op_id).await?;
 
@@ -3154,10 +3155,10 @@ pub async fn update_working_copy(
         .check_out(repo.op_id().clone(), old_tree.as_ref(), new_commit)
         .await
         .map_err(|err| {
-            internal_error_with_message(
+            maybe_add_partial_clone_hint(internal_error_with_message(
                 format!("Failed to check out commit {}", new_commit.id().hex()),
                 err,
-            )
+            ))
         })?;
     Ok(stats)
 }

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -224,6 +224,35 @@ pub fn internal_error_with_message(
     CommandError::with_message(CommandErrorKind::Internal, message, source)
 }
 
+const PARTIAL_CLONE_HINT: &str = r#"Is this Git repository a partial clone (cloned with the --filter argument)?
+jj currently does not support partial clones.
+To use jj with this repository, try converting to a full clone:
+
+git config --unset remote.origin.partialclonefilter
+git fetch --refetch origin"#;
+
+/// Returns true if the given error's source chain contains a
+/// `BackendError::ObjectNotFound`.
+fn has_object_not_found_error(err: &(dyn error::Error + 'static)) -> bool {
+    let mut source: Option<&(dyn error::Error + 'static)> = Some(err);
+    while let Some(err) = source {
+        if let Some(BackendError::ObjectNotFound { .. }) = err.downcast_ref::<BackendError>() {
+            return true;
+        }
+        source = err.source();
+    }
+    false
+}
+
+/// Adds a partial clone hint to a `CommandError` if the error's source chain
+/// contains a `BackendError::ObjectNotFound`.
+pub fn maybe_add_partial_clone_hint(mut cmd_err: CommandError) -> CommandError {
+    if has_object_not_found_error(&*cmd_err.error) {
+        cmd_err.add_hint(PARTIAL_CLONE_HINT);
+    }
+    cmd_err
+}
+
 fn format_similarity_hint<S: AsRef<str>>(candidates: &[S]) -> Option<String> {
     match candidates {
         [] => None,
@@ -319,6 +348,10 @@ impl From<BackendError> for CommandError {
     fn from(err: BackendError) -> Self {
         match &err {
             BackendError::Unsupported(_) => user_error(err),
+            BackendError::ObjectNotFound { .. } => {
+                internal_error_with_message("Unexpected error from backend", err)
+                    .hinted(PARTIAL_CLONE_HINT)
+            }
             _ => internal_error_with_message("Unexpected error from backend", err),
         }
     }
@@ -544,13 +577,7 @@ mod git {
         fn from(err: GitImportError) -> Self {
             let hint = match &err {
                 GitImportError::MissingHeadTarget { .. }
-                | GitImportError::MissingRefAncestor { .. } => Some(
-                    "\
-Is this Git repository a partial clone (cloned with the --filter argument)?
-jj currently does not support partial clones. To use jj with this repository, try re-cloning with \
-                     the full repository contents."
-                        .to_string(),
-                ),
+                | GitImportError::MissingRefAncestor { .. } => Some(PARTIAL_CLONE_HINT.to_string()),
                 GitImportError::Backend(_) => None,
                 GitImportError::Index(_) => None,
                 GitImportError::Git(_) => None,

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1753,6 +1753,119 @@ fn get_bookmark_output(work_dir: &TestWorkDir) -> CommandOutput {
     work_dir.run_jj(["bookmark", "list", "--all-remotes", "--quiet"])
 }
 
+#[test]
+fn test_missing_object_hint_on_diff() -> TestResult {
+    // Simulate a partial clone scenario where blob objects are missing.
+    // jj should provide a helpful hint about partial clones.
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Create a commit with a file so a blob object exists in the git store.
+    work_dir.write_file("file.txt", "content\n");
+    work_dir.run_jj(["new", "-m", "first"]).success();
+
+    // Get the blob hash via git so we can delete it.
+    let git_output = std::process::Command::new("git")
+        .current_dir(work_dir.root())
+        .args(["hash-object", "file.txt"])
+        .output()?;
+    let blob_hash = String::from_utf8(git_output.stdout)?.trim().to_string();
+
+    // Delete the blob object from the git object store to simulate a partial
+    // clone with missing blobs.
+    let git_object_path = {
+        let (shard, file_name) = blob_hash.split_at(2);
+        work_dir
+            .root()
+            .join(".git")
+            .join("objects")
+            .join(shard)
+            .join(file_name)
+    };
+    std::fs::remove_file(&git_object_path)?;
+
+    // Running `jj diff` on the parent commit should show the partial clone hint.
+    let output = work_dir.run_jj(["diff", "-r", "@-"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Internal error: Unexpected error from backend
+    Caused by:
+    1: Object d95f3ad14dee633a758d2e331151e950dd13e4ed of type file not found
+    2: An object with id d95f3ad14dee633a758d2e331151e950dd13e4ed could not be found
+    Hint: Is this Git repository a partial clone (cloned with the --filter argument)?
+    jj currently does not support partial clones.
+    To use jj with this repository, try converting to a full clone:
+
+    git config --unset remote.origin.partialclonefilter
+    git fetch --refetch origin
+    [EOF]
+    [exit status: 255]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn test_missing_object_hint_on_checkout() -> TestResult {
+    // Simulate a partial clone scenario where a blob object needed during
+    // checkout is missing.
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Create a commit with a file.
+    work_dir.write_file("file.txt", "some content\n");
+
+    // Get the blob hash before moving to a new commit.
+    let git_output = std::process::Command::new("git")
+        .current_dir(work_dir.root())
+        .args(["hash-object", "file.txt"])
+        .output()?;
+    let blob_hash = String::from_utf8(git_output.stdout)?.trim().to_string();
+
+    // Commit the file, then start a new empty commit so the file is not in the
+    // working copy.
+    work_dir.run_jj(["commit", "-m", "add file"]).success();
+    work_dir.remove_file("file.txt");
+
+    // Delete the blob object to simulate a partial clone with missing blobs.
+    let git_object_path = {
+        let (shard, file_name) = blob_hash.split_at(2);
+        work_dir
+            .root()
+            .join(".git")
+            .join("objects")
+            .join(shard)
+            .join(file_name)
+    };
+    std::fs::remove_file(&git_object_path)?;
+
+    // Edit the commit that has the file — jj needs to check out its tree,
+    // which requires reading the now-missing blob.
+    let output = work_dir.run_jj(["edit", "@-"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Internal error: Failed to check out commit cb34f79bcd758c1d50066a75384b3ca20fa6f8de
+    Caused by:
+    1: Internal backend error
+    2: Object 2ef267e25bd6c6a300bb473e604b092b6a48523b of type file not found
+    3: An object with id 2ef267e25bd6c6a300bb473e604b092b6a48523b could not be found
+    Hint: Is this Git repository a partial clone (cloned with the --filter argument)?
+    jj currently does not support partial clones.
+    To use jj with this repository, try converting to a full clone:
+
+    git config --unset remote.origin.partialclonefilter
+    git fetch --refetch origin
+    [EOF]
+    [exit status: 255]
+    "#);
+    Ok(())
+}
+
 #[must_use]
 fn get_colocation_status(work_dir: &TestWorkDir) -> CommandOutput {
     work_dir.run_jj([


### PR DESCRIPTION
Consolidate and extend the partial clone hint so it appears whenever jj encounters a missing git object, not just during git import. This covers additional cases such as jj rebase on partial clones and adds a hint with the git commands to run to convert to a full clone.

See #8920

Having a hint on how to address errors from partial clones would have been very helpful to me when I bumped into this (and actually would be help going forward to remind me of the commands).

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
