### PR TITLE
make `jj arrange`'s "swap up/down" actions follow graph edges only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj arrange` uses the default log template (`builtin_log_compact`) instead of
    the shorter commit summary style.
 
+* In the `jj arrange` TUI, the "swap up/down" actions now move along graph edges
+  even if the commit rows are not adjacent.
+
 * [Diff colors](docs/config.md#diff-colors-and-styles) can now be configured
   differently for each format.
 

--- a/cli/src/commands/arrange.rs
+++ b/cli/src/commands/arrange.rs
@@ -173,14 +173,14 @@ enum UiAction {
 }
 
 /// The state of a single commit in the UI
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct CommitState {
     commit: Commit,
     action: UiAction,
     parents: Vec<CommitId>,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct State {
     /// Commits in the target set, as well as any external children and parents.
     commits: HashMap<CommitId, CommitState>,
@@ -285,14 +285,6 @@ impl State {
         self.current_order = commit_ids.into_iter().cloned().collect();
     }
 
-    /// Check if one commit is a parent of the other or vice versa.
-    fn are_graph_neighbors(&self, a_idx: usize, b_idx: usize) -> bool {
-        let a_id = &self.current_order[a_idx];
-        let b_id = &self.current_order[b_idx];
-        self.commits.get(b_id).unwrap().parents.contains(a_id)
-            || self.commits.get(a_id).unwrap().parents.contains(b_id)
-    }
-
     fn swap_commits(&mut self, a_id: &CommitId, b_id: &CommitId) {
         if a_id == b_id {
             return;
@@ -357,24 +349,37 @@ impl State {
         RewritePlan { rewrites }
     }
 
+    /// Swap the selected commit with its parent. Does nothing if there is not
+    /// exactly one parent or if the parent is an external parent.
     fn swap_selection_down(&mut self) {
-        if self.current_selection + 1 < self.current_order.len()
-            && self.are_graph_neighbors(self.current_selection, self.current_selection + 1)
-        {
-            let current_id = self.current_id().clone();
-            let next_id = self.current_order[self.current_selection + 1].clone();
-            self.swap_commits(&current_id, &next_id);
+        let current_id = self.current_id().clone();
+        let [parent] = self.commits.get(&current_id).unwrap().parents.as_slice() else {
+            return;
+        };
+        if self.external_parents.contains(parent) {
+            return;
         }
+        let parent = parent.clone();
+        self.swap_commits(&current_id, &parent);
     }
 
+    /// Swap the selected commit with one of its children. Does nothing if there
+    /// is not exactly one child or if the child is an external child.
     fn swap_selection_up(&mut self) {
-        if self.current_selection > 0
-            && self.are_graph_neighbors(self.current_selection, self.current_selection - 1)
-        {
-            let current_id = self.current_id().clone();
-            let prev_id = self.current_order[self.current_selection - 1].clone();
-            self.swap_commits(&current_id, &prev_id);
+        let current_id = self.current_id().clone();
+        let children: Vec<_> = self
+            .commits
+            .iter()
+            .filter(|(_, state)| state.parents.contains(&current_id))
+            .map(|(id, _)| id.clone())
+            .collect();
+        let [child] = children.as_slice() else {
+            return;
+        };
+        if self.external_children.contains(child) {
+            return;
         }
+        self.swap_commits(&current_id, child);
     }
 }
 
@@ -716,12 +721,6 @@ mod tests {
             ]
         );
 
-        // C is only a neighbor of B
-        assert!(!state.are_graph_neighbors(1, 0));
-        assert!(!state.are_graph_neighbors(1, 1));
-        assert!(state.are_graph_neighbors(1, 2));
-        assert!(!state.are_graph_neighbors(1, 3));
-
         // Update parents and head order and check that the commit order changes.
         state.commits.get_mut(commit_a.id()).unwrap().parents = vec![commit_c.id().clone()];
         state.commits.get_mut(commit_b.id()).unwrap().parents =
@@ -738,11 +737,6 @@ mod tests {
             ]
         );
 
-        // C is now a neighbor of A and B
-        assert!(!state.are_graph_neighbors(2, 0));
-        assert!(state.are_graph_neighbors(2, 1));
-        assert!(!state.are_graph_neighbors(2, 2));
-        assert!(state.are_graph_neighbors(2, 3));
         Ok(())
     }
 
@@ -930,6 +924,228 @@ mod tests {
                 commit_c.id().clone()
             ]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_swap_selection_down() -> TestResult {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        // Construct the graph:
+        // f
+        // |
+        // D e
+        // |\|
+        // B C
+        // |/
+        // A
+        // |
+        // root
+        //
+        // Lowercase nodes are external to the set
+        let mut tx = test_repo.repo.start_transaction();
+        let mut create_commit = |parents| {
+            tx.repo_mut()
+                .new_commit(parents, empty_tree.clone())
+                .write_unwrap()
+        };
+        let commit_a = create_commit(vec![store.root_commit_id().clone()]);
+        let commit_b = create_commit(vec![commit_a.id().clone()]);
+        let commit_c = create_commit(vec![commit_a.id().clone()]);
+        let commit_d = create_commit(vec![commit_b.id().clone(), commit_c.id().clone()]);
+        let commit_e = create_commit(vec![commit_c.id().clone()]);
+        let commit_f = create_commit(vec![commit_d.id().clone()]);
+
+        let mut state = State::new(
+            vec![
+                commit_d.clone(),
+                commit_c.clone(),
+                commit_b.clone(),
+                commit_a.clone(),
+            ],
+            vec![commit_e.clone(), commit_f.clone()],
+        )
+        .block_on()?;
+        assert_eq!(
+            state.current_order,
+            vec![
+                commit_d.id().clone(),
+                commit_b.id().clone(),
+                commit_c.id().clone(),
+                commit_a.id().clone(),
+            ]
+        );
+
+        // Attempting to swap D down should have no effect because it has two parents
+        state.current_selection = 0;
+        assert_eq!(state.current_id(), commit_d.id());
+        let state_before = state.clone();
+        state.swap_selection_down();
+        assert_eq!(state, state_before);
+
+        // Swap B down:
+        // f           f
+        // |           |
+        // D e         D e
+        // |\|         |\|
+        // B C    =>   A C
+        // |/          |/
+        // A           B
+        // |           |
+        // root        root
+        //
+        state.current_selection = 1;
+        assert_eq!(state.current_id(), commit_b.id());
+        state.swap_selection_down();
+        assert_eq!(
+            state.current_order,
+            vec![
+                commit_d.id().clone(),
+                commit_a.id().clone(),
+                commit_c.id().clone(),
+                commit_b.id().clone(),
+            ]
+        );
+        assert_eq!(state.current_selection, 3);
+
+        // Swap C down:
+        // f           f
+        // |           |
+        // D e         D e
+        // |\|         |\|
+        // A C    =>   A B
+        // |/          |/
+        // B           C
+        // |           |
+        // root        root
+        //
+        state.current_selection = 2;
+        assert_eq!(state.current_id(), commit_c.id());
+        state.swap_selection_down();
+        assert_eq!(
+            state.current_order,
+            vec![
+                commit_d.id().clone(),
+                commit_a.id().clone(),
+                commit_b.id().clone(),
+                commit_c.id().clone(),
+            ]
+        );
+        assert_eq!(state.current_selection, 3);
+
+        // Attempting to swap C down should have no effect because it would move outside
+        // of range
+        state.current_selection = 3;
+        assert_eq!(state.current_id(), commit_c.id());
+        let state_before = state.clone();
+        state.swap_selection_down();
+        assert_eq!(state, state_before);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_swap_selection_up() -> TestResult {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        // Construct the graph:
+        // f
+        // |
+        // D e
+        // |\|
+        // B C
+        // |/
+        // A
+        // |
+        // root
+        //
+        // Lowercase nodes are external to the set
+        let mut tx = test_repo.repo.start_transaction();
+        let mut create_commit = |parents| {
+            tx.repo_mut()
+                .new_commit(parents, empty_tree.clone())
+                .write_unwrap()
+        };
+        let commit_a = create_commit(vec![store.root_commit_id().clone()]);
+        let commit_b = create_commit(vec![commit_a.id().clone()]);
+        let commit_c = create_commit(vec![commit_a.id().clone()]);
+        let commit_d = create_commit(vec![commit_b.id().clone(), commit_c.id().clone()]);
+        let commit_e = create_commit(vec![commit_c.id().clone()]);
+        let commit_f = create_commit(vec![commit_d.id().clone()]);
+
+        let mut state = State::new(
+            vec![
+                commit_d.clone(),
+                commit_c.clone(),
+                commit_b.clone(),
+                commit_a.clone(),
+            ],
+            vec![commit_e.clone(), commit_f.clone()],
+        )
+        .block_on()?;
+        assert_eq!(
+            state.current_order,
+            vec![
+                commit_d.id().clone(),
+                commit_b.id().clone(),
+                commit_c.id().clone(),
+                commit_a.id().clone(),
+            ]
+        );
+
+        // Attempting to swap A up should have no effect because it has two children
+        state.current_selection = 3;
+        assert_eq!(state.current_id(), commit_a.id());
+        let state_before = state.clone();
+        state.swap_selection_up();
+        assert_eq!(state, state_before);
+
+        // Attempting to swap C up should have no effect because it has two children
+        // even though one is external. We could change this to ignore the external
+        // child.
+        state.current_selection = 2;
+        assert_eq!(state.current_id(), commit_c.id());
+        let state_before = state.clone();
+        state.swap_selection_up();
+        assert_eq!(state, state_before);
+
+        // Swap B up:
+        // f           f
+        // |           |
+        // D e         B e
+        // |\|         |\|
+        // B C    =>   D C
+        // |/          |/
+        // A           A
+        // |           |
+        // root        root
+        //
+        state.current_selection = 1;
+        assert_eq!(state.current_id(), commit_b.id());
+        state.swap_selection_up();
+        assert_eq!(
+            state.current_order,
+            vec![
+                commit_b.id().clone(),
+                commit_d.id().clone(),
+                commit_c.id().clone(),
+                commit_a.id().clone(),
+            ]
+        );
+        assert_eq!(state.current_selection, 0);
+
+        // Attempting to swap B up should have no effect because it would move outside
+        // of range
+        state.current_selection = 0;
+        assert_eq!(state.current_id(), commit_b.id());
+        let state_before = state.clone();
+        state.swap_selection_up();
+        assert_eq!(state, state_before);
+
         Ok(())
     }
 


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
