### PR TITLE
ci: add riscv64 release binary via cross-rs

### DIFF
--- a/.cargo/config-ci.toml
+++ b/.cargo/config-ci.toml
@@ -11,3 +11,6 @@ rustflags = ["-Clink-arg=-fuse-ld=mold"]
 
 [target.aarch64-unknown-linux-gnu]
 rustflags = ["-Clink-arg=-fuse-ld=mold"]
+
+[target.riscv64gc-unknown-linux-musl]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, macos-x86_64, macos-aarch64, win-x86_64]
+        build: [linux-x86_64-musl, linux-x86_64-gnu, linux-aarch64-musl, linux-aarch64-gnu, linux-riscv64-musl, macos-x86_64, macos-aarch64, win-x86_64]
         include:
         - build: linux-x86_64-musl
           os: ubuntu-24.04
@@ -27,6 +27,11 @@ jobs:
         - build: linux-aarch64-gnu
           os: ubuntu-24.04-arm
           target: aarch64-unknown-linux-gnu
+        - build: linux-riscv64-musl
+          os: ubuntu-24.04
+          target: riscv64gc-unknown-linux-musl
+          use_cross: true
+          cargo_extra_flags: "--config .cargo/config-ci.toml"
         - build: macos-x86_64
           os: macos-15
           target: x86_64-apple-darwin
@@ -57,9 +62,14 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev f86fd03bb70b4c6802847c18087e21391498b0b4
       - name: Build release binary
         shell: bash
-        run: cargo build --target ${{ matrix.target }} --verbose --release
+        env:
+          BUILD_TOOL: ${{ matrix.use_cross && 'cross' || 'cargo' }}
+        run: $BUILD_TOOL build --target ${{ matrix.target }} --verbose --release ${{ matrix.cargo_extra_flags || '' }}
 
       - name: Set up artifact directory
         shell: bash


### PR DESCRIPTION
Adds `riscv64gc-unknown-linux-musl` to the release matrix using cross-rs for cross-compilation on a standard `ubuntu-24.04` runner, as discussed in #9183.

Changes:
- Add `linux-riscv64-musl` to the build matrix with `use_cross: true`
- Install `cross` before the build step (only for riscv64)
- Use `cross build` instead of `cargo build` for riscv64; all other targets are unchanged

Closes #9183