### PR TITLE
docs: document revset-based tag filtering as alternative to `git tag --contains`

### DIFF
--- a/cli/src/commands/tag/list.rs
+++ b/cli/src/commands/tag/list.rs
@@ -41,6 +41,15 @@ use crate::ui::Ui;
 /// different from the local tag. An untracked remote tag won't be listed. For a
 /// conflicted tag (both local and remote), old target revisions are preceded by
 /// a "-" and new target revisions are preceded by a "+".
+///
+/// The `-r` flag combined with revset expressions can be used for filtering.
+/// For example:
+///
+/// * `jj tag list -r 'REV::'` shows tags whose targets are descendants of REV
+///   (similar to `git tag --contains REV`).
+///
+/// * `jj tag list -r '::REV'` shows tags whose targets are ancestors of REV
+///   (similar to `git tag --merged REV`).
 #[derive(clap::Args, Clone, Debug)]
 pub struct TagListArgs {
     /// Show all tracked and untracked remote tags including the ones whose

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3252,6 +3252,12 @@ List tags and their targets
 
 By default, a tracked remote tag will be included only if its target is different from the local tag. An untracked remote tag won't be listed. For a conflicted tag (both local and remote), old target revisions are preceded by a "-" and new target revisions are preceded by a "+".
 
+The `-r` flag combined with revset expressions can be used for filtering. For example:
+
+* `jj tag list -r 'REV::'` shows tags whose targets are descendants of REV (similar to `git tag --contains REV`).
+
+* `jj tag list -r '::REV'` shows tags whose targets are ancestors of REV (similar to `git tag --merged REV`).
+
 **Usage:** `jj tag list [OPTIONS] [NAMES]...`
 
 **Command Alias:** `l`

--- a/docs/git-command-table.yml
+++ b/docs/git-command-table.yml
@@ -400,6 +400,45 @@
     `jj bookmark delete <name>`
   Notes: ''
 
+- Use case: List tags
+  Git command: >
+    `git tag -l`
+  Jujutsu command: >
+    `jj tag list`
+  Notes: ''
+
+- Use case: Create a tag
+  Git command: >
+    `git tag <name> <revision>`
+  Jujutsu command: >
+    `jj tag set <name> -r <revision>`
+  Notes: ''
+
+- Use case: Delete a tag
+  Git command: >
+    `git tag -d <name>`
+  Jujutsu command: >
+    `jj tag delete <name>`
+  Notes: ''
+
+- Use case: List tags that contain a revision (targets are descendants of the revision)
+  Git command: >
+    `git tag --contains <revision>`
+  Jujutsu command: >
+    `jj tag list -r '<revision>::'`
+  Notes: >
+    Uses jj's revset language. The `::` postfix operator selects all
+    descendants of the given revision.
+
+- Use case: List tags merged into a revision (targets are ancestors of the revision)
+  Git command: >
+    `git tag --merged <revision>`
+  Jujutsu command: >
+    `jj tag list -r '::<revision>'`
+  Notes: >
+    Uses jj's revset language. The `::` prefix operator selects all
+    ancestors of the given revision.
+
 - Use case: See log of operations performed on the repo
   Git command: Not supported
   Jujutsu command: >


### PR DESCRIPTION
Add documentation showing how `jj tag list -r` with revset expressions can be used to filter tags, replacing the need for dedicated flags like `git tag --contains` or `git tag --merged`. For example, `jj tag list -r 'REV::'` lists tags whose targets descend from REV.

Tag operations were missing entirely from the Git command comparison table, so this also adds entries for listing, creating, and deleting tags alongside the filtering equivalents. The `jj tag list` help text and the revsets doc both gain examples demonstrating these patterns.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
