### PR TITLE
diff.git: Add a show-path-prefix option to disable a/ and b/ prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A new global flag `--no-integrate-operation` lets you run a command without
   impacting the repo state or the working copy.
 
+* A new config option `diff.git.show-path-prefix` can be used to suppress the
+  `a/` and `b/` path prefixes in the `diff --git` output.
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -447,6 +447,11 @@
                             "type": "integer",
                             "description": "Number of lines of context to show",
                             "default": 3
+                        },
+                        "show-path-prefix": {
+                            "type": "boolean",
+                            "description": "Whether to show the 'a/' and 'b/' path prefixes",
+                            "default": true
                         }
                     }
                 }

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -15,6 +15,7 @@ context = 3
 
 [diff.git]
 context = 3
+show-path-prefix = true
 
 [experimental-advance-branches]
 enabled-branches = []

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1626,6 +1626,8 @@ pub async fn show_file_by_file_diff(
 pub struct UnifiedDiffOptions {
     /// Number of context lines to show.
     pub context: usize,
+    /// Whether to show the 'a/' and 'b/' path prefixes.
+    pub show_path_prefix: bool,
     /// How lines are tokenized and compared.
     pub line_diff: LineDiffOptions,
 }
@@ -1634,6 +1636,7 @@ impl UnifiedDiffOptions {
     pub fn from_settings(settings: &UserSettings) -> Result<Self, ConfigGetError> {
         Ok(Self {
             context: settings.get("diff.git.context")?,
+            show_path_prefix: settings.get("diff.git.show-path-prefix")?,
             line_diff: LineDiffOptions::default(),
         })
     }
@@ -1722,6 +1725,8 @@ pub async fn show_git_diff(
     while let Some(MaterializedTreeDiffEntry { path, values }) = diff_stream.next().await {
         let left_path = path.source();
         let right_path = path.target();
+        let left_prefix = if options.show_path_prefix { "a/" } else { "" };
+        let right_prefix = if options.show_path_prefix { "b/" } else { "" };
         let left_path_string = left_path.as_internal_file_string();
         let right_path_string = right_path.as_internal_file_string();
         let values = values?;
@@ -1733,7 +1738,7 @@ pub async fn show_git_diff(
             let mut formatter = formatter.labeled("file_header");
             writeln!(
                 formatter,
-                "diff --git a/{left_path_string} b/{right_path_string}"
+                "diff --git {left_prefix}{left_path_string} {right_prefix}{right_path_string}"
             )?;
             let left_hash = &left_part.hash;
             let right_hash = &right_part.hash;
@@ -1775,11 +1780,11 @@ pub async fn show_git_diff(
         }
 
         let left_path = match left_part.mode {
-            Some(_) => format!("a/{left_path_string}"),
+            Some(_) => format!("{left_prefix}{left_path_string}"),
             None => "/dev/null".to_owned(),
         };
         let right_path = match right_part.mode {
-            Some(_) => format!("b/{right_path_string}"),
+            Some(_) => format!("{right_prefix}{right_path_string}"),
             None => "/dev/null".to_owned(),
         };
         if left_part.content.is_binary || right_part.content.is_binary {

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -204,6 +204,27 @@ fn test_diff_basic() {
     [EOF]
     ");
 
+    let output = work_dir.run_jj(["diff", "--git", "--config=diff.git.show-path-prefix=false"]);
+    insta::assert_snapshot!(output, @"
+    diff --git file2 file2
+    index 94ebaf9001..1ffc51b472 100644
+    --- file2
+    +++ file2
+    @@ -1,4 +1,3 @@
+     1
+    -2
+    +5
+     3
+    -4
+    diff --git file1 file3
+    rename from file1
+    rename to file3
+    diff --git file2 file4
+    copy from file2
+    copy to file4
+    [EOF]
+    ");
+
     let output = work_dir.run_jj(["diff", "--stat"]);
     insta::assert_snapshot!(output, @"
     file2            | 3 +--

--- a/docs/config.md
+++ b/docs/config.md
@@ -427,9 +427,13 @@ In git diffs you can change the default number of lines of context shown.
 
 * `context`: Number of lines of context to show in the diff. The default is `3`.
 
+* `show-path-prefix`: Whether to show the `a/` and `b/` path prefixes in
+  `diff --git` output. The default is `true`.
+
 ```toml
 [diff.git]
 context = 3
+show-path-prefix = true
 ```
 
 ### Generating diffs by external command


### PR DESCRIPTION
Adding this based on the feature request in #9102.

There's a question there of whether a convenience flag would be helpful (presumably something like `--git-path-prefix`. This PR isn't adding that because I thought `--config=diff.git.show-path-prefix=<value>` might be good enough; i.e., maybe flipping back and forth won't be a common operation and so keeping the `jj diff` options smaller would be better.

Fixes #9102