### PR TITLE
uv: freeze pygments at <2.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dev = [
 
 [tool.uv]
 package = false
+# Pygments 2.20.0 caused https://github.com/jj-vcs/jj/issues/9230
+# For example, the `github` docs ended up having literal "```shell" in them,
+# see the exact breakage in
+# https://github.com/jj-vcs/jj/commit/8a13bde3bb9555ba1d25ace3d3ecff71ef5e0f76#diff-b50ce796f4ee4de132496e90aa1f463d50f2454bbd41796013e52b06ed1da691R1943-R1947
+# TODO: Consider fixing this if our planned transition to starlight docs doesn't work out for some reason.
+constraint-dependencies = ["pygments<2.20"]
 
 [tool.codespell]
 # codespell must be run **from the repo root** for these settings

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 
+[manifest]
+constraints = [{ name = "pygments", specifier = "<2.20" }]
+
 [[package]]
 name = "babel"
 version = "2.17.0"
@@ -923,11 +926,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
2.20 causes https://github.com/jj-vcs/jj/issues/9230. Not sure why yet, but this is the fix.

~~I may or may not investigate further;~~ (**Update:** See Claude note below), if we transition to starlight
soon, this will become irrelevant.

Reverts https://github.com/jj-vcs/jj/commit/2f4277e9fa285a37f5b3eb4402ebd18e8511b790 (logically, not textually)

Fixes #9230

~~According to Claude, this is caused by https://github.com/pygments/pygments/pull/3078 and will be fixed in the next pygments patch release.~~ Might be a red herring.

# Checklist

If applicable:

- n/a I have updated `CHANGELOG.md`
- n/a I have updated the documentation (`README.md`, `docs/`, `demos/`)
- n/a I have updated the config schema (`cli/src/config-schema.json`)
- n/a I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
