### PR TITLE
ci: treat Rust compiler warnings as errors

### DIFF
--- a/.cargo/config-ci.toml
+++ b/.cargo/config-ci.toml
@@ -6,6 +6,9 @@ include = [
 debug = "none"
 incremental = false
 
+[target.'cfg(all())']
+rustflags = ["-D", "warnings"]
+
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-Clink-arg=-fuse-ld=mold"]
 


### PR DESCRIPTION
Add RUSTFLAGS=-D warnings to all Cargo build steps in GitHub CI workflow
to enforce stricter code quality.
This is especially useful with platform-specific [#cfg], to not let
platform-specific warnings unnoticed.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
