### PR TITLE
gerrit: Refactor change-id logic out of upload.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `log-graph-prioritize` revset.
   [#9975](https://github.com/jj-vcs/jj/issues/9975)
 
+* `jj gerrit upload` on commits with unrelated Links can be uploaded again.
+
 ## [0.44.0] - 2026-08-05
 
 ### Release highlights
@@ -543,7 +545,6 @@ Thanks to the people who made this release happen!
 * Thomas Axelsson (@thomasa88)
 * xtqqczze (@xtqqczze)
 * Yuya Nishihara (@yuja)
-
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -15,9 +15,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::Write as _;
-use std::sync::Arc;
 
-use bstr::BStr;
 use futures::TryStreamExt as _;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
@@ -29,10 +27,6 @@ use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo::Repo as _;
 use jj_lib::revset::RevsetExpression;
-use jj_lib::settings::UserSettings;
-use jj_lib::store::Store;
-use jj_lib::trailer::Trailer;
-use jj_lib::trailer::parse_description_trailers;
 use percent_encoding::NON_ALPHANUMERIC;
 use percent_encoding::utf8_percent_encode;
 
@@ -43,6 +37,11 @@ use crate::command_error::CommandError;
 use crate::command_error::internal_error;
 use crate::command_error::user_error;
 use crate::command_error::user_error_with_message;
+use crate::gerrit_util::calculate_gerrit_remote;
+use crate::gerrit_util::calculate_gerrit_remote_branch;
+use crate::gerrit_util::generate_gerrit_description;
+use crate::gerrit_util::gerrit_change_id;
+use crate::gerrit_util::get_gerrit_review_url;
 use crate::git_util::GitSubprocessUi;
 use crate::git_util::print_push_stats;
 use crate::ui::Ui;
@@ -245,80 +244,9 @@ pub enum EmailNotification {
     All,
 }
 
-fn calculate_push_remote(
-    store: &Arc<Store>,
-    settings: &UserSettings,
-    remote: Option<&str>,
-) -> Result<String, CommandError> {
-    let git_repo = git::get_git_repo(store)?; // will fail if not a git repo
-    let remotes = git_repo.remote_names();
-
-    // If --remote was provided, use that
-    if let Some(remote) = remote {
-        if remotes.contains(BStr::new(&remote)) {
-            return Ok(remote.to_string());
-        }
-        return Err(user_error(format!(
-            "The remote '{remote}' (specified via `--remote`) does not exist",
-        )));
-    }
-
-    // If the Gerrit-specific config was set, use that
-    if let Ok(remote) = settings.get_string("gerrit.default-remote") {
-        if remotes.contains(BStr::new(&remote)) {
-            return Ok(remote);
-        }
-        return Err(user_error(format!(
-            "The remote '{remote}' (configured via `gerrit.default-remote`) does not exist",
-        )));
-    }
-
-    // If a general push remote was configured, use that
-    if let Some(remote) = git_repo.remote_default_name(gix::remote::Direction::Push) {
-        return Ok(remote.to_string());
-    }
-
-    // If there is a Git remote called "gerrit", use that
-    if remotes.iter().any(|r| r == "gerrit") {
-        return Ok("gerrit".to_owned());
-    }
-
-    // Otherwise error out
-    Err(user_error(
-        "No remote specified, and no 'gerrit' remote was found",
-    ))
-}
-
-/// Determine what Gerrit ref and remote to use. The logic is:
-///
-/// 1. If the user specifies `--remote-branch branch`, use that
-/// 2. If the user has 'gerrit.default-remote-branch' configured, use that
-/// 3. Otherwise, bail out
-fn calculate_push_ref(
-    settings: &UserSettings,
-    remote_branch: Option<String>,
-) -> Result<String, CommandError> {
-    // case 1
-    if let Some(remote_branch) = remote_branch {
-        return Ok(remote_branch);
-    }
-
-    // case 2
-    if let Ok(branch) = settings.get_string("gerrit.default-remote-branch") {
-        return Ok(branch);
-    }
-
-    // case 3
-    Err(user_error(
-        "No target branch specified via --remote-branch, and no 'gerrit.default-remote-branch' \
-         was found",
-    ))
-}
-
 fn encode_message(message: &str) -> String {
     utf8_percent_encode(message, NON_ALPHANUMERIC).to_string()
 }
-
 fn push_options(args: &UploadArgs) -> Result<Vec<String>, CommandError> {
     for c in &args.custom {
         if !c.contains(':') {
@@ -512,8 +440,10 @@ pub async fn cmd_gerrit_upload(
         .map_err(internal_error)?;
 
     let subprocess_options = GitSubprocessOptions::from_settings(command.settings())?;
-    let remote = calculate_push_remote(&store, command.settings(), args.remote.as_deref())?;
-    let remote_branch = calculate_push_ref(command.settings(), args.remote_branch.clone())?;
+    let remote = calculate_gerrit_remote(&store, command.settings(), args.remote.as_deref())?;
+    let remote_branch =
+        calculate_gerrit_remote_branch(command.settings(), args.remote_branch.clone())?;
+    let review_url = get_gerrit_review_url(command.settings());
 
     // Immediately error and reject any commits that shouldn't be uploaded.
     for commit in &to_upload {
@@ -538,91 +468,29 @@ pub async fn cmd_gerrit_upload(
 
     let mut old_to_new: HashMap<CommitId, Commit> = HashMap::new();
     for original_commit in to_upload.into_iter().rev() {
-        let trailers = parse_description_trailers(original_commit.description());
-
-        let change_id_trailers: Vec<&Trailer> = trailers
-            .iter()
-            .filter(|trailer| trailer.key == "Change-Id" || trailer.key == "Link")
-            .collect();
-
-        // There shouldn't be multiple change-ID fields. So just error out if
-        // there is.
-        if change_id_trailers.len() > 1 {
-            return Err(user_error(format!(
-                "Multiple Change-Id footers in revision {}",
-                short_change_hash(original_commit.change_id())
-            )));
-        }
-
-        // The user can choose to explicitly set their own change-ID to
-        // override the default change-ID based on the jj change-ID.
-        let new_description = if let Some(trailer) = change_id_trailers.first() {
-            // Check the change-id format is correct, intentionally leave the
-            // invalid change IDs as-is.
-            if trailer.key == "Change-Id"
-                && (trailer.value.len() != 41 || !trailer.value.starts_with('I'))
-            {
-                writeln!(
-                    ui.warning_default(),
-                    "Invalid Change-Id footer in revision {}",
-                    short_change_hash(original_commit.change_id()),
-                )?;
-            }
-            if trailer.key == "Link"
-                && !matches!(trailer.value.split_once("/id/I"), Some((_url, id)) if id.len() == 40)
-            {
-                writeln!(
-                    ui.warning_default(),
-                    "Invalid Link footer in revision {}",
-                    short_change_hash(original_commit.change_id()),
-                )?;
-            }
-
-            original_commit.description().to_owned()
-        } else {
-            // Gerrit change id is 40 chars, jj change id is 32, so we need padding.
-            // To be consistent with `format_gerrit_change_id_trailer``, we pad with
-            // 6a6a6964 (hex of "jjid").
-            let gerrit_change_id = format!("I{}6a6a6964", original_commit.change_id().hex());
-
-            let change_id_trailer =
-                if let Ok(review_url) = command.settings().get_string("gerrit.review-url") {
-                    format!(
-                        "Link: {}/id/{gerrit_change_id}",
-                        review_url.trim_end_matches('/'),
-                    )
-                } else {
-                    format!("Change-Id: {gerrit_change_id}")
-                };
-
-            format!(
-                "{}{}{}\n",
-                original_commit.description().trim(),
-                if trailers.is_empty() { "\n\n" } else { "\n" },
-                change_id_trailer,
-            )
-        };
-
         let new_parents = original_commit
             .parent_ids()
             .iter()
             .map(|id| old_to_new.get(id).map_or(id, |p| p.id()).clone())
             .collect();
 
-        if new_description == original_commit.description()
-            && new_parents == original_commit.parent_ids()
-        {
-            // map the old commit to itself
-            old_to_new.insert(original_commit.id().clone(), original_commit);
-            continue;
-        }
+        let description = if gerrit_change_id(&original_commit)?.is_some() {
+            if new_parents == original_commit.parent_ids() {
+                // map the old commit to itself
+                old_to_new.insert(original_commit.id().clone(), original_commit);
+                continue;
+            }
+            original_commit.description().to_owned()
+        } else {
+            generate_gerrit_description(review_url.as_deref(), &original_commit)
+        };
 
         // rewrite the set of parents to point to the commits that were
         // previously rewritten in toposort order
         let new_commit = tx
             .repo_mut()
             .rewrite_commit(&original_commit)
-            .set_description(new_description)
+            .set_description(description)
             .set_parents(new_parents)
             // Set the timestamp back to the timestamp of the original commit.
             // Otherwise, `jj gerrit upload @ && jj gerrit upload @` will upload

--- a/cli/src/gerrit_util.rs
+++ b/cli/src/gerrit_util.rs
@@ -1,0 +1,320 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bstr::BStr;
+use jj_lib::backend::ChangeId;
+use jj_lib::commit::Commit;
+use jj_lib::git;
+use jj_lib::object_id::ObjectId as _;
+use jj_lib::settings::UserSettings;
+use jj_lib::store::Store;
+use jj_lib::trailer::parse_description_trailers;
+use thiserror::Error;
+
+use crate::cli_util::short_change_hash;
+use crate::command_error::CommandError;
+use crate::command_error::user_error;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ChangeIdError {
+    #[error("Invalid change ID \"{change_id}\" in revision {revision}")]
+    InvalidChangeId { revision: String, change_id: String },
+
+    #[error("Invalid link footer {footer} in revision {revision}")]
+    InvalidLinkFooter { revision: String, footer: String },
+
+    #[error("Multiple Change-Id or Link footers in revision {revision}")]
+    MultipleFooters { revision: String },
+}
+
+impl From<ChangeIdError> for CommandError {
+    fn from(err: ChangeIdError) -> Self {
+        user_error(err)
+    }
+}
+
+/// Determine the gerrit remote to use.
+pub fn calculate_gerrit_remote(
+    store: &Arc<Store>,
+    settings: &UserSettings,
+    remote: Option<&str>,
+) -> Result<String, CommandError> {
+    let git_repo = git::get_git_repo(store)?; // will fail if not a git repo
+    let remotes = git_repo.remote_names();
+
+    // If --remote was provided, use that
+    if let Some(remote) = remote {
+        if remotes.contains(BStr::new(&remote)) {
+            return Ok(remote.to_string());
+        }
+        return Err(user_error(format!(
+            "The remote '{remote}' (specified via `--remote`) does not exist",
+        )));
+    }
+
+    // If the Gerrit-specific config was set, use that
+    if let Ok(remote) = settings.get_string("gerrit.default-remote") {
+        if remotes.contains(BStr::new(&remote)) {
+            return Ok(remote);
+        }
+        return Err(user_error(format!(
+            "The remote '{remote}' (configured via `gerrit.default-remote`) does not exist",
+        )));
+    }
+
+    // If a general push remote was configured, use that
+    if let Some(remote) = git_repo.remote_default_name(gix::remote::Direction::Push) {
+        let r: &BStr = remote.as_ref();
+        return Ok(r.to_string());
+    }
+
+    // If there is a Git remote called "gerrit", use that
+    if remotes.iter().any(|r| r == "gerrit") {
+        return Ok("gerrit".to_owned());
+    }
+
+    // Otherwise error out
+    Err(user_error(
+        "No remote specified, and no 'gerrit' remote was found",
+    ))
+}
+
+/// Determine what Gerrit remote branch to use. The logic is:
+///
+/// 1. If the user specifies a preferred branch, use that
+/// 2. If the user has 'gerrit.default-remote-branch' configured, use that
+/// 3. Otherwise, bail out
+pub fn calculate_gerrit_remote_branch(
+    settings: &UserSettings,
+    remote_branch: Option<String>,
+) -> Result<String, CommandError> {
+    // case 1
+    if let Some(remote_branch) = remote_branch {
+        return Ok(remote_branch);
+    }
+
+    // case 2
+    if let Ok(branch) = settings.get_string("gerrit.default-remote-branch") {
+        return Ok(branch);
+    }
+
+    // case 3
+    Err(user_error(
+        "No target branch specified via --remote-branch, and no 'gerrit.default-remote-branch' \
+         was found",
+    ))
+}
+
+pub fn get_gerrit_review_url(settings: &UserSettings) -> Option<String> {
+    settings
+        .get_string("gerrit.review-url")
+        .ok()
+        .map(|url| url.trim_end_matches('/').to_string())
+}
+
+// Calculates the gerrit change ID for a given change.
+pub fn gerrit_change_id(commit: &Commit) -> Result<Option<String>, ChangeIdError> {
+    let desc_change_ids = parse_description_trailers(commit.description())
+        .into_iter()
+        .filter_map(|trailer| {
+            if trailer.key == "Change-Id" {
+                if trailer.value.len() != 41 || !trailer.value.starts_with('I') {
+                    Some(Err(ChangeIdError::InvalidChangeId {
+                        revision: short_change_hash(commit.change_id()),
+                        change_id: trailer.value,
+                    }))
+                } else {
+                    Some(Ok(trailer.value))
+                }
+            } else if trailer.key == "Link"
+                && let Some((_, id)) = trailer.value.split_once("/id/I")
+            {
+                let full_id = format!("I{id}");
+                if full_id.len() != 41 {
+                    Some(Err(ChangeIdError::InvalidLinkFooter {
+                        revision: short_change_hash(commit.change_id()),
+                        footer: trailer.value,
+                    }))
+                } else {
+                    Some(Ok(full_id))
+                }
+            } else {
+                None
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if desc_change_ids.len() > 1 {
+        return Err(ChangeIdError::MultipleFooters {
+            revision: short_change_hash(commit.change_id()),
+        });
+    }
+    Ok(desc_change_ids.into_iter().next())
+}
+
+// Generates a change ID based on the jj change ID.
+pub fn generate_gerrit_change_id(commit: &Commit) -> String {
+    // Gerrit change id is 40 chars, jj change id is 32, so we need padding.
+    // To be consistent with `format_gerrit_change_id_trailer``, we pad with
+    // 6a6a6964 (hex of "jjid").
+    let make_change_id = |id: &ChangeId| format!("I{}6a6a6964", id.hex());
+    make_change_id(commit.change_id())
+}
+
+/// Generates a commit description containing the gerrit change id in a footer.
+pub fn generate_gerrit_description(review_url: Option<&str>, commit: &Commit) -> String {
+    let gerrit_change_id = generate_gerrit_change_id(commit);
+    let trailers = parse_description_trailers(commit.description());
+    let change_id_trailer = if let Some(review_url) = review_url {
+        format!("Link: {review_url}/id/{gerrit_change_id}")
+    } else {
+        format!("Change-Id: {gerrit_change_id}")
+    };
+
+    format!(
+        "{}{}{}\n",
+        commit.description().trim(),
+        if trailers.is_empty() { "\n\n" } else { "\n" },
+        change_id_trailer,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use jj_lib::repo::Repo as _;
+    use testutils::CommitBuilderExt as _;
+    use testutils::TestRepo;
+
+    use super::*;
+
+    #[test]
+    fn test_gerrit_change_id() {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        let mut tx = test_repo.repo.start_transaction();
+
+        // Commit with no change ID
+        let commit = tx
+            .repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test 1")
+            .write_unwrap();
+        let id = gerrit_change_id(&commit).unwrap();
+        assert_eq!(id, None);
+
+        // Commit with valid Change-Id footer
+        let commit = tx
+            .repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test\n\nChange-Id: I1234567890123456789012345678901234567890")
+            .write_unwrap();
+        let id = gerrit_change_id(&commit).unwrap();
+        assert_eq!(
+            id,
+            Some("I1234567890123456789012345678901234567890".to_string())
+        );
+
+        // Commit with invalid Change-Id footer
+        let commit = tx
+            .repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test\n\nChange-Id: I12")
+            .write_unwrap();
+        assert_eq!(
+            gerrit_change_id(&commit).unwrap_err(),
+            ChangeIdError::InvalidChangeId {
+                revision: short_change_hash(commit.change_id()),
+                change_id: "I12".to_string(),
+            }
+        );
+
+        // Commit with valid link footer
+        let commit = tx.repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test\n\nLink: ignored\nLink: https://review.example.com/id/I1234567890123456789012345678901234567890")
+            .write_unwrap();
+        let id = gerrit_change_id(&commit).unwrap();
+        assert_eq!(
+            id,
+            Some("I1234567890123456789012345678901234567890".to_string())
+        );
+
+        // Commit with invalid link footer
+        let commit = tx
+            .repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test\n\nLink: https://review.example.com/id/I1")
+            .write_unwrap();
+        assert_eq!(
+            gerrit_change_id(&commit).unwrap_err(),
+            ChangeIdError::InvalidLinkFooter {
+                revision: short_change_hash(commit.change_id()),
+                footer: "https://review.example.com/id/I1".to_string(),
+            }
+        );
+
+        // Commit with both link and change-id footer
+        let commit = tx.repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test\n\nChange-Id: I1234567890123456789012345678901234567890\nLink: https://review.example.com/id/I0987654321098765432109876543210987654321")
+            .write_unwrap();
+        assert_eq!(
+            gerrit_change_id(&commit).unwrap_err(),
+            ChangeIdError::MultipleFooters {
+                revision: short_change_hash(commit.change_id()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_generate_gerrit_change_id() {
+        let test_repo = TestRepo::init();
+        let store = test_repo.repo.store();
+        let empty_tree = store.empty_merged_tree();
+
+        let mut tx = test_repo.repo.start_transaction();
+
+        let commit = tx
+            .repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test 1")
+            .write_unwrap();
+
+        let new_desc = generate_gerrit_description(None, &commit);
+
+        let expected_gerrit_id = "I781199f9d55d18e855a7aa84c5e4b40d6a6a6964";
+        assert_eq!(
+            new_desc,
+            format!("test 1\n\nChange-Id: {expected_gerrit_id}\n")
+        );
+
+        let commit = tx
+            .repo_mut()
+            .new_commit(vec![store.root_commit_id().clone()], empty_tree.clone())
+            .set_description("test 1")
+            .write_unwrap();
+
+        let new_desc = generate_gerrit_description(Some("https://review.example.com"), &commit);
+
+        let expected_gerrit_id = "Ia2c96fc88f32e487328f04927f20c4b16a6a6964";
+        assert_eq!(
+            new_desc,
+            format!("test 1\n\nLink: https://review.example.com/id/{expected_gerrit_id}\n")
+        );
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -27,6 +27,8 @@ pub mod diff_util;
 pub mod formatter;
 pub mod generic_templater;
 #[cfg(feature = "git")]
+pub mod gerrit_util;
+#[cfg(feature = "git")]
 pub mod git_util;
 pub mod graphlog;
 pub mod merge_tools;

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -730,7 +730,11 @@ fn test_gerrit_upload_bad_change_ids() {
         ])
         .success();
     local_dir
-        .run_jj(["describe", "-rb3", "-m\n\nLink: malformed\n"])
+        .run_jj([
+            "describe",
+            "-rb3",
+            "-m\n\nLink: ignored\nChange-Id: I0000000000000000000000000000000000000000\n",
+        ])
         .success();
     local_dir
         .run_jj([
@@ -777,39 +781,35 @@ fn test_gerrit_upload_bad_change_ids() {
         .success();
 
     let output = local_dir.run_jj(["gerrit", "upload", "-rc", "--remote-branch=main"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Multiple Change-Id footers in revision wqnwkozpkust
+    Error: Multiple Change-Id or Link footers in revision wqnwkozpkust
     [EOF]
     [exit status: 1]
     ");
     let output = local_dir.run_jj(["gerrit", "upload", "-rd", "--remote-branch=main"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Multiple Change-Id footers in revision kxryzmorwvtz
+    Error: Multiple Change-Id or Link footers in revision kxryzmorwvtz
     [EOF]
     [exit status: 1]
     ");
     let output = local_dir.run_jj(["gerrit", "upload", "-re", "--remote-branch=main"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
-    Error: Multiple Change-Id footers in revision uyznsvlquzzm
+    Error: Multiple Change-Id or Link footers in revision uyznsvlquzzm
     [EOF]
     [exit status: 1]
     ");
 
     // check both badly and slightly malformed Change-Id / Link trailers
     let output = local_dir.run_jj(["gerrit", "upload", "-rb4", "--remote-branch=main"]);
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ------- stderr -------
-    Warning: Invalid Change-Id footer in revision mzvwutvlkqwt
-    Warning: Invalid Change-Id footer in revision yqosqzytrlsw
-    Warning: Invalid Link footer in revision yostqsxwqrlt
-    Warning: Invalid Link footer in revision kpqxywonksrl
-    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'.
-    Pushing kpqxywon 69536ef3 b4
+    Error: Invalid change ID "malformed" in revision mzvwutvlkqwt
     [EOF]
-    ");
+    [exit status: 1]
+    "#);
 }
 
 #[test]


### PR DESCRIPTION
This significantly simplifies upload.rs, and allows other future gerrit features to use the change ID.

Note: gerrit_util is not under commands::gerrit because I intend to use it in the templater to add a function to print the review url.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
