### PR TITLE
cli: file-search: Support string pattern syntax for `--pattern`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Breaking changes
 
+* The `--pattern` flag for `file search` now defaults to `regex:` instead of `glob:`.
+
 * `jj git push --all`/`--tracked`/`-r REVSETS` no longer fails when revisions to
   push are private or have conflicts. Bookmarks which aren't eligible to push
   will be skipped.
@@ -22,6 +24,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   deprecated in favor of `.attributes()`.
 
 ### New features
+
+* The `--pattern` flag for `file search` now accepts various pattern kinds through
+  `kind:pattern` syntax.
 
 * A new global flag `--no-integrate-operation` lets you run a command without
   impacting the repo state or the working copy.

--- a/cli/src/commands/file/search.rs
+++ b/cli/src/commands/file/search.rs
@@ -41,10 +41,16 @@ pub(crate) struct FileSearchArgs {
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
     revision: RevisionArg,
 
-    /// The glob pattern to search for
+    /// The pattern to search for in a single line
     ///
-    /// The whole line must match the pattern, so you may want to pass something
-    /// like `--pattern '*foo*'`.
+    /// It is a [string pattern syntax] like `kind:pattern`.  The kind
+    /// defaults to regex when omitted.
+    ///
+    /// If it is a glob pattern, the whole line must match the pattern,
+    /// so you may want to pass something like `--pattern 'glob:*foo*'`.
+    ///
+    /// [string pattern syntax]:
+    ///     https://docs.jj-vcs.dev/latest/revsets/#string-patterns
     #[arg(long, short, value_name = "PATTERN")]
     pattern: String,
 
@@ -72,8 +78,12 @@ pub(crate) async fn cmd_file_search(
     let mut formatter = ui.stdout_formatter();
     let store = workspace_command.repo().store().clone();
 
-    // TODO: Support other patterns than glob
-    let pattern = StringPattern::glob(&args.pattern).map_err(|err| cli_error(err.to_string()))?;
+    let pattern = if let Some((kind, pattern)) = args.pattern.split_once(':') {
+        StringPattern::from_str_kind(pattern, kind)
+    } else {
+        StringPattern::from_str_kind(args.pattern.as_str(), "regex")
+    }
+    .map_err(cli_error)?;
     let pattern_matcher = pattern.to_matcher();
     // TODO: Read files concurrently (depending on backend)
     for (path, value) in tree.entries_matching(file_matcher.as_ref()) {

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1215,9 +1215,13 @@ This is an early version of the command. It only supports glob matching for now,
 * `-r`, `--revision <REVSET>` — The revision to search files in
 
   Default value: `@`
-* `-p`, `--pattern <PATTERN>` — The glob pattern to search for
+* `-p`, `--pattern <PATTERN>` — The pattern to search for in a single line
 
-   The whole line must match the pattern, so you may want to pass something like `--pattern '*foo*'`.
+   It is a [string pattern syntax] like `kind:pattern`.  The kind defaults to regex when omitted.
+
+   If it is a glob pattern, the whole line must match the pattern, so you may want to pass something like `--pattern 'glob:*foo*'`.
+
+   [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 
 
 

--- a/cli/tests/test_file_search_command.rs
+++ b/cli/tests/test_file_search_command.rs
@@ -27,38 +27,67 @@ fn test_file_search() {
     work_dir.write_file("dir/file3", "-foobar-");
 
     // Searches all files in the current revision by default
-    let output = work_dir.run_jj(["file", "search", "--pattern=*foo*"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     dir/file3
     file1
     [EOF]
     ");
 
-    // Matches only the whole line
-    let output = work_dir.run_jj(["file", "search", "--pattern=foo"]);
+    // Matches only the whole line for glob pattern
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:foo"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"");
 
     // Can search files in another revision
-    let output = work_dir.run_jj(["file", "search", "--pattern=*foo*", "-r=@-"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*", "-r=@-"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     file1
     [EOF]
     ");
 
     // Can filter by path
-    let output = work_dir.run_jj(["file", "search", "--pattern=*foo*", "dir"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*", "dir"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     dir/file3
     [EOF]
     ");
 
     // Warning if path doesn't exist
-    let output = work_dir.run_jj(["file", "search", "--pattern=*foo*", "file9"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*", "file9"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     ------- stderr -------
     Warning: No matching entries for paths: file9
     [EOF]
     ");
+
+    // The default is regex
+    let output = work_dir.run_jj(["file", "search", "--pattern=f.o"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    dir/file3
+    file1
+    [EOF]
+    ");
+
+    // Can specify the kind
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob-i:*foo*"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    dir/file3
+    file1
+    [EOF]
+    ");
+
+    // The part before the first colon is treated as the kind.
+    let output = work_dir.run_jj(["file", "search", "--pattern=foo:bar"]);
+    insta::assert_snapshot!(output.normalize_stderr_exit_status(), @"
+    ------- stderr -------
+    Error: Invalid string pattern kind `foo:`
+    [EOF]
+    [exit status: 2]
+    ");
+
+    // Colons can be in the pattern part.
+    let output = work_dir.run_jj(["file", "search", "--pattern=regex-i:foo:bar"]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"");
 }
 
 #[test]
@@ -87,24 +116,24 @@ fn test_file_search_conflicts() {
     ");
 
     // Matches positive terms
-    let output = work_dir.run_jj(["file", "search", "--pattern=*foo*"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*foo*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     file1
     [EOF]
     ");
-    let output = work_dir.run_jj(["file", "search", "--pattern=*bar*"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*bar*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"");
-    let output = work_dir.run_jj(["file", "search", "--pattern=*baz*"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*baz*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     file1
     [EOF]
     ");
 
     // Doesn't match the conflict markers
-    let output = work_dir.run_jj(["file", "search", "--pattern=*%%%*"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*%%%*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"");
 
     // Doesn't list file if the pattern doesn't match
-    let output = work_dir.run_jj(["file", "search", "--pattern=*qux*"]);
+    let output = work_dir.run_jj(["file", "search", "--pattern=glob:*qux*"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"");
 }


### PR DESCRIPTION
The `--pattern` flag now supports `kind:pattern` syntax. The `kind` part is optional, and the pattern is treated as regex when omitted.

Related to #7940 

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
