### PR TITLE
lib: Refactor run_mergetool_external_single_file

### DIFF
--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -203,7 +203,7 @@ async fn run_mergetool_external_single_file(
             editor,
             store.merge_options(),
             default_conflict_marker_style,
-            repo_path,
+            Some(repo_path),
             &file.contents,
             &file.labels,
         )?;
@@ -256,11 +256,60 @@ async fn run_mergetool_external_single_file(
     Ok(())
 }
 
+/// Runs the merge tool on content with materialized conflict markers, and
+/// returns the new merged content.
+pub async fn run_mergetool_external_with_materialized_content(
+    editor: &ExternalMergeTool,
+    merge_options: &MergeOptions,
+    materialized_conflicted_contents: &Merge<BString>,
+    conflict_labels: &ConflictLabels,
+    default_conflict_marker_style: ConflictMarkerStyle,
+) -> Result<Option<Merge<BString>>, ConflictResolveError> {
+    let (conflict_marker_len, exit_status, exit_status_implies_conflict, output_file_contents) =
+        run_mergetool_external_inner(
+            editor,
+            merge_options,
+            default_conflict_marker_style,
+            None, // There is no repo_path to pass around.
+            materialized_conflicted_contents,
+            conflict_labels,
+        )?;
+
+    let new_contents = if editor.merge_tool_edits_conflict_markers || exit_status_implies_conflict {
+        tracing::info!(
+            ?exit_status_implies_conflict,
+            "jj is reparsing output for conflicts, `merge-tool-edits-conflict-markers = {}` in \
+             TOML config;",
+            editor.merge_tool_edits_conflict_markers
+        );
+        let (new_contents, _unchanged) = conflicts::update_from_materialized_content(
+            materialized_conflicted_contents,
+            output_file_contents.as_slice(),
+            conflict_marker_len,
+            merge_options,
+        );
+        new_contents
+    } else {
+        Some(Merge::resolved(BString::new(output_file_contents)))
+    };
+
+    // If the exit status indicated there should be conflict markers but there
+    // weren't any, it's likely that the tool generated invalid conflict markers, so
+    // we need to inform the user. If we didn't treat this as an error, the user
+    // might think the conflict was resolved successfully.
+    if exit_status_implies_conflict && new_contents.as_ref().is_none_or(|c| c.is_resolved()) {
+        return Err(ConflictResolveError::ExternalTool(
+            ExternalToolError::InvalidConflictMarkers { exit_status },
+        ));
+    }
+    Ok(new_contents)
+}
+
 fn run_mergetool_external_inner(
     editor: &ExternalMergeTool,
     merge_options: &MergeOptions,
     default_conflict_marker_style: ConflictMarkerStyle,
-    repo_path: &RepoPathBuf,
+    repo_path: Option<&RepoPathBuf>,
     materialized_conflicted_contents: &Merge<BString>,
     conflict_labels: &ConflictLabels,
 ) -> Result<(usize, ExitStatus, bool, Vec<u8>), ConflictResolveError> {
@@ -298,10 +347,12 @@ fn run_mergetool_external_inner(
     };
 
     let temp_dir = new_utf8_temp_dir("jj-resolve-").map_err(ExternalToolError::SetUpDir)?;
-    let suffix = if let Some(filename) = repo_path.components().next_back() {
+    let suffix = if let Some(real_repo_path) = repo_path
+        && let Some(filename) = real_repo_path.components().next_back()
+    {
         let name = filename
             .to_fs_name()
-            .map_err(|err| err.with_path(repo_path))?;
+            .map_err(|err| err.with_path(real_repo_path))?;
         format!("_{name}")
     } else {
         // This should never actually trigger, but we support it just in case
@@ -326,7 +377,9 @@ fn run_mergetool_external_inner(
         })
         .try_collect()?;
     variables.insert("marker_length", conflict_marker_len.to_string());
-    variables.insert("path", repo_path.as_internal_file_string().to_string());
+    if let Some(real_repo_path) = repo_path {
+        variables.insert("path", real_repo_path.as_internal_file_string().to_string());
+    }
 
     let mut cmd = Command::new(&editor.program);
     cmd.args(interpolate_variables(&editor.merge_args, &variables));

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -11,6 +11,7 @@ use bstr::BString;
 use itertools::Itertools as _;
 use jj_lib::backend::CopyId;
 use jj_lib::backend::TreeValue;
+use jj_lib::conflict_labels::ConflictLabels;
 use jj_lib::conflicts;
 use jj_lib::conflicts::ConflictMarkerStyle;
 use jj_lib::conflicts::ConflictMaterializeOptions;
@@ -23,8 +24,10 @@ use jj_lib::merge::Diff;
 use jj_lib::merge::Merge;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::merged_tree_builder::MergedTreeBuilder;
+use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::store::Store;
+use jj_lib::tree_merge::MergeOptions;
 use thiserror::Error;
 
 use super::ConflictResolveError;
@@ -194,10 +197,75 @@ async fn run_mergetool_external_single_file(
         conflict,
         file,
     } = merge_tool_file;
-    let file_contents = &file.contents;
-    let file_labels = &file.labels;
-    let merge_options = store.merge_options();
 
+    let (conflict_marker_len, exit_status, exit_status_implies_conflict, output_file_contents) =
+        run_mergetool_external_inner(
+            editor,
+            store.merge_options(),
+            default_conflict_marker_style,
+            repo_path,
+            &file.contents,
+            &file.labels,
+        )?;
+
+    let new_file_ids = if editor.merge_tool_edits_conflict_markers || exit_status_implies_conflict {
+        tracing::info!(
+            ?exit_status_implies_conflict,
+            "jj is reparsing output for conflicts, `merge-tool-edits-conflict-markers = {}` in \
+             TOML config;",
+            editor.merge_tool_edits_conflict_markers
+        );
+        conflicts::update_from_content(
+            &file.unsimplified_ids,
+            store,
+            repo_path,
+            output_file_contents.as_slice(),
+            conflict_marker_len,
+        )
+        .await?
+    } else {
+        let new_file_id = store
+            .write_file(repo_path, &mut output_file_contents.as_slice())
+            .await?;
+        Merge::normal(new_file_id)
+    };
+
+    // If the exit status indicated there should be conflict markers but there
+    // weren't any, it's likely that the tool generated invalid conflict markers, so
+    // we need to inform the user. If we didn't treat this as an error, the user
+    // might think the conflict was resolved successfully.
+    if exit_status_implies_conflict && new_file_ids.is_resolved() {
+        return Err(ConflictResolveError::ExternalTool(
+            ExternalToolError::InvalidConflictMarkers { exit_status },
+        ));
+    }
+
+    let new_tree_value = match new_file_ids.into_resolved() {
+        Ok(file_id) => {
+            let executable = file.executable.expect("should have been resolved");
+            Merge::resolved(file_id.map(|id| TreeValue::File {
+                id,
+                executable,
+                copy_id: CopyId::placeholder(),
+            }))
+        }
+        // Update the file ids only, leaving the executable flags unchanged
+        Err(file_ids) => conflict.with_new_file_ids(&file_ids),
+    };
+    tree_builder.set_or_remove(repo_path.to_owned(), new_tree_value);
+    Ok(())
+}
+
+fn run_mergetool_external_inner(
+    editor: &ExternalMergeTool,
+    merge_options: &MergeOptions,
+    default_conflict_marker_style: ConflictMarkerStyle,
+    repo_path: &RepoPathBuf,
+    materialized_conflicted_contents: &Merge<BString>,
+    conflict_labels: &ConflictLabels,
+) -> Result<(usize, ExitStatus, bool, Vec<u8>), ConflictResolveError> {
+    let file_contents = materialized_conflicted_contents;
+    let file_labels = conflict_labels;
     let uses_marker_length = find_all_variables(&editor.merge_args).contains(&"marker_length");
 
     // If the merge tool doesn't get conflict markers pre-populated in the output
@@ -287,53 +355,12 @@ async fn run_mergetool_external_single_file(
     if output_file_contents.is_empty() || output_file_contents == initial_output_content {
         return Err(ConflictResolveError::EmptyOrUnchanged);
     }
-
-    let new_file_ids = if editor.merge_tool_edits_conflict_markers || exit_status_implies_conflict {
-        tracing::info!(
-            ?exit_status_implies_conflict,
-            "jj is reparsing output for conflicts, `merge-tool-edits-conflict-markers = {}` in \
-             TOML config;",
-            editor.merge_tool_edits_conflict_markers
-        );
-        conflicts::update_from_content(
-            &file.unsimplified_ids,
-            store,
-            repo_path,
-            output_file_contents.as_slice(),
-            conflict_marker_len,
-        )
-        .await?
-    } else {
-        let new_file_id = store
-            .write_file(repo_path, &mut output_file_contents.as_slice())
-            .await?;
-        Merge::normal(new_file_id)
-    };
-
-    // If the exit status indicated there should be conflict markers but there
-    // weren't any, it's likely that the tool generated invalid conflict markers, so
-    // we need to inform the user. If we didn't treat this as an error, the user
-    // might think the conflict was resolved successfully.
-    if exit_status_implies_conflict && new_file_ids.is_resolved() {
-        return Err(ConflictResolveError::ExternalTool(
-            ExternalToolError::InvalidConflictMarkers { exit_status },
-        ));
-    }
-
-    let new_tree_value = match new_file_ids.into_resolved() {
-        Ok(file_id) => {
-            let executable = file.executable.expect("should have been resolved");
-            Merge::resolved(file_id.map(|id| TreeValue::File {
-                id,
-                executable,
-                copy_id: CopyId::placeholder(),
-            }))
-        }
-        // Update the file ids only, leaving the executable flags unchanged
-        Err(file_ids) => conflict.with_new_file_ids(&file_ids),
-    };
-    tree_builder.set_or_remove(repo_path.to_owned(), new_tree_value);
-    Ok(())
+    Ok((
+        conflict_marker_len,
+        exit_status,
+        exit_status_implies_conflict,
+        output_file_contents,
+    ))
 }
 
 pub async fn run_mergetool_external(

--- a/cli/src/merge_tools/external.rs
+++ b/cli/src/merge_tools/external.rs
@@ -194,6 +194,9 @@ async fn run_mergetool_external_single_file(
         conflict,
         file,
     } = merge_tool_file;
+    let file_contents = &file.contents;
+    let file_labels = &file.labels;
+    let merge_options = store.merge_options();
 
     let uses_marker_length = find_all_variables(&editor.merge_args).contains(&"marker_length");
 
@@ -202,7 +205,7 @@ async fn run_mergetool_external_single_file(
     // MIN_CONFLICT_MARKER_LEN since the merge tool can't know about our rules for
     // conflict marker length.
     let conflict_marker_len = if editor.merge_tool_edits_conflict_markers || uses_marker_length {
-        choose_materialized_conflict_marker_len(&file.contents)
+        choose_materialized_conflict_marker_len(file_contents)
     } else {
         MIN_CONFLICT_MARKER_LEN
     };
@@ -212,17 +215,17 @@ async fn run_mergetool_external_single_file(
                 .conflict_marker_style
                 .unwrap_or(default_conflict_marker_style),
             marker_len: Some(conflict_marker_len),
-            merge: store.merge_options().clone(),
+            merge: merge_options.clone(),
         };
-        materialize_merge_result_to_bytes(&file.contents, &file.labels, &options)
+        materialize_merge_result_to_bytes(file_contents, file_labels, &options)
     } else {
         BString::default()
     };
-    assert_eq!(file.contents.num_sides(), 2);
+    assert_eq!(file_contents.num_sides(), 2);
     let files: HashMap<&str, &[u8]> = maplit::hashmap! {
-        "base" => file.contents.get_remove(0).unwrap().as_slice(),
-        "left" => file.contents.get_add(0).unwrap().as_slice(),
-        "right" => file.contents.get_add(1).unwrap().as_slice(),
+        "base" => file_contents.get_remove(0).unwrap().as_slice(),
+        "left" => file_contents.get_add(0).unwrap().as_slice(),
+        "right" => file_contents.get_add(1).unwrap().as_slice(),
         "output" => initial_output_content.as_slice(),
     };
 

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -18,6 +18,7 @@ mod external;
 
 use std::sync::Arc;
 
+use bstr::BString;
 use futures::future::try_join_all;
 use jj_lib::backend::BackendError;
 use jj_lib::backend::CopyId;
@@ -26,6 +27,7 @@ use jj_lib::backend::TreeValue;
 use jj_lib::config::ConfigGetError;
 use jj_lib::config::ConfigGetResultExt as _;
 use jj_lib::config::ConfigNamePathBuf;
+use jj_lib::conflict_labels::ConflictLabels;
 use jj_lib::conflicts::ConflictMarkerStyle;
 use jj_lib::conflicts::MaterializedFileConflictValue;
 use jj_lib::conflicts::try_materialize_file_conflict_value;
@@ -40,6 +42,7 @@ use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::settings::UserSettings;
+use jj_lib::tree_merge::MergeOptions;
 use jj_lib::working_copy::SnapshotError;
 use thiserror::Error;
 
@@ -463,6 +466,37 @@ impl MergeEditor {
                     tree,
                     &merge_tool_files,
                     self.conflict_marker_style,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Starts a merge editor with the given conflicted content.
+    pub async fn merge_conflicted_content(
+        &self,
+        merge_options: &MergeOptions,
+        materialized_conflicted_contents: &Merge<BString>,
+        conflict_labels: &ConflictLabels,
+        default_conflict_marker_style: ConflictMarkerStyle,
+    ) -> Result<Option<Merge<BString>>, ConflictResolveError> {
+        match &self.tool {
+            MergeTool::Builtin => {
+                todo!();
+            }
+            MergeTool::Ours => {
+                todo!();
+            }
+            MergeTool::Theirs => {
+                todo!();
+            }
+            MergeTool::External(editor) => {
+                external::run_mergetool_external_with_materialized_content(
+                    editor,
+                    merge_options,
+                    materialized_conflicted_contents,
+                    conflict_labels,
+                    default_conflict_marker_style,
                 )
                 .await
             }

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -1063,45 +1063,22 @@ pub async fn update_from_content(
     let simplified_file_ids = file_ids.simplify();
 
     let old_contents = extract_as_single_hunk(&simplified_file_ids, store, path).await?;
-    let old_hunks = files::merge_hunks(&old_contents, store.merge_options());
 
-    // Parse conflicts from the new content using the arity of the simplified
-    // conflicts.
-    let new_hunks = parse_conflict(
+    let (contents, unchanged) = update_from_materialized_content(
+        &old_contents,
         content,
-        simplified_file_ids.num_sides(),
         conflict_marker_len,
+        store.merge_options(),
     );
-
-    // Check if the new hunks are unchanged. This makes sure that unchanged file
-    // conflicts aren't updated to partially-resolved contents.
-    let unchanged = match (&old_hunks, &new_hunks) {
-        (MergeResult::Resolved(old), None) => old == content,
-        (MergeResult::Conflict(old), Some(new)) => old == new,
-        (MergeResult::Resolved(_), Some(_)) | (MergeResult::Conflict(_), None) => false,
-    };
     if unchanged {
         return Ok(file_ids.clone());
     }
 
-    let Some(hunks) = new_hunks else {
+    let Some(contents) = contents else {
         // Either there are no markers or they don't have the expected arity
         let file_id = store.write_file(path, &mut &content[..]).await?;
         return Ok(Merge::normal(file_id));
     };
-
-    let mut contents = simplified_file_ids.map(|_| vec![]);
-    for hunk in hunks {
-        if let Some(slice) = hunk.as_resolved() {
-            for content in &mut contents {
-                content.extend_from_slice(slice);
-            }
-        } else {
-            for (content, slice) in zip(&mut contents, hunk) {
-                content.extend(Vec::from(slice));
-            }
-        }
-    }
 
     // Now write the new files contents we found by parsing the file with conflict
     // markers.
@@ -1129,6 +1106,43 @@ pub async fn update_from_content(
         Merge::from_vec(new_file_ids)
     };
     Ok(new_file_ids)
+}
+
+/// Parses conflict markers in `content` and returns the new contents (if any)
+/// and an indicator of whether the content was unchanged.
+pub fn update_from_materialized_content(
+    old_contents: &Merge<BString>,
+    content: &[u8],
+    conflict_marker_len: usize,
+    merge_options: &MergeOptions,
+) -> (Option<Merge<BString>>, bool) {
+    let old_hunks = files::merge_hunks(old_contents, merge_options);
+    let new_hunks = parse_conflict(content, old_contents.num_sides(), conflict_marker_len);
+    let unchanged = match (&old_hunks, &new_hunks) {
+        (MergeResult::Resolved(old), None) => old == content,
+        (MergeResult::Conflict(old), Some(new)) => old == new,
+        (MergeResult::Resolved(_), Some(_)) | (MergeResult::Conflict(_), None) => false,
+    };
+    if unchanged {
+        return (None, true);
+    }
+    let Some(hunks) = new_hunks else {
+        return (None, false);
+    };
+    let mut contents = old_contents.map(|_| vec![]);
+    for hunk in hunks {
+        if let Some(slice) = hunk.as_resolved() {
+            for content in &mut contents {
+                content.extend_from_slice(slice);
+            }
+        } else {
+            for (content, slice) in zip(&mut contents, hunk) {
+                content.extend(Vec::from(slice));
+            }
+        }
+    }
+    let contents: Merge<BString> = contents.into_map(BString::new);
+    (Some(contents), false)
 }
 
 #[cfg(test)]

--- a/lib/tests/test_conflicts.rs
+++ b/lib/tests/test_conflicts.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bstr::BString;
 use indoc::indoc;
 use itertools::Itertools as _;
 use jj_lib::backend::FileId;
@@ -24,6 +25,7 @@ use jj_lib::conflicts::extract_as_single_hunk;
 use jj_lib::conflicts::materialize_merge_result_to_bytes;
 use jj_lib::conflicts::parse_conflict;
 use jj_lib::conflicts::update_from_content;
+use jj_lib::conflicts::update_from_materialized_content;
 use jj_lib::files::FileMergeHunkLevel;
 use jj_lib::merge::Merge;
 use jj_lib::merge::SameChange;
@@ -638,6 +640,57 @@ fn test_materialize_update_roundtrip(style: ConflictMarkerStyle) -> TestResult {
     .block_on()?;
 
     assert_eq!(parsed, conflict);
+    Ok(())
+}
+
+#[test_case(ConflictMarkerStyle::Diff)]
+#[test_case(ConflictMarkerStyle::Snapshot)]
+#[test_case(ConflictMarkerStyle::Git)]
+fn test_materialize_update_roundtrip_raw(style: ConflictMarkerStyle) -> TestResult {
+    let test_repo = TestRepo::init();
+    let store = test_repo.repo.store();
+
+    let base_content = indoc! {"
+            line 1
+            line 2 base
+            line 3 base
+            line 4 base
+            line 5
+        "};
+    let a_content = indoc! {"
+            line 1
+            line 2 a.1
+            line 3 a.2
+            line 4 base
+            line 5
+        "};
+    let b_content = indoc! {"
+            line 1
+            line 2 b.1
+            line 3 base
+            line 4 b.2
+            line 5
+        "};
+    let conflict = Merge::from_removes_adds(
+        vec![BString::new(base_content.into())],
+        vec![
+            BString::new(a_content.into()),
+            BString::new(b_content.into()),
+        ],
+    );
+
+    let materialized =
+        materialize_conflict_string_with_labels_raw(&conflict, style, &ConflictLabels::unlabeled());
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
+
     Ok(())
 }
 
@@ -1806,6 +1859,80 @@ fn test_update_conflict_from_content() -> TestResult {
 }
 
 #[test]
+fn test_update_conflict_from_content_raw() -> TestResult {
+    let test_repo = TestRepo::init();
+    let store = test_repo.repo.store();
+    let base_content = "line 1\nline 2\nline 3\n";
+    let left_content = "left 1\nline 2\nleft 3\n";
+    let right_content = "right 1\nline 2\nright 3\n";
+    let conflict = Merge::from_removes_adds(
+        vec![BString::new(base_content.into())],
+        vec![
+            BString::new(left_content.into()),
+            BString::new(right_content.into()),
+        ],
+    );
+
+    // If the content is unchanged compared to the materialized value, we get the
+    // old conflict back.
+    let materialized = materialize_conflict_string_with_labels_raw(
+        &conflict,
+        ConflictMarkerStyle::Diff,
+        &ConflictLabels::unlabeled(),
+    );
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
+
+    // If the conflict is resolved, we get None back to indicate that.
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            b"resolved 1\nline 2\nresolved 3\n",
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, false)
+    );
+
+    // If the conflict is partially resolved, we get a new conflict back.
+    let (new_contents, unchanged) = update_from_materialized_content(
+        &conflict,
+        b"resolved 1\nline 2\n<<<<<<<\n%%%%%%%\n-line 3\n+left 3\n+++++++\nright 3\n>>>>>>>\n",
+        MIN_CONFLICT_MARKER_LEN,
+        store.merge_options(),
+    );
+    assert!(!unchanged);
+    let new_contents = new_contents.unwrap();
+    assert_eq!(new_contents.num_sides(), 2);
+    insta::assert_snapshot!(new_contents.first(), @r"
+        resolved 1
+        line 2
+        left 3
+        "
+    );
+    insta::assert_snapshot!(new_contents.get_remove(0).unwrap(), @r"
+        resolved 1
+        line 2
+        line 3
+        "
+    );
+    insta::assert_snapshot!(new_contents.get_add(1).unwrap(), @r"
+        resolved 1
+        line 2
+        right 3
+        "
+    );
+    Ok(())
+}
+
+#[test]
 fn test_update_conflict_from_content_modify_delete() -> TestResult {
     let test_repo = TestRepo::init();
     let store = test_repo.repo.store();
@@ -1940,6 +2067,103 @@ fn test_update_conflict_from_content_simplified_conflict() -> TestResult {
                 Some(new_right_file_id.clone())
             ]
         )
+    );
+    Ok(())
+}
+
+#[test]
+fn test_update_conflict_from_content_simplified_conflict_raw() -> TestResult {
+    let test_repo = TestRepo::init();
+    let store = test_repo.repo.store();
+
+    let base_content = "line 1\nline 2\nline 3\n";
+    let left_content = "left 1\nline 2\nleft 3\n";
+    let right_content = "right 1\nline 2\nright 3\n";
+    // Conflict: left - base + base - base + right
+    let conflict = Merge::from_removes_adds(
+        vec![
+            BString::new(base_content.into()),
+            BString::new(base_content.into()),
+        ],
+        vec![
+            BString::new(left_content.into()),
+            BString::new(base_content.into()),
+            BString::new(right_content.into()),
+        ],
+    );
+    let simplified_conflict = conflict.simplify();
+
+    // If the content is unchanged compared to the materialized value, we get the
+    // old conflict id back.
+    let materialized = materialize_conflict_string_with_labels_raw(
+        &simplified_conflict,
+        ConflictMarkerStyle::Diff,
+        &ConflictLabels::unlabeled(),
+    );
+
+    insta::assert_snapshot!(
+        materialized,
+        @r"
+    <<<<<<< conflict 1 of 2
+    %%%%%%% diff from: base
+    \\\\\\\        to: side #1
+    -line 1
+    +left 1
+    +++++++ side #2
+    right 1
+    >>>>>>> conflict 1 of 2 ends
+    line 2
+    <<<<<<< conflict 2 of 2
+    %%%%%%% diff from: base
+    \\\\\\\        to: side #1
+    -line 3
+    +left 3
+    +++++++ side #2
+    right 3
+    >>>>>>> conflict 2 of 2 ends
+    "
+    );
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, false)
+    );
+
+    // If the conflict is resolved, we get a normal merge back to indicate that.
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            b"resolved 1\nline 2\nresolved 3\n",
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, false)
+    );
+
+    // If the conflict is partially resolved, we get a new conflict back.
+    let materialized = indoc! {"
+        resolved 1
+        line 2
+        <<<<<<< conflict 2 of 2
+        %%%%%%% diff from base to side #1
+        -edited line 3
+        +edited left 3
+        +++++++ side #2
+        edited right 3
+        >>>>>>> conflict 2 of 2 ends
+    "};
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, false)
     );
     Ok(())
 }
@@ -2109,19 +2333,252 @@ fn test_update_conflict_from_content_with_long_markers() -> TestResult {
 }
 
 #[test]
+fn test_update_conflict_from_content_with_long_markers_raw() -> TestResult {
+    let test_repo = TestRepo::init();
+    let store = test_repo.repo.store();
+
+    // Create conflicts which contain conflict markers of varying lengths
+    let base_content = indoc! {"
+            line 1
+            line 2
+            line 3
+        "};
+    let left_content = indoc! {"
+            <<<< left 1
+            line 2
+            <<<<<<<<<<<< left 3
+        "};
+    let right_content = indoc! {"
+            >>>>>>> right 1
+            line 2
+            >>>>>>>>>>>> right 3
+        "};
+    let conflict = Merge::from_removes_adds(
+        vec![BString::new(base_content.into())],
+        vec![
+            BString::new(left_content.into()),
+            BString::new(right_content.into()),
+        ],
+    );
+
+    // The conflict should be materialized using long conflict markers
+    let materialized_marker_len = choose_materialized_conflict_marker_len(&conflict);
+    assert!(materialized_marker_len > MIN_CONFLICT_MARKER_LEN);
+    let materialized = materialize_conflict_string_with_labels_raw(
+        &conflict,
+        ConflictMarkerStyle::Snapshot,
+        &ConflictLabels::unlabeled(),
+    );
+    insta::assert_snapshot!(materialized, @"
+    <<<<<<<<<<<<<<<< conflict 1 of 2
+    ++++++++++++++++ side #1
+    <<<< left 1
+    ---------------- base
+    line 1
+    ++++++++++++++++ side #2
+    >>>>>>> right 1
+    >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+    line 2
+    <<<<<<<<<<<<<<<< conflict 2 of 2
+    ++++++++++++++++ side #1
+    <<<<<<<<<<<< left 3
+    ---------------- base
+    line 3
+    ++++++++++++++++ side #2
+    >>>>>>>>>>>> right 3
+    >>>>>>>>>>>>>>>> conflict 2 of 2 ends
+    "
+    );
+
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            materialized.as_bytes(),
+            materialized_marker_len,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
+
+    // Test resolving the conflict, leaving some fake conflict markers which should
+    // not be parsed since they are too short
+    let resolved_file_contents = indoc! {"
+        <<<<<<<<<<<< not a real conflict!
+        ++++++++++++
+        left
+        ------------
+        base
+        ++++++++++++
+        right
+        >>>>>>>>>>>>
+    "};
+
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict,
+            resolved_file_contents.as_bytes(),
+            materialized_marker_len,
+            store.merge_options(),
+        ),
+        (None, false)
+    );
+
+    // Resolve one of the conflicts, decreasing the minimum conflict marker length
+    let new_conflict_contents = indoc! {"
+        <<<<<<<<<<<<<<<< conflict 1 of 2
+        ++++++++++++++++ side #1
+        <<<< left 1
+        ---------------- base
+        line 1
+        ++++++++++++++++ side #2
+        >>>>>>> right 1
+        >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+        line 2
+        line 3
+    "};
+
+    // Confirm that the new conflict parsed correctly
+    let (new_contents, unchanged) = update_from_materialized_content(
+        &conflict,
+        new_conflict_contents.as_bytes(),
+        materialized_marker_len,
+        store.merge_options(),
+    );
+    assert!(!unchanged);
+
+    let new_base_content = indoc! {"
+            line 1
+            line 2
+            line 3
+        "};
+    let new_left_content = indoc! {"
+            <<<< left 1
+            line 2
+            line 3
+        "};
+    let new_right_content = indoc! {"
+            >>>>>>> right 1
+            line 2
+            line 3
+        "};
+    let new_contents = new_contents.unwrap();
+    assert_eq!(
+        new_contents,
+        Merge::from_removes_adds(
+            vec![BString::new(new_base_content.into())],
+            vec![
+                BString::new(new_left_content.into()),
+                BString::new(new_right_content.into()),
+            ],
+        )
+    );
+
+    // The conflict markers should still parse in future snapshots even though
+    // they're now longer than necessary
+
+    {
+        let (new_contents, unchanged) = update_from_materialized_content(
+            &new_contents,
+            new_conflict_contents.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        );
+        assert!(!unchanged);
+        let new_contents = new_contents.unwrap();
+        assert_eq!(new_contents.num_sides(), 2);
+        insta::assert_snapshot!(new_contents.first(), @r"
+        <<<< left 1
+        >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+        line 2
+        line 3
+        ");
+        insta::assert_snapshot!(new_contents.get_remove(0).unwrap(), @r"
+        line 1
+        >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+        line 2
+        line 3
+        ");
+        insta::assert_snapshot!(new_contents.get_add(1).unwrap(), @r"
+        >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+        line 2
+        line 3
+        ");
+
+        let (new_contents, unchanged) = update_from_materialized_content(
+            &new_contents,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        );
+        assert!(!unchanged);
+        let new_contents = new_contents.unwrap();
+        assert_eq!(new_contents.num_sides(), 2);
+        insta::assert_snapshot!(new_contents.first(), @r"
+        <<<< left 1
+        >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+        line 2
+        <<<<<<<<<<<<<<<< conflict 2 of 2
+        ++++++++++++++++ side #1
+        <<<<<<<<<<<< left 3
+        ---------------- base
+        line 3
+        ++++++++++++++++ side #2
+        >>>>>>>>>>>> right 3
+        >>>>>>>>>>>>>>>> conflict 2 of 2 ends
+        ");
+        insta::assert_snapshot!(new_contents.get_remove(0).unwrap(), @r"
+        line 1
+        >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+        line 2
+        <<<<<<<<<<<<<<<< conflict 2 of 2
+        ++++++++++++++++ side #1
+        <<<<<<<<<<<< left 3
+        ---------------- base
+        line 3
+        ++++++++++++++++ side #2
+        >>>>>>>>>>>> right 3
+        >>>>>>>>>>>>>>>> conflict 2 of 2 ends
+        ");
+        insta::assert_snapshot!(new_contents.get_add(1).unwrap(), @r"
+        >>>>>>>>>>>>>>>> conflict 1 of 2 ends
+        line 2
+        <<<<<<<<<<<<<<<< conflict 2 of 2
+        ++++++++++++++++ side #1
+        <<<<<<<<<<<< left 3
+        ---------------- base
+        line 3
+        ++++++++++++++++ side #2
+        >>>>>>>>>>>> right 3
+        >>>>>>>>>>>>>>>> conflict 2 of 2 ends
+        ");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_update_conflict_from_content_no_eol() -> TestResult {
     let test_repo = TestRepo::init();
     let store = test_repo.repo.store();
 
     let path = repo_path("file");
-    let base_id = testutils::write_file(store, path, "line 1\nline 2\nline 3\nbase");
-    let left_empty_id =
-        testutils::write_file(store, path, "line 1\nline 2 left\nline 3\nbase\nleft\n");
-    let right_id = testutils::write_file(store, path, "line 1\nline 2 right\nline 3\nright");
+    let base_content = "line 1\nline 2\nline 3\nbase";
+    let left_content = "line 1\nline 2 left\nline 3\nbase\nleft\n";
+    let right_content = "line 1\nline 2 right\nline 3\nright";
+    let base_id = testutils::write_file(store, path, base_content);
+    let left_empty_id = testutils::write_file(store, path, left_content);
+    let right_id = testutils::write_file(store, path, right_content);
 
     let conflict = Merge::from_removes_adds(
         vec![Some(base_id)],
         vec![Some(left_empty_id), Some(right_id)],
+    );
+    let conflict_merge = Merge::from_removes_adds(
+        vec![BString::new(base_content.into())],
+        vec![
+            BString::new(left_content.into()),
+            BString::new(right_content.into()),
+        ],
     );
 
     let materialized =
@@ -2159,6 +2616,15 @@ fn test_update_conflict_from_content_no_eol() -> TestResult {
         )
         .block_on()?,
         conflict
+    );
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict_merge,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, true)
     );
 
     let materialized =
@@ -2198,6 +2664,15 @@ fn test_update_conflict_from_content_no_eol() -> TestResult {
         .block_on()?,
         conflict
     );
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict_merge,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
 
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Git);
@@ -2234,6 +2709,16 @@ fn test_update_conflict_from_content_no_eol() -> TestResult {
         .block_on()?,
         conflict
     );
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict_merge,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
+
     Ok(())
 }
 
@@ -2256,17 +2741,32 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() -> TestResult {
 
     let conflict = Merge::from_removes_adds(
         vec![
-            Some(base_1_id),
-            Some(base_2_id),
-            Some(base_3_id),
-            Some(base_4_id),
+            Some(base_1_id.clone()),
+            Some(base_2_id.clone()),
+            Some(base_3_id.clone()),
+            Some(base_4_id.clone()),
         ],
         vec![
-            Some(side_1_id),
-            Some(side_2_id),
-            Some(side_3_id),
-            Some(side_4_id),
-            Some(side_5_id),
+            Some(side_1_id.clone()),
+            Some(side_2_id.clone()),
+            Some(side_3_id.clone()),
+            Some(side_4_id.clone()),
+            Some(side_5_id.clone()),
+        ],
+    );
+    let conflict_merge = Merge::from_removes_adds(
+        [
+            BString::new(testutils::read_file(store, path, &base_1_id)),
+            BString::new(testutils::read_file(store, path, &base_2_id)),
+            BString::new(testutils::read_file(store, path, &base_3_id)),
+            BString::new(testutils::read_file(store, path, &base_4_id)),
+        ],
+        [
+            BString::new(testutils::read_file(store, path, &side_1_id)),
+            BString::new(testutils::read_file(store, path, &side_2_id)),
+            BString::new(testutils::read_file(store, path, &side_3_id)),
+            BString::new(testutils::read_file(store, path, &side_4_id)),
+            BString::new(testutils::read_file(store, path, &side_5_id)),
         ],
     );
 
@@ -2313,6 +2813,16 @@ fn test_update_conflict_from_content_no_eol_in_diff_hunk() -> TestResult {
         .block_on()?,
         conflict
     );
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict_merge,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
+
     Ok(())
 }
 
@@ -2324,12 +2834,22 @@ fn test_update_conflict_from_content_only_no_eol_change() -> TestResult {
     let path = repo_path("file");
     // Create a conflict which would be resolved by the "A-B+A = A" rule if the
     // missing newline is wrongly ignored
-    let left_id = testutils::write_file(store, path, "line 1\nline 2");
-    let base_id = testutils::write_file(store, path, "line 1\n");
-    let right_id = testutils::write_file(store, path, "line 1\nline 2\n");
+    let left_content = "line 1\nline 2";
+    let base_content = "line 1\n";
+    let right_content = "line 1\nline 2\n";
+    let left_id = testutils::write_file(store, path, left_content);
+    let base_id = testutils::write_file(store, path, base_content);
+    let right_id = testutils::write_file(store, path, right_content);
 
     let conflict =
         Merge::from_removes_adds(vec![Some(base_id)], vec![Some(left_id), Some(right_id)]);
+    let conflict_merge = Merge::from_removes_adds(
+        vec![BString::new(base_content.into())],
+        vec![
+            BString::new(left_content.into()),
+            BString::new(right_content.into()),
+        ],
+    );
 
     let materialized =
         &materialize_conflict_string(store, path, &conflict, ConflictMarkerStyle::Diff);
@@ -2357,6 +2877,16 @@ fn test_update_conflict_from_content_only_no_eol_change() -> TestResult {
         .block_on()?,
         conflict
     );
+    assert_eq!(
+        update_from_materialized_content(
+            &conflict_merge,
+            materialized.as_bytes(),
+            MIN_CONFLICT_MARKER_LEN,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
+
     Ok(())
 }
 
@@ -2366,42 +2896,40 @@ fn test_update_from_content_malformed_conflict() -> TestResult {
     let store = test_repo.repo.store();
 
     let path = repo_path("dir/file");
-    let base_file_id = testutils::write_file(
-        store,
-        path,
-        indoc! {"
+    let base_content = indoc! {"
             line 1
             line 2
             line 3
             line 4
             line 5
-        "},
-    );
-    let left_file_id = testutils::write_file(
-        store,
-        path,
-        indoc! {"
+        "};
+    let left_content = indoc! {"
             line 1
             line 2 left
             line 3
             line 4 left
             line 5
-        "},
-    );
-    let right_file_id = testutils::write_file(
-        store,
-        path,
-        indoc! {"
+        "};
+    let right_content = indoc! {"
             line 1
             line 2 right
             line 3
             line 4 right
             line 5
-        "},
-    );
+        "};
+    let base_file_id = testutils::write_file(store, path, base_content);
+    let left_file_id = testutils::write_file(store, path, left_content);
+    let right_file_id = testutils::write_file(store, path, right_content);
     let conflict = Merge::from_removes_adds(
         vec![Some(base_file_id.clone())],
         vec![Some(left_file_id.clone()), Some(right_file_id.clone())],
+    );
+    let confict_merge = Merge::from_removes_adds(
+        vec![BString::new(base_content.into())],
+        vec![
+            BString::new(left_content.into()),
+            BString::new(right_content.into()),
+        ],
     );
 
     // The conflict should be materialized with normal markers
@@ -2441,6 +2969,15 @@ fn test_update_from_content_malformed_conflict() -> TestResult {
             .unwrap()
     };
     assert_eq!(parse(&conflict, materialized.as_bytes()), conflict);
+    assert_eq!(
+        update_from_materialized_content(
+            &confict_merge,
+            materialized.as_bytes(),
+            materialized_marker_len,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
 
     // Make a change to the second conflict that causes it to become invalid
     let new_conflict_contents = indoc! {"
@@ -2509,10 +3046,32 @@ fn test_update_from_content_malformed_conflict() -> TestResult {
     line 5
     ");
 
+    let (new_contents, unchanged) = update_from_materialized_content(
+        &confict_merge,
+        new_conflict_contents.as_bytes(),
+        materialized_marker_len,
+        store.merge_options(),
+    );
+    assert!(!unchanged);
+    let new_contents = new_contents.unwrap();
+    assert_eq!(new_contents.num_sides(), 2);
+    assert_eq!(new_contents.first(), new_left_side.as_bytes());
+    assert_eq!(new_contents.get_remove(0).unwrap(), new_base.as_bytes());
+    assert_eq!(new_contents.get_add(1).unwrap(), new_right_side.as_bytes());
+
     // Even though the file now contains markers of length 7, the materialized
     // markers of length 7 are still parsed
     let second_snapshot = parse(&new_conflict, new_conflict_contents.as_bytes());
     assert_eq!(second_snapshot, new_conflict);
+    assert_eq!(
+        update_from_materialized_content(
+            &new_contents,
+            new_conflict_contents.as_bytes(),
+            materialized_marker_len,
+            store.merge_options(),
+        ),
+        (None, true)
+    );
     Ok(())
 }
 
@@ -2541,6 +3100,14 @@ fn materialize_conflict_string_with_labels(
     let contents = extract_as_single_hunk(conflict, store, path)
         .block_on()
         .unwrap();
+    materialize_conflict_string_with_labels_raw(&contents, marker_style, conflict_labels)
+}
+
+fn materialize_conflict_string_with_labels_raw(
+    conflict: &Merge<BString>,
+    marker_style: ConflictMarkerStyle,
+    conflict_labels: &ConflictLabels,
+) -> String {
     let options = ConflictMaterializeOptions {
         marker_style,
         marker_len: None,
@@ -2549,8 +3116,6 @@ fn materialize_conflict_string_with_labels(
             same_change: SameChange::Accept,
         },
     };
-    String::from_utf8(
-        materialize_merge_result_to_bytes(&contents, conflict_labels, &options).into(),
-    )
-    .unwrap()
+    String::from_utf8(materialize_merge_result_to_bytes(conflict, conflict_labels, &options).into())
+        .unwrap()
 }


### PR DESCRIPTION
The goal is to extract a library function that can be used to invoke the merge tool to merge arbitrary strings. This is useful to the work-in-progress jj converge command to be able to bring up the user's merge tool to merge various commit descriptions.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
