### PR TITLE
snapshot: Reduce lock contention in `snapshot_progress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj status` filters untracked paths by fileset
   [#9287](https://github.com/jj-vcs/jj/issues/9287)
 
+* Improved performance for snapshot progress, visibly improving `jj status`
+  speed for large repositories.
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -103,10 +103,15 @@ pub fn snapshot_progress(ui: &Ui) -> Option<impl Fn(&RepoPath) + use<>> {
     let writer = Mutex::new(ProgressWriter::new(ui, "Snapshotting")?);
 
     Some(move |path: &RepoPath| {
-        writer
-            .lock()
-            .unwrap()
-            .display(path.to_fs_path_unchecked(Path::new("")).to_str().unwrap())
-            .ok();
+        // When the lock is held, skip updates to reduce contention.
+        //
+        // Executing the "future work" above may change this locking. Check
+        // performance with output going to a tty so that writes are slower and
+        // any lock contention is more visible.
+        if let Ok(mut progress) = writer.try_lock() {
+            progress
+                .display(path.to_fs_path_unchecked(Path::new("")).to_str().unwrap())
+                .ok();
+        }
     })
 }


### PR DESCRIPTION
When output is to a tty (or generally user visible), there's a lot of lock contention on snapshotting. Essentially file snapshots are happening faster than the lock can keep up. Reducing the update rate (e.g. 30 -> 10) doesn't affect this because the lock is the issue.

By using `try_lock`, this discards updates when an update is currently occurring. Any lock contention results in a lost update, instead of a delay.

In the below benchmark, I used https://github.com/mozilla-firefox/firefox

```
╚╡hyperfine --parameter-list rev 'perf,main' --setup 'jj new "{rev}" && cargo build --release' --warmup 1 --runs 30 --show-output './target/release/jj --repository ../firefox status'
Benchmark 1: ./target/release/jj --repository ../firefox status (rev = perf)
(eliding output from --show-output)
  Time (mean ± σ):     632.7 ms ±   9.2 ms    [User: 1109.5 ms, System: 980.3 ms]
  Range (min … max):   595.1 ms … 646.9 ms    30 runs

Benchmark 2: ./target/release/jj --repository ../firefox status (rev = main)
(eliding output from --show-output)
  Time (mean ± σ):     963.1 ms ±  26.8 ms    [User: 1903.4 ms, System: 3186.6 ms]
  Range (min … max):   912.6 ms … 1036.9 ms    30 runs

Summary
  ./target/release/jj --repository ../firefox status (rev = perf) ran
    1.52 ± 0.05 times faster than ./target/release/jj --repository ../firefox status (rev = main)
```

Assisted-by: Google Antigravity with Gemini
