### PR TITLE
gitignore: use `gix_ignore` crate as `gix::ignore`

### DIFF
--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -34,7 +34,7 @@ pub enum GitIgnoreError {
 #[derive(Debug)]
 pub struct GitIgnoreFile {
     parent: Option<Arc<Self>>,
-    matcher: gix_ignore::Search,
+    matcher: gix::ignore::Search,
     prefix: String,
 }
 
@@ -42,7 +42,7 @@ impl GitIgnoreFile {
     pub fn empty() -> Arc<Self> {
         Arc::new(Self {
             parent: None,
-            matcher: gix_ignore::Search::default(),
+            matcher: gix::ignore::Search::default(),
             prefix: "".to_string(),
         })
     }
@@ -59,7 +59,7 @@ impl GitIgnoreFile {
     ) -> Result<Arc<Self>, GitIgnoreError> {
         assert!(prefix.is_empty() || prefix.ends_with('/'));
         // Construct the gix search object.
-        let mut matcher = gix_ignore::Search::default();
+        let mut matcher = gix::ignore::Search::default();
         let root = if prefix.is_empty() {
             None
         } else {
@@ -69,7 +69,7 @@ impl GitIgnoreFile {
             input,
             ignore_path,
             root,
-            gix_ignore::search::Ignore {
+            gix::ignore::search::Ignore {
                 support_precious: false,
             },
         );
@@ -131,7 +131,7 @@ impl GitIgnoreFile {
                 let m = file.matcher.pattern_matching_relative_path(
                     relative_path.as_bytes().as_bstr(),
                     Some(is_dir),
-                    gix_ignore::glob::pattern::Case::Sensitive,
+                    gix::ignore::glob::pattern::Case::Sensitive,
                 );
                 if let Some(m) = m {
                     return !m.pattern.is_negative();


### PR DESCRIPTION
This is consistent with how we use it elsewhere. It makes it slightly easier to use at Google where we don't use Cargo and the `gix_ignore` crate isn't visible without a direct dependency on the `gix_ignore` crate.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
