### PR TITLE
status: respect path filters in working copy summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fixed a panic in `jj gerrit upload` when run without `-r` and the
   inferred revision was immutable. [#9398](https://github.com/jj-vcs/jj/issues/9398)
 
+* `jj status` respects path filters in working copy summaries.
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -95,9 +95,7 @@ pub(crate) async fn cmd_status(
             [&status.tree],
         )?;
 
-        let mut matching_untracked_paths = status.untracked_paths_matching(&matcher).peekable();
-
-        if !status.has_any_tracked_changes() && matching_untracked_paths.peek().is_none() {
+        if !status.has_any_tracked_changes() && !status.has_any_untracked_paths() {
             writeln!(formatter, "The working copy has no changes.")?;
         } else {
             if status.has_any_tracked_changes() {
@@ -127,6 +125,7 @@ pub(crate) async fn cmd_status(
                 }
             }
 
+            let mut matching_untracked_paths = status.untracked_paths_matching(&matcher).peekable();
             if matching_untracked_paths.peek().is_some() {
                 writeln!(formatter, "Untracked paths:")?;
                 visit_collapsed_untracked_files(
@@ -260,6 +259,10 @@ struct WorkingCopyStatus {
 impl WorkingCopyStatus {
     fn has_any_tracked_changes(&self) -> bool {
         self.tree.tree_ids() != self.parent_tree.tree_ids()
+    }
+
+    fn has_any_untracked_paths(&self) -> bool {
+        !self.untracked_paths.is_empty()
     }
 
     fn untracked_paths_matching(&self, matcher: &dyn Matcher) -> impl Iterator<Item = &RepoPath> {

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+
 use futures::TryStreamExt as _;
 use itertools::Itertools as _;
+use jj_lib::commit::Commit;
 use jj_lib::copies::CopyRecords;
+use jj_lib::matchers::Matcher;
 use jj_lib::merge::Diff;
 use jj_lib::merged_tree::MergedTree;
-use jj_lib::repo::Repo as _;
+use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetFilterPredicate;
+use jj_lib::working_copy::SnapshotStats;
+use jj_lib::working_copy::UntrackedReason;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
@@ -81,27 +87,26 @@ pub(crate) async fn cmd_status(
     let formatter = formatter.as_mut();
 
     if let Some(wc_commit) = &maybe_wc_commit {
-        let parent_tree = wc_commit.parent_tree(repo.as_ref()).await?;
-        let tree = wc_commit.tree();
+        let status = collect_working_copy_status(repo.as_ref(), wc_commit, snapshot_stats).await?;
+        print_unmatched_explicit_paths(
+            ui,
+            &workspace_command,
+            &fileset_expression,
+            [&status.tree],
+        )?;
 
-        print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+        let mut matching_untracked_paths = status.untracked_paths_matching(&matcher).peekable();
 
-        let wc_has_changes = tree.tree_ids() != parent_tree.tree_ids();
-        let filtered_untracked = snapshot_stats
-            .untracked_paths
-            .keys()
-            .filter(|path| matcher.matches(path))
-            .collect_vec();
-        let wc_has_untracked = !filtered_untracked.is_empty();
-        if !wc_has_changes && !wc_has_untracked {
+        if !status.has_any_tracked_changes() && matching_untracked_paths.peek().is_none() {
             writeln!(formatter, "The working copy has no changes.")?;
         } else {
-            if wc_has_changes {
+            if status.has_any_tracked_changes() {
                 writeln!(formatter, "Working copy changes:")?;
                 let mut copy_records = CopyRecords::default();
-                for parent in wc_commit.parent_ids() {
+                for parent in &status.parents {
                     let records =
-                        get_copy_records(repo.store(), parent, wc_commit.id(), &matcher).await?;
+                        get_copy_records(repo.store(), parent.id(), status.commit.id(), &matcher)
+                            .await?;
                     copy_records.add_records(records);
                 }
                 let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
@@ -110,7 +115,7 @@ pub(crate) async fn cmd_status(
                     .show_diff(
                         ui,
                         formatter,
-                        Diff::new(&parent_tree, &tree),
+                        Diff::new(&status.parent_tree, &status.tree),
                         &matcher,
                         &copy_records,
                         width,
@@ -118,11 +123,11 @@ pub(crate) async fn cmd_status(
                     .await?;
             }
 
-            if wc_has_untracked {
+            if matching_untracked_paths.peek().is_some() {
                 writeln!(formatter, "Untracked paths:")?;
                 visit_collapsed_untracked_files(
-                    filtered_untracked,
-                    tree.clone(),
+                    matching_untracked_paths,
+                    status.tree.clone(),
                     |path, is_dir| {
                         let ui_path = workspace_command.path_converter().format_file_path(path);
                         writeln!(
@@ -143,24 +148,24 @@ pub(crate) async fn cmd_status(
 
         let template = workspace_command.commit_summary_template();
         write!(formatter, "Working copy  (@) : ")?;
-        template.format(wc_commit, formatter)?;
+        template.format(&status.commit, formatter)?;
         writeln!(formatter)?;
-        for parent in wc_commit.parents().await? {
+        for parent in &status.parents {
             //                "Working copy  (@) : "
             write!(formatter, "Parent commit (@-): ")?;
-            template.format(&parent, formatter)?;
+            template.format(parent, formatter)?;
             writeln!(formatter)?;
         }
 
-        if wc_commit.has_conflict() {
-            let conflicts = wc_commit.tree().conflicts_matching(&matcher).collect_vec();
+        if status.commit.has_conflict() {
+            let conflicts = status.tree.conflicts_matching(&matcher).collect_vec();
             writeln!(
                 formatter.labeled("warning").with_heading("Warning: "),
                 "There are unresolved conflicts at these paths:"
             )?;
             print_conflicted_paths(conflicts, formatter, &workspace_command)?;
 
-            let wc_revset = RevsetExpression::commit(wc_commit.id().clone());
+            let wc_revset = RevsetExpression::commit(status.commit.id().clone());
 
             // Ancestors with conflicts, excluding the current working copy commit.
             let ancestors_conflicts: Vec<_> = workspace_command
@@ -179,7 +184,7 @@ pub(crate) async fn cmd_status(
                 .report_repo_conflicts(formatter, repo, ancestors_conflicts)
                 .await?;
         } else {
-            for parent in wc_commit.parents().await? {
+            for parent in &status.parents {
                 if parent.has_conflict() {
                     writeln!(
                         formatter.labeled("hint").with_heading("Hint: "),
@@ -238,6 +243,47 @@ pub(crate) async fn cmd_status(
     }
 
     Ok(())
+}
+
+struct WorkingCopyStatus {
+    commit: Commit,
+    parents: Vec<Commit>,
+    parent_tree: MergedTree,
+    tree: MergedTree,
+    untracked_paths: BTreeMap<RepoPathBuf, UntrackedReason>,
+}
+
+impl WorkingCopyStatus {
+    fn has_any_tracked_changes(&self) -> bool {
+        self.tree.tree_ids() != self.parent_tree.tree_ids()
+    }
+
+    fn untracked_paths_matching(&self, matcher: &dyn Matcher) -> impl Iterator<Item = &RepoPath> {
+        self.untracked_paths
+            .keys()
+            .filter(|path| matcher.matches(path))
+            .map(|path| path.as_ref())
+    }
+}
+
+async fn collect_working_copy_status(
+    repo: &dyn Repo,
+    commit: &Commit,
+    snapshot_stats: SnapshotStats,
+) -> Result<WorkingCopyStatus, CommandError> {
+    let commit = commit.clone();
+    let parents = commit.parents().await?;
+    let parent_tree = commit.parent_tree(repo).await?;
+    let tree = commit.tree();
+    let untracked_paths = snapshot_stats.untracked_paths;
+
+    Ok(WorkingCopyStatus {
+        commit,
+        parents,
+        parent_tree,
+        tree,
+        untracked_paths,
+    })
 }
 
 async fn visit_collapsed_untracked_files(

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -101,7 +101,6 @@ pub(crate) async fn cmd_status(
             writeln!(formatter, "The working copy has no changes.")?;
         } else {
             if status.has_any_tracked_changes() {
-                writeln!(formatter, "Working copy changes:")?;
                 let mut copy_records = CopyRecords::default();
                 for parent in &status.parents {
                     let records =
@@ -111,16 +110,21 @@ pub(crate) async fn cmd_status(
                 }
                 let diff_renderer = workspace_command.diff_renderer(vec![DiffFormat::Summary]);
                 let width = ui.term_width();
+                let mut diff_output = vec![];
                 diff_renderer
                     .show_diff(
                         ui,
-                        formatter,
+                        ui.new_formatter(&mut diff_output).as_mut(),
                         Diff::new(&status.parent_tree, &status.tree),
                         &matcher,
                         &copy_records,
                         width,
                     )
                     .await?;
+                if !diff_output.is_empty() {
+                    writeln!(formatter, "Working copy changes:")?;
+                    formatter.raw()?.write_all(&diff_output)?;
+                }
             }
 
             if matching_untracked_paths.peek().is_some() {

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -109,12 +109,60 @@ fn test_status_filtered() {
     [EOF]
     ");
 
+    // The diff summary should preserve ANSI color codes instead of sanitizing them.
+    let output = work_dir.run_jj(["status", "file_1", "--color=always"]);
+    insta::assert_snapshot!(output, @"
+    Working copy changes:
+    [38;5;2mA file_1[39m
+    Working copy  (@) : [1m[38;5;13mq[38;5;8mpvuntsm[39m [38;5;12m2[38;5;8mf169edb[39m [38;5;3m(no description set)[0m
+    Parent commit (@-): [1m[38;5;5mz[0m[38;5;8mzzzzzzz[39m [1m[38;5;4m0[0m[38;5;8m0000000[39m [38;5;2m(empty)[39m [38;5;2m(no description set)[39m
+    [EOF]
+    ");
+
     // The output filtered to a non-existent file should display a warning.
     let output = work_dir.run_jj(["status", "nonexistent"]);
     insta::assert_snapshot!(output, @"
-    Working copy changes:
     Working copy  (@) : qpvuntsm 2f169edb (no description set)
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
+    [EOF]
+    ------- stderr -------
+    Warning: No matching entries for paths: nonexistent
+    [EOF]
+    ");
+
+    // The output filtered to file_1 should not print an empty changes header
+    // when only file_2 changed.
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file_2", "updated");
+
+    let output = work_dir.run_jj(["status", "file_1"]);
+    insta::assert_snapshot!(output, @"
+    Working copy  (@) : mzvwutvl d977fd8e (no description set)
+    Parent commit (@-): qpvuntsm 2f169edb (no description set)
+    [EOF]
+    ");
+
+    // The output filtered to file_1 and a non-existent file should display
+    // only the warning.
+    let output = work_dir.run_jj(["status", "file_1", "nonexistent"]);
+    insta::assert_snapshot!(output, @"
+    Working copy  (@) : mzvwutvl d977fd8e (no description set)
+    Parent commit (@-): qpvuntsm 2f169edb (no description set)
+    [EOF]
+    ------- stderr -------
+    Warning: No matching entries for paths: nonexistent
+    [EOF]
+    ");
+
+    // The output filtered to a non-existent file in a clean working copy should
+    // report no changes and display a warning.
+    work_dir.run_jj(["new"]).success();
+
+    let output = work_dir.run_jj(["status", "nonexistent"]);
+    insta::assert_snapshot!(output, @"
+    The working copy has no changes.
+    Working copy  (@) : vruxwmqv bc1fcb38 (empty) (no description set)
+    Parent commit (@-): mzvwutvl d977fd8e (no description set)
     [EOF]
     ------- stderr -------
     Warning: No matching entries for paths: nonexistent

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -680,10 +680,10 @@ fn test_status_filtered_untracked() {
     [EOF]
     ");
 
-    // Filter to nonexistent: no untracked paths, "no changes" message
+    // Filter to nonexistent: no matching untracked paths, but unrelated
+    // untracked changes still make the working copy dirty.
     let output = work_dir.run_jj(["status", "nonexistent"]);
     insta::assert_snapshot!(output, @"
-    The working copy has no changes.
     Working copy  (@) : qpvuntsm e8849ae1 (empty) (no description set)
     Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
     [EOF]


### PR DESCRIPTION
When `jj status <fileset>` filtered out every tracked change, the command could still print `Working copy changes:` because it only checked whether the working-copy tree differed from its parent. 
In the opposite case, if the working copy only had untracked paths outside the requested fileset, it could print `The working copy has no changes.` even though the working copy was still dirty.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
