### PR TITLE
gitignore: use RepoPath to guarantee that path is slash-separated

### DIFF
--- a/cli/examples/custom-working-copy/main.rs
+++ b/cli/examples/custom-working-copy/main.rs
@@ -31,6 +31,7 @@ use jj_lib::op_store::OperationId;
 use jj_lib::ref_name::WorkspaceName;
 use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::ReadonlyRepo;
+use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
@@ -243,7 +244,7 @@ impl LockedWorkingCopy for LockedConflictsWorkingCopy {
     ) -> Result<(MergedTree, SnapshotStats), SnapshotError> {
         let options = SnapshotOptions {
             base_ignores: options.base_ignores.chain(
-                "",
+                RepoPath::root(),
                 Path::new(""),
                 "/.conflicts".as_bytes(),
             )?,

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1605,14 +1605,16 @@ to the current parents may contain changes from multiple commits.
         if let Ok(git_backend) = jj_lib::git::get_git_backend(self.repo().store()) {
             let git_repo = git_backend.git_repo();
             if let Some(excludes_file_path) = get_excludes_file_path(&git_repo.config_snapshot()) {
-                git_ignores = git_ignores.chain_with_file("", excludes_file_path)?;
+                git_ignores = git_ignores.chain_with_file(RepoPath::root(), excludes_file_path)?;
             }
-            git_ignores = git_ignores
-                .chain_with_file("", git_backend.git_repo_path().join("info").join("exclude"))?;
+            git_ignores = git_ignores.chain_with_file(
+                RepoPath::root(),
+                git_backend.git_repo_path().join("info").join("exclude"),
+            )?;
         } else if let Ok(git_config) = gix::config::File::from_globals()
             && let Some(excludes_file_path) = get_excludes_file_path(&git_config)
         {
-            git_ignores = git_ignores.chain_with_file("", excludes_file_path)?;
+            git_ignores = git_ignores.chain_with_file(RepoPath::root(), excludes_file_path)?;
         }
         Ok(git_ignores)
     }

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -57,7 +57,7 @@ impl GitIgnoreFile {
         ignore_path: &Path,
         input: &[u8],
     ) -> Result<Arc<Self>, GitIgnoreError> {
-        assert!(prefix.is_empty() || prefix.ends_with('/'));
+        assert!(!prefix.ends_with('/'));
         // Construct the gix search object.
         let mut matcher = gix_ignore::Search::default();
         // Since we strip the path prefix manually in matches(), the root path
@@ -81,7 +81,11 @@ impl GitIgnoreFile {
         Ok(Arc::new(Self {
             parent,
             matcher,
-            prefix: prefix.to_string(),
+            prefix: if prefix.is_empty() {
+                prefix.to_owned()
+            } else {
+                format!("{prefix}/")
+            },
         }))
     }
 
@@ -179,7 +183,7 @@ mod tests {
     #[test]
     fn test_gitignore_empty_file_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir/", ignore_path(), b"")
+            .chain("dir", ignore_path(), b"")
             .unwrap();
         assert!(!file.matches_file("dir/foo"));
     }
@@ -199,7 +203,7 @@ mod tests {
     #[test]
     fn test_gitignore_literal_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir/", ignore_path(), b"foo\n")
+            .chain("dir", ignore_path(), b"foo\n")
             .unwrap();
         assert!(file.matches_file("dir/foo"));
         assert!(file.matches_file("dir/subdir/foo"));
@@ -208,7 +212,7 @@ mod tests {
     #[test]
     fn test_gitignore_pattern_same_as_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir/", ignore_path(), b"dir\n")
+            .chain("dir", ignore_path(), b"dir\n")
             .unwrap();
         assert!(file.matches_file("dir/dir"));
         // We don't want the "dir" pattern to apply to the parent directory
@@ -227,7 +231,7 @@ mod tests {
     #[test]
     fn test_gitignore_rooted_literal_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir/", ignore_path(), b"/foo\n")
+            .chain("dir", ignore_path(), b"/foo\n")
             .unwrap();
         assert!(file.matches_file("dir/foo"));
         assert!(!file.matches_file("dir/subdir/foo"));
@@ -251,9 +255,9 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"/dummy\n")
             .unwrap()
-            .chain("dir1/", ignore_path(), b"/dummy\n")
+            .chain("dir1", ignore_path(), b"/dummy\n")
             .unwrap()
-            .chain("dir1/dir2/", ignore_path(), b"/dir3\n")
+            .chain("dir1/dir2", ignore_path(), b"/dir3\n")
             .unwrap();
         assert!(!file.matches_file("foo"));
         assert!(!file.matches_dir("dir1"));
@@ -358,7 +362,7 @@ mod tests {
     #[test]
     fn test_gitignore_leading_dir_glob_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir1/dir2/", ignore_path(), b"**/foo\n")
+            .chain("dir1/dir2", ignore_path(), b"**/foo\n")
             .unwrap();
         assert!(file.matches_file("dir1/dir2/foo"));
         assert!(!file.matches_file("dir1/dir2/bar"));
@@ -408,7 +412,7 @@ mod tests {
     #[test]
     fn test_gitignore_glob_all_subdir() {
         let file = GitIgnoreFile::empty()
-            .chain("foo/", ignore_path(), b"*\n")
+            .chain("foo", ignore_path(), b"*\n")
             .unwrap();
         assert!(!file.matches_dir(""));
         assert!(!file.matches_file("foo"));
@@ -458,13 +462,13 @@ mod tests {
         assert!(!file1.matches_file("foo/bar"));
         assert!(!file1.matches_file("foo/bar/baz"));
 
-        let file2 = file1.chain("foo/", ignore_path(), b"!/bar").unwrap();
+        let file2 = file1.chain("foo", ignore_path(), b"!/bar").unwrap();
         assert!(file1.matches_dir("foo"));
         assert!(!file2.matches_file("foo/bar"));
         assert!(!file2.matches_file("foo/bar/baz"));
         assert!(!file2.matches_file("foo/baz"));
 
-        let file3 = file2.chain("foo/bar/", ignore_path(), b"/baz").unwrap();
+        let file3 = file2.chain("foo/bar", ignore_path(), b"/baz").unwrap();
         assert!(!file2.matches_dir("foo/bar"));
         assert!(file3.matches_file("foo/bar/baz"));
         assert!(!file3.matches_file("foo/bar/qux"));

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -105,8 +105,7 @@ impl GitIgnoreFile {
         }
     }
 
-    /// Returns whether the specified path should be ignored. Directories must
-    /// have a trailing `/`.
+    /// Returns whether the specified file path should be ignored.
     ///
     /// This method does not directly define which files should not be tracked
     /// in the repository. Instead, it performs a simple matching against the
@@ -119,10 +118,19 @@ impl GitIgnoreFile {
     ///
     /// The path should always be a slash-separated repository path, even on
     /// Windows. This will never treat backslashes as path separators.
-    pub fn matches(&self, path: &str) -> bool {
-        let is_dir = path.ends_with('/');
-        let clean_path = path.strip_suffix('/').unwrap_or(path);
+    pub fn matches_file(&self, path: &str) -> bool {
+        self.matches(path, false)
+    }
 
+    /// Returns whether the specified directory path should be ignored.
+    ///
+    /// See [`GitIgnoreFile::matches_file()`] for details.
+    pub fn matches_dir(&self, path: &str) -> bool {
+        self.matches(path, true)
+    }
+
+    fn matches(&self, clean_path: &str, is_dir: bool) -> bool {
+        assert!(!clean_path.ends_with("/"));
         for file in iter::successors(Some(self), |file| file.parent.as_deref()) {
             // This uses string manipulation instead of `Path` to avoid Windows
             // path separator semantics.
@@ -156,13 +164,16 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("", ignore_path(), input)
             .unwrap();
-        file.matches(path)
+        match path.strip_suffix('/') {
+            Some(dir) => file.matches_dir(dir),
+            None => file.matches_file(path),
+        }
     }
 
     #[test]
     fn test_gitignore_empty_file() {
         let file = GitIgnoreFile::empty();
-        assert!(!file.matches("foo"));
+        assert!(!file.matches_file("foo"));
     }
 
     #[test]
@@ -170,7 +181,7 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("dir/", ignore_path(), b"")
             .unwrap();
-        assert!(!file.matches("dir/foo"));
+        assert!(!file.matches_file("dir/foo"));
     }
 
     #[test]
@@ -178,11 +189,11 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"foo\n")
             .unwrap();
-        assert!(file.matches("foo"));
-        assert!(file.matches("dir/foo"));
-        assert!(file.matches("dir/subdir/foo"));
-        assert!(!file.matches("food"));
-        assert!(!file.matches("dir/food"));
+        assert!(file.matches_file("foo"));
+        assert!(file.matches_file("dir/foo"));
+        assert!(file.matches_file("dir/subdir/foo"));
+        assert!(!file.matches_file("food"));
+        assert!(!file.matches_file("dir/food"));
     }
 
     #[test]
@@ -190,8 +201,8 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("dir/", ignore_path(), b"foo\n")
             .unwrap();
-        assert!(file.matches("dir/foo"));
-        assert!(file.matches("dir/subdir/foo"));
+        assert!(file.matches_file("dir/foo"));
+        assert!(file.matches_file("dir/subdir/foo"));
     }
 
     #[test]
@@ -199,9 +210,9 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("dir/", ignore_path(), b"dir\n")
             .unwrap();
-        assert!(file.matches("dir/dir"));
+        assert!(file.matches_file("dir/dir"));
         // We don't want the "dir" pattern to apply to the parent directory
-        assert!(!file.matches("dir/foo"));
+        assert!(!file.matches_file("dir/foo"));
     }
 
     #[test]
@@ -209,8 +220,8 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"/foo\n")
             .unwrap();
-        assert!(file.matches("foo"));
-        assert!(!file.matches("dir/foo"));
+        assert!(file.matches_file("foo"));
+        assert!(!file.matches_file("dir/foo"));
     }
 
     #[test]
@@ -218,8 +229,8 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("dir/", ignore_path(), b"/foo\n")
             .unwrap();
-        assert!(file.matches("dir/foo"));
-        assert!(!file.matches("dir/subdir/foo"));
+        assert!(file.matches_file("dir/foo"));
+        assert!(!file.matches_file("dir/subdir/foo"));
     }
 
     #[test]
@@ -227,11 +238,11 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"/dir1/dir2/dir3\n")
             .unwrap();
-        assert!(!file.matches("foo"));
-        assert!(!file.matches("dir1/"));
-        assert!(!file.matches("dir1/dir2/"));
-        assert!(file.matches("dir1/dir2/dir3/"));
-        assert!(!file.matches("dir1/dir2/dir3/dir4/"));
+        assert!(!file.matches_file("foo"));
+        assert!(!file.matches_dir("dir1"));
+        assert!(!file.matches_dir("dir1/dir2"));
+        assert!(file.matches_dir("dir1/dir2/dir3"));
+        assert!(!file.matches_dir("dir1/dir2/dir3/dir4"));
     }
 
     #[test]
@@ -244,11 +255,11 @@ mod tests {
             .unwrap()
             .chain("dir1/dir2/", ignore_path(), b"/dir3\n")
             .unwrap();
-        assert!(!file.matches("foo"));
-        assert!(!file.matches("dir1/"));
-        assert!(!file.matches("dir1/dir2/"));
-        assert!(file.matches("dir1/dir2/dir3/"));
-        assert!(!file.matches("dir1/dir2/dir3/dir4/"));
+        assert!(!file.matches_file("foo"));
+        assert!(!file.matches_dir("dir1"));
+        assert!(!file.matches_dir("dir1/dir2"));
+        assert!(file.matches_dir("dir1/dir2/dir3"));
+        assert!(!file.matches_dir("dir1/dir2/dir3/dir4"));
     }
 
     #[test]
@@ -256,9 +267,9 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"/dir/\n")
             .unwrap();
-        assert!(!file.matches("dir"));
-        assert!(file.matches("dir/"));
-        assert!(!file.matches("dir/subdir"));
+        assert!(!file.matches_file("dir"));
+        assert!(file.matches_dir("dir"));
+        assert!(!file.matches_file("dir/subdir"));
     }
 
     #[test]
@@ -335,13 +346,13 @@ mod tests {
         let file1 = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"**/foo\n")
             .unwrap();
-        assert!(file1.matches("foo"));
-        assert!(file1.matches("dir1/dir2/foo"));
-        assert!(!file1.matches("foo/file"));
+        assert!(file1.matches_file("foo"));
+        assert!(file1.matches_file("dir1/dir2/foo"));
+        assert!(!file1.matches_file("foo/file"));
 
         let file2 = file1.chain("", ignore_path(), b"**/foo\n").unwrap();
-        assert!(file2.matches("dir/foo"));
-        assert!(file2.matches("dir1/dir2/dir/foo"));
+        assert!(file2.matches_file("dir/foo"));
+        assert!(file2.matches_file("dir1/dir2/dir/foo"));
     }
 
     #[test]
@@ -349,10 +360,10 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("dir1/dir2/", ignore_path(), b"**/foo\n")
             .unwrap();
-        assert!(file.matches("dir1/dir2/foo"));
-        assert!(!file.matches("dir1/dir2/bar"));
-        assert!(file.matches("dir1/dir2/sub1/sub2/foo"));
-        assert!(!file.matches("dir1/dir2/sub1/sub2/bar"));
+        assert!(file.matches_file("dir1/dir2/foo"));
+        assert!(!file.matches_file("dir1/dir2/bar"));
+        assert!(file.matches_file("dir1/dir2/sub1/sub2/foo"));
+        assert!(!file.matches_file("dir1/dir2/sub1/sub2/bar"));
     }
 
     #[test]
@@ -387,11 +398,11 @@ mod tests {
         // TODO: Since "*" in sub directory doesn't match "sub/", "*" in the
         // root directory shouldn't probably match "". This doesn't matter in
         // practice because the root directory path is never tested.
-        assert!(file.matches(""));
-        assert!(file.matches("foo"));
-        assert!(file.matches("foo/"));
-        assert!(file.matches("foo/bar"));
-        assert!(file.matches("foo/bar/"));
+        assert!(file.matches_dir(""));
+        assert!(file.matches_file("foo"));
+        assert!(file.matches_dir("foo"));
+        assert!(file.matches_file("foo/bar"));
+        assert!(file.matches_dir("foo/bar"));
     }
 
     #[test]
@@ -399,13 +410,13 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("foo/", ignore_path(), b"*\n")
             .unwrap();
-        assert!(!file.matches(""));
-        assert!(!file.matches("foo"));
-        assert!(!file.matches("foo/"));
-        assert!(file.matches("foo/bar"));
-        assert!(file.matches("foo/bar/"));
-        assert!(!file.matches("bar/baz"));
-        assert!(!file.matches("bar/baz/"));
+        assert!(!file.matches_dir(""));
+        assert!(!file.matches_file("foo"));
+        assert!(!file.matches_dir("foo"));
+        assert!(file.matches_file("foo/bar"));
+        assert!(file.matches_dir("foo/bar"));
+        assert!(!file.matches_file("bar/baz"));
+        assert!(!file.matches_dir("bar/baz"));
     }
 
     #[test]
@@ -419,23 +430,23 @@ mod tests {
         let file1 = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"foo*\n!foobar*\n")
             .unwrap();
-        assert!(file1.matches("foo"));
-        assert!(!file1.matches("foobar"));
-        assert!(!file1.matches("foobarbaz"));
+        assert!(file1.matches_file("foo"));
+        assert!(!file1.matches_file("foobar"));
+        assert!(!file1.matches_file("foobarbaz"));
 
         let file2 = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"foo*\n!foobar*\nfoobarbaz")
             .unwrap();
-        assert!(file2.matches("foo"));
-        assert!(!file2.matches("foobar"));
-        assert!(file2.matches("foobarbaz"));
-        assert!(!file2.matches("foobarquux"));
+        assert!(file2.matches_file("foo"));
+        assert!(!file2.matches_file("foobar"));
+        assert!(file2.matches_file("foobarbaz"));
+        assert!(!file2.matches_file("foobarquux"));
 
         let file3 = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"foo/*\n!foo/bar")
             .unwrap();
-        assert!(file3.matches("foo/baz"));
-        assert!(!file3.matches("foo/bar"));
+        assert!(file3.matches_file("foo/baz"));
+        assert!(!file3.matches_file("foo/bar"));
     }
 
     #[test]
@@ -443,20 +454,20 @@ mod tests {
         let file1 = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"/foo\n")
             .unwrap();
-        assert!(file1.matches("foo"));
-        assert!(!file1.matches("foo/bar"));
-        assert!(!file1.matches("foo/bar/baz"));
+        assert!(file1.matches_file("foo"));
+        assert!(!file1.matches_file("foo/bar"));
+        assert!(!file1.matches_file("foo/bar/baz"));
 
         let file2 = file1.chain("foo/", ignore_path(), b"!/bar").unwrap();
-        assert!(file1.matches("foo/"));
-        assert!(!file2.matches("foo/bar"));
-        assert!(!file2.matches("foo/bar/baz"));
-        assert!(!file2.matches("foo/baz"));
+        assert!(file1.matches_dir("foo"));
+        assert!(!file2.matches_file("foo/bar"));
+        assert!(!file2.matches_file("foo/bar/baz"));
+        assert!(!file2.matches_file("foo/baz"));
 
         let file3 = file2.chain("foo/bar/", ignore_path(), b"/baz").unwrap();
-        assert!(!file2.matches("foo/bar/"));
-        assert!(file3.matches("foo/bar/baz"));
-        assert!(!file3.matches("foo/bar/qux"));
+        assert!(!file2.matches_dir("foo/bar"));
+        assert!(file3.matches_file("foo/bar/baz"));
+        assert!(!file3.matches_file("foo/bar/qux"));
     }
 
     #[test]
@@ -464,10 +475,10 @@ mod tests {
         let file = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"/*/\n")
             .unwrap();
-        assert!(!file.matches("foo"));
-        assert!(file.matches("foo/"));
-        assert!(!file.matches("foo/bar"));
-        assert!(!file.matches("foo/bar/baz"));
+        assert!(!file.matches_file("foo"));
+        assert!(file.matches_dir("foo"));
+        assert!(!file.matches_file("foo/bar"));
+        assert!(!file.matches_file("foo/bar/baz"));
     }
 
     #[test]
@@ -487,12 +498,12 @@ mod tests {
         let ignore = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"foo/bar.*\n!/foo/\n")
             .unwrap();
-        assert!(ignore.matches("foo/bar.ext"));
+        assert!(ignore.matches_file("foo/bar.ext"));
 
         let ignore = GitIgnoreFile::empty()
             .chain("", ignore_path(), b"!/foo/\nfoo/bar.*\n")
             .unwrap();
-        assert!(ignore.matches("foo/bar.ext"));
+        assert!(ignore.matches_file("foo/bar.ext"));
     }
 
     #[test]

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -60,11 +60,10 @@ impl GitIgnoreFile {
         assert!(prefix.is_empty() || prefix.ends_with('/'));
         // Construct the gix search object.
         let mut matcher = gix_ignore::Search::default();
-        let root = if prefix.is_empty() {
-            None
-        } else {
-            Some(Path::new(prefix))
-        };
+        // Since we strip the path prefix manually in matches(), the root path
+        // shouldn't be set. add_patterns_buffer() expects filesystem path pairs
+        // e.g. ignore_path = "/repo/bar/.gitignore" and root = "/repo".
+        let root = None;
         matcher.add_patterns_buffer(
             input,
             ignore_path,

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -380,6 +380,35 @@ mod tests {
     }
 
     #[test]
+    fn test_gitignore_glob_all_root() {
+        let file = GitIgnoreFile::empty()
+            .chain("", ignore_path(), b"*\n")
+            .unwrap();
+        // TODO: Since "*" in sub directory doesn't match "sub/", "*" in the
+        // root directory shouldn't probably match "". This doesn't matter in
+        // practice because the root directory path is never tested.
+        assert!(file.matches(""));
+        assert!(file.matches("foo"));
+        assert!(file.matches("foo/"));
+        assert!(file.matches("foo/bar"));
+        assert!(file.matches("foo/bar/"));
+    }
+
+    #[test]
+    fn test_gitignore_glob_all_subdir() {
+        let file = GitIgnoreFile::empty()
+            .chain("foo/", ignore_path(), b"*\n")
+            .unwrap();
+        assert!(!file.matches(""));
+        assert!(!file.matches("foo"));
+        assert!(!file.matches("foo/"));
+        assert!(file.matches("foo/bar"));
+        assert!(file.matches("foo/bar/"));
+        assert!(!file.matches("bar/baz"));
+        assert!(!file.matches("bar/baz/"));
+    }
+
+    #[test]
     fn test_gitignore_with_utf8_bom() {
         assert!(matches(b"\xef\xbb\xbffoo\n", "foo"));
         assert!(!matches(b"\n\xef\xbb\xbffoo\n", "foo"));

--- a/lib/src/gitignore.rs
+++ b/lib/src/gitignore.rs
@@ -21,8 +21,10 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use bstr::ByteSlice as _;
 use thiserror::Error;
+
+use crate::repo_path::RepoPath;
+use crate::repo_path::RepoPathBuf;
 
 #[derive(Debug, Error)]
 pub enum GitIgnoreError {
@@ -35,7 +37,7 @@ pub enum GitIgnoreError {
 pub struct GitIgnoreFile {
     parent: Option<Arc<Self>>,
     matcher: gix_ignore::Search,
-    prefix: String,
+    prefix: RepoPathBuf,
 }
 
 impl GitIgnoreFile {
@@ -43,21 +45,17 @@ impl GitIgnoreFile {
         Arc::new(Self {
             parent: None,
             matcher: gix_ignore::Search::default(),
-            prefix: "".to_string(),
+            prefix: RepoPathBuf::root(),
         })
     }
 
     /// Concatenates new `.gitignore` content at the `prefix` directory.
-    ///
-    /// The `prefix` should be a slash-separated path relative to the workspace
-    /// root.
     pub fn chain(
         self: &Arc<Self>,
-        prefix: &str,
+        prefix: &RepoPath,
         ignore_path: &Path,
         input: &[u8],
     ) -> Result<Arc<Self>, GitIgnoreError> {
-        assert!(!prefix.ends_with('/'));
         // Construct the gix search object.
         let mut matcher = gix_ignore::Search::default();
         // Since we strip the path prefix manually in matches(), the root path
@@ -81,21 +79,14 @@ impl GitIgnoreFile {
         Ok(Arc::new(Self {
             parent,
             matcher,
-            prefix: if prefix.is_empty() {
-                prefix.to_owned()
-            } else {
-                format!("{prefix}/")
-            },
+            prefix: prefix.to_owned(),
         }))
     }
 
     /// Concatenates new `.gitignore` file at the `prefix` directory.
-    ///
-    /// The `prefix` should be a slash-separated path relative to the workspace
-    /// root.
     pub fn chain_with_file(
         self: &Arc<Self>,
-        prefix: &str,
+        prefix: &RepoPath,
         file: PathBuf,
     ) -> Result<Arc<Self>, GitIgnoreError> {
         if file.is_file() {
@@ -119,28 +110,24 @@ impl GitIgnoreFile {
     /// directories. Callers shouldn't recursively match inside ignored
     /// directories, because all (untracked) child files should also be ignored;
     /// the exact matching logic won't give correct results in that case.
-    ///
-    /// The path should always be a slash-separated repository path, even on
-    /// Windows. This will never treat backslashes as path separators.
-    pub fn matches_file(&self, path: &str) -> bool {
+    pub fn matches_file(&self, path: &RepoPath) -> bool {
         self.matches(path, false)
     }
 
     /// Returns whether the specified directory path should be ignored.
     ///
     /// See [`GitIgnoreFile::matches_file()`] for details.
-    pub fn matches_dir(&self, path: &str) -> bool {
+    pub fn matches_dir(&self, path: &RepoPath) -> bool {
         self.matches(path, true)
     }
 
-    fn matches(&self, clean_path: &str, is_dir: bool) -> bool {
-        assert!(!clean_path.ends_with("/"));
+    fn matches(&self, path: &RepoPath, is_dir: bool) -> bool {
         for file in iter::successors(Some(self), |file| file.parent.as_deref()) {
-            // This uses string manipulation instead of `Path` to avoid Windows
-            // path separator semantics.
-            if let Some(relative_path) = clean_path.strip_prefix(&file.prefix) {
+            if let Some(relative_path) = path.strip_prefix(&file.prefix)
+                && !relative_path.is_root()
+            {
                 let m = file.matcher.pattern_matching_relative_path(
-                    relative_path.as_bytes().as_bstr(),
+                    relative_path.as_internal_file_string().as_ref(),
                     Some(is_dir),
                     gix_ignore::glob::pattern::Case::Sensitive,
                 );
@@ -164,116 +151,120 @@ mod tests {
         Path::new(".gitignore")
     }
 
+    fn repo_path(value: &str) -> &RepoPath {
+        RepoPath::from_internal_string(value).unwrap()
+    }
+
     fn matches(input: &[u8], path: &str) -> bool {
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), input)
+            .chain(RepoPath::root(), ignore_path(), input)
             .unwrap();
         match path.strip_suffix('/') {
-            Some(dir) => file.matches_dir(dir),
-            None => file.matches_file(path),
+            Some(dir) => file.matches_dir(repo_path(dir)),
+            None => file.matches_file(repo_path(path)),
         }
     }
 
     #[test]
     fn test_gitignore_empty_file() {
         let file = GitIgnoreFile::empty();
-        assert!(!file.matches_file("foo"));
+        assert!(!file.matches_file(repo_path("foo")));
     }
 
     #[test]
     fn test_gitignore_empty_file_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir", ignore_path(), b"")
+            .chain(repo_path("dir"), ignore_path(), b"")
             .unwrap();
-        assert!(!file.matches_file("dir/foo"));
+        assert!(!file.matches_file(repo_path("dir/foo")));
     }
 
     #[test]
     fn test_gitignore_literal() {
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"foo\n")
+            .chain(RepoPath::root(), ignore_path(), b"foo\n")
             .unwrap();
-        assert!(file.matches_file("foo"));
-        assert!(file.matches_file("dir/foo"));
-        assert!(file.matches_file("dir/subdir/foo"));
-        assert!(!file.matches_file("food"));
-        assert!(!file.matches_file("dir/food"));
+        assert!(file.matches_file(repo_path("foo")));
+        assert!(file.matches_file(repo_path("dir/foo")));
+        assert!(file.matches_file(repo_path("dir/subdir/foo")));
+        assert!(!file.matches_file(repo_path("food")));
+        assert!(!file.matches_file(repo_path("dir/food")));
     }
 
     #[test]
     fn test_gitignore_literal_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir", ignore_path(), b"foo\n")
+            .chain(repo_path("dir"), ignore_path(), b"foo\n")
             .unwrap();
-        assert!(file.matches_file("dir/foo"));
-        assert!(file.matches_file("dir/subdir/foo"));
+        assert!(file.matches_file(repo_path("dir/foo")));
+        assert!(file.matches_file(repo_path("dir/subdir/foo")));
     }
 
     #[test]
     fn test_gitignore_pattern_same_as_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir", ignore_path(), b"dir\n")
+            .chain(repo_path("dir"), ignore_path(), b"dir\n")
             .unwrap();
-        assert!(file.matches_file("dir/dir"));
+        assert!(file.matches_file(repo_path("dir/dir")));
         // We don't want the "dir" pattern to apply to the parent directory
-        assert!(!file.matches_file("dir/foo"));
+        assert!(!file.matches_file(repo_path("dir/foo")));
     }
 
     #[test]
     fn test_gitignore_rooted_literal() {
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"/foo\n")
+            .chain(RepoPath::root(), ignore_path(), b"/foo\n")
             .unwrap();
-        assert!(file.matches_file("foo"));
-        assert!(!file.matches_file("dir/foo"));
+        assert!(file.matches_file(repo_path("foo")));
+        assert!(!file.matches_file(repo_path("dir/foo")));
     }
 
     #[test]
     fn test_gitignore_rooted_literal_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir", ignore_path(), b"/foo\n")
+            .chain(repo_path("dir"), ignore_path(), b"/foo\n")
             .unwrap();
-        assert!(file.matches_file("dir/foo"));
-        assert!(!file.matches_file("dir/subdir/foo"));
+        assert!(file.matches_file(repo_path("dir/foo")));
+        assert!(!file.matches_file(repo_path("dir/subdir/foo")));
     }
 
     #[test]
     fn test_gitignore_deep_dir() {
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"/dir1/dir2/dir3\n")
+            .chain(RepoPath::root(), ignore_path(), b"/dir1/dir2/dir3\n")
             .unwrap();
-        assert!(!file.matches_file("foo"));
-        assert!(!file.matches_dir("dir1"));
-        assert!(!file.matches_dir("dir1/dir2"));
-        assert!(file.matches_dir("dir1/dir2/dir3"));
-        assert!(!file.matches_dir("dir1/dir2/dir3/dir4"));
+        assert!(!file.matches_file(repo_path("foo")));
+        assert!(!file.matches_dir(repo_path("dir1")));
+        assert!(!file.matches_dir(repo_path("dir1/dir2")));
+        assert!(file.matches_dir(repo_path("dir1/dir2/dir3")));
+        assert!(!file.matches_dir(repo_path("dir1/dir2/dir3/dir4")));
     }
 
     #[test]
     fn test_gitignore_deep_dir_chained() {
         // Prefix is relative to root, not to parent file
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"/dummy\n")
+            .chain(RepoPath::root(), ignore_path(), b"/dummy\n")
             .unwrap()
-            .chain("dir1", ignore_path(), b"/dummy\n")
+            .chain(repo_path("dir1"), ignore_path(), b"/dummy\n")
             .unwrap()
-            .chain("dir1/dir2", ignore_path(), b"/dir3\n")
+            .chain(repo_path("dir1/dir2"), ignore_path(), b"/dir3\n")
             .unwrap();
-        assert!(!file.matches_file("foo"));
-        assert!(!file.matches_dir("dir1"));
-        assert!(!file.matches_dir("dir1/dir2"));
-        assert!(file.matches_dir("dir1/dir2/dir3"));
-        assert!(!file.matches_dir("dir1/dir2/dir3/dir4"));
+        assert!(!file.matches_file(repo_path("foo")));
+        assert!(!file.matches_dir(repo_path("dir1")));
+        assert!(!file.matches_dir(repo_path("dir1/dir2")));
+        assert!(file.matches_dir(repo_path("dir1/dir2/dir3")));
+        assert!(!file.matches_dir(repo_path("dir1/dir2/dir3/dir4")));
     }
 
     #[test]
     fn test_gitignore_match_only_dir() {
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"/dir/\n")
+            .chain(RepoPath::root(), ignore_path(), b"/dir/\n")
             .unwrap();
-        assert!(!file.matches_file("dir"));
-        assert!(file.matches_dir("dir"));
-        assert!(!file.matches_file("dir/subdir"));
+        assert!(!file.matches_file(repo_path("dir")));
+        assert!(file.matches_dir(repo_path("dir")));
+        assert!(!file.matches_file(repo_path("dir/subdir")));
     }
 
     #[test]
@@ -348,26 +339,28 @@ mod tests {
     #[test]
     fn test_gitignore_leading_dir_glob() {
         let file1 = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"**/foo\n")
+            .chain(RepoPath::root(), ignore_path(), b"**/foo\n")
             .unwrap();
-        assert!(file1.matches_file("foo"));
-        assert!(file1.matches_file("dir1/dir2/foo"));
-        assert!(!file1.matches_file("foo/file"));
+        assert!(file1.matches_file(repo_path("foo")));
+        assert!(file1.matches_file(repo_path("dir1/dir2/foo")));
+        assert!(!file1.matches_file(repo_path("foo/file")));
 
-        let file2 = file1.chain("", ignore_path(), b"**/foo\n").unwrap();
-        assert!(file2.matches_file("dir/foo"));
-        assert!(file2.matches_file("dir1/dir2/dir/foo"));
+        let file2 = file1
+            .chain(RepoPath::root(), ignore_path(), b"**/foo\n")
+            .unwrap();
+        assert!(file2.matches_file(repo_path("dir/foo")));
+        assert!(file2.matches_file(repo_path("dir1/dir2/dir/foo")));
     }
 
     #[test]
     fn test_gitignore_leading_dir_glob_with_prefix() {
         let file = GitIgnoreFile::empty()
-            .chain("dir1/dir2", ignore_path(), b"**/foo\n")
+            .chain(repo_path("dir1/dir2"), ignore_path(), b"**/foo\n")
             .unwrap();
-        assert!(file.matches_file("dir1/dir2/foo"));
-        assert!(!file.matches_file("dir1/dir2/bar"));
-        assert!(file.matches_file("dir1/dir2/sub1/sub2/foo"));
-        assert!(!file.matches_file("dir1/dir2/sub1/sub2/bar"));
+        assert!(file.matches_file(repo_path("dir1/dir2/foo")));
+        assert!(!file.matches_file(repo_path("dir1/dir2/bar")));
+        assert!(file.matches_file(repo_path("dir1/dir2/sub1/sub2/foo")));
+        assert!(!file.matches_file(repo_path("dir1/dir2/sub1/sub2/bar")));
     }
 
     #[test]
@@ -397,30 +390,27 @@ mod tests {
     #[test]
     fn test_gitignore_glob_all_root() {
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"*\n")
+            .chain(RepoPath::root(), ignore_path(), b"*\n")
             .unwrap();
-        // TODO: Since "*" in sub directory doesn't match "sub/", "*" in the
-        // root directory shouldn't probably match "". This doesn't matter in
-        // practice because the root directory path is never tested.
-        assert!(file.matches_dir(""));
-        assert!(file.matches_file("foo"));
-        assert!(file.matches_dir("foo"));
-        assert!(file.matches_file("foo/bar"));
-        assert!(file.matches_dir("foo/bar"));
+        assert!(!file.matches_dir(RepoPath::root()));
+        assert!(file.matches_file(repo_path("foo")));
+        assert!(file.matches_dir(repo_path("foo")));
+        assert!(file.matches_file(repo_path("foo/bar")));
+        assert!(file.matches_dir(repo_path("foo/bar")));
     }
 
     #[test]
     fn test_gitignore_glob_all_subdir() {
         let file = GitIgnoreFile::empty()
-            .chain("foo", ignore_path(), b"*\n")
+            .chain(repo_path("foo"), ignore_path(), b"*\n")
             .unwrap();
-        assert!(!file.matches_dir(""));
-        assert!(!file.matches_file("foo"));
-        assert!(!file.matches_dir("foo"));
-        assert!(file.matches_file("foo/bar"));
-        assert!(file.matches_dir("foo/bar"));
-        assert!(!file.matches_file("bar/baz"));
-        assert!(!file.matches_dir("bar/baz"));
+        assert!(!file.matches_dir(RepoPath::root()));
+        assert!(!file.matches_file(repo_path("foo")));
+        assert!(!file.matches_dir(repo_path("foo")));
+        assert!(file.matches_file(repo_path("foo/bar")));
+        assert!(file.matches_dir(repo_path("foo/bar")));
+        assert!(!file.matches_file(repo_path("bar/baz")));
+        assert!(!file.matches_dir(repo_path("bar/baz")));
     }
 
     #[test]
@@ -432,57 +422,65 @@ mod tests {
     #[test]
     fn test_gitignore_line_ordering() {
         let file1 = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"foo*\n!foobar*\n")
+            .chain(RepoPath::root(), ignore_path(), b"foo*\n!foobar*\n")
             .unwrap();
-        assert!(file1.matches_file("foo"));
-        assert!(!file1.matches_file("foobar"));
-        assert!(!file1.matches_file("foobarbaz"));
+        assert!(file1.matches_file(repo_path("foo")));
+        assert!(!file1.matches_file(repo_path("foobar")));
+        assert!(!file1.matches_file(repo_path("foobarbaz")));
 
         let file2 = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"foo*\n!foobar*\nfoobarbaz")
+            .chain(
+                RepoPath::root(),
+                ignore_path(),
+                b"foo*\n!foobar*\nfoobarbaz",
+            )
             .unwrap();
-        assert!(file2.matches_file("foo"));
-        assert!(!file2.matches_file("foobar"));
-        assert!(file2.matches_file("foobarbaz"));
-        assert!(!file2.matches_file("foobarquux"));
+        assert!(file2.matches_file(repo_path("foo")));
+        assert!(!file2.matches_file(repo_path("foobar")));
+        assert!(file2.matches_file(repo_path("foobarbaz")));
+        assert!(!file2.matches_file(repo_path("foobarquux")));
 
         let file3 = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"foo/*\n!foo/bar")
+            .chain(RepoPath::root(), ignore_path(), b"foo/*\n!foo/bar")
             .unwrap();
-        assert!(file3.matches_file("foo/baz"));
-        assert!(!file3.matches_file("foo/bar"));
+        assert!(file3.matches_file(repo_path("foo/baz")));
+        assert!(!file3.matches_file(repo_path("foo/bar")));
     }
 
     #[test]
     fn test_gitignore_file_ordering() {
         let file1 = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"/foo\n")
+            .chain(RepoPath::root(), ignore_path(), b"/foo\n")
             .unwrap();
-        assert!(file1.matches_file("foo"));
-        assert!(!file1.matches_file("foo/bar"));
-        assert!(!file1.matches_file("foo/bar/baz"));
+        assert!(file1.matches_file(repo_path("foo")));
+        assert!(!file1.matches_file(repo_path("foo/bar")));
+        assert!(!file1.matches_file(repo_path("foo/bar/baz")));
 
-        let file2 = file1.chain("foo", ignore_path(), b"!/bar").unwrap();
-        assert!(file1.matches_dir("foo"));
-        assert!(!file2.matches_file("foo/bar"));
-        assert!(!file2.matches_file("foo/bar/baz"));
-        assert!(!file2.matches_file("foo/baz"));
+        let file2 = file1
+            .chain(repo_path("foo"), ignore_path(), b"!/bar")
+            .unwrap();
+        assert!(file1.matches_dir(repo_path("foo")));
+        assert!(!file2.matches_file(repo_path("foo/bar")));
+        assert!(!file2.matches_file(repo_path("foo/bar/baz")));
+        assert!(!file2.matches_file(repo_path("foo/baz")));
 
-        let file3 = file2.chain("foo/bar", ignore_path(), b"/baz").unwrap();
-        assert!(!file2.matches_dir("foo/bar"));
-        assert!(file3.matches_file("foo/bar/baz"));
-        assert!(!file3.matches_file("foo/bar/qux"));
+        let file3 = file2
+            .chain(repo_path("foo/bar"), ignore_path(), b"/baz")
+            .unwrap();
+        assert!(!file2.matches_dir(repo_path("foo/bar")));
+        assert!(file3.matches_file(repo_path("foo/bar/baz")));
+        assert!(!file3.matches_file(repo_path("foo/bar/qux")));
     }
 
     #[test]
     fn test_gitignore_slash_after_glob() {
         let file = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"/*/\n")
+            .chain(RepoPath::root(), ignore_path(), b"/*/\n")
             .unwrap();
-        assert!(!file.matches_file("foo"));
-        assert!(file.matches_dir("foo"));
-        assert!(!file.matches_file("foo/bar"));
-        assert!(!file.matches_file("foo/bar/baz"));
+        assert!(!file.matches_file(repo_path("foo")));
+        assert!(file.matches_dir(repo_path("foo")));
+        assert!(!file.matches_file(repo_path("foo/bar")));
+        assert!(!file.matches_file(repo_path("foo/bar/baz")));
     }
 
     #[test]
@@ -500,20 +498,20 @@ mod tests {
         // A/B.ext
         // ```
         let ignore = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"foo/bar.*\n!/foo/\n")
+            .chain(RepoPath::root(), ignore_path(), b"foo/bar.*\n!/foo/\n")
             .unwrap();
-        assert!(ignore.matches_file("foo/bar.ext"));
+        assert!(ignore.matches_file(repo_path("foo/bar.ext")));
 
         let ignore = GitIgnoreFile::empty()
-            .chain("", ignore_path(), b"!/foo/\nfoo/bar.*\n")
+            .chain(RepoPath::root(), ignore_path(), b"!/foo/\nfoo/bar.*\n")
             .unwrap();
-        assert!(ignore.matches_file("foo/bar.ext"));
+        assert!(ignore.matches_file(repo_path("foo/bar.ext")));
     }
 
     #[test]
     fn test_gitignore_invalid_utf8() {
         // Non-UTF-8 paths should be parsed without an error.
-        let ignore = GitIgnoreFile::empty().chain("", ignore_path(), &[224]);
+        let ignore = GitIgnoreFile::empty().chain(RepoPath::root(), ignore_path(), &[224]);
         assert!(ignore.is_ok());
     }
 }

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1523,7 +1523,7 @@ impl FileSnapshotter<'_> {
         } = directory_to_visit;
 
         let git_ignore = git_ignore
-            .chain_with_file(&dir.to_internal_dir_string(), disk_dir.join(".gitignore"))?;
+            .chain_with_file(dir.as_internal_file_string(), disk_dir.join(".gitignore"))?;
         let dir_entries: Vec<_> = disk_dir
             .read_dir()
             .and_then(|entries| entries.try_collect())

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1522,8 +1522,7 @@ impl FileSnapshotter<'_> {
             file_states,
         } = directory_to_visit;
 
-        let git_ignore = git_ignore
-            .chain_with_file(dir.as_internal_file_string(), disk_dir.join(".gitignore"))?;
+        let git_ignore = git_ignore.chain_with_file(&dir, disk_dir.join(".gitignore"))?;
         let dir_entries: Vec<_> = disk_dir
             .read_dir()
             .and_then(|entries| entries.try_collect())
@@ -1594,7 +1593,7 @@ impl FileSnapshotter<'_> {
                 }
             }
 
-            if git_ignore.matches_dir(path.as_internal_file_string())
+            if git_ignore.matches_dir(&path)
                 && self.force_tracking_matcher.visit(&path).is_nothing()
             {
                 // If the whole directory is ignored by .gitignore, visit only
@@ -1624,8 +1623,7 @@ impl FileSnapshotter<'_> {
                 progress(&path);
             }
             if maybe_current_file_state.is_none()
-                && (git_ignore.matches_file(path.as_internal_file_string())
-                    && !self.force_tracking_matcher.matches(&path))
+                && (git_ignore.matches_file(&path) && !self.force_tracking_matcher.matches(&path))
             {
                 // If it wasn't already tracked and it matches
                 // the ignored paths, then ignore it.

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1594,7 +1594,7 @@ impl FileSnapshotter<'_> {
                 }
             }
 
-            if git_ignore.matches(&path.to_internal_dir_string())
+            if git_ignore.matches_dir(path.as_internal_file_string())
                 && self.force_tracking_matcher.visit(&path).is_nothing()
             {
                 // If the whole directory is ignored by .gitignore, visit only
@@ -1624,7 +1624,7 @@ impl FileSnapshotter<'_> {
                 progress(&path);
             }
             if maybe_current_file_state.is_none()
-                && (git_ignore.matches(path.as_internal_file_string())
+                && (git_ignore.matches_file(path.as_internal_file_string())
                     && !self.force_tracking_matcher.matches(&path))
             {
                 // If it wasn't already tracked and it matches

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -1788,8 +1788,11 @@ fn test_git_submodule(gitignore_content: &str) -> TestResult {
     let repo = test_workspace.repo.clone();
     let store = repo.store().clone();
     let workspace_root = test_workspace.workspace.workspace_root().to_owned();
-    let base_ignores =
-        GitIgnoreFile::empty().chain("", Path::new(""), gitignore_content.as_bytes())?;
+    let base_ignores = GitIgnoreFile::empty().chain(
+        RepoPath::root(),
+        Path::new(""),
+        gitignore_content.as_bytes(),
+    )?;
     let snapshot_options = SnapshotOptions {
         base_ignores,
         ..empty_snapshot_options()


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
