### PR TITLE
git_backend: In write_file, compute hashes outside locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `jj status` filters untracked paths by fileset
   [#9287](https://github.com/jj-vcs/jj/issues/9287)
 
-* Improved performance for snapshot progress, visibly improving `jj status`
+* Improved performance for snapshotting, visibly improving `jj status`
   speed for large repositories.
 
 ## [0.40.0] - 2026-04-01

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -38,6 +38,8 @@ use futures::StreamExt as _;
 use futures::stream::BoxStream;
 use gix::bstr::BString;
 use gix::objs::CommitRefIter;
+use gix::objs::Exists as _;
+use gix::objs::Write as _;
 use gix::objs::WriteTo as _;
 use itertools::Itertools as _;
 use once_cell::sync::OnceCell as OnceLock;
@@ -501,6 +503,38 @@ impl GitBackend {
             .map_err(|err| map_not_found_err(err, &tree_id))?
             .try_into_tree()
             .map_err(|err| to_read_object_err(err, &tree_id))
+    }
+
+    // Similar to gix's write_blob, but compute the hash outside our lock to
+    // reduce contention.
+    fn write_blob(
+        &self,
+        bytes: &[u8],
+        object_type: &'static str,
+    ) -> BackendResult<gix::hash::ObjectId> {
+        let oid = gix::objs::compute_hash(
+            self.base_repo.objects.object_hash(),
+            gix::objs::Kind::Blob,
+            bytes,
+        )
+        .map_err(|err| BackendError::WriteObject {
+            object_type,
+            source: Box::new(err),
+        })?;
+
+        let locked_repo = self.lock_git_repo();
+        if !locked_repo.objects.exists(&oid) {
+            // write_buf recomputes the hash; gix does the same in write_blob.
+            let write_oid = locked_repo
+                .objects
+                .write_buf(gix::objs::Kind::Blob, bytes)
+                .map_err(|err| BackendError::WriteObject {
+                    object_type,
+                    source: err,
+                })?;
+            assert!(oid == write_oid);
+        }
+        Ok(oid)
     }
 }
 
@@ -1019,13 +1053,8 @@ impl Backend for GitBackend {
     ) -> BackendResult<FileId> {
         let mut bytes = Vec::new();
         contents.read_to_end(&mut bytes).await.unwrap();
-        let locked_repo = self.lock_git_repo();
-        let oid = locked_repo
-            .write_blob(bytes)
-            .map_err(|err| BackendError::WriteObject {
-                object_type: "file",
-                source: Box::new(err),
-            })?;
+
+        let oid = self.write_blob(&bytes, "file")?;
         Ok(FileId::new(oid.as_bytes().to_vec()))
     }
 
@@ -1043,14 +1072,7 @@ impl Backend for GitBackend {
     }
 
     async fn write_symlink(&self, _path: &RepoPath, target: &str) -> BackendResult<SymlinkId> {
-        let locked_repo = self.lock_git_repo();
-        let oid =
-            locked_repo
-                .write_blob(target.as_bytes())
-                .map_err(|err| BackendError::WriteObject {
-                    object_type: "symlink",
-                    source: Box::new(err),
-                })?;
+        let oid = self.write_blob(target.as_bytes(), "symlink")?;
         Ok(SymlinkId::new(oid.as_bytes().to_vec()))
     }
 


### PR DESCRIPTION
gix's `write_blob` can be found at:
https://github.com/GitoxideLabs/gitoxide/blob/26a5f65e24befea6e540178bb776d3f018f3ed39/gix/src/repository/object.rs#L290-L301

The `write_blob` call I'm added is intended to be equivalent, just inserting the jj-owned lock call after the hash to reduce contention. When snapshotting, it looks like there are lots of calls to this on an unmodified repo. As a consequence I expect the `has_object` call is typically true, and nothing's written. Maybe it's possible for jj to be aware of this and avoid the write call altogether, but either way calculating the sha's outside the lock is an improvement.

It was also discussed whether we should make the gix::Repository thread-local, instead of singleton. My thought here is that the bottleneck seems to be (mostly) gone, and I'm cautious of changing GitBackend substantially because it may have negative side-effects elsewhere, even if it looks good for `status`. I'm more confident that this change should only be an improvement (though a small repo like jj is too small to be helped).

Here's an example with https://github.com/mozilla-firefox/firefox:

```
╚╡hyperfine --parameter-list rev 'compute-hash,main' --setup 'jj new "{rev}" && cargo build --release' --warmup 1 --runs 30 --show-output './target/release/jj --repository ../firefox status'
Benchmark 1: ./target/release/jj --repository ../firefox status (rev = compute-hash)
(eliding output due to `--show-output`)
  Time (mean ± σ):     312.4 ms ±   9.5 ms    [User: 1212.8 ms, System: 1007.9 ms]
  Range (min … max):   294.5 ms … 333.6 ms    30 runs

Benchmark 2: ./target/release/jj --repository ../firefox status (rev = main)
(eliding output due to `--show-output`)
  Time (mean ± σ):     635.9 ms ±   6.5 ms    [User: 1119.5 ms, System: 999.4 ms]
  Range (min … max):   627.3 ms … 656.7 ms    30 runs

Summary
  ./target/release/jj --repository ../firefox status (rev = compute-hash) ran
    2.04 ± 0.07 times faster than ./target/release/jj --repository ../firefox status (rev = main)
```

This is now fast enough for me that status progress isn't showing anymore: though the duration is over 250ms, the amount spent with progress tracking is under that threshold. I'll take comfort that #9295 will still help larger repos or slower machines, though.

Assisted-by: Google Antigravity with Gemini
