### PR TITLE
ui: Make can_prompt return false when stdout is null

### DIFF
--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -560,15 +560,15 @@ impl Ui {
         old_output.finalize(self);
     }
 
-    pub fn can_prompt() -> bool {
-        io::stderr().is_terminal()
+    pub fn can_prompt(&self) -> bool {
+        matches!(&self.output, UiOutput::Terminal { stderr, .. } if stderr.is_terminal())
             || env::var("JJ_INTERACTIVE")
                 .map(|v| v == "1")
                 .unwrap_or(false)
     }
 
     pub fn prompt(&self, prompt: &str) -> io::Result<String> {
-        if !Self::can_prompt() {
+        if !self.can_prompt() {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "Cannot prompt for input since the output is not connected to a terminal",
@@ -654,7 +654,7 @@ impl Ui {
         // Parse the default to ensure that the text is valid.
         let default = default.map(|text| (parse(text).expect("default should be valid"), text));
 
-        if !Self::can_prompt()
+        if !self.can_prompt()
             && let Some((value, text)) = default
         {
             // Choose the default automatically without waiting.


### PR DESCRIPTION
This occurs during autocompletion.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
