### PR TITLE
git: avoid changing subprocess encoding to latin variant

### DIFF
--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -129,9 +129,12 @@ impl GitSubprocessContext {
             .args(["-c", "submodule.recurse=false"])
             .arg("--git-dir")
             .arg(&self.git_dir)
-            // Disable translation and other locale-dependent behavior so we can
-            // parse the output. LC_ALL precedes LC_* and LANG.
-            .env("LC_ALL", "C")
+            // Disable translation so we can parse the output. We don't set
+            // LC_ALL=C because it would change the encoding. Also note that
+            // "C.UTF-8" locale isn't always available.
+            .env_remove("LC_ALL")
+            .env_remove("LANGUAGE")
+            .env("LC_MESSAGES", "C")
             .stdin(Stdio::null())
             .stderr(Stdio::piped());
 


### PR DESCRIPTION
Fixes #9281

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
