### PR TITLE
contributing: Clarify that it's ok to resolve conversations

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,11 +75,14 @@ commit. You can do that by creating a new commit on top of the initial commit
 `jj git push`
 will automatically force-push the bookmark.
 
+Mark conversation threads as resolved when you have addressed them. If you
+realize that a comment requires non-trivial changes, write a reply instead and
+ask your reviewer to take another look after updating the code.
+
 When your first PR has been approved, we typically invite you to the
 `jj-vcs/contributors` team to give you contributor access,
 so you can address any remaining minor comments and then merge the PR yourself
-when you're ready. If you realize that some comments require non-trivial
-changes, please ask your reviewer to take another look.
+when you're ready.
 
 If your employer pays anyone (not necessarily you) to contribute to Jujutsu,
 please make sure your GitHub username is [recorded](paid_contributors.md).


### PR DESCRIPTION
Try to clarify that it is OK for the author to resolve review conversations.

Based on chat input: https://discord.com/channels/968932220549103686/969291218347524238/1493653697790738684

It slightly changes the meaning of the moved sentence.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [n/a ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [n/a ] I have updated the config schema (`cli/src/config-schema.json`)
- [n/a ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [n/a ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
