### PR TITLE
lib: new methods to get merged trees without resolving.

### DIFF
--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -38,6 +38,7 @@ use crate::merge::Merge;
 use crate::merged_tree::MergedTree;
 use crate::repo::Repo;
 use crate::rewrite::merge_commit_trees;
+use crate::rewrite::merge_commit_trees_no_resolve;
 use crate::signing::SignResult;
 use crate::signing::Verification;
 use crate::store::Store;
@@ -139,6 +140,19 @@ impl Commit {
         }
         let parents = self.parents().await?;
         merge_commit_trees(repo, &parents).await
+    }
+
+    /// Returns the parent tree, merging the parent trees if there are multiple
+    /// parents, without resolving conflicts.
+    pub async fn parent_tree_no_resolve(&self, repo: &dyn Repo) -> BackendResult<MergedTree> {
+        // Avoid merging parent trees if known to be empty. The index could be
+        // queried only when parents.len() > 1, but index query would be cheaper
+        // than extracting parent commit from the store.
+        if is_commit_empty_by_index(repo, &self.id)? == Some(true) {
+            return Ok(self.tree());
+        }
+        let parents = self.parents().await?;
+        merge_commit_trees_no_resolve(repo, &parents).await
     }
 
     /// Returns whether commit's content is empty. Commit description is not

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -60,10 +60,22 @@ pub async fn merge_commit_trees(repo: &dyn Repo, commits: &[Commit]) -> BackendR
     if let [commit] = commits {
         Ok(commit.tree())
     } else {
-        merge_commit_trees_no_resolve_without_repo(repo.store(), repo.index(), commits)
+        merge_commit_trees_no_resolve(repo, commits)
             .await?
             .resolve()
             .await
+    }
+}
+
+/// Merges `commits` without attempting to resolve file conflicts.
+pub async fn merge_commit_trees_no_resolve(
+    repo: &dyn Repo,
+    commits: &[Commit],
+) -> BackendResult<MergedTree> {
+    if let [commit] = commits {
+        Ok(commit.tree())
+    } else {
+        merge_commit_trees_no_resolve_without_repo(repo.store(), repo.index(), commits).await
     }
 }
 

--- a/lib/tests/test_rewrite.rs
+++ b/lib/tests/test_rewrite.rs
@@ -38,6 +38,7 @@ use jj_lib::rewrite::RewriteRefsOptions;
 use jj_lib::rewrite::find_duplicate_divergent_commits;
 use jj_lib::rewrite::find_recursive_merge_commits;
 use jj_lib::rewrite::merge_commit_trees;
+use jj_lib::rewrite::merge_commit_trees_no_resolve;
 use jj_lib::rewrite::rebase_commit_with_options;
 use jj_lib::rewrite::restore_tree;
 use maplit::hashmap;
@@ -91,22 +92,39 @@ fn test_merge_criss_cross() -> TestResult {
             .set_description(description)
             .write_unwrap()
     };
-    let commit_a = make_commit("A", vec![repo.store().root_commit_id().clone()], tree_a);
-    let commit_b = make_commit("B", vec![commit_a.id().clone()], tree_b);
-    let commit_c = make_commit("C", vec![commit_a.id().clone()], tree_c);
+    let commit_a = make_commit(
+        "A",
+        vec![repo.store().root_commit_id().clone()],
+        tree_a.clone(),
+    );
+    let commit_b = make_commit("B", vec![commit_a.id().clone()], tree_b.clone());
+    let commit_c = make_commit("C", vec![commit_a.id().clone()], tree_c.clone());
     let commit_d = make_commit(
         "D",
         vec![commit_b.id().clone(), commit_c.id().clone()],
-        tree_d,
+        tree_d.clone(),
     );
     let commit_e = make_commit(
         "E",
         vec![commit_b.id().clone(), commit_c.id().clone()],
-        tree_e,
+        tree_e.clone(),
     );
-    let merged = merge_commit_trees(tx.repo_mut(), &[commit_d, commit_e]).block_on()?;
-
+    let merged =
+        merge_commit_trees(tx.repo_mut(), &[commit_d.clone(), commit_e.clone()]).block_on()?;
     assert_tree_eq!(merged, tree_expected);
+
+    let tree_unresolved_expected = MergedTree::merge_no_resolve(Merge::from_vec(vec![
+        (tree_d, commit_d.conflict_label()),
+        (tree_b, commit_b.conflict_label()),
+        (tree_a, commit_a.conflict_label()),
+        (tree_c, commit_c.conflict_label()),
+        (tree_e, commit_e.conflict_label()),
+    ]));
+    let unresolved_merged =
+        merge_commit_trees_no_resolve(tx.repo_mut(), &[commit_d, commit_e]).block_on()?;
+    assert_tree_eq!(unresolved_merged, tree_unresolved_expected);
+    assert_tree_eq!(unresolved_merged.resolve().block_on()?, tree_expected);
+
     Ok(())
 }
 


### PR DESCRIPTION
This commit adds new basic APIs:
* Commit::parent_tree_no_resolve
* merge_commit_trees_no_resolve

Those new APIs will be used in the converge algorithm, to converge trees withouth resolving trees along the way, delaying the resolve step until the every end.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
