### PR TITLE
metaedit: add option for preserving committer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   lines and fine-grained control over when the tool is run. If you have set the `line-range-arg`
   config, use `--all-lines` to match the previous behavior of formatting the entire file.
 
+* `jj metadit` gained `--preserved-committer` and
+  `--preserve-committer-timestamp` options.
+
 ### Fixed bugs
 
 * Improving consistency with `git` handling of `.gitignore`, including `/`

--- a/cli/src/commands/metaedit.rs
+++ b/cli/src/commands/metaedit.rs
@@ -113,6 +113,20 @@ pub(crate) struct MetaeditArgs {
     )]
     author_timestamp: Option<Timestamp>,
 
+    /// Preserve the committer name and email
+    ///
+    /// By default, when any metadata is updated, the committer name, email, and
+    /// timestamp are also updated to the current user and time.
+    #[arg(long, conflicts_with = "force_rewrite")]
+    preserve_committer: bool,
+
+    /// Preserve the committer timestamp
+    ///
+    /// By default, when any metadata is updated, the committer name, email, and
+    /// timestamp are also updated to the current user and time.
+    #[arg(long, conflicts_with = "force_rewrite")]
+    preserve_committer_timestamp: bool,
+
     /// Rewrite the commit, even if no other metadata changed
     ///
     /// This updates the committer timestamp to the current time, as well as the
@@ -210,6 +224,7 @@ pub(crate) async fn cmd_metaedit(
                     || rewriter.parents_changed();
 
                 let old_author = rewriter.old_commit().author().clone();
+                let old_commiter = rewriter.old_commit().committer().clone();
                 let mut commit_builder = rewriter.reparent();
                 let mut new_author = commit_builder.author().clone();
                 if let Some((name, email)) = args.author.clone() {
@@ -237,6 +252,15 @@ pub(crate) async fn cmd_metaedit(
                     commit_builder = commit_builder.set_author(new_author);
                     rewrite = true;
                 }
+                let mut new_committer = commit_builder.committer().clone();
+                if args.preserve_committer {
+                    new_committer.name = old_commiter.name;
+                    new_committer.email = old_commiter.email;
+                }
+                if args.preserve_committer_timestamp {
+                    new_committer.timestamp = old_commiter.timestamp;
+                }
+                commit_builder = commit_builder.set_committer(new_committer);
 
                 if let Some(description) = &new_description
                     && description != commit_builder.description()

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2083,6 +2083,12 @@ Whenever any metadata is updated, the committer name, email, and timestamp are a
    [RFC2822]: https://datatracker.ietf.org/doc/html/rfc2822
 
    [RFC3339]: https://datatracker.ietf.org/doc/html/rfc3339
+* `--preserve-committer` — Preserve the committer name and email
+
+   By default, when any metadata is updated, the committer name, email, and timestamp are also updated to the current user and time.
+* `--preserve-committer-timestamp` — Preserve the committer timestamp
+
+   By default, when any metadata is updated, the committer name, email, and timestamp are also updated to the current user and time.
 * `--force-rewrite` — Rewrite the commit, even if no other metadata changed
 
    This updates the committer timestamp to the current time, as well as the committer name and email.

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -830,6 +830,61 @@ fn test_metaedit_set_same_timestamp_twice() {
     ");
 }
 
+#[test]
+fn test_metaedit_preserve_commmitter() {
+    let mut test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+
+    // Verify that the configured user is used for committer by default
+    insta::assert_snapshot!(test_env.work_dir("repo").run_jj(["show"]), @"
+    Commit ID: e8849ae12c709f2321908879bc724fdb2ab8a781
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:07)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:07)
+
+        (no description set)
+
+    [EOF]
+    ");
+
+    // Make sure the timestamp is not updated with --preserve-committer-timestamp
+    test_env.add_env_var("JJ_USER", "user1");
+    test_env.add_env_var("JJ_EMAIL", "user1@example.com");
+    let work_dir = test_env.work_dir("repo");
+    work_dir
+        .run_jj(["metaedit", "--message=m1", "--preserve-committer-timestamp"])
+        .success();
+    insta::assert_snapshot!(work_dir.run_jj(["show"]), @"
+    Commit ID: 49c961253fd0005b56c27d8412a3d843e2c5760b
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:07)
+    Committer: user1 <user1@example.com> (2001-02-03 08:05:07)
+
+        m1
+
+    [EOF]
+    ");
+    drop(work_dir);
+
+    // Make sure name and email are not updated with --preserve-committer
+    test_env.add_env_var("JJ_USER", "user2");
+    test_env.add_env_var("JJ_EMAIL", "user2@example.com");
+    let work_dir = test_env.work_dir("repo");
+    work_dir
+        .run_jj(["metaedit", "--message=m2", "--preserve-committer"])
+        .success();
+    insta::assert_snapshot!(work_dir.run_jj(["show"]), @"
+    Commit ID: 4fb16d256d659efa45b0cc37955e4aea52edccfc
+    Change ID: qpvuntsmwlqtpsluzzsnyyzlmlwvmlnu
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:07)
+    Committer: user1 <user1@example.com> (2001-02-03 08:05:11)
+
+        m2
+
+    [EOF]
+    ");
+}
+
 #[must_use]
 fn get_log(work_dir: &TestWorkDir) -> CommandOutput {
     work_dir.run_jj([


### PR DESCRIPTION
I didn't split it up into `--preserve-committer` and `--preserve-committer-timestamp` becuase it just doesn't seem useful.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
