### PR TITLE
cli: add new wc only to workspaces that became immutable this transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Pre-existing Git submodule directories are no longer considered conflicts in
   checkouts. [#8065](https://github.com/jj-vcs/jj/issues/8065).
 
+* Stop stacking empty revisions on other workspaces that were already immutable
+  before a transaction (e.g., under `immutable_heads() = working_copies() ~ @`).
+  Workspaces whose working copy is made immutable *by* the transaction (e.g., a
+  tag pointing to it) still get a new commit stacked on top.
+  [#7751](https://github.com/jj-vcs/jj/issues/7751)
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1013,6 +1013,18 @@ impl WorkspaceCommandEnvironment {
         repo: &dyn Repo,
         to_rewrite_expr: &Arc<ResolvedRevsetExpression>,
     ) -> Result<Option<CommitId>, CommandError> {
+        self.find_immutable_commit_with(repo, to_rewrite_expr, self.immutable_expression())
+            .await
+    }
+
+    /// Returns first immutable commit, evaluating immutability with the given
+    /// expression (overriding the current workspace's parsed one).
+    async fn find_immutable_commit_with(
+        &self,
+        repo: &dyn Repo,
+        to_rewrite_expr: &Arc<ResolvedRevsetExpression>,
+        immutable_expression: Arc<UserRevsetExpression>,
+    ) -> Result<Option<CommitId>, CommandError> {
         let immutable_expression = if self.command.global_args().ignore_immutable {
             UserRevsetExpression::root()
         } else {

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -983,6 +983,49 @@ impl WorkspaceCommandEnvironment {
         Ok(expression)
     }
 
+    /// Immutable-set expression evaluated as if `workspace_name` were the
+    /// current workspace. This matters for configs that reference `@`, e.g.
+    /// `immutable_heads() = builtin_immutable_heads() | (working_copies() ~
+    /// @)`, where the set depends on which workspace's `@` is substituted.
+    fn immutable_expression_for_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Arc<UserRevsetExpression>, CommandError> {
+        if workspace_name == &*self.workspace_name {
+            return Ok(self.immutable_expression());
+        }
+        let workspace_context = RevsetWorkspaceContext {
+            path_converter: &self.path_converter,
+            workspace_name,
+        };
+        let now = if let Some(timestamp) = self.settings.commit_timestamp() {
+            chrono::Local
+                .timestamp_millis_opt(timestamp.timestamp.0)
+                .unwrap()
+        } else {
+            chrono::Local::now()
+        };
+        let context = RevsetParseContext {
+            aliases_map: &self.revset_aliases_map,
+            local_variables: HashMap::new(),
+            user_email: self.settings.user_email(),
+            date_pattern_context: now.into(),
+            default_ignored_remote: self.default_ignored_remote,
+            fileset_aliases_map: &self.fileset_aliases_map,
+            use_glob_by_default: self.revsets_use_glob_by_default,
+            extensions: self.command.revset_extensions(),
+            workspace: Some(workspace_context),
+        };
+        let mut diagnostics = RevsetDiagnostics::new();
+        let heads = revset_util::parse_immutable_heads_expression(&mut diagnostics, &context)
+            .map_err(|e| {
+                config_error_with_message("Invalid `revset-aliases.immutable_heads()`", e)
+            })?;
+        // Diagnostics were already surfaced when parsing for the current
+        // workspace, so skip re-printing them here.
+        Ok(heads.ancestors())
+    }
+
     fn load_short_prefixes_expression(
         &self,
         ui: &Ui,
@@ -1028,7 +1071,7 @@ impl WorkspaceCommandEnvironment {
         let immutable_expression = if self.command.global_args().ignore_immutable {
             UserRevsetExpression::root()
         } else {
-            self.immutable_expression()
+            immutable_expression
         };
 
         // Not using self.id_prefix_context() because the disambiguation data
@@ -2212,12 +2255,40 @@ to the current parents may contain changes from multiple commits.
             writeln!(ui.status(), "Rebased {num_rebased} descendant commits")?;
         }
 
-        for (name, wc_commit_id) in &tx.repo().view().wc_commit_ids().clone() {
+        // For each workspace wc, check if previously mutable in tx.base_repo()
+        // and has become immutable in this transaction. If so, push empty
+        // commit on top. For non-current workspaces, evaluate immutability
+        // from that workspace's own perspective so that configs like
+        // `immutable_heads() = builtin_immutable_heads() | (working_copies() ~ @)`
+        // don't treat every other workspace's wc as perpetually immutable.
+        let current_name = self.workspace_name().to_owned();
+        let new_wc_commit_ids = tx.repo().view().wc_commit_ids().clone();
+        for (name, new_wc_commit_id) in &new_wc_commit_ids {
+            let wc_expr = RevsetExpression::commit(new_wc_commit_id.clone());
+            let immutable_expr = self.env.immutable_expression_for_workspace(name)?;
+            if name != &current_name {
+                let was_immutable = matches!(
+                    self.env
+                        .find_immutable_commit_with(
+                            tx.base_repo().as_ref(),
+                            &wc_expr,
+                            immutable_expr.clone(),
+                        )
+                        .await,
+                    Ok(Some(_))
+                );
+                if was_immutable {
+                    continue;
+                }
+            }
             // This can fail if trunk() bookmark gets deleted or conflicted. If
             // the unresolvable trunk() issue gets addressed differently, it
             // should be okay to propagate the error.
-            let wc_expr = RevsetExpression::commit(wc_commit_id.clone());
-            let is_immutable = match self.env.find_immutable_commit(tx.repo(), &wc_expr).await {
+            let is_immutable = match self
+                .env
+                .find_immutable_commit_with(tx.repo(), &wc_expr, immutable_expr)
+                .await
+            {
                 Ok(commit_id) => commit_id.is_some(),
                 Err(CommandError { error, .. }) => {
                     writeln!(
@@ -2230,7 +2301,7 @@ to the current parents may contain changes from multiple commits.
                 }
             };
             if is_immutable {
-                let wc_commit = tx.repo().store().get_commit_async(wc_commit_id).await?;
+                let wc_commit = tx.repo().store().get_commit_async(new_wc_commit_id).await?;
                 tx.repo_mut().check_out(name.clone(), &wc_commit).await?;
                 writeln!(
                     ui.warning_default(),

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -230,21 +230,18 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace_already_immutable() {
     let output = work_dir
         .run_jj(["workspace", "add", "../workspace1"])
         .success();
-    // TODO: The current workspace is immutable from the new workspace's
-    // perspective, but we should not create a new commit for it.
+    // The current workspace is not immutable from its own perspective
+    // (working_copies() ~ @ excludes @), so no warning is shown.
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Created workspace in "../workspace1"
-    Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
     Working copy  (@) now at: pmmvwywv 1cd27236 (empty) (no description set)
     Parent commit (@-)      : qpvuntsm e8849ae1 (empty) (no description set)
     [EOF]
     "#);
     let output = work_dir.run_jj(["log", "-r=::"]);
     insta::assert_snapshot!(output, @r"
-    @  yxszmlut test.user@example.com 2001-02-03 08:05:09 default@ 88a6c421
-    │  (empty) (no description set)
-    ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 167b8dbf
+    @  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 default@ 167b8dbf
     │  (empty) a
     │ ◆  pmmvwywv test.user@example.com 2001-02-03 08:05:09 workspace1@ 1cd27236
     ├─╯  (empty) (no description set)
@@ -253,14 +250,97 @@ fn test_new_wc_commit_when_wc_immutable_multi_workspace_already_immutable() {
     ◆  zzzzzzzz root() 00000000
     [EOF]
     ");
-    // TODO: The other workspace was already immutable from the current workspace's
-    // perspective, so we don't create a new commit for it.
+    // The other workspace is already immutable from the current workspace's
+    // perspective, but we only check the current workspace's immutability.
     let output = work_dir.run_jj(["new"]);
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
+    Working copy  (@) now at: mzvwutvl b6d970c6 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 167b8dbf (empty) a
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_new_wc_commit_when_wc_becomes_immutable_via_tag_on_other_workspace() {
+    // When a transaction tags another workspace's working copy, the tagged
+    // commit becomes immutable (tags() is in builtin_immutable_heads()). A new
+    // commit should be stacked on top so the other workspace is still usable.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.run_jj(["new", "-m=a"]).success();
+    work_dir
+        .run_jj(["workspace", "add", "../workspace1"])
+        .success();
+    let output = work_dir.run_jj(["tag", "set", "tag-r", "-r=workspace1@"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Warning: Target revision is empty.
+    Created 1 tags pointing to pmmvwywv 1cd27236 (empty) (no description set)
     Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
-    Working copy  (@) now at: mzvwutvl c460fde3 (empty) (no description set)
-    Parent commit (@-)      : yxszmlut 88a6c421 (empty) (no description set)
+    [EOF]
+    ");
+    let workspace1_dir = test_env.work_dir("workspace1");
+    workspace1_dir
+        .run_jj(["workspace", "update-stale"])
+        .success();
+    let output = workspace1_dir.run_jj(["log", "-r=::"]);
+    insta::assert_snapshot!(output, @r"
+    @  zsuskuln test.user@example.com 2001-02-03 08:05:10 workspace1@ a70299e3
+    │  (empty) (no description set)
+    ◆  pmmvwywv test.user@example.com 2001-02-03 08:05:09 tag-r 1cd27236
+    │  (empty) (no description set)
+    │ ○  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 default@ 167b8dbf
+    ├─╯  (empty) a
+    ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    │  (empty) (no description set)
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_new_wc_commit_when_wc_becomes_immutable_via_tag_on_other_workspace_with_wc_exclusion() {
+    // Regression test: with `immutable_heads() = ... | (working_copies() ~ @)`,
+    // the other workspace's wc looks "immutable" from the current workspace's
+    // perspective even before the transaction, because it's in
+    // `working_copies() ~ @`. Immutability should be evaluated from the
+    // target workspace's own perspective, so tagging workspace1's wc still
+    // triggers stacking a new commit on top.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    test_env.add_config(
+        r#"revset-aliases."immutable_heads()" = "builtin_immutable_heads() | (working_copies() ~ @)""#,
+    );
+    work_dir.run_jj(["new", "-m=a"]).success();
+    work_dir
+        .run_jj(["workspace", "add", "../workspace1"])
+        .success();
+    let output = work_dir.run_jj(["tag", "set", "tag-r", "-r=workspace1@"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Warning: Target revision is empty.
+    Created 1 tags pointing to pmmvwywv 1cd27236 (empty) (no description set)
+    Warning: The working-copy commit in workspace 'workspace1' became immutable, so a new commit has been created on top of it.
+    [EOF]
+    ");
+    let workspace1_dir = test_env.work_dir("workspace1");
+    workspace1_dir
+        .run_jj(["workspace", "update-stale"])
+        .success();
+    let output = workspace1_dir.run_jj(["log", "-r=::"]);
+    insta::assert_snapshot!(output, @r"
+    @  zsuskuln test.user@example.com 2001-02-03 08:05:10 workspace1@ a70299e3
+    │  (empty) (no description set)
+    ◆  pmmvwywv test.user@example.com 2001-02-03 08:05:09 tag-r 1cd27236
+    │  (empty) (no description set)
+    │ ◆  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 default@ 167b8dbf
+    ├─╯  (empty) a
+    ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:07 e8849ae1
+    │  (empty) (no description set)
+    ◆  zzzzzzzz root() 00000000
     [EOF]
     ");
 }


### PR DESCRIPTION
`finish_transaction` iterated every workspace's working copy and stacked a new commit on top of any that were immutable in the post-transaction repo. With workspace-dependent immutability (e.g. `immutable_heads() = working_copies() ~ @`), every other workspace's wc looks immutable from the current workspace, so running `jj new` spuriously created empty commits on workspaces the user wasn't touching.

Now, we evaluate each workspace's wc immutability from that workspace's _own perspective_ when deciding whether to stack: `immutable_heads()` is re-parsed in the context of the target workspace.

For non-current workspaces, the stacking step is skipped if the wc was already immutable under its own perspective in the pre-transaction repo. Under `immutable_heads() = working_copies() ~ @` this correctly excludes the target workspace's own wc while still treating it as immutable if something else in the transaction (e.g. a tag on its `@`) makes it so.

Fixes #7751

See also [this discord thread in #development](https://discord.com/channels/968932220549103686/1492271154180657232/1492272699924283592).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
