### PR TITLE
git: reject remote names invalid in fetch refspecs

### DIFF
--- a/cli/tests/test_git_remotes.rs
+++ b/cli/tests/test_git_remotes.rs
@@ -152,6 +152,33 @@ fn test_git_remote_add() {
     [EOF]
     [exit status: 1]
     ");
+    let output = work_dir.run_jj(["git", "remote", "add", "", "http://example.com/repo/empty"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Git remote named '""' is incompatible with jj/Git fetch refspecs
+    [EOF]
+    [exit status: 1]
+    "#);
+    let output = work_dir.run_jj([
+        "git",
+        "remote",
+        "add",
+        "this also fails",
+        "http://example.com/repo/space",
+    ]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Git remote named '"this also fails"' is incompatible with jj/Git fetch refspecs
+    [EOF]
+    [exit status: 1]
+    "#);
+    let output = work_dir.run_jj(["git", "remote", "add", "  ", "http://example.com/repo/ws"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Git remote named '"  "' is incompatible with jj/Git fetch refspecs
+    [EOF]
+    [exit status: 1]
+    "#);
     let output = work_dir.run_jj(["git", "remote", "list"]);
     insta::assert_snapshot!(output, @"
     foo http://example.com/repo/foo

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -148,6 +148,11 @@ pub enum GitRemoteNameError {
     ReservedForLocalGitRepo,
     #[error("Git remotes with slashes are incompatible with jj: {}", .0.as_symbol())]
     WithSlash(RemoteNameBuf),
+    #[error(
+        "Git remote named '{}' is incompatible with jj/Git fetch refspecs",
+        .0.as_symbol()
+    )]
+    IncompatibleWithRefspec(RemoteNameBuf),
 }
 
 fn validate_remote_name(name: &RemoteName) -> Result<(), GitRemoteNameError> {
@@ -155,6 +160,8 @@ fn validate_remote_name(name: &RemoteName) -> Result<(), GitRemoteNameError> {
         Err(GitRemoteNameError::ReservedForLocalGitRepo)
     } else if name.as_str().contains('/') {
         Err(GitRemoteNameError::WithSlash(name.to_owned()))
+    } else if gix::remote::name::validated(name.as_str()).is_err() {
+        Err(GitRemoteNameError::IncompatibleWithRefspec(name.to_owned()))
     } else {
         Ok(())
     }


### PR DESCRIPTION
Fixes #9099

`jj git remote add` currently panics if the symbolic remote name can't be used in the generated fetch refspec.
For example, `jj git remote add 'this also fails' https://github.com/jj-vcs/jj.git` aborts with `ReferenceName(InvalidByte { byte: " " })` instead of returning a user-facing error.

This validates symbolic remote names with `gix::remote::name::validated()` before writing the remote config, so invalid names fail cleanly instead of panicking.
I also added CLI coverage for empty, whitespace-containing, and whitespace-only remote names.

Validation:
- `cargo test -q -p jj-cli --test runner test_git_remote`

# Checklist

If applicable:

- [n/a] I have updated `CHANGELOG.md`
- [n/a] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [n/a] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
