### PR TITLE
completion: alias descriptions in TOML properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Shell completions now surface descriptions for custom aliases,
+  revset-aliases, template-aliases, and fileset-aliases. Descriptions are
+  extracted from the `.doc` field of the alias definition if it is a table
+  with `.doc` and `.definition` properties.
+
 ### Fixed bugs
 
 * `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -525,7 +525,7 @@ impl CommandHelper {
                 "Use `jj config edit --repo` to adjust the `trunk()` alias."
             )?;
             env.revset_aliases_map
-                .insert("trunk()", fallback)
+                .insert("trunk()", fallback, None)
                 .expect("valid syntax");
             env.reload_revset_expressions(ui)?;
         }
@@ -3879,7 +3879,12 @@ fn resolve_aliases(
                 )));
             }
             if let Some(&alias_name) = defined_aliases.get(&*alias_name) {
-                let alias_definition: Vec<String> = config.get(["aliases", alias_name])?;
+                let alias_definition: Vec<String> = match config.get(["aliases", alias_name]) {
+                    Ok(definition) => definition,
+                    Err(original_err) => config
+                        .get(["aliases", alias_name, "definition"])
+                        .map_err(|_| original_err)?,
+                };
                 assert!(string_args.ends_with(&alias_args));
                 string_args.truncate(string_args.len() - 1 - alias_args.len());
                 string_args.extend(alias_definition);

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -277,7 +277,10 @@ pub fn template_aliases() -> Vec<CompletionCandidate> {
         };
         Ok(template_aliases
             .symbol_names()
-            .map(CompletionCandidate::new)
+            .map(|name| {
+                let doc = template_aliases.get_symbol(name).unwrap().2;
+                CompletionCandidate::new(name).help(doc.map(|doc| doc.to_owned().into()))
+            })
             .sorted()
             .collect())
     })
@@ -292,7 +295,14 @@ pub fn aliases() -> Vec<CompletionCandidate> {
             // aliases don't need to be completed and they would only clutter
             // the output of `jj <TAB>`.
             .filter(|alias| alias.len() > 2)
-            .map(CompletionCandidate::new)
+            .map(|alias| {
+                CompletionCandidate::new(alias).help(
+                    settings
+                        .get_string(["aliases", alias, "doc"])
+                        .ok()
+                        .map(|doc| doc.into()),
+                )
+            })
             .collect())
     })
 }
@@ -426,9 +436,11 @@ fn revisions(match_prefix: &str, revset_filter: Option<&str>) -> Vec<CompletionC
                 .into_iter()
                 .filter(|symbol| symbol.starts_with(match_prefix))
                 .map(|symbol| {
-                    let (_, defn) = revset_aliases.get_symbol(symbol).unwrap();
+                    let (_, defn, doc) = revset_aliases.get_symbol(symbol).unwrap();
+                    // Prefer TOML `.doc` over definition text
+                    let help: String = doc.map(|s| s.to_owned()).unwrap_or_else(|| defn.clone());
                     CompletionCandidate::new(symbol)
-                        .help(Some(defn.into()))
+                        .help(Some(help.into()))
                         .display_order(Some(REVSET_ALIAS))
                 }),
         );

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -461,7 +461,25 @@
             "type": "object",
             "description": "Custom symbols/function aliases that can be used in fileset expressions",
             "additionalProperties": {
-                "type": "string"
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "definition": {
+                                "type": "string"
+                            },
+                            "doc": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "definition"
+                        ]
+                    }
+                ]
             }
         },
         "git": {
@@ -719,7 +737,7 @@
         },
         "revset-aliases": {
             "type": "object",
-            "description": "Custom symbols/function aliases that can used in revset expressions",
+            "description": "Custom symbols/function aliases that can be used in revset expressions",
             "properties": {
                 "immutable_heads()": {
                     "type": "string",
@@ -728,24 +746,81 @@
                 }
             },
             "additionalProperties": {
-                "type": "string"
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "definition": {
+                                "type": "string"
+                            },
+                            "doc": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "definition"
+                        ]
+                    }
+                ]
             }
         },
         "template-aliases": {
             "type": "object",
-            "description": "Custom symbols/function aliases that can used in templates",
+            "description": "Custom symbols/function aliases that can be used in templates",
             "additionalProperties": {
-                "type": "string"
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "definition": {
+                                "type": "string"
+                            },
+                            "doc": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "definition"
+                        ]
+                    }
+                ]
             }
         },
         "aliases": {
             "type": "object",
             "description": "Custom subcommand aliases to be supported by the jj command",
             "additionalProperties": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
+                "oneOf": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "definition": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "doc": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "definition"
+                        ]
+                    }
+                ]
             }
         },
         "snapshot": {

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -986,10 +986,22 @@ where
             }
         };
         for (decl, item) in table.iter() {
-            let r = item
-                .as_str()
-                .ok_or_else(|| format!("Expected a string, but is {}", item.type_name()))
-                .and_then(|v| aliases_map.insert(decl, v).map_err(|e| format!("{e}")));
+            let (definition, doc) = if let Some(t) = item.as_table_like() {
+                let definition = t.get("definition").and_then(|i| i.as_str());
+                let doc = t.get("doc").and_then(|i| i.as_str()).map(|s| s.to_owned());
+                (definition, doc)
+            } else {
+                (item.as_str(), None)
+            };
+
+            let r = definition
+                .ok_or_else(|| {
+                    format!(
+                        "Expected a string or a table with a `definition` string key, but is {}",
+                        item.type_name()
+                    )
+                })
+                .and_then(|v| aliases_map.insert(decl, v, doc).map_err(|e| format!("{e}")));
             if let Err(s) = r {
                 writeln!(
                     ui.warning_default(),

--- a/cli/src/revset_util.rs
+++ b/cli/src/revset_util.rs
@@ -194,7 +194,7 @@ pub fn parse_immutable_heads_expression(
     diagnostics: &mut RevsetDiagnostics,
     context: &RevsetParseContext,
 ) -> Result<Arc<UserRevsetExpression>, RevsetParseError> {
-    let (_, _, immutable_heads_str) = context
+    let (_, _, immutable_heads_str, _) = context
         .aliases_map
         .get_function(USER_IMMUTABLE_HEADS, 0)
         .unwrap();
@@ -210,7 +210,7 @@ pub(super) fn try_resolve_trunk_alias(
     repo: &dyn Repo,
     context: &RevsetParseContext,
 ) -> Result<Option<Arc<ResolvedRevsetExpression>>, RevsetResolutionError> {
-    let (_, _, revset_str) = context
+    let (_, _, revset_str, _) = context
         .aliases_map
         .get_function("trunk", 0)
         .expect("trunk() should be defined by default");

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -3078,7 +3078,7 @@ mod tests {
         }
 
         fn add_alias(&mut self, decl: impl AsRef<str>, defn: impl Into<String>) {
-            self.aliases_map.insert(decl, defn).unwrap();
+            self.aliases_map.insert(decl, defn, None).unwrap();
         }
 
         fn add_color(&mut self, label: &str, fg: crossterm::style::Color) {

--- a/cli/src/template_parser.rs
+++ b/cli/src/template_parser.rs
@@ -853,7 +853,7 @@ mod tests {
     ) -> WithTemplateAliasesMap {
         let mut aliases_map = TemplateAliasesMap::new();
         for (decl, defn) in aliases {
-            aliases_map.insert(decl, defn).unwrap();
+            aliases_map.insert(decl, defn, None).unwrap();
         }
         WithTemplateAliasesMap(aliases_map)
     }
@@ -1357,34 +1357,35 @@ mod tests {
     #[test]
     fn test_parse_alias_decl() -> TestResult {
         let mut aliases_map = TemplateAliasesMap::new();
-        aliases_map.insert("sym", r#""is symbol""#)?;
-        aliases_map.insert("pat:a", r#""is pattern a""#)?;
-        aliases_map.insert("pat:b", r#""is pattern b""#)?;
-        aliases_map.insert("func()", r#""is function 0""#)?;
-        aliases_map.insert("func(a, b)", r#""is function 2""#)?;
-        aliases_map.insert("func(a)", r#""is function a""#)?;
-        aliases_map.insert("func(b)", r#""is function b""#)?;
+        aliases_map.insert("sym", r#""is symbol""#, Some("symbol doc".to_owned()))?;
+        aliases_map.insert("pat:a", r#""is pattern a""#, Some("pattern doc".to_owned()))?;
+        aliases_map.insert("pat:b", r#""is pattern b""#, None)?;
+        aliases_map.insert("func()", r#""is function 0""#, Some("func doc".to_owned()))?;
+        aliases_map.insert("func(a, b)", r#""is function 2""#, None)?;
+        aliases_map.insert("func(a)", r#""is function a""#, None)?;
+        aliases_map.insert("func(b)", r#""is function b""#, None)?;
 
-        let (id, defn) = aliases_map.get_symbol("sym").unwrap();
+        let (id, defn, doc) = aliases_map.get_symbol("sym").unwrap();
         assert_eq!(id, AliasId::Symbol("sym"));
         assert_eq!(defn, r#""is symbol""#);
+        assert_eq!(doc, Some("symbol doc"));
 
-        let (id, param, defn) = aliases_map.get_pattern("pat").unwrap();
+        let (id, param, defn, _doc) = aliases_map.get_pattern("pat").unwrap();
         assert_eq!(id, AliasId::Pattern("pat", "b"));
         assert_eq!(param, "b");
         assert_eq!(defn, r#""is pattern b""#);
 
-        let (id, params, defn) = aliases_map.get_function("func", 0).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 0).unwrap();
         assert_eq!(id, AliasId::Function("func", &[]));
         assert!(params.is_empty());
         assert_eq!(defn, r#""is function 0""#);
 
-        let (id, params, defn) = aliases_map.get_function("func", 1).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 1).unwrap();
         assert_eq!(id, AliasId::Function("func", &["b".to_owned()]));
         assert_eq!(params, ["b"]);
         assert_eq!(defn, r#""is function b""#);
 
-        let (id, params, defn) = aliases_map.get_function("func", 2).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 2).unwrap();
         assert_eq!(
             id,
             AliasId::Function("func", &["a".to_owned(), "b".to_owned()])
@@ -1396,28 +1397,31 @@ mod tests {
 
         // Formal parameter 'a' can't be redefined
         assert_eq!(
-            aliases_map.insert("f(a, a)", r#""""#).unwrap_err().kind,
+            aliases_map
+                .insert("f(a, a)", r#""""#, None)
+                .unwrap_err()
+                .kind,
             TemplateParseErrorKind::RedefinedFunctionParameter
         );
 
         // Boolean literal cannot be used as a symbol, pattern, function, or
         // parameter name
-        assert!(aliases_map.insert("false", r#"""#).is_err());
-        assert!(aliases_map.insert("false:x", r#"""#).is_err());
-        assert!(aliases_map.insert("p:true", r#"""#).is_err());
-        assert!(aliases_map.insert("true()", r#"""#).is_err());
-        assert!(aliases_map.insert("f(false)", r#"""#).is_err());
+        assert!(aliases_map.insert("false", r#"""#, None).is_err());
+        assert!(aliases_map.insert("false:x", r#"""#, None).is_err());
+        assert!(aliases_map.insert("p:true", r#"""#, None).is_err());
+        assert!(aliases_map.insert("true()", r#"""#, None).is_err());
+        assert!(aliases_map.insert("f(false)", r#"""#, None).is_err());
 
         // Trailing comma isn't allowed for empty parameter
-        assert!(aliases_map.insert("f(,)", r#"""#).is_err());
+        assert!(aliases_map.insert("f(,)", r#"""#, None).is_err());
         // Trailing comma is allowed for the last parameter
-        assert!(aliases_map.insert("g(a,)", r#"""#).is_ok());
-        assert!(aliases_map.insert("h(a ,  )", r#"""#).is_ok());
-        assert!(aliases_map.insert("i(,a)", r#"""#).is_err());
-        assert!(aliases_map.insert("j(a,,)", r#"""#).is_err());
-        assert!(aliases_map.insert("k(a  , , )", r#"""#).is_err());
-        assert!(aliases_map.insert("l(a,b,)", r#"""#).is_ok());
-        assert!(aliases_map.insert("m(a,,b)", r#"""#).is_err());
+        assert!(aliases_map.insert("g(a,)", r#"""#, None).is_ok());
+        assert!(aliases_map.insert("h(a ,  )", r#"""#, None).is_ok());
+        assert!(aliases_map.insert("i(,a)", r#"""#, None).is_err());
+        assert!(aliases_map.insert("j(a,,)", r#"""#, None).is_err());
+        assert!(aliases_map.insert("k(a  , , )", r#"""#, None).is_err());
+        assert!(aliases_map.insert("l(a,b,)", r#"""#, None).is_ok());
+        assert!(aliases_map.insert("m(a,,b)", r#"""#, None).is_err());
         Ok(())
     }
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -922,6 +922,88 @@ fn test_aliases_are_completed(shell: Shell) {
 }
 
 #[test]
+fn test_alias_descriptions_in_completions() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // alias with a description
+    test_env.add_config(indoc! {r#"
+        [aliases]
+        'compact-log'.doc = 'Show the log in a compact format'
+        'compact-log'.definition = ["log", "--no-graph"]
+    "#});
+
+    // fish displays help text after a tab
+    let output = work_dir.complete_fish(["compact-l"]);
+    insta::assert_snapshot!(output, @"
+    compact-log	Show the log in a compact format
+    [EOF]
+    ");
+
+    // alias with multi-line string description
+    test_env.add_config(indoc! {r#"
+        [aliases]
+        'status-short'.doc = 'Show the status of the working copy in short format'
+        'status-short'.definition = ["status", "--format=summary"]
+    "#});
+
+    let output = work_dir.complete_fish(["status-shor"]);
+    insta::assert_snapshot!(output, @"
+    status-short	Show the status of the working copy in short format
+    [EOF]
+    ");
+
+    // alias without a .doc property should have no description
+    test_env.add_config(indoc! {r#"
+        [aliases]
+        plain-alias = ["status"]
+    "#});
+
+    let output = work_dir.complete_fish(["plain-alia"]);
+    insta::assert_snapshot!(output, @"
+    plain-alias
+    [EOF]
+    ");
+
+    // revset alias with doc
+    test_env.add_config(indoc! {r#"
+        [revset-aliases]
+        'mine'.doc = 'All my work'
+        'mine'.definition = "author(foo)"
+    "#});
+
+    let output = work_dir.complete_fish(["log", "-r", "min"]);
+    insta::assert_snapshot!(output, @"
+    mine	All my work
+    [EOF]
+    ");
+
+    // template alias with doc
+    test_env.add_config(indoc! {r#"
+        [template-aliases]
+        'sh'.doc = 'Short hash'
+        'sh'.definition = "commit_id.short()"
+    "#});
+
+    let output = work_dir.complete_fish(["log", "-T", "s"]);
+    insta::assert_snapshot!(output, @"
+    sh	Short hash
+    [EOF]
+    ");
+
+    // fileset alias with doc
+    test_env.add_config(indoc! {r#"
+        [fileset-aliases]
+        'LOCK'.doc = 'Lockfiles'
+        'LOCK'.definition = '**/Cargo.lock'
+    "#});
+
+    let output = work_dir.complete_fish(["log", "-r", "all()", "L"]);
+    insta::assert_snapshot!(output, @"");
+}
+
+#[test]
 fn test_revisions() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/docs/config.md
+++ b/docs/config.md
@@ -995,6 +995,27 @@ You can define aliases for commands, including their arguments. For example:
 l = ["log", "-r", "(main..@):: | (main..@)-"]
 ```
 
+### Alias descriptions
+
+Alias descriptions can be surfaced in shell completions by defining the alias
+as a table with `.doc` and `.definition` properties. For example:
+
+```toml
+[aliases]
+l = {
+    definition = ["log", "-r", "(main..@):: | (main..@)-"],
+    doc = "Log pending changes"
+}
+```
+
+You can also use the dotted key syntax:
+
+```toml
+[aliases]
+l.definition = ["log", "-r", "(main..@):: | (main..@)-"]
+l.doc = "Log pending changes"
+```
+
 This alias syntax can only run a single jj command. However, you may want to
 execute multiple jj commands with a single alias, or run arbitrary scripts that
 complement your version control workflow. This can be done, but be aware of the

--- a/docs/filesets.md
+++ b/docs/filesets.md
@@ -99,8 +99,29 @@ For example:
 
 ```toml
 [fileset-aliases]
-'LOCK' = '**/Cargo.lock | **/package-lock.json | **/uv.lock'
+LOCK = '**/Cargo.lock | **/package-lock.json | **/uv.lock'
 'not:x' = '~x'
+```
+
+### Alias descriptions
+
+Alias descriptions can be surfaced in shell completions by defining the alias
+as a table with `.doc` and `.definition` properties. For example:
+
+```toml
+[fileset-aliases]
+LOCK = {
+    definition = '**/Cargo.lock | **/package-lock.json | **/uv.lock',
+    doc = 'Lockfiles'
+}
+```
+
+You can also use the dotted key syntax:
+
+```toml
+[fileset-aliases]
+LOCK.definition = '**/Cargo.lock | **/package-lock.json | **/uv.lock'
+LOCK.doc = 'Lockfiles'
 ```
 
 ## Examples

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -576,10 +576,28 @@ For example:
 
 ```toml
 [revset-aliases]
-'HEAD' = '@-'
+HEAD = '@-'
 'user()' = 'user("me@example.org")'
 'user(x)' = 'author(x) | committer(x)'
 'grep:x' = 'description(regex:x)'
+```
+
+### Alias descriptions
+
+Alias descriptions can be surfaced in shell completions by defining the alias
+as a table with `.doc` and `.definition` properties. For example:
+
+```toml
+[revset-aliases]
+HEAD = { definition = '@-', doc = 'The parent of the working-copy commit' }
+```
+
+You can also use the dotted key syntax:
+
+```toml
+[revset-aliases]
+HEAD.definition = '@-'
+HEAD.doc = 'The parent of the working-copy commit'
 ```
 
 ### Built-in Aliases

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -850,12 +850,32 @@ For example:
 
 ```toml
 [template-aliases]
+sh = "commit_id.short()"
 'commit_change_ids' = '''
 concat(
   format_field("Commit ID", commit_id),
   format_field("Change ID", change_id),
 )
 '''
+```
+
+### Alias descriptions
+
+Alias descriptions can be surfaced in shell completions by defining the alias
+as a table with `.doc` and `.definition` properties. For example:
+
+```toml
+[template-aliases]
+sh = { definition = 'commit_id.short()', doc = 'Short commit ID' }
+```
+
+You can also use the dotted key syntax:
+
+```toml
+[template-aliases]
+sh.definition = 'commit_id.short()'
+sh.doc = 'Short commit ID'
+```
 'format_field(key, value)' = 'key ++ ": " ++ value ++ "\n"'
 'json:x' = 'json(x) ++ "\n"'
 ```

--- a/lib/src/dsl_util.rs
+++ b/lib/src/dsl_util.rs
@@ -562,14 +562,17 @@ impl<R: RuleType> FunctionCallParser<R> {
     }
 }
 
+/// A function alias containing `(params, definition, description)`.
+type FunctionAlias<V> = (Vec<String>, V, Option<String>);
+
 /// Map of symbol, pattern, and function aliases.
 #[derive(Clone, Debug, Default)]
 pub struct AliasesMap<P, V> {
-    symbol_aliases: HashMap<String, V>,
+    symbol_aliases: HashMap<String, (V, Option<String>)>,
     // name: (param, defn)
-    pattern_aliases: HashMap<String, (String, V)>,
+    pattern_aliases: HashMap<String, (String, V, Option<String>)>,
     // name: [(params, defn)] (sorted by arity)
-    function_aliases: HashMap<String, Vec<(Vec<String>, V)>>,
+    function_aliases: HashMap<String, Vec<FunctionAlias<V>>>,
     // Parser type P helps prevent misuse of AliasesMap of different language.
     parser: P,
 }
@@ -592,22 +595,27 @@ impl<P, V> AliasesMap<P, V> {
     ///
     /// Returns error if `decl` is invalid. The `defn` part isn't checked. A bad
     /// `defn` will be reported when the alias is substituted.
-    pub fn insert(&mut self, decl: impl AsRef<str>, defn: impl Into<V>) -> Result<(), P::Error>
+    pub fn insert(
+        &mut self,
+        decl: impl AsRef<str>,
+        defn: impl Into<V>,
+        doc: Option<String>,
+    ) -> Result<(), P::Error>
     where
         P: AliasDeclarationParser,
     {
         match self.parser.parse_declaration(decl.as_ref())? {
             AliasDeclaration::Symbol(name) => {
-                self.symbol_aliases.insert(name, defn.into());
+                self.symbol_aliases.insert(name, (defn.into(), doc));
             }
             AliasDeclaration::Pattern(name, param) => {
-                self.pattern_aliases.insert(name, (param, defn.into()));
+                self.pattern_aliases.insert(name, (param, defn.into(), doc));
             }
             AliasDeclaration::Function(name, params) => {
                 let overloads = self.function_aliases.entry(name).or_default();
-                match overloads.binary_search_by_key(&params.len(), |(params, _)| params.len()) {
-                    Ok(i) => overloads[i] = (params, defn.into()),
-                    Err(i) => overloads.insert(i, (params, defn.into())),
+                match overloads.binary_search_by_key(&params.len(), |(params, _, _)| params.len()) {
+                    Ok(i) => overloads[i] = (params, defn.into(), doc),
+                    Err(i) => overloads.insert(i, (params, defn.into(), doc)),
                 }
             }
         }
@@ -629,24 +637,36 @@ impl<P, V> AliasesMap<P, V> {
         self.function_aliases.keys().map(|n| n.as_ref())
     }
 
-    /// Looks up symbol alias by name. Returns identifier and definition text.
-    pub fn get_symbol(&self, name: &str) -> Option<(AliasId<'_>, &V)> {
+    /// Looks up symbol alias by name. Returns identifier, definition text, and
+    /// optional description.
+    pub fn get_symbol(&self, name: &str) -> Option<(AliasId<'_>, &V, Option<&str>)> {
         self.symbol_aliases
             .get_key_value(name)
-            .map(|(name, defn)| (AliasId::Symbol(name), defn))
+            .map(|(name, (defn, doc))| (AliasId::Symbol(name), defn, doc.as_deref()))
     }
 
-    /// Looks up pattern alias by name. Returns identifier, parameter name, and
-    /// definition text.
-    pub fn get_pattern(&self, name: &str) -> Option<(AliasId<'_>, &str, &V)> {
+    /// Looks up pattern alias by name. Returns identifier, parameter name,
+    /// definition text, and optional description.
+    pub fn get_pattern(&self, name: &str) -> Option<(AliasId<'_>, &str, &V, Option<&str>)> {
         self.pattern_aliases
             .get_key_value(name)
-            .map(|(name, (param, defn))| (AliasId::Pattern(name, param), param.as_ref(), defn))
+            .map(|(name, (param, defn, doc))| {
+                (
+                    AliasId::Pattern(name, param),
+                    param.as_ref(),
+                    defn,
+                    doc.as_deref(),
+                )
+            })
     }
 
     /// Looks up function alias by name and arity. Returns identifier, list of
-    /// parameter names, and definition text.
-    pub fn get_function(&self, name: &str, arity: usize) -> Option<(AliasId<'_>, &[String], &V)> {
+    /// parameter names, definition text, and optional description.
+    pub fn get_function(
+        &self,
+        name: &str,
+        arity: usize,
+    ) -> Option<(AliasId<'_>, &[String], &V, Option<&str>)> {
         let overloads = self.get_function_overloads(name)?;
         overloads.find_by_arity(arity)
     }
@@ -661,12 +681,12 @@ impl<P, V> AliasesMap<P, V> {
 #[derive(Clone, Debug)]
 struct AliasFunctionOverloads<'a, V> {
     name: &'a String,
-    overloads: &'a Vec<(Vec<String>, V)>,
+    overloads: &'a Vec<(Vec<String>, V, Option<String>)>,
 }
 
 impl<'a, V> AliasFunctionOverloads<'a, V> {
     fn arities(&self) -> impl DoubleEndedIterator<Item = usize> + ExactSizeIterator {
-        self.overloads.iter().map(|(params, _)| params.len())
+        self.overloads.iter().map(|(params, _, _)| params.len())
     }
 
     fn min_arity(&self) -> usize {
@@ -677,16 +697,24 @@ impl<'a, V> AliasFunctionOverloads<'a, V> {
         self.arities().next_back().unwrap()
     }
 
-    fn find_by_arity(&self, arity: usize) -> Option<(AliasId<'a>, &'a [String], &'a V)> {
+    fn find_by_arity(
+        &self,
+        arity: usize,
+    ) -> Option<(AliasId<'a>, &'a [String], &'a V, Option<&'a str>)> {
         let index = self
             .overloads
-            .binary_search_by_key(&arity, |(params, _)| params.len())
+            .binary_search_by_key(&arity, |(params, _, _)| params.len())
             .ok()?;
-        let (params, defn) = &self.overloads[index];
+        let (params, defn, doc) = &self.overloads[index];
         // Exact parameter names aren't needed to identify a function, but they
         // provide a better error indication. (e.g. "foo(x, y)" is easier to
         // follow than "foo/2".)
-        Some((AliasId::Function(self.name, params), params, defn))
+        Some((
+            AliasId::Function(self.name, params),
+            params,
+            defn,
+            doc.as_deref(),
+        ))
     }
 }
 
@@ -840,7 +868,7 @@ where
         if let Some(subst) = self.current_locals().get(name) {
             let id = AliasId::Parameter(name);
             Ok(T::alias_expanded(id, Box::new(subst.clone())))
-        } else if let Some((id, defn)) = self.aliases_map.get_symbol(name) {
+        } else if let Some((id, defn, _doc)) = self.aliases_map.get_symbol(name) {
             let locals = HashMap::new(); // Don't spill out the current scope
             self.expand_defn(id, defn, locals, span)
         } else {
@@ -853,7 +881,7 @@ where
         pattern: Box<PatternNode<'i, T>>,
         span: pest::Span<'i>,
     ) -> Result<T, Self::Error> {
-        if let Some((id, param, defn)) = self.aliases_map.get_pattern(pattern.name) {
+        if let Some((id, param, defn, _doc)) = self.aliases_map.get_pattern(pattern.name) {
             // Resolve argument in the current scope, and pass it in to the
             // alias expansion scope.
             let arg = self.fold_expression(pattern.value)?;
@@ -877,7 +905,7 @@ where
             function
                 .ensure_no_keyword_arguments()
                 .map_err(E::invalid_arguments)?;
-            let Some((id, params, defn)) = overloads.find_by_arity(function.arity()) else {
+            let Some((id, params, defn, _doc)) = overloads.find_by_arity(function.arity()) else {
                 let min = overloads.min_arity();
                 let max = overloads.max_arity();
                 let err = if max - min + 1 == overloads.arities().len() {

--- a/lib/src/fileset_parser.rs
+++ b/lib/src/fileset_parser.rs
@@ -603,7 +603,7 @@ mod tests {
     ) -> WithFilesetAliasesMap {
         let mut aliases_map = FilesetAliasesMap::new();
         for (decl, defn) in aliases {
-            aliases_map.insert(decl, defn).unwrap();
+            aliases_map.insert(decl, defn, None).unwrap();
         }
         WithFilesetAliasesMap { aliases_map }
     }
@@ -1037,58 +1037,58 @@ mod tests {
     #[test]
     fn test_parse_alias_symbol_decl() -> TestResult {
         let mut aliases_map = FilesetAliasesMap::new();
-        aliases_map.insert("sym", "symbol")?;
+        aliases_map.insert("sym", "symbol", None)?;
         assert_eq!(aliases_map.symbol_names().count(), 1);
-        let (id, defn) = aliases_map.get_symbol("sym").unwrap();
+        let (id, defn, _doc) = aliases_map.get_symbol("sym").unwrap();
         assert_eq!(id, AliasId::Symbol("sym"));
         assert_eq!(defn, "symbol");
 
         // Non-ASCII character isn't allowed in alias symbol. This rule can be
         // relaxed if needed.
-        assert!(aliases_map.insert("柔術", "none()").is_err());
+        assert!(aliases_map.insert("柔術", "none()", None).is_err());
         Ok(())
     }
 
     #[test]
     fn test_parse_alias_pattern_decl() -> TestResult {
         let mut aliases_map = FilesetAliasesMap::new();
-        assert!(aliases_map.insert("pat:", "bad_pattern").is_err());
-        aliases_map.insert("pat:a", "pattern_a")?;
-        aliases_map.insert("pat:b", "pattern_b")?;
+        assert!(aliases_map.insert("pat:", "bad_pattern", None).is_err());
+        aliases_map.insert("pat:a", "pattern_a", None)?;
+        aliases_map.insert("pat:b", "pattern_b", None)?;
         assert_eq!(aliases_map.pattern_names().count(), 1);
-        let (id, param, defn) = aliases_map.get_pattern("pat").unwrap();
+        let (id, param, defn, _doc) = aliases_map.get_pattern("pat").unwrap();
         assert_eq!(id, AliasId::Pattern("pat", "b"));
         assert_eq!(param, "b");
         assert_eq!(defn, "pattern_b");
 
         // Non-ASCII character isn't allowed. This rule can be relaxed if
         // needed.
-        assert!(aliases_map.insert("柔術:x", "none()").is_err());
-        assert!(aliases_map.insert("x:柔術", "none()").is_err());
+        assert!(aliases_map.insert("柔術:x", "none()", None).is_err());
+        assert!(aliases_map.insert("x:柔術", "none()", None).is_err());
         Ok(())
     }
 
     #[test]
     fn test_parse_alias_func_decl() -> TestResult {
         let mut aliases_map = FilesetAliasesMap::new();
-        assert!(aliases_map.insert("5func()", "bad_function").is_err());
-        aliases_map.insert("func()", "function_0")?;
-        aliases_map.insert("func(a)", "function_1a")?;
-        aliases_map.insert("func(b)", "function_1b")?;
-        aliases_map.insert("func(a, b)", "function_2")?;
+        assert!(aliases_map.insert("5func()", "bad_function", None).is_err());
+        aliases_map.insert("func()", "function_0", None)?;
+        aliases_map.insert("func(a)", "function_1a", None)?;
+        aliases_map.insert("func(b)", "function_1b", None)?;
+        aliases_map.insert("func(a, b)", "function_2", None)?;
         assert_eq!(aliases_map.function_names().count(), 1);
 
-        let (id, params, defn) = aliases_map.get_function("func", 0).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 0).unwrap();
         assert_eq!(id, AliasId::Function("func", &[]));
         assert!(params.is_empty());
         assert_eq!(defn, "function_0");
 
-        let (id, params, defn) = aliases_map.get_function("func", 1).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 1).unwrap();
         assert_eq!(id, AliasId::Function("func", &["b".to_owned()]));
         assert_eq!(params, ["b"]);
         assert_eq!(defn, "function_1b");
 
-        let (id, params, defn) = aliases_map.get_function("func", 2).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 2).unwrap();
         assert_eq!(
             id,
             AliasId::Function("func", &["a".to_owned(), "b".to_owned()])
@@ -1105,19 +1105,19 @@ mod tests {
         let mut aliases_map = FilesetAliasesMap::new();
         // Formal parameter 'a' can't be redefined
         assert_eq!(
-            aliases_map.insert("f(a, a)", "bad").unwrap_err().kind,
+            aliases_map.insert("f(a, a)", "bad", None).unwrap_err().kind,
             FilesetParseErrorKind::RedefinedFunctionParameter
         );
         // Trailing comma isn't allowed for empty parameter
-        assert!(aliases_map.insert("f(,)", "bad").is_err());
+        assert!(aliases_map.insert("f(,)", "bad", None).is_err());
         // Trailing comma is allowed for the last parameter
-        assert!(aliases_map.insert("g(a,)", "bad").is_ok());
-        assert!(aliases_map.insert("h(a ,  )", "bad").is_ok());
-        assert!(aliases_map.insert("i(,a)", "bad").is_err());
-        assert!(aliases_map.insert("j(a,,)", "bad").is_err());
-        assert!(aliases_map.insert("k(a  , , )", "bad").is_err());
-        assert!(aliases_map.insert("l(a,b,)", "bad").is_ok());
-        assert!(aliases_map.insert("m(a,,b)", "bad").is_err());
+        assert!(aliases_map.insert("g(a,)", "bad", None).is_ok());
+        assert!(aliases_map.insert("h(a ,  )", "bad", None).is_ok());
+        assert!(aliases_map.insert("i(,a)", "bad", None).is_err());
+        assert!(aliases_map.insert("j(a,,)", "bad", None).is_err());
+        assert!(aliases_map.insert("k(a  , , )", "bad", None).is_err());
+        assert!(aliases_map.insert("l(a,b,)", "bad", None).is_ok());
+        assert!(aliases_map.insert("m(a,,b)", "bad", None).is_err());
     }
 
     #[test]

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -3663,7 +3663,7 @@ mod tests {
     ) -> Result<Arc<UserRevsetExpression>, RevsetParseError> {
         let mut aliases_map = RevsetAliasesMap::new();
         for (decl, defn) in aliases {
-            aliases_map.insert(decl, defn)?;
+            aliases_map.insert(decl, defn, None)?;
         }
         let context = RevsetParseContext {
             aliases_map: &aliases_map,
@@ -3695,7 +3695,7 @@ mod tests {
         };
         let mut aliases_map = RevsetAliasesMap::new();
         for (decl, defn) in aliases {
-            aliases_map.insert(decl, defn)?;
+            aliases_map.insert(decl, defn, None)?;
         }
         let context = RevsetParseContext {
             aliases_map: &aliases_map,

--- a/lib/src/revset_parser.rs
+++ b/lib/src/revset_parser.rs
@@ -860,7 +860,7 @@ mod tests {
     ) -> WithRevsetAliasesMap<'i> {
         let mut aliases_map = RevsetAliasesMap::new();
         for (decl, defn) in aliases {
-            aliases_map.insert(decl, defn).unwrap();
+            aliases_map.insert(decl, defn, None).unwrap();
         }
         WithRevsetAliasesMap {
             aliases_map,
@@ -1435,54 +1435,58 @@ mod tests {
     fn test_parse_revset_alias_symbol_decl() {
         let mut aliases_map = RevsetAliasesMap::new();
         // Working copy or remote symbol cannot be used as an alias name.
-        assert!(aliases_map.insert("@", "none()").is_err());
-        assert!(aliases_map.insert("a@", "none()").is_err());
-        assert!(aliases_map.insert("a@b", "none()").is_err());
+        assert!(aliases_map.insert("@", "none()", None).is_err());
+        assert!(aliases_map.insert("a@", "none()", None).is_err());
+        assert!(aliases_map.insert("a@b", "none()", None).is_err());
         // Non-ASCII character isn't allowed in alias symbol. This rule can be
         // relaxed if needed.
-        assert!(aliases_map.insert("柔術", "none()").is_err());
+        assert!(aliases_map.insert("柔術", "none()", None).is_err());
     }
 
     #[test]
     fn test_parse_revset_alias_pattern_decl() -> TestResult {
         let mut aliases_map = RevsetAliasesMap::new();
-        assert!(aliases_map.insert("foo:", "none()").is_err());
+        assert!(aliases_map.insert("foo:", "none()", None).is_err());
         assert_eq!(aliases_map.pattern_names().count(), 0);
 
-        aliases_map.insert("bar:baz", "'bar pattern'")?;
+        aliases_map.insert("bar:baz", "'bar pattern'", None)?;
         assert_eq!(aliases_map.pattern_names().count(), 1);
-        let (id, param, defn) = aliases_map.get_pattern("bar").unwrap();
+        let (id, param, defn, _doc) = aliases_map.get_pattern("bar").unwrap();
         assert_eq!(id, AliasId::Pattern("bar", "baz"));
         assert_eq!(param, "baz");
         assert_eq!(defn, "'bar pattern'");
 
         // Non-ASCII character isn't allowed. This rule can be relaxed if
         // needed.
-        assert!(aliases_map.insert("柔術:x", "none()").is_err());
-        assert!(aliases_map.insert("x:柔術", "none()").is_err());
+        assert!(aliases_map.insert("柔術:x", "none()", None).is_err());
+        assert!(aliases_map.insert("x:柔術", "none()", None).is_err());
         Ok(())
     }
 
     #[test]
     fn test_parse_revset_alias_func_decl() -> TestResult {
         let mut aliases_map = RevsetAliasesMap::new();
-        assert!(aliases_map.insert("5func()", r#""is function 0""#).is_err());
-        aliases_map.insert("func()", r#""is function 0""#)?;
-        aliases_map.insert("func(a, b)", r#""is function 2""#)?;
-        aliases_map.insert("func(a)", r#""is function a""#)?;
-        aliases_map.insert("func(b)", r#""is function b""#)?;
+        assert!(
+            aliases_map
+                .insert("5func()", r#""is function 0""#, None)
+                .is_err()
+        );
+        aliases_map.insert("func()", r#""is function 0""#, None)?;
+        aliases_map.insert("func(a, b)", r#""is function 2""#, None)?;
+        aliases_map.insert("func(a)", r#""is function a""#, None)?;
+        aliases_map.insert("func(b)", r#""is function b""#, None)?;
 
-        let (id, params, defn) = aliases_map.get_function("func", 0).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 0).unwrap();
         assert_eq!(id, AliasId::Function("func", &[]));
         assert!(params.is_empty());
         assert_eq!(defn, r#""is function 0""#);
 
-        let (id, params, defn) = aliases_map.get_function("func", 1).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 1).unwrap();
         assert_eq!(id, AliasId::Function("func", &["b".to_owned()]));
         assert_eq!(params, ["b"]);
         assert_eq!(defn, r#""is function b""#);
 
-        let (id, params, defn) = aliases_map.get_function("func", 2).unwrap();
+        let (id, params, defn, _doc) = aliases_map.get_function("func", 2).unwrap();
         assert_eq!(
             id,
             AliasId::Function("func", &["a".to_owned(), "b".to_owned()])
@@ -1498,19 +1502,19 @@ mod tests {
     fn test_parse_revset_alias_formal_parameter() {
         let mut aliases_map = RevsetAliasesMap::new();
         // Working copy or remote symbol cannot be used as an parameter name.
-        assert!(aliases_map.insert("f(@)", "none()").is_err());
-        assert!(aliases_map.insert("f(a@)", "none()").is_err());
-        assert!(aliases_map.insert("f(a@b)", "none()").is_err());
+        assert!(aliases_map.insert("f(@)", "none()", None).is_err());
+        assert!(aliases_map.insert("f(a@)", "none()", None).is_err());
+        assert!(aliases_map.insert("f(a@b)", "none()", None).is_err());
         // Trailing comma isn't allowed for empty parameter
-        assert!(aliases_map.insert("f(,)", "none()").is_err());
+        assert!(aliases_map.insert("f(,)", "none()", None).is_err());
         // Trailing comma is allowed for the last parameter
-        assert!(aliases_map.insert("g(a,)", "none()").is_ok());
-        assert!(aliases_map.insert("h(a ,  )", "none()").is_ok());
-        assert!(aliases_map.insert("i(,a)", "none()").is_err());
-        assert!(aliases_map.insert("j(a,,)", "none()").is_err());
-        assert!(aliases_map.insert("k(a  , , )", "none()").is_err());
-        assert!(aliases_map.insert("l(a,b,)", "none()").is_ok());
-        assert!(aliases_map.insert("m(a,,b)", "none()").is_err());
+        assert!(aliases_map.insert("g(a,)", "none()", None).is_ok());
+        assert!(aliases_map.insert("h(a ,  )", "none()", None).is_ok());
+        assert!(aliases_map.insert("i(,a)", "none()", None).is_err());
+        assert!(aliases_map.insert("j(a,,)", "none()", None).is_err());
+        assert!(aliases_map.insert("k(a  , , )", "none()", None).is_err());
+        assert!(aliases_map.insert("l(a,b,)", "none()", None).is_ok());
+        assert!(aliases_map.insert("m(a,,b)", "none()", None).is_err());
     }
 
     #[test]


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

Enable dynamic shell completions (e.g., in Fish) to render descriptions for custom aliases. Descriptions are defined using the `.doc` property, while the alias itself is specified in the `.definition` property in the config.toml file.

This applies to all alias namespaces: `[aliases]`, `[revset-aliases]`, `[template-aliases]`, and `[fileset-aliases]`.

For example, we get:

<img width="1086" height="81" alt="image" src="https://github.com/user-attachments/assets/5e396b30-6d51-4b80-bf74-a631b8a591b7" />


for the following `config.toml`:

```toml
[aliases]
# Using dotted key syntax
tug.definition = ["bookmark", "advance"]
tug.doc = "Moves the closest ancestral bookmark(s) up to the parent of your working copy (@-)"

# Using table syntax
[aliases.tug-push]
definition = ["util", "exec", "--", "bash", "-c", "jj tug && jj git push"]
doc = "Tugs the nearest ancestral bookmark and pushes it to git"

# Alternatively
...
[aliases]
tug = { 
    definition = ["bookmark", "advance"],
    doc = "Moves the closest ancestral bookmark(s) up to the parent of your working copy (@-)"
}
```


# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
