### PR TITLE
make `walk_predecessors()` return stream instead of iterator

### DIFF
--- a/cli/examples/custom-commit-templater/main.rs
+++ b/cli/examples/custom-commit-templater/main.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use futures::TryStreamExt as _;
 use jj_cli::cli_util::CliRunner;
 use jj_cli::commit_templater::CommitTemplateBuildFnTable;
 use jj_cli::commit_templater::CommitTemplateLanguageExtension;
@@ -37,6 +38,7 @@ use jj_lib::revset::RevsetResolutionError;
 use jj_lib::revset::SymbolResolverExtension;
 use jj_lib::revset::UserRevsetExpression;
 use once_cell::sync::OnceCell;
+use pollster::FutureExt as _;
 
 struct HexCounter;
 
@@ -71,9 +73,12 @@ impl MostDigitsInId {
             RevsetExpression::all()
                 .evaluate(repo)
                 .unwrap()
+                .stream()
+                .try_collect::<Vec<_>>()
+                .block_on()
+                .unwrap()
                 .iter()
-                .map(Result::unwrap)
-                .map(|id| num_digits_in_id(&id))
+                .map(num_digits_in_id)
                 .max()
                 .unwrap_or(0)
         })
@@ -98,9 +103,13 @@ impl PartialSymbolResolver for TheDigitestResolver {
         Ok(RevsetExpression::all()
             .evaluate(repo)
             .map_err(|err| RevsetResolutionError::Other(err.into()))?
+            .stream()
+            .try_collect::<Vec<_>>()
+            .block_on()
+            .unwrap()
             .iter()
-            .map(Result::unwrap)
-            .find(|id| num_digits_in_id(id) == self.cache.count(repo)))
+            .find(|id| num_digits_in_id(id) == self.cache.count(repo))
+            .cloned())
     }
 }
 

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -14,7 +14,9 @@
 
 use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
+use futures::StreamExt as _;
 use futures::TryStreamExt as _;
+use futures::executor::block_on_stream;
 use itertools::Itertools as _;
 use jj_lib::commit::Commit;
 use jj_lib::evolution::CommitEvolutionEntry;
@@ -144,7 +146,8 @@ pub(crate) async fn cmd_evolog(
     let formatter = formatter.as_mut();
 
     let repo = workspace_command.repo();
-    let evolution_entries = walk_predecessors(repo, &start_commit_ids);
+    let evolution_entries =
+        block_on_stream(walk_predecessors(repo, &start_commit_ids).boxed_local());
     if !args.no_graph {
         let mut raw_output = formatter.raw()?;
         let mut graph = get_graphlog(graph_style, raw_output.as_mut());

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -16,7 +16,10 @@ use std::cmp::min;
 
 use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
+use futures::StreamExt as _;
 use futures::TryStreamExt as _;
+use futures::stream;
+use futures::stream::LocalBoxStream;
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
@@ -28,7 +31,7 @@ use jj_lib::repo::Repo as _;
 use jj_lib::revset::RevsetEvaluationError;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetFilterPredicate;
-use jj_lib::revset::RevsetIteratorExt as _;
+use jj_lib::revset::RevsetStreamExt as _;
 use pollster::FutureExt as _;
 use tracing::instrument;
 
@@ -170,9 +173,10 @@ pub(crate) async fn cmd_log(
             min(lower, limit)
         } else {
             revset
-                .iter()
+                .stream()
                 .take(limit)
-                .process_results(|iter| iter.count())?
+                .try_fold(0, |count, _| async move { Ok(count + 1) })
+                .await?
         };
         let mut formatter = ui.stdout_formatter();
         writeln!(formatter, "{count}")?;
@@ -320,17 +324,17 @@ pub(crate) async fn cmd_log(
                 }
             }
         } else {
-            let iter: Box<dyn Iterator<Item = Result<CommitId, RevsetEvaluationError>>> = {
-                let forward_iter = revset.iter().take(args.limit.unwrap_or(usize::MAX));
+            let id_stream: LocalBoxStream<Result<CommitId, RevsetEvaluationError>> = {
+                let forward_stream = revset.stream().take(args.limit.unwrap_or(usize::MAX));
                 if args.reversed {
-                    let entries: Vec<_> = forward_iter.try_collect()?;
-                    Box::new(entries.into_iter().rev().map(Ok))
+                    let entries: Vec<_> = forward_stream.try_collect().await?;
+                    stream::iter(entries.into_iter().rev().map(Ok)).boxed_local()
                 } else {
-                    Box::new(forward_iter)
+                    forward_stream.boxed_local()
                 }
             };
-            for commit_or_error in iter.commits(store) {
-                let commit = commit_or_error?;
+            let mut commit_stream = id_stream.commits(store);
+            while let Some(commit) = commit_stream.try_next().await? {
                 with_content_format
                     .write(formatter, |formatter| template.format(&commit, formatter))?;
                 if let Some(renderer) = &diff_renderer {

--- a/lib/src/evolution.rs
+++ b/lib/src/evolution.rs
@@ -117,9 +117,11 @@ impl<I> WalkPredecessors<'_, I>
 where
     I: Stream<Item = OpStoreResult<Operation>> + Unpin,
 {
-    async fn try_next(&mut self) -> Result<Option<CommitEvolutionEntry>, WalkPredecessorsError> {
+    async fn try_next_impl(
+        &mut self,
+    ) -> Result<Option<CommitEvolutionEntry>, WalkPredecessorsError> {
         while !self.to_visit.is_empty() && self.queued.is_empty() {
-            let Some(op) = self.op_ancestors.next().await.transpose()? else {
+            let Some(op) = self.op_ancestors.try_next().await? else {
                 // Scanned all operations, no fallback needed.
                 self.flush_commits().await?;
                 break;
@@ -269,7 +271,7 @@ where
     type Item = Result<CommitEvolutionEntry, WalkPredecessorsError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.try_next().block_on().transpose()
+        self.try_next_impl().block_on().transpose()
     }
 }
 

--- a/lib/src/evolution.rs
+++ b/lib/src/evolution.rs
@@ -26,8 +26,8 @@ use futures::StreamExt as _;
 use futures::TryStreamExt as _;
 use futures::future::join_all;
 use futures::future::try_join_all;
+use futures::stream;
 use itertools::Itertools as _;
-use pollster::FutureExt as _;
 use thiserror::Error;
 
 use crate::backend::BackendError;
@@ -96,14 +96,18 @@ pub enum WalkPredecessorsError {
 pub fn walk_predecessors<'repo>(
     repo: &'repo ReadonlyRepo,
     start_commits: &[CommitId],
-) -> impl Iterator<Item = Result<CommitEvolutionEntry, WalkPredecessorsError>> + use<'repo> {
+) -> impl Stream<Item = Result<CommitEvolutionEntry, WalkPredecessorsError>> + use<'repo> {
     let op_ancestors = op_walk::walk_ancestors(slice::from_ref(repo.operation())).boxed_local();
-    WalkPredecessors {
+    let state = WalkPredecessors {
         repo,
         op_ancestors,
         to_visit: start_commits.to_vec(),
         queued: VecDeque::new(),
-    }
+    };
+    stream::unfold(state, |mut state| async move {
+        let result = state.try_next_impl().await.transpose()?;
+        Some((result, state))
+    })
 }
 
 struct WalkPredecessors<'repo, I> {
@@ -261,17 +265,6 @@ where
             });
         }
         Ok(())
-    }
-}
-
-impl<I> Iterator for WalkPredecessors<'_, I>
-where
-    I: Stream<Item = OpStoreResult<Operation>> + Unpin,
-{
-    type Item = Result<CommitEvolutionEntry, WalkPredecessorsError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.try_next_impl().block_on().transpose()
     }
 }
 

--- a/lib/tests/test_evolution_predecessors.rs
+++ b/lib/tests/test_evolution_predecessors.rs
@@ -15,6 +15,8 @@
 use std::slice;
 
 use assert_matches::assert_matches;
+use futures::StreamExt as _;
+use futures::TryStreamExt as _;
 use itertools::Itertools as _;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
@@ -39,6 +41,7 @@ use testutils::write_random_commit;
 fn collect_predecessors(repo: &ReadonlyRepo, start_commit: &CommitId) -> Vec<CommitEvolutionEntry> {
     walk_predecessors(repo, slice::from_ref(start_commit))
         .try_collect()
+        .block_on()
         .unwrap()
 }
 
@@ -452,7 +455,10 @@ fn test_walk_predecessors_direct_cycle_within_op() -> TestResult {
         loader.load_at(&op).block_on()?
     };
     assert_matches!(
-        walk_predecessors(&repo1, slice::from_ref(commit1.id())).next(),
+        walk_predecessors(&repo1, slice::from_ref(commit1.id()))
+            .boxed_local()
+            .next()
+            .block_on(),
         Some(Err(WalkPredecessorsError::CycleDetected(_)))
     );
     Ok(())
@@ -482,7 +488,10 @@ fn test_walk_predecessors_indirect_cycle_within_op() -> TestResult {
         loader.load_at(&op).block_on()?
     };
     assert_matches!(
-        walk_predecessors(&repo1, slice::from_ref(commit3.id())).next(),
+        walk_predecessors(&repo1, slice::from_ref(commit3.id()))
+            .boxed_local()
+            .next()
+            .block_on(),
         Some(Err(WalkPredecessorsError::CycleDetected(_)))
     );
     Ok(())

--- a/lib/tests/test_operations.rs
+++ b/lib/tests/test_operations.rs
@@ -45,6 +45,7 @@ use testutils::write_random_commit_with_parents;
 fn get_predecessors(repo: &ReadonlyRepo, id: &CommitId) -> Vec<CommitId> {
     let entries: Vec<_> = walk_predecessors(repo, slice::from_ref(id))
         .try_collect()
+        .block_on()
         .expect("unreachable predecessors shouldn't be visited");
     let first = entries
         .first()


### PR DESCRIPTION
Extracted and fixed from PR #9165

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
