### PR TITLE
templater: provide `TreeEntry.last_modified() -> Commit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * New `ByteString` template type for things like file content.
 
+* `TreeEntry` and `TreeDiffEntry` template types now have a `last_modified()`
+  method that returns the most recent ancestor `Commit` that modified the given
+  file path. This enables `jj file list` (and other template contexts that
+  expose file entries) to display per-file last-modified commit information. Example: `jj file list -T 'path ++ " " ++ self.last_modified().description().first_line() ++ "\n"'`
+
 ### Fixed bugs
 
 * Improving consistency with `git` handling of `.gitignore`, including `/`

--- a/cli/src/commands/file/list.rs
+++ b/cli/src/commands/file/list.rs
@@ -82,6 +82,7 @@ pub(crate) async fn cmd_file_list(
     let mut formatter = ui.stdout_formatter();
     for (path, value) in tree.entries_matching(matcher.as_ref()) {
         let entry = TreeEntry {
+            commit: Some(commit.clone()),
             path,
             value: value?,
         };

--- a/cli/src/commands/file/show.rs
+++ b/cli/src/commands/file/show.rs
@@ -110,6 +110,7 @@ pub(crate) async fn cmd_file_show(
         if !value.is_tree() {
             ui.request_pager();
             let entry = TreeEntry {
+                commit: Some(commit.clone()),
                 path: path.to_owned(),
                 value,
             };
@@ -127,7 +128,11 @@ pub(crate) async fn cmd_file_show(
         &tree,
         tree.entries_matching(matcher.as_ref())
             .map(|(path, value)| Ok((path, value?)))
-            .map_ok(|(path, value)| TreeEntry { path, value }),
+            .map_ok(|(path, value)| TreeEntry {
+                commit: Some(commit.clone()),
+                path,
+                value,
+            }),
     )
     .await?;
     print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -70,6 +70,8 @@ use jj_lib::revset;
 use jj_lib::revset::Revset;
 use jj_lib::revset::RevsetContainingFn;
 use jj_lib::revset::RevsetDiagnostics;
+use jj_lib::revset::RevsetExpression;
+use jj_lib::revset::RevsetFilterPredicate;
 use jj_lib::revset::RevsetParseContext;
 use jj_lib::revset::UserRevsetExpression;
 use jj_lib::rewrite::rebase_to_dest_parent;
@@ -1371,7 +1373,13 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                 let tree = commit.tree();
                 let entries: Vec<_> = tree
                     .entries_matching(&*matcher)
-                    .map(|(path, value)| value.map(|value| TreeEntry { path, value }))
+                    .map(|(path, value)| {
+                        value.map(|value| TreeEntry {
+                            commit: Some(commit.clone()),
+                            path,
+                            value,
+                        })
+                    })
                     .try_collect()?;
                 Ok(entries)
             });
@@ -1386,7 +1394,13 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
                 let tree = commit.tree();
                 let entries: Vec<_> = tree
                     .conflicts()
-                    .map(|(path, value)| value.map(|value| TreeEntry { path, value }))
+                    .map(|(path, value)| {
+                        value.map(|value| TreeEntry {
+                            commit: Some(commit.clone()),
+                            path,
+                            value,
+                        })
+                    })
                     .try_collect()?;
                 Ok(entries)
             });
@@ -1526,6 +1540,8 @@ fn builtin_commit_evolution_entry_methods<'repo>()
                     rebase_to_dest_parent(repo, &predecessors, &entry.commit).block_on()?;
                 let to_tree = entry.commit.tree();
                 Ok(TreeDiff {
+                    from_commits: Some(predecessors),
+                    to_commit: Some(entry.commit.clone()),
                     from_tree,
                     to_tree,
                     matcher: matcher.clone(),
@@ -2329,6 +2345,8 @@ fn builtin_shortest_id_prefix_methods<'repo>()
 /// Pair of trees to be diffed.
 #[derive(Debug)]
 pub struct TreeDiff {
+    from_commits: Option<Vec<Commit>>,
+    to_commit: Option<Commit>,
     from_tree: MergedTree,
     to_tree: MergedTree,
     matcher: Rc<dyn Matcher>,
@@ -2348,6 +2366,8 @@ impl TreeDiff {
             copy_records.add_records(records);
         }
         Ok(Self {
+            from_commits: Some(commit.parents().await?),
+            to_commit: Some(commit.clone()),
             from_tree: commit.parent_tree(repo).await?,
             to_tree: commit.tree(),
             matcher,
@@ -2361,8 +2381,16 @@ impl TreeDiff {
     }
 
     async fn collect_entries(&self) -> BackendResult<Vec<TreeDiffEntry>> {
+        let from_commits = self.from_commits.clone();
+        let to_commit = self.to_commit.clone();
         self.diff_stream()
-            .map(TreeDiffEntry::from_backend_entry_with_copies)
+            .map(move |entry| {
+                TreeDiffEntry::from_backend_entry_with_copies(
+                    entry,
+                    from_commits.clone(),
+                    to_commit.clone(),
+                )
+            })
             .try_collect()
             .await
     }
@@ -2565,13 +2593,21 @@ fn builtin_tree_diff_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, T
 /// [`MergedTree`] diff entry.
 #[derive(Clone, Debug)]
 pub struct TreeDiffEntry {
+    pub from_commits: Option<Vec<Commit>>,
+    pub to_commit: Option<Commit>,
     pub path: CopiesTreeDiffEntryPath,
     pub values: Diff<MergedTreeValue>,
 }
 
 impl TreeDiffEntry {
-    pub fn from_backend_entry_with_copies(entry: CopiesTreeDiffEntry) -> BackendResult<Self> {
+    pub fn from_backend_entry_with_copies(
+        entry: CopiesTreeDiffEntry,
+        from_commits: Option<Vec<Commit>>,
+        to_commit: Option<Commit>,
+    ) -> BackendResult<Self> {
         Ok(Self {
+            from_commits,
+            to_commit,
             path: entry.path,
             values: entry.values?,
         })
@@ -2583,6 +2619,10 @@ impl TreeDiffEntry {
 
     fn into_source_entry(self) -> TreeEntry {
         TreeEntry {
+            // TODO: source() is ambiguous for merge diffs.
+            commit: self
+                .from_commits
+                .and_then(|commits| commits.first().cloned()),
             path: self.path.source.map_or(self.path.target, |(path, _)| path),
             value: self.values.before,
         }
@@ -2590,6 +2630,7 @@ impl TreeDiffEntry {
 
     fn into_target_entry(self) -> TreeEntry {
         TreeEntry {
+            commit: self.to_commit,
             path: self.path.target,
             value: self.values.after,
         }
@@ -2661,12 +2702,45 @@ fn builtin_tree_diff_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'r
             Ok(out_property.into_dyn_wrapped())
         },
     );
+    map.insert(
+        "last_modified",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let repo = language.repo;
+            let out_property = self_property.and_then(move |entry| {
+                let commit = entry.to_commit.as_ref().ok_or_else(|| {
+                    TemplatePropertyError(
+                        "No commit context available for last_modified()"
+                            .to_string()
+                            .into(),
+                    )
+                })?;
+                let path = entry.path.target();
+                let expr = RevsetExpression::commit(commit.id().clone())
+                    .ancestors()
+                    .intersection(&RevsetExpression::filter(RevsetFilterPredicate::File(
+                        FilesetExpression::file_path(path.to_owned()),
+                    )))
+                    .heads();
+                let revset = expr
+                    .evaluate(repo)
+                    .map_err(|err| TemplatePropertyError(err.into_backend_error().into()))?;
+                let mut iter = revset.iter();
+                if let Some(id) = iter.next() {
+                    return Ok(repo.store().get_commit(&id?)?);
+                }
+                Ok(commit.clone())
+            });
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
     map
 }
 
 /// [`MergedTree`] entry.
 #[derive(Clone, Debug)]
 pub struct TreeEntry {
+    pub commit: Option<Commit>,
     pub path: RepoPathBuf,
     pub value: MergedTreeValue,
 }
@@ -2680,6 +2754,39 @@ fn builtin_tree_entry_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, 
         |_language, _diagnostics, _build_ctx, self_property, function| {
             function.expect_no_arguments()?;
             let out_property = self_property.map(|entry| entry.path);
+            Ok(out_property.into_dyn_wrapped())
+        },
+    );
+    map.insert(
+        "last_modified",
+        |language, _diagnostics, _build_ctx, self_property, function| {
+            function.expect_no_arguments()?;
+            let repo = language.repo;
+            let out_property = self_property.and_then(move |entry| {
+                let commit = entry.commit.ok_or_else(|| {
+                    TemplatePropertyError(
+                        "No commit context available for last_modified()"
+                            .to_string()
+                            .into(),
+                    )
+                })?;
+                let expr = RevsetExpression::commit(commit.id().clone())
+                    .ancestors()
+                    .intersection(&RevsetExpression::filter(RevsetFilterPredicate::File(
+                        FilesetExpression::file_path(entry.path),
+                    )))
+                    .heads();
+                let revset = expr
+                    .evaluate(repo)
+                    .map_err(|err| TemplatePropertyError(err.into_backend_error().into()))?;
+                let mut iter = revset.iter();
+                if let Some(id) = iter.next() {
+                    return Ok(repo.store().get_commit(&id?)?);
+                }
+                // Fallback to the current commit if no ancestor modified it (shouldn't happen
+                // if the file exists)
+                Ok(commit)
+            });
             Ok(out_property.into_dyn_wrapped())
         },
     );
@@ -3050,7 +3157,6 @@ mod tests {
     use jj_lib::config::ConfigSource;
     use jj_lib::fileset::FilesetAliasesMap;
     use jj_lib::revset::RevsetAliasesMap;
-    use jj_lib::revset::RevsetExpression;
     use jj_lib::revset::RevsetExtensions;
     use jj_lib::revset::RevsetWorkspaceContext;
     use testutils::TestRepoBackend;

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -2232,7 +2232,8 @@ pub async fn show_templated(
     template: &TemplateRenderer<'_, commit_templater::TreeDiffEntry>,
 ) -> Result<(), DiffRenderError> {
     while let Some(entry) = tree_diff.next().await {
-        let entry = commit_templater::TreeDiffEntry::from_backend_entry_with_copies(entry)?;
+        let entry =
+            commit_templater::TreeDiffEntry::from_backend_entry_with_copies(entry, None, None)?;
         template.format(&entry, formatter)?;
     }
     Ok(())

--- a/cli/tests/test_file_list_command.rs
+++ b/cli/tests/test_file_list_command.rs
@@ -93,3 +93,27 @@ fn test_file_list() {
     [EOF]
     ");
 }
+
+#[test]
+fn test_file_list_last_modified() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1", "content1");
+    work_dir.run_jj(["commit", "-m", "commit 1"]).success();
+
+    work_dir.write_file("file2", "content2");
+    work_dir.run_jj(["commit", "-m", "commit 2"]).success();
+
+    work_dir.write_file("file1", "content1 modified");
+    work_dir.run_jj(["commit", "-m", "commit 3"]).success();
+
+    let template = r#"path ++ " " ++ self.last_modified().description().first_line() ++ "\n""#;
+    let output = work_dir.run_jj(["file", "list", "-T", template]);
+    insta::assert_snapshot!(output.normalize_backslash(), @"
+    file1 commit 3
+    file2 commit 2
+    [EOF]
+    ");
+}

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -765,6 +765,9 @@ This type cannot be printed. The following methods are defined.
   `"A"` for added, `"D"` for removed, `"C"` for copied, or `"R"` for renamed.
 * `.source() -> TreeEntry`: The source (or left) entry.
 * `.target() -> TreeEntry`: The target (or right) entry.
+* `.last_modified() -> Commit`: The most recent ancestor commit that modified this
+  file path. Walks ancestors of the entry's commit filtered by the file path and
+  returns the head of that set.
 
 ### `TreeEntry` type
 
@@ -779,6 +782,9 @@ This type cannot be printed. The following methods are defined.
 * `.file_type() -> String`: One of `"file"`, `"symlink"`, `"tree"`,
   `"git-submodule"`, or `"conflict"`.
 * `.executable() -> Boolean`: True if the entry is an executable file.
+* `.last_modified() -> Commit`: The most recent ancestor commit that modified this
+  file path. Walks ancestors of the entry's commit filtered by the file path and
+  returns the head of that set.
 
 ### `WorkspaceRef` type
 


### PR DESCRIPTION
Hello,

Today, while browsing Mastodon, I came across [`llimllib/git-ls`](https://github.com/llimllib/git-ls), a small tool that show for each file, the commit that last modified it. I really liked the idea and started wondering: _could we do the same thing natively in JJ, using the template system_ ? This PR is the premises of a solution.

To answer "_which commit last modified this file ?_", every file entry needs to know _which commit it belongs to_. Both `TreeEntry` and `TreeDiffEntry` were extended with optional fields:

- `TreeEntry` with `commit: Option<Commit>`
- `TreeDiffEntry` with `from_commits: Option<Vec<Commit>>` and `to_commit: Option<Commit>`

These fields are `Option` so that call sites that do not have commit context (e.g. raw diff rendering in `diff_util.rs`) are not forced to provide one.

Also, all places that build a `TreeEntry` or `TreeDiffEntry` had to be updated to fill in the commit context:

- `file list` and `file show` commands now pass `Some(commit.clone())` when constructing entries
- `builtin_commit_methods` (the `files()` and `conflicts()` template methods on a `Commit`) also carry the commit through
- `TreeDiff::from_commit()` constructor populates `from_commits` (the commit's parents) and `to_commit`
- `into_source_entry()` and `into_target_entry()` on `TreeDiffEntry` map those fields down to the resulting `TreeEntry`

The core of the feature has been given to me on Discord by adding a `self.last_modified()` template method. Both types now expose a `last_modified()` method that:

1. Takes the entry's commit as a starting point
2. Builds a revset: `ancestors(commit) & file(path) | heads(...)`: essentially "_walk backwards from here, keep only commits that touched this path, take the most recent_"
3. Returns the first result as a `Commit`, enabling full template chaining like `last_modified().description().first_line()`, which is precisely what we ultimately want !
4. Falls back to the current commit if the revset yields nothing (_defensive, should not normally happen for a file that exists in the tree_)

Finally, a new test verifies the end-to-end behaviour.

<img width="1443" height="532" alt="image" src="https://github.com/user-attachments/assets/517049e9-4612-4faf-82fd-6d121bedfc2e" />

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
