### PR TITLE
templater: add `revset(query) -> List<Commit>`

### DIFF
--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -71,6 +71,8 @@ use jj_lib::revset::Revset;
 use jj_lib::revset::RevsetContainingFn;
 use jj_lib::revset::RevsetDiagnostics;
 use jj_lib::revset::RevsetParseContext;
+use jj_lib::revset::RevsetParseError;
+use jj_lib::revset::RevsetStreamExt as _;
 use jj_lib::revset::UserRevsetExpression;
 use jj_lib::rewrite::rebase_to_dest_parent;
 use jj_lib::settings::UserSettings;
@@ -100,6 +102,7 @@ use crate::operation_templater::OperationTemplateEnvironment;
 use crate::operation_templater::OperationTemplatePropertyKind;
 use crate::operation_templater::OperationTemplatePropertyVar;
 use crate::revset_util;
+use crate::revset_util::UserRevsetEvaluationError;
 use crate::template_builder;
 use crate::template_builder::BuildContext;
 use crate::template_builder::CoreTemplateBuildFnTable;
@@ -1027,10 +1030,58 @@ impl<'repo> CommitKeywordCache<'repo> {
     }
 }
 
+fn user_revset_template_parse_error(
+    err: RevsetParseError,
+    span: pest::Span<'_>,
+) -> TemplateParseError {
+    TemplateParseError::expression("In revset expression", span).with_source(err)
+}
+
+fn user_revset_template_evaluation_error(
+    err: UserRevsetEvaluationError,
+    span: pest::Span<'_>,
+) -> TemplateParseError {
+    TemplateParseError::expression("Failed to evaluate revset", span).with_source(err)
+}
+
 /// Builtin functions for the commit template language.
 fn builtin_commit_template_functions<'repo>()
 -> TemplateBuildFunctionFnMap<'repo, CommitTemplateLanguage<'repo>> {
     let mut map = TemplateBuildFunctionFnMap::<CommitTemplateLanguage>::new();
+    map.insert("revset", |language, diagnostics, build_ctx, function| {
+        let [query_node] = function.expect_exact_arguments()?;
+        let query_property =
+            expect_stringify_expression(language, diagnostics, build_ctx, query_node)?;
+        let repo = language.repo;
+        let revset_parse_context = language.revset_parse_context.clone();
+        let id_prefix_context = language.id_prefix_context;
+        if let Ok(query) = query_property.extract() {
+            let (expression, inner_diagnostics) =
+                parse_user_revset_expression(&revset_parse_context, &query)
+                    .map_err(|err| user_revset_template_parse_error(err, query_node.span))?;
+            let commits = evaluate_user_revset_commits(
+                repo,
+                &revset_parse_context,
+                id_prefix_context,
+                &expression,
+            )
+            .map_err(|err| user_revset_template_evaluation_error(err, query_node.span))?;
+            extend_user_revset_diagnostics(diagnostics, query_node.span, inner_diagnostics);
+            Ok(Literal(commits).into_dyn_wrapped())
+        } else {
+            let out_property = query_property.and_then(move |query| {
+                let (expression, _) = parse_user_revset_expression(&revset_parse_context, &query)?;
+                let commits = evaluate_user_revset_commits(
+                    repo,
+                    &revset_parse_context,
+                    id_prefix_context,
+                    &expression,
+                )?;
+                Ok(commits)
+            });
+            Ok(out_property.into_dyn_wrapped())
+        }
+    });
     map.insert(
         "git_web_url",
         |language, diagnostics, build_ctx, function| {
@@ -1304,18 +1355,45 @@ fn builtin_commit_methods<'repo>() -> CommitTemplateBuildMethodFnMap<'repo, Comm
     );
     map.insert(
         "contained_in",
-        |language, diagnostics, _build_ctx, self_property, function| {
+        |language, diagnostics, build_ctx, self_property, function| {
             let [revset_node] = function.expect_exact_arguments()?;
-
-            let is_contained =
-                template_parser::catch_aliases(diagnostics, revset_node, |diagnostics, node| {
-                    let text = template_parser::expect_string_literal(node)?;
-                    let revset = evaluate_user_revset(language, diagnostics, node.span, text)?;
-                    Ok(revset.containing_fn())
-                })?;
-
-            let out_property = self_property.and_then(move |commit| Ok(is_contained(commit.id())?));
-            Ok(out_property.into_dyn_wrapped())
+            let query_property =
+                expect_stringify_expression(language, diagnostics, build_ctx, revset_node)?;
+            let repo = language.repo;
+            let revset_parse_context = language.revset_parse_context.clone();
+            let id_prefix_context = language.id_prefix_context;
+            if let Ok(query) = query_property.extract() {
+                let (expression, inner_diagnostics) =
+                    parse_user_revset_expression(&revset_parse_context, &query)
+                        .map_err(|err| user_revset_template_parse_error(err, revset_node.span))?;
+                let is_contained = evaluate_user_revset_containing_fn(
+                    repo,
+                    &revset_parse_context,
+                    id_prefix_context,
+                    &expression,
+                )
+                .map_err(|err| user_revset_template_evaluation_error(err, revset_node.span))?;
+                extend_user_revset_diagnostics(diagnostics, revset_node.span, inner_diagnostics);
+                let out_property = self_property.and_then(move |commit| {
+                    Ok(is_contained(commit.id()).map_err(UserRevsetEvaluationError::Evaluation)?)
+                });
+                Ok(out_property.into_dyn_wrapped())
+            } else {
+                let out_property =
+                    (self_property, query_property).and_then(move |(commit, query)| {
+                        let (expression, _) =
+                            parse_user_revset_expression(&revset_parse_context, &query)?;
+                        let is_contained = evaluate_user_revset_containing_fn(
+                            repo,
+                            &revset_parse_context,
+                            id_prefix_context,
+                            &expression,
+                        )?;
+                        Ok(is_contained(commit.id())
+                            .map_err(UserRevsetEvaluationError::Evaluation)?)
+                    });
+                Ok(out_property.into_dyn_wrapped())
+            }
         },
     );
     map.insert(
@@ -1420,6 +1498,72 @@ fn extract_working_copies(repo: &dyn Repo, commit: &Commit) -> Vec<WorkspaceRef>
         .collect()
 }
 
+fn extend_user_revset_diagnostics(
+    diagnostics: &mut TemplateDiagnostics,
+    span: pest::Span<'_>,
+    inner_diagnostics: RevsetDiagnostics,
+) {
+    diagnostics.extend_with(inner_diagnostics, |diag| {
+        TemplateParseError::expression("In revset expression", span).with_source(diag)
+    });
+}
+
+fn evaluate_user_revset_commits<'repo>(
+    repo: &'repo dyn Repo,
+    revset_parse_context: &RevsetParseContext<'repo>,
+    id_prefix_context: &'repo IdPrefixContext,
+    expression: &UserRevsetExpression,
+) -> Result<Vec<Commit>, UserRevsetEvaluationError> {
+    let revset = evaluate_user_revset(repo, revset_parse_context, id_prefix_context, expression)?;
+    let mut commits: Vec<_> = revset
+        .stream()
+        .commits(repo.store())
+        .try_collect::<Vec<_>>()
+        .block_on()
+        .map_err(UserRevsetEvaluationError::Evaluation)?;
+    commits.sort_by_key(|c| std::cmp::Reverse(c.committer().timestamp.timestamp));
+    Ok(commits)
+}
+
+fn evaluate_user_revset_containing_fn<'repo>(
+    repo: &'repo dyn Repo,
+    revset_parse_context: &RevsetParseContext<'repo>,
+    id_prefix_context: &'repo IdPrefixContext,
+    expression: &UserRevsetExpression,
+) -> Result<Box<RevsetContainingFn<'repo>>, UserRevsetEvaluationError> {
+    let revset = evaluate_user_revset(repo, revset_parse_context, id_prefix_context, expression)?;
+    Ok(revset.containing_fn())
+}
+
+fn parse_user_revset_expression(
+    revset_parse_context: &RevsetParseContext<'_>,
+    revset_str: &str,
+) -> Result<(Arc<UserRevsetExpression>, RevsetDiagnostics), RevsetParseError> {
+    let mut diagnostics = RevsetDiagnostics::new();
+    let expression = revset::parse(&mut diagnostics, revset_str, revset_parse_context)?;
+    let expression = expression.intersection(&UserRevsetExpression::all());
+    Ok((expression, diagnostics))
+}
+
+fn evaluate_user_revset<'repo>(
+    repo: &'repo dyn Repo,
+    revset_parse_context: &RevsetParseContext<'repo>,
+    id_prefix_context: &'repo IdPrefixContext,
+    expression: &UserRevsetExpression,
+) -> Result<Box<dyn Revset + 'repo>, UserRevsetEvaluationError> {
+    let symbol_resolver = revset_util::default_symbol_resolver(
+        repo,
+        revset_parse_context.extensions.symbol_resolvers(),
+        id_prefix_context,
+    );
+    let revset = expression
+        .resolve_user_expression(repo, &symbol_resolver)
+        .map_err(UserRevsetEvaluationError::Resolution)?
+        .evaluate(repo)
+        .map_err(UserRevsetEvaluationError::Evaluation)?;
+    Ok(revset)
+}
+
 fn expect_fileset_literal(
     diagnostics: &mut TemplateDiagnostics,
     node: &ExpressionNode,
@@ -1456,25 +1600,6 @@ fn evaluate_revset_expression<'repo>(
         .evaluate(repo)
         .map_err(|err| make_error().with_source(err))?;
     Ok(revset)
-}
-
-fn evaluate_user_revset<'repo>(
-    language: &CommitTemplateLanguage<'repo>,
-    diagnostics: &mut TemplateDiagnostics,
-    span: pest::Span<'_>,
-    revset: &str,
-) -> Result<Box<dyn Revset + 'repo>, TemplateParseError> {
-    let mut inner_diagnostics = RevsetDiagnostics::new();
-    let expression = revset::parse(
-        &mut inner_diagnostics,
-        revset,
-        &language.revset_parse_context,
-    )
-    .map_err(|err| TemplateParseError::expression("In revset expression", span).with_source(err))?;
-    diagnostics.extend_with(inner_diagnostics, |diag| {
-        TemplateParseError::expression("In revset expression", span).with_source(diag)
-    });
-    evaluate_revset_expression(language, span, &expression)
 }
 
 fn builtin_commit_evolution_entry_methods<'repo>()

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1035,6 +1035,181 @@ fn test_log_contained_in() {
     [EOF]
     [exit status: 1]
     "#);
+
+    let template = r#"description.first_line() ++ " " ++ if(self.contained_in("commit_id(" ++ commit_id ++ ")"), "[contained_in]") ++ "\n""#;
+    let output = work_dir.run_jj(["log", "-r::", "-T", template]);
+    insta::assert_snapshot!(output, @"
+    @  D [contained_in]
+    │ ○  C [contained_in]
+    │ ○  B [contained_in]
+    │ ○  A [contained_in]
+    ├─╯
+    ◆   [contained_in]
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_log_revset_function() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.run_jj(["new", "-mA", "root()"]).success();
+    work_dir.run_jj(["new", "-mB"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "main"])
+        .success();
+    work_dir.run_jj(["new", "-mC"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "feature/foo"])
+        .success();
+
+    let output = work_dir.run_jj([
+        "log",
+        "--no-graph",
+        "-r",
+        "@",
+        "-T",
+        r#"revset("ancestors(@, 2)").map(|c| c.description().first_line()).join(", ") ++ "\n""#,
+    ]);
+    insta::assert_snapshot!(output, @r"
+    C, B
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "log",
+        "--no-graph",
+        "-r",
+        "@",
+        "-T",
+        r#"revset("feature/foo").map(|c| c.description().first_line()).join(", ") ++ "\n""#,
+    ]);
+    insta::assert_snapshot!(output, @r"
+    C
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "log",
+        "--no-graph",
+        "-r",
+        "@",
+        "-T",
+        r#"revset("feature/foo", "extra").map(|c| c.description().first_line()).join(", ") ++ "\n""#,
+    ]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Failed to parse template: Function `revset`: Expected 1 arguments
+    Caused by:  --> 1:8
+      |
+    1 | revset("feature/foo", "extra").map(|c| c.description().first_line()).join(", ") ++ "\n"
+      |        ^--------------------^
+      |
+      = Function `revset`: Expected 1 arguments
+    [EOF]
+    [exit status: 1]
+    "#);
+}
+
+#[test]
+fn test_log_revset_visibility_and_sorting() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Create a few commits with different timestamps
+    test_env.add_config(r#"ui.timestamp = "2001-02-03T04:05:06+07:00""#);
+    work_dir.run_jj(["new", "-m1", "root()"]).success();
+    test_env.add_config(r#"ui.timestamp = "2001-02-03T04:05:07+07:00""#);
+    work_dir.run_jj(["new", "-m2", "root()"]).success();
+    test_env.add_config(r#"ui.timestamp = "2001-02-03T04:05:08+07:00""#);
+    work_dir.run_jj(["new", "-m3", "root()"]).success();
+
+    // Now we have:
+    // root -> 1 (06)
+    // root -> 2 (07)
+    // root -> 3 (08)
+
+    // Check sorting (should be 3, 2, 1)
+    let template =
+        r#"revset("all() & ~root()").map(|c| c.description().first_line()).join(", ") ++ "\n""#;
+    let output = work_dir.run_jj(["log", "--no-graph", "-r@", "-T", template]);
+    insta::assert_snapshot!(output, @r"
+    3, 2, 1
+    [EOF]
+    ");
+
+    // Test visibility: hide commit 2 (by abandoning it)
+    work_dir.run_jj(["abandon", "description(2)"]).success();
+
+    // Now 2 is hidden. revset("all()") should only show 3, 2, 1 (all is literal)
+    let output = work_dir.run_jj(["log", "--no-graph", "-r@", "-T", template]);
+    insta::assert_snapshot!(output, @r"
+    3, 2, 1
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_log_revset_parse_error() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let template = r#"revset("bad(").map(|c| c.description().first_line()).join(", ") ++ "\n""#;
+    let output = work_dir.run_jj(["log", "--no-graph", "-r@", "-T", template]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Failed to parse template: In revset expression
+    Caused by:
+    1:  --> 1:8
+      |
+    1 | revset("bad(").map(|c| c.description().first_line()).join(", ") ++ "\n"
+      |        ^----^
+      |
+      = In revset expression
+    2:  --> 1:5
+      |
+    1 | bad(
+      |     ^---
+      |
+      = expected <strict_identifier> or <expression>
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    [EOF]
+    [exit status: 1]
+    "#);
+}
+
+#[test]
+fn test_log_revset_parse_error_for_static_expression() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let template =
+        r#"revset("ba" ++ "d(").map(|c| c.description().first_line()).join(", ") ++ "\n""#;
+    let output = work_dir.run_jj(["log", "--no-graph", "-r@", "-T", template]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Failed to parse template: In revset expression
+    Caused by:
+    1:  --> 1:8
+      |
+    1 | revset("ba" ++ "d(").map(|c| c.description().first_line()).join(", ") ++ "\n"
+      |        ^----------^
+      |
+      = In revset expression
+    2:  --> 1:5
+      |
+    1 | bad(
+      |     ^---
+      |
+      = expected <strict_identifier> or <expression>
+    Hint: See https://docs.jj-vcs.dev/latest/revsets/ or use `jj help -k revsets` for revsets syntax and how to quote symbols.
+    [EOF]
+    [exit status: 1]
+    "#);
 }
 
 #[test]

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -131,6 +131,8 @@ The following functions are defined.
   Surround **non-empty** content with texts such as parentheses.
 * `config(name: Stringify) -> Option<ConfigValue>`: Look up configuration
    value by `name`.
+* `revsets(query: Stringify) -> List<Commit>`: Evaluate a revset from the
+  provided `query` string.
 * `git_web_url([remote: String]) -> String`: Best-effort conversion of a git
   remote URL to an HTTPS web URL. Defaults to the "origin" remote. Returns an
   empty string on failure. SSH host alias resolution is currently unsupported.


### PR DESCRIPTION
This is a follow up of #9363 . I decided to create a new PR and close the previous just in case we would like to have `last_modified()` at some point in the future.

<img width="1429" height="1060" alt="image" src="https://github.com/user-attachments/assets/894a2317-be8e-4d7d-a5e5-7d9063d2893d" />

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
