### PR TITLE
gerrit: Use GitPushOptions::remote_push_options instead of extra_args 

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -381,7 +381,7 @@ fn push_options(args: &UploadArgs) -> Result<Vec<String>, CommandError> {
     .chain(args.reviewer.iter().map(|arg| Some(("r", arg.clone()))))
     .chain(args.cc.iter().map(|arg| Some(("cc", arg.clone()))))
     .flatten()
-    .map(|(k, v)| vec!["-o".to_string(), format!("{k}={v}")])
+    .map(|(k, v)| format!("{k}={v}"))
     .chain(
         [
             args.edit.then_some("edit"),
@@ -396,12 +396,9 @@ fn push_options(args: &UploadArgs) -> Result<Vec<String>, CommandError> {
             args.submit.then_some("submit"),
         ]
         .into_iter()
-        .map(|item| match item {
-            Some(k) => vec!["-o".to_string(), k.to_string()],
-            None => vec![],
-        }),
+        .flatten()
+        .map(str::to_string),
     )
-    .flatten()
     .collect())
 }
 
@@ -412,9 +409,7 @@ pub async fn cmd_gerrit_upload(
 ) -> Result<(), CommandError> {
     // Do this first because the validation is cheap.
     let push_options = GitPushOptions {
-        // TODO: migrate push_options() away from extra_args?
-        extra_args: push_options(args)?,
-        remote_push_options: vec![],
+        remote_push_options: push_options(args)?,
     };
 
     let mut workspace_command = command.workspace_helper(ui)?;
@@ -727,25 +722,15 @@ mod tests {
             })
             .unwrap(),
             [
-                "-o",
                 "notify=NONE",
-                "-o",
                 "topic=my-topic",
-                "-o",
                 "message=Uploaded%20with%20jj%21",
-                "-o",
                 "r=foo@example.com",
-                "-o",
                 "cc=bar@example.com",
-                "-o",
                 "cc=baz@example.com",
-                "-o",
                 "edit",
-                "-o",
                 "wip",
-                "-o",
                 "private",
-                "-o",
                 "publish-comments",
             ]
             .into_iter()
@@ -771,35 +756,20 @@ mod tests {
             })
             .unwrap(),
             [
-                "-o",
                 "notify=ALL",
-                "-o",
                 "trace=my-trace",
-                "-o",
                 "deadline=yesterday",
-                "-o",
                 "label=Auto-Submit",
-                "-o",
                 "label=Commit-Queue+2",
-                "-o",
                 "hashtag=my-hashtag",
-                "-o",
                 "hashtag=my-second-hashtag",
-                "-o",
                 "custom-keyed-value=foo:bar",
-                "-o",
                 "custom-keyed-value=baz:quux",
-                "-o",
                 "ready",
-                "-o",
                 "remove-private",
-                "-o",
                 "no-publish-comments",
-                "-o",
                 "skip-validation",
-                "-o",
                 "ignore-attention-set",
-                "-o",
                 "submit",
             ]
             .into_iter()

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -378,7 +378,11 @@ fn push_options(args: &UploadArgs) -> Result<Vec<String>, CommandError> {
             .iter()
             .map(|arg| Some(("custom-keyed-value", arg.clone()))),
     )
-    .chain(args.reviewer.iter().map(|arg| Some(("r", arg.clone()))))
+    .chain(
+        args.reviewer
+            .iter()
+            .map(|arg| Some(("reviewer", arg.clone()))),
+    )
     .chain(args.cc.iter().map(|arg| Some(("cc", arg.clone()))))
     .flatten()
     .map(|(k, v)| format!("{k}={v}"))
@@ -725,7 +729,7 @@ mod tests {
                 "notify=NONE",
                 "topic=my-topic",
                 "message=Uploaded%20with%20jj%21",
-                "r=foo@example.com",
+                "reviewer=foo@example.com",
                 "cc=bar@example.com",
                 "cc=baz@example.com",
                 "edit",

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -579,7 +579,6 @@ pub async fn cmd_git_push(
 
     let git_settings = GitSettings::from_settings(tx.settings())?;
     let options = GitPushOptions {
-        extra_args: vec![],
         remote_push_options: args.option.clone(),
     };
     let push_stats = git::push_refs(

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -3085,8 +3085,6 @@ pub struct GitRefUpdate {
 /// Miscellaneous options for Git push command.
 #[derive(Clone, Debug, Default)]
 pub struct GitPushOptions {
-    /// Extra arguments passed in to `git push` command.
-    pub extra_args: Vec<String>,
     /// `--push-option` arguments.
     pub remote_push_options: Vec<String>,
 }

--- a/lib/src/git_subprocess.rs
+++ b/lib/src/git_subprocess.rs
@@ -292,7 +292,6 @@ impl GitSubprocessContext {
                 .iter()
                 .map(|reference| format!("--force-with-lease={}", reference.to_git_lease())),
         );
-        command.args(&options.extra_args);
         command.args(["--", remote_name.as_str()]);
         // with --force-with-lease we cannot have the forced refspec,
         // as it ignores the lease

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -6250,7 +6250,6 @@ fn test_push_updates_with_options() -> TestResult {
         }],
         &mut callback,
         &GitPushOptions {
-            extra_args: vec![],
             remote_push_options: vec![
                 "merge_request.create".to_owned(),
                 "merge_request.draft".to_owned(),


### PR DESCRIPTION
Just two small cleanup changes in gerrit upload. Resolves a `// TODO` comment.
This doesn't cause any behaviour changes for users.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
