### PR TITLE
cli: add commit allow-empty config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A new config option `diff.git.show-path-prefix` can be used to suppress the
   `a/` and `b/` path prefixes in the `diff --git` output.
 
+* A new config option `commit.allow-empty=false` can be used to make `jj commit`
+  reject commits with no file modifications.
+
 * `jj fix` now supports line range-limited formatting via the `fix.tools.<name>.line-range-arg`
   and `run-tool-if-zero-line-ranges` configs. This allows running tools only on modified
   lines and fine-grained control over when the tool is run. If you have set the `line-range-arg`

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -222,6 +222,12 @@ new working-copy commit.
         description
     };
     commit_builder.set_description(description);
+    if !tx.settings().get_bool("commit.allow-empty")? && commit_builder.is_empty(tx.repo()).await? {
+        return Err(
+            user_error("Empty commits are disabled by `commit.allow-empty=false`")
+                .hinted("Set `commit.allow-empty=true` to allow this commit."),
+        );
+    }
     let new_commit = commit_builder.write(tx.repo_mut()).await?;
 
     let workspace_names = tx.repo().view().workspaces_for_wc_commit_id(commit.id());

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -740,6 +740,17 @@
                 }
             }
         },
+        "commit": {
+            "type": "object",
+            "description": "Settings for jj commit",
+            "properties": {
+                "allow-empty": {
+                    "type": "boolean",
+                    "description": "Whether jj commit may create commits that match the empty() revset",
+                    "default": true
+                }
+            }
+        },
         "snapshot": {
             "type": "object",
             "description": "Parameters governing automatic capture of files into the working copy commit",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -8,6 +8,9 @@ ci = ["commit"]
 desc = ["describe"]
 st = ["status"]
 
+[commit]
+allow-empty = true
+
 [diff.color-words]
 conflict = "materialize"
 max-inline-alternation = 3

--- a/cli/tests/sample-configs/valid/commit.toml
+++ b/cli/tests/sample-configs/valid/commit.toml
@@ -1,0 +1,3 @@
+#:schema ../../../src/config-schema.json
+[commit]
+allow-empty = false

--- a/cli/tests/test_commit_command.rs
+++ b/cli/tests/test_commit_command.rs
@@ -160,6 +160,51 @@ fn test_commit_with_empty_description_from_editor() -> TestResult {
 }
 
 #[test]
+fn test_commit_disallow_empty() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("commit.allow-empty = false");
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["commit", "-m=empty"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Empty commits are disabled by `commit.allow-empty=false`
+    Hint: Set `commit.allow-empty=true` to allow this commit.
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  e8849ae12c70
+    ◆  000000000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_commit_disallow_empty_allows_non_empty() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("commit.allow-empty = false");
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1", "foo\n");
+    let output = work_dir.run_jj(["commit", "-m=non-empty"]).success();
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Working copy  (@) now at: rlvkpnrz 476f2e2f (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm f9cdcc16 non-empty
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  476f2e2f44ba
+    ○  f9cdcc163cc8 non-empty
+    ◆  000000000000
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_commit_interactive() -> TestResult {
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_editor();

--- a/docs/config.md
+++ b/docs/config.md
@@ -559,6 +559,21 @@ edit = true
 You can pass the `--no-edit` flag to `prev` and `next` if you find yourself
 needing the original behavior.
 
+## Commit settings
+
+### Allow empty commits
+
+By default, `jj commit` can create commits with no file modifications. To make
+`jj commit` reject commits that match the `empty()` revset, set:
+
+```toml
+[commit]
+allow-empty = false
+```
+
+This setting only affects `jj commit`. It does not prevent jj from creating
+empty working-copy commits, which are part of the normal working-copy model.
+
 ## List
 
 ### Default Template


### PR DESCRIPTION
## Summary

Add `commit.allow-empty`, defaulting to `true`, so users can configure `jj commit` to reject commits that match the `empty()` revset.

This intentionally only affects `jj commit`; jj can still create empty working-copy commits as part of its normal working-copy model.

## Tests

- `cargo test -p jj-cli test_commit_disallow_empty --test runner`
- `cargo test -p jj-cli test_config_schema --test runner`
- `cargo test -p jj-cli --test datatest_runner`
- `rustfmt --check cli/src/commands/commit.rs`
- `cargo clippy -p jj-cli --test runner -- -D warnings`
