### PR TITLE
WIP: gerrit: Use `base` to upload exact revisions

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::io::Write as _;
 use std::sync::Arc;
@@ -25,9 +27,10 @@ use jj_lib::git;
 use jj_lib::git::GitPushOptions;
 use jj_lib::git::GitRefUpdate;
 use jj_lib::git::GitSubprocessOptions;
+use jj_lib::index::IndexResult;
 use jj_lib::merge::Diff;
 use jj_lib::object_id::ObjectId as _;
-use jj_lib::repo::Repo as _;
+use jj_lib::repo::Repo;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::settings::UserSettings;
 use jj_lib::store::Store;
@@ -405,6 +408,37 @@ fn push_options(args: &UploadArgs) -> Result<Vec<String>, CommandError> {
     .collect())
 }
 
+pub fn find_bases(
+    commit: CommitId,
+    commits_to_upload: &HashSet<CommitId>,
+    repo: &dyn Repo,
+) -> IndexResult<Vec<CommitId>> {
+    let index = repo.index();
+    let root_commit = repo.store().root_commit_id();
+
+    let mut bases = Vec::new();
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::from([commit]);
+
+    while let Some(current_commit) = queue.pop_front() {
+        let parents = index.parents(&current_commit)?;
+        for parent in parents {
+            if commits_to_upload.contains(&parent) {
+                if !visited.contains(&parent) {
+                    visited.insert(parent.clone());
+                    queue.push_back(parent);
+                }
+            } else {
+                if parent != *root_commit {
+                    bases.push(parent);
+                }
+            }
+        }
+    }
+
+    Ok(bases)
+}
+
 pub async fn cmd_gerrit_upload(
     ui: &mut Ui,
     command: &CommandHelper,
@@ -416,6 +450,11 @@ pub async fn cmd_gerrit_upload(
         extra_args: push_options(args)?,
         remote_push_options: vec![],
     };
+
+    let upload_exact_refs = command
+        .settings()
+        .get_bool("gerrit.upload-exact-refs")
+        .unwrap_or(false);
 
     let mut workspace_command = command.workspace_helper(ui)?;
 
@@ -469,19 +508,25 @@ pub async fn cmd_gerrit_upload(
         return Ok(());
     }
 
-    // If you have the changes main -> A -> B, and then run `jj gerrit upload -r B`,
-    // then that uploads both A and B. Thus, we need to ensure that A also
-    // has a Change-ID.
-    // We make an assumption here that all immutable commits already have a
-    // Change-ID.
-    let to_upload: Vec<Commit> = workspace_command
-        .attach_revset_evaluator(
+    let to_upload_expr = workspace_command
+        .attach_revset_evaluator(if upload_exact_refs {
+            RevsetExpression::intersection(
+                &RevsetExpression::commits(revisions.clone()),
+                &RevsetExpression::negated(&workspace_command.env().immutable_expression()),
+            )
+        } else {
             workspace_command
                 .env()
                 .immutable_expression()
-                .range(&RevsetExpression::commits(revisions.clone())),
-        )
-        .evaluate_to_commits()?
+                .range(&RevsetExpression::commits(revisions.clone()))
+        })
+        .resolve()?;
+    workspace_command
+        .check_rewritable_expr(&to_upload_expr)
+        .await?;
+
+    let to_upload: Vec<Commit> = to_upload_expr
+        .evaluate_to_commits(workspace_command.repo().as_ref())?
         .try_collect()
         .await?;
 
@@ -529,7 +574,7 @@ pub async fn cmd_gerrit_upload(
     }
 
     let mut old_to_new: HashMap<CommitId, Commit> = HashMap::new();
-    for original_commit in to_upload.into_iter().rev() {
+    for original_commit in to_upload.clone().into_iter().rev() {
         let trailers = parse_description_trailers(original_commit.description());
 
         let change_id_trailers: Vec<&Trailer> = trailers
@@ -627,6 +672,11 @@ pub async fn cmd_gerrit_upload(
         old_to_new.insert(original_commit.id().clone(), new_commit);
     }
 
+    let to_upload_ids: HashSet<CommitId> = old_to_new
+        .values()
+        .map(|commit| commit.id().to_owned())
+        .collect();
+
     let remote_ref = format!("refs/for/{remote_branch}");
     writeln!(
         ui.status(),
@@ -641,6 +691,9 @@ pub async fn cmd_gerrit_upload(
     // push_updates in theory supports multiple GitRefUpdates at once, because
     // we obviously can't push multiple heads to the same ref.
     for head in &old_heads {
+        let new_commit = old_to_new.get(head).unwrap();
+        let head_bases = find_bases(new_commit.id().clone(), &to_upload_ids, tx.repo())?;
+
         if let Some(mut formatter) = ui.status_formatter() {
             if args.dry_run {
                 write!(formatter, "Dry-run: Would push ")?;
@@ -652,6 +705,17 @@ pub async fn cmd_gerrit_upload(
             // "hidden".
             tx.base_workspace_helper()
                 .write_commit_summary(formatter.as_mut(), &store.get_commit(head).unwrap())?;
+            if upload_exact_refs && !head_bases.is_empty() {
+                write!(formatter, " with bases ")?;
+                for (i, base) in head_bases.iter().enumerate() {
+                    if i > 0 {
+                        write!(formatter, ", ")?;
+                    }
+                    let base_commit = store.get_commit_async(base).await?;
+                    tx.base_workspace_helper()
+                        .write_commit_summary(formatter.as_mut(), &base_commit)?;
+                }
+            }
             writeln!(formatter)?;
         }
 
@@ -659,7 +723,14 @@ pub async fn cmd_gerrit_upload(
             continue;
         }
 
-        let new_commit = old_to_new.get(head).unwrap();
+        let mut head_push_options = push_options.clone();
+        if upload_exact_refs {
+            for base in &head_bases {
+                head_push_options
+                    .remote_push_options
+                    .push(format!("base={}", base.hex()));
+            }
+        }
 
         // how do we get better errors from the remote? 'git push' tells us
         // about rejected refs AND ALSO '(nothing changed)' when there are no

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -31,6 +31,9 @@ push-new-bookmarks = false
 sign-on-push = false
 track-default-bookmark-on-clone = true
 
+[gerrit]
+upload-exact-refs = false
+
 [ui]
 color = "auto"
 diff-formatter = ":color-words"

--- a/cli/src/movement_util.rs
+++ b/cli/src/movement_util.rs
@@ -18,11 +18,9 @@ use std::sync::Arc;
 use futures::TryStreamExt as _;
 use jj_lib::backend::CommitId;
 use jj_lib::commit::Commit;
-use jj_lib::repo::Repo as _;
 use jj_lib::revset::ResolvedRevsetExpression;
 use jj_lib::revset::RevsetExpression;
 use jj_lib::revset::RevsetFilterPredicate;
-use jj_lib::revset::RevsetStreamExt as _;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::WorkspaceCommandHelper;
@@ -181,9 +179,7 @@ async fn get_target_commit(
     let target_revset = direction.build_target_revset(&wc_revset, &start_revset, args)?;
 
     let targets: Vec<Commit> = target_revset
-        .evaluate(workspace_command.repo().as_ref())?
-        .stream()
-        .commits(workspace_command.repo().store())
+        .evaluate_to_commits(workspace_command.repo().as_ref())?
         .try_collect()
         .await?;
 
@@ -192,9 +188,7 @@ async fn get_target_commit(
         [] => {
             // We found no ancestor/descendant.
             let start_commits: Vec<Commit> = start_revset
-                .evaluate(workspace_command.repo().as_ref())?
-                .stream()
-                .commits(workspace_command.repo().store())
+                .evaluate_to_commits(workspace_command.repo().as_ref())?
                 .try_collect()
                 .await?;
             return Err(direction.target_not_found_error(workspace_command, args, &start_commits));

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use test_case::test_case;
 use testutils::TestResult;
 
 use crate::common::TestEnvironment;
@@ -88,7 +89,99 @@ fn test_gerrit_upload_dryrun() {
 }
 
 #[test]
-fn test_gerrit_upload_default_revision() {
+fn test_gerrit_upload_explicit_revision() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    test_env.add_config(r#"gerrit.upload-exact-refs=true"#);
+
+    create_commit(&work_dir, "parent1", &[]);
+    create_commit(&work_dir, "parent2", &[]);
+    create_commit(&work_dir, "commit", &["parent1"]);
+    create_commit(&work_dir, "merge-commit", &["parent1", "parent2"]);
+    create_commit(&work_dir, "a", &["parent1"]);
+    create_commit(&work_dir, "b", &["a"]);
+    create_commit(&work_dir, "c", &["b"]);
+
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "b"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: No remote specified, and no 'gerrit' remote was found
+    [EOF]
+    [exit status: 1]
+    ");
+
+    // With remote specified but.
+    test_env.add_config(r#"gerrit.default-remote="origin""#);
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "b"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: The remote 'origin' (configured via `gerrit.default-remote`) does not exist
+    [EOF]
+    [exit status: 1]
+    ");
+
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "b", "--remote=origin"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: The remote 'origin' (specified via `--remote`) does not exist
+    [EOF]
+    [exit status: 1]
+    ");
+
+    let output = work_dir.run_jj([
+        "git",
+        "remote",
+        "add",
+        "origin",
+        "http://example.com/repo/foo",
+    ]);
+    insta::assert_snapshot!(output, @"");
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "b", "--remote=origin"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: No target branch specified via --remote-branch, and no 'gerrit.default-remote-branch' was found
+    [EOF]
+    [exit status: 1]
+    ");
+
+    test_env.add_config(r#"gerrit.default-remote-branch="main""#);
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "commit", "--dry-run"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
+    Dry-run: Would push royxmykx a9e50b23 commit | commit with bases rlvkpnrz cca5e48f parent1 | parent1
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "merge-commit", "--dry-run"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
+    Dry-run: Would push vruxwmqv 072b6a84 merge-commit | merge-commit with bases rlvkpnrz cca5e48f parent1 | parent1, zsuskuln eeea04d7 parent2 | parent2
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "b::c", "--dry-run"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
+    Dry-run: Would push lylxulpl 0874f538 c | c with bases znkkpsqq 30c5dc88 a | a
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["gerrit", "upload", "-r", "::c", "--dry-run"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
+    Dry-run: Would push lylxulpl 0874f538 c | c with bases znkkpsqq 30c5dc88 a | a
+    [EOF]
+    ");
+}
+
+#[test_case(false; "default")]
+#[test_case(true; "exact-refs")]
+fn test_gerrit_upload_default_revision(upload_exact_refs: bool) {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
@@ -104,12 +197,14 @@ fn test_gerrit_upload_default_revision() {
         .success();
     test_env.add_config(r#"gerrit.default-remote="origin""#);
     test_env.add_config(r#"gerrit.default-remote-branch="main""#);
+    test_env.add_config(format!(r#"gerrit.upload-exact-refs={upload_exact_refs}"#));
 
     work_dir
         .run_jj(["new", "--message", "parent", "root()"])
         .success();
     work_dir.write_file("parent", "parent");
     let output = work_dir.run_jj(["gerrit", "upload", "--dry-run"]);
+    insta::allow_duplicates! {
     insta::assert_snapshot!(output, @r"
     ------- stderr -------
     No revision provided. Defaulting to @
@@ -117,7 +212,9 @@ fn test_gerrit_upload_default_revision() {
     Dry-run: Would push kkmpptxz a41ea4e9 parent
     [EOF]
     ");
+    }
 
+    insta::allow_duplicates! {
     work_dir.run_jj(["new"]).success();
     let output = work_dir.run_jj(["gerrit", "upload", "--dry-run"]);
     insta::assert_snapshot!(output, @r"
@@ -127,7 +224,9 @@ fn test_gerrit_upload_default_revision() {
     Dry-run: Would push kkmpptxz a41ea4e9 parent
     [EOF]
     ");
+    }
 
+    insta::allow_duplicates! {
     work_dir.run_jj(["new", "@", "@-"]).success();
     let output = work_dir.run_jj(["gerrit", "upload", "--dry-run"]);
     insta::assert_snapshot!(output, @r"
@@ -137,7 +236,9 @@ fn test_gerrit_upload_default_revision() {
     [EOF]
     [exit status: 1]
     ");
+    }
 
+    insta::allow_duplicates! {
     work_dir.run_jj(["workspace", "forget"]).success();
     let output = work_dir.run_jj(["gerrit", "upload", "--dry-run"]);
     insta::assert_snapshot!(output, @"
@@ -147,6 +248,7 @@ fn test_gerrit_upload_default_revision() {
     [EOF]
     [exit status: 1]
     ");
+    }
 }
 
 #[test]

--- a/lib/src/default_index/composite.rs
+++ b/lib/src/default_index/composite.rs
@@ -512,6 +512,13 @@ impl CompositeCommitIndex {
         }
         Ok(found_heads)
     }
+
+    pub fn parents(&self, commit_id: &CommitId) -> Vec<CommitId> {
+        match self.entry_by_id(commit_id) {
+            Some(entry) => entry.parents().map(|pos| pos.commit_id()).collect(),
+            None => Vec::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -629,6 +636,10 @@ impl Index for CompositeIndex {
         candidate_ids: &mut dyn Iterator<Item = &CommitId>,
     ) -> IndexResult<Vec<CommitId>> {
         Ok(self.commits().heads(candidate_ids))
+    }
+
+    fn parents(&self, commit_id: &CommitId) -> IndexResult<Vec<CommitId>> {
+        Ok(self.commits().parents(commit_id))
     }
 
     fn changed_paths_in_commit(

--- a/lib/src/default_index/mod.rs
+++ b/lib/src/default_index/mod.rs
@@ -1292,6 +1292,60 @@ mod tests {
     }
 
     #[test]
+    fn test_parents() -> TestResult {
+        let mut new_change_id = change_id_generator();
+        let mut index = DefaultMutableIndex::full(TEST_FIELD_LENGTHS);
+        // 5
+        // |\
+        // | \
+        // |\ \
+        // | 4 |
+        // | |\|
+        // 1 2 3
+        // |/ /
+        // | /
+        // |/
+        // 0
+        let id_0 = CommitId::from_hex("000000");
+        let id_1 = CommitId::from_hex("111111");
+        let id_2 = CommitId::from_hex("222222");
+        let id_3 = CommitId::from_hex("333333");
+        let id_4 = CommitId::from_hex("444444");
+        let id_5 = CommitId::from_hex("555555");
+        index.add_commit_data(id_0.clone(), new_change_id(), &[]);
+        index.add_commit_data(id_1.clone(), new_change_id(), &[id_0.clone()]);
+        index.add_commit_data(id_2.clone(), new_change_id(), &[id_0.clone()]);
+        index.add_commit_data(id_3.clone(), new_change_id(), &[id_0.clone()]);
+        index.add_commit_data(id_4.clone(), new_change_id(), &[id_2.clone(), id_3.clone()]);
+        index.add_commit_data(
+            id_5.clone(),
+            new_change_id(),
+            &[id_1.clone(), id_4.clone(), id_3.clone()],
+        );
+
+        // root commit
+        assert_eq!(index.parents(&id_0.clone())?, vec![]);
+
+        // single parent
+        assert_eq!(index.parents(&id_1.clone())?, vec![id_0.clone()]);
+        assert_eq!(index.parents(&id_2.clone())?, vec![id_0.clone()]);
+        assert_eq!(index.parents(&id_3.clone())?, vec![id_0.clone()]);
+
+        // two parents (merge)
+        assert_eq!(
+            index.parents(&id_4.clone())?,
+            vec![id_2.clone(), id_3.clone()]
+        );
+
+        // more parents (multi-merge)
+        assert_eq!(
+            index.parents(&id_5.clone())?,
+            vec![id_1.clone(), id_4.clone(), id_3.clone()]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_heads_range_with_filter() -> TestResult {
         let mut new_change_id = change_id_generator();
         let mut index = DefaultMutableIndex::full(TEST_FIELD_LENGTHS);

--- a/lib/src/default_index/mutable.rs
+++ b/lib/src/default_index/mutable.rs
@@ -581,6 +581,10 @@ impl Index for DefaultMutableIndex {
         self.0.heads(candidates)
     }
 
+    fn parents(&self, commit_id: &CommitId) -> IndexResult<Vec<CommitId>> {
+        self.0.parents(commit_id)
+    }
+
     fn changed_paths_in_commit(
         &self,
         commit_id: &CommitId,

--- a/lib/src/default_index/readonly.rs
+++ b/lib/src/default_index/readonly.rs
@@ -747,6 +747,10 @@ impl Index for DefaultReadonlyIndex {
         self.0.heads(candidates)
     }
 
+    fn parents(&self, commit_id: &CommitId) -> IndexResult<Vec<CommitId>> {
+        self.0.parents(commit_id)
+    }
+
     fn changed_paths_in_commit(
         &self,
         commit_id: &CommitId,

--- a/lib/src/index.rs
+++ b/lib/src/index.rs
@@ -140,6 +140,9 @@ pub trait Index: Send + Sync {
     /// `candidates` list it will appear at most once in the output.
     fn heads(&self, candidates: &mut dyn Iterator<Item = &CommitId>) -> IndexResult<Vec<CommitId>>;
 
+    /// Returns the parents of commit ID `commit_id`
+    fn parents(&self, commit_id: &CommitId) -> IndexResult<Vec<CommitId>>;
+
     /// Returns iterator over paths changed at the specified commit. The paths
     /// are sorted. Returns `None` if the commit wasn't indexed.
     fn changed_paths_in_commit(

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -685,6 +685,18 @@ impl ResolvedRevsetExpression {
         repo.index().evaluate_revset(&expr, repo.store())
     }
 
+    pub fn evaluate_to_commits(
+        self: Arc<Self>,
+        repo: &dyn Repo,
+    ) -> Result<LocalBoxStream<'_, Result<Commit, RevsetEvaluationError>>, RevsetEvaluationError>
+    {
+        Ok(self
+            .evaluate(repo)?
+            .stream()
+            .commits(repo.store())
+            .boxed_local())
+    }
+
     /// Evaluates this expression without optimizing it.
     ///
     /// Use this function if `self` is already optimized, or to debug


### PR DESCRIPTION
Closes #9364.

Work in progress.

This adds the changes proposed in #9364. Because they are breaking changes they are hidden behind a config option for now. The default value of this config option could then be flipped after a deprecation period.

This still needs a bit more testing and probably a few edge case fixes. Opening as draft PR to enable design discussions. Not yet for code review (I know there's a bunch of stuff to fix).
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
