### PR TITLE
Add flag to push to gerrit with no-change-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `--merged`. You can now also pass multiple hashtags by repeating the
   `--hashtag` option.
 
+* `jj gerrit upload` now supports `--no-change-id` to push to Gerrit without
+  adding a `Change-Id` footer. Commits that already have a `Change-Id` or `Link`
+  footer are unaffected.
+
 ### Fixed bugs
 
 * Improving consistency with `git` handling of `.gitignore`, including `/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   jj workspace can have its own Git HEAD. Existing repositories are migrated
   automatically.
 
+* `jj gerrit upload` now supports `--no-change-id` to push to Gerrit without
+  adding a `Change-Id` footer. Commits that already have a `Change-Id` or `Link`
+  footer are unaffected.
+
 ### Fixed bugs
 
 * The default pager flags now include `-K` (`--quit-on-intr`), so pressing

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -217,6 +217,17 @@ pub struct UploadArgs {
     /// See https://gerrit-review.googlesource.com/Documentation/user-upload.html#trace
     #[arg(long)]
     trace: Option<String>,
+
+    /// Do not add a `Change-Id` footer to commits that lack one
+    ///
+    /// By default, a `Change-Id` footer is automatically derived from the jj
+    /// change ID and appended to commits that do not already have one. This
+    /// flag disables that behaviour, leaving such commits unchanged. Commits
+    /// that already contain a `Change-Id` or `Link` footer are never modified,
+    /// regardless of this flag.
+    #[arg(long)]
+    no_change_id: bool,
+
     // Note: An option "message" exists on Gerrit hosts. It is currently not
     // implemented because it could be easy to confuse a "-m"/"--message" flag
     // for a patchset with a message for a commit description.
@@ -548,6 +559,8 @@ pub async fn cmd_gerrit_upload(
 
         // The user can choose to explicitly set their own change-ID to
         // override the default change-ID based on the jj change-ID.
+        // When --no-change-id is given and no existing footer is present,
+        // skip adding one and use the original description unchanged.
         let new_description = if let Some(trailer) = change_id_trailers.first() {
             // Check the change-id format is correct, intentionally leave the
             // invalid change IDs as-is.
@@ -570,6 +583,8 @@ pub async fn cmd_gerrit_upload(
                 )?;
             }
 
+            original_commit.description().to_owned()
+        } else if args.no_change_id {
             original_commit.description().to_owned()
         } else {
             // Gerrit change id is 40 chars, jj change id is 32, so we need padding.

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -221,6 +221,17 @@ pub struct UploadArgs {
     /// See https://gerrit-review.googlesource.com/Documentation/user-upload.html#trace
     #[arg(long)]
     trace: Option<String>,
+
+    /// Do not add a `Change-Id` footer to commits that lack one
+    ///
+    /// By default, a `Change-Id` footer is automatically derived from the jj
+    /// change ID and appended to commits that do not already have one. This
+    /// flag disables that behaviour, leaving such commits unchanged. Commits
+    /// that already contain a `Change-Id` or `Link` footer are never modified,
+    /// regardless of this flag.
+    #[arg(long)]
+    no_change_id: bool,
+
     // Note: An option "message" exists on Gerrit hosts. It is currently not
     // implemented because it could be easy to confuse a "-m"/"--message" flag
     // for a patchset with a message for a commit description.
@@ -556,6 +567,8 @@ pub async fn cmd_gerrit_upload(
 
         // The user can choose to explicitly set their own change-ID to
         // override the default change-ID based on the jj change-ID.
+        // When --no-change-id is given and no existing footer is present,
+        // skip adding one and use the original description unchanged.
         let new_description = if let Some(trailer) = change_id_trailers.first() {
             // Check the change-id format is correct, intentionally leave the
             // invalid change IDs as-is.
@@ -578,6 +591,8 @@ pub async fn cmd_gerrit_upload(
                 )?;
             }
 
+            original_commit.description().to_owned()
+        } else if args.no_change_id {
             original_commit.description().to_owned()
         } else {
             // Gerrit change id is 40 chars, jj change id is 32, so we need padding.

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -835,3 +835,65 @@ fn test_gerrit_upload_rejected_by_remote() -> TestResult {
     ");
     Ok(())
 }
+
+#[test]
+fn test_gerrit_upload_no_change_id() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "remote"])
+        .success();
+    let remote_dir = test_env.work_dir("remote");
+    create_commit(&remote_dir, "a", &[]);
+
+    test_env
+        .run_jj_in(".", ["git", "clone", "remote", "local"])
+        .success();
+    let local_dir = test_env.work_dir("local");
+
+    // b has no Change-Id; c has an explicit Change-Id
+    create_commit(&local_dir, "b", &["a@origin"]);
+    create_commit(&local_dir, "c", &["b"]);
+    local_dir
+        .run_jj([
+            "describe",
+            "c",
+            "-m",
+            "c\n\nChange-Id: Id39b308212fe7e0b746d16c13355f3a90712d7f9\n",
+        ])
+        .success();
+
+    // With --no-change-id, b should be pushed without a footer being added,
+    // and c should keep its existing Change-Id unchanged.
+    let output =
+        local_dir.run_jj(["gerrit", "upload", "-r", "c", "--remote-branch=main", "--no-change-id"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
+    Pushing yqosqzyt 8d46d915 c | c
+    [EOF]
+    ");
+
+    let output = remote_dir.run_jj(["util", "exec", "--", "git", "log", "refs/for/main"]);
+    insta::assert_snapshot!(output, @"
+    commit 8d46d915c5de09e193bd2fb3b9e38d64ec8c56c1
+    Author: Test User <test.user@example.com>
+    Date:   Sat Feb 3 04:05:13 2001 +0700
+
+        c
+
+        Change-Id: Id39b308212fe7e0b746d16c13355f3a90712d7f9
+
+    commit 3bcb28c47ce6e2af5e90fadd2d3e0b5e10d13b22
+    Author: Test User <test.user@example.com>
+    Date:   Sat Feb 3 04:05:11 2001 +0700
+
+        b
+
+    commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Author: Test User <test.user@example.com>
+    Date:   Sat Feb 3 04:05:08 2001 +0700
+
+        a
+    [EOF]
+    ");
+}

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -872,3 +872,65 @@ fn test_gerrit_upload_rejected_by_remote() -> TestResult {
     ");
     Ok(())
 }
+
+#[test]
+fn test_gerrit_upload_no_change_id() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "remote"])
+        .success();
+    let remote_dir = test_env.work_dir("remote");
+    create_commit(&remote_dir, "a", &[]);
+
+    test_env
+        .run_jj_in(".", ["git", "clone", "remote", "local"])
+        .success();
+    let local_dir = test_env.work_dir("local");
+
+    // b has no Change-Id; c has an explicit Change-Id
+    create_commit(&local_dir, "b", &["a@origin"]);
+    create_commit(&local_dir, "c", &["b"]);
+    local_dir
+        .run_jj([
+            "describe",
+            "c",
+            "-m",
+            "c\n\nChange-Id: Id39b308212fe7e0b746d16c13355f3a90712d7f9\n",
+        ])
+        .success();
+
+    // With --no-change-id, b should be pushed without a footer being added,
+    // and c should keep its existing Change-Id unchanged.
+    let output =
+        local_dir.run_jj(["gerrit", "upload", "-r", "c", "--remote-branch=main", "--no-change-id"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Found 1 heads to push to Gerrit (remote 'origin'), target branch 'main'
+    Pushing yqosqzyt 8d46d915 c | c
+    [EOF]
+    ");
+
+    let output = remote_dir.run_jj(["util", "exec", "--", "git", "log", "refs/for/main"]);
+    insta::assert_snapshot!(output, @"
+    commit 8d46d915c5de09e193bd2fb3b9e38d64ec8c56c1
+    Author: Test User <test.user@example.com>
+    Date:   Sat Feb 3 04:05:13 2001 +0700
+
+        c
+
+        Change-Id: Id39b308212fe7e0b746d16c13355f3a90712d7f9
+
+    commit 3bcb28c47ce6e2af5e90fadd2d3e0b5e10d13b22
+    Author: Test User <test.user@example.com>
+    Date:   Sat Feb 3 04:05:11 2001 +0700
+
+        b
+
+    commit 7d980be7a1d499e4d316ab4c01242885032f7eaf
+    Author: Test User <test.user@example.com>
+    Date:   Sat Feb 3 04:05:08 2001 +0700
+
+        a
+    [EOF]
+    ");
+}

--- a/docs/gerrit.md
+++ b/docs/gerrit.md
@@ -151,6 +151,22 @@ footers associated with the desired changes. Be sure not to duplicate the same
 duplicate `Change-Id`s, but if the uploads are done separately, you may
 unintentionally overwrite an existing change.
 
+### Uploading without a `Change-Id` footer
+
+If you are working with a Gerrit host that natively understands JJ change IDs,
+you can skip the automatic `Change-Id` footer injection with `--no-change-id`:
+
+```shell
+$ jj gerrit upload --no-change-id
+```
+
+Commits that already contain a `Change-Id` or `Link` footer are never modified,
+regardless of this flag.
+
+> Note: Native JJ change-ID support in Gerrit is not yet merged upstream. The
+> default behaviour (adding a `Change-Id` footer) remains correct for all
+> current Gerrit installations.
+
 ## Alternative `Link` trailer
 
 Since version 3.3.1 Gerrit supports an alternative to the `Change-Id` trailer,


### PR DESCRIPTION
As Gerrit moves towards natively supporting JJ style change-ids, there should be an option to push to gerrit without adding a Gerrit change-id footer. For now support in Gerrit is not yet merged, therefore by default we should still add it.

Once Gerrit support JJ change-ids natively, we can switch the logic so that by default JJ doesn't add it.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
