### PR TITLE
cli: bookmark forget: only report counts that reflect actual changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no
+  local bookmarks were actually forgotten (e.g. when only an untracked remote
+  bookmark matched). [#9181](https://github.com/jj-vcs/jj/issues/9181).
+
 ## [0.41.0] - 2026-05-06
 
 ### Release highlights

--- a/cli/src/commands/bookmark/forget.rs
+++ b/cli/src/commands/bookmark/forget.rs
@@ -73,8 +73,12 @@ pub async fn cmd_bookmark_forget(
     }
 
     let mut tx = workspace_command.start_transaction();
+    let mut forgotten_local: usize = 0;
     let mut forgotten_remote: usize = 0;
     for (name, bookmark_target) in &matched_bookmarks {
+        if bookmark_target.local_target.is_present() {
+            forgotten_local += 1;
+        }
         tx.repo_mut()
             .set_local_bookmark_target(name, RefTarget::absent());
         for (remote, _) in &bookmark_target.remote_refs {
@@ -94,11 +98,9 @@ pub async fn cmd_bookmark_forget(
             tx.repo_mut().untrack_remote_bookmark(symbol);
         }
     }
-    writeln!(
-        ui.status(),
-        "Forgot {} local bookmarks.",
-        matched_bookmarks.len()
-    )?;
+    if forgotten_local != 0 {
+        writeln!(ui.status(), "Forgot {forgotten_local} local bookmarks.")?;
+    }
     if forgotten_remote != 0 {
         writeln!(ui.status(), "Forgot {forgotten_remote} remote bookmarks.")?;
     }

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1558,11 +1558,11 @@ fn test_bookmark_forget_deleted_or_nonexistent_bookmark() {
 
     // ============ End of test setup ============
 
-    // We can forget a deleted bookmark
+    // We can forget a deleted bookmark. The local bookmark was already absent,
+    // so only the remote count is reported.
     let output = work_dir.run_jj(["bookmark", "forget", "--include-remotes", "feature1"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Forgot 1 local bookmarks.
     Forgot 1 remote bookmarks.
     [EOF]
     ");
@@ -1574,6 +1574,57 @@ fn test_bookmark_forget_deleted_or_nonexistent_bookmark() {
     ------- stderr -------
     Warning: No matching bookmarks for names: i_do_not_exist
     No bookmarks to forget.
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_bookmark_forget_untracked_remote_only_bookmark() {
+    // Regression test for https://github.com/jj-vcs/jj/issues/9181:
+    // `jj bookmark forget` on a remote-only, untracked bookmark used to print
+    // a contradictory "Forgot 1 local bookmarks." line followed by "Nothing
+    // changed." Now neither line is printed since nothing was forgotten.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let git_repo_path = test_env.env_root().join("git-repo");
+    let git_repo = git::init_bare(git_repo_path);
+    git::add_commit(
+        &git_repo,
+        "refs/heads/feature1",
+        "file",
+        b"content",
+        "message",
+        &[],
+    );
+    work_dir
+        .run_jj(["git", "remote", "add", "origin", "../git-repo"])
+        .success();
+
+    // Fetch without auto-tracking, so feature1@origin is untracked and there
+    // is no local feature1 bookmark.
+    let output = work_dir.run_jj(["git", "fetch", "--remote=origin"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    bookmark: feature1@origin [new] untracked
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
+    feature1@origin: qomsplrm ebeb70d8 message
+    [EOF]
+    ");
+
+    // Without `--include-remotes`, forgetting an untracked remote-only
+    // bookmark is a no-op. We should not claim any local bookmarks were
+    // forgotten.
+    let output = work_dir.run_jj(["bookmark", "forget", "feature1"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+    insta::assert_snapshot!(get_bookmark_output(&work_dir), @r"
+    feature1@origin: qomsplrm ebeb70d8 message
     [EOF]
     ");
 }


### PR DESCRIPTION
Fixes #9181.

`jj bookmark forget` printed `Forgot N local bookmarks.` even when no
local bookmarks were actually forgotten (e.g. forgetting an untracked
remote-only bookmark, where the only thing that happens is we untrack
the remote ref and the transaction is a no-op). The line was usually
followed by `Nothing changed.` from the transaction commit, which read
as a contradiction in the issue.

The fix tracks `forgotten_local` and `forgotten_remote` independently
and only prints each line when its count is non-zero. The unconditional
`set_local_bookmark_target(name, RefTarget::absent())` call is
preserved so the existing tombstone cleanup on `remote_views` is not
affected.

I added a regression test for the exact scenario from the issue, and
updated one existing snapshot in `test_bookmark_forget_deleted_or_nonexistent_bookmark`
where forgetting a previously-deleted bookmark with `--include-remotes`
no longer claims to have forgotten a local bookmark (the local was
already absent at that point).

# Checklist

- [x] I have updated `CHANGELOG.md`
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant.