### PR TITLE
cli: add --allow-immutable as a synonym for --ignore-immutable

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1013,7 +1013,7 @@ impl WorkspaceCommandEnvironment {
         repo: &dyn Repo,
         to_rewrite_expr: &Arc<ResolvedRevsetExpression>,
     ) -> Result<Option<CommitId>, CommandError> {
-        let immutable_expression = if self.command.global_args().ignore_immutable {
+        let immutable_expression = if self.command.global_args().allow_immutable {
             UserRevsetExpression::root()
         } else {
             self.immutable_expression()
@@ -3619,8 +3619,10 @@ pub struct GlobalArgs {
     ///
     /// This option only affects the check. It does not affect the
     /// `immutable_heads()` revset or the `immutable` template keyword.
-    #[arg(long, global = true)]
-    pub ignore_immutable: bool,
+    ///
+    /// `--ignore-immutable` is an alias for this option.
+    #[arg(long, visible_alias = "ignore-immutable", global = true)]
+    pub allow_immutable: bool,
 
     /// Operation to load the repo at
     ///

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -205,11 +205,13 @@ To get started, see the tutorial [`jj help -k tutorial`].
    The command will print the resulting operation ID. You can pass that to e.g. `jj --at-op` to inspect the resulting repo state, or you can pass it to `jj op restore` to restore the repo to that state. You can also pass the ID to `jj op integrate` to integrate the operation.
 
    Note that this does *not* prevent side effects outside the repo. For example, `jj git push --no-integrate-operation` will still perform the push.
-* `--ignore-immutable` — Allow rewriting immutable commits
+* `--allow-immutable` [alias: `ignore-immutable`] — Allow rewriting immutable commits
 
    By default, Jujutsu prevents rewriting commits in the configured set of immutable commits. This option disables that check and lets you rewrite any commit but the root commit.
 
    This option only affects the check. It does not affect the `immutable_heads()` revset or the `immutable` template keyword.
+
+   `--ignore-immutable` is an alias for this option.
 * `--at-operation <AT_OPERATION>` [alias: `at-op`] — Operation to load the repo at
 
    Operation to load the repo at. By default, Jujutsu loads the repo at the most recent operation, or at the merge of the divergent operations if any.

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1820,13 +1820,13 @@ fn test_bookmark_track_conflict() {
 
     // adjust main and push to origin2, again for origin3
     work_dir
-        .run_jj(["describe", "-m", "b", "-r", "main", "--ignore-immutable"])
+        .run_jj(["describe", "-m", "b", "-r", "main", "--allow-immutable"])
         .success();
     work_dir
         .run_jj(["git", "push", "-N", "-b", "main", "--remote", "origin2"])
         .success();
     work_dir
-        .run_jj(["describe", "-m", "c", "-r", "main", "--ignore-immutable"])
+        .run_jj(["describe", "-m", "c", "-r", "main", "--allow-immutable"])
         .success();
     work_dir
         .run_jj(["git", "push", "-N", "-b", "main", "--remote", "origin3"])

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -229,7 +229,7 @@ fn test_bookmark_names() {
     --repository	Path to repository to operate on
     --ignore-working-copy	Don't snapshot the working copy, and don't update it
     --no-integrate-operation	Run the command as usual but don't integrate any operations
-    --ignore-immutable	Allow rewriting immutable commits
+    --allow-immutable	Allow rewriting immutable commits
     --at-operation	Operation to load the repo at
     --debug	Enable debug logging
     --color	When to colorize output
@@ -721,7 +721,7 @@ fn test_command_completion_short_name() {
     --repository	Path to repository to operate on
     --ignore-working-copy	Don't snapshot the working copy, and don't update it
     --no-integrate-operation	Run the command as usual but don't integrate any operations
-    --ignore-immutable	Allow rewriting immutable commits
+    --allow-immutable	Allow rewriting immutable commits
     --at-operation	Operation to load the repo at
     --debug	Enable debug logging
     --color	When to colorize output

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -1289,7 +1289,7 @@ fn test_help() {
       -R, --repository <REPOSITORY>      Path to repository to operate on
           --ignore-working-copy          Don't snapshot the working copy, and don't update it
           --no-integrate-operation       Run the command as usual but don't integrate any operations
-          --ignore-immutable             Allow rewriting immutable commits
+          --allow-immutable              Allow rewriting immutable commits [aliases: --ignore-immutable]
           --at-operation <AT_OPERATION>  Operation to load the repo at [aliases: --at-op]
           --debug                        Enable debug logging
           --color <WHEN>                 When to colorize output [possible values: always, never, debug,

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -97,17 +97,24 @@ fn test_rewrite_immutable_generic() {
     [EOF]
     ");
 
-    // Can use --ignore-immutable to override
+    // Can use --allow-immutable to override
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "main""#);
-    let output = work_dir.run_jj(["--ignore-immutable", "edit", "main"]);
+    let output = work_dir.run_jj(["--allow-immutable", "edit", "main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Working copy  (@) now at: kkmpptxz 9d190342 main | b
     Parent commit (@-)      : qpvuntsm c8c8515a a
     [EOF]
     ");
+    // Can also use the alias --ignore-immutable
+    let output = work_dir.run_jj(["--ignore-immutable", "edit", "main"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Already editing that commit
+    [EOF]
+    ");
     // ... but not the root commit
-    let output = work_dir.run_jj(["--ignore-immutable", "edit", "root()"]);
+    let output = work_dir.run_jj(["--allow-immutable", "edit", "root()"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Error: The root commit 000000000000 is immutable
@@ -122,7 +129,7 @@ fn test_rewrite_immutable_generic() {
     let output = work_dir.run_jj(["new", "main"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Working copy  (@) now at: wqnwkozp 8fc35e6e (empty) (no description set)
+    Working copy  (@) now at: lylxulpl 883af231 (empty) (no description set)
     Parent commit (@-)      : kkmpptxz 9d190342 main | b
     [EOF]
     ");
@@ -680,8 +687,8 @@ fn test_immutable_log() {
     work_dir.run_jj(["new"]).success();
     test_env.add_config(r#"revset-aliases."immutable_heads()" = "@-""#);
     // The immutable commits should be indicated in the graph even with
-    // `--ignore-immutable`
-    let output = work_dir.run_jj(["log", "--ignore-immutable"]);
+    // `--allow-immutable`
+    let output = work_dir.run_jj(["log", "--allow-immutable"]);
     insta::assert_snapshot!(output, @"
     @  rlvkpnrz test.user@example.com 2001-02-03 08:05:08 43444d88
     │  (empty) (no description set)

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -3160,12 +3160,12 @@ fn test_op_immutable_revisions() {
 
     // Abandon the immutable stack
     work_dir
-        .run_jj(["abandon", "--ignore-immutable", "::t1 & ~root()"])
+        .run_jj(["abandon", "--allow-immutable", "::t1 & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    52517772e194 test-username@host.example.com default@ 2001-02-03 04:05:15.000 +07:00 - 2001-02-03 04:05:15.000 +07:00
+    3e22c9b7ebd3 test-username@host.example.com default@ 2001-02-03 04:05:15.000 +07:00 - 2001-02-03 04:05:15.000 +07:00
     abandon commit 9c86781f3fe9097ffc530e65fd2ab4aff1e654bd and 5 more
-    args: jj abandon --ignore-immutable '::t1 & ~root()'
+    args: jj abandon --allow-immutable '::t1 & ~root()'
 
     Changed commits:
     ○  - royxmykx/0 9c86781f (hidden) (empty) commit 5
@@ -3176,8 +3176,8 @@ fn test_op_immutable_revisions() {
     // Undo
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    f9e504c0dd85 test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
-    revert operation 52517772e194b55d56c84c18b868306d9077e768cfe6e33f886ffb621bcc681f8e508e1fd53a8be18470f76c14d8fd00e6a2775c92fab8d6de6553f33a2de4fd
+    58baf6b41cdb test-username@host.example.com default@ 2001-02-03 04:05:17.000 +07:00 - 2001-02-03 04:05:17.000 +07:00
+    revert operation 3e22c9b7ebd3ecc5db33e8b4cc422eb26e06d4753986234247ea2e48b8a6d53c65159f2388c2b05b1dc1caf2644df113477e3ad804475296d8144000943d0488
     args: jj op revert
 
     Changed commits:
@@ -3202,13 +3202,13 @@ fn test_op_immutable_revisions() {
 
     // Abandon both chains
     work_dir
-        .run_jj(["abandon", "--ignore-immutable", "(::f1 | ::f2) & ~root()"])
+        .run_jj(["abandon", "--allow-immutable", "(::f1 | ::f2) & ~root()"])
         .success();
     let op_id_for_diff = work_dir.current_operation_id();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    f90e225dba79 test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
+    8b019f1fbd0c test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
     abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
-    args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
+    args: jj abandon --allow-immutable '(::f1 | ::f2) & ~root()'
 
     Changed commits:
     ○  - xtnwkqum/0 e7f51c58 (hidden) (empty) f2 3
@@ -3221,9 +3221,9 @@ fn test_op_immutable_revisions() {
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    f90e225dba79 test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
+    8b019f1fbd0c test-username@host.example.com default@ 2001-02-03 04:05:28.000 +07:00 - 2001-02-03 04:05:28.000 +07:00
     abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
-    args: jj abandon --ignore-immutable '(::f1 | ::f2) & ~root()'
+    args: jj abandon --allow-immutable '(::f1 | ::f2) & ~root()'
 
     Changed commits:
        (Elided 10+ newly removed revisions)
@@ -3253,12 +3253,12 @@ fn test_op_immutable_revisions() {
 
     // Rebase bb chain onto ba head.
     work_dir
-        .run_jj(["rebase", "--ignore-immutable", "-s", "bb----", "-d", "ba"])
+        .run_jj(["rebase", "--allow-immutable", "-s", "bb----", "-d", "ba"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    9d3cfa89448a test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
+    8096b34a8474 test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
     rebase commit c09af48da0b4dcbbe6be869823d17bf6cd73a4db and descendants
-    args: jj rebase --ignore-immutable -s bb---- -d ba
+    args: jj rebase --allow-immutable -s bb---- -d ba
 
     Changed commits:
     ○  + nsrwusvy caaf0759 (empty) (no description set)
@@ -3280,9 +3280,9 @@ fn test_op_immutable_revisions() {
 
     // Use `--show-changes-in none()` to see only elisions
     insta::assert_snapshot!(work_dir.run_jj(["op", "show", "--show-changes-in", "none()"]), @"
-    9d3cfa89448a test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
+    8096b34a8474 test-username@host.example.com default@ 2001-02-03 04:05:43.000 +07:00 - 2001-02-03 04:05:43.000 +07:00
     rebase commit c09af48da0b4dcbbe6be869823d17bf6cd73a4db and descendants
-    args: jj rebase --ignore-immutable -s bb---- -d ba
+    args: jj rebase --allow-immutable -s bb---- -d ba
 
     Changed commits:
        (Elided 6 newly added and 6 newly removed revisions)
@@ -3308,12 +3308,12 @@ fn test_op_immutable_revisions() {
         .success();
     // Abandon to see single removal elision
     work_dir
-        .run_jj(["abandon", "--ignore-immutable", "::ts & ~root()"])
+        .run_jj(["abandon", "--allow-immutable", "::ts & ~root()"])
         .success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    f5a4f77da069 test-username@host.example.com default@ 2001-02-03 04:05:49.000 +07:00 - 2001-02-03 04:05:49.000 +07:00
+    f15fdc3ba328 test-username@host.example.com default@ 2001-02-03 04:05:49.000 +07:00 - 2001-02-03 04:05:49.000 +07:00
     abandon commit 0a2e24c8d8d8010243ed72f9c50ee69b57291eff and 1 more
-    args: jj abandon --ignore-immutable '::ts & ~root()'
+    args: jj abandon --allow-immutable '::ts & ~root()'
 
     Changed commits:
     ○  + sryyqqkq 46f2f483 (empty) (no description set)
@@ -3330,8 +3330,8 @@ fn test_op_immutable_revisions() {
     // Undo to see single addition elision
     work_dir.run_jj(["op", "revert"]).success();
     insta::assert_snapshot!(work_dir.run_jj(["op", "show"]), @"
-    3d2e63a4b374 test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
-    revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    25ce7034bf2f test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
+    revert operation f15fdc3ba328035972eec2cfb8ffa3d30f4142eee69b800f708960c2cd1414d2b87412b7d41922ab8eb4c6ac79a6b44f12a264732f690038305e0754da463e5f
     args: jj op revert
 
     Changed commits:
@@ -3348,8 +3348,8 @@ fn test_op_immutable_revisions() {
 
     // 5. op diff and op log tests
     insta::assert_snapshot!(work_dir.run_jj(["op", "diff", "--from", &op_id_for_diff]), @"
-    From operation: f90e225dba79 (2001-02-03 08:05:28) abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
-      To operation: 3d2e63a4b374 (2001-02-03 08:05:51) revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    From operation: 8b019f1fbd0c (2001-02-03 08:05:28) abandon commit e7f51c58b0862dc0c255d9efd11fb9a89f07eb88 and 11 more
+      To operation: 25ce7034bf2f (2001-02-03 08:05:51) revert operation f15fdc3ba328035972eec2cfb8ffa3d30f4142eee69b800f708960c2cd1414d2b87412b7d41922ab8eb4c6ac79a6b44f12a264732f690038305e0754da463e5f
 
     Changed commits:
     ○  + sryyqqkq d41cf466 (empty) (no description set)
@@ -3379,8 +3379,8 @@ fn test_op_immutable_revisions() {
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["op", "log", "-p", "--limit", "1"]), @"
-    @  3d2e63a4b374 test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
-    │  revert operation f5a4f77da0696b42e0acbd785ebe11040e31e15bebf4d2bd4b09a521af16dba25d9df24e4ce06185485edfcfe8a634dc1853e3542a9baeb6c5b7606e4b3f6d0a
+    @  25ce7034bf2f test-username@host.example.com default@ 2001-02-03 04:05:51.000 +07:00 - 2001-02-03 04:05:51.000 +07:00
+    │  revert operation f15fdc3ba328035972eec2cfb8ffa3d30f4142eee69b800f708960c2cd1414d2b87412b7d41922ab8eb4c6ac79a6b44f12a264732f690038305e0754da463e5f
     │  args: jj op revert
     │
     │  Changed commits:
@@ -3442,7 +3442,7 @@ fn test_op_immutable_revisions() {
     // Operation A: Hide acc-c3 by abandoning it. c1 and c2 remain visible via
     // bookmarks.
     work_dir
-        .run_jj(["abandon", "--ignore-immutable", "-r", &c3_id])
+        .run_jj(["abandon", "--allow-immutable", "-r", &c3_id])
         .success();
     let op_a = work_dir.current_operation_id();
 
@@ -3450,7 +3450,7 @@ fn test_op_immutable_revisions() {
     // newly_hidden = {c1, c2}.
     // Option 1 (Fix) shows the head (c2) and elides the parent (c1).
     work_dir
-        .run_jj(["abandon", "--ignore-immutable", "-r", &c1_id, "-r", &c2_id])
+        .run_jj(["abandon", "--allow-immutable", "-r", &c1_id, "-r", &c2_id])
         .success();
     let op_b = work_dir.current_operation_id();
 
@@ -3467,8 +3467,8 @@ fn test_op_immutable_revisions() {
         "all()",
     ]);
     insta::assert_snapshot!(output, @"
-    From operation: db293dfe6244 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
-      To operation: 10ca7b3a86f8 (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
+    From operation: 9526ac3dc680 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
+      To operation: a2abcf82512c (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
 
     Changed commits:
     ○  - knltnxnu/0 61c62511 (hidden) (empty) acc-c2
@@ -3488,8 +3488,8 @@ fn test_op_immutable_revisions() {
     // of the newly hidden set and elide c1.
     let output = work_dir.run_jj(["op", "diff", "--from", &op_a, "--to", &op_b]);
     insta::assert_snapshot!(output, @"
-    From operation: db293dfe6244 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
-      To operation: 10ca7b3a86f8 (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
+    From operation: 9526ac3dc680 (2001-02-03 08:06:05) abandon commit 5ff32b4e633551c9d0e40760cd4f8b61937395c6
+      To operation: a2abcf82512c (2001-02-03 08:06:06) abandon commit 61c625114e83805c3b25709d71cebedcf2be7406 and 1 more
 
     Changed commits:
     ○  - knltnxnu/0 61c62511 (hidden) (empty) acc-c2

--- a/demos/demo_operation_log.sh
+++ b/demos/demo_operation_log.sh
@@ -6,7 +6,7 @@ new_tmp_dir
 {
     jj git clone https://github.com/octocat/Hello-World
     cd Hello-World
-    jj abandon --ignore-immutable octocat-patch-1@origin
+    jj abandon --allow-immutable octocat-patch-1@origin
     jj bookmark forget octocat-patch-1
     jj bookmark track test@origin
 } > /dev/null 2>&1

--- a/demos/demo_resolve_conflicts.sh
+++ b/demos/demo_resolve_conflicts.sh
@@ -6,7 +6,7 @@ new_tmp_dir
 {
     jj git clone https://github.com/octocat/Hello-World
     cd Hello-World
-    jj abandon --ignore-immutable test@origin
+    jj abandon --allow-immutable test@origin
     jj bookmark forget test
 } > /dev/null 2>&1
 

--- a/demos/demo_working_copy.sh
+++ b/demos/demo_working_copy.sh
@@ -6,9 +6,9 @@ new_tmp_dir
 {
     jj git clone https://github.com/octocat/Hello-World
     cd Hello-World
-    jj abandon --ignore-immutable test@origin
+    jj abandon --allow-immutable test@origin
     jj bookmark forget test
-    jj abandon --ignore-immutable octocat-patch-1@origin
+    jj abandon --allow-immutable octocat-patch-1@origin
     jj bookmark forget octocat-patch-1
 }> /dev/null 2>&1
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -535,11 +535,11 @@ Ancestors of the configured set are also immutable. The root commit is always
 immutable even if the set is empty.
 
 Immutable commits (other than the root commit) can be rewritten using the
-`--ignore-immutable` CLI flag.
+`--allow-immutable` (alias `--ignore-immutable`) CLI flag.
 
 !!! warning
 
-    Using `--ignore-immutable` will allow you to rewrite any commit in the
+    Using `--allow-immutable` will allow you to rewrite any commit in the
     history, and all descendants, without warning. Use this power wisely, and
     remember `jj undo`.
 

--- a/web/docs/src/content/docs/config.md
+++ b/web/docs/src/content/docs/config.md
@@ -454,12 +454,14 @@ Ancestors of the configured set are also immutable. The root commit is always
 immutable even if the set is empty.
 
 Immutable commits (other than the root commit) can be rewritten using the
-`--ignore-immutable` CLI flag.
+`--allow-immutable` (alias `--ignore-immutable`) CLI flag.
 
 :::caution
-Using `--ignore-immutable` will allow you to rewrite any commit in the
+
+Using `--allow-immutable` will allow you to rewrite any commit in the
 history, and all descendants, without warning. Use this power wisely, and
 remember `jj undo`.
+
 :::
 
 ### Behavior of prev and next commands


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

In https://github.com/jj-vcs/jj/issues/9377#issue-4328717455

> `--ignore-immutable` does the opposite of what it says. ... Well, strictly speaking I assume it means something like "ignore immutable flag/status of the commit", in which case it is correct. But the option doesn't says _what_ is immutable. And when using `jj`, a changeset/revision is the target of an operation, not its flags/status, so it make more sense to think of the option as meaning "ignore immutable changeset/revision", which is the opposite of what one wants.
> 
> Case in point, `jj`'s own help says "Allow rewriting immutable commit" as the main description of the option, which makes me think this is not just a "me" issue, and thus this FR.
> 
> In practice, this creates a mental dissonance. For me, this result in having to pause and think every time I use the option, and more often that not, having to correct what I already started to type, which is really annoying.
> 
> So I suggested replacing `--ignore-immutable` with `--allow-immutable`. Ideally, `--ignore-immutable` would be deprecated, to avoid adding more confusion by having two options with seemingly opposite meanings do the same thing. Potentially, this could translate into only mentioning `--ignore-immutable` inside the help, something like:
> 
> ```
> --allow-immutable
>     Allow rewriting immutable commits
>     [...]
>     `--ignore-immutable` is an alias for this option, supported for historical reasons
> ```



This is a PR implementing the suggestion in https://github.com/jj-vcs/jj/issues/9377. I think the discussion had not finished or 'matured' yet but nevertheless here's a PR with the change. 
I'll mark this as draft for that reason.

Closes #9377

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
