### PR TITLE
cli: add JJ_PAGER env override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * New `remotes.<name>.fetch-bookmarks`/`fetch-tags` options to [configure
   default fetch targets.](docs/config.md#default-bookmarks-and-tags-to-fetch)
 
+* `JJ_PAGER` can now override the `ui.pager` config, matching `JJ_EDITOR` for
+  callers that need a jj-specific environment override.
+
 ### Fixed bugs
 
 * Improving consistency with `git` handling of `.gitignore`, including `/`

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -747,6 +747,9 @@ fn env_overrides_layer() -> ConfigLayer {
     if let Ok(value) = env::var("JJ_EDITOR") {
         layer.set_value("ui.editor", value).unwrap();
     }
+    if let Ok(value) = env::var("JJ_PAGER") {
+        layer.set_value("ui.pager", value).unwrap();
+    }
     layer
 }
 

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -722,6 +722,37 @@ fn test_color_config() {
 }
 
 #[test]
+fn test_pager_env_config() {
+    let mut test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    test_env.add_config(r#"ui.pager = "user""#);
+    test_env.add_env_var("PAGER", "env-base");
+    test_env.add_env_var("JJ_PAGER", "env-override");
+    let work_dir = test_env.work_dir("repo");
+
+    let output = work_dir.run_jj(["config", "list", "ui.pager", "--include-overridden"]);
+    insta::assert_snapshot!(output, @r#"
+        # ui.pager = "user"
+        ui.pager = "env-override"
+        [EOF]
+    "#);
+
+    let output = work_dir.run_jj([
+        "config",
+        "list",
+        "ui.pager",
+        "--include-overridden",
+        "--config=ui.pager=\"command-arg\"",
+    ]);
+    insta::assert_snapshot!(output, @r#"
+        # ui.pager = "user"
+        # ui.pager = "env-override"
+        ui.pager = "command-arg"
+        [EOF]
+    "#);
+}
+
+#[test]
 fn test_color_ui_messages() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/docs/config.md
+++ b/docs/config.md
@@ -823,6 +823,10 @@ Which pager to use can be customized by setting `ui.pager`. When choosing a
 pager, ensure that it either supports color codes or that you disable color (see
 [Colorizing output](#colorizing-output)).
 
+The `JJ_PAGER` environment variable overrides `ui.pager`, and is useful for
+tool-specific environments that should not affect other programs. The generic
+`PAGER` environment variable is ignored.
+
 Examples:
 
 ```shell


### PR DESCRIPTION
Fixes #9394.

This adds `JJ_PAGER` as a jj-specific environment override for `ui.pager`, matching the existing `JJ_EDITOR` pattern for `ui.editor`. The intent is to give non-interactive tools a narrow way to configure jj pager behavior without restoring generic `$PAGER` handling and the out-of-the-box issues from #3502.

`cli/src/config-schema.json` is not updated because this does not add or change a config key; it adds an environment-derived override for the existing `ui.pager` config.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.