### PR TITLE
Move update-stale recovery commit description to the `jj_lib` crate

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -133,6 +133,7 @@ use jj_lib::transaction::TransactionCommitError;
 use jj_lib::working_copy;
 use jj_lib::working_copy::CheckoutStats;
 use jj_lib::working_copy::LockedWorkingCopy;
+use jj_lib::working_copy::RECOVERY_COMMIT_DESCRIPTION;
 use jj_lib::working_copy::SnapshotOptions;
 use jj_lib::working_copy::SnapshotStats;
 use jj_lib::working_copy::UntrackedReason;
@@ -1454,14 +1455,7 @@ impl WorkspaceCommandHelper {
             locked_ws.locked_wc(),
             &self.user_repo.repo,
             workspace_name,
-            "RECOVERY COMMIT FROM `jj workspace update-stale`
-
-This commit contains changes that were written to the working copy by an
-operation that was subsequently lost (or was at least unavailable when you ran
-`jj workspace update-stale`). Because the operation was lost, we don't know
-what the parent commits are supposed to be. That means that the diff compared
-to the current parents may contain changes from multiple commits.
-",
+            RECOVERY_COMMIT_DESCRIPTION,
         )
         .await?;
 

--- a/lib/src/working_copy.rs
+++ b/lib/src/working_copy.rs
@@ -423,6 +423,17 @@ pub enum RecoverWorkspaceError {
     WorkspaceMissingWorkingCopy(WorkspaceNameBuf),
 }
 
+/// The commit message for the recovery commit generated in the update-stale
+/// workflow.
+pub const RECOVERY_COMMIT_DESCRIPTION: &str = "RECOVERY COMMIT FROM `jj workspace update-stale`
+
+This commit contains changes that were written to the working copy by an
+operation that was subsequently lost (or was at least unavailable when you ran
+`jj workspace update-stale`). Because the operation was lost, we don't know
+what the parent commits are supposed to be. That means that the diff compared
+to the current parents may contain changes from multiple commits.
+";
+
 /// Recover this workspace to its last known checkout.
 pub async fn create_and_check_out_recovery_commit(
     locked_wc: &mut dyn LockedWorkingCopy,


### PR DESCRIPTION
When `jj workspace update-stale` fails to find an operation, it generates a recovery commit using a hardcoded message. To support this functionality on Google servers - which utilize `jj_lib` directly rather than `jj_cli`, we'd like to move this message string into the jj_lib crate to allow reuse.

This PR is entirely hand written without any AI involvement.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
