### PR TITLE
cli: git-push: enable limiting number of refs in a single push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### New features
 
+* Add `remotes.<name>.ref_push_max_batch_size` setting to push a maximum of n
+  refs in a single push and for more use sequential git push commands rather
+  than updating all at once. Useful for some remote restrictions, for example
+  for multiple history rewrites or limited number of CI runs per push, which
+  usually guard against `git push --all` or `git push --mirror` but get tripped
+  by normal jj usage.
+
 ### Fixed bugs
 
 ## [0.44.0] - 2026-08-05

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -419,6 +419,7 @@ pub async fn cmd_gerrit_upload(
     // Do this first because the validation is cheap.
     let push_options = GitPushOptions {
         remote_push_options: push_options(args)?,
+        ref_push_max_batch_size: None,
     };
 
     let mut workspace_command = command.workspace_helper(ui).await?;

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -18,6 +18,7 @@ use std::future;
 use std::io;
 use std::io::Write as _;
 use std::iter;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use clap::ArgGroup;
@@ -285,6 +286,8 @@ pub async fn cmd_git_push(
         default_remote = get_default_push_remote(ui, &workspace_command)?;
         &default_remote
     };
+
+    let remote_settings = workspace_command.settings().remote_settings()?;
 
     let mut tx = workspace_command.start_transaction();
     let view = tx.repo().view();
@@ -573,8 +576,14 @@ pub async fn cmd_git_push(
     }
 
     let git_settings = GitSettings::from_settings(tx.settings())?;
+    let ref_push_max_batch_size = remote_settings
+        .get(remote)
+        .and_then(|s| s.ref_push_max_batch_size)
+        .and_then(NonZeroUsize::new);
+
     let options = GitPushOptions {
         remote_push_options: args.option.clone(),
+        ref_push_max_batch_size,
     };
     let push_stats = git::push_refs(
         tx.repo_mut(),

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -584,6 +584,11 @@
                     "fetch-tags": {
                         "type": "string",
                         "description": "A string pattern describing the tags to fetch by default"
+                    },
+                    "ref-push-max-batch-size": {
+                        "type": "integer",
+                        "description": "Maximum number of refs in a single push operation (0 means unlimited)",
+                        "default": 0
                     }
                 }
             }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -23,6 +23,7 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::iter;
 use std::num::NonZeroU32;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -207,6 +208,13 @@ impl GitPushStats {
     /// pushed to the remote and exported to the local Git repo.
     pub fn some_exported(&self) -> bool {
         self.pushed.len() > self.unexported_bookmarks.len()
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.pushed.extend(other.pushed);
+        self.rejected.extend(other.rejected);
+        self.remote_rejected.extend(other.remote_rejected);
+        self.unexported_bookmarks.extend(other.unexported_bookmarks);
     }
 }
 
@@ -3217,6 +3225,8 @@ pub struct GitRefUpdate {
 pub struct GitPushOptions {
     /// `--push-option` arguments.
     pub remote_push_options: Vec<String>,
+    /// don't push multiple refs at once
+    pub ref_push_max_batch_size: Option<NonZeroUsize>,
 }
 
 /// Pushes the specified refs and updates the repo view accordingly.
@@ -3379,7 +3389,15 @@ pub fn push_updates(
         .map(|full_refspec| RefToPush::new(full_refspec, &qualified_remote_refs_expected_locations))
         .collect();
 
-    let mut push_stats = git_ctx.spawn_push(remote_name, &refs_to_push, callback, options)?;
+    let mut push_stats = if let Some(batch_size) = options.ref_push_max_batch_size {
+        let mut stats = GitPushStats::default();
+        for refs in refs_to_push.chunks(batch_size.get()) {
+            stats.merge(git_ctx.spawn_push(remote_name, refs, callback, options)?);
+        }
+        stats
+    } else {
+        git_ctx.spawn_push(remote_name, &refs_to_push, callback, options)?
+    };
     push_stats.pushed.sort();
     push_stats.rejected.sort();
     push_stats.remote_rejected.sort();

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -76,6 +76,10 @@ pub struct RemoteSettings {
     /// Tag name expression to fetch by default.
     #[serde(default)]
     pub fetch_tags: Option<String>,
+    /// Maximum number of refs in a single git push operation,
+    /// None or Some(0) means unlimited
+    #[serde(default)]
+    pub ref_push_max_batch_size: Option<usize>,
 }
 
 impl RemoteSettings {

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -6756,6 +6756,7 @@ fn test_push_updates_with_options() -> TestResult {
                 "merge_request.create".to_owned(),
                 "merge_request.draft".to_owned(),
             ],
+            ref_push_max_batch_size: None,
         },
     )?;
 


### PR DESCRIPTION
Bit of an edge case of a setting, but since I'm unable to convince our admins to change bitbucket control freak settings, and now found an issue where at least one other person needs something like this, I thought I'd take a shot at this.
I'm not too happy with the naming of things here yet, so I'll gladly take suggestions for improvements :)

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
