### PR TITLE
docs: make redacted log templates visible in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,8 +25,15 @@ Feel free to remove any of the sections below if they don't seem useful. -->
 
 ## Actual Behavior
 
-<!-- Please include `jj log -T builtin_log_redacted` and/or
-`jj op log -T builtin_op_log_redacted` if it seems relevant. -->
+
+## Redacted Log Output
+
+<!-- These commands anonymize personal data so they are safe to share publicly. -->
+
+If relevant, please include the output of:
+
+- `jj log -T builtin_log_redacted`
+- `jj op log -T builtin_op_log_redacted`
 
 ## Specifications
 


### PR DESCRIPTION
The instructions to include `jj log -T builtin_log_redacted` and
`jj op log -T builtin_op_log_redacted` output were hidden inside an HTML comment
in the bug report template, making them invisible to users filing issues.

This moves them into a dedicated **Redacted Log Output** section so reporters
are more likely to include this diagnostic info. The section also notes that
these commands anonymize personal data, so users know it's safe to share.

Closes #9372