### PR TITLE
gerrit: check default upload revisions are rewritable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Pre-existing Git submodule directories are no longer considered conflicts in
   checkouts. [#8065](https://github.com/jj-vcs/jj/issues/8065).
 
+* Fixed a panic in `jj gerrit upload` when run without `-r` and the
+  inferred revision was immutable. [#9398](https://github.com/jj-vcs/jj/issues/9398)
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -430,7 +430,7 @@ pub async fn cmd_gerrit_upload(
             }
             // This distinguishes between the "squash workflow" and "edit workflow".
             Some(commit) => {
-                if commit.description().is_empty() {
+                let revisions = if commit.description().is_empty() {
                     let parents = commit.parent_ids();
                     if parents.len() != 1 {
                         return Err(user_error(
@@ -447,7 +447,14 @@ pub async fn cmd_gerrit_upload(
                 } else {
                     writeln!(ui.status(), "No revision provided. Defaulting to @")?;
                     vec![commit.id().clone()]
-                }
+                };
+
+                let revisions_expr = RevsetExpression::commits(revisions.clone());
+                workspace_command
+                    .check_rewritable_expr(&revisions_expr)
+                    .await?;
+
+                revisions
             }
         }
     } else {

--- a/cli/tests/test_gerrit_upload.rs
+++ b/cli/tests/test_gerrit_upload.rs
@@ -150,6 +150,43 @@ fn test_gerrit_upload_default_revision() {
 }
 
 #[test]
+fn test_gerrit_upload_default_revision_already_in_trunk() {
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "remote"])
+        .success();
+    let remote_dir = test_env.work_dir("remote");
+    create_commit(&remote_dir, "main", &[]);
+
+    test_env
+        .run_jj_in(".", ["git", "clone", "remote", "local"])
+        .success();
+    let local_dir = test_env.work_dir("local");
+    test_env.add_config(r#"gerrit.default-remote="origin""#);
+    test_env.add_config(r#"gerrit.default-remote-branch="main""#);
+    test_env.add_config(r#"revset-aliases."trunk()" = "main@origin""#);
+
+    // Make @ an empty working-copy commit over immutable main@origin.
+    local_dir.run_jj(["new", "main@origin"]).success();
+    local_dir.run_jj(["describe", "-m="]).success();
+
+    let output = local_dir.run_jj(["gerrit", "upload", "--dry-run"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    No revision provided and @ has no description. Defaulting to @-
+    Error: Commit 57df4838fd85 is immutable
+    Hint: Could not modify commit: rlvkpnrz 57df4838 main@origin | main
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, \"Set of immutable commits\"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
 fn test_gerrit_upload_option_failure() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();


### PR DESCRIPTION
The implicit revision-selection path for `jj gerrit upload` bypassed the usual rewritability check. If the selected revision was immutable, the later upload logic could panic instead of returning a user-facing error.

This change runs the rewritability check before continuing, so the command now fails with the standard immutable commit error instead. I verified the fix by reproducing the scenario from the linked issue.

Closes https://github.com/jj-vcs/jj/issues/9398

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
