### PR TITLE
gerrit: use check_rewritable() for default upload revision

### DIFF
--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -449,11 +449,7 @@ pub async fn cmd_gerrit_upload(
                     vec![commit.id().clone()]
                 };
 
-                let revisions_expr = RevsetExpression::commits(revisions.clone());
-                workspace_command
-                    .check_rewritable_expr(&revisions_expr)
-                    .await?;
-
+                workspace_command.check_rewritable(&revisions).await?;
                 revisions
             }
         }


### PR DESCRIPTION
Use `workspace_command.check_rewritable()` directly for the implicitly selected revision in gerrit upload instead of constructing a `RevsetExpression` only to run the rewritability check.

Based on the comment raised in https://github.com/jj-vcs/jj/pull/9412#discussion_r3176163450

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
