### PR TITLE
git: remove hint about not running `git clean -xdf`

### DIFF
--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -288,13 +288,6 @@ pub async fn cmd_git_clone(
         }
     }
 
-    if colocate {
-        writeln!(
-            ui.hint_default(),
-            r"Running `git clean -xdf` will remove `.jj/`!",
-        )?;
-    }
-
     Ok(())
 }
 

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -137,12 +137,6 @@ pub async fn cmd_git_init(
         r#"Initialized repo in "{}""#,
         relative_wc_path.display()
     )?;
-    if colocate {
-        writeln!(
-            ui.hint_default(),
-            r"Running `git clean -xdf` will remove `.jj/`!",
-        )?;
-    }
 
     Ok(())
 }

--- a/cli/tests/test_git_clone.rs
+++ b/cli/tests/test_git_clone.rs
@@ -254,7 +254,6 @@ fn test_git_clone_colocate() -> TestResult {
     ------- stderr -------
     Fetching into new repo in "$TEST_ENV/empty"
     Nothing changed.
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -278,7 +277,6 @@ fn test_git_clone_colocate() -> TestResult {
     Working copy  (@) now at: uuqppmxq 3711b3b5 (empty) (no description set)
     Parent commit (@-)      : qomsplrm ebeb70d8 main | message
     Added 1 files, modified 0 files, removed 0 files
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     let clone_dir = test_env.work_dir("clone");
@@ -424,7 +422,6 @@ fn test_git_clone_colocate() -> TestResult {
     Working copy  (@) now at: vzqnnsmr fea36bca (empty) (no description set)
     Parent commit (@-)      : qomsplrm ebeb70d8 main | message
     Added 1 files, modified 0 files, removed 0 files
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     Ok(())
@@ -450,7 +447,6 @@ fn test_git_clone_colocate_via_config() {
     Working copy  (@) now at: sqpuoqvx 1ca44815 (empty) (no description set)
     Parent commit (@-)      : qomsplrm ebeb70d8 main | message
     Added 1 files, modified 0 files, removed 0 files
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     let clone_dir = test_env.work_dir("clone");
@@ -619,7 +615,6 @@ fn test_git_clone_tags() {
     Working copy  (@) now at: sqpuoqvx 88542a00 (empty) (no description set)
     Parent commit (@-)      : lnmyztun e93ca54d main | message
     Added 2 files, modified 0 files, removed 0 files
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -632,7 +627,6 @@ fn test_git_clone_tags() {
     Working copy  (@) now at: uuqppmxq 676b2fd8 (empty) (no description set)
     Parent commit (@-)      : lnmyztun e93ca54d main | message
     Added 2 files, modified 0 files, removed 0 files
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -646,7 +640,6 @@ fn test_git_clone_tags() {
     Working copy  (@) now at: pmmvwywv cd5996a2 (empty) (no description set)
     Parent commit (@-)      : lnmyztun e93ca54d main | message
     Added 2 files, modified 0 files, removed 0 files
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -658,7 +651,6 @@ fn test_git_clone_tags() {
     Working copy  (@) now at: rzvqmyuk 61c45a3c (empty) (no description set)
     Parent commit (@-)      : lnmyztun e93ca54d main | message
     Added 2 files, modified 0 files, removed 0 files
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1643,7 +1643,6 @@ fn test_git_colocated_operation_cleanup() -> TestResult {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 

--- a/cli/tests/test_git_init.rs
+++ b/cli/tests/test_git_init.rs
@@ -192,7 +192,6 @@ fn test_git_init_external(bare: bool) {
     Parent commit (@-)      : nntyzxmz e80a42cc my-bookmark | My commit message
     Added 1 files, modified 0 files, removed 0 files
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     }
@@ -257,7 +256,6 @@ fn test_git_init_external_with_colocate_config() {
     Parent commit (@-)      : nntyzxmz e80a42cc my-bookmark | My commit message
     Added 1 files, modified 0 files, removed 0 files
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     }
@@ -308,7 +306,6 @@ fn test_git_init_external_import_trunk(bare: bool) -> TestResult {
     Parent commit (@-)      : nntyzxmz e80a42cc my-bookmark trunk@origin | My commit message
     Added 1 files, modified 0 files, removed 0 files
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     }
@@ -385,7 +382,6 @@ fn test_git_init_external_import_trunk_upstream_takes_precedence() -> TestResult
     Parent commit (@-)      : nntyzxmz e80a42cc develop@upstream my-bookmark trunk@origin | My commit message
     Added 1 files, modified 0 files, removed 0 files
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     }
@@ -448,7 +444,6 @@ fn test_git_init_colocated_via_git_repo_path() {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -511,7 +506,6 @@ fn test_git_init_colocated_via_git_repo_path_gitlink() {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
@@ -560,7 +554,6 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory() -> TestResult {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
@@ -615,7 +608,6 @@ fn test_git_init_colocated_via_git_repo_path_symlink_directory_without_bare_conf
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
@@ -672,7 +664,6 @@ fn test_git_init_colocated_via_git_repo_path_symlink_gitlink() -> TestResult {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     insta::assert_snapshot!(read_git_target(&jj_work_dir), @"../../../.git");
@@ -750,7 +741,6 @@ fn test_git_init_colocated_via_git_repo_path_imported_refs() {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     insta::assert_snapshot!(get_bookmark_output(&local_dir), @"
@@ -776,7 +766,6 @@ fn test_git_init_colocated_via_git_repo_path_imported_refs() {
     Hint: Run the following command to keep local bookmarks updated on future pulls:
       jj bookmark track local-remote --remote=origin
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     insta::assert_snapshot!(get_bookmark_output(&local_dir), @"
@@ -830,7 +819,6 @@ fn test_git_init_colocated_dirty_working_copy() {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -911,7 +899,6 @@ fn test_git_init_external_but_git_dir_exists() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -949,7 +936,6 @@ fn test_git_init_colocated_via_flag_git_dir_exists() {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -995,7 +981,6 @@ fn test_git_init_colocated_via_config_git_dir_exists() {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -1075,7 +1060,6 @@ fn test_git_init_colocated_via_flag_overrides_false_config() {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 
@@ -1101,7 +1085,6 @@ fn test_git_init_colocated_via_flag_git_dir_not_exists() {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     // No HEAD ref is available yet
@@ -1188,7 +1171,6 @@ fn test_git_init_conditional_config() {
     insta::assert_snapshot!(output.normalize_backslash(), @r#"
     ------- stderr -------
     Initialized repo in "../new"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
     run_jj(&new_workspace_dir, &["new"]).success();
@@ -1327,7 +1309,6 @@ fn test_git_init_colocate_gitlink_not_worktree() -> TestResult {
     ------- stderr -------
     Done importing changes from the underlying Git repo.
     Initialized repo in "."
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 

--- a/cli/tests/test_global_opts.rs
+++ b/cli/tests/test_global_opts.rs
@@ -1169,7 +1169,6 @@ fn test_default_config() -> TestResult {
     insta::assert_snapshot!(output, @r#"
     ------- stderr -------
     Initialized repo in "repo"
-    Hint: Running `git clean -xdf` will remove `.jj/`!
     [EOF]
     "#);
 


### PR DESCRIPTION
It seems clear that the consensus is that this message is not useful enough to be worth the spam and confusion.

Fixes #7421.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
