### PR TITLE
Some more asyncification of get_commit() callers

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1312,7 +1312,7 @@ impl WorkspaceCommandHelper {
         let new_git_head = tx.repo().view().git_head().clone();
         if let Some(new_git_head_id) = new_git_head.as_normal() {
             let workspace_name = self.workspace_name().to_owned();
-            let new_git_head_commit = tx.repo().store().get_commit(new_git_head_id)?;
+            let new_git_head_commit = tx.repo().store().get_commit_async(new_git_head_id).await?;
             let wc_commit = tx
                 .repo_mut()
                 .check_out(workspace_name, &new_git_head_commit)

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3306,17 +3306,17 @@ impl LogContentFormat {
     }
 
     /// Writes content which will optionally be wrapped at the current width.
-    pub fn write<E: From<io::Error>>(
+    pub async fn write<E: From<io::Error>>(
         &self,
         formatter: &mut dyn Formatter,
-        content_fn: impl FnOnce(&mut dyn Formatter) -> Result<(), E>,
+        content_fn: impl AsyncFnOnce(&mut dyn Formatter) -> Result<(), E>,
     ) -> Result<(), E> {
         if self.word_wrap {
             let mut recorder = FormatRecorder::new(formatter.maybe_color());
-            content_fn(&mut recorder)?;
+            content_fn(&mut recorder).await?;
             text_util::write_wrapped(formatter, &recorder, self.width)?;
         } else {
-            content_fn(formatter)?;
+            content_fn(formatter).await?;
         }
         Ok(())
     }

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -129,7 +129,11 @@ pub(crate) async fn cmd_commit(
     let commit_id = workspace_command
         .get_wc_commit_id()
         .ok_or_else(|| user_error("This command requires a working copy"))?;
-    let commit = workspace_command.repo().store().get_commit(commit_id)?;
+    let commit = workspace_command
+        .repo()
+        .store()
+        .get_commit_async(commit_id)
+        .await?;
     let matcher = workspace_command
         .parse_file_patterns(ui, &args.paths)?
         .to_matcher();

--- a/cli/src/commands/config/set.rs
+++ b/cli/src/commands/config/set.rs
@@ -73,9 +73,9 @@ pub async fn cmd_config_set(
     // If the user is trying to change the author config, we should warn them that
     // it won't affect the working copy author
     if args.name == ConfigNamePathBuf::from_iter(vec!["user", "name"]) {
-        check_wc_author(ui, command, &args.value, AuthorChange::Name)?;
+        check_wc_author(ui, command, &args.value, AuthorChange::Name).await?;
     } else if args.name == ConfigNamePathBuf::from_iter(vec!["user", "email"]) {
-        check_wc_author(ui, command, &args.value, AuthorChange::Email)?;
+        check_wc_author(ui, command, &args.value, AuthorChange::Email).await?;
     }
 
     file.set_value(&args.name, &args.value)
@@ -85,15 +85,15 @@ pub async fn cmd_config_set(
 }
 
 /// Returns the commit of the working copy if it exists.
-fn maybe_wc_commit(helper: &WorkspaceCommandHelper) -> Option<Commit> {
+async fn maybe_wc_commit(helper: &WorkspaceCommandHelper) -> Option<Commit> {
     let repo = helper.repo();
     let id = helper.get_wc_commit_id()?;
-    repo.store().get_commit(id).ok()
+    repo.store().get_commit_async(id).await.ok()
 }
 
 /// Check if the working copy author name matches the user's config value
 /// If it doesn't, print a warning message
-fn check_wc_author(
+async fn check_wc_author(
     ui: &mut Ui,
     command: &CommandHelper,
     new_value: &toml_edit::Value,
@@ -103,7 +103,7 @@ fn check_wc_author(
         // config set should work even if cwd isn't a jj repo
         return Ok(());
     };
-    if let Some(wc_commit) = maybe_wc_commit(&helper) {
+    if let Some(wc_commit) = maybe_wc_commit(&helper).await {
         let author = wc_commit.author();
         let orig_value = match author_change {
             AuthorChange::Name => &author.name,

--- a/cli/src/commands/debug/object.rs
+++ b/cli/src/commands/debug/object.rs
@@ -117,7 +117,7 @@ pub async fn cmd_debug_object(
         DebugObjectArgs::Commit(args) => {
             let id = CommitId::try_from_hex(&args.id)
                 .ok_or_else(|| user_error(format!(r#"Invalid hex commit id: "{}""#, args.id)))?;
-            let commit = repo_loader.store().get_commit(&id)?;
+            let commit = repo_loader.store().get_commit_async(&id).await?;
             writeln!(ui.stdout(), "{:#?}", commit.store_commit())?;
         }
         DebugObjectArgs::File(args) => {

--- a/cli/src/commands/evolog.rs
+++ b/cli/src/commands/evolog.rs
@@ -184,9 +184,11 @@ pub(crate) async fn cmd_evolog(
             let mut buffer = vec![];
             let within_graph =
                 with_content_format.sub_width(graph.width(entry.commit.id(), &edges));
-            within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
-                template.format(&entry, formatter)
-            })?;
+            within_graph
+                .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
+                    template.format(&entry, formatter)
+                })
+                .await?;
             if let Some(renderer) = &diff_renderer {
                 let predecessors = entry.predecessors().await?;
                 let mut formatter = ui.new_formatter(&mut buffer);
@@ -219,7 +221,11 @@ pub(crate) async fn cmd_evolog(
         };
 
         while let Some(entry) = evolution_entries.try_next().await? {
-            with_content_format.write(formatter, |formatter| template.format(&entry, formatter))?;
+            with_content_format
+                .write(formatter, async |formatter| {
+                    template.format(&entry, formatter)
+                })
+                .await?;
             if let Some(renderer) = &diff_renderer {
                 let predecessors = entry.predecessors().await?;
                 let width = ui.term_width();

--- a/cli/src/commands/file/annotate.rs
+++ b/cli/src/commands/file/annotate.rs
@@ -108,14 +108,14 @@ pub(crate) async fn cmd_file_annotate(
         .await?;
     let annotation = annotator.to_annotation();
 
-    render_file_annotation(repo.as_ref(), ui, &template, &annotation)?;
+    render_file_annotation(repo.as_ref(), ui, &template, &annotation).await?;
     Ok(())
 }
 
-fn render_file_annotation(
+async fn render_file_annotation(
     repo: &dyn Repo,
     ui: &mut Ui,
-    template_render: &TemplateRenderer<AnnotationLine>,
+    template_render: &TemplateRenderer<'_, AnnotationLine>,
     annotation: &FileAnnotation,
 ) -> Result<(), CommandError> {
     ui.request_pager();
@@ -131,7 +131,10 @@ fn render_file_annotation(
     };
     for (line_number, (line_origin, content)) in annotation.line_origins().enumerate() {
         let line_origin = line_origin.unwrap_or(&default_line_origin);
-        let commit = repo.store().get_commit(&line_origin.commit_id)?;
+        let commit = repo
+            .store()
+            .get_commit_async(&line_origin.commit_id)
+            .await?;
         let first_line_in_hunk = last_id != Some(&line_origin.commit_id);
         let annotation_line = AnnotationLine {
             commit,

--- a/cli/src/commands/gerrit/upload.rs
+++ b/cli/src/commands/gerrit/upload.rs
@@ -652,8 +652,10 @@ pub async fn cmd_gerrit_upload(
             // We have to write the old commit here, because until we finish
             // the transaction (which we don't), the new commit is labeled as
             // "hidden".
-            tx.base_workspace_helper()
-                .write_commit_summary(formatter.as_mut(), &store.get_commit(head).unwrap())?;
+            tx.base_workspace_helper().write_commit_summary(
+                formatter.as_mut(),
+                &store.get_commit_async(head).await.unwrap(),
+            )?;
             writeln!(formatter)?;
         }
 

--- a/cli/src/commands/git/clone.rs
+++ b/cli/src/commands/git/clone.rs
@@ -277,7 +277,7 @@ pub async fn cmd_git_clone(
             .get_remote_bookmark(working_symbol);
         if let Some(commit_id) = working_branch_remote_ref.target.as_normal().cloned() {
             let mut tx = workspace_command.start_transaction();
-            if let Ok(commit) = tx.repo().store().get_commit(&commit_id) {
+            if let Ok(commit) = tx.repo().store().get_commit_async(&commit_id).await {
                 tx.check_out(&commit)?;
             }
             tx.finish(

--- a/cli/src/commands/git/colocation.rs
+++ b/cli/src/commands/git/colocation.rs
@@ -197,7 +197,11 @@ async fn cmd_git_colocation_enable(
     maybe_add_gitignore(&workspace_command)?;
 
     // Finally, update git HEAD to point to the working-copy commit's parent
-    let wc_commit = workspace_command.repo().store().get_commit(&wc_commit_id)?;
+    let wc_commit = workspace_command
+        .repo()
+        .store()
+        .get_commit_async(&wc_commit_id)
+        .await?;
     set_git_head_to_wc_parent(ui, &mut workspace_command, &wc_commit).await?;
 
     writeln!(

--- a/cli/src/commands/git/init.rs
+++ b/cli/src/commands/git/init.rs
@@ -228,7 +228,7 @@ async fn do_init(
                 let mut tx = workspace_command.start_transaction();
                 jj_lib::git::import_head(tx.repo_mut()).await?;
                 if let Some(git_head_id) = tx.repo().view().git_head().as_normal().cloned() {
-                    let git_head_commit = tx.repo().store().get_commit(&git_head_id)?;
+                    let git_head_commit = tx.repo().store().get_commit_async(&git_head_id).await?;
                     tx.check_out(&git_head_commit)?;
                 }
                 if tx.repo().has_changes() {

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -272,7 +272,7 @@ pub(crate) async fn cmd_log(
                 }
                 let mut buffer = vec![];
                 let key = (commit_id, false);
-                let commit = store.get_commit(&key.0)?;
+                let commit = store.get_commit_async(&key.0).await?;
                 let within_graph =
                     with_content_format.sub_width(graph.width(&key, &graphlog_edges));
                 within_graph

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -275,9 +275,11 @@ pub(crate) async fn cmd_log(
                 let commit = store.get_commit(&key.0)?;
                 let within_graph =
                     with_content_format.sub_width(graph.width(&key, &graphlog_edges));
-                within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
-                    template.format(&commit, formatter)
-                })?;
+                within_graph
+                    .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
+                        template.format(&commit, formatter)
+                    })
+                    .await?;
                 if let Some(renderer) = &diff_renderer {
                     let mut formatter = ui.new_formatter(&mut buffer);
                     renderer
@@ -312,9 +314,11 @@ pub(crate) async fn cmd_log(
                     let mut buffer = vec![];
                     let within_graph =
                         with_content_format.sub_width(graph.width(&elided_key, &edges));
-                    within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
-                        writeln!(formatter.labeled("elided"), "(elided revisions)")
-                    })?;
+                    within_graph
+                        .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
+                            writeln!(formatter.labeled("elided"), "(elided revisions)")
+                        })
+                        .await?;
                     let node_symbol = format_template(ui, &None, &node_template);
                     graph.add_node(
                         &elided_key,
@@ -337,7 +341,10 @@ pub(crate) async fn cmd_log(
             let mut commit_stream = id_stream.commits(store);
             while let Some(commit) = commit_stream.try_next().await? {
                 with_content_format
-                    .write(formatter, |formatter| template.format(&commit, formatter))?;
+                    .write(formatter, async |formatter| {
+                        template.format(&commit, formatter)
+                    })
+                    .await?;
                 if let Some(renderer) = &diff_renderer {
                     let width = ui.term_width();
                     renderer

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -281,16 +281,18 @@ pub async fn show_op_diff(
         }
         Err(err) => {
             writeln!(formatter)?;
-            with_content_format.write(formatter, |formatter| {
-                writeln!(
-                    formatter.labeled("warning"),
-                    "Warning: Could not resolve revset expression for elision: {err}"
-                )?;
-                writeln!(
-                    formatter,
-                    "   (Use --show-changes-in=all() to see all changes)"
-                )
-            })?;
+            with_content_format
+                .write(formatter, async |formatter| {
+                    writeln!(
+                        formatter.labeled("warning"),
+                        "Warning: Could not resolve revset expression for elision: {err}"
+                    )?;
+                    writeln!(
+                        formatter,
+                        "   (Use --show-changes-in=all() to see all changes)"
+                    )
+                })
+                .await?;
             None
         }
     };
@@ -301,9 +303,11 @@ pub async fn show_op_diff(
         let revset = RevsetExpression::commits(op_commits_diff.changes.keys().cloned().collect())
             .evaluate(current_repo)?;
         writeln!(formatter)?;
-        with_content_format.write(formatter, |formatter| {
-            writeln!(formatter, "Changed commits:")
-        })?;
+        with_content_format
+            .write(formatter, async |formatter| {
+                writeln!(formatter, "Changed commits:")
+            })
+            .await?;
         if let Some(graph_style) = graph_style {
             let mut raw_output = formatter.raw()?;
             let mut graph = get_graphlog(graph_style, raw_output.as_mut());
@@ -317,13 +321,15 @@ pub async fn show_op_diff(
 
                 let mut buffer = vec![];
                 let within_graph = with_content_format.sub_width(graph.width(&commit_id, &edges));
-                within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
-                    write_modified_change_summary(
-                        formatter,
-                        commit_summary_template,
-                        modified_change,
-                    )
-                })?;
+                within_graph
+                    .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
+                        write_modified_change_summary(
+                            formatter,
+                            commit_summary_template,
+                            modified_change,
+                        )
+                    })
+                    .await?;
                 if let Some(diff_renderer) = diff_renderer {
                     let mut formatter = ui.new_formatter(&mut buffer);
                     show_change_diff(
@@ -349,20 +355,22 @@ pub async fn show_op_diff(
             let mut commit_ids = revset.stream();
             while let Some(commit_id) = commit_ids.try_next().await? {
                 let modified_change = op_commits_diff.changes.get(&commit_id).unwrap();
-                with_content_format.write(formatter, |formatter| {
-                    write_modified_change_summary(
-                        formatter,
-                        commit_summary_template,
-                        modified_change,
-                    )
-                })?;
+                with_content_format
+                    .write(formatter, async |formatter| {
+                        write_modified_change_summary(
+                            formatter,
+                            commit_summary_template,
+                            modified_change,
+                        )
+                    })
+                    .await?;
                 if let Some(diff_renderer) = diff_renderer {
                     let width = with_content_format.width();
                     show_change_diff(ui, formatter, diff_renderer, modified_change, width).await?;
                 }
             }
         }
-        write_elided_commit_counts(formatter, with_content_format, &op_commits_diff)?;
+        write_elided_commit_counts(formatter, with_content_format, &op_commits_diff).await?;
     }
 
     let changed_working_copies = diff_named_commit_ids(
@@ -373,29 +381,33 @@ pub async fn show_op_diff(
     if !changed_working_copies.is_empty() {
         writeln!(formatter)?;
         for (name, (from_commit, to_commit)) in changed_working_copies {
-            with_content_format.write(formatter, |formatter| {
-                // Usually, there is at most one working copy changed per operation, so we put
-                // the working copy name in the heading.
-                write!(formatter, "Changed working copy ")?;
-                write!(formatter.labeled("working_copies"), "{}@", name.as_symbol())?;
-                writeln!(formatter, ":")?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    &RefTarget::resolved(to_commit.cloned()),
-                    true,
-                    None,
-                )?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    &RefTarget::resolved(from_commit.cloned()),
-                    false,
-                    None,
-                )
-            })?;
+            with_content_format
+                .write(formatter, async |formatter| {
+                    // Usually, there is at most one working copy changed per operation, so we put
+                    // the working copy name in the heading.
+                    write!(formatter, "Changed working copy ")?;
+                    write!(formatter.labeled("working_copies"), "{}@", name.as_symbol())?;
+                    writeln!(formatter, ":")?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        &RefTarget::resolved(to_commit.cloned()),
+                        true,
+                        None,
+                    )
+                    .await?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        &RefTarget::resolved(from_commit.cloned()),
+                        false,
+                        None,
+                    )
+                    .await
+                })
+                .await?;
         }
     }
 
@@ -406,29 +418,35 @@ pub async fn show_op_diff(
     .collect_vec();
     if !changed_local_bookmarks.is_empty() {
         writeln!(formatter)?;
-        with_content_format.write(formatter, |formatter| {
-            writeln!(formatter, "Changed local bookmarks:")
-        })?;
+        with_content_format
+            .write(formatter, async |formatter| {
+                writeln!(formatter, "Changed local bookmarks:")
+            })
+            .await?;
         for (name, (from_target, to_target)) in changed_local_bookmarks {
-            with_content_format.write(formatter, |formatter| {
-                writeln!(formatter, "{name}:", name = name.as_symbol())?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    to_target,
-                    true,
-                    None,
-                )?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    from_target,
-                    false,
-                    None,
-                )
-            })?;
+            with_content_format
+                .write(formatter, async |formatter| {
+                    writeln!(formatter, "{name}:", name = name.as_symbol())?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        to_target,
+                        true,
+                        None,
+                    )
+                    .await?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        from_target,
+                        false,
+                        None,
+                    )
+                    .await
+                })
+                .await?;
         }
     }
 
@@ -437,29 +455,35 @@ pub async fn show_op_diff(
             .collect_vec();
     if !changed_local_tags.is_empty() {
         writeln!(formatter)?;
-        with_content_format.write(formatter, |formatter| {
-            writeln!(formatter, "Changed local tags:")
-        })?;
+        with_content_format
+            .write(formatter, async |formatter| {
+                writeln!(formatter, "Changed local tags:")
+            })
+            .await?;
         for (name, (from_target, to_target)) in changed_local_tags {
-            with_content_format.write(formatter, |formatter| {
-                writeln!(formatter, "{name}:", name = name.as_symbol())?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    to_target,
-                    true,
-                    None,
-                )?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    from_target,
-                    false,
-                    None,
-                )
-            })?;
+            with_content_format
+                .write(formatter, async |formatter| {
+                    writeln!(formatter, "{name}:", name = name.as_symbol())?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        to_target,
+                        true,
+                        None,
+                    )
+                    .await?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        from_target,
+                        false,
+                        None,
+                    )
+                    .await
+                })
+                .await?;
         }
     }
 
@@ -479,29 +503,35 @@ pub async fn show_op_diff(
     .collect_vec();
     if !changed_remote_bookmarks.is_empty() {
         writeln!(formatter)?;
-        with_content_format.write(formatter, |formatter| {
-            writeln!(formatter, "Changed remote bookmarks:")
-        })?;
+        with_content_format
+            .write(formatter, async |formatter| {
+                writeln!(formatter, "Changed remote bookmarks:")
+            })
+            .await?;
         for (symbol, (from_ref, to_ref)) in changed_remote_bookmarks {
-            with_content_format.write(formatter, |formatter| {
-                writeln!(formatter, "{symbol}:")?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    &to_ref.target,
-                    true,
-                    Some(get_remote_ref_prefix(to_ref)),
-                )?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    &from_ref.target,
-                    false,
-                    Some(get_remote_ref_prefix(from_ref)),
-                )
-            })?;
+            with_content_format
+                .write(formatter, async |formatter| {
+                    writeln!(formatter, "{symbol}:")?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        &to_ref.target,
+                        true,
+                        Some(get_remote_ref_prefix(to_ref)),
+                    )
+                    .await?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        &from_ref.target,
+                        false,
+                        Some(get_remote_ref_prefix(from_ref)),
+                    )
+                    .await
+                })
+                .await?;
         }
     }
 
@@ -515,36 +545,42 @@ pub async fn show_op_diff(
     .collect_vec();
     if !changed_remote_tags.is_empty() {
         writeln!(formatter)?;
-        with_content_format.write(formatter, |formatter| {
-            writeln!(formatter, "Changed remote tags:")
-        })?;
+        with_content_format
+            .write(formatter, async |formatter| {
+                writeln!(formatter, "Changed remote tags:")
+            })
+            .await?;
         for (symbol, (from_ref, to_ref)) in changed_remote_tags {
-            with_content_format.write(formatter, |formatter| {
-                writeln!(formatter, "{symbol}:")?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    &to_ref.target,
-                    true,
-                    Some(get_remote_ref_prefix(to_ref)),
-                )?;
-                write_ref_target_summary(
-                    formatter,
-                    current_repo,
-                    commit_summary_template,
-                    &from_ref.target,
-                    false,
-                    Some(get_remote_ref_prefix(from_ref)),
-                )
-            })?;
+            with_content_format
+                .write(formatter, async |formatter| {
+                    writeln!(formatter, "{symbol}:")?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        &to_ref.target,
+                        true,
+                        Some(get_remote_ref_prefix(to_ref)),
+                    )
+                    .await?;
+                    write_ref_target_summary(
+                        formatter,
+                        current_repo,
+                        commit_summary_template,
+                        &from_ref.target,
+                        false,
+                        Some(get_remote_ref_prefix(from_ref)),
+                    )
+                    .await
+                })
+                .await?;
         }
     }
 
     Ok(())
 }
 
-fn write_elided_commit_counts(
+async fn write_elided_commit_counts(
     formatter: &mut dyn Formatter,
     with_content_format: &LogContentFormat,
     op_commits_diff: &OperationCommitsDiff,
@@ -571,9 +607,11 @@ fn write_elided_commit_counts(
         return Ok(());
     }
 
-    with_content_format.write(formatter, |formatter| {
-        writeln!(formatter, "   (Elided {} revisions)", parts.join(" and "))
-    })?;
+    with_content_format
+        .write(formatter, async |formatter| {
+            writeln!(formatter, "   (Elided {} revisions)", parts.join(" and "))
+        })
+        .await?;
     Ok(())
 }
 
@@ -599,10 +637,10 @@ fn write_modified_change_summary(
 }
 
 /// Writes a summary for the given `RefTarget`.
-fn write_ref_target_summary(
+async fn write_ref_target_summary(
     formatter: &mut dyn Formatter,
     repo: &dyn Repo,
-    commit_summary_template: &TemplateRenderer<Commit>,
+    commit_summary_template: &TemplateRenderer<'_, Commit>,
     ref_target: &RefTarget,
     added: bool,
     prefix: Option<&str>,

--- a/cli/src/commands/operation/diff.rs
+++ b/cli/src/commands/operation/diff.rs
@@ -667,21 +667,21 @@ async fn write_ref_target_summary(
         for commit_id in ref_target.added_ids() {
             write_prefix(formatter, added, prefix)?;
             write!(formatter, "(added) ")?;
-            let commit = repo.store().get_commit(commit_id)?;
+            let commit = repo.store().get_commit_async(commit_id).await?;
             commit_summary_template.format(&commit, formatter)?;
             writeln!(formatter)?;
         }
         for commit_id in ref_target.removed_ids() {
             write_prefix(formatter, added, prefix)?;
             write!(formatter, "(removed) ")?;
-            let commit = repo.store().get_commit(commit_id)?;
+            let commit = repo.store().get_commit_async(commit_id).await?;
             commit_summary_template.format(&commit, formatter)?;
             writeln!(formatter)?;
         }
     } else {
         write_prefix(formatter, added, prefix)?;
         let commit_id = ref_target.as_normal().unwrap();
-        let commit = repo.store().get_commit(commit_id)?;
+        let commit = repo.store().get_commit_async(commit_id).await?;
         commit_summary_template.format(&commit, formatter)?;
         writeln!(formatter)?;
     }
@@ -799,7 +799,7 @@ async fn compute_operation_commits_diff(
             abandoned_commits.remove(id);
         }
         let change = ModifiedChange::Existing {
-            commit: store.get_commit(&commit_id)?,
+            commit: store.get_commit_async(&commit_id).await?,
             predecessors: predecessor_ids
                 .iter()
                 .map(|id| store.get_commit(id))
@@ -811,7 +811,7 @@ async fn compute_operation_commits_diff(
     // Record remainders as abandoned.
     for commit_id in abandoned_commits {
         let change = ModifiedChange::Abandoned {
-            commit: store.get_commit(&commit_id)?,
+            commit: store.get_commit_async(&commit_id).await?,
         };
         changes.insert(commit_id, change);
     }

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -249,9 +249,11 @@ async fn do_op_log(
             let (op, edges) = node?;
             let mut buffer = vec![];
             let within_graph = with_content_format.sub_width(graph.width(op.id(), &edges));
-            within_graph.write(ui.new_formatter(&mut buffer).as_mut(), |formatter| {
-                template.format(&op, formatter)
-            })?;
+            within_graph
+                .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
+                    template.format(&op, formatter)
+                })
+                .await?;
             if let Some(show) = &maybe_show_op_diff {
                 let mut formatter = ui.new_formatter(&mut buffer);
                 show(ui, formatter.as_mut(), &op, &within_graph).await?;
@@ -271,7 +273,9 @@ async fn do_op_log(
             stream.boxed_local()
         };
         while let Some(op) = stream.try_next().await? {
-            with_content_format.write(formatter, |formatter| template.format(&op, formatter))?;
+            with_content_format
+                .write(formatter, async |formatter| template.format(&op, formatter))
+                .await?;
             if let Some(show) = &maybe_show_op_diff {
                 show(ui, formatter, &op, &with_content_format).await?;
             }

--- a/cli/src/commands/rebase.rs
+++ b/cli/src/commands/rebase.rs
@@ -498,7 +498,11 @@ async fn plan_rebase_source(
     .await?;
     if rebase_destination.onto.is_some() {
         for id in &source_commit_ids {
-            let commit = workspace_command.repo().store().get_commit(id)?;
+            let commit = workspace_command
+                .repo()
+                .store()
+                .get_commit_async(id)
+                .await?;
             check_rebase_destinations(workspace_command.repo(), &new_parent_ids, &commit)?;
         }
     }
@@ -555,7 +559,11 @@ async fn plan_rebase_branch(
         .await?;
     if rebase_destination.onto.is_some() {
         for id in &root_commit_ids {
-            let commit = workspace_command.repo().store().get_commit(id)?;
+            let commit = workspace_command
+                .repo()
+                .store()
+                .get_commit_async(id)
+                .await?;
             check_rebase_destinations(workspace_command.repo(), &new_parent_ids, &commit)?;
         }
     }

--- a/cli/src/commands/workspace/add.rs
+++ b/cli/src/commands/workspace/add.rs
@@ -188,7 +188,8 @@ pub async fn cmd_workspace_add(
         {
             tx.repo()
                 .store()
-                .get_commit(old_wc_commit_id)?
+                .get_commit_async(old_wc_commit_id)
+                .await?
                 .parents()
                 .await?
         } else {

--- a/cli/src/commands/workspace/list.rs
+++ b/cli/src/commands/workspace/list.rs
@@ -69,7 +69,7 @@ pub async fn cmd_workspace_list(
     let mut formatter = ui.stdout_formatter();
 
     for (name, wc_commit_id) in repo.view().wc_commit_ids() {
-        let commit = repo.store().get_commit(wc_commit_id)?;
+        let commit = repo.store().get_commit_async(wc_commit_id).await?;
         let ws_ref = WorkspaceRef::new(name.clone(), commit);
 
         template.format(&ws_ref, formatter.as_mut())?;


### PR DESCRIPTION
Perhaps we should rename `get_commit()` to `get_commit_sync()` and `get_commit_async()` to `get_commit()` now that there are quite few `get_commit()` callers left.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
