### PR TITLE
cli: bookmark: Undeprecate `name@remote` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fixed a panic in `jj gerrit upload` when run without `-r` and the
   inferred revision was immutable. [#9398](https://github.com/jj-vcs/jj/issues/9398)
 
+* `bookmark@remote` syntax remains supported for literal remote bookmark names,
+  matching how Jujutsu displays them. For string patterns, pass the bookmark and
+  remote patterns separately with `--remote`; for example, use `jj bookmark
+  track 'glob:feature*' --remote=origin` instead of `jj bookmark track
+  'glob:feature*@origin'`.
+
 ## [0.40.0] - 2026-04-01
 
 ### Release highlights

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -3389,7 +3389,6 @@ impl DiffSelector {
     }
 }
 
-// TODO: Delete in jj 0.43+
 #[derive(Clone, Debug)]
 pub(crate) struct RemoteBookmarkNamePattern {
     pub bookmark: StringPattern,
@@ -3400,24 +3399,16 @@ impl FromStr for RemoteBookmarkNamePattern {
     type Err = String;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        // The kind prefix applies to both bookmark and remote fragments. It's
-        // weird that unanchored patterns like substring:bookmark@remote is split
-        // into two, but I can't think of a better syntax.
-        // TODO: should we disable substring pattern? what if we added regex?
-        let (maybe_kind, pat) = src
-            .split_once(':')
-            .map_or((None, src), |(kind, pat)| (Some(kind), pat));
-        let to_pattern = |pat: &str| {
-            if let Some(kind) = maybe_kind {
-                StringPattern::from_str_kind(pat, kind).map_err(|err| err.to_string())
-            } else {
-                StringPattern::glob(pat).map_err(|err| err.to_string())
-            }
+        let to_pattern = |pat: &str| StringPattern::glob(pat).map_err(|err| err.to_string());
+        let Some((bookmark, remote)) = src.rsplit_once('@') else {
+            unreachable!("RemoteBookmarkNamePattern should only parse `bookmark@remote` syntax");
         };
-        // TODO: maybe reuse revset parser to handle bookmark/remote name containing @
-        let (bookmark, remote) = pat.rsplit_once('@').ok_or_else(|| {
-            "remote bookmark must be specified in bookmark@remote form".to_owned()
-        })?;
+        if bookmark.contains(':') {
+            return Err(format!(
+                "Pattern syntax is not supported with `bookmark@remote` syntax. Use `{bookmark} \
+                 --remote={remote}` instead."
+            ));
+        }
         Ok(Self {
             bookmark: to_pattern(bookmark)?,
             remote: to_pattern(remote)?,

--- a/cli/src/commands/bookmark/track.rs
+++ b/cli/src/commands/bookmark/track.rs
@@ -78,11 +78,6 @@ pub async fn cmd_bookmark_track(
     let repo = workspace_command.repo().clone();
     let view = repo.view();
     let matched_refs = if args.remotes.is_none() && args.names.iter().all(|s| s.contains('@')) {
-        // TODO: Delete in jj 0.43+
-        writeln!(
-            ui.warning_default(),
-            "<bookmark>@<remote> syntax is deprecated, use `<bookmark> --remote=<remote>` instead."
-        )?;
         let name_patterns: Vec<RemoteBookmarkNamePattern> = args
             .names
             .iter()

--- a/cli/src/commands/bookmark/untrack.rs
+++ b/cli/src/commands/bookmark/untrack.rs
@@ -78,11 +78,6 @@ pub async fn cmd_bookmark_untrack(
         // suppress unmatched remotes warning for default-ignored remote
         .filter(|name| view.get_remote_view(name).is_some());
     let matched_refs = if args.remotes.is_none() && args.names.iter().all(|s| s.contains('@')) {
-        // TODO: Delete in jj 0.43+
-        writeln!(
-            ui.warning_default(),
-            "<bookmark>@<remote> syntax is deprecated, use `<bookmark> --remote=<remote>` instead."
-        )?;
         let name_patterns: Vec<RemoteBookmarkNamePattern> = args
             .names
             .iter()

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1636,7 +1636,6 @@ fn test_bookmark_track_untrack() -> TestResult {
     ]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: <bookmark>@<remote> syntax is deprecated, use `<bookmark> --remote=<remote>` instead.
     Warning: No matching remote bookmarks for names: nonexistent@origin
     Started tracking 2 remote bookmarks.
     [EOF]
@@ -1684,7 +1683,6 @@ fn test_bookmark_track_untrack() -> TestResult {
     let output = work_dir.run_jj(["bookmark", "untrack", "feature1@origin", "feature2@origin"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Warning: <bookmark>@<remote> syntax is deprecated, use `<bookmark> --remote=<remote>` instead.
     Stopped tracking 2 remote bookmarks.
     [EOF]
     ");
@@ -1905,6 +1903,23 @@ fn test_bookmark_track_untrack_patterns() -> TestResult {
     bookmark: feature1@origin [new] untracked
     bookmark: feature2@origin [new] untracked
     [EOF]
+    ");
+
+    // Pattern syntax should be used with --remote instead of `bookmark@remote`
+    // syntax.
+    insta::assert_snapshot!(
+        work_dir.run_jj(["bookmark", "track", "glob:feature*@origin"]), @"
+    ------- stderr -------
+    Error: Pattern syntax is not supported with `bookmark@remote` syntax. Use `glob:feature* --remote=origin` instead.
+    [EOF]
+    [exit status: 2]
+    ");
+    insta::assert_snapshot!(
+        work_dir.run_jj(["bookmark", "untrack", "glob:feature*@origin"]), @"
+    ------- stderr -------
+    Error: Pattern syntax is not supported with `bookmark@remote` syntax. Use `glob:feature* --remote=origin` instead.
+    [EOF]
+    [exit status: 2]
     ");
 
     // Track/untrack new bookmark that doesn't exist at remote

--- a/docs/bookmarks.md
+++ b/docs/bookmarks.md
@@ -103,6 +103,11 @@ $ # A local bookmark <bookmark name> should have been created or updated while f
 $ jj new <bookmark name> # Do some local testing, etc.
 ```
 
+For exact bookmark and remote names, you can also write `jj bookmark track
+<bookmark name>@<remote name>` as shorthand. Pattern syntax must use the full
+`--remote` form, for example `jj bookmark track 'glob:feature-*'
+--remote=origin`.
+
 ### Untracking a bookmark
 
 To stop following a remote bookmark, you can `jj bookmark untrack` it. After that,
@@ -122,6 +127,11 @@ $ # From this point on, this remote bookmark won't be imported anymore.
 $ # The local bookmark (e.g. stuff) is unaffected. It may or may not still
 $ # be tracking bookmarks on other remotes (e.g. stuff@upstream).
 ```
+
+For exact bookmark and remote names, you can also write `jj bookmark untrack
+<bookmark name>@<remote name>` as shorthand. Pattern syntax must use the full
+`--remote` form, for example `jj bookmark untrack 'glob:feature-*'
+--remote=origin`.
 
 ### Listing tracked bookmarks
 


### PR DESCRIPTION
A follow up to #8244.

Moving pattern syntax exclusively to `--remote` syntax is a good move that will make using it more straightforward, but `name@remote` syntax is intuitive and is what we teach to our users (by printing it in log outputs), so dropping support for it is IMO a UX regression.

This change removes deprecation messages for `name@remote` syntax, as well as detecting attempts to use `pattern:name@remote` and guiding users to use `pattern:name --remote remote` instead.

Closes #9226

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
