### PR TITLE
templater: add `available_width()` function containing printable width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   changes/conflicts are propagated accordingly, e.g., `jj run -- cargo check
   --all-features` or `jj run -- cargo fix` behaves as one might expect.
 
+* Templates now support `available_width() -> Option<Integer>`. This will
+  provide the number of columns available for the template, subtracting the
+  width of the graph lines. This is only available in graph logs, i.e. `jj log`
+  and `jj op log`.
+
 ### Fixed bugs
 
 * `jj` now creates a new working-copy revision during snapshotting if the

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -277,7 +277,11 @@ pub(crate) async fn cmd_log(
                     with_content_format.sub_width(graph.width(&key, &graphlog_edges));
                 within_graph
                     .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
-                        template.format(&commit, formatter)
+                        template.format_with_available_width(
+                            &commit,
+                            within_graph.width(),
+                            formatter,
+                        )
                     })
                     .await?;
                 if let Some(renderer) = &diff_renderer {

--- a/cli/src/commands/operation/log.rs
+++ b/cli/src/commands/operation/log.rs
@@ -251,7 +251,7 @@ async fn do_op_log(
             let within_graph = with_content_format.sub_width(graph.width(op.id(), &edges));
             within_graph
                 .write(ui.new_formatter(&mut buffer).as_mut(), async |formatter| {
-                    template.format(&op, formatter)
+                    template.format_with_available_width(&op, within_graph.width(), formatter)
                 })
                 .await?;
             if let Some(show) = &maybe_show_op_diff {

--- a/cli/src/template_builder.rs
+++ b/cli/src/template_builder.rs
@@ -911,6 +911,7 @@ pub struct BuildContext<'i, P> {
     /// This could be `local_variables["self"]`, but keyword lookup shouldn't be
     /// overridden by a user-defined `self` variable.
     self_variable: &'i dyn Fn() -> P,
+    available_width: PropertyPlaceholder<Option<i64>>,
 }
 
 fn build_keyword<'a, L: TemplateLanguage<'a> + ?Sized>(
@@ -2310,6 +2311,7 @@ fn build_lambda_expression<'i, P, T>(
     let inner_build_ctx = BuildContext {
         local_variables,
         self_variable: build_ctx.self_variable,
+        available_width: build_ctx.available_width.clone(),
     };
     build_body(&inner_build_ctx, &lambda.body)
 }
@@ -2409,6 +2411,14 @@ fn builtin_functions<'a, L: TemplateLanguage<'a> + ?Sized>() -> TemplateBuildFun
             let template =
                 new_truncate_template(content, ellipsis, width, text_util::write_truncated_end);
             Ok(L::Property::wrap_template(template))
+        },
+    );
+    map.insert(
+        "available_width",
+        |_language, _diagnostics, build_ctx, function| {
+            function.expect_no_arguments()?;
+            let width = build_ctx.available_width.clone();
+            Ok(L::Property::wrap_property(Box::new(width)))
         },
     );
     map.insert("hash", |language, diagnostics, build_ctx, function| {
@@ -2819,12 +2829,19 @@ where
     L::Property: WrapTemplateProperty<'a, C>,
 {
     let self_placeholder = PropertyPlaceholder::new();
+    let available_width_placeholder = PropertyPlaceholder::new();
+    available_width_placeholder.set(None);
     let build_ctx = BuildContext {
         local_variables: HashMap::new(),
         self_variable: &|| self_placeholder.clone().into_dyn_wrapped(),
+        available_width: available_width_placeholder.clone(),
     };
     let template = expect_template_expression(language, diagnostics, &build_ctx, node)?;
-    Ok(TemplateRenderer::new(template, self_placeholder))
+    Ok(TemplateRenderer::new(
+        template,
+        self_placeholder,
+        available_width_placeholder,
+    ))
 }
 
 /// Parses text, expands aliases, then builds template evaluation tree.

--- a/cli/src/templater.rs
+++ b/cli/src/templater.rs
@@ -948,15 +948,21 @@ impl<O: Clone> TemplateProperty for PropertyPlaceholder<O> {
 /// Adapter that renders compiled `template` with the `placeholder` value set.
 pub struct TemplateRenderer<'a, C> {
     template: Box<dyn Template + 'a>,
-    placeholder: PropertyPlaceholder<C>,
+    self_placeholder: PropertyPlaceholder<C>,
+    available_width_placeholder: PropertyPlaceholder<Option<i64>>,
     labels: Vec<String>,
 }
 
 impl<'a, C: Clone> TemplateRenderer<'a, C> {
-    pub fn new(template: Box<dyn Template + 'a>, placeholder: PropertyPlaceholder<C>) -> Self {
+    pub fn new(
+        template: Box<dyn Template + 'a>,
+        self_placeholder: PropertyPlaceholder<C>,
+        available_width_placeholder: PropertyPlaceholder<Option<i64>>,
+    ) -> Self {
         Self {
             template,
-            placeholder,
+            self_placeholder,
+            available_width_placeholder,
             labels: Vec::new(),
         }
     }
@@ -974,8 +980,24 @@ impl<'a, C: Clone> TemplateRenderer<'a, C> {
 
     pub fn format(&self, context: &C, formatter: &mut dyn Formatter) -> io::Result<()> {
         let mut wrapper = TemplateFormatter::new(formatter, format_property_error_inline);
-        self.placeholder.with_value(context.clone(), || {
+        self.self_placeholder.with_value(context.clone(), || {
             format_labeled(&mut wrapper, &self.template, &self.labels)
+        })
+    }
+
+    pub fn format_with_available_width(
+        &self,
+        context: &C,
+        available_width: usize,
+        formatter: &mut dyn Formatter,
+    ) -> io::Result<()> {
+        let available_width = available_width.try_into().unwrap_or(i64::MAX);
+        let mut wrapper = TemplateFormatter::new(formatter, format_property_error_inline);
+        self.self_placeholder.with_value(context.clone(), || {
+            self.available_width_placeholder
+                .with_value(Some(available_width), || {
+                    format_labeled(&mut wrapper, &self.template, &self.labels)
+                })
         })
     }
 

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1589,6 +1589,44 @@ fn test_log_diff_stat_width() {
 }
 
 #[test]
+fn test_log_available_width() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    let render = |args: &[&str], columns: u32| {
+        work_dir.run_jj_with(|cmd| cmd.args(args).env("COLUMNS", columns.to_string()))
+    };
+
+    work_dir.run_jj(["new", "--no-edit", "root()"]).success();
+    work_dir.run_jj(["new", "--no-edit", "root()"]).success();
+    work_dir.run_jj(["new", "--no-edit", "root()"]).success();
+    work_dir.run_jj(["new", "root()+"]).success();
+
+    insta::assert_snapshot!(render(&["log", "-T", "available_width()"], 20), @"
+    @        11
+    ├─┬─┬─╮
+    │ │ │ ○  11
+    │ │ ○ │  11
+    │ │ ├─╯
+    │ ○ │  13
+    │ ├─╯
+    ○ │  15
+    ├─╯
+    ◆  17
+    [EOF]
+    ");
+    insta::assert_snapshot!(render(&["log", "-T", "available_width() + 0 ++ '\n'", "--no-graph"], 20), @"
+    <Error: No Integer available>
+    <Error: No Integer available>
+    <Error: No Integer available>
+    <Error: No Integer available>
+    <Error: No Integer available>
+    <Error: No Integer available>
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_elided() {
     // Test that elided commits are shown as synthetic nodes.
     let test_env = TestEnvironment::default();

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -477,8 +477,15 @@ fn test_op_log_word_wrap() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
     let work_dir = test_env.work_dir("repo");
+
+    // Create a merge operation
     work_dir.write_file("file1", "foo\n".repeat(100));
-    work_dir.run_jj(["debug", "snapshot"]).success();
+    work_dir.run_jj(["util", "snapshot"]).success();
+    work_dir.write_file("file2", "bar\n".repeat(100));
+    work_dir
+        .run_jj(["commit", "-m", "commit 1", "--at-op=@-"])
+        .success();
+    work_dir.run_jj(["status"]).success();
 
     let render = |args: &[&str], columns: u32, word_wrap: bool| {
         let word_wrap = to_toml_value(word_wrap);
@@ -491,22 +498,54 @@ fn test_op_log_word_wrap() {
 
     // ui.log-word-wrap option works
     insta::assert_snapshot!(render(&["op", "log"], 40, false), @"
-    @  5ea39824268b test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    @  e31c6b8db4d8 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
     │  snapshot working copy
-    │  args: jj debug snapshot
+    │  args: jj status
+    ○    72995cf9d0a8 test-username@host.example.com default@ 2001-02-03 04:05:10.000 +07:00 - 2001-02-03 04:05:10.000 +07:00
+    ├─╮  reconcile divergent operations
+    │ │  args: jj status
+    ○ │  c58716a19a3d test-username@host.example.com default@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │ │  snapshot working copy
+    │ │  args: jj util snapshot
+    │ ○  eb6b089ded63 test-username@host.example.com default@ 2001-02-03 04:05:09.000 +07:00 - 2001-02-03 04:05:09.000 +07:00
+    ├─╯  commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │    args: jj commit -m 'commit 1' '--at-op=@-'
     ○  90267f31f904 test-username@host.example.com 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log"], 40, true), @"
-    @  5ea39824268b
+    @  e31c6b8db4d8
     │  test-username@host.example.com
-    │  default@ 2001-02-03 04:05:08.000
-    │  +07:00 - 2001-02-03 04:05:08.000
+    │  default@ 2001-02-03 04:05:10.000
+    │  +07:00 - 2001-02-03 04:05:10.000
     │  +07:00
     │  snapshot working copy
-    │  args: jj debug snapshot
+    │  args: jj status
+    ○    72995cf9d0a8
+    ├─╮  test-username@host.example.com
+    │ │  default@ 2001-02-03 04:05:10.000
+    │ │  +07:00 - 2001-02-03 04:05:10.000
+    │ │  +07:00
+    │ │  reconcile divergent operations
+    │ │  args: jj status
+    ○ │  c58716a19a3d
+    │ │  test-username@host.example.com
+    │ │  default@ 2001-02-03 04:05:08.000
+    │ │  +07:00 - 2001-02-03 04:05:08.000
+    │ │  +07:00
+    │ │  snapshot working copy
+    │ │  args: jj util snapshot
+    │ ○  eb6b089ded63
+    ├─╯  test-username@host.example.com
+    │    default@ 2001-02-03 04:05:09.000
+    │    +07:00 - 2001-02-03 04:05:09.000
+    │    +07:00
+    │    commit
+    │    e8849ae12c709f2321908879bc724fdb2ab8a781
+    │    args: jj commit -m 'commit 1'
+    │    '--at-op=@-'
     ○  90267f31f904
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
@@ -518,25 +557,74 @@ fn test_op_log_word_wrap() {
 
     // Nested graph should be wrapped
     insta::assert_snapshot!(render(&["op", "log", "--op-diff"], 40, true), @"
-    @  5ea39824268b
+    @  e31c6b8db4d8
     │  test-username@host.example.com
-    │  default@ 2001-02-03 04:05:08.000
-    │  +07:00 - 2001-02-03 04:05:08.000
+    │  default@ 2001-02-03 04:05:10.000
+    │  +07:00 - 2001-02-03 04:05:10.000
     │  +07:00
     │  snapshot working copy
-    │  args: jj debug snapshot
+    │  args: jj status
     │
     │  Changed commits:
-    │  ○  + qpvuntsm 79f0968d (no
+    │  ○  + qpvuntsm/0 0d9c7580 (divergent)
+    │     (no description set)
+    │     - qpvuntsm/2 79f0968d (hidden) (no
     │     description set)
-    │     - qpvuntsm/1 e8849ae1 (hidden)
-    │     (empty) (no description set)
     │
     │  Changed working copy default@:
-    │  + qpvuntsm 79f0968d (no description
-    │  set)
-    │  - qpvuntsm/1 e8849ae1 (hidden)
-    │  (empty) (no description set)
+    │  + qpvuntsm/0 0d9c7580 (divergent) (no
+    │  description set)
+    │  - qpvuntsm/2 79f0968d (hidden) (no
+    │  description set)
+    ○    72995cf9d0a8
+    ├─╮  test-username@host.example.com
+    │ │  default@ 2001-02-03 04:05:10.000
+    │ │  +07:00 - 2001-02-03 04:05:10.000
+    │ │  +07:00
+    │ │  reconcile divergent operations
+    │ │  args: jj status
+    ○ │  c58716a19a3d
+    │ │  test-username@host.example.com
+    │ │  default@ 2001-02-03 04:05:08.000
+    │ │  +07:00 - 2001-02-03 04:05:08.000
+    │ │  +07:00
+    │ │  snapshot working copy
+    │ │  args: jj util snapshot
+    │ │
+    │ │  Changed commits:
+    │ │  ○  + qpvuntsm 79f0968d (no
+    │ │     description set)
+    │ │     - qpvuntsm/1 e8849ae1 (hidden)
+    │ │     (empty) (no description set)
+    │ │
+    │ │  Changed working copy default@:
+    │ │  + qpvuntsm 79f0968d (no description
+    │ │  set)
+    │ │  - qpvuntsm/1 e8849ae1 (hidden)
+    │ │  (empty) (no description set)
+    │ ○  eb6b089ded63
+    ├─╯  test-username@host.example.com
+    │    default@ 2001-02-03 04:05:09.000
+    │    +07:00 - 2001-02-03 04:05:09.000
+    │    +07:00
+    │    commit
+    │    e8849ae12c709f2321908879bc724fdb2ab8a781
+    │    args: jj commit -m 'commit 1'
+    │    '--at-op=@-'
+    │
+    │    Changed commits:
+    │    ○  + kkmpptxz b09ce45c (empty) (no
+    │    │  description set)
+    │    ○  + qpvuntsm 8d942956 (empty)
+    │       commit 1
+    │       - qpvuntsm/1 e8849ae1 (hidden)
+    │       (empty) (no description set)
+    │
+    │    Changed working copy default@:
+    │    + kkmpptxz b09ce45c (empty) (no
+    │    description set)
+    │    - qpvuntsm/1 e8849ae1 (hidden)
+    │    (empty) (no description set)
     ○  90267f31f904
     │  test-username@host.example.com
     │  2001-02-03 04:05:07.000 +07:00 -
@@ -557,48 +645,50 @@ fn test_op_log_word_wrap() {
 
     // Nested diff stat shouldn't exceed the terminal width
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--stat"], 40, true), @"
-    @  5ea39824268b
+    @  e31c6b8db4d8
     │  test-username@host.example.com
-    │  default@ 2001-02-03 04:05:08.000
-    │  +07:00 - 2001-02-03 04:05:08.000
+    │  default@ 2001-02-03 04:05:10.000
+    │  +07:00 - 2001-02-03 04:05:10.000
     │  +07:00
     │  snapshot working copy
-    │  args: jj debug snapshot
+    │  args: jj status
     │
     │  Changed commits:
-    │  ○  + qpvuntsm 79f0968d (no
+    │  ○  + qpvuntsm/0 0d9c7580 (divergent)
+    │     (no description set)
+    │     - qpvuntsm/2 79f0968d (hidden) (no
     │     description set)
-    │     - qpvuntsm/1 e8849ae1 (hidden)
-    │     (empty) (no description set)
-    │     file1 | 100 ++++++++++++++++++++++
+    │     file2 | 100 ++++++++++++++++++++++
     │     1 file changed, 100 insertions(+), 0 deletions(-)
     │
     │  Changed working copy default@:
-    │  + qpvuntsm 79f0968d (no description
-    │  set)
-    │  - qpvuntsm/1 e8849ae1 (hidden)
-    │  (empty) (no description set)
+    │  + qpvuntsm/0 0d9c7580 (divergent) (no
+    │  description set)
+    │  - qpvuntsm/2 79f0968d (hidden) (no
+    │  description set)
     [EOF]
     ");
     insta::assert_snapshot!(render(&["op", "log", "-n1", "--no-graph", "--stat"], 40, true), @"
-    5ea39824268b
+    e31c6b8db4d8
     test-username@host.example.com default@
-    2001-02-03 04:05:08.000 +07:00 -
-    2001-02-03 04:05:08.000 +07:00
+    2001-02-03 04:05:10.000 +07:00 -
+    2001-02-03 04:05:10.000 +07:00
     snapshot working copy
-    args: jj debug snapshot
+    args: jj status
 
     Changed commits:
-    + qpvuntsm 79f0968d (no description set)
-    - qpvuntsm/1 e8849ae1 (hidden) (empty)
-    (no description set)
-    file1 | 100 ++++++++++++++++++++++++++++
+    + qpvuntsm/0 0d9c7580 (divergent) (no
+    description set)
+    - qpvuntsm/2 79f0968d (hidden) (no
+    description set)
+    file2 | 100 ++++++++++++++++++++++++++++
     1 file changed, 100 insertions(+), 0 deletions(-)
 
     Changed working copy default@:
-    + qpvuntsm 79f0968d (no description set)
-    - qpvuntsm/1 e8849ae1 (hidden) (empty)
-    (no description set)
+    + qpvuntsm/0 0d9c7580 (divergent) (no
+    description set)
+    - qpvuntsm/2 79f0968d (hidden) (no
+    description set)
     [EOF]
     ");
 
@@ -623,6 +713,18 @@ fn test_op_log_word_wrap() {
     │  5 6 7 8 9
     │  - 0 1 2 3 4
     │  5 6 7 8 9
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(render(&["op", "log", "-T", "available_width()"], 15, false), @"
+    @  12
+    ○    10
+    ├─╮
+    ○ │  10
+    │ ○  10
+    ├─╯
+    ○  12
+    ○  12
     [EOF]
     ");
 }

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -87,6 +87,8 @@ The following functions are defined.
   Truncate `content` by removing trailing characters. The `content` shouldn't
   have newline character. If `ellipsis` is provided and `content` was truncated,
   append the `ellipsis` to the result.
+* `available_width() -> Option<Integer>`: The available width for printing,
+  taking into account the graph edges. Only available in `jj log` and `jj op log`.
 * `hash(content: Stringify) -> String`:
   Hash the input and return a hexadecimal string representation of the digest.
 * `label(label: Stringify, content: Template) -> Template`: Apply a custom


### PR DESCRIPTION
This takes into account both the terminal size and the width taken up by the graph lines.

The function will cause a parse error in contexts where printable width is not available. Currently, width is only available in `jj log` without the `--no-graph` switch.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
