### PR TITLE
git: explain that `jj git fetch/import` may abandon commits

### DIFF
--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -58,6 +58,11 @@ use crate::ui::Ui;
 /// `remotes.<name>.fetch-bookmarks` is not configured, the default fetch
 /// refspecs for the selected remotes are read from the Git configuration.
 ///
+/// Commits that are no longer reachable from any branch on the remote will be
+/// considered abandoned by the remote, and will be abandoned in the local repo
+/// to match the remote. Set `git.abandon-unreachable-commits` to `false` to
+/// disable this behavior.
+///
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
 #[derive(clap::Args, Clone, Debug)]

--- a/cli/src/commands/git/import.rs
+++ b/cli/src/commands/git/import.rs
@@ -23,6 +23,11 @@ use crate::ui::Ui;
 
 /// Update repo with changes made in the underlying Git repo
 ///
+/// Commits that are no longer reachable from any branch in the Git repo will be
+/// considered abandoned in the Git repo, and will be abandoned in the jj
+/// repo to match the Git repo. Set `git.abandon-unreachable-commits` to `false`
+/// to disable this behavior.
+///
 /// If a working-copy commit gets abandoned, it will be given a new, empty
 /// commit. This is true in general; it is not specific to this command.
 ///

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1650,6 +1650,8 @@ If no remotes are specified, fetches the remotes specified by the `git.fetch` se
 
 If no branches nor tags are specified, fetches bookmarks and tags specified by the `remotes.<name>.fetch-bookmarks`/`fetch-tags` settings. If `remotes.<name>.fetch-bookmarks` is not configured, the default fetch refspecs for the selected remotes are read from the Git configuration.
 
+Commits that are no longer reachable from any branch on the remote will be considered abandoned by the remote, and will be abandoned in the local repo to match the remote. Set `git.abandon-unreachable-commits` to `false` to disable this behavior.
+
 If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
 
 **Usage:** `jj git fetch [OPTIONS]`
@@ -1678,6 +1680,8 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 ## `jj git import`
 
 Update repo with changes made in the underlying Git repo
+
+Commits that are no longer reachable from any branch in the Git repo will be considered abandoned in the Git repo, and will be abandoned in the jj repo to match the Git repo. Set `git.abandon-unreachable-commits` to `false` to disable this behavior.
 
 If a working-copy commit gets abandoned, it will be given a new, empty commit. This is true in general; it is not specific to this command.
 


### PR DESCRIPTION
This is surprising behavior to many users. #9365

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
