### PR TITLE
lib: Make tokio optional by replacing tokio traits with future traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,7 +2570,6 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.18",
  "timeago",
- "tokio",
  "toml",
  "toml_edit",
  "tracing",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -104,7 +104,6 @@ tempfile = { workspace = true }
 textwrap = { workspace = true }
 thiserror = { workspace = true }
 timeago = { workspace = true }
-tokio = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }

--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -17,6 +17,7 @@ use std::pin::Pin;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use futures::AsyncRead;
 use futures::stream::BoxStream;
 use jj_cli::cli_util::CliRunner;
 use jj_cli::cli_util::CommandHelper;
@@ -47,7 +48,6 @@ use jj_lib::settings::UserSettings;
 use jj_lib::signing::Signer;
 use jj_lib::workspace::Workspace;
 use jj_lib::workspace::WorkspaceInitError;
-use tokio::io::AsyncRead;
 
 #[derive(clap::Parser, Clone, Debug)]
 enum CustomCommand {

--- a/cli/src/commands/debug/object.rs
+++ b/cli/src/commands/debug/object.rs
@@ -16,6 +16,7 @@ use std::fmt::Debug;
 use std::io::Write as _;
 
 use clap::Subcommand;
+use futures::AsyncReadExt as _;
 use jj_lib::backend::CommitId;
 use jj_lib::backend::FileId;
 use jj_lib::backend::SymlinkId;
@@ -26,7 +27,6 @@ use jj_lib::op_store::OperationId;
 use jj_lib::op_store::ViewId;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
-use tokio::io::AsyncReadExt as _;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use std::process::Stdio;
 
 use clap_complete::ArgValueCompleter;
+use futures::AsyncReadExt as _;
 use futures::TryStreamExt as _;
 use itertools::Itertools as _;
 use jj_lib::backend::FileId;
@@ -41,7 +42,6 @@ use jj_lib::revset::RevsetStreamExt as _;
 use jj_lib::settings::UserSettings;
 use jj_lib::store::Store;
 use pollster::FutureExt as _;
-use tokio::io::AsyncReadExt as _;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -64,7 +64,7 @@ smallvec = { workspace = true }
 strsim = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, optional = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
 watchman_client = { workspace = true, optional = true }
@@ -97,7 +97,7 @@ nix = { workspace = true, features = [ "fs" ] }
 [features]
 default = ["git"]
 git = ["dep:gix"]
-watchman = ["dep:watchman_client"]
+watchman = ["dep:watchman_client", "dep:tokio"]
 testing = ["git"]
 
 [lints]

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -23,9 +23,9 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 use chrono::TimeZone as _;
+use futures::AsyncRead;
 use futures::stream::BoxStream;
 use thiserror::Error;
-use tokio::io::AsyncRead;
 
 use crate::content_hash::ContentHash;
 use crate::hex_util;

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -23,14 +23,14 @@ use bstr::BStr;
 use bstr::BString;
 use bstr::ByteSlice as _;
 use bstr::ByteVec as _;
+use futures::AsyncRead;
+use futures::AsyncReadExt as _;
 use futures::Stream;
 use futures::StreamExt as _;
 use futures::future::try_join_all;
 use futures::stream::BoxStream;
 use futures::try_join;
 use itertools::Itertools as _;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt as _;
 
 use crate::backend::BackendError;
 use crate::backend::BackendResult;

--- a/lib/src/eol.rs
+++ b/lib/src/eol.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Cursor;
-
 use bstr::ByteSlice as _;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt as _;
+use futures::AsyncRead;
+use futures::AsyncReadExt as _;
+use futures::io::Cursor;
 
 use crate::config::ConfigGetError;
 use crate::settings::UserSettings;
@@ -236,12 +235,12 @@ mod tests {
         fn poll_read(
             mut self: Pin<&mut Self>,
             _cx: &mut std::task::Context<'_>,
-            _buf: &mut tokio::io::ReadBuf<'_>,
-        ) -> Poll<std::io::Result<()>> {
+            _buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
             if let Some(e) = self.0.take() {
                 return Poll::Ready(Err(e));
             }
-            Poll::Ready(Ok(()))
+            Poll::Ready(Ok(0))
         }
     }
 

--- a/lib/src/file_util.rs
+++ b/lib/src/file_util.rs
@@ -20,20 +20,16 @@ use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::ErrorKind;
-use std::io::Read;
 use std::io::Write;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
-use std::pin::Pin;
-use std::task::Poll;
 
+use futures::AsyncRead;
+use futures::AsyncReadExt as _;
 use tempfile::NamedTempFile;
 use tempfile::PersistError;
 use thiserror::Error;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt as _;
-use tokio::io::ReadBuf;
 
 #[cfg(unix)]
 pub use self::platform::check_executable_bit_support;
@@ -301,32 +297,6 @@ pub async fn copy_async_to_sync<R: AsyncRead, W: Write + ?Sized>(
     }
 }
 
-/// `AsyncRead` implementation backed by a `Read`. It is not actually async;
-/// the goal is simply to avoid reading the full contents from the `Read` into
-/// memory.
-pub struct BlockingAsyncReader<R> {
-    reader: R,
-}
-
-impl<R: Read + Unpin> BlockingAsyncReader<R> {
-    /// Creates a new `BlockingAsyncReader`
-    pub fn new(reader: R) -> Self {
-        Self { reader }
-    }
-}
-
-impl<R: Read + Unpin> AsyncRead for BlockingAsyncReader<R> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<()>> {
-        let num_bytes_read = self.reader.read(buf.initialize_unfilled())?;
-        buf.advance(num_bytes_read);
-        Poll::Ready(Ok(()))
-    }
-}
-
 #[cfg(unix)]
 mod platform {
     use std::convert::Infallible;
@@ -481,9 +451,9 @@ mod fallback {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
     use std::io::Write as _;
 
+    use futures::io::Cursor;
     use itertools::Itertools as _;
     use pollster::FutureExt as _;
     use test_case::test_case;
@@ -697,36 +667,6 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result?, 40000);
         assert_eq!(output, input);
-        Ok(())
-    }
-
-    #[test]
-    fn test_blocking_async_reader() -> TestResult {
-        let input = b"hello";
-        let sync_reader = Cursor::new(&input);
-        let mut async_reader = BlockingAsyncReader::new(sync_reader);
-
-        let mut buf = [0u8; 3];
-        let num_bytes_read = async_reader.read(&mut buf).block_on()?;
-        assert_eq!(num_bytes_read, 3);
-        assert_eq!(&buf, &input[0..3]);
-
-        let num_bytes_read = async_reader.read(&mut buf).block_on()?;
-        assert_eq!(num_bytes_read, 2);
-        assert_eq!(&buf[0..2], &input[3..5]);
-        Ok(())
-    }
-
-    #[test]
-    fn test_blocking_async_reader_read_to_end() -> TestResult {
-        let input = b"hello";
-        let sync_reader = Cursor::new(&input);
-        let mut async_reader = BlockingAsyncReader::new(sync_reader);
-
-        let mut buf = vec![];
-        let num_bytes_read = async_reader.read_to_end(&mut buf).block_on()?;
-        assert_eq!(num_bytes_read, input.len());
-        assert_eq!(&buf, &input);
         Ok(())
     }
 }

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Error;
 use std::fmt::Formatter;
 use std::fs;
 use std::io;
-use std::io::Cursor;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -34,7 +33,10 @@ use std::sync::MutexGuard;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use futures::AsyncRead;
+use futures::AsyncReadExt as _;
 use futures::StreamExt as _;
+use futures::io::Cursor;
 use futures::stream::BoxStream;
 use gix::bstr::BString;
 use gix::objs::CommitRefIter;
@@ -47,8 +49,6 @@ use pollster::FutureExt as _;
 use prost::Message as _;
 use smallvec::SmallVec;
 use thiserror::Error;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt as _;
 
 use crate::backend::Backend;
 use crate::backend::BackendError;

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -43,7 +43,10 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 use either::Either;
+use futures::AsyncRead;
+use futures::AsyncReadExt as _;
 use futures::StreamExt as _;
+use futures::io::AllowStdIo;
 use itertools::EitherOrBoth;
 use itertools::Itertools as _;
 use once_cell::unsync::OnceCell;
@@ -54,8 +57,6 @@ use rayon::prelude::IndexedParallelIterator as _;
 use rayon::prelude::ParallelIterator as _;
 use tempfile::NamedTempFile;
 use thiserror::Error;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt as _;
 use tracing::instrument;
 use tracing::trace_span;
 
@@ -79,7 +80,6 @@ use crate::conflicts::materialize_merge_result_to_bytes;
 use crate::conflicts::materialize_tree_value;
 pub use crate::eol::EolConversionMode;
 use crate::eol::TargetEolStrategy;
-use crate::file_util::BlockingAsyncReader;
 use crate::file_util::FileIdentity;
 use crate::file_util::check_symlink_support;
 use crate::file_util::copy_async_to_sync;
@@ -1910,7 +1910,7 @@ impl FileSnapshotter<'_> {
             })?;
             self.tree_state
                 .target_eol_strategy
-                .convert_eol_for_snapshot(BlockingAsyncReader::new(file))
+                .convert_eol_for_snapshot(AllowStdIo::new(file))
                 .await
                 .map_err(|err| SnapshotError::Other {
                     message: "Failed to convert the EOL".to_string(),
@@ -1975,7 +1975,7 @@ impl FileSnapshotter<'_> {
         let mut contents = self
             .tree_state
             .target_eol_strategy
-            .convert_eol_for_snapshot(BlockingAsyncReader::new(file))
+            .convert_eol_for_snapshot(AllowStdIo::new(file))
             .await
             .map_err(|err| SnapshotError::Other {
                 message: "Failed to convert the EOL".to_string(),

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -19,8 +19,8 @@ use std::pin::Pin;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use futures::AsyncRead;
 use futures::stream::BoxStream;
-use tokio::io::AsyncRead;
 
 use crate::backend::Backend;
 use crate::backend::BackendError;

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -17,7 +17,6 @@
 use std::fmt::Debug;
 use std::fs;
 use std::fs::File;
-use std::io::Cursor;
 use std::io::Read as _;
 use std::io::Write as _;
 use std::path::Path;
@@ -28,14 +27,15 @@ use std::time::SystemTime;
 use async_trait::async_trait;
 use blake2::Blake2b512;
 use blake2::Digest as _;
+use futures::AsyncRead;
+use futures::AsyncReadExt as _;
 use futures::StreamExt as _;
+use futures::io::Cursor;
 use futures::stream;
 use futures::stream::BoxStream;
 use pollster::FutureExt as _;
 use prost::Message as _;
 use tempfile::NamedTempFile;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt as _;
 
 use crate::backend::Backend;
 use crate::backend::BackendError;

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -22,9 +22,9 @@ use std::sync::Mutex;
 use std::time::SystemTime;
 
 use clru::CLruCache;
+use futures::AsyncRead;
 use futures::stream::BoxStream;
 use pollster::FutureExt as _;
-use tokio::io::AsyncRead;
 
 use crate::backend;
 use crate::backend::Backend;

--- a/lib/src/tree_merge.rs
+++ b/lib/src/tree_merge.rs
@@ -21,13 +21,13 @@ use std::iter::zip;
 use std::sync::Arc;
 use std::vec;
 
+use futures::AsyncReadExt as _;
 use futures::FutureExt as _;
 use futures::StreamExt as _;
 use futures::future::BoxFuture;
 use futures::future::try_join_all;
 use futures::stream::FuturesUnordered;
 use itertools::Itertools as _;
-use tokio::io::AsyncReadExt as _;
 
 use crate::backend;
 use crate::backend::BackendError;

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -26,6 +26,7 @@ use std::time::SystemTime;
 
 use assert_matches::assert_matches;
 use bstr::BString;
+use futures::AsyncReadExt as _;
 use gix::odb::pack::FindExt as _;
 use indoc::indoc;
 use itertools::Itertools as _;
@@ -83,7 +84,6 @@ use testutils::repo_path;
 use testutils::repo_path_buf;
 use testutils::repo_path_component;
 use testutils::write_random_commit;
-use tokio::io::AsyncReadExt as _;
 
 fn check_icase_fs(dir: &Path) -> bool {
     let test_file = tempfile::Builder::new()

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -25,6 +25,7 @@ use std::process::Command;
 use std::process::Stdio;
 use std::sync::Arc;
 
+use futures::AsyncReadExt as _;
 use itertools::Itertools as _;
 use jj_lib::backend;
 use jj_lib::backend::Backend;
@@ -75,7 +76,6 @@ use jj_lib::working_copy::SnapshotStats;
 use jj_lib::workspace::Workspace;
 use pollster::FutureExt as _;
 use tempfile::TempDir;
-use tokio::io::AsyncReadExt as _;
 
 use crate::test_backend::TestBackendFactory;
 

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Error;
 use std::fmt::Formatter;
-use std::io::Cursor;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -26,7 +25,10 @@ use std::sync::MutexGuard;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use futures::AsyncRead;
+use futures::AsyncReadExt as _;
 use futures::StreamExt as _;
+use futures::io::Cursor;
 use futures::stream;
 use futures::stream::BoxStream;
 use jj_lib::backend::Backend;
@@ -51,8 +53,6 @@ use jj_lib::index::Index;
 use jj_lib::object_id::ObjectId as _;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt as _;
 use tokio::runtime::Runtime;
 
 const HASH_LENGTH: usize = 10;


### PR DESCRIPTION
This enables having custom async runtimes, without having to depend on a huge tokio dependency, just for traits.

tokio is still enabled in testing, and if watchman feature is enabled.

Commit replaces `AsyncRead(Ext)` from tokio to futures(which is already a dependency), as a sideeffect it uses `Cursor` from futures.

This commit also gets rid of `BlockingAsyncReader` by using futures's `AllowStdIo`

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
