### PR TITLE
ci: allow macos-x86_64 to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           extra_targets: ""
     runs-on: ${{ matrix.os }}
 
+    # macos-x86_64 runners are inconsistent and prone to hitting the timeout
+    continue-on-error: ${{ matrix.os == 'macos-x86_64' }}
+
     # TODO FIXME (aseipp): keep the timeout limit to ~20 minutes. this is long
     # enough to give us runway for the future, but also once we hit it, we're at
     # the "builds are taking too long" stage and we should start looking at ways


### PR DESCRIPTION
- [n/a] I have updated `CHANGELOG.md`
- [n/a] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [n/a] I have updated the config schema (`cli/src/config-schema.json`)
- [n/a] I have added/updated tests to cover my changes
- [n/a] No LLMs were involved in the creation of this PR.