### PR TITLE
config: use XDG_DATA_DIR for secure configuration

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -276,13 +276,14 @@ fn create_dir_all(path: &Path) -> std::io::Result<()> {
 #[derive(Clone, Default, Debug)]
 struct UnresolvedConfigEnv {
     config_dir: Option<PathBuf>,
+    data_dir: Option<PathBuf>,
     home_dir: Option<PathBuf>,
     jj_config: Option<String>,
 }
 
 impl UnresolvedConfigEnv {
-    fn root_config_dir(&self) -> Option<PathBuf> {
-        self.config_dir.as_deref().map(|c| c.join("jj"))
+    fn root_data_dir(&self) -> Option<PathBuf> {
+        self.data_dir.as_deref().map(|c| c.join("jj"))
     }
 
     fn resolve(self) -> Vec<ConfigPath> {
@@ -334,7 +335,7 @@ impl UnresolvedConfigEnv {
 #[derive(Clone, Debug)]
 pub struct ConfigEnv {
     home_dir: Option<PathBuf>,
-    root_config_dir: Option<PathBuf>,
+    root_data_dir: Option<PathBuf>,
     repo_path: Option<PathBuf>,
     workspace_path: Option<PathBuf>,
     user_config_paths: Vec<ConfigPath>,
@@ -352,6 +353,7 @@ impl ConfigEnv {
         let config_dir = etcetera::choose_base_strategy()
             .ok()
             .map(|s| s.config_dir());
+        let data_dir = etcetera::choose_base_strategy().ok().map(|s| s.data_dir());
 
         // Canonicalize home as we do canonicalize cwd in CliRunner. $HOME might
         // point to symlink.
@@ -361,6 +363,7 @@ impl ConfigEnv {
 
         let env = UnresolvedConfigEnv {
             config_dir,
+            data_dir,
             home_dir: home_dir.clone(),
             jj_config: env::var("JJ_CONFIG").ok(),
         };
@@ -374,7 +377,7 @@ impl ConfigEnv {
             .collect();
         Self {
             home_dir,
-            root_config_dir: env.root_config_dir(),
+            root_data_dir: env.root_data_dir(),
             repo_path: None,
             workspace_path: None,
             user_config_paths: env.resolve(),
@@ -406,13 +409,13 @@ impl ConfigEnv {
         kind: &str,
         force: bool,
     ) -> Result<Option<LoadedSecureConfig>, CommandError> {
-        Ok(match (config, self.root_config_dir.as_ref()) {
-            (Some(config), Some(root_config_dir)) => {
+        Ok(match (config, self.root_data_dir.as_ref()) {
+            (Some(config), Some(root_data_dir)) => {
                 let mut guard = self.rng.lock().unwrap();
                 let loaded_config = if force {
-                    config.load_config(&mut guard, &root_config_dir.join(kind))
+                    config.load_config(&mut guard, &root_data_dir.join(kind))
                 } else {
-                    config.maybe_load_config(&mut guard, &root_config_dir.join(kind))
+                    config.maybe_load_config(&mut guard, &root_data_dir.join(kind))
                 }?;
                 for warning in &loaded_config.warnings {
                     writeln!(ui.warning_default(), "{warning}")?;
@@ -1863,6 +1866,7 @@ mod tests {
         let home_dir = env.home_dir.as_ref().map(|p| root.join(p));
         let env = UnresolvedConfigEnv {
             config_dir: env.config_dir.as_ref().map(|p| root.join(p)),
+            data_dir: env.data_dir.as_ref().map(|p| root.join(p)),
             home_dir: home_dir.clone(),
             jj_config: env.jj_config.as_ref().map(|p| {
                 join_paths(split_paths(p).map(|p| {
@@ -1878,7 +1882,7 @@ mod tests {
         };
         ConfigEnv {
             home_dir,
-            root_config_dir: None,
+            root_data_dir: None,
             repo_path: None,
             workspace_path: None,
             user_config_paths: env.resolve(),

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -340,7 +340,7 @@ fn test_config_list_origin() {
     ]);
     insta::assert_snapshot!(output, @r#"
     test-key = "test-val" # user $TEST_ENV/config/config.toml
-    test-layered-key = "test-layered-val" # repo $TEST_ENV/home/.config/jj/repos/0757f5ec8418b4f0983d/config.toml
+    test-layered-key = "test-layered-val" # repo $TEST_ENV/home/.local/share/jj/repos/0757f5ec8418b4f0983d/config.toml
     user.name = "Test User" # env
     user.email = "test.user@example.com" # env
     debug.commit-timestamp = "2001-02-03T04:05:11+07:00" # env
@@ -720,7 +720,7 @@ fn test_config_set_for_repo() -> TestResult {
         .run_jj(["config", "set", "--repo", "test-table.foo", "true"])
         .success();
     // Ensure test-key successfully written to user config.
-    let config_dir = test_env.work_dir("home/.config/jj/repos/8e4fac809cbb3b162c95");
+    let config_dir = test_env.work_dir("home/.local/share/jj/repos/8e4fac809cbb3b162c95");
     let repo_config_toml = config_dir.read_file("config.toml");
     insta::assert_snapshot!(repo_config_toml, @r#"
     #:schema https://docs.jj-vcs.dev/latest/config-schema.json
@@ -734,7 +734,7 @@ fn test_config_set_for_repo() -> TestResult {
     std::fs::remove_dir_all(config_dir.root())?;
     let output = work_dir.run_jj(["config", "path", "--repo"]);
     insta::assert_snapshot!(output, @"
-    $TEST_ENV/home/.config/jj/repos/8e4fac809cbb3b162c95/config.toml
+    $TEST_ENV/home/.local/share/jj/repos/8e4fac809cbb3b162c95/config.toml
     [EOF]
     ------- stderr -------
     Warning: Per-repo config not found. Generating an empty one.
@@ -768,7 +768,7 @@ fn test_config_set_for_workspace() {
 
     // Read workspace config
     let workspace_config = &test_env
-        .work_dir("home/.config/jj/workspaces/0757f5ec8418b4f0983d")
+        .work_dir("home/.local/share/jj/workspaces/0757f5ec8418b4f0983d")
         .read_file("config.toml");
     insta::assert_snapshot!(workspace_config, @r#"
     #:schema https://docs.jj-vcs.dev/latest/config-schema.json
@@ -989,7 +989,7 @@ fn test_config_unset_for_repo() {
         .success();
 
     let repo_config_toml = &test_env
-        .work_dir("home/.config/jj/repos/8e4fac809cbb3b162c95")
+        .work_dir("home/.local/share/jj/repos/8e4fac809cbb3b162c95")
         .read_file("config.toml");
     insta::assert_snapshot!(repo_config_toml, @"");
 }
@@ -1014,7 +1014,7 @@ fn test_config_unset_for_workspace() {
         .success();
 
     let workspace_config = &test_env
-        .work_dir("home/.config/jj/workspaces/0757f5ec8418b4f0983d")
+        .work_dir("home/.local/share/jj/workspaces/0757f5ec8418b4f0983d")
         .read_file("config.toml");
     insta::assert_snapshot!(workspace_config, @"");
 }
@@ -1079,7 +1079,7 @@ fn test_config_edit_repo() -> TestResult {
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_editor();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();
-    let repo_config_dir = test_env.home_dir().join(".config/jj/repos");
+    let repo_config_dir = test_env.home_dir().join(".local/share/jj/repos");
     assert!(!repo_config_dir.is_dir());
 
     std::fs::write(edit_script, "dump-path path")?;
@@ -1087,7 +1087,7 @@ fn test_config_edit_repo() -> TestResult {
     work_dir.run_jj(["config", "edit", "--repo"]).success();
 
     let repo_config_path = test_env
-        .work_dir("home/.config/jj/repos/8e4fac809cbb3b162c95")
+        .work_dir("home/.local/share/jj/repos/8e4fac809cbb3b162c95")
         .root()
         .join("config.toml");
 
@@ -1117,7 +1117,7 @@ fn test_config_edit_invalid_config() -> TestResult {
     });
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Editing file: $TEST_ENV/home/.config/jj/repos/8e4fac809cbb3b162c95/config.toml
+    Editing file: $TEST_ENV/home/.local/share/jj/repos/8e4fac809cbb3b162c95/config.toml
     Warning: An error has been found inside the config:
     Caused by:
     1: Configuration cannot be parsed as TOML document
@@ -1147,7 +1147,7 @@ fn test_config_edit_invalid_config() -> TestResult {
     });
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    Editing file: $TEST_ENV/home/.config/jj/repos/8e4fac809cbb3b162c95/config.toml
+    Editing file: $TEST_ENV/home/.local/share/jj/repos/8e4fac809cbb3b162c95/config.toml
     Warning: An error has been found inside the config:
     Caused by:
     1: Configuration cannot be parsed as TOML document
@@ -1195,7 +1195,7 @@ fn test_config_path() {
     );
 
     insta::assert_snapshot!(work_dir.run_jj(["config", "path", "--repo"]), @"
-    $TEST_ENV/home/.config/jj/repos/ffdaa62087a280bddc5e/config.toml
+    $TEST_ENV/home/.local/share/jj/repos/ffdaa62087a280bddc5e/config.toml
     [EOF]
     ");
     assert!(
@@ -1211,7 +1211,7 @@ fn test_config_path() {
     ");
 
     insta::assert_snapshot!(work_dir.run_jj(["config", "path", "--workspace"]), @"
-    $TEST_ENV/home/.config/jj/workspaces/d043564ef93650b06a70/config.toml
+    $TEST_ENV/home/.local/share/jj/workspaces/d043564ef93650b06a70/config.toml
     [EOF]
     ");
     assert!(

--- a/docs/design/secure-config.md
+++ b/docs/design/secure-config.md
@@ -181,11 +181,11 @@ fn load_repo_config_path(repo: &Path) -> Result<PathBuf, ConfigLoadError> {
 
 Normally we will simply:
 1. Load the `config-id` file
-2. Check that `$HOME/.config/jj/repos/$CONFIG_ID` exists
-3. Validate that the path in `$HOME/.config/jj/repos/$CONFIG_ID/metadata.binpb`
+2. Check that `$HOME/.local/share/jj/repos/$CONFIG_ID` exists
+3. Validate that the path in `$HOME/.local/share/jj/repos/$CONFIG_ID/metadata.binpb`
    matches the repo's path
 4. Find the corresponding config in
-   `$HOME/.config/jj/repos/$CONFIG_ID/config.toml`
+   `$HOME/.local/share/jj/repos/$CONFIG_ID/config.toml`
 5. Load that config.
 
 However, these steps can fail. The following sections are how we will handle

--- a/lib/src/secure_config.rs
+++ b/lib/src/secure_config.rs
@@ -407,6 +407,7 @@ mod tests {
         config: SecureConfig,
         repo_dir: PathBuf,
         config_dir: PathBuf,
+        data_dir: PathBuf,
     }
 
     impl TestEnv {
@@ -416,12 +417,15 @@ mod tests {
             fs::create_dir(&repo_dir).unwrap();
             let config_dir = td.path().join("config");
             fs::create_dir(&config_dir).unwrap();
+            let data_dir = td.path().join("data");
+            fs::create_dir(&data_dir).unwrap();
             Self {
                 _td: td,
                 rng: ChaCha20Rng::seed_from_u64(0),
                 config: SecureConfig::new(repo_dir.clone(), "config-id", "legacy-config.toml"),
                 repo_dir,
                 config_dir,
+                data_dir,
             }
         }
 
@@ -445,7 +449,7 @@ mod tests {
         assert!(env.config.cache.borrow().is_some());
 
         // load_config should generate the config if it previously didn't exist.
-        let loaded = env.config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded = env.config.load_config(&mut env.rng, &env.data_dir)?;
         let path = loaded.config_file.unwrap();
         let components: Vec<_> = path.components().rev().collect();
         assert_eq!(
@@ -454,7 +458,7 @@ mod tests {
         );
         assert_eq!(
             components[2],
-            std::path::Component::Normal(OsStr::new("config"))
+            std::path::Component::Normal(OsStr::new("data"))
         );
         assert!(!loaded.metadata.path.as_deref().unwrap().is_empty());
         assert!(loaded.warnings.is_empty());
@@ -463,7 +467,7 @@ mod tests {
         // Empty the cache to ensure the function is actually being tested
         assert!(env.config.cache.borrow().is_some());
         *env.config.cache.borrow_mut() = None;
-        let loaded2 = env.config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded2 = env.config.load_config(&mut env.rng, &env.data_dir)?;
         assert_eq!(loaded2.config_file.unwrap(), path);
         assert_eq!(loaded2.metadata, loaded.metadata);
         assert!(loaded2.warnings.is_empty());
@@ -497,13 +501,13 @@ mod tests {
     #[test]
     fn test_repo_moved() -> TestResult {
         let mut env = TestEnv::new();
-        let loaded = env.config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded = env.config.load_config(&mut env.rng, &env.data_dir)?;
         let path = loaded.config_file.unwrap();
 
         let dest = env.repo_dir.parent().unwrap().join("moved");
         fs::rename(&env.repo_dir, &dest)?;
         let config = env.secure_config_for_dir(dest);
-        let loaded2 = config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded2 = config.load_config(&mut env.rng, &env.data_dir)?;
         assert_eq!(loaded2.config_file.unwrap(), path);
         assert_ne!(loaded.metadata.path, loaded2.metadata.path);
         assert!(loaded2.warnings.is_empty());
@@ -513,7 +517,7 @@ mod tests {
     #[test]
     fn test_repo_copied() -> TestResult {
         let mut env = TestEnv::new();
-        let loaded = env.config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded = env.config.load_config(&mut env.rng, &env.data_dir)?;
         let path = loaded.config_file.unwrap();
         fs::write(&path, "config")?;
 
@@ -521,7 +525,7 @@ mod tests {
         fs::create_dir(&dest)?;
         fs::copy(env.repo_dir.join("config-id"), dest.join("config-id"))?;
         let config = env.secure_config_for_dir(dest);
-        let loaded2 = config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded2 = config.load_config(&mut env.rng, &env.data_dir)?;
         let path2 = loaded2.config_file.unwrap();
         assert_ne!(path, path2);
         let path2_contents = fs::read_to_string(path2)?;
@@ -538,13 +542,13 @@ mod tests {
     #[test]
     fn test_repo_aliased() -> TestResult {
         let mut env = TestEnv::new();
-        let loaded = env.config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded = env.config.load_config(&mut env.rng, &env.data_dir)?;
         let path = loaded.config_file.unwrap();
 
         let dest = env.repo_dir.parent().unwrap().join("copied");
         std::os::unix::fs::symlink(&env.repo_dir, &dest)?;
         let config = env.secure_config_for_dir(dest);
-        let loaded2 = config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded2 = config.load_config(&mut env.rng, &env.data_dir)?;
         assert_eq!(loaded2.config_file.unwrap(), path);
         assert_eq!(loaded.metadata.path, loaded2.metadata.path);
         assert!(loaded2.warnings.is_empty());
@@ -554,13 +558,13 @@ mod tests {
     #[test]
     fn test_missing_config() -> TestResult {
         let mut env = TestEnv::new();
-        let loaded = env.config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded = env.config.load_config(&mut env.rng, &env.data_dir)?;
         let path = loaded.config_file.unwrap();
 
         fs::remove_dir_all(path.parent().unwrap())?;
         *env.config.cache.borrow_mut() = None;
 
-        let loaded2 = env.config.load_config(&mut env.rng, &env.config_dir)?;
+        let loaded2 = env.config.load_config(&mut env.rng, &env.data_dir)?;
         assert_eq!(loaded2.config_file.unwrap(), path);
         assert_eq!(loaded.metadata.path, loaded2.metadata.path);
         // It should have recreated the directory.


### PR DESCRIPTION
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [n/a] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] No LLMs were involved in the creation of this PR.
