### PR TITLE
lib: op_walk function to find all common ancestors.

### DIFF
--- a/lib/src/dag_walk_async.rs
+++ b/lib/src/dag_walk_async.rs
@@ -22,8 +22,11 @@ use std::iter;
 use std::mem;
 
 use futures::Stream;
+use futures::StreamExt as _;
+use futures::TryStreamExt as _;
 use futures::future::try_join_all;
 use futures::stream;
+use indexmap::IndexSet;
 use itertools::Itertools as _;
 use smallvec::SmallVec;
 use smallvec::smallvec_inline;
@@ -563,6 +566,113 @@ where
         }
     }
     Ok(None)
+}
+
+/// Finds all the closest common ancestors of `heads`. Returns an error if a
+/// cycle is found. The result is sorted in the order they are visited.
+pub async fn find_all_closest_common_ancestors<T, ID, E, II, NI>(
+    heads: II,
+    id_fn: impl Fn(&T) -> ID + Clone,
+    mut neighbors_fn: impl AsyncFnMut(&T) -> NI + Clone,
+) -> Result<Vec<ID>, E>
+where
+    T: Ord,
+    ID: Hash + Eq + Clone,
+    II: IntoIterator<Item = Result<T, E>>,
+    NI: IntoIterator<Item = Result<T, E>>,
+{
+    let heads: Vec<T> = heads.into_iter().try_collect()?;
+    assert!(!heads.is_empty(), "heads should be non-empty");
+    if heads.len() == 1 {
+        return Ok(vec![id_fn(&heads[0])]);
+    }
+    let all_heads: usize = (1 << heads.len()) - 1;
+
+    // Maps from node to a bitset representing which heads are reachable from it.
+    let mut reachable_heads: HashMap<ID, usize> = HashMap::new();
+    // The nodes we need to visit, but we don't yet know if they are a common
+    // ancestor. Initialized with heads.
+    let mut to_visit_1 = HashSet::with_capacity(heads.len());
+    // The nodes we need to visit that we know are a common ancestor of all heads.
+    let mut to_visit_2 = HashSet::new();
+
+    // All common ancestors.
+    let mut common_ancestors = IndexSet::new();
+    // All common ancestors which are descendants of other common ancestors.
+    let mut non_closest_common_ancestors = IndexSet::new();
+
+    // Initialize our data structures.
+    for (i, head) in heads.iter().enumerate() {
+        let head_id = id_fn(head);
+        assert!(to_visit_1.insert(head_id.clone()));
+        reachable_heads.insert(head_id, 1 << i);
+    }
+
+    let mut stream = topo_order_reverse_lazy(
+        heads.into_iter().map(Ok),
+        id_fn.clone(),
+        neighbors_fn.clone(),
+        |_| panic!("graph has cycle"),
+    )
+    .boxed_local();
+
+    while let Some(node) = stream.try_next().await? {
+        let node_id = id_fn(&node);
+        let heads_reachable_from_node = reachable_heads
+            .get(&node_id)
+            .copied()
+            .expect("entry should exist");
+
+        // node is a common ancestor iff all heads are reachable from it.
+        let node_is_common_ancestor = heads_reachable_from_node == all_heads;
+
+        // node must be in exactly one of to_visit_1 or to_visit_2. Remove it from the
+        // set it's in.
+        if node_is_common_ancestor {
+            assert!(to_visit_2.remove(&node_id));
+            if to_visit_1.is_empty() {
+                // All remaining nodes to visit are common ancestors of all heads, so there is
+                // no point in visiting any more nodes.
+                break;
+            }
+        } else {
+            assert!(to_visit_1.remove(&node_id));
+        }
+
+        for parent in neighbors_fn(&node).await {
+            let parent = parent?;
+            let parent_id = id_fn(&parent);
+            let heads_reachable_from_parent = reachable_heads.entry(parent_id.clone()).or_default();
+            if node_is_common_ancestor {
+                // Since node is a common ancestor, parent is also a (non-closest) common
+                // ancestor. We add it to to_visit_2. We also remove it from to_visit_1 (if it's
+                // there).
+                *heads_reachable_from_parent = all_heads;
+                to_visit_2.insert(parent_id.clone());
+                to_visit_1.remove(&parent_id);
+                non_closest_common_ancestors.insert(parent_id);
+            } else {
+                // Take the union of the heads we already knew were reachable from parent and
+                // the heads reachable from node and update the entry in the map.
+                *heads_reachable_from_parent |= heads_reachable_from_node;
+                if *heads_reachable_from_parent == all_heads {
+                    // We know parent is a common ancestor, so we add it to to_visit_2. We also
+                    // remove it from to_visit_1 (if it's there).
+                    common_ancestors.insert(parent_id.clone());
+                    to_visit_2.insert(parent_id.clone());
+                    to_visit_1.remove(&parent_id);
+                } else {
+                    // Add it to to_visit_1 since we don't know if it's a common ancestor yet.
+                    to_visit_1.insert(parent_id.clone());
+                }
+            }
+        }
+    }
+    let closest_common_ancestors = common_ancestors
+        .difference(&non_closest_common_ancestors)
+        .cloned()
+        .collect_vec();
+    Ok(closest_common_ancestors)
 }
 
 #[cfg(test)]

--- a/lib/src/op_walk.rs
+++ b/lib/src/op_walk.rs
@@ -289,6 +289,19 @@ pub fn walk_ancestors(
     .map_ok(|OperationByEndTime(op)| op)
 }
 
+/// Finds all the closest common ancestors of `head_ops`.
+pub async fn find_all_closest_common_ancestor_operations(
+    head_ops: &[Operation],
+) -> Result<Vec<OperationId>, OpStoreError> {
+    let heads_iter = head_ops.iter().cloned().map(Ok);
+    let id_fn = |op: &Operation| op.id().clone();
+    let neighbors_fn = async |op: &Operation| match op.parents().await {
+        Ok(parents) => parents.iter().cloned().map(Ok).collect_vec(),
+        Err(err) => vec![Err(err)],
+    };
+    dag_walk_async::find_all_closest_common_ancestors(heads_iter, id_fn, neighbors_fn).await
+}
+
 /// Walks ancestors from `head_ops` in reverse topological order, excluding
 /// ancestors of `root_ops`.
 pub fn walk_ancestors_range(


### PR DESCRIPTION
The goal is to use this in a new implementation of merge_operations which properly deals with criss-cross merges in the op log (when reconciling operations).

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
