### PR TITLE
templates: add commit_summary_redacted for redacted op log diffs

### DIFF
--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -361,6 +361,29 @@ label(if(commit.current_working_copy(), "working_copy"),
 )
 '''
 
+'format_commit_summary_redacted(commit)' = '''
+label(if(commit.current_working_copy(), "working_copy"),
+  separate(" ",
+    format_short_change_id_with_change_offset(commit),
+    format_short_commit_id(commit.commit_id()),
+    separate(commit_summary_separator,
+      commit.bookmarks().map(|bookmark| concat(
+        "bookmark-", hash(bookmark.name()).substr(0, 4),
+        if(bookmark.remote(),
+          "@remote-" ++ hash(bookmark.remote()).substr(0, 4),
+          if(!bookmark.synced(), "*")
+        )
+      )),
+      separate(" ",
+        format_commit_labels(commit),
+        if(commit.empty(), empty_commit_marker),
+        label("description", "(redacted)"),
+      ),
+    ),
+  ),
+)
+'''
+
 'format_root_commit(root)' = '''
 label("immutable",
   separate(" ",

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -3139,6 +3139,59 @@ fn test_op_log_anonymize() {
 }
 
 #[test]
+fn test_op_log_anonymize_diff() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir
+        .run_jj(["describe", "-m", "description 0"])
+        .success();
+
+    // Without overriding commit_summary, the changed commits section is not
+    // redacted even when using builtin_op_log_redacted.
+    let output = work_dir.run_jj(["op", "log", "-Tbuiltin_op_log_redacted", "-d", "-n1"]);
+    insta::assert_snapshot!(output, @"
+    @  8501e29d2d94 user-5910 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  (redacted)
+    │
+    │  Changed commits:
+    │  ○  + qpvuntsm 3ae22e7f (empty) description 0
+    │     - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
+    │
+    │  Changed working copy default@:
+    │  + qpvuntsm 3ae22e7f (empty) description 0
+    │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (no description set)
+    [EOF]
+    ");
+
+    // With commit_summary overridden, the changed commits section is also redacted.
+    let output = work_dir.run_jj([
+        "op",
+        "log",
+        "-Tbuiltin_op_log_redacted",
+        "-d",
+        "-n1",
+        "--config",
+        "templates.commit_summary=format_commit_summary_redacted(self)",
+    ]);
+    insta::assert_snapshot!(output, @"
+    @  8501e29d2d94 user-5910 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
+    │  (redacted)
+    │
+    │  Changed commits:
+    │  ○  + qpvuntsm 3ae22e7f (empty) (redacted)
+    │     - qpvuntsm/1 e8849ae1 (hidden) (empty) (redacted)
+    │
+    │  Changed working copy default@:
+    │  + qpvuntsm 3ae22e7f (empty) (redacted)
+    │  - qpvuntsm/1 e8849ae1 (hidden) (empty) (redacted)
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_op_immutable_revisions() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/docs/config.md
+++ b/docs/config.md
@@ -706,6 +706,36 @@ your config:
 log = "builtin_log_compact_full_description"
 ```
 
+### Redacting sensitive information
+
+For sharing repository state without exposing sensitive information (such as commit
+descriptions or bookmark names), jj provides redacted templates. These replace
+actual content with placeholders like `(redacted)` or hashed identifiers.
+
+To use a redacted template for `jj op log`:
+
+```sh
+jj op log -T builtin_op_log_redacted
+```
+
+By default, `builtin_op_log_redacted` redacts the operation description but not the
+commit information shown in diffs (with `-d`). To also redact commit descriptions
+and bookmark names in the diff output, configure the `commit_summary` template:
+
+```sh
+jj op log -T builtin_op_log_redacted -d --config 'templates.commit_summary=format_commit_summary_redacted(self)'
+```
+
+Or permanently in your config:
+
+```toml
+[templates]
+commit_summary = 'format_commit_summary_redacted(self)'
+```
+
+The `format_commit_summary_redacted` function replaces commit descriptions
+with `(redacted)` and bookmark names with short hashes like `bookmark-a1b2`.
+
 ### Graph style
 
 ```toml


### PR DESCRIPTION
Adds `commit_summary_redacted` template alias and `format_commit_summary_with_refs_redacted` helper so that `jj op log -T builtin_op_log_redacted -d` produces fully redacted output — the "Changed commits" section now redacts descriptions and bookmark names in the same style as `builtin_log_redacted`.

Addresses #9375