### PR TITLE
add garbage collection for config files of deleted repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* `jj config gc` will delete configuration of deleted/moved repos from
+  `~/.config/jj/repos` folder.
+  [#9362](https://github.com/jj-vcs/jj/issues/9362)
+
+
 ### Release highlights
 
 ### Breaking changes
@@ -43,6 +48,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   0.30.
 
 ### New features
+
 
 * Shell completions now surface descriptions for custom aliases,
   revset-aliases, template-aliases, and fileset-aliases. Descriptions are

--- a/cli/src/commands/config/gc.rs
+++ b/cli/src/commands/config/gc.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use jj_lib::secure_config;
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::command_error::CommandError;
+use crate::command_error::user_error;
+use crate::command_error::user_error_with_message;
+use crate::ui::Ui;
+
+/// Find and optionally delete repo-level config directories whose repo path
+/// no longer exists.
+// TODO: also gc workspace-level config directories under
+// `$HOME/.config/jj/workspaces/`.
+// TODO: support a path argument to filter which repo paths to delete, e.g.
+// `jj config gc /tmp` to only delete repo configs whose recorded path is
+// under `/tmp`.
+#[derive(clap::Args, Clone, Debug)]
+pub struct ConfigGcArgs {}
+
+#[instrument(skip_all)]
+pub async fn cmd_config_gc(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    _args: &ConfigGcArgs,
+) -> Result<(), CommandError> {
+    let root = command
+        .config_env()
+        .repo_configs_root_dir()
+        .ok_or_else(|| user_error("No config directory found"))?;
+
+    let missing = find_missing_repo_configs(&root)?;
+
+    if let Some(mut formatter) = ui.status_formatter() {
+        writeln!(
+            formatter,
+            "Missing repo configs (repo path no longer exists):"
+        )?;
+        if missing.is_empty() {
+            writeln!(formatter, "  (none)")?;
+        } else {
+            for (config_dir, repo_path) in &missing {
+                writeln!(formatter, "  {}", config_dir.display())?;
+                writeln!(formatter, "    repo path: {}", repo_path.display())?;
+            }
+        }
+    }
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let prompt = format!("Delete {} missing repo config directories?", missing.len());
+    if !ui.prompt_yes_no(&prompt, Some(false))? {
+        writeln!(ui.status(), "Aborted; nothing was deleted.")?;
+        return Ok(());
+    }
+
+    let mut deleted = 0;
+    for (config_dir, _) in &missing {
+        match secure_config::remove_repo_config_dir(config_dir) {
+            Ok(()) => deleted += 1,
+            Err(err) => writeln!(
+                ui.warning_default(),
+                "Failed to delete {}: {err}",
+                config_dir.display()
+            )?,
+        }
+    }
+    writeln!(ui.status(), "Deleted {deleted} config directories.")?;
+    Ok(())
+}
+
+/// Returns `(config_dir, repo_path)` pairs for every per-repo config
+/// directory under `root` whose recorded repo path no longer exists on
+/// disk. The list is sorted by config directory name.
+pub(crate) fn find_missing_repo_configs(
+    root: &Path,
+) -> Result<Vec<(PathBuf, PathBuf)>, CommandError> {
+    if !root.try_exists().map_err(|err| {
+        user_error_with_message(format!("Failed to check {}", root.display()), err)
+    })? {
+        return Ok(Vec::new());
+    }
+    let read_dir = fs::read_dir(root).map_err(|err| {
+        user_error_with_message(format!("Failed to read {}", root.display()), err)
+    })?;
+
+    let mut missing = Vec::new();
+    for dir_entry in read_dir {
+        let dir_entry = dir_entry.map_err(|err| {
+            user_error_with_message(format!("Failed to read {}", root.display()), err)
+        })?;
+        let config_dir = dir_entry.path();
+        if !config_dir.is_dir() {
+            continue;
+        }
+        let Ok(metadata) = secure_config::read_metadata(&config_dir) else {
+            continue;
+        };
+        let Ok(Some(repo_path)) = secure_config::metadata_path(&metadata) else {
+            continue;
+        };
+        // Treat "exists" errors (e.g. permission denied) as "still exists" so
+        // we don't propose deleting configs we can't actually verify.
+        if !repo_path.try_exists().unwrap_or(true) {
+            missing.push((config_dir, repo_path.to_path_buf()));
+        }
+    }
+    missing.sort();
+    Ok(missing)
+}

--- a/cli/src/commands/config/mod.rs
+++ b/cli/src/commands/config/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod edit;
+mod gc;
 mod get;
 mod list;
 mod path;
@@ -28,6 +29,8 @@ use tracing::instrument;
 
 use self::edit::ConfigEditArgs;
 use self::edit::cmd_config_edit;
+use self::gc::ConfigGcArgs;
+use self::gc::cmd_config_gc;
 use self::get::ConfigGetArgs;
 use self::get::cmd_config_get;
 use self::list::ConfigListArgs;
@@ -155,6 +158,7 @@ impl ConfigLevelArgs {
 pub(crate) enum ConfigCommand {
     #[command(visible_alias("e"))]
     Edit(ConfigEditArgs),
+    Gc(ConfigGcArgs),
     #[command(visible_alias("g"))]
     Get(ConfigGetArgs),
     #[command(visible_alias("l"))]
@@ -175,6 +179,7 @@ pub(crate) async fn cmd_config(
 ) -> Result<(), CommandError> {
     match subcommand {
         ConfigCommand::Edit(args) => cmd_config_edit(ui, command, args).await,
+        ConfigCommand::Gc(args) => cmd_config_gc(ui, command, args).await,
         ConfigCommand::Get(args) => cmd_config_get(ui, command, args).await,
         ConfigCommand::List(args) => cmd_config_list(ui, command, args).await,
         ConfigCommand::Path(args) => cmd_config_path(ui, command, args).await,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -503,6 +503,14 @@ impl ConfigEnv {
             .and_then(|c| c.config_file))
     }
 
+    /// Returns the directory under which all repo-specific config
+    /// subdirectories (one per config ID) are stored.
+    pub fn repo_configs_root_dir(&self) -> Option<PathBuf> {
+        self.root_config_dir
+            .as_ref()
+            .map(|dir| dir.join(REPO_CONFIG_DIR))
+    }
+
     /// Returns repo configuration files for modification. Instantiates one if
     /// `config` has no repo configuration layers.
     ///

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -30,6 +30,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj commit`↴](#jj-commit)
 * [`jj config`↴](#jj-config)
 * [`jj config edit`↴](#jj-config-edit)
+* [`jj config gc`↴](#jj-config-gc)
 * [`jj config get`↴](#jj-config-get)
 * [`jj config list`↴](#jj-config-list)
 * [`jj config path`↴](#jj-config-path)
@@ -730,6 +731,7 @@ See [`jj help -k config`] to know more about file locations, supported config op
 ###### **Subcommands:**
 
 * `edit` — Start an editor on a jj config file
+* `gc` — Find and optionally delete repo-level config directories whose repo path no longer exists
 * `get` — Get the value of a given config option.
 * `list` — List variables set in config files, along with their values
 * `path` — Print the paths to the config files
@@ -753,6 +755,14 @@ Creates the file if it doesn't already exist regardless of what the editor does.
 * `--user` — Target the user-level config
 * `--repo` — Target the repo-level config
 * `--workspace` — Target the workspace-level config
+
+
+
+## `jj config gc`
+
+Find and optionally delete repo-level config directories whose repo path no longer exists
+
+**Usage:** `jj config gc`
 
 
 

--- a/cli/tests/test_completion.rs
+++ b/cli/tests/test_completion.rs
@@ -713,6 +713,7 @@ fn test_command_completion_short_name() {
     let output = test_env.complete_fish(["config", ""]);
     insta::assert_snapshot!(output, @"
     edit	Start an editor on a jj config file
+    gc	Find and optionally delete repo-level config directories whose repo path no longer exists
     get	Get the value of a given config option.
     list	List variables set in config files, along with their values
     path	Print the paths to the config files

--- a/cli/tests/test_config_command.rs
+++ b/cli/tests/test_config_command.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::env::join_paths;
+use std::path::Path;
 use std::path::PathBuf;
 
 use indoc::indoc;
@@ -1865,4 +1866,135 @@ fn test_config_author_change_warning_root_env() {
 fn find_stdout_lines(keyname_pattern: &str, stdout: &str) -> String {
     let key_line_re = Regex::new(&format!(r"(?m)^{keyname_pattern} = .*\n")).unwrap();
     key_line_re.find_iter(stdout).map(|m| m.as_str()).collect()
+}
+
+/// Set up a per-repo config directory by running `config set --repo`. Returns
+/// the path to the per-repo config directory
+/// (e.g. `~/.config/jj/repos/<config_id>/`).
+fn create_repo_with_config(test_env: &mut TestEnvironment, repo_name: &str) -> TestResult<PathBuf> {
+    test_env
+        .run_jj_in(".", ["git", "init", repo_name])
+        .success();
+    let work_dir = test_env.work_dir(repo_name);
+    work_dir
+        .run_jj(["config", "set", "--repo", "user.name", "test"])
+        .success();
+    let output = work_dir.run_jj(["config", "path", "--repo"]).success();
+    let config_file = Path::new(output.stdout.raw().trim_end_matches('\n'));
+    Ok(config_file.parent().unwrap().to_path_buf())
+}
+
+#[test]
+fn test_config_gc_no_repos_dir() {
+    let test_env = TestEnvironment::default();
+    // No repo config dir created at all.
+    let output = test_env.run_jj_in(".", ["config", "gc"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Missing repo configs (repo path no longer exists):
+      (none)
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_config_gc_all_existing() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    create_repo_with_config(&mut test_env, "repo")?;
+
+    let output = test_env.run_jj_in(".", ["config", "gc"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Missing repo configs (repo path no longer exists):
+      (none)
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
+fn test_config_gc_missing_default_no() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let config_dir = create_repo_with_config(&mut test_env, "repo")?;
+    // Remove the repo so its metadata path no longer exists.
+    std::fs::remove_dir_all(test_env.env_root().join("repo"))?;
+
+    // Non-interactive: the prompt auto-answers with the default ("no").
+    let output = test_env.run_jj_in(".", ["config", "gc"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Missing repo configs (repo path no longer exists):
+      $TEST_ENV/home/.config/jj/repos/8e4fac809cbb3b162c95
+        repo path: $TEST_ENV/repo/.jj/repo
+    Delete 1 missing repo config directories? (yN): n
+    Aborted; nothing was deleted.
+    [EOF]
+    ");
+    // The directory should still be there.
+    assert!(config_dir.is_dir());
+    Ok(())
+}
+
+#[test]
+fn test_config_gc_missing_confirmed() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let config_dir = create_repo_with_config(&mut test_env, "repo")?;
+    std::fs::remove_dir_all(test_env.env_root().join("repo"))?;
+
+    let output = test_env.work_dir("").run_jj_with(|cmd| {
+        force_interactive(cmd)
+            .args(["config", "gc"])
+            .write_stdin("y\n")
+    });
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Missing repo configs (repo path no longer exists):
+      $TEST_ENV/home/.config/jj/repos/8e4fac809cbb3b162c95
+        repo path: $TEST_ENV/repo/.jj/repo
+    Delete 1 missing repo config directories? (yN): Deleted 1 config directories.
+    [EOF]
+    ");
+    assert!(!config_dir.exists());
+    Ok(())
+}
+
+#[test]
+fn test_config_gc_missing_with_extra_file() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let config_dir = create_repo_with_config(&mut test_env, "repo")?;
+    std::fs::remove_dir_all(test_env.env_root().join("repo"))?;
+    // An unrelated file in the per-repo config directory should prevent us
+    // from deleting it: we only remove the known jj-managed files and then
+    // try to rmdir the (hopefully empty) directory.
+    let extra_file = config_dir.join("unexpected.txt");
+    std::fs::write(&extra_file, b"hello")?;
+
+    let output = test_env.work_dir("").run_jj_with(|cmd| {
+        force_interactive(cmd)
+            .args(["config", "gc"])
+            .write_stdin("y\n")
+    });
+    insta::assert_snapshot!(output.normalize_stderr_with(|s| {
+        // The OS-specific "directory not empty" message varies, so strip the
+        // trailing detail after the path for a stable snapshot.
+        regex::Regex::new(r"(?m)(Failed to delete \S+):.*$")
+            .unwrap()
+            .replace_all(&s, "$1: <directory not empty>")
+            .into_owned()
+    }), @r"
+    ------- stderr -------
+    Missing repo configs (repo path no longer exists):
+      $TEST_ENV/home/.config/jj/repos/8e4fac809cbb3b162c95
+        repo path: $TEST_ENV/repo/.jj/repo
+    Delete 1 missing repo config directories? (yN): Warning: Failed to delete $TEST_ENV/home/.config/jj/repos/8e4fac809cbb3b162c95: <directory not empty>
+    Deleted 0 config directories.
+    [EOF]
+    ");
+    // The directory must still be there (with the unrelated file intact).
+    assert!(config_dir.is_dir());
+    assert!(extra_file.is_file());
+    // The known jj-managed files should be gone.
+    assert!(!config_dir.join("config.toml").exists());
+    assert!(!config_dir.join("metadata.binpb").exists());
+    Ok(())
 }

--- a/docs/design/secure-config.md
+++ b/docs/design/secure-config.md
@@ -270,14 +270,19 @@ unavoidable.
 
 ### Garbage collection
 
-We could, in the future, add a `gc` command to garbage-collect configs to
-deleted repo configs. However, there are some things to consider before doing
-so:
-* Each config would likely be very small, so cleaning it up may have limited
-  benefit.
+There is `jj config gc` command to delete configuration for repos that
+are deleted/moved. The command asks for user approval because of the
+following considerations:
+
 * It is impossible to distinguish "deleted" from "moved".
 * If you have something like a chroot or a dual boot where you share the
   config, you may have references to config IDs with a different path.
+
+For safety, the command only removes the well-known files it manages
+(`config.toml` and `metadata.binpb`) and then removes the per-repo
+directory non-recursively. If a user (or another tool) has placed an
+unrelated file inside the directory, the directory is left in place and
+a warning is printed instead.
 
 ### Attack vectors remaining
 

--- a/lib/src/secure_config.rs
+++ b/lib/src/secure_config.rs
@@ -117,6 +117,36 @@ fn update_metadata(config_dir: &Path, metadata: &ConfigMetadata) -> Result<(), S
     Ok(())
 }
 
+/// Reads and decodes the `metadata.binpb` file in the given per-repo config
+/// directory.
+pub fn read_metadata(config_dir: &Path) -> Result<ConfigMetadata, SecureConfigError> {
+    let metadata_path = config_dir.join(METADATA_FILE);
+    let bytes = fs::read(&metadata_path).context(&metadata_path)?;
+    Ok(ConfigMetadata::decode(bytes.as_slice())?)
+}
+
+/// Returns the repo/workspace path stored in the metadata, if present.
+pub fn metadata_path(metadata: &ConfigMetadata) -> Result<Option<&Path>, BadPathEncoding> {
+    metadata.path.as_deref().map(path_from_bytes).transpose()
+}
+
+/// Removes the well-known files inside a per-repo config directory
+/// (`config.toml` and `metadata.binpb`) and then the directory itself.
+///
+/// The directory is removed non-recursively, so this errors out if any other
+/// file or subdirectory is present — better to leave a user-placed file in
+/// place than to silently delete it as part of a recursive `rm`.
+pub fn remove_repo_config_dir(config_dir: &Path) -> std::io::Result<()> {
+    for path in [config_dir.join(CONFIG_FILE), config_dir.join(METADATA_FILE)] {
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
+    }
+    fs::remove_dir(config_dir)
+}
+
 impl SecureConfig {
     /// Creates a secure config.
     fn new(
@@ -192,7 +222,7 @@ impl SecureConfig {
         mut metadata: ConfigMetadata,
     ) -> Result<LoadedSecureConfig, SecureConfigError> {
         let encoded = path_to_bytes(&self.repo_dir).ok();
-        let got = metadata.path.as_deref().map(path_from_bytes).transpose()?;
+        let got = metadata_path(&metadata)?;
 
         if got == encoded.is_some().then_some(self.repo_dir.as_path()) {
             return Ok(LoadedSecureConfig {
@@ -343,15 +373,11 @@ impl SecureConfig {
                     return Err(SecureConfigError::BadConfigIdError);
                 }
                 let config_dir = root_config_dir.join(&config_id);
-                let metadata_path = config_dir.join(METADATA_FILE);
-                match fs::read(&metadata_path).context(&metadata_path) {
-                    Ok(buf) => self.handle_metadata_path(
-                        rng,
-                        root_config_dir,
-                        config_dir,
-                        ConfigMetadata::decode(buf.as_slice())?,
-                    )?,
-                    Err(e) if e.source.kind() == NotFound => {
+                match read_metadata(&config_dir) {
+                    Ok(metadata) => {
+                        self.handle_metadata_path(rng, root_config_dir, config_dir, metadata)?
+                    }
+                    Err(SecureConfigError::PathError(e)) if e.source.kind() == NotFound => {
                         let (path, metadata) =
                             self.generate_initial_config(root_config_dir, &config_id)?;
                         LoadedSecureConfig {
@@ -360,7 +386,7 @@ impl SecureConfig {
                             warnings: vec![CONFIG_NOT_FOUND.to_string()],
                         }
                     }
-                    Err(e) => return Err(e.into()),
+                    Err(e) => return Err(e),
                 }
             }
             Err(e) if e.source.kind() == NotFound => {


### PR DESCRIPTION
<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->
This PR addresses issue https://github.com/jj-vcs/jj/issues/9362 and adds a `jj config gc` command to cleanup the config files after repos have been created and deleted. I'm aware of this section: https://docs.jj-vcs.dev/v0.36.0/design/secure-config/#garbage-collection , so the cleanup only happens after user confirmation.

To test manually:
1. `jj git clone <some-repo>`
2. `rm -rf <some-repo>`
3. `jj config gc` will print <some-repo> as gone and asks for confirmation.


# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
N/A
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
