### PR TITLE
cli bookmark create: restore comment explaining existence of the `--to` alias

### DIFF
--- a/cli/src/commands/bookmark/create.rs
+++ b/cli/src/commands/bookmark/create.rs
@@ -31,6 +31,9 @@ use crate::ui::Ui;
 #[derive(clap::Args, Clone, Debug)]
 pub struct BookmarkCreateArgs {
     /// The bookmark's target revision
+    //
+    // The `--to` alias exists for making it easier for the user to switch
+    // between `bookmark create`, `bookmark move`, and `bookmark set`.
     #[arg(
         long,
         short,


### PR DESCRIPTION
This comment was accidentally deleted in 6b4b2c7 but had existed before dd73b5a (the
commit being reverted by the former).

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
