### PR TITLE
docs/gerrit: remove explicit `--colocate` flags from `jj git init` instructions

### DIFF
--- a/docs/gerrit.md
+++ b/docs/gerrit.md
@@ -15,12 +15,12 @@ This guide assumes a basic understanding of Git, Gerrit, and Jujutsu.
 
 Jujutsu communicates with Gerrit by pushing commits to a Git remote. If you're
 starting from an existing Git repository with Gerrit remotes already configured,
-you can use `jj git init --colocate` to start using JJ in that repo. Otherwise,
-set up your Gerrit remote.
+you can use `jj git init` to start using JJ in that repo. Otherwise, set up your
+Gerrit remote.
 
 ```shell
 # Option 1: Start JJ in an existing Git repo with Gerrit remotes
-$ jj git init --colocate
+$ jj git init
 
 # Option 2: Add a Gerrit remote to a JJ repo
 $ jj git remote add gerrit https://review.gerrithub.io/yourname/yourproject

--- a/web/docs/src/content/docs/gerrit.md
+++ b/web/docs/src/content/docs/gerrit.md
@@ -17,12 +17,12 @@ This guide assumes a basic understanding of Git, Gerrit, and Jujutsu.
 
 Jujutsu communicates with Gerrit by pushing commits to a Git remote. If you're
 starting from an existing Git repository with Gerrit remotes already configured,
-you can use `jj git init --colocate` to start using JJ in that repo. Otherwise,
-set up your Gerrit remote.
+you can use `jj git init` to start using JJ in that repo. Otherwise, set up your
+Gerrit remote.
 
 ```shell
 # Option 1: Start JJ in an existing Git repo with Gerrit remotes
-$ jj git init --colocate
+$ jj git init
 
 # Option 2: Add a Gerrit remote to a JJ repo
 $ jj git remote add gerrit https://review.gerrithub.io/yourname/yourproject


### PR DESCRIPTION
Since `--colocate` is the default.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
