### PR TITLE
lib: introduce file metadata getter to Backend

### DIFF
--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -34,6 +34,7 @@ use jj_lib::backend::CopyHistory;
 use jj_lib::backend::CopyId;
 use jj_lib::backend::CopyRecord;
 use jj_lib::backend::FileId;
+use jj_lib::backend::FileMetadata;
 use jj_lib::backend::RelatedCopy;
 use jj_lib::backend::SigningFn;
 use jj_lib::backend::SymlinkId;
@@ -142,6 +143,10 @@ impl Backend for JitBackend {
 
     fn concurrency(&self) -> usize {
         1
+    }
+
+    async fn get_file_metadata(&self, path: &RepoPath, id: &FileId) -> BackendResult<FileMetadata> {
+        self.inner.get_file_metadata(path, id).await
     }
 
     async fn read_file(

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -533,6 +533,12 @@ pub fn make_root_commit(root_change_id: ChangeId, empty_tree_id: TreeId) -> Comm
     }
 }
 
+/// Metadata describing a file
+pub struct FileMetadata {
+    /// Number of bytes contained in the file
+    pub size: u64,
+}
+
 /// Defines the interface for commit backends.
 #[async_trait]
 pub trait Backend: Any + Send + Sync + Debug {
@@ -568,6 +574,9 @@ pub trait Backend: Any + Send + Sync + Debug {
     /// sent. It is the backend's responsibility to make sure it doesn't put
     /// too much load on its storage, e.g. by queueing requests if necessary.
     fn concurrency(&self) -> usize;
+
+    /// Returns metadata describing a file.
+    async fn get_file_metadata(&self, path: &RepoPath, id: &FileId) -> BackendResult<FileMetadata>;
 
     /// Returns a reader for reading the contents of a file from the backend.
     async fn read_file(

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -62,6 +62,7 @@ use crate::backend::CopyHistory;
 use crate::backend::CopyId;
 use crate::backend::CopyRecord;
 use crate::backend::FileId;
+use crate::backend::FileMetadata;
 use crate::backend::MillisSinceEpoch;
 use crate::backend::RelatedCopy;
 use crate::backend::SecureSig;
@@ -1035,6 +1036,21 @@ impl Backend for GitBackend {
 
     fn concurrency(&self) -> usize {
         1
+    }
+
+    async fn get_file_metadata(
+        &self,
+        _path: &RepoPath,
+        id: &FileId,
+    ) -> BackendResult<FileMetadata> {
+        let git_blob_id = validate_git_object_id(id)?;
+        let locked_repo = self.lock_git_repo();
+        let header = locked_repo
+            .find_header(git_blob_id)
+            .map_err(|err| map_not_found_err(err, id))?;
+        Ok(FileMetadata {
+            size: header.size(),
+        })
     }
 
     async fn read_file(

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -33,6 +33,7 @@ use crate::backend::CopyHistory;
 use crate::backend::CopyId;
 use crate::backend::CopyRecord;
 use crate::backend::FileId;
+use crate::backend::FileMetadata;
 use crate::backend::RelatedCopy;
 use crate::backend::SigningFn;
 use crate::backend::SymlinkId;
@@ -113,6 +114,10 @@ impl Backend for SecretBackend {
 
     fn concurrency(&self) -> usize {
         1
+    }
+
+    async fn get_file_metadata(&self, path: &RepoPath, id: &FileId) -> BackendResult<FileMetadata> {
+        self.inner.get_file_metadata(path, id).await
     }
 
     async fn read_file(

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -47,6 +47,7 @@ use crate::backend::CopyHistory;
 use crate::backend::CopyId;
 use crate::backend::CopyRecord;
 use crate::backend::FileId;
+use crate::backend::FileMetadata;
 use crate::backend::MillisSinceEpoch;
 use crate::backend::RelatedCopy;
 use crate::backend::SecureSig;
@@ -178,6 +179,16 @@ impl Backend for SimpleBackend {
 
     fn concurrency(&self) -> usize {
         1
+    }
+
+    async fn get_file_metadata(
+        &self,
+        _path: &RepoPath,
+        id: &FileId,
+    ) -> BackendResult<FileMetadata> {
+        let disk_path = self.file_path(id);
+        let meta = fs::metadata(disk_path).map_err(to_other_err)?;
+        Ok(FileMetadata { size: meta.len() })
     }
 
     async fn read_file(

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -33,6 +33,7 @@ use crate::backend::ChangeId;
 use crate::backend::CommitId;
 use crate::backend::CopyRecord;
 use crate::backend::FileId;
+use crate::backend::FileMetadata;
 use crate::backend::SigningFn;
 use crate::backend::SymlinkId;
 use crate::backend::TreeId;
@@ -225,6 +226,14 @@ impl Store {
         }
 
         Ok(Tree::new(self.clone(), path.to_owned(), tree_id, data))
+    }
+
+    pub async fn get_file_metadata(
+        &self,
+        path: &RepoPath,
+        id: &FileId,
+    ) -> BackendResult<FileMetadata> {
+        self.backend.get_file_metadata(path, id).await
     }
 
     pub async fn read_file(

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -41,6 +41,7 @@ use jj_lib::backend::CopyHistory;
 use jj_lib::backend::CopyId;
 use jj_lib::backend::CopyRecord;
 use jj_lib::backend::FileId;
+use jj_lib::backend::FileMetadata;
 use jj_lib::backend::RelatedCopy;
 use jj_lib::backend::SecureSig;
 use jj_lib::backend::SigningFn;
@@ -197,6 +198,24 @@ impl Backend for TestBackend {
     fn concurrency(&self) -> usize {
         // Not optimal, just for testing the async code more
         10
+    }
+
+    async fn get_file_metadata(&self, path: &RepoPath, id: &FileId) -> BackendResult<FileMetadata> {
+        let path = path.to_owned();
+        let id = id.clone();
+        self.run_async(
+            move |data| match data.files.get(&path).and_then(|items| items.get(&id)) {
+                None => Err(BackendError::ObjectNotFound {
+                    object_type: "file".to_string(),
+                    hash: id.hex(),
+                    source: format!("at path {path:?}").into(),
+                }),
+                Some(item) => Ok(FileMetadata {
+                    size: item.len() as u64,
+                }),
+            },
+        )
+        .await
     }
 
     async fn read_file(


### PR DESCRIPTION
Some initial groundwork for implementing an efficient VFS directly atop jj-lib.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
