### PR TITLE
squash: support `--restore-descendants`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,10 @@ Thanks to the people who made this release happen!
 * `JJ_PAGER` can now override the `ui.pager` config, matching `JJ_EDITOR` for
   callers that need a jj-specific environment override.
 
+* `jj squash` now accepts a `--restore-descendants` flag, matching `jj abandon`,
+  `jj diffedit`, and `jj restore`. When used, descendants of the squashed
+  commits keep their original content rather than being 3-way merged.
+
 ### Fixed bugs
 
 * Improving consistency with `git` handling of `.gitignore`, including `/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   where you need to pass multiple arguments to the tool, such as separate args
   for the range start and range end.
 
+* `jj squash` now accepts a `--restore-descendants` flag, matching `jj abandon`,
+  `jj diffedit`, and `jj restore`. When used, descendants of the destination
+  commit keep their original content rather than being 3-way merged.
+
 ### Fixed bugs
 
 ## [0.45.1] - 2026-09-03

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -176,6 +176,10 @@ pub(crate) struct SquashArgs {
     /// The source revision will not be abandoned
     #[arg(long, short)]
     keep_emptied: bool,
+
+    /// Preserve the content (not the diff) when rebasing descendants
+    #[arg(long)]
+    restore_descendants: bool,
 }
 
 #[instrument(skip_all)]
@@ -293,7 +297,11 @@ pub(crate) async fn cmd_squash(
                             .collect(),
                     );
                 }
-                let new_commit = rewriter.rebase().await?.write().await?;
+                let new_commit = if args.restore_descendants {
+                    rewriter.reparent().write().await?
+                } else {
+                    rewriter.rebase().await?.write().await?
+                };
                 rewritten.insert(old_commit_id, new_commit);
                 num_rebased += 1;
                 Ok(())
@@ -305,6 +313,12 @@ pub(crate) async fn cmd_squash(
             }
         }
         commit
+    };
+
+    let descendants_msg_suffix = if args.restore_descendants {
+        " (while preserving their content)"
+    } else {
+        ""
     };
 
     let fileset_expression = tx
@@ -332,6 +346,7 @@ pub(crate) async fn cmd_squash(
         &source_commits,
         &destination,
         args.keep_emptied,
+        args.restore_descendants,
     )
     .await?
     {
@@ -391,7 +406,11 @@ pub(crate) async fn cmd_squash(
             );
         }
         let commit = commit_builder.write(tx.repo_mut()).await?;
-        let num_rebased = tx.repo_mut().rebase_descendants().await?;
+        let num_rebased = if args.restore_descendants {
+            tx.repo_mut().reparent_descendants().await?
+        } else {
+            tx.repo_mut().rebase_descendants().await?
+        };
         if let Some(mut formatter) = ui.status_formatter() {
             if insert_destination_commit {
                 write!(formatter, "Created new commit ")?;
@@ -399,7 +418,10 @@ pub(crate) async fn cmd_squash(
                 writeln!(formatter)?;
             }
             if num_rebased > 0 {
-                writeln!(formatter, "Rebased {num_rebased} descendant commits.")?;
+                writeln!(
+                    formatter,
+                    "Rebased {num_rebased} descendant commits{descendants_msg_suffix}."
+                )?;
             }
         }
     } else {
@@ -414,7 +436,10 @@ pub(crate) async fn cmd_squash(
                 writeln!(formatter)?;
             }
             if num_rebased > 0 {
-                writeln!(formatter, "Rebased {num_rebased} descendant commits.")?;
+                writeln!(
+                    formatter,
+                    "Rebased {num_rebased} descendant commits{descendants_msg_suffix}."
+                )?;
             }
         }
 

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::iter::once;
+use std::slice;
 
 use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
@@ -178,6 +179,10 @@ pub(crate) struct SquashArgs {
     /// The source revision will not be abandoned
     #[arg(long, short)]
     keep_emptied: bool,
+
+    /// Preserve the content (not the diff) when rebasing descendants
+    #[arg(long)]
+    restore_descendants: bool,
 }
 
 #[instrument(skip_all)]
@@ -311,7 +316,11 @@ pub(crate) async fn cmd_squash(
                             .collect(),
                     );
                 }
-                let new_commit = rewriter.rebase().await?.write().await?;
+                let new_commit = if args.restore_descendants {
+                    rewriter.reparent().write().await?
+                } else {
+                    rewriter.rebase().await?.write().await?
+                };
                 rewritten.insert(old_commit_id, new_commit);
                 num_rebased += 1;
                 Ok(())
@@ -323,6 +332,12 @@ pub(crate) async fn cmd_squash(
             }
         }
         commit
+    };
+
+    let descendants_msg_suffix = if args.restore_descendants {
+        " (while preserving their content)"
+    } else {
+        ""
     };
 
     let fileset_expression = tx
@@ -351,6 +366,7 @@ pub(crate) async fn cmd_squash(
         &source_commits,
         &destination,
         args.keep_emptied,
+        args.restore_descendants,
     )
     .await?
     {
@@ -409,8 +425,19 @@ pub(crate) async fn cmd_squash(
                     .collect(),
             );
         }
+        // Squashing into a descendant rewrites the destination, and the remaining
+        // descendants are based on that version, not on the one we started with.
+        // This has to be resolved before writing the squashed commit, which
+        // rewrites the destination again.
+        let restore_roots = tx.repo().new_parents(slice::from_ref(destination.id()));
         let commit = commit_builder.write(tx.repo_mut()).await?;
-        let num_rebased = tx.repo_mut().rebase_descendants().await?;
+        let num_rebased = if args.restore_descendants {
+            tx.repo_mut()
+                .rebase_descendants_reparenting_under(&restore_roots)
+                .await?
+        } else {
+            tx.repo_mut().rebase_descendants().await?
+        };
         if let Some(mut formatter) = ui.status_formatter() {
             if insert_destination_commit {
                 write!(formatter, "Created new commit ")?;
@@ -418,7 +445,10 @@ pub(crate) async fn cmd_squash(
                 writeln!(formatter)?;
             }
             if num_rebased > 0 {
-                writeln!(formatter, "Rebased {num_rebased} descendant commits.")?;
+                writeln!(
+                    formatter,
+                    "Rebased {num_rebased} descendant commits{descendants_msg_suffix}."
+                )?;
             }
         }
     } else {
@@ -433,7 +463,10 @@ pub(crate) async fn cmd_squash(
                 writeln!(formatter)?;
             }
             if num_rebased > 0 {
-                writeln!(formatter, "Rebased {num_rebased} descendant commits.")?;
+                writeln!(
+                    formatter,
+                    "Rebased {num_rebased} descendant commits{descendants_msg_suffix}."
+                )?;
             }
         }
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3321,6 +3321,7 @@ An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. U
 * `-i`, `--interactive` — Interactively choose which parts to squash
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-k`, `--keep-emptied` — The source revision will not be abandoned
+* `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3431,6 +3431,7 @@ An alternative squashing UI is available via the `-o`, `-A`, and `-B` options. U
 * `-i`, `--interactive` — Interactively choose which parts to squash
 * `--tool <NAME>` — Specify diff editor to be used (implies --interactive)
 * `-k`, `--keep-emptied` — The source revision will not be abandoned
+* `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
 
 
 

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -449,6 +449,548 @@ fn test_squash_keep_emptied() {
 }
 
 #[test]
+fn test_squash_restore_descendants_into_siblings() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "foo\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "bar\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file", "baz\n");
+    work_dir.run_jj(["new", "a"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "d"])
+        .success();
+    work_dir.write_file("other", "stuff\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 d cc693ac7
+    │  (no description set)
+    │  Added regular file other:
+    │          1: stuff
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 4a345448
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : bar
+    │ │          1: baz
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b 7da98866
+    ├─╯  (no description set)
+    │    Modified regular file file:
+    │       1     : foo
+    │            1: bar
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 5ab2019f
+    │  (no description set)
+    │  Added regular file file:
+    │          1: foo
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "--from",
+        "b",
+        "--into",
+        "d",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 descendant commits (while preserving their content).
+    Working copy  (@) now at: yqosqzyt 00d05534 d | (no description set)
+    Parent commit (@-)      : qpvuntsm 5ab2019f a b | (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 d 00d05534
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : foo
+    │          1: bar
+    │  Added regular file other:
+    │          1: stuff
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:16 c cdf46a07
+    ├─╯  (no description set)
+    │    Modified regular file file:
+    │       1     : foo
+    │            1: baz
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a b 5ab2019f
+    │  (no description set)
+    │  Added regular file file:
+    │          1: foo
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_into_descendant() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file2", "extra\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "B\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file", "C\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "d"])
+        .success();
+    work_dir.write_file("file", "D\n");
+    work_dir.run_jj(["new", "a"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "e"])
+        .success();
+    work_dir.write_file("file", "E\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yostqsxw test.user@example.com 2001-02-03 08:05:17 e ba2b1ded
+    │  (no description set)
+    │  Added regular file file:
+    │          1: E
+    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:15 d 21f21ea1
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : C
+    │ │          1: D
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c c30cf113
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : B
+    │ │          1: C
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b 55357dd3
+    ├─╯  (no description set)
+    │    Added regular file file:
+    │            1: B
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 03702910
+    │  (no description set)
+    │  Added regular file file2:
+    │          1: extra
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "--from",
+        "a",
+        "--into",
+        "c",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 descendant commits (while preserving their content).
+    Working copy  (@) now at: yostqsxw 6c28fd67 e | (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 a | (empty) (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yostqsxw test.user@example.com 2001-02-03 08:05:18 e 6c28fd67
+    │  (no description set)
+    │  Added regular file file:
+    │          1: E
+    │  Added regular file file2:
+    │          1: extra
+    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:18 d 3dcddd86
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : C
+    │ │          1: D
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:18 c 4dad5015
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : B
+    │ │          1: C
+    │ │  Added regular file file2:
+    │ │          1: extra
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:18 b 9dcf425c
+    ├─╯  (no description set)
+    │    Added regular file file:
+    │            1: B
+    ◆  zzzzzzzz root() 00000000 a
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_into_ancestor() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "A\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "B\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file2", "extra\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "d"])
+        .success();
+    work_dir.write_file("file", "D\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 d 43f1d4c5
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : B
+    │          1: D
+    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 316511ed
+    │  (no description set)
+    │  Added regular file file2:
+    │          1: extra
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b 76a4f6a5
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : A
+    │          1: B
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 69899708
+    │  (no description set)
+    │  Added regular file file:
+    │          1: A
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "--from",
+        "c",
+        "--into",
+        "a",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: yqosqzyt 94196734 d | (no description set)
+    Parent commit (@-)      : kkmpptxz 2c47ce29 b c | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 d 94196734
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : B
+    │          1: D
+    │  Added regular file file2:
+    │          1: extra
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:16 b c 2c47ce29
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : A
+    │          1: B
+    │  Removed regular file file2:
+    │     1     : extra
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a c3f685a1
+    │  (no description set)
+    │  Added regular file file:
+    │          1: A
+    │  Added regular file file2:
+    │          1: extra
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_keep_emptied() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "b\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file", "c\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c c6fd7a79
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b fed4d1a2
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a e88768e6
+    │  (no description set)
+    │  Added regular file file:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "-r",
+        "b",
+        "--keep-emptied",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: mzvwutvl 91d6cb0b c | (no description set)
+    Parent commit (@-)      : kkmpptxz 0a0dd329 b | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:14 c 91d6cb0b
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : a
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:14 b 0a0dd329
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: a
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:14 a 39ffcc09
+    │  (no description set)
+    │  Added regular file file:
+    │          1: b
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_fanout() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "b\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c1"])
+        .success();
+    work_dir.write_file("file", "c1\n");
+    work_dir.run_jj(["new", "b"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c2"])
+        .success();
+    work_dir.write_file("file", "c2\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c2 1eb43759
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: c2
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c1 0dc5077c
+    ├─╯  (no description set)
+    │    Modified regular file file:
+    │       1     : b
+    │            1: c1
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b fed4d1a2
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a e88768e6
+    │  (no description set)
+    │  Added regular file file:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["squash", "-r", "b", "--restore-descendants"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: yqosqzyt 52bf8ab6 c2 | (no description set)
+    Parent commit (@-)      : qpvuntsm 9382e024 a b | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 c2 52bf8ab6
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: c2
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:16 c1 c632d97b
+    ├─╯  (no description set)
+    │    Modified regular file file:
+    │       1     : b
+    │            1: c1
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a b 9382e024
+    │  (no description set)
+    │  Added regular file file:
+    │          1: b
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_partial() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file1", "a\n");
+    work_dir.write_file("file2", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file1", "b\n");
+    work_dir.write_file("file2", "b\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file1", "c\n");
+    work_dir.write_file("file2", "c\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 87059ac9
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : b
+    │          1: c
+    │  Modified regular file file2:
+    │     1     : b
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b f2c9709f
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : a
+    │          1: b
+    │  Modified regular file file2:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 64ea60be
+    │  (no description set)
+    │  Added regular file file1:
+    │          1: a
+    │  Added regular file file2:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["squash", "-r", "b", "file1", "--restore-descendants"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: mzvwutvl 5e5d8791 c | (no description set)
+    Parent commit (@-)      : kkmpptxz ecdaed26 b | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:14 c 5e5d8791
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : a
+    │          1: c
+    │  Modified regular file file2:
+    │     1     : b
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:14 b ecdaed26
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : b
+    │          1: a
+    │  Modified regular file file2:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:14 a 0ff0de75
+    │  (no description set)
+    │  Added regular file file1:
+    │          1: b
+    │  Added regular file file2:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_no_descendants() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file", "b\n");
+
+    let output = work_dir.run_jj(["squash", "--restore-descendants"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Working copy  (@) now at: kkmpptxz 56c5264f (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 668074c7 (no description set)
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_squash_from_to() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_squash_command.rs
+++ b/cli/tests/test_squash_command.rs
@@ -498,6 +498,652 @@ fn test_squash_keep_emptied() {
 }
 
 #[test]
+fn test_squash_restore_descendants_into_siblings() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "foo\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "bar\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file", "baz\n");
+    work_dir.run_jj(["new", "a"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "d"])
+        .success();
+    work_dir.write_file("other", "stuff\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 d cc693ac7
+    │  (no description set)
+    │  Added regular file other:
+    │          1: stuff
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 4a345448
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : bar
+    │ │          1: baz
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b 7da98866
+    ├─╯  (no description set)
+    │    Modified regular file file:
+    │       1     : foo
+    │            1: bar
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 5ab2019f
+    │  (no description set)
+    │  Added regular file file:
+    │          1: foo
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "--from",
+        "b",
+        "--into",
+        "d",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 descendant commits (while preserving their content).
+    Working copy  (@) now at: yqosqzyt 00d05534 d | (no description set)
+    Parent commit (@-)      : qpvuntsm 5ab2019f a b | (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    New conflicts appeared in 1 commits:
+      mzvwutvl c53c75f0 c | (conflict) (no description set)
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
+      jj new mzvwutvl
+    Then use `jj resolve`, or edit the conflict markers in the file directly.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
+    Then run `jj squash` to move the resolution into the conflicted commit.
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @r"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 d 00d05534
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : foo
+    │          1: bar
+    │  Added regular file other:
+    │          1: stuff
+    │ ×  mzvwutvl test.user@example.com 2001-02-03 08:05:16 c c53c75f0 (conflict)
+    ├─╯  (no description set)
+    │    Created conflict in file:
+    │       1     : foo
+    │            1: <<<<<<< conflict 1 of 1
+    │            2: %%%%%%% diff from: kkmpptxz 7da98866 (parents of rebased revision)
+    │            3: \\\\\\\        to: qpvuntsm 5ab2019f (rebase destination)
+    │            4: -bar
+    │            5: +foo
+    │            6: +++++++ mzvwutvl 4a345448 (rebased revision)
+    │            7: baz
+    │            8: >>>>>>> conflict 1 of 1 ends
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a b 5ab2019f
+    │  (no description set)
+    │  Added regular file file:
+    │          1: foo
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_into_descendant() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file2", "extra\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "B\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file", "C\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "d"])
+        .success();
+    work_dir.write_file("file", "D\n");
+    work_dir.run_jj(["new", "a"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "e"])
+        .success();
+    work_dir.write_file("file", "E\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yostqsxw test.user@example.com 2001-02-03 08:05:17 e ba2b1ded
+    │  (no description set)
+    │  Added regular file file:
+    │          1: E
+    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:15 d 21f21ea1
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : C
+    │ │          1: D
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c c30cf113
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : B
+    │ │          1: C
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b 55357dd3
+    ├─╯  (no description set)
+    │    Added regular file file:
+    │            1: B
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 03702910
+    │  (no description set)
+    │  Added regular file file2:
+    │          1: extra
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "--from",
+        "a",
+        "--into",
+        "c",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 descendant commits (while preserving their content).
+    Working copy  (@) now at: yostqsxw c2f3c260 e | (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 a | (empty) (no description set)
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yostqsxw test.user@example.com 2001-02-03 08:05:18 e c2f3c260
+    │  (no description set)
+    │  Added regular file file:
+    │          1: E
+    │ ○  yqosqzyt test.user@example.com 2001-02-03 08:05:18 d 3dcddd86
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : C
+    │ │          1: D
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:18 c 4dad5015
+    │ │  (no description set)
+    │ │  Modified regular file file:
+    │ │     1     : B
+    │ │          1: C
+    │ │  Added regular file file2:
+    │ │          1: extra
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:18 b 9dcf425c
+    ├─╯  (no description set)
+    │    Added regular file file:
+    │            1: B
+    ◆  zzzzzzzz root() 00000000 a
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_into_ancestor() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "A\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "B\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file2", "extra\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "d"])
+        .success();
+    work_dir.write_file("file", "D\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 d 43f1d4c5
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : B
+    │          1: D
+    ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 316511ed
+    │  (no description set)
+    │  Added regular file file2:
+    │          1: extra
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b 76a4f6a5
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : A
+    │          1: B
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 69899708
+    │  (no description set)
+    │  Added regular file file:
+    │          1: A
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "--from",
+        "c",
+        "--into",
+        "a",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: yqosqzyt 94196734 d | (no description set)
+    Parent commit (@-)      : kkmpptxz 2c47ce29 b c | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 d 94196734
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : B
+    │          1: D
+    │  Added regular file file2:
+    │          1: extra
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:16 b c 2c47ce29
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : A
+    │          1: B
+    │  Removed regular file file2:
+    │     1     : extra
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a c3f685a1
+    │  (no description set)
+    │  Added regular file file:
+    │          1: A
+    │  Added regular file file2:
+    │          1: extra
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_keep_emptied() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "b\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file", "c\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c c6fd7a79
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b fed4d1a2
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a e88768e6
+    │  (no description set)
+    │  Added regular file file:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "-r",
+        "b",
+        "--keep-emptied",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: mzvwutvl 91d6cb0b c | (no description set)
+    Parent commit (@-)      : kkmpptxz 0a0dd329 b | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:14 c 91d6cb0b
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : a
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:14 b 0a0dd329
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: a
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:14 a 39ffcc09
+    │  (no description set)
+    │  Added regular file file:
+    │          1: b
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_fanout() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file", "b\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c1"])
+        .success();
+    work_dir.write_file("file", "c1\n");
+    work_dir.run_jj(["new", "b"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c2"])
+        .success();
+    work_dir.write_file("file", "c2\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c2 1eb43759
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: c2
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c1 0dc5077c
+    ├─╯  (no description set)
+    │    Modified regular file file:
+    │       1     : b
+    │            1: c1
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b fed4d1a2
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a e88768e6
+    │  (no description set)
+    │  Added regular file file:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["squash", "-r", "b", "--restore-descendants"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: yqosqzyt 52bf8ab6 c2 | (no description set)
+    Parent commit (@-)      : qpvuntsm 9382e024 a b | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 c2 52bf8ab6
+    │  (no description set)
+    │  Modified regular file file:
+    │     1     : b
+    │          1: c2
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:16 c1 c632d97b
+    ├─╯  (no description set)
+    │    Modified regular file file:
+    │       1     : b
+    │            1: c1
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a b 9382e024
+    │  (no description set)
+    │  Added regular file file:
+    │          1: b
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_partial() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file1", "a\n");
+    work_dir.write_file("file2", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file1", "b\n");
+    work_dir.write_file("file2", "b\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file1", "c\n");
+    work_dir.write_file("file2", "c\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:13 c 87059ac9
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : b
+    │          1: c
+    │  Modified regular file file2:
+    │     1     : b
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b f2c9709f
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : a
+    │          1: b
+    │  Modified regular file file2:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a 64ea60be
+    │  (no description set)
+    │  Added regular file file1:
+    │          1: a
+    │  Added regular file file2:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["squash", "-r", "b", "file1", "--restore-descendants"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 2 descendant commits (while preserving their content).
+    Working copy  (@) now at: mzvwutvl 5e5d8791 c | (no description set)
+    Parent commit (@-)      : kkmpptxz ecdaed26 b | (no description set)
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  mzvwutvl test.user@example.com 2001-02-03 08:05:14 c 5e5d8791
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : a
+    │          1: c
+    │  Modified regular file file2:
+    │     1     : b
+    │          1: c
+    ○  kkmpptxz test.user@example.com 2001-02-03 08:05:14 b ecdaed26
+    │  (no description set)
+    │  Modified regular file file1:
+    │     1     : b
+    │          1: a
+    │  Modified regular file file2:
+    │     1     : a
+    │          1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:14 a 0ff0de75
+    │  (no description set)
+    │  Added regular file file1:
+    │          1: b
+    │  Added regular file file2:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_no_descendants() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir.write_file("file", "b\n");
+
+    let output = work_dir.run_jj(["squash", "--restore-descendants"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Working copy  (@) now at: kkmpptxz 56c5264f (empty) (no description set)
+    Parent commit (@-)      : qpvuntsm 668074c7 (no description set)
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_squash_restore_descendants_only_destination_subtree() {
+    // a ─┬─ b (destination) ── d
+    //    └─ c
+    //
+    // `d` descends from the destination, so it keeps its content. `c` doesn't,
+    // so it should be rebased like it would be without `--restore-descendants`,
+    // instead of keeping the content that was moved out of `a`.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "a"])
+        .success();
+    work_dir.write_file("file1", "a\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "b"])
+        .success();
+    work_dir.write_file("file2", "b\n");
+    work_dir.run_jj(["new"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "d"])
+        .success();
+    work_dir.write_file("file3", "d\n");
+    work_dir.run_jj(["new", "a"]).success();
+    work_dir
+        .run_jj(["bookmark", "create", "-r@", "c"])
+        .success();
+    work_dir.write_file("file4", "c\n");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:15 c c9be50ae
+    │  (no description set)
+    │  Added regular file file4:
+    │          1: c
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:13 d 41827346
+    │ │  (no description set)
+    │ │  Added regular file file3:
+    │ │          1: d
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:11 b d848c532
+    ├─╯  (no description set)
+    │    Added regular file file2:
+    │            1: b
+    ○  qpvuntsm test.user@example.com 2001-02-03 08:05:09 a e6086990
+    │  (no description set)
+    │  Added regular file file1:
+    │          1: a
+    ◆  zzzzzzzz root() 00000000
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj([
+        "squash",
+        "--from",
+        "a",
+        "--into",
+        "b",
+        "--restore-descendants",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 descendant commits (while preserving their content).
+    Working copy  (@) now at: yqosqzyt 7f7cc1a6 c | (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 a | (empty) (no description set)
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["log", "-p"]), @"
+    @  yqosqzyt test.user@example.com 2001-02-03 08:05:16 c 7f7cc1a6
+    │  (no description set)
+    │  Added regular file file4:
+    │          1: c
+    │ ○  mzvwutvl test.user@example.com 2001-02-03 08:05:16 d ad3f40d8
+    │ │  (no description set)
+    │ │  Added regular file file3:
+    │ │          1: d
+    │ ○  kkmpptxz test.user@example.com 2001-02-03 08:05:16 b c91aa747
+    ├─╯  (no description set)
+    │    Added regular file file1:
+    │            1: a
+    │    Added regular file file2:
+    │            1: b
+    ◆  zzzzzzzz root() 00000000 a
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_squash_from_to() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -62,6 +62,7 @@ use crate::index::IndexStoreError;
 use crate::index::MutableIndex;
 use crate::index::ReadonlyIndex;
 use crate::index::ResolvedChangeTargets;
+use crate::iter_util::fallible_any;
 use crate::merge::MergeBuilder;
 use crate::merge::SameChange;
 use crate::merge::trivial_merge;
@@ -1561,6 +1562,47 @@ impl MutableRepo {
         .await?;
         self.parent_mapping.clear();
         Ok(num_reparented)
+    }
+
+    /// Rebases descendants of the rewritten commits, reparenting the descendants
+    /// of `restore_roots`.
+    ///
+    /// The descendants of the commits registered in `self.parent_mappings` will
+    /// be recursively rebased onto the new version of their parents, except for
+    /// the descendants of `restore_roots`, which will be reparented so that
+    /// their content remains untouched.
+    /// Returns the number of rewritten descendants.
+    pub async fn rebase_descendants_reparenting_under(
+        &mut self,
+        restore_roots: &[CommitId],
+    ) -> BackendResult<usize> {
+        let roots = self.parent_mapping.keys().cloned().collect_vec();
+        let mut num_rebased = 0;
+        self.transform_descendants(roots, async |mut rewriter| {
+            if rewriter.parents_changed() {
+                let old_commit_id = rewriter.old_commit().id().clone();
+                let restore = fallible_any(restore_roots, async |root| {
+                    rewriter
+                        .repo_mut()
+                        .index()
+                        .is_ancestor(root, &old_commit_id)
+                        .await
+                })
+                .await
+                // TODO: indexing error shouldn't be a "BackendError"
+                .map_err(|err| BackendError::Other(err.into()))?;
+                if restore {
+                    rewriter.reparent().write().await?;
+                } else {
+                    rewriter.rebase().await?.write().await?;
+                }
+                num_rebased += 1;
+            }
+            Ok(())
+        })
+        .await?;
+        self.parent_mapping.clear();
+        Ok(num_rebased)
     }
 
     pub fn set_wc_commit(

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -1365,11 +1365,15 @@ pub struct SquashedCommit<'repo> {
 /// Squash `sources` into `destination` and return a [`SquashedCommit`] for the
 /// resulting commit. Caller is responsible for setting the description and
 /// finishing the commit.
+///
+/// If `restore_descendants` is set, descendants of the destination keep their
+/// original content (they are reparented rather than 3-way merged).
 pub async fn squash_commits<'repo>(
     repo: &'repo mut MutableRepo,
     sources: &[CommitWithSelection],
     destination: &Commit,
     keep_emptied: bool,
+    restore_descendants: bool,
 ) -> BackendResult<Option<SquashedCommit<'repo>>> {
     struct SourceCommit<'a> {
         commit: &'a CommitWithSelection,
@@ -1439,17 +1443,50 @@ pub async fn squash_commits<'repo>(
         // rewritten sources. Otherwise it will likely already have the content
         // changes we're moving, so applying them will have no effect and the
         // changes will disappear.
+        //
+        // When `restore_descendants` is set, commits that descend from the destination
+        // are reparented to preserve their content, rather than rebased.
         let immutable = RevsetExpression::none();
         let options = RebaseOptions::default();
-        repo.rebase_descendants_with_options(&immutable, &options, |old_commit, rebased_commit| {
-            if old_commit.id() != destination.id() {
-                return;
-            }
-            rewritten_destination = match rebased_commit {
-                RebasedCommit::Rewritten(commit) => commit,
-                RebasedCommit::Abandoned { .. } => panic!("all commits should be kept"),
-            };
-        })
+        let roots = source_commits
+            .iter()
+            .map(|source| source.commit.commit.id().clone())
+            .collect_vec();
+        let destination_id = destination.id().clone();
+        repo.transform_descendants_with_options(
+            roots,
+            &immutable,
+            &HashMap::new(),
+            &options.rewrite_refs,
+            async |mut rewriter| {
+                if rewriter.parents_changed() {
+                    let old_commit_id = rewriter.old_commit().id().clone();
+                    let restore = restore_descendants
+                        && old_commit_id != destination_id
+                        && rewriter
+                            .repo_mut()
+                            .index()
+                            .is_ancestor(&destination_id, &old_commit_id)
+                            .await
+                            // TODO: indexing error shouldn't be a "BackendError"
+                            .map_err(|err| BackendError::Other(err.into()))?;
+                    if restore {
+                        rewriter.reparent().write().await?;
+                    } else {
+                        let rebased = rebase_commit_with_options(rewriter, &options).await?;
+                        if old_commit_id == destination_id {
+                            rewritten_destination = match rebased {
+                                RebasedCommit::Rewritten(commit) => commit,
+                                RebasedCommit::Abandoned { .. } => {
+                                    panic!("all commits should be kept")
+                                }
+                            };
+                        }
+                    }
+                }
+                Ok(())
+            },
+        )
         .await?;
     }
     let mut predecessors = vec![destination.id().clone()];

--- a/lib/src/rewrite.rs
+++ b/lib/src/rewrite.rs
@@ -1315,11 +1315,18 @@ pub struct SquashedCommit<'repo> {
 /// Squash `sources` into `destination` and return a [`SquashedCommit`] for the
 /// resulting commit. Caller is responsible for setting the description and
 /// finishing the commit.
+///
+/// If `restore_descendants` is set, descendants of the destination keep their
+/// original content (they are reparented rather than 3-way merged). Commits on
+/// the path between any source and the destination, and the destination itself,
+/// are still rebased — their trees must be recomputed for the squash to be
+/// correct.
 pub async fn squash_commits<'repo>(
     repo: &'repo mut MutableRepo,
     sources: &[CommitWithSelection],
     destination: &Commit,
     keep_emptied: bool,
+    restore_descendants: bool,
 ) -> BackendResult<Option<SquashedCommit<'repo>>> {
     struct SourceCommit<'a> {
         commit: &'a CommitWithSelection,
@@ -1385,21 +1392,59 @@ pub async fn squash_commits<'repo>(
     // TODO: indexing error shouldn't be a "BackendError"
     .map_err(|err| BackendError::Other(err.into()))?
     {
-        // If we're moving changes to a descendant, first rebase descendants onto the
-        // rewritten sources. Otherwise it will likely already have the content
-        // changes we're moving, so applying them will have no effect and the
-        // changes will disappear.
+        // If we're moving changes to a descendant, first rewrite descendants of
+        // the rewritten sources. Otherwise the destination would already have
+        // the content changes we're moving, so applying them would have no
+        // effect and the changes would disappear.
+        //
+        // Commits on the path from any source to the destination (including the
+        // destination) must be rebased so the destination's tree is correct.
+        // Strict descendants of the destination can be reparented to preserve
+        // their content when `restore_descendants` is set.
         let immutable = RevsetExpression::none();
-        let options = RebaseOptions::default();
-        repo.rebase_descendants_with_options(&immutable, &options, |old_commit, rebased_commit| {
-            if old_commit.id() != destination.id() {
-                return;
-            }
-            rewritten_destination = match rebased_commit {
-                RebasedCommit::Rewritten(commit) => commit,
-                RebasedCommit::Abandoned { .. } => panic!("all commits should be kept"),
-            };
-        })
+        let rebase_options = RebaseOptions::default();
+        let roots = source_commits
+            .iter()
+            .map(|s| s.commit.commit.id().clone())
+            .collect_vec();
+        let dest_id = destination.id().clone();
+        repo.transform_descendants_with_options(
+            roots,
+            &immutable,
+            &HashMap::new(),
+            &rebase_options.rewrite_refs,
+            async |mut rewriter| {
+                if !rewriter.parents_changed() {
+                    return Ok(());
+                }
+                let old_commit_id = rewriter.old_commit().id().clone();
+                let on_path = old_commit_id == dest_id || {
+                    rewriter
+                        .repo_mut()
+                        .index()
+                        .is_ancestor(&old_commit_id, &dest_id)
+                        .await
+                        // TODO: indexing error shouldn't be a "BackendError"
+                        .map_err(|err| BackendError::Other(err.into()))?
+                };
+                if on_path {
+                    let rebased = rebase_commit_with_options(rewriter, &rebase_options).await?;
+                    if old_commit_id == dest_id {
+                        rewritten_destination = match rebased {
+                            RebasedCommit::Rewritten(commit) => commit,
+                            RebasedCommit::Abandoned { .. } => {
+                                unreachable!("destination is on the rebase path, never abandoned")
+                            }
+                        };
+                    }
+                } else if restore_descendants {
+                    rewriter.reparent().write().await?;
+                } else {
+                    rebase_commit_with_options(rewriter, &rebase_options).await?;
+                }
+                Ok(())
+            },
+        )
         .await?;
     }
     let mut predecessors = vec![destination.id().clone()];


### PR DESCRIPTION
Sometimes it is convenient to be able to make changes to a commit in the past without affecting descendants -- I already have a workflow that tracks the commits of all children, makes the changes, and then restores manually, but that performs a lot more rebases than necessary, which adds up when history is long. Supporting `--restore-descendants` for `jj squash` helps this workflow greatly.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.

# Prior Art

I found #6141 but haven't looked too far into it.