### PR TITLE
backend: support random-access reads

### DIFF
--- a/cli/examples/custom-backend/main.rs
+++ b/cli/examples/custom-backend/main.rs
@@ -148,8 +148,9 @@ impl Backend for JitBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
+        offset: u64,
     ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
-        self.inner.read_file(path, id).await
+        self.inner.read_file(path, id, offset).await
     }
 
     async fn write_file(

--- a/cli/src/commands/debug/object.rs
+++ b/cli/src/commands/debug/object.rs
@@ -135,7 +135,7 @@ pub async fn cmd_debug_object(
                 FileId::try_from_hex(file_id)
                     .ok_or_else(|| user_error(format!(r#"Invalid hex file id: "{file_id}""#)))?
             };
-            let mut contents = repo_loader.store().read_file(&path, &id).await?;
+            let mut contents = repo_loader.store().read_file(&path, &id, 0).await?;
             let mut buf = vec![];
             contents.read_to_end(&mut buf).await?;
             ui.stdout().write_all(&buf)?;

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -302,7 +302,7 @@ async fn fix_one_file(
     // limit for both `old_content` and `base_content`.
     let mut old_content = vec![];
     let mut read = store
-        .read_file(&file_to_fix.repo_path, &file_to_fix.file_id)
+        .read_file(&file_to_fix.repo_path, &file_to_fix.file_id, 0)
         .await?;
     read.read_to_end(&mut old_content).await?;
 
@@ -319,7 +319,7 @@ async fn fix_one_file(
             Some(base_file_id) if matching_tools.clone().any(|t| t.line_range_arg.is_some()) => {
                 let mut content = vec![];
                 let mut read = store
-                    .read_file(&file_to_fix.repo_path, base_file_id)
+                    .read_file(&file_to_fix.repo_path, base_file_id, 0)
                     .await?;
                 read.read_to_end(&mut content).await?;
                 Some(content)

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -569,11 +569,13 @@ pub trait Backend: Any + Send + Sync + Debug {
     /// too much load on its storage, e.g. by queueing requests if necessary.
     fn concurrency(&self) -> usize;
 
-    /// Returns a reader for reading the contents of a file from the backend.
+    /// Returns a reader for reading the contents of a file from the backend,
+    /// starting from `offset`.
     async fn read_file(
         &self,
         path: &RepoPath,
         id: &FileId,
+        offset: u64,
     ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>>;
 
     /// Writes the contents of the writer to the backend. Returns the ID of the

--- a/lib/src/conflicts.rs
+++ b/lib/src/conflicts.rs
@@ -100,7 +100,7 @@ async fn get_file_contents(
 ) -> BackendResult<BString> {
     match term {
         Some(id) => {
-            let mut reader = store.read_file(path, id).await?;
+            let mut reader = store.read_file(path, id, 0).await?;
             let mut content = vec![];
             reader
                 .read_to_end(&mut content)
@@ -231,7 +231,7 @@ async fn materialize_tree_value_no_access_denied(
             executable,
             copy_id,
         })) => {
-            let reader = store.read_file(path, &id).await?;
+            let reader = store.read_file(path, &id, 0).await?;
             Ok(MaterializedTreeValue::File(MaterializedFileValue {
                 id,
                 executable,

--- a/lib/src/git_backend.rs
+++ b/lib/src/git_backend.rs
@@ -1041,8 +1041,11 @@ impl Backend for GitBackend {
         &self,
         _path: &RepoPath,
         id: &FileId,
+        offset: u64,
     ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
-        let data = self.read_file_sync(id)?;
+        let mut data = self.read_file_sync(id)?;
+        // gix doesn't presently support random access to blobs
+        data.drain(..offset as usize);
         Ok(Box::pin(Cursor::new(data)))
     }
 

--- a/lib/src/secret_backend.rs
+++ b/lib/src/secret_backend.rs
@@ -119,6 +119,7 @@ impl Backend for SecretBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
+        offset: u64,
     ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         if path.as_internal_file_string().contains("secret")
             || SECRET_CONTENTS_HEX.contains(&id.hex().as_ref())
@@ -129,7 +130,7 @@ impl Backend for SecretBackend {
                 source: "No access".into(),
             });
         }
-        self.inner.read_file(path, id).await
+        self.inner.read_file(path, id, offset).await
     }
 
     async fn write_file(

--- a/lib/src/simple_backend.rs
+++ b/lib/src/simple_backend.rs
@@ -18,6 +18,8 @@ use std::fmt::Debug;
 use std::fs;
 use std::fs::File;
 use std::io::Read as _;
+use std::io::Seek as _;
+use std::io::SeekFrom;
 use std::io::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
@@ -184,11 +186,13 @@ impl Backend for SimpleBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
+        offset: u64,
     ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         let disk_path = self.file_path(id);
         let mut file = File::open(disk_path).map_err(|err| map_not_found_err(err, id))?;
         let mut buf = vec![];
-        file.read_to_end(&mut buf)
+        file.seek(SeekFrom::Start(offset))
+            .and_then(|_| file.read_to_end(&mut buf))
             .map_err(|err| BackendError::ReadFile {
                 path: path.to_owned(),
                 id: id.clone(),

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -231,8 +231,9 @@ impl Store {
         &self,
         path: &RepoPath,
         id: &FileId,
+        offset: u64,
     ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
-        self.backend.read_file(path, id).await
+        self.backend.read_file(path, id, offset).await
     }
 
     pub async fn write_file(

--- a/lib/src/tree_merge.rs
+++ b/lib/src/tree_merge.rs
@@ -477,7 +477,7 @@ async fn try_resolve_file_conflict(
     let contents = file_id_conflict
         .try_map_async(async |file_id| {
             let mut content = vec![];
-            let mut reader = store.read_file(filename, file_id).await?;
+            let mut reader = store.read_file(filename, file_id, 0).await?;
             reader
                 .read_to_end(&mut content)
                 .await

--- a/lib/tests/test_local_working_copy.rs
+++ b/lib/tests/test_local_working_copy.rs
@@ -1385,7 +1385,7 @@ fn test_snapshot_modified_materialized_conflict(
             test_workspace
                 .repo
                 .store()
-                .read_file(file_repo_path, id)
+                .read_file(file_repo_path, id, 0)
                 .await
                 .unwrap()
                 .read_to_end(&mut contents)

--- a/lib/testutils/src/lib.rs
+++ b/lib/testutils/src/lib.rs
@@ -419,7 +419,7 @@ pub fn repo_path_buf(value: impl Into<String>) -> RepoPathBuf {
 }
 
 pub fn read_file(store: &Store, path: &RepoPath, id: &FileId) -> Vec<u8> {
-    let mut reader = store.read_file(path, id).block_on().unwrap();
+    let mut reader = store.read_file(path, id, 0).block_on().unwrap();
     let mut content = vec![];
     reader.read_to_end(&mut content).block_on().unwrap();
     content

--- a/lib/testutils/src/test_backend.rs
+++ b/lib/testutils/src/test_backend.rs
@@ -203,6 +203,7 @@ impl Backend for TestBackend {
         &self,
         path: &RepoPath,
         id: &FileId,
+        offset: u64,
     ) -> BackendResult<Pin<Box<dyn AsyncRead + Send>>> {
         let path = path.to_owned();
         let id = id.clone();
@@ -218,7 +219,8 @@ impl Backend for TestBackend {
                     hash: id.hex(),
                     source: format!("at path {path:?}").into(),
                 }),
-                Some(contents) => {
+                Some(mut contents) => {
+                    contents.drain(..offset as usize);
                     let reader: Pin<Box<dyn AsyncRead + Send>> = Box::pin(Cursor::new(contents));
                     Ok(reader)
                 }


### PR DESCRIPTION
Potential speed-up for front-ends such as VFS which may directly manipulate large files.

Of the public backends, this only turned out to have a useful implementation for `SimpleBackend`, so merging this may be premature today. With changes to gix, it might be useful on the git backend, and would likely be useful with future network backends.

We could instead return `dyn AsyncRead + AsyncSeek` or similar from `read_file`. That would cause slightly less API churn, but be much more difficult to implement on top of e.g. HTTP. I think the current approach is simpler, but don't feel very strongly.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
