### PR TITLE
cli operation revert: add hint when trying to revert merge operation

### DIFF
--- a/cli/src/commands/operation/revert.rs
+++ b/cli/src/commands/operation/revert.rs
@@ -61,7 +61,10 @@ pub async fn cmd_op_revert(
     let parent_of_bad_op = match bad_op.parents().await?.into_iter().at_most_one() {
         Ok(Some(parent_of_bad_op)) => parent_of_bad_op,
         Ok(None) => return Err(user_error("Cannot revert root operation")),
-        Err(_) => return Err(user_error("Cannot revert a merge operation")),
+        Err(_) => {
+            return Err(user_error("Cannot revert a merge operation")
+                .hinted("Consider using `jj op restore` instead"));
+        }
     };
 
     let mut tx = workspace_command.start_transaction();

--- a/cli/tests/test_op_revert_command.rs
+++ b/cli/tests/test_op_revert_command.rs
@@ -48,6 +48,7 @@ fn test_revert_merge_operation() {
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Error: Cannot revert a merge operation
+    Hint: Consider using `jj op restore` instead
     [EOF]
     [exit status: 1]
     ");


### PR DESCRIPTION
The hint is copied from the one from `jj undo`.

Extracted from #8553.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
