### PR TITLE
revset: add `same_change()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   extracted from the `.doc` field of the alias definition if it is a table
   with `.doc` and `.definition` properties.
 
+* New `same_change()` revset function for finding commits with the same
+  change ID as the input(s).
+
 ### Fixed bugs
 
 * `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -287,6 +287,8 @@ revsets (expressions) as arguments.
   change is divergent, this resolves to multiple commits. It is an error to use a
   non-unique prefix. Unmatched prefix isn't an error.
 
+* `same_change(x)`: Commits with a change ID that matches any change ID in `x`.
+
 * `commit_id(prefix)`: Commits with the given commit ID prefix. It is an error
   to use a non-unique prefix. Unmatched prefix isn't an error.
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -316,6 +316,7 @@ pub enum RevsetExpression<St: ExpressionState> {
     Roots(Arc<Self>),
     ForkPoint(Arc<Self>),
     Bisect(Arc<Self>),
+    SameChange(Arc<Self>),
     HasSize {
         candidates: Arc<Self>,
         count: usize,
@@ -484,6 +485,11 @@ impl<St: ExpressionState> RevsetExpression<St> {
     /// Commits in `self` that don't have ancestors in `self`.
     pub fn roots(self: &Arc<Self>) -> Arc<Self> {
         Arc::new(Self::Roots(self.clone()))
+    }
+
+    /// Commits with the same change ID as the commits in `self`.
+    pub fn same_change(self: &Arc<Self>) -> Arc<Self> {
+        Arc::new(Self::SameChange(self.clone()))
     }
 
     /// Parents of `self`.
@@ -1190,6 +1196,11 @@ static BUILTIN_FUNCTION_MAP: LazyLock<HashMap<&str, RevsetFunction>> = LazyLock:
             candidates,
         }))
     });
+    map.insert("same_change", |diagnostics, function, context| {
+        let [arg] = function.expect_exact_arguments()?;
+        let expression = lower_expression(diagnostics, arg, context)?;
+        Ok(expression.same_change())
+    });
     map.insert("coalesce", |diagnostics, function, context| {
         let ([], args) = function.expect_some_arguments()?;
         let expressions: Vec<_> = args
@@ -1615,6 +1626,9 @@ fn try_transform_expression<St: ExpressionState, E>(
             RevsetExpression::Bisect(expression) => {
                 transform_rec(expression, pre, post)?.map(RevsetExpression::Bisect)
             }
+            RevsetExpression::SameChange(candidates) => {
+                transform_rec(candidates, pre, post)?.map(RevsetExpression::SameChange)
+            }
             RevsetExpression::HasSize { candidates, count } => {
                 transform_rec(candidates, pre, post)?.map(|candidates| RevsetExpression::HasSize {
                     candidates,
@@ -1862,6 +1876,10 @@ where
         RevsetExpression::Bisect(expression) => {
             let expression = folder.fold_expression(expression)?;
             RevsetExpression::Bisect(expression).into()
+        }
+        RevsetExpression::SameChange(candidates) => {
+            let candidates = folder.fold_expression(candidates)?;
+            RevsetExpression::SameChange(candidates).into()
         }
         RevsetExpression::HasSize { candidates, count } => {
             let candidates = folder.fold_expression(candidates)?;
@@ -3084,6 +3102,33 @@ impl ExpressionStateFolder<UserExpressionState, ResolvedExpressionState>
         expression: &UserRevsetExpression,
     ) -> Result<Arc<ResolvedRevsetExpression>, Self::Error> {
         match expression {
+            RevsetExpression::SameChange(candidates) => {
+                let resolved_candidates = self.fold_expression(candidates)?;
+                let revset = resolved_candidates
+                    .evaluate(self.repo())
+                    .map_err(|err| RevsetResolutionError::Other(Box::new(err)))?;
+                let stream = revset.commit_change_ids();
+                let pairs: Vec<Result<(CommitId, ChangeId), RevsetEvaluationError>> =
+                    stream.collect().block_on();
+                let mut change_ids = std::collections::HashSet::new();
+                for pair in pairs {
+                    let (_, change_id) =
+                        pair.map_err(|err| RevsetResolutionError::Other(Box::new(err)))?;
+                    change_ids.insert(change_id);
+                }
+                let mut commit_ids = Vec::new();
+                for change_id in change_ids {
+                    if let Some(visible) = self
+                        .repo()
+                        .resolve_change_id(&change_id)
+                        .map_err(|err| RevsetResolutionError::Other(Box::new(err)))?
+                        .and_then(ResolvedChangeTargets::into_visible)
+                    {
+                        commit_ids.extend(visible);
+                    }
+                }
+                Ok(RevsetExpression::commits(commit_ids))
+            }
             // 'present(x)' opens new symbol resolution scope to map error to 'none()'
             RevsetExpression::Present(candidates) => {
                 self.fold_expression(candidates).or_else(|err| match err {
@@ -3181,6 +3226,9 @@ impl VisibilityResolutionContext<'_> {
                 ResolvedExpression::Commits(commit_ids.clone())
             }
             RevsetExpression::CommitRef(commit_ref) => match *commit_ref {},
+            RevsetExpression::SameChange(_) => {
+                unreachable!("SameChange should be resolved during symbol resolution")
+            }
             RevsetExpression::Ancestors {
                 heads,
                 generation,
@@ -3377,6 +3425,9 @@ impl VisibilityResolutionContext<'_> {
             | RevsetExpression::HasSize { .. }
             | RevsetExpression::Latest { .. } => {
                 ResolvedPredicateExpression::Set(self.resolve(expression).into())
+            }
+            RevsetExpression::SameChange(_) => {
+                unreachable!("SameChange should be resolved during symbol resolution")
             }
             RevsetExpression::Filter(predicate) => {
                 ResolvedPredicateExpression::Filter(predicate.clone())

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -5251,3 +5251,47 @@ fn test_revset_containing_fn() -> TestResult {
     assert!(revset_has_commit(commit_d.id())?);
     Ok(())
 }
+
+#[test]
+fn test_evaluate_expression_same_change() -> TestResult {
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    let mut tx = repo.start_transaction();
+    let mut_repo = tx.repo_mut();
+
+    let commit1 = write_random_commit(mut_repo);
+    let commit2 = create_random_commit(mut_repo)
+        .set_change_id(commit1.change_id().clone())
+        .write_unwrap();
+    let commit3 = write_random_commit(mut_repo);
+
+    let repo = tx.commit("test").block_on()?;
+
+    // Single commit input
+    assert_eq!(
+        resolve_commit_ids(repo.as_ref(), &format!("same_change({})", commit1.id())),
+        vec![commit2.id().clone(), commit1.id().clone()]
+    );
+
+    // Multiple commit input
+    assert_eq!(
+        resolve_commit_ids(
+            repo.as_ref(),
+            &format!("same_change({} | {})", commit1.id(), commit3.id())
+        ),
+        vec![
+            commit3.id().clone(),
+            commit2.id().clone(),
+            commit1.id().clone()
+        ]
+    );
+
+    // Empty input
+    assert_eq!(
+        resolve_commit_ids(repo.as_ref(), "same_change(none())"),
+        vec![]
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Add a revset function that resolves to the set of commits with change IDs that match any of the inputs to the function.

Fixes #8359

Note to reviewers: I am not 100% sure that the implementation in ExpressionSymbolResolver is in the right place (rather than VisibilityResolutionContext). The comment above `revset.rs:resolve_visibility()`  ("Symbols and commit refs in the expression should have been resolved") makes me think this is the right place, but please correct me if I'm wrong.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
