### PR TITLE
git: clean up error handling and iteration of changed refs in import_refs()

### DIFF
--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -553,6 +553,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
                 ),
                 GitImportError::Backend(_) => None,
                 GitImportError::Index(_) => None,
+                GitImportError::RevsetEvaluation(_) => None,
                 GitImportError::Git(_) => None,
                 GitImportError::UnexpectedBackend(_) => None,
             };

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -602,15 +602,26 @@ async fn import_refs_inner(
         failed_ref_names,
     } = refs_to_import;
 
+    let iter_changed_refs = || itertools::chain(&changed_remote_bookmarks, &changed_remote_tags);
+    // List of changed old/new ref heads, which may include duplicates.
+    let (old_referenced_heads, new_referenced_heads) = {
+        let mut old_heads = Vec::new();
+        let mut new_heads = Vec::new();
+        for (_, (old_remote_ref, new_target)) in iter_changed_refs() {
+            old_heads.extend(old_remote_ref.target.added_ids().cloned());
+            new_heads.extend(new_target.added_ids().cloned());
+        }
+        (old_heads, new_heads)
+    };
+
     // Bulk-import all reachable Git commits to the backend to reduce overhead
     // of table merging and ref updates.
     //
     // changed_git_refs aren't respected because changed_remote_bookmarks/tags
     // should include all heads that will become reachable in jj.
-    let iter_changed_refs = || itertools::chain(&changed_remote_bookmarks, &changed_remote_tags);
     let index = mut_repo.index();
-    let missing_head_ids: Vec<&CommitId> = iter_changed_refs()
-        .flat_map(|(_, (_, new_target))| new_target.added_ids())
+    let missing_head_ids: Vec<&CommitId> = new_referenced_heads
+        .iter()
         .filter_map(|id| match index.has_id(id) {
             Ok(false) => Some(Ok(id)),
             Ok(true) => None,
@@ -634,6 +645,8 @@ async fn import_refs_inner(
         }
         store.get_commit_async(id).await.map_err(missing_ref_err)
     };
+    // Uses iter_changed_refs() instead of new_referenced_heads to report error
+    // with ref name.
     for (symbol, (_, new_target)) in iter_changed_refs() {
         for id in new_target.added_ids() {
             let commit = get_commit(id, symbol).await?;
@@ -686,8 +699,7 @@ async fn import_refs_inner(
     }
 
     let abandoned_commits = if options.abandon_unreachable_commits {
-        abandon_unreachable_commits(mut_repo, &changed_remote_bookmarks, &changed_remote_tags)
-            .await?
+        abandon_unreachable_commits(mut_repo, old_referenced_heads).await?
     } else {
         vec![]
     };
@@ -704,13 +716,8 @@ async fn import_refs_inner(
 /// Those commits will be recorded as abandoned in the `MutableRepo`.
 async fn abandon_unreachable_commits(
     mut_repo: &mut MutableRepo,
-    changed_remote_bookmarks: &[(RemoteRefSymbolBuf, (RemoteRef, RefTarget))],
-    changed_remote_tags: &[(RemoteRefSymbolBuf, (RemoteRef, RefTarget))],
+    hidable_git_heads: Vec<CommitId>,
 ) -> Result<Vec<CommitId>, GitImportError> {
-    let hidable_git_heads = itertools::chain(changed_remote_bookmarks, changed_remote_tags)
-        .flat_map(|(_, (old_remote_ref, _))| old_remote_ref.target.added_ids())
-        .cloned()
-        .collect_vec();
     if hidable_git_heads.is_empty() {
         return Ok(vec![]);
     }

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -35,7 +35,6 @@ use itertools::Itertools as _;
 use thiserror::Error;
 
 use crate::backend::BackendError;
-use crate::backend::BackendResult;
 use crate::backend::CommitId;
 use crate::backend::TreeValue;
 use crate::commit::Commit;
@@ -70,6 +69,7 @@ use crate::ref_name::RemoteRefSymbolBuf;
 use crate::repo::MutableRepo;
 use crate::repo::Repo;
 use crate::repo_path::RepoPath;
+use crate::revset::RevsetEvaluationError;
 use crate::revset::RevsetExpression;
 use crate::settings::UserSettings;
 use crate::store::Store;
@@ -494,6 +494,8 @@ pub enum GitImportError {
     #[error(transparent)]
     Index(#[from] IndexError),
     #[error(transparent)]
+    RevsetEvaluation(#[from] RevsetEvaluationError),
+    #[error(transparent)]
     Git(Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     UnexpectedBackend(#[from] UnexpectedGitBackendError),
@@ -704,7 +706,7 @@ async fn abandon_unreachable_commits(
     mut_repo: &mut MutableRepo,
     changed_remote_bookmarks: &[(RemoteRefSymbolBuf, (RemoteRef, RefTarget))],
     changed_remote_tags: &[(RemoteRefSymbolBuf, (RemoteRef, RefTarget))],
-) -> BackendResult<Vec<CommitId>> {
+) -> Result<Vec<CommitId>, GitImportError> {
     let hidable_git_heads = itertools::chain(changed_remote_bookmarks, changed_remote_tags)
         .flat_map(|(_, (old_remote_ref, _))| old_remote_ref.target.added_ids())
         .cloned()
@@ -725,12 +727,10 @@ async fn abandon_unreachable_commits(
         // Don't include already-abandoned commits in GitImportStats
         .intersection(&RevsetExpression::visible_heads().ancestors());
     let abandoned_commit_ids: Vec<_> = abandoned_expression
-        .evaluate(mut_repo)
-        .map_err(|err| err.into_backend_error())?
+        .evaluate(mut_repo)?
         .stream()
         .try_collect()
-        .await
-        .map_err(|err| err.into_backend_error())?;
+        .await?;
     for id in &abandoned_commit_ids {
         let commit = mut_repo.store().get_commit_async(id).await?;
         mut_repo.record_abandoned_commit(&commit);

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -625,7 +625,7 @@ async fn import_refs_inner(
             err,
         };
         // If bulk-import failed, try again to find bad head or ref.
-        if !heads_imported && !index.has_id(id).map_err(GitImportError::Index)? {
+        if !heads_imported && !index.has_id(id)? {
             git_backend
                 .import_head_commits([id])
                 .map_err(missing_ref_err)?;
@@ -640,10 +640,7 @@ async fn import_refs_inner(
     }
     // It's unlikely the imported commits were missing, but I/O-related error
     // can still occur.
-    mut_repo
-        .add_heads(&head_commits)
-        .await
-        .map_err(GitImportError::Backend)?;
+    mut_repo.add_heads(&head_commits).await?;
 
     // Apply the change that happened in git since last time we imported refs.
     for (full_name, new_target) in changed_git_refs {
@@ -688,8 +685,7 @@ async fn import_refs_inner(
 
     let abandoned_commits = if options.abandon_unreachable_commits {
         abandon_unreachable_commits(mut_repo, &changed_remote_bookmarks, &changed_remote_tags)
-            .await
-            .map_err(GitImportError::Backend)?
+            .await?
     } else {
         vec![]
     };
@@ -1033,14 +1029,8 @@ pub async fn import_head(mut_repo: &mut MutableRepo) -> Result<(), GitImportErro
         }
         // It's unlikely the imported commits were missing, but I/O-related
         // error can still occur.
-        let commit = store
-            .get_commit_async(head_id)
-            .await
-            .map_err(GitImportError::Backend)?;
-        mut_repo
-            .add_head(&commit)
-            .await
-            .map_err(GitImportError::Backend)?;
+        let commit = store.get_commit_async(head_id).await?;
+        mut_repo.add_head(&commit).await?;
     }
 
     mut_repo.set_git_head_target(RefTarget::resolved(new_git_head_id));


### PR DESCRIPTION
# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
