### PR TITLE
git fetch: add --rebase to rewrite upstream changes in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   extracted from the `.doc` field of the alias definition if it is a table
   with `.doc` and `.definition` properties.
 
+* `jj git fetch` now supports `--rebase` to treat an upstream rewrite of an
+  existing change as a rewrite of the local revision rather than as a
+  divergent change. Bookmarks, the working copy, and descendants are moved
+  onto the new revision, and the old revision is hidden. Rewrite mappings
+  are recorded for every change in an upstream-rebased stack, not only the
+  head. The import aborts if any change is already divergent before the
+  fetch, or if the fetch itself introduces multiple new revisions for the
+  same change; every such problem is reported in one error so you can
+  resolve them together before retrying.
+
 ### Fixed bugs
 
 * `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -542,6 +542,12 @@ mod git {
 
     impl From<GitImportError> for CommandError {
         fn from(err: GitImportError) -> Self {
+            // `GitImportError::DivergentChanges` only originates from
+            // `jj git fetch --rebase`; that command intercepts the error to
+            // render commit summaries via the workspace's
+            // `commit_summary_template`. The generic conversion here is just a
+            // fallback for any other call site that ever surfaces the error
+            // through `?` — the Display impl still includes a useful summary.
             let hint = match &err {
                 GitImportError::MissingHeadTarget { .. }
                 | GitImportError::MissingRefAncestor { .. } => Some(
@@ -551,6 +557,7 @@ jj currently does not support partial clones. To use jj with this repository, tr
                      the full repository contents."
                         .to_string(),
                 ),
+                GitImportError::DivergentChanges { .. } => None,
                 GitImportError::Backend(_) => None,
                 GitImportError::Index(_) => None,
                 GitImportError::RevsetEvaluation(_) => None,

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -126,6 +126,25 @@ pub struct GitFetchArgs {
     /// Fetch from all remotes
     #[arg(long, conflicts_with = "remotes")]
     all_remotes: bool,
+
+    /// Rewrite changes from upstream in place instead of creating divergent
+    /// changes
+    ///
+    /// When upstream rewrites a change (e.g. amends or rebases) and you fetch
+    /// the new revision, the default behavior is to keep your old revision
+    /// alongside the new one as a divergent change. With `--rebase`, the
+    /// incoming revision rewrites your existing revision in place: bookmarks,
+    /// the working copy, and descendants are moved onto the new revision, and
+    /// the old revision is hidden.
+    ///
+    /// If upstream rewrites a stack of changes, rewrite mappings are recorded
+    /// for every change in the stack, not only the head. Aborts if any change
+    /// is already divergent in your repo before the fetch, or if the fetch
+    /// itself introduces multiple new revisions for the same change. All such
+    /// problems are reported in one error so you can resolve them together
+    /// before retrying.
+    #[arg(long)]
+    rebase: bool,
 }
 
 #[tracing::instrument(skip_all)]
@@ -230,7 +249,8 @@ pub async fn cmd_git_fetch(
     }
 
     let git_settings = GitSettings::from_settings(tx.settings())?;
-    let import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
+    let mut import_options = load_git_import_options(ui, &git_settings, &remote_settings)?;
+    import_options.replace_divergent_changes = args.rebase;
     let mut git_fetch = GitFetch::new(
         tx.repo_mut(),
         git_settings.to_subprocess_options(),
@@ -245,7 +265,16 @@ pub async fn cmd_git_fetch(
         git_fetch.fetch(remote, expanded, &mut callback, None, fetch_tags)?;
     }
 
-    let import_stats = git_fetch.import_refs().await?;
+    let import_stats = match git_fetch.import_refs().await {
+        Ok(stats) => stats,
+        // `--rebase` produces a structured DivergentChanges error; render it
+        // here so the per-problem hints can include commit summaries pretty-
+        // printed via the workspace's commit_summary template.
+        Err(jj_lib::git::GitImportError::DivergentChanges { problems }) => {
+            return Err(crate::git_util::divergent_changes_error(&tx, problems).await?);
+        }
+        Err(err) => return Err(err.into()),
+    };
     print_git_import_stats(ui, &tx, &import_stats).await?;
 
     if let Some(bookmark_expr) = &common_bookmark_expr {

--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -30,8 +30,11 @@ use futures::future::try_join_all;
 use indoc::writedoc;
 use itertools::Itertools as _;
 use jj_lib::git;
+use jj_lib::git::DivergentChangeKind;
+use jj_lib::git::DivergentChangeProblem;
 use jj_lib::git::FailedRefExportReason;
 use jj_lib::git::GitExportStats;
+use jj_lib::git::GitImportError;
 use jj_lib::git::GitImportOptions;
 use jj_lib::git::GitImportStats;
 use jj_lib::git::GitProgress;
@@ -55,6 +58,7 @@ use crate::cli_util::print_updated_commits;
 use crate::command_error::CommandError;
 use crate::command_error::cli_error;
 use crate::command_error::user_error;
+use crate::command_error::user_error_with_message;
 use crate::formatter::Formatter;
 use crate::formatter::FormatterExt as _;
 use crate::revset_util::parse_remote_auto_track_bookmarks_map;
@@ -213,6 +217,7 @@ pub fn load_git_import_options(
         auto_local_bookmark: git_settings.auto_local_bookmark,
         abandon_unreachable_commits: git_settings.abandon_unreachable_commits,
         remote_auto_track_bookmarks: parse_remote_auto_track_bookmarks_map(ui, remote_settings)?,
+        replace_divergent_changes: false,
     })
 }
 
@@ -296,6 +301,71 @@ fn print_failed_git_import(ui: &Ui, stats: &GitImportStats) -> Result<(), Comman
         )?;
     }
     Ok(())
+}
+
+/// Builds the user-visible error for a `jj git fetch --rebase` that produced
+/// one or more divergent-change problems. Each problem becomes a formatted
+/// hint listing the affected commits via the workspace's `commit_summary`
+/// template, followed by action hints for each kind that appears.
+pub async fn divergent_changes_error(
+    tx: &WorkspaceCommandTransaction<'_>,
+    problems: Vec<DivergentChangeProblem>,
+) -> Result<CommandError, CommandError> {
+    let template = tx.commit_summary_template();
+    let mut cmd_err = user_error_with_message(
+        "Failed to import refs from underlying Git repo",
+        GitImportError::DivergentChanges {
+            problems: problems.clone(),
+        },
+    );
+    let mut has_pre_existing = false;
+    let mut has_newly_introduced = false;
+    for problem in &problems {
+        let (header, commit_ids) = match &problem.kind {
+            DivergentChangeKind::PreExisting { existing_commits } => {
+                has_pre_existing = true;
+                (
+                    format!(
+                        "Already divergent ({} visible local commits):",
+                        existing_commits.len(),
+                    ),
+                    existing_commits.clone(),
+                )
+            }
+            DivergentChangeKind::NewlyIntroduced { new_commits } => {
+                has_newly_introduced = true;
+                (
+                    format!(
+                        "Fetch-introduced divergence ({} incoming commits):",
+                        new_commits.len(),
+                    ),
+                    new_commits.clone(),
+                )
+            }
+        };
+        let commits = try_join_all(
+            commit_ids
+                .iter()
+                .map(|id| tx.repo().store().get_commit_async(id)),
+        )
+        .await?;
+        cmd_err.add_formatted_hint_with(|formatter| {
+            writeln!(formatter, "{header}")?;
+            print_updated_commits(formatter, &template, &commits)
+        });
+    }
+    if has_pre_existing {
+        cmd_err.add_hint(
+            "Resolve already-divergent changes (e.g. with `jj abandon` or `jj duplicate`) and \
+             re-run with `--rebase`.",
+        );
+    }
+    if has_newly_introduced {
+        cmd_err.add_hint(
+            "Re-run without `--rebase` to accept the fetch-introduced divergent change(s).",
+        );
+    }
+    Ok(cmd_err)
 }
 
 /// Prints only the summary of git import stats (abandoned count, failed refs).

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1674,6 +1674,11 @@ If a working-copy commit gets abandoned, it will be given a new, empty commit. T
 
    [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 * `--all-remotes` — Fetch from all remotes
+* `--rebase` — Rewrite changes from upstream in place instead of creating divergent changes
+
+   When upstream rewrites a change (e.g. amends or rebases) and you fetch the new revision, the default behavior is to keep your old revision alongside the new one as a divergent change. With `--rebase`, the incoming revision rewrites your existing revision in place: bookmarks, the working copy, and descendants are moved onto the new revision, and the old revision is hidden.
+
+   If upstream rewrites a stack of changes, rewrite mappings are recorded for every change in the stack, not only the head. Aborts if any change is already divergent in your repo before the fetch, or if the fetch itself introduces multiple new revisions for the same change. All such problems are reported in one error so you can resolve them together before retrying.
 
 
 

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2363,3 +2363,57 @@ fn test_git_fetch_auto_track_bookmarks() {
     [EOF]
     ");
 }
+
+// The --rebase logic is covered at the lib level in
+// lib/tests/test_git.rs (`test_import_refs_rebase_*`). The single CLI test
+// below covers only the user-visible rendering of the divergent-changes error
+// (the `divergent_changes_error` helper in `cli/src/git_util.rs`), which the
+// lib layer can't reach. The lib tests pin the `GitImportError::Display`
+// strings for all three `summary()` branches (pre-only / new-only / mixed);
+// this test pins the formatter structure — hint header, indented commit list
+// rendered through `commit_summary_template`, and the trailing hint — using
+// the pre-existing case as a representative. New tests for --rebase behavior
+// belong in lib/tests/test_git.rs.
+#[test]
+fn test_git_fetch_rebase_divergent_changes_error_rendering() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config("remotes.origin.auto-track-bookmarks = '*'");
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "none()""#);
+
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "source"])
+        .success();
+    let source = test_env.work_dir("source");
+    create_commit(&source, "feat", &[]);
+
+    test_env.run_jj_in(".", ["git", "init", "target"]).success();
+    let target = test_env.work_dir("target");
+    target
+        .run_jj(["git", "remote", "add", "origin", "../source/.git"])
+        .success();
+    target.run_jj(["git", "fetch"]).success();
+
+    // Pin the initial upstream commit with a local bookmark so the next plain
+    // fetch can't hide it via `abandon-unreachable-commits` (which only
+    // considers local bookmarks/tags as pins). Two amend + fetch cycles then
+    // produce pre-existing divergence the third --rebase fetch must reject.
+    target
+        .run_jj(["bookmark", "create", "-r=feat@origin", "keepalive"])
+        .success();
+    source.run_jj(["describe", "feat", "-m=feat v2"]).success();
+    target.run_jj(["git", "fetch"]).success();
+    source.run_jj(["describe", "feat", "-m=feat v3"]).success();
+
+    let output = target.run_jj(["git", "fetch", "--rebase"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Failed to import refs from underlying Git repo
+    Caused by: Cannot rewrite changes in place: 1 already-divergent change(s) in the repo
+    Hint: Already divergent (2 visible local commits):
+      rlvkpnrz/1 abf1fac5 (divergent) feat v2
+      rlvkpnrz/2 00d0d0ee keepalive* | (divergent) feat
+    Hint: Resolve already-divergent changes (e.g. with `jj abandon` or `jj duplicate`) and re-run with `--rebase`.
+    [EOF]
+    [exit status: 1]
+    "#);
+}

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -31,10 +31,12 @@ use bstr::BString;
 use futures::StreamExt as _;
 use futures::TryStreamExt as _;
 use gix::refspec::Instruction;
+use indexmap::IndexMap;
 use itertools::Itertools as _;
 use thiserror::Error;
 
 use crate::backend::BackendError;
+use crate::backend::ChangeId;
 use crate::backend::CommitId;
 use crate::backend::TreeValue;
 use crate::commit::Commit;
@@ -475,6 +477,44 @@ fn resolve_git_ref_to_commit_id(
     is_commit.then_some(peeled_id.detach())
 }
 
+/// A single change that `--rebase` (i.e. `replace_divergent_changes`) cannot
+/// pair cleanly. Collected across the whole import so the user sees every
+/// problem at once instead of one at a time.
+#[derive(Debug, Clone)]
+pub struct DivergentChangeProblem {
+    pub change_id: ChangeId,
+    pub kind: DivergentChangeKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum DivergentChangeKind {
+    /// Two or more visible local commits already share this change id; the
+    /// import has no unambiguous rewrite target to point at.
+    PreExisting { existing_commits: Vec<CommitId> },
+    /// The fetch itself brought in two or more new commits with this change
+    /// id, so there's no unambiguous rewrite target among the incoming
+    /// revisions.
+    NewlyIntroduced { new_commits: Vec<CommitId> },
+}
+
+impl DivergentChangeProblem {
+    fn summary(problems: &[Self]) -> String {
+        let mut pre = 0;
+        let mut new = 0;
+        for p in problems {
+            match p.kind {
+                DivergentChangeKind::PreExisting { .. } => pre += 1,
+                DivergentChangeKind::NewlyIntroduced { .. } => new += 1,
+            }
+        }
+        match (pre, new) {
+            (n, 0) if n > 0 => format!("{n} already-divergent change(s) in the repo"),
+            (0, n) if n > 0 => format!("{n} change(s) made divergent by this fetch"),
+            (p, n) => format!("{p} already-divergent and {n} fetch-introduced divergent change(s)"),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum GitImportError {
     #[error("Failed to read Git HEAD target commit {id}")]
@@ -488,6 +528,13 @@ pub enum GitImportError {
         symbol: RemoteRefSymbolBuf,
         #[source]
         err: BackendError,
+    },
+    #[error(
+        "Cannot rewrite changes in place: {}",
+        DivergentChangeProblem::summary(problems)
+    )]
+    DivergentChanges {
+        problems: Vec<DivergentChangeProblem>,
     },
     #[error(transparent)]
     Backend(#[from] BackendError),
@@ -516,6 +563,11 @@ pub struct GitImportOptions {
     pub abandon_unreachable_commits: bool,
     /// Per-remote patterns whether to track bookmarks automatically.
     pub remote_auto_track_bookmarks: HashMap<RemoteNameBuf, StringMatcher>,
+    /// Whether to treat an incoming commit that belongs to the same change as
+    /// an existing visible revision as a rewrite of that revision, rather than
+    /// producing a divergent change. Aborts if the change is already divergent
+    /// in the repo, since there is no unambiguous rewrite target in that case.
+    pub replace_divergent_changes: bool,
 }
 
 /// Describes changes made by `import_refs()` or `fetch()`.
@@ -620,15 +672,17 @@ async fn import_refs_inner(
     // changed_git_refs aren't respected because changed_remote_bookmarks/tags
     // should include all heads that will become reachable in jj.
     let index = mut_repo.index();
-    let missing_head_ids: Vec<&CommitId> = new_referenced_heads
+    let newly_imported_ids: HashSet<CommitId> = new_referenced_heads
         .iter()
         .filter_map(|id| match index.has_id(id) {
-            Ok(false) => Some(Ok(id)),
+            Ok(false) => Some(Ok(id.clone())),
             Ok(true) => None,
             Err(e) => Some(Err(e)),
         })
         .try_collect()?;
-    let heads_imported = git_backend.import_head_commits(missing_head_ids).is_ok();
+    let heads_imported = git_backend
+        .import_head_commits(newly_imported_ids.iter())
+        .is_ok();
 
     // Import new remote heads
     let mut head_commits = Vec::new();
@@ -698,8 +752,14 @@ async fn import_refs_inner(
         mut_repo.set_remote_tag(symbol, new_remote_ref);
     }
 
+    let replaced_old_ids: HashSet<CommitId> = if options.replace_divergent_changes {
+        replace_divergent_changes(mut_repo, &head_commits)?
+    } else {
+        HashSet::new()
+    };
+
     let abandoned_commits = if options.abandon_unreachable_commits {
-        abandon_unreachable_commits(mut_repo, old_referenced_heads).await?
+        abandon_unreachable_commits(mut_repo, old_referenced_heads, &replaced_old_ids).await?
     } else {
         vec![]
     };
@@ -712,11 +772,147 @@ async fn import_refs_inner(
     Ok(stats)
 }
 
+/// For each new commit (head plus newly-visible ancestors) that belongs to the
+/// same change as an existing visible revision, records the revision as having
+/// been rewritten to the new commit.
+///
+/// Collects every change the import can't pair cleanly — already-divergent
+/// local changes and fetch-introduced divergent changes alike — and returns
+/// them in a single [`GitImportError::DivergentChanges`] error. No rewrite
+/// mapping is recorded if any problem is found, so the failed import is
+/// retryable once the user has resolved the listed conflicts.
+fn replace_divergent_changes(
+    mut_repo: &mut MutableRepo,
+    new_heads: &[Commit],
+) -> Result<HashSet<CommitId>, GitImportError> {
+    // Walk every commit that *just* became visible to jj — head commits plus
+    // any newly-imported ancestors. Resolving change ids one head at a time
+    // (as the previous implementation did) missed two cases the reviewer
+    // flagged: rewrites along an upstream-rebased stack (only the head got
+    // paired) and a single fetch that brings in two new revisions for the
+    // same change (the second observed the first as already-visible).
+    let newly_visible = collect_newly_visible_commits(mut_repo, new_heads)?;
+    let newly_visible_set: HashSet<&CommitId> = newly_visible.iter().map(|c| c.id()).collect();
+
+    // change_id -> commit_ids among `newly_visible`, in iteration order so the
+    // collected problem list is deterministic.
+    let mut new_by_change: IndexMap<ChangeId, Vec<CommitId>> = IndexMap::new();
+    for commit in &newly_visible {
+        new_by_change
+            .entry(commit.change_id().clone())
+            .or_default()
+            .push(commit.id().clone());
+    }
+
+    // We collect all rewrites *and* all problems before mutating the repo so
+    // either every rewrite lands or none do — leaving the failed import
+    // retryable after the user resolves the listed conflicts.
+    let mut rewrites: Vec<(CommitId, CommitId)> = Vec::new();
+    let mut problems: Vec<DivergentChangeProblem> = Vec::new();
+    for (change_id, news) in &new_by_change {
+        let resolved = mut_repo
+            .resolve_change_id(change_id)
+            .map_err(GitImportError::Index)?;
+        let Some(resolved) = resolved else { continue };
+        let Some(visible) = resolved.into_visible() else {
+            continue;
+        };
+        let olds: Vec<CommitId> = visible
+            .into_iter()
+            .filter(|id| !newly_visible_set.contains(id))
+            .collect();
+        match (olds.len(), news.len()) {
+            // No existing commit shares this change; nothing to rewrite.
+            (0, _) => {}
+            // The clean case: a single old commit, a single new commit.
+            (1, 1) => rewrites.push((olds.into_iter().next().unwrap(), news[0].clone())),
+            // Two or more old commits — the local view was already divergent
+            // for this change before the fetch.
+            (n, _) if n >= 2 => problems.push(DivergentChangeProblem {
+                change_id: change_id.clone(),
+                kind: DivergentChangeKind::PreExisting {
+                    existing_commits: olds,
+                },
+            }),
+            // olds.len() == 1, news.len() >= 2: the fetch itself introduces
+            // divergence. There's no unambiguous rewrite target.
+            _ => problems.push(DivergentChangeProblem {
+                change_id: change_id.clone(),
+                kind: DivergentChangeKind::NewlyIntroduced {
+                    new_commits: news.clone(),
+                },
+            }),
+        }
+    }
+    if !problems.is_empty() {
+        return Err(GitImportError::DivergentChanges { problems });
+    }
+    let replaced_old_ids: HashSet<CommitId> = rewrites.iter().map(|(old, _)| old.clone()).collect();
+    for (old_id, new_id) in rewrites {
+        mut_repo.set_rewritten_commit(old_id, new_id);
+    }
+    Ok(replaced_old_ids)
+}
+
+/// Walks the commits that just became reachable in jj's view: the supplied
+/// head commits plus their ancestors, stopping at any commit that was already
+/// reachable from a pre-transaction head. Used by [`replace_divergent_changes`]
+/// to find every commit that needs change-id pairing, not just the heads.
+fn collect_newly_visible_commits(
+    mut_repo: &MutableRepo,
+    new_heads: &[Commit],
+) -> Result<Vec<Commit>, GitImportError> {
+    let base_repo = mut_repo.base_repo();
+    let base_index = base_repo.index();
+    let base_heads: Vec<CommitId> = base_repo.view().heads().iter().cloned().collect();
+    let root_id = mut_repo.store().root_commit_id().clone();
+
+    let was_visible = |id: &CommitId| -> Result<bool, GitImportError> {
+        if id == &root_id {
+            return Ok(true);
+        }
+        if !base_index.has_id(id).map_err(GitImportError::Index)? {
+            return Ok(false);
+        }
+        for head in &base_heads {
+            if base_index
+                .is_ancestor(id, head)
+                .map_err(GitImportError::Index)?
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    };
+
+    let mut newly_visible: Vec<Commit> = Vec::new();
+    let mut visited: HashSet<CommitId> = HashSet::new();
+    let mut worklist: Vec<CommitId> = new_heads.iter().map(|c| c.id().clone()).collect();
+    while let Some(id) = worklist.pop() {
+        if !visited.insert(id.clone()) {
+            continue;
+        }
+        if was_visible(&id)? {
+            continue;
+        }
+        let commit = mut_repo
+            .store()
+            .get_commit(&id)
+            .map_err(GitImportError::Backend)?;
+        for parent in commit.parent_ids() {
+            worklist.push(parent.clone());
+        }
+        newly_visible.push(commit);
+    }
+    Ok(newly_visible)
+}
+
 /// Finds commits that used to be reachable in git that no longer are reachable.
 /// Those commits will be recorded as abandoned in the `MutableRepo`.
 async fn abandon_unreachable_commits(
     mut_repo: &mut MutableRepo,
     hidable_git_heads: Vec<CommitId>,
+    exclude: &HashSet<CommitId>,
 ) -> Result<Vec<CommitId>, GitImportError> {
     if hidable_git_heads.is_empty() {
         return Ok(vec![]);
@@ -738,6 +934,15 @@ async fn abandon_unreachable_commits(
         .stream()
         .try_collect()
         .await?;
+    // Skip commits that have already been recorded as rewritten (e.g. by
+    // `replace_divergent_changes`). Calling `record_abandoned_commit` for them
+    // would overwrite the rewrite mapping in `parent_mapping`, causing
+    // descendants to be reparented onto the old commit's parents instead of
+    // onto the rewrite target.
+    let abandoned_commit_ids = abandoned_commit_ids
+        .into_iter()
+        .filter(|id| !exclude.contains(id))
+        .collect_vec();
     for id in &abandoned_commit_ids {
         let commit = mut_repo.store().get_commit_async(id).await?;
         mut_repo.record_abandoned_commit(&commit);

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -40,6 +40,7 @@ use jj_lib::commit_builder::CommitBuilder;
 use jj_lib::config::ConfigLayer;
 use jj_lib::config::ConfigSource;
 use jj_lib::git;
+use jj_lib::git::DivergentChangeKind;
 use jj_lib::git::FailedRefExportReason;
 use jj_lib::git::FetchTagsOverride;
 use jj_lib::git::GitFetch;
@@ -143,6 +144,45 @@ fn empty_git_commit(
         &format!("random commit {}", rand::random::<u32>()),
         parents,
     )
+}
+
+/// Writes a Git commit carrying an explicit `change-id` extra header so that
+/// the resulting jj commit shares the given change id. Used to simulate
+/// upstream amending or rebasing a change.
+fn git_commit_with_change_id(
+    git_repo: &gix::Repository,
+    ref_name: &str,
+    parents: &[gix::ObjectId],
+    change_id: &ChangeId,
+    message: &str,
+) -> gix::ObjectId {
+    let empty_tree_id = git_repo.empty_tree().id().detach();
+    let signature = gix::actor::Signature {
+        name: "Some One".into(),
+        email: "some.one@example.com".into(),
+        time: gix::date::Time::new(0, 0),
+    };
+    let commit = gix::objs::Commit {
+        message: message.into(),
+        tree: empty_tree_id,
+        author: signature.clone(),
+        committer: signature,
+        encoding: None,
+        parents: parents.iter().copied().collect(),
+        extra_headers: vec![("change-id".into(), change_id.reverse_hex().into())],
+    };
+    let commit_id = git_repo.write_object(&commit).unwrap().detach();
+    if !ref_name.is_empty() {
+        git_repo
+            .reference(
+                ref_name,
+                commit_id,
+                gix::refs::transaction::PreviousValue::Any,
+                "",
+            )
+            .unwrap();
+    }
+    commit_id
 }
 
 fn jj_id(id: gix::ObjectId) -> CommitId {
@@ -6286,6 +6326,7 @@ fn default_import_options() -> GitImportOptions {
         auto_local_bookmark: false,
         abandon_unreachable_commits: true,
         remote_auto_track_bookmarks: HashMap::new(),
+        replace_divergent_changes: false,
     }
 }
 
@@ -6391,6 +6432,887 @@ fn test_set_remote_urls() -> TestResult {
         remote_name,
         Some("https://example.com/repo/path3"),
         Some("git@example.com:repo/path3"),
+    );
+    Ok(())
+}
+
+fn rebase_import_options() -> GitImportOptions {
+    GitImportOptions {
+        replace_divergent_changes: true,
+        ..auto_track_import_options()
+    }
+}
+
+fn change_id_from_byte(b: u8) -> ChangeId {
+    ChangeId::new(vec![b; 16])
+}
+
+#[test]
+fn test_import_refs_rebase_replaces_commit() -> TestResult {
+    // Happy path: upstream amends a commit (same change id, different commit
+    // id); import_refs with replace_divergent_changes records a rewrite mapping
+    // and the local bookmark moves to the new commit instead of producing a
+    // divergent change.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    assert_eq!(
+        repo.view().get_local_bookmark("feat".as_ref()),
+        &RefTarget::normal(jj_id(a1)),
+    );
+
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("rebase fetch").block_on()?;
+
+    let view = repo.view();
+    assert_eq!(
+        view.get_local_bookmark("feat".as_ref()),
+        &RefTarget::normal(jj_id(a2)),
+    );
+    assert_eq!(
+        view.get_remote_bookmark(remote_symbol("feat", "origin"))
+            .target,
+        RefTarget::normal(jj_id(a2)),
+        "remote-tracking ref must follow the rewrite",
+    );
+    assert!(view.heads().contains(&jj_id(a2)));
+    assert!(!view.heads().contains(&jj_id(a1)));
+    assert_eq!(
+        repo.resolve_change_id(&change_x)?
+            .and_then(ResolvedChangeTargets::into_visible),
+        Some(vec![jj_id(a2)]),
+    );
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_no_op_for_new_commits() -> TestResult {
+    // --rebase on a fresh fetch (no overlap with an existing change) behaves
+    // identically to a normal fetch.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    let view = repo.view();
+    assert_eq!(
+        view.get_local_bookmark("feat".as_ref()),
+        &RefTarget::normal(jj_id(a1)),
+    );
+    assert!(view.heads().contains(&jj_id(a1)));
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_rebases_descendants() -> TestResult {
+    // A local descendant on top of the upstream commit should be reparented
+    // onto the new upstream commit when --rebase replaces it.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    // Build a local descendant on top of A1.
+    let mut tx = repo.start_transaction();
+    let local = create_random_commit(tx.repo_mut())
+        .set_parents(vec![jj_id(a1)])
+        .set_description("local work")
+        .write_unwrap();
+    let local_id = local.id().clone();
+    let local_change_id = local.change_id().clone();
+    let repo = tx.commit("local work").block_on()?;
+
+    // Upstream amends to A2.
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("rebase fetch").block_on()?;
+
+    // The local commit should now sit on top of A2, preserving its change id.
+    let rebased_local_ids = repo
+        .resolve_change_id(&local_change_id)?
+        .and_then(ResolvedChangeTargets::into_visible)
+        .unwrap_or_default();
+    assert_eq!(rebased_local_ids.len(), 1);
+    let rebased_local_id = &rebased_local_ids[0];
+    assert_ne!(
+        rebased_local_id, &local_id,
+        "descendant should be rewritten"
+    );
+    let rebased_local = repo.store().get_commit(rebased_local_id)?;
+    assert_eq!(rebased_local.parent_ids(), &[jj_id(a2)]);
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_aborts_on_preexisting_divergence() -> TestResult {
+    // If a change is already divergent locally before the fetch, --rebase must
+    // abort with an error rather than pick an arbitrary rewrite target.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    // Pin A1 with a local bookmark so the next fetch can't abandon it.
+    let mut tx = repo.start_transaction();
+    tx.repo_mut()
+        .set_local_bookmark_target("keepalive".as_ref(), RefTarget::normal(jj_id(a1)));
+    let repo = tx.commit("pin a1").block_on()?;
+
+    // Upstream amends. Fetch without --rebase to create local divergence.
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("plain fetch").block_on()?;
+
+    // Sanity: both A1 and A2 visible (divergent).
+    let visible = repo
+        .resolve_change_id(&change_x)?
+        .and_then(ResolvedChangeTargets::into_visible)
+        .unwrap_or_default();
+    assert_eq!(visible.len(), 2);
+
+    // Upstream amends again; --rebase must abort.
+    let _a3 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v3",
+    );
+    let mut tx = repo.start_transaction();
+    let err = git::import_refs(tx.repo_mut(), &rebase_import_options())
+        .block_on()
+        .expect_err("import_refs should reject pre-existing divergence");
+    assert_eq!(
+        err.to_string(),
+        "Cannot rewrite changes in place: 1 already-divergent change(s) in the repo",
+        "Display rendering is the user-facing error line (CLI relays this)",
+    );
+    let GitImportError::DivergentChanges { problems } = err else {
+        panic!("expected DivergentChanges, got an unexpected variant");
+    };
+    assert_eq!(problems.len(), 1);
+    assert_eq!(problems[0].change_id, change_x);
+    let DivergentChangeKind::PreExisting { existing_commits } = &problems[0].kind else {
+        panic!("expected PreExisting, got: {:?}", problems[0].kind);
+    };
+    // The two visible divergent revisions are A1 (pinned by the local bookmark)
+    // and A2 (imported by the plain fetch). A3 has not been imported yet — the
+    // abort runs before that — so it must not appear here.
+    let mut existing_sorted = existing_commits.clone();
+    existing_sorted.sort();
+    let mut expected_sorted = vec![jj_id(a1), jj_id(a2)];
+    expected_sorted.sort();
+    assert_eq!(existing_sorted, expected_sorted);
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_works_after_op_rollback() -> TestResult {
+    // CLI-side analog: after `jj git fetch --rebase; jj undo; jj git fetch
+    // --rebase`, the second fetch must still pair A1 -> A2 the same way a
+    // fresh single fetch would. The reviewer flagged the `newly_imported_ids`
+    // filter as suspicious here — at the lib level we confirm that rolling
+    // back the op and re-running import_refs produces the same end state.
+    //
+    // Note: a `reload_at(pre_op)` loads the jj index *as of that op*, so A2 is
+    // not in `index().has_id()` at that point — the import_head_commits path
+    // for A2 still runs. The `newly_imported_ids` filter therefore happens to
+    // be safe today (it gates a git-side import, not the rewrite-mapping
+    // logic, which iterates the unfiltered head_commits). If a future
+    // refactor pushes that filter into the rewrite path, this test catches it.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo_before_fetch = tx.commit("initial").block_on()?;
+
+    // First --rebase fetch.
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+    let mut tx = repo_before_fetch.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let _repo_after_first = tx.commit("first --rebase").block_on()?;
+
+    // Roll back to the pre-fetch view. The git ref is still at A2.
+    let pre_op = repo_before_fetch.operation().clone();
+    let repo = repo_before_fetch.reload_at(&pre_op).block_on()?;
+
+    // Second --rebase fetch: must still pair A1 -> A2.
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("second --rebase").block_on()?;
+
+    let view = repo.view();
+    assert_eq!(
+        view.get_local_bookmark("feat".as_ref()),
+        &RefTarget::normal(jj_id(a2)),
+    );
+    assert!(!view.heads().contains(&jj_id(a1)));
+    assert_eq!(
+        repo.resolve_change_id(&change_x)?
+            .and_then(ResolvedChangeTargets::into_visible),
+        Some(vec![jj_id(a2)]),
+    );
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_rewrites_ancestors() -> TestResult {
+    // BUG REPRO (reviewer's point about ancestors of bookmarked revisions):
+    // when upstream rebases a *stack* (head + ancestors share change ids with
+    // local commits), only the head currently gets a rewrite mapping. The
+    // ancestor commits are imported as fresh commits; the old ancestors are
+    // hidden via abandon_unreachable_commits. A local commit that descends
+    // from an old ancestor (rather than from the head) is therefore reparented
+    // onto the *root* (since its parent was abandoned, not rewritten) instead
+    // of onto the new ancestor.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_a = change_id_from_byte(0xaa);
+    let change_b = change_id_from_byte(0xbb);
+
+    // upstream: feat -> B1 -> A1
+    let a1 = git_commit_with_change_id(&git_repo, "", &[], &change_a, "A v1");
+    let _b1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[a1],
+        &change_b,
+        "B v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    // Local side branch L sitting on top of the *intermediate* A1, not on B.
+    let mut tx = repo.start_transaction();
+    let local = create_random_commit(tx.repo_mut())
+        .set_parents(vec![jj_id(a1)])
+        .set_description("local side branch")
+        .write_unwrap();
+    let local_change_id = local.change_id().clone();
+    tx.repo_mut()
+        .set_local_bookmark_target("side".as_ref(), RefTarget::normal(local.id().clone()));
+    let repo = tx.commit("add side").block_on()?;
+
+    // Upstream "rebases" the stack: A2 / B2 with the same change ids.
+    let a2 = git_commit_with_change_id(&git_repo, "", &[], &change_a, "A v2");
+    let _b2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[a2],
+        &change_b,
+        "B v2",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("rebase fetch").block_on()?;
+
+    // The side commit should be reparented onto A2 (because A1 is conceptually
+    // rewritten to A2 by the upstream rebase).
+    let side_ids = repo
+        .resolve_change_id(&local_change_id)?
+        .and_then(ResolvedChangeTargets::into_visible)
+        .unwrap_or_default();
+    assert_eq!(side_ids.len(), 1);
+    let rebased_side = repo.store().get_commit(&side_ids[0])?;
+    assert_eq!(
+        rebased_side.parent_ids(),
+        &[jj_id(a2)],
+        "side branch must follow A1 -> A2 rewrite (it currently lands on root because only B is \
+         rewritten and A1 is abandoned)",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_handles_reorder() -> TestResult {
+    // Upstream reorders two commits in a stack. The change ids are preserved
+    // but the parent relationship between them is swapped. Both commits
+    // should be paired independently and end up at their new positions.
+    //
+    // A local descendant of the *intermediate* B1 makes the missing rewrite
+    // mapping observable: without the B1 -> B2 mapping, B1 is abandoned by
+    // `abandon_unreachable_commits` and the local descendant gets reparented
+    // onto B1's old parent (A1, which is itself being rewritten away) rather
+    // than onto B2.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_a = change_id_from_byte(0xaa);
+    let change_b = change_id_from_byte(0xbb);
+
+    // Pre: feat -> B1 -> A1
+    let a1 = git_commit_with_change_id(&git_repo, "", &[], &change_a, "A v1");
+    let b1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[a1],
+        &change_b,
+        "B v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    // Local descendant L on top of B1.
+    let mut tx = repo.start_transaction();
+    let local = create_random_commit(tx.repo_mut())
+        .set_parents(vec![jj_id(b1)])
+        .set_description("local work on top of B")
+        .write_unwrap();
+    let local_change_id = local.change_id().clone();
+    let repo = tx.commit("add local").block_on()?;
+
+    // Post: feat -> A2 -> B2 (swapped)
+    let b2 = git_commit_with_change_id(&git_repo, "", &[], &change_b, "B v2");
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[b2],
+        &change_a,
+        "A v2",
+    );
+
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("rebase fetch").block_on()?;
+
+    // Each change should resolve to its new commit, and the parent
+    // relationship should reflect the new order.
+    assert_eq!(
+        repo.resolve_change_id(&change_a)?
+            .and_then(ResolvedChangeTargets::into_visible),
+        Some(vec![jj_id(a2)]),
+    );
+    assert_eq!(
+        repo.resolve_change_id(&change_b)?
+            .and_then(ResolvedChangeTargets::into_visible),
+        Some(vec![jj_id(b2)]),
+    );
+    let a2_commit = repo.store().get_commit(&jj_id(a2))?;
+    assert_eq!(a2_commit.parent_ids(), &[jj_id(b2)]);
+
+    // Local descendant of B1 must follow the B1 -> B2 rewrite and end up as
+    // a child of B2 (regardless of A2's new position relative to B2).
+    let local_ids = repo
+        .resolve_change_id(&local_change_id)?
+        .and_then(ResolvedChangeTargets::into_visible)
+        .unwrap_or_default();
+    assert_eq!(local_ids.len(), 1);
+    let rebased_local = repo.store().get_commit(&local_ids[0])?;
+    assert_eq!(
+        rebased_local.parent_ids(),
+        &[jj_id(b2)],
+        "descendant of B1 must follow B1 -> B2 rewrite",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_does_not_resurrect_hidden_commit() -> TestResult {
+    // A previously-hidden commit shares a change id with an incoming new
+    // commit. The hidden commit should stay hidden (no rewrite mapping is
+    // needed — it isn't in the visible set), and the new commit becomes the
+    // sole visible revision of that change.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    // Stage A1 on `refs/remotes/origin/feat`, import, then hide A1 by
+    // deleting the ref and re-importing (abandon_unreachable_commits drops
+    // it because nothing pins it).
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("import").block_on()?;
+    delete_git_ref(&git_repo, "refs/remotes/origin/feat");
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("hide a1").block_on()?;
+    // Sanity: A1 is hidden, change X has no visible revisions.
+    assert_eq!(
+        repo.resolve_change_id(&change_x)?
+            .and_then(ResolvedChangeTargets::into_visible),
+        None,
+    );
+
+    // Now upstream pushes a new commit A2 with the same change id.
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("rebase fetch").block_on()?;
+
+    // A2 is the only visible revision; A1 stays hidden.
+    assert_eq!(
+        repo.resolve_change_id(&change_x)?
+            .and_then(ResolvedChangeTargets::into_visible),
+        Some(vec![jj_id(a2)]),
+    );
+    assert!(!repo.view().heads().contains(&jj_id(a1)));
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_unchanged_remote_ref_pinning_old_commit() -> TestResult {
+    // A1 is shared by two tracked remote bookmarks: `feat@origin` (which
+    // upstream amends) and `legacy@origin` (which upstream leaves alone). The
+    // rewrite mapping for change X is still recorded, and rebase_descendants
+    // moves the local `legacy` bookmark along with the rewrite — so the local
+    // view is clean (heads = {A2}, both bookmarks at A2) even though
+    // `legacy@origin` still records A1 upstream.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    git_ref(&git_repo, "refs/remotes/origin/legacy", a1);
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("rebase fetch").block_on()?;
+
+    let view = repo.view();
+    assert_eq!(
+        view.get_local_bookmark("feat".as_ref()),
+        &RefTarget::normal(jj_id(a2)),
+    );
+    assert_eq!(
+        view.get_local_bookmark("legacy".as_ref()),
+        &RefTarget::normal(jj_id(a2)),
+        "the local `legacy` bookmark should follow the rewrite of A1",
+    );
+    // The remote-tracking ref for legacy still reflects the upstream state.
+    assert_eq!(
+        view.get_remote_bookmark(remote_symbol("legacy", "origin"))
+            .target,
+        RefTarget::normal(jj_id(a1)),
+    );
+    // No divergence locally.
+    assert_eq!(
+        repo.resolve_change_id(&change_x)?
+            .and_then(ResolvedChangeTargets::into_visible),
+        Some(vec![jj_id(a2)]),
+    );
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_newly_divergent_from_one_fetch() -> TestResult {
+    // A single fetch brings in two new commits sharing a change id with one
+    // existing local commit. There is no unambiguous rewrite target, so the
+    // import aborts with a `NewlyIntroduced` problem — distinct from
+    // `PreExisting` (which means the local side was already divergent before
+    // the fetch).
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let _a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    // Replace `feat` upstream with A2, and add a second bookmark `feat-copy`
+    // pointing at a *different* commit A3 that also shares change X.
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+    let a3 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat-copy",
+        &[],
+        &change_x,
+        "feat alt",
+    );
+
+    let mut tx = repo.start_transaction();
+    let err = git::import_refs(tx.repo_mut(), &rebase_import_options())
+        .block_on()
+        .expect_err("import_refs should reject fetch-introduced divergence");
+    assert_eq!(
+        err.to_string(),
+        "Cannot rewrite changes in place: 1 change(s) made divergent by this fetch",
+    );
+    let GitImportError::DivergentChanges { problems } = err else {
+        panic!("expected DivergentChanges, got an unexpected variant");
+    };
+    assert_eq!(problems.len(), 1);
+    assert_matches!(
+        problems[0].kind,
+        DivergentChangeKind::NewlyIntroduced { .. }
+    );
+    assert_eq!(problems[0].change_id, change_x);
+    let DivergentChangeKind::NewlyIntroduced { new_commits } = &problems[0].kind else {
+        panic!("expected NewlyIntroduced, got: {:?}", problems[0].kind);
+    };
+    let mut new_sorted = new_commits.clone();
+    new_sorted.sort();
+    let mut expected_sorted = vec![jj_id(a2), jj_id(a3)];
+    expected_sorted.sort();
+    assert_eq!(new_sorted, expected_sorted);
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_collects_multiple_problems_in_one_error() -> TestResult {
+    // A single --rebase fetch surfaces *every* problematic change in one
+    // error, mixing both kinds: one change is already locally divergent
+    // (PreExisting), another is made divergent by this fetch
+    // (NewlyIntroduced).
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+    let change_y = change_id_from_byte(0xbb);
+
+    let x1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "X v1",
+    );
+    git_ref(&git_repo, "refs/remotes/origin/keepalive", x1);
+    let _y1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/other",
+        &[],
+        &change_y,
+        "Y v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+
+    // Force pre-existing divergence on change_x by fetching a second X
+    // without --rebase, while `keepalive` still pins X1.
+    let _x2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "X v2",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("plain fetch").block_on()?;
+    assert_eq!(
+        repo.resolve_change_id(&change_x)?
+            .and_then(ResolvedChangeTargets::into_visible)
+            .map(|v| v.len()),
+        Some(2),
+    );
+
+    // Now move `feat` to X3 *and* introduce a second new commit for change_y
+    // on a brand-new bookmark `other-copy`. In a single --rebase fetch we
+    // expect both problems reported.
+    let _x3 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "X v3",
+    );
+    let _y2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/other",
+        &[],
+        &change_y,
+        "Y v2",
+    );
+    let _y3 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/other-copy",
+        &[],
+        &change_y,
+        "Y alt",
+    );
+
+    let mut tx = repo.start_transaction();
+    let err = git::import_refs(tx.repo_mut(), &rebase_import_options())
+        .block_on()
+        .expect_err("import_refs should reject the divergent fetch");
+    assert_eq!(
+        err.to_string(),
+        "Cannot rewrite changes in place: 1 already-divergent and 1 fetch-introduced divergent \
+         change(s)",
+        "the mixed-kind summary must mention both buckets",
+    );
+
+    let GitImportError::DivergentChanges { problems } = err else {
+        panic!("expected DivergentChanges, got an unexpected variant");
+    };
+    assert_eq!(problems.len(), 2);
+    let mut saw_pre = false;
+    let mut saw_new = false;
+    for p in &problems {
+        match &p.kind {
+            DivergentChangeKind::PreExisting { existing_commits } => {
+                assert_eq!(p.change_id, change_x);
+                assert_eq!(existing_commits.len(), 2);
+                saw_pre = true;
+            }
+            DivergentChangeKind::NewlyIntroduced { new_commits } => {
+                assert_eq!(p.change_id, change_y);
+                assert_eq!(new_commits.len(), 2);
+                saw_new = true;
+            }
+        }
+    }
+    assert!(saw_pre && saw_new, "expected one of each kind");
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_failed_import_leaves_no_op_to_undo() -> TestResult {
+    // Recovery story: an aborted --rebase fetch must not commit a partial
+    // operation. The repo's latest op should still be the pre-fetch op, so
+    // there is nothing for `jj undo` to roll back and a retry can proceed
+    // without recovery commands.
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let _a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+    let pre_fetch_op_id = repo.op_id().clone();
+
+    // Newly-introduced divergence → --rebase aborts.
+    let _a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+    let _a3 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat-copy",
+        &[],
+        &change_x,
+        "feat alt",
+    );
+    let mut tx = repo.start_transaction();
+    let result = git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on();
+    assert!(result.is_err());
+    // The production CLI returns before `tx.finish` after this error; mirror
+    // that by dropping the tx without committing.
+    drop(tx);
+
+    let repo = repo.reload_at_head().block_on()?;
+    assert_eq!(
+        repo.op_id(),
+        &pre_fetch_op_id,
+        "failed --rebase import must not commit an operation",
+    );
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_rebase_successful_import_is_undoable() -> TestResult {
+    // Dual of the above: a successful --rebase fetch commits one new op, and
+    // reloading at the pre-fetch op restores the pre-fetch view (the lib-side
+    // analog of `jj undo`).
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+    let change_x = change_id_from_byte(0xaa);
+
+    let a1 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v1",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &auto_track_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let repo = tx.commit("initial").block_on()?;
+    let pre_fetch_op = repo.operation().clone();
+
+    let a2 = git_commit_with_change_id(
+        &git_repo,
+        "refs/remotes/origin/feat",
+        &[],
+        &change_x,
+        "feat v2",
+    );
+    let mut tx = repo.start_transaction();
+    git::import_refs(tx.repo_mut(), &rebase_import_options()).block_on()?;
+    tx.repo_mut().rebase_descendants().block_on()?;
+    let post_repo = tx.commit("rebase fetch").block_on()?;
+    assert_ne!(post_repo.op_id(), pre_fetch_op.id());
+    assert_eq!(
+        post_repo.view().get_local_bookmark("feat".as_ref()),
+        &RefTarget::normal(jj_id(a2)),
+    );
+
+    let restored = post_repo.reload_at(&pre_fetch_op).block_on()?;
+    assert_eq!(
+        restored.view().get_local_bookmark("feat".as_ref()),
+        &RefTarget::normal(jj_id(a1)),
     );
     Ok(())
 }


### PR DESCRIPTION
When upstream rewrites a change (e.g. amends or rebases) and you fetch the new revision, a normal `jj git fetch` keeps your old revision alongside the new one as a divergent change. With `--rebase`, the incoming revision rewrites your existing one in place: bookmarks, the working copy, and descendants are moved onto the new revision, and the old revision is hidden -- the same outcome jj produces when the rewrite happens locally.

If a change already has multiple visible revisions in the repo before the fetch, there is no unambiguous old-to-new mapping, so the import aborts with an error and a hint pointing at `jj abandon` / `jj duplicate`.

`abandon_unreachable_commits` now takes an exclusion set so that commits already recorded as rewritten don't have their `Rewritten` entry in `parent_mapping` overwritten with `Abandoned`, which would otherwise reparent descendants onto the old commit's parents instead of onto the rewrite target.

Implementation:
- GitImportOptions gains `replace_divergent_changes`, applied in `import_refs_inner` after refs are updated but before `abandon_unreachable_commits`.
- The pairing pass only considers commits that this fetch actually imported (tracked via `newly_imported_ids`), so an unchanged ref target that happens to be in the repo isn't treated as a rewrite of something.
- `abandon_unreachable_commits` now takes an exclusion set so it doesn't overwrite the `Rewritten` entry in `parent_mapping` with `Abandoned`, which would otherwise reparent descendants onto the old commit's parents instead of onto the rewrite target. 

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.

Note: the changes and much of the PR description have definitely been generated by LLM. However, I've tried my best to make sure everything user-facing fits with how the rest of Jujutsu's help is written. As far as I can tell, this implementation is correct (I've looked it over myself to the best of my ability), and I've been using this workflow myself since just a couple hours after [this comment](https://github.com/jj-vcs/jj/issues/1039#issuecomment-4441654897).