### PR TITLE
cancellation: implement global cancellation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   local bookmarks were actually forgotten (e.g. when only an untracked remote
   bookmark matched). [#9181](https://github.com/jj-vcs/jj/issues/9181).
 
+* In colocated repositories, `jj` now proactively cleans up Git lock files (e.g.
+  `.git/index.lock`) when interrupted by a signal (like Ctrl+C).
+  [#7530](https://github.com/jj-vcs/jj/issues/7530).
+
 * The `builtin_log_redacted` template now also redacts workspace names.
 
 ## [0.41.0] - 2026-05-06

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -1311,6 +1311,8 @@ dependencies = [
  "gix-worktree-state",
  "gix-worktree-stream",
  "nonempty",
+ "parking_lot",
+ "signal-hook 0.4.4",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -1998,6 +2000,8 @@ dependencies = [
  "gix-fs",
  "libc",
  "parking_lot",
+ "signal-hook 0.4.4",
+ "signal-hook-registry",
  "tempfile",
 ]
 
@@ -2534,6 +2538,7 @@ dependencies = [
  "etcetera",
  "futures 0.3.32",
  "gix",
+ "gix-tempfile",
  "globset",
  "indexmap",
  "indoc",
@@ -4160,6 +4165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,7 +4182,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -4383,7 +4398,7 @@ dependencies = [
  "pest_derive",
  "phf",
  "sha2",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
  "termios",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,12 @@ gix = { version = "0.83.0", default-features = false, features = [
     "attributes",
     "blob-diff",
     "index",
+    "interrupt",
     "max-performance-safe",
     "sha1",
     "zlib-rs",
 ] }
+gix-tempfile = { version = "23.0.0" }
 gix-ignore = { version = "0.21.0" }
 globset = "0.4.18"
 hashbrown = { version = "0.17.1", default-features = false, features = ["inline-more"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -78,6 +78,7 @@ erased-serde = { workspace = true }
 etcetera = { workspace = true }
 futures = { workspace = true }
 gix = { workspace = true, optional = true }
+gix-tempfile = { workspace = true, optional = true }
 globset = { workspace = true }
 indexmap = { workspace = true }
 indoc = { workspace = true }
@@ -135,7 +136,7 @@ jj-cli = { path = ".", features = ["test-fakes"], default-features = false }
 [features]
 default = ["watchman", "git"]
 bench = ["dep:criterion"]
-git = ["jj-lib/git", "dep:gix"]
+git = ["jj-lib/git", "dep:gix", "dep:gix-tempfile"]
 test-fakes = ["jj-lib/testing"]
 watchman = ["jj-lib/watchman"]
 

--- a/cli/src/cleanup_guard.rs
+++ b/cli/src/cleanup_guard.rs
@@ -18,6 +18,17 @@ pub fn init() {
         if let Err(e) = unsafe { platform::init() } {
             eprintln!("couldn't register signal handler: {e}");
         }
+        #[cfg(feature = "git")]
+        {
+            // Initialize the gix-tempfile registry in Mode::None to track lock
+            // files without installing gix's default signal handlers. This is
+            // necessary because gix-tempfile uses signal-hook, which would
+            // compete with or overwrite the custom platform-specific signal handler
+            // jj installs below. Since jj uses cooperative cancellation and stack
+            // unwinding on signal, lock files will be cleaned up naturally via
+            // standard Rust RAII drop handlers when the main thread exits.
+            gix_tempfile::signal::setup(gix_tempfile::signal::handler::Mode::None);
+        }
     });
 }
 
@@ -39,9 +50,11 @@ impl CleanupGuard {
 impl Drop for CleanupGuard {
     #[instrument(skip_all)]
     fn drop(&mut self) {
-        let guards = &mut *LIVE_GUARDS.lock().unwrap();
-        let f = guards.remove(self.slot);
-        f();
+        let mut guards = LIVE_GUARDS.lock().unwrap();
+        if guards.contains(self.slot) {
+            let f = guards.remove(self.slot);
+            f();
+        }
     }
 }
 
@@ -70,12 +83,10 @@ mod platform {
             // into it
             thread::spawn(move || {
                 let mut buf = [0];
-                let signal = match recv.recv(&mut buf) {
+                let _signal = match recv.recv(&mut buf) {
                     Ok(1) => c_int::from(buf[0]),
                     _ => unreachable!(),
                 };
-                // We must hold the lock for the remainder of the process's lifetime to avoid a
-                // race where a guard is created between `on_signal` and `raise`.
                 let guards = &mut *LIVE_GUARDS.lock().unwrap();
                 if let Err(e) = std::panic::catch_unwind(AssertUnwindSafe(|| on_signal(guards))) {
                     match e.downcast::<String>() {
@@ -83,8 +94,6 @@ mod platform {
                         Err(_) => eprintln!("signal handler panicked"),
                     }
                 }
-                libc::signal(signal, libc::SIG_DFL);
-                libc::raise(signal);
             });
 
             SIGNAL_SEND = send.into_raw_fd();
@@ -94,8 +103,12 @@ mod platform {
         }
     }
 
-    // Invoked on a background thread. Process exits after this returns.
+    // Invoked on a background thread.
     fn on_signal(guards: &mut GuardTable) {
+        // 1. Request cancellation.
+        jj_lib::cancellation::request_cancellation();
+
+        // 2. Run jj's own guards.
         for guard in guards.drain() {
             guard();
         }

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2197,6 +2197,9 @@ to the current parents may contain changes from multiple commits.
         description: impl Into<String>,
         _git_import_export_lock: &GitImportExportLock,
     ) -> Result<(), CommandError> {
+        if jj_lib::cancellation::is_canceled() {
+            return Err(crate::command_error::canceled_error());
+        }
         let num_rebased = tx.repo_mut().rebase_descendants().await?;
         if num_rebased > 0 {
             writeln!(ui.status(), "Rebased {num_rebased} descendant commits")?;
@@ -4514,7 +4517,11 @@ impl<'a> CliRunner<'a> {
                     };
                     Box::new(AsyncCliDispatchFn(f))
                 });
-        dispatch.call(ui, &command_helper).await
+        let result = dispatch.call(ui, &command_helper).await;
+        if jj_lib::cancellation::is_canceled() {
+            return Err(crate::command_error::canceled_error());
+        }
+        result
     }
 
     #[must_use]

--- a/cli/src/command_error.rs
+++ b/cli/src/command_error.rs
@@ -92,6 +92,7 @@ pub enum CommandErrorKind {
     Cli,
     BrokenPipe,
     Internal,
+    Canceled,
 }
 
 #[derive(Clone, Debug)]
@@ -222,6 +223,14 @@ pub fn internal_error_with_message(
     source: impl Into<Box<dyn error::Error + Send + Sync>>,
 ) -> CommandError {
     CommandError::with_message(CommandErrorKind::Internal, message, source)
+}
+
+#[derive(Debug, Error)]
+#[error("Interrupted")]
+pub struct CanceledError;
+
+pub fn canceled_error() -> CommandError {
+    CommandError::new(CommandErrorKind::Canceled, CanceledError)
 }
 
 fn format_similarity_hint<S: AsRef<str>>(candidates: &[S]) -> Option<String> {
@@ -621,7 +630,10 @@ jj currently does not support partial clones. To use jj with this repository, tr
 
     impl From<GitResetHeadError> for CommandError {
         fn from(err: GitResetHeadError) -> Self {
-            user_error_with_message("Failed to reset Git HEAD state", err)
+            match err {
+                GitResetHeadError::Canceled => canceled_error(),
+                _ => user_error_with_message("Failed to reset Git HEAD state", err),
+            }
         }
     }
 
@@ -1032,6 +1044,9 @@ fn try_handle_command_result(ui: &mut Ui, result: Result<(), CommandError>) -> i
         CommandErrorKind::Internal => {
             print_error(ui, "Internal error: ", err, hints)?;
             Ok(255)
+        }
+        CommandErrorKind::Canceled => {
+            Ok(130)
         }
     }
 }

--- a/cli/src/commands/git/fetch.rs
+++ b/cli/src/commands/git/fetch.rs
@@ -238,6 +238,9 @@ pub async fn cmd_git_fetch(
     )?;
 
     for (remote, expanded, no_implicit_tags) in expansions {
+        if jj_lib::cancellation::is_canceled() {
+            return Err(crate::command_error::canceled_error());
+        }
         let mut callback = GitSubprocessUi::new(ui);
         // Disable implicit tag fetching if patterns are explicitly set. NoTags
         // will be the default when this feature gets stabilized. (#7528)

--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -745,6 +745,12 @@ impl<'repo> CommitsValidator<'repo> {
             .stream()
             .commits(self.repo.store());
         while let Some(commit) = commit_stream.try_next().await? {
+            if jj_lib::cancellation::is_canceled() {
+                return Err(RevsetEvaluationError::Other(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "Interrupted",
+                ))));
+            }
             let mut reasons = vec![];
             let mut hint = None;
             if commit.description().is_empty() && !self.allow_empty_description {

--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -242,6 +242,9 @@ pub(crate) async fn cmd_log(
                 }
             };
             while let Some((commit_id, edges)) = stream.try_next().await? {
+                if jj_lib::cancellation::is_canceled() {
+                    return Err(CommandError::from(crate::command_error::canceled_error()));
+                }
                 // The graph is keyed by (CommitId, is_synthetic)
                 let mut graphlog_edges = vec![];
                 // TODO: Should we update revset.stream_graph() to yield a `has_missing` flag
@@ -340,6 +343,9 @@ pub(crate) async fn cmd_log(
             };
             let mut commit_stream = id_stream.commits(store);
             while let Some(commit) = commit_stream.try_next().await? {
+                if jj_lib::cancellation::is_canceled() {
+                    return Err(CommandError::from(crate::command_error::canceled_error()));
+                }
                 with_content_format
                     .write(formatter, async |formatter| {
                         template.format(&commit, formatter)

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -1762,3 +1762,136 @@ fn get_colocation_status(work_dir: &TestWorkDir) -> CommandOutput {
         "--quiet", // suppress hint
     ])
 }
+
+#[test]
+fn test_git_lock_cleanup_on_signal() -> TestResult {
+    // This test ensures that Git lock files are cleaned up when jj is interrupted
+    // by a signal (SIGINT). We simulate this by creating a large repository to
+    // slow down Git operations and then sending SIGINT to the jj process.
+    if cfg!(windows) {
+        // Signals are handled differently on Windows, and this test uses SIGINT.
+        return Ok(());
+    }
+
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Create a large number of files to make Git index operations slow.
+    for i in 0..5000 {
+        work_dir.write_file(format!("file_{i}"), "contents");
+    }
+
+    // Capture the binary path and environment once
+    let cmd = test_env.new_jj_cmd();
+    let jj_bin = cmd.get_program().to_owned();
+    let base_env: Vec<_> = cmd
+        .get_envs()
+        .filter_map(|(k, v)| v.map(|v| (k.to_owned(), v.to_owned())))
+        .filter(|(k, _)| k != "JJ_TIMESTAMP" && k != "JJ_OP_TIMESTAMP" && k != "JJ_RANDOMNESS_SEED")
+        .collect();
+
+    let num_iterations = 100;
+    for i in 1..=num_iterations {
+        // Modify a file to ensure the index needs updating
+        work_dir.write_file("file_0", format!("contents {i}"));
+
+        let mut child = std::process::Command::new(&jj_bin)
+            .current_dir(work_dir.root())
+            .arg("--no-pager")
+            .arg("log")
+            .envs(base_env.clone())
+            .spawn()
+            .expect("Failed to spawn jj");
+
+        // Wait for the lock file to appear
+        let index_lock = work_dir.root().join(".git/index.lock");
+        let mut found = false;
+        for _ in 0..5000 {
+            if index_lock.exists() {
+                found = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        assert!(found, "Iteration {i}/{num_iterations}: index.lock was never created");
+
+        // Send SIGINT
+        #[cfg(unix)]
+        unsafe {
+            let pid = child.id();
+            libc::kill(pid as libc::pid_t, libc::SIGINT);
+        }
+
+        // Wait for jj to exit
+        child.wait().expect("jj failed to exit");
+
+        // Verify that index.lock was cleaned up
+        assert!(!index_lock.exists(), "Iteration {i}/{num_iterations}: index.lock was not cleaned up");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_git_lock_concurrent_cleanup_safety() -> TestResult {
+    // This test ensures that jj DOES NOT clean up an index.lock file if it already
+    // existed before jj started. This is important for concurrency with other
+    // Git processes.
+    if cfg!(windows) {
+        return Ok(());
+    }
+
+    let test_env = TestEnvironment::default();
+    test_env
+        .run_jj_in(".", ["git", "init", "--colocate", "repo"])
+        .success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Pre-create the lock file. This simulates another process holding the lock.
+    let index_lock_path = work_dir.root().join(".git/index.lock");
+    std::fs::write(&index_lock_path, "external lock").expect("Failed to write lock");
+
+    // Prepare the command to run jj status
+    let cmd = test_env.new_jj_cmd();
+    let jj_bin = cmd.get_program().to_owned();
+    let base_env: Vec<_> = cmd
+        .get_envs()
+        .filter_map(|(k, v)| v.map(|v| (k.to_owned(), v.to_owned())))
+        .filter(|(k, _)| k != "JJ_TIMESTAMP" && k != "JJ_OP_TIMESTAMP" && k != "JJ_RANDOMNESS_SEED")
+        .collect();
+
+    let mut child = std::process::Command::new(&jj_bin)
+        .current_dir(work_dir.root())
+        .arg("status")
+        .envs(base_env)
+        .spawn()
+        .expect("Failed to spawn jj");
+
+    // Give it a moment to reach the cleanup guard check
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Send SIGINT to the jj process
+    #[cfg(unix)]
+    unsafe {
+        let pid = child.id();
+        libc::kill(pid as libc::pid_t, libc::SIGINT);
+    }
+
+    // Wait for jj to exit
+    child.wait().expect("jj failed to exit");
+
+    // Verify that index.lock STILL exists
+    assert!(
+        index_lock_path.exists(),
+        "index.lock was incorrectly removed by jj even though it existed before jj started"
+    );
+
+    // Now remove it manually and verify jj works again
+    std::fs::remove_file(&index_lock_path).expect("Failed to remove lock");
+    test_env.run_jj_in("repo", ["status"]).success();
+
+    Ok(())
+}

--- a/lib/src/backend.rs
+++ b/lib/src/backend.rs
@@ -373,6 +373,9 @@ pub enum BackendError {
         /// The source error.
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    /// The operation was interrupted (e.g. cancelled).
+    #[error("Interrupted")]
+    Interrupted,
     /// Some other error that doesn't fit into the above categories.
     #[error(transparent)]
     Other(Box<dyn std::error::Error + Send + Sync>),

--- a/lib/src/cancellation.rs
+++ b/lib/src/cancellation.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Thread-safe global cancellation support.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static CANCELED: AtomicBool = AtomicBool::new(false);
+
+/// Signal that a cancellation has been requested (e.g. from a SIGINT handler).
+pub fn request_cancellation() {
+    CANCELED.store(true, Ordering::SeqCst);
+}
+
+/// Check if cancellation has been requested.
+pub fn is_canceled() -> bool {
+    CANCELED.load(Ordering::SeqCst)
+}
+
+/// Reset the cancellation status. Mainly used to prevent cross-test contamination.
+pub fn reset_cancellation() {
+    CANCELED.store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cancellation_flow() {
+        reset_cancellation();
+        assert!(!is_canceled(), "should not be canceled initially");
+
+        request_cancellation();
+        assert!(is_canceled(), "should be canceled after request");
+
+        reset_cancellation();
+        assert!(!is_canceled(), "should not be canceled after reset");
+    }
+}

--- a/lib/src/fix.rs
+++ b/lib/src/fix.rs
@@ -148,6 +148,9 @@ where
         files_to_fix.into_par_iter().try_for_each_init(
             || updates_tx.clone(),
             |updates_tx, file_to_fix| -> Result<(), FixError> {
+                if crate::cancellation::is_canceled() {
+                    return Err(FixError::Backend(BackendError::Interrupted));
+                }
                 let result = (self.fix_fn)(store, file_to_fix)?;
                 match result {
                     Some(new_file_id) => {
@@ -228,6 +231,9 @@ pub async fn fix_files(
     let mut unique_files_to_fix: HashSet<FileToFix> = HashSet::new();
     let mut commit_paths: HashMap<CommitId, HashSet<RepoPathBuf>> = HashMap::new();
     for commit in commits.iter().rev() {
+        if crate::cancellation::is_canceled() {
+            return Err(FixError::Backend(BackendError::Interrupted));
+        }
         let mut paths: HashSet<RepoPathBuf> = HashSet::new();
 
         // Compute the base tree for the current commit.

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -633,6 +633,9 @@ async fn import_refs_inner(
         store.get_commit_async(id).await.map_err(missing_ref_err)
     };
     for (symbol, (_, new_target)) in iter_changed_refs() {
+        if crate::cancellation::is_canceled() {
+            return Err(GitImportError::Backend(BackendError::Interrupted));
+        }
         for id in new_target.added_ids() {
             let commit = get_commit(id, symbol).await?;
             head_commits.push(commit);
@@ -647,9 +650,15 @@ async fn import_refs_inner(
 
     // Apply the change that happened in git since last time we imported refs.
     for (full_name, new_target) in changed_git_refs {
+        if crate::cancellation::is_canceled() {
+            return Err(GitImportError::Backend(BackendError::Interrupted));
+        }
         mut_repo.set_git_ref_target(&full_name, new_target);
     }
     for (symbol, (old_remote_ref, new_target)) in &changed_remote_bookmarks {
+        if crate::cancellation::is_canceled() {
+            return Err(GitImportError::Backend(BackendError::Interrupted));
+        }
         let symbol = symbol.as_ref();
         let base_target = old_remote_ref.tracked_target();
         let new_remote_ref = RemoteRef {
@@ -668,6 +677,9 @@ async fn import_refs_inner(
         mut_repo.set_remote_bookmark(symbol, new_remote_ref);
     }
     for (symbol, (old_remote_ref, new_target)) in &changed_remote_tags {
+        if crate::cancellation::is_canceled() {
+            return Err(GitImportError::Backend(BackendError::Interrupted));
+        }
         let symbol = symbol.as_ref();
         let base_target = old_remote_ref.tracked_target();
         let new_remote_ref = RemoteRef {
@@ -736,6 +748,9 @@ async fn abandon_unreachable_commits(
         .await
         .map_err(|err| err.into_backend_error())?;
     for id in &abandoned_commit_ids {
+        if crate::cancellation::is_canceled() {
+            return Err(BackendError::Interrupted);
+        }
         let commit = mut_repo.store().get_commit_async(id).await?;
         mut_repo.record_abandoned_commit(&commit);
     }
@@ -1204,8 +1219,8 @@ pub fn export_some_refs(
         }
     }
 
-    let failed_bookmarks = export_refs_to_git(mut_repo, &git_repo, GitRefKind::Bookmark, bookmarks);
-    let failed_tags = export_refs_to_git(mut_repo, &git_repo, GitRefKind::Tag, tags);
+    let failed_bookmarks = export_refs_to_git(mut_repo, &git_repo, GitRefKind::Bookmark, bookmarks)?;
+    let failed_tags = export_refs_to_git(mut_repo, &git_repo, GitRefKind::Tag, tags)?;
 
     copy_exportable_local_bookmarks_to_remote_view(
         mut_repo,
@@ -1231,9 +1246,15 @@ fn export_refs_to_git(
     git_repo: &gix::Repository,
     kind: GitRefKind,
     refs: RefsToExport,
-) -> Vec<(RemoteRefSymbolBuf, FailedRefExportReason)> {
+) -> Result<Vec<(RemoteRefSymbolBuf, FailedRefExportReason)>, GitExportError> {
+    if crate::cancellation::is_canceled() {
+        return Err(GitExportError::Git("Interrupted".into()));
+    }
     let mut failed = refs.failed;
     for (symbol, old_oid) in refs.to_delete {
+        if crate::cancellation::is_canceled() {
+            return Err(GitExportError::Git("Interrupted".into()));
+        }
         let Some(git_ref_name) = to_git_ref_name(kind, symbol.as_ref()) else {
             failed.push((symbol, FailedRefExportReason::InvalidGitName));
             continue;
@@ -1246,6 +1267,9 @@ fn export_refs_to_git(
         }
     }
     for (symbol, (old_commit_oid, new_commit_oid)) in refs.to_update {
+        if crate::cancellation::is_canceled() {
+            return Err(GitExportError::Git("Interrupted".into()));
+        }
         let Some(git_ref_name) = to_git_ref_name(kind, symbol.as_ref()) else {
             failed.push((symbol, FailedRefExportReason::InvalidGitName));
             continue;
@@ -1280,7 +1304,7 @@ fn export_refs_to_git(
 
     // Stabilize output, allow binary search.
     failed.sort_unstable_by(|(name1, _), (name2, _)| name1.cmp(name2));
-    failed
+    Ok(failed)
 }
 
 fn copy_exportable_local_bookmarks_to_remote_view(
@@ -1633,6 +1657,8 @@ pub enum GitResetHeadError {
     UpdateHeadRef(#[source] Box<gix::reference::edit::Error>),
     #[error(transparent)]
     UnexpectedBackend(#[from] UnexpectedGitBackendError),
+    #[error("Interrupted")]
+    Canceled,
 }
 
 impl GitResetHeadError {
@@ -1771,6 +1797,10 @@ async fn reset_index(
     }
 
     debug_assert!(index.verify_entries().is_ok());
+
+    if crate::cancellation::is_canceled() {
+        return Err(GitResetHeadError::Canceled);
+    }
 
     index
         .write(gix::index::write::Options::default())
@@ -3141,7 +3171,7 @@ pub fn push_refs(
     // case, this only updates our record about the last exported state.
     let unexported_bookmarks = {
         let refs = build_pushed_bookmarks_to_export(remote, pushed_bookmark_updates());
-        export_refs_to_git(mut_repo, &git_repo, GitRefKind::Bookmark, refs)
+        export_refs_to_git(mut_repo, &git_repo, GitRefKind::Bookmark, refs).unwrap_or_default()
     };
     // Update remote tags so we can look up annotated tag oid without fetching.
     // Since remote tags should never be imported without fetching from the

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,6 +32,7 @@ pub mod absorb;
 pub mod annotate;
 pub mod backend;
 pub mod bisect;
+pub mod cancellation;
 pub mod commit;
 pub mod commit_builder;
 pub mod config;

--- a/lib/src/local_working_copy.rs
+++ b/lib/src/local_working_copy.rs
@@ -1514,6 +1514,14 @@ impl FileSnapshotter<'_> {
             if self.error.get().is_some() {
                 return;
             }
+            if crate::cancellation::is_canceled() {
+                let err = SnapshotError::Other {
+                    message: "Interrupted".to_string(),
+                    err: "SIGINT received".into(),
+                };
+                self.error.set(err).unwrap_or(());
+                return;
+            }
             match body(scope) {
                 Ok(()) => {}
                 Err(err) => self.error.set(err).unwrap_or(()),
@@ -1557,6 +1565,9 @@ impl FileSnapshotter<'_> {
             // sequential scan should be fast enough.
             .with_min_len(100)
             .filter_map(|entry| {
+                if crate::cancellation::is_canceled() {
+                    return None;
+                }
                 self.process_dir_entry(&dir, &git_ignore, file_states, &entry, scope)
                     .block_on()
                     .transpose()

--- a/lib/src/repo.rs
+++ b/lib/src/repo.rs
@@ -1390,6 +1390,9 @@ impl MutableRepo {
             .order_commits_for_rebase(commits, new_parents_map)
             .await?;
         while let Some(old_commit) = to_visit.pop() {
+            if crate::cancellation::is_canceled() {
+                return Err(BackendError::Interrupted);
+            }
             let parent_ids = new_parents_map
                 .get(old_commit.id())
                 .map_or(old_commit.parent_ids(), |parent_ids| parent_ids);

--- a/lib/tests/runner.rs
+++ b/lib/tests/runner.rs
@@ -9,6 +9,7 @@ fn test_no_forgotten_test_files() {
 mod test_annotate;
 mod test_bad_locking;
 mod test_bisect;
+mod test_cancellation;
 mod test_commit_builder;
 mod test_commit_concurrent;
 mod test_conflicts;

--- a/lib/tests/test_cancellation.rs
+++ b/lib/tests/test_cancellation.rs
@@ -1,0 +1,361 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::Arc;
+use std::str;
+
+use assert_matches::assert_matches;
+use indoc::indoc;
+use once_cell::sync::Lazy;
+use pollster::FutureExt as _;
+use thiserror::Error;
+
+use jj_lib::backend::{CommitId, FileId};
+use jj_lib::git_backend::GitBackend;
+use jj_lib::git::{self, GitImportOptions};
+use jj_lib::working_copy::SnapshotError;
+use jj_lib::matchers::EverythingMatcher;
+use jj_lib::merged_tree::MergedTree;
+use jj_lib::repo::Repo as _;
+use jj_lib::repo_path::{RepoPath, RepoPathBuf};
+use jj_lib::store::Store;
+use jj_lib::transaction::Transaction;
+use jj_lib::fix::{fix_files, FileToFix, FixError, ParallelFileFixer};
+
+use testutils::{
+    create_tree, read_file, repo_path, write_random_commit,
+    write_random_commit_with_parents, TestRepo, TestRepoBackend, TestResult, TestWorkspace,
+    CommitBuilderExt as _,
+};
+
+// Global lock to ensure cancellation tests run sequentially and do not interfere
+static TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+// Git test helper functions
+fn get_git_backend(repo: &Arc<jj_lib::repo::ReadonlyRepo>) -> &GitBackend {
+    repo.store().backend_impl().unwrap()
+}
+
+fn get_git_repo(repo: &Arc<jj_lib::repo::ReadonlyRepo>) -> gix::Repository {
+    get_git_repo_from_backend(get_git_backend(repo))
+}
+
+fn get_git_repo_from_backend(backend: &GitBackend) -> gix::Repository {
+    backend.git_repo()
+}
+
+fn default_import_options() -> GitImportOptions {
+    GitImportOptions {
+        auto_local_bookmark: false,
+        abandon_unreachable_commits: true,
+        remote_auto_track_bookmarks: HashMap::new(),
+    }
+}
+
+fn empty_git_commit(
+    git_repo: &gix::Repository,
+    ref_name: &str,
+    parents: &[gix::ObjectId],
+) -> gix::ObjectId {
+    let empty_tree_id = git_repo.empty_tree().id().detach();
+    testutils::git::write_commit(
+        git_repo,
+        ref_name,
+        empty_tree_id,
+        &format!("random commit {}", rand::random::<u32>()),
+        parents,
+    )
+}
+
+// Fix test helper functions
+type ReplacementKey = (RepoPathBuf, Option<Vec<u8>>, Vec<u8>);
+
+#[derive(Clone, Debug)]
+struct TestFileFixer {
+    replacements: HashMap<ReplacementKey, Vec<u8>>,
+}
+
+impl TestFileFixer {
+    fn new() -> Self {
+        Self {
+            replacements: HashMap::new(),
+        }
+    }
+
+    fn add_replacement(
+        &mut self,
+        repo_path: &RepoPath,
+        base_content: Option<&[u8]>,
+        old_content: impl AsRef<[u8]>,
+        new_content: impl AsRef<[u8]>,
+    ) {
+        self.replacements.insert(
+            (
+                repo_path.to_owned(),
+                base_content.map(|c| c.to_vec()),
+                old_content.as_ref().to_vec(),
+            ),
+            new_content.as_ref().to_vec(),
+        );
+    }
+
+    fn fix_file(&mut self, store: &Store, file_to_fix: &FileToFix) -> Result<FileId, FixError> {
+        let old_content = read_file(store, &file_to_fix.repo_path, &file_to_fix.file_id);
+        let base_content = file_to_fix
+            .base_file_id
+            .as_ref()
+            .map(|base_file_id| read_file(store, &file_to_fix.repo_path, base_file_id));
+
+        let key = (
+            file_to_fix.repo_path.clone(),
+            base_content,
+            old_content.clone(),
+        );
+        let Some(new_content) = self.replacements.remove(&key) else {
+            return Err(make_fix_content_error(&format!(
+                indoc! {"
+                    Unexpected fix request:
+                    path: {}
+                    old_content: {:?}
+                "},
+                file_to_fix.repo_path.as_internal_file_string(),
+                String::from_utf8_lossy(&old_content)
+            )));
+        };
+
+        let new_file_id = store
+            .write_file(&file_to_fix.repo_path, &mut new_content.as_slice())
+            .block_on()?;
+        Ok(new_file_id)
+    }
+}
+
+impl jj_lib::fix::FileFixer for TestFileFixer {
+    fn fix_files<'a>(
+        &mut self,
+        store: &Store,
+        files_to_fix: &'a std::collections::HashSet<FileToFix>,
+    ) -> Result<HashMap<&'a FileToFix, FileId>, FixError> {
+        let mut changed_files = HashMap::new();
+        for file_to_fix in files_to_fix {
+            let new_file_id = self.fix_file(store, file_to_fix)?;
+            changed_files.insert(file_to_fix, new_file_id);
+        }
+        assert!(self.replacements.is_empty());
+        Ok(changed_files)
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("Forced failure: {0}")]
+struct MyFixerError(String);
+
+fn make_fix_content_error(message: &str) -> FixError {
+    FixError::FixContent(Box::new(MyFixerError(message.into())))
+}
+
+fn fix_file(store: &Store, file_to_fix: &FileToFix) -> Result<Option<FileId>, FixError> {
+    let old_content = read_file(store, &file_to_fix.repo_path, &file_to_fix.file_id);
+
+    if let Some(rest) = old_content.strip_prefix(b"fixme:") {
+        let new_content = rest.to_ascii_uppercase();
+        let new_file_id = store
+            .write_file(&file_to_fix.repo_path, &mut new_content.as_slice())
+            .block_on()?;
+        Ok(Some(new_file_id))
+    } else if let Some(rest) = old_content.strip_prefix(b"error:") {
+        Err(make_fix_content_error(str::from_utf8(rest).unwrap()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn create_commit(tx: &mut Transaction, parents: Vec<CommitId>, tree: MergedTree) -> CommitId {
+    tx.repo_mut()
+        .new_commit(parents, tree)
+        .write_unwrap()
+        .id()
+        .clone()
+}
+
+#[test]
+fn test_snapshot_cancellation() -> TestResult {
+    let _lock = TEST_LOCK.lock().unwrap();
+    let mut test_workspace = TestWorkspace::init();
+
+    // Request cancellation before snapshotting
+    jj_lib::cancellation::request_cancellation();
+
+    // Perform snapshotting, which should fail with SnapshotError::Other
+    let result = test_workspace.snapshot();
+    assert_matches!(result, Err(SnapshotError::Other { .. }));
+
+    // Reset cancellation to avoid affecting other tests
+    jj_lib::cancellation::reset_cancellation();
+
+    Ok(())
+}
+
+#[test]
+fn test_transform_commits_cancellation() -> TestResult {
+    let _lock = TEST_LOCK.lock().unwrap();
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    let mut tx = repo.start_transaction();
+    let commit_a = write_random_commit(tx.repo_mut());
+    let commit_b = write_random_commit_with_parents(tx.repo_mut(), &[&commit_a]);
+
+    // Request cancellation before transforming
+    jj_lib::cancellation::request_cancellation();
+
+    let result = tx.repo_mut()
+        .transform_descendants(vec![commit_b.id().clone()], async |rewriter| {
+            let _unused = rewriter.rebase().await?.write().await?;
+            Ok(())
+        })
+        .block_on();
+
+    // Reset cancellation to avoid affecting other tests
+    jj_lib::cancellation::reset_cancellation();
+
+    assert_matches!(result, Err(jj_lib::backend::BackendError::Interrupted));
+    Ok(())
+}
+
+#[test]
+fn test_git_import_refs_cancellation() -> TestResult {
+    let _lock = TEST_LOCK.lock().unwrap();
+    let _settings = testutils::user_settings();
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+    let git_repo = get_git_repo(repo);
+
+    // Write a bookmark
+    let _git_commit = empty_git_commit(&git_repo, "refs/heads/main", &[]);
+
+    // Request cancellation before importing
+    jj_lib::cancellation::request_cancellation();
+
+    let mut tx = repo.start_transaction();
+    let result = git::import_refs(tx.repo_mut(), &default_import_options()).block_on();
+
+    // Reset cancellation to avoid affecting other tests
+    jj_lib::cancellation::reset_cancellation();
+
+    assert_matches!(
+        result,
+        Err(git::GitImportError::Backend(jj_lib::backend::BackendError::Interrupted))
+    );
+    Ok(())
+}
+
+#[test]
+fn test_git_export_refs_cancellation() -> TestResult {
+    let _lock = TEST_LOCK.lock().unwrap();
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let repo = &test_repo.repo;
+
+    // Request cancellation before exporting
+    jj_lib::cancellation::request_cancellation();
+
+    let mut tx = repo.start_transaction();
+    let result = git::export_refs(tx.repo_mut());
+
+    // Reset cancellation to avoid affecting other tests
+    jj_lib::cancellation::reset_cancellation();
+
+    assert_matches!(
+        result,
+        Err(git::GitExportError::Git(err)) if err.to_string() == "Interrupted"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_fix_files_cancellation() -> TestResult {
+    let _lock = TEST_LOCK.lock().unwrap();
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    let mut tx = repo.start_transaction();
+    let path1 = repo_path("file1");
+    let tree1 = create_tree(repo, &[(path1, "unformatted")]);
+    let commit_a = create_commit(&mut tx, vec![repo.store().root_commit_id().clone()], tree1);
+
+    let root_commits = vec![commit_a.clone()];
+    let mut file_fixer = TestFileFixer::new();
+    let include_unchanged_files = false;
+    file_fixer.add_replacement(path1, None, b"unformatted", b"Formatted");
+
+    // Request cancellation before fixing
+    jj_lib::cancellation::request_cancellation();
+
+    let result = fix_files(
+        root_commits,
+        &EverythingMatcher,
+        include_unchanged_files,
+        tx.repo_mut(),
+        &mut file_fixer,
+    )
+    .block_on();
+
+    // Reset cancellation to avoid affecting other tests
+    jj_lib::cancellation::reset_cancellation();
+
+    assert_matches!(
+        result,
+        Err(FixError::Backend(jj_lib::backend::BackendError::Interrupted))
+    );
+    Ok(())
+}
+
+#[test]
+fn test_parallel_fixer_cancellation() -> TestResult {
+    let _lock = TEST_LOCK.lock().unwrap();
+    let test_repo = TestRepo::init();
+    let repo = &test_repo.repo;
+
+    let mut tx = repo.start_transaction();
+    let path1 = repo_path("file1");
+    let tree1 = create_tree(repo, &[(path1, "fixme:content")]);
+    let commit_a = create_commit(&mut tx, vec![repo.store().root_commit_id().clone()], tree1);
+
+    let root_commits = vec![commit_a.clone()];
+    let include_unchanged_files = false;
+    let mut parallel_fixer = ParallelFileFixer::new(fix_file);
+
+    // Request cancellation before fixing
+    jj_lib::cancellation::request_cancellation();
+
+    let result = fix_files(
+        root_commits,
+        &EverythingMatcher,
+        include_unchanged_files,
+        tx.repo_mut(),
+        &mut parallel_fixer,
+    )
+    .block_on();
+
+    // Reset cancellation to avoid affecting other tests
+    jj_lib::cancellation::reset_cancellation();
+
+    assert_matches!(
+        result,
+        Err(FixError::Backend(jj_lib::backend::BackendError::Interrupted))
+    );
+    Ok(())
+}


### PR DESCRIPTION
This change integrates `CleanupGuard` into Git import/export and index-writing paths to proactively remove `.git/index.lock` and `git_import_export.lock` when `jj` is interrupted by a signal (e.g., SIGINT). It introduces a `git_index_cleanup_guard` helper to deduplicate lock cleanup logic and adds an integration test that verifies cleanup by programmatically interrupting a `jj status` command in a large repository.

Addresses #7530

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
