### PR TITLE
cli: Add `jj file edit/set/delete` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `revsets.log` now defaults to `builtin_log()`, so custom log revsets can
   reuse the built-in default instead of copying its full expression.
 
-* Added commands `jj file edit` and `jj file set` for editing files in any
-  revision without needing to change the working copy.
+* Added commands `jj file edit`, `jj file set`, and `jj file delete` for editing
+  files in any revision without needing to change the working copy.
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `revsets.log` now defaults to `builtin_log()`, so custom log revsets can
   reuse the built-in default instead of copying its full expression.
 
+* Added command `jj file edit` for editing files in any revision without
+  needing to change the working copy.
+
 ### Fixed bugs
 
 * Recursive alias definitions are detected more precisely. jj can now expand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `revsets.log` now defaults to `builtin_log()`, so custom log revsets can
   reuse the built-in default instead of copying its full expression.
 
-* Added command `jj file edit` for editing files in any revision without
-  needing to change the working copy.
+* Added commands `jj file edit` and `jj file set` for editing files in any
+  revision without needing to change the working copy.
 
 ### Fixed bugs
 

--- a/cli/src/commands/file/delete.rs
+++ b/cli/src/commands/file/delete.rs
@@ -38,6 +38,10 @@ pub(crate) struct FileDeleteArgs {
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     revision: RevisionArg,
 
+    /// Preserve the content (not the diff) when rebasing descendants
+    #[arg(long)]
+    restore_descendants: bool,
+
     /// Files or directories to delete (filesets are accepted)
     #[arg(required = true, value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
     #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
@@ -78,11 +82,21 @@ pub(crate) async fn cmd_file_delete(
         .set_tree(new_tree)
         .write()
         .await?;
-    let num_rebased = tx.repo_mut().rebase_descendants().await?;
+    let (num_rebased, extra_msg) = if args.restore_descendants {
+        (
+            tx.repo_mut().reparent_descendants().await?,
+            " (while preserving their content)",
+        )
+    } else {
+        (tx.repo_mut().rebase_descendants().await?, "")
+    };
     if let Some(mut formatter) = ui.status_formatter()
         && num_rebased > 0
     {
-        writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
+        writeln!(
+            formatter,
+            "Rebased {num_rebased} descendant commits{extra_msg}"
+        )?;
     }
     tx.finish(ui, format!("delete paths in commit {}", commit.id().hex()))
         .await?;

--- a/cli/src/commands/file/delete.rs
+++ b/cli/src/commands/file/delete.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write as _;
+
+use clap_complete::ArgValueCompleter;
+use jj_lib::merge::Merge;
+use jj_lib::merged_tree_builder::MergedTreeBuilder;
+use jj_lib::object_id::ObjectId as _;
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::cli_util::RevisionArg;
+use crate::cli_util::print_unmatched_explicit_paths;
+use crate::command_error::CommandError;
+use crate::complete;
+use crate::ui::Ui;
+
+/// Delete files from the given revision
+///
+/// Removes all files matched by the given filesets from the specified revision.
+/// Descendants are rebased on top of the rewritten commit.
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct FileDeleteArgs {
+    /// The revision to delete the files in
+    #[arg(long, short, default_value = "@", value_name = "REVSET")]
+    #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
+    revision: RevisionArg,
+
+    /// Files or directories to delete (filesets are accepted)
+    #[arg(required = true, value_name = "FILESETS", value_hint = clap::ValueHint::AnyPath)]
+    #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
+    paths: Vec<String>,
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn cmd_file_delete(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &FileDeleteArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui).await?;
+    let commit = workspace_command
+        .resolve_single_rev(ui, &args.revision)
+        .await?;
+    workspace_command.check_rewritable([commit.id()]).await?;
+
+    let tree = commit.tree();
+    let fileset_expression = workspace_command.parse_file_patterns(ui, &args.paths)?;
+    let matcher = fileset_expression.to_matcher();
+    print_unmatched_explicit_paths(ui, &workspace_command, &fileset_expression, [&tree])?;
+
+    let mut tree_builder = MergedTreeBuilder::new(commit.tree());
+    for (path, _value) in tree.entries_matching(matcher.as_ref()) {
+        tree_builder.set_or_remove(path, Merge::absent());
+    }
+    let new_tree = tree_builder.write_tree().await?;
+
+    if new_tree.tree_ids() == commit.tree().tree_ids() {
+        writeln!(ui.status(), "Nothing changed.")?;
+        return Ok(());
+    }
+
+    let mut tx = workspace_command.start_transaction();
+    tx.repo_mut()
+        .rewrite_commit(&commit)
+        .set_tree(new_tree)
+        .write()
+        .await?;
+    let num_rebased = tx.repo_mut().rebase_descendants().await?;
+    if let Some(mut formatter) = ui.status_formatter()
+        && num_rebased > 0
+    {
+        writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
+    }
+    tx.finish(ui, format!("delete paths in commit {}", commit.id().hex()))
+        .await?;
+    Ok(())
+}

--- a/cli/src/commands/file/edit.rs
+++ b/cli/src/commands/file/edit.rs
@@ -57,6 +57,10 @@ pub(crate) struct FileEditArgs {
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
     revision: RevisionArg,
 
+    /// Preserve the content (not the diff) when rebasing descendants
+    #[arg(long)]
+    restore_descendants: bool,
+
     /// The file to edit
     #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
     #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
@@ -176,11 +180,21 @@ pub(crate) async fn cmd_file_edit(
         .set_tree(new_tree)
         .write()
         .await?;
-    let num_rebased = tx.repo_mut().rebase_descendants().await?;
+    let (num_rebased, extra_msg) = if args.restore_descendants {
+        (
+            tx.repo_mut().reparent_descendants().await?,
+            " (while preserving their content)",
+        )
+    } else {
+        (tx.repo_mut().rebase_descendants().await?, "")
+    };
     if let Some(mut formatter) = ui.status_formatter()
         && num_rebased > 0
     {
-        writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
+        writeln!(
+            formatter,
+            "Rebased {num_rebased} descendant commits{extra_msg}"
+        )?;
     }
     tx.finish(
         ui,

--- a/cli/src/commands/file/edit.rs
+++ b/cli/src/commands/file/edit.rs
@@ -1,0 +1,191 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write as _;
+
+use clap_complete::ArgValueCompleter;
+use jj_lib::conflicts::MaterializedTreeValue;
+use jj_lib::conflicts::materialize_tree_value;
+use jj_lib::fsmonitor::FsmonitorSettings;
+use jj_lib::gitignore::GitIgnoreFile;
+use jj_lib::local_working_copy::EolConversionMode;
+use jj_lib::local_working_copy::ExecChangeSetting;
+use jj_lib::local_working_copy::TreeState;
+use jj_lib::local_working_copy::TreeStateSettings;
+use jj_lib::matchers::EverythingMatcher;
+use jj_lib::matchers::NothingMatcher;
+use jj_lib::object_id::ObjectId as _;
+use jj_lib::repo::Repo as _;
+use jj_lib::working_copy::SnapshotOptions;
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::cli_util::RevisionArg;
+use crate::command_error::CommandError;
+use crate::command_error::internal_error;
+use crate::command_error::user_error;
+use crate::complete;
+use crate::description_util::TempTextEditError;
+use crate::merge_tools::new_utf8_temp_dir;
+use crate::ui::Ui;
+
+/// Edit the contents of a file in a revision
+///
+/// The file is opened with the contents from the given revision. After the
+/// editor exits, the file is saved back to the revision and descendants are
+/// rebased on top of the updated commit.
+///
+/// If the file does not yet exist in the revision, a new file will be created.
+///
+/// If the file is conflicted, the conflict markers are materialized in the
+/// editor. Editing the conflict markers can resolve the conflict.
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct FileEditArgs {
+    /// The revision to edit the file in
+    #[arg(long, short, default_value = "@", value_name = "REVSET")]
+    #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
+    revision: RevisionArg,
+
+    /// The file to edit
+    #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
+    #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
+    path: String,
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn cmd_file_edit(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &FileEditArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui).await?;
+    let commit = workspace_command
+        .resolve_single_rev(ui, &args.revision)
+        .await?;
+    workspace_command.check_rewritable([commit.id()]).await?;
+
+    let repo_path = workspace_command.parse_file_path(&args.path)?;
+    let repo = workspace_command.repo().clone();
+    let tree = commit.tree();
+
+    let value = tree.path_value(&repo_path).await?;
+    let ui_path = workspace_command.format_file_path(&repo_path);
+    if value.is_tree() {
+        return Err(user_error(format!("Path is a directory: {ui_path}")));
+    }
+
+    // Validate that the path points at something we can materialize and edit as
+    // text.
+    let conflict_marker_style = workspace_command.env().conflict_marker_style();
+    let materialized =
+        materialize_tree_value(repo.store(), &repo_path, value, tree.labels()).await?;
+    match materialized {
+        MaterializedTreeValue::File(_)
+        | MaterializedTreeValue::FileConflict(_)
+        | MaterializedTreeValue::Absent => {}
+        MaterializedTreeValue::OtherConflict { .. } => {
+            return Err(user_error(format!(
+                "Path '{ui_path}' has a non-file conflict and cannot be edited"
+            )));
+        }
+        MaterializedTreeValue::Symlink { .. } | MaterializedTreeValue::GitSubmodule(_) => {
+            return Err(user_error(format!(
+                "Path '{ui_path}' is not a regular file"
+            )));
+        }
+        MaterializedTreeValue::AccessDenied(err) => {
+            return Err(user_error(format!(
+                "Path '{ui_path}' exists but access is denied: {err}"
+            )));
+        }
+        MaterializedTreeValue::Tree(_) => {
+            panic!("tree value was already checked above")
+        }
+    }
+
+    // Materialize a sparse working copy in a temporary directory containing only
+    // the file being edited, open the editor on it, then snapshot the result.
+    let temp_dir = new_utf8_temp_dir("jj-file-edit-")?;
+    let wc_path = temp_dir.path().join("wc");
+    let state_dir = temp_dir.path().join("state");
+    std::fs::create_dir(&wc_path)?;
+    std::fs::create_dir(&state_dir)?;
+    let tree_state_settings = TreeStateSettings {
+        conflict_marker_style,
+        eol_conversion_mode: EolConversionMode::None,
+        exec_change_setting: ExecChangeSetting::Auto,
+        fsmonitor_settings: FsmonitorSettings::None,
+    };
+    let mut tree_state = TreeState::init(
+        repo.store().clone(),
+        wc_path,
+        state_dir,
+        &tree_state_settings,
+    )
+    .map_err(internal_error)?;
+    tree_state
+        .set_sparse_patterns(vec![repo_path.clone()])
+        .map_err(internal_error)?;
+    tree_state.check_out(&tree).map_err(internal_error)?;
+
+    let file_path = repo_path
+        .to_fs_path(tree_state.working_copy_path())
+        .map_err(internal_error)?;
+    let editor = workspace_command.text_editor()?;
+    if let Err(err) = editor.edit_file(&file_path) {
+        // Keep the temporary working copy so the user can recover their edits.
+        let _kept_dir = temp_dir.keep();
+        return Err(TempTextEditError {
+            error: Box::new(err),
+            name: None,
+            path: Some(file_path),
+        }
+        .into());
+    }
+
+    tree_state
+        .snapshot(&SnapshotOptions {
+            base_ignores: GitIgnoreFile::empty(),
+            progress: None,
+            start_tracking_matcher: &EverythingMatcher,
+            force_tracking_matcher: &NothingMatcher,
+            max_new_file_size: u64::MAX,
+        })
+        .await?;
+    let new_tree = tree_state.current_tree().clone();
+
+    if new_tree.tree_ids() == commit.tree().tree_ids() {
+        writeln!(ui.status(), "Nothing changed.")?;
+        return Ok(());
+    }
+
+    let mut tx = workspace_command.start_transaction();
+    tx.repo_mut()
+        .rewrite_commit(&commit)
+        .set_tree(new_tree)
+        .write()
+        .await?;
+    let num_rebased = tx.repo_mut().rebase_descendants().await?;
+    if let Some(mut formatter) = ui.status_formatter()
+        && num_rebased > 0
+    {
+        writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
+    }
+    tx.finish(
+        ui,
+        format!("edit file {} in commit {}", ui_path, commit.id().hex()),
+    )
+    .await?;
+    Ok(())
+}

--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -14,6 +14,7 @@
 
 mod annotate;
 mod chmod;
+mod delete;
 mod edit;
 mod list;
 mod search;
@@ -31,6 +32,7 @@ use crate::ui::Ui;
 pub enum FileCommand {
     Annotate(annotate::FileAnnotateArgs),
     Chmod(chmod::FileChmodArgs),
+    Delete(delete::FileDeleteArgs),
     Edit(edit::FileEditArgs),
     List(list::FileListArgs),
     Search(search::FileSearchArgs),
@@ -48,6 +50,7 @@ pub async fn cmd_file(
     match subcommand {
         FileCommand::Annotate(args) => annotate::cmd_file_annotate(ui, command, args).await,
         FileCommand::Chmod(args) => chmod::cmd_file_chmod(ui, command, args).await,
+        FileCommand::Delete(args) => delete::cmd_file_delete(ui, command, args).await,
         FileCommand::Edit(args) => edit::cmd_file_edit(ui, command, args).await,
         FileCommand::List(args) => list::cmd_file_list(ui, command, args).await,
         FileCommand::Search(args) => search::cmd_file_search(ui, command, args).await,

--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -14,6 +14,7 @@
 
 mod annotate;
 mod chmod;
+mod edit;
 mod list;
 mod search;
 mod show;
@@ -29,6 +30,7 @@ use crate::ui::Ui;
 pub enum FileCommand {
     Annotate(annotate::FileAnnotateArgs),
     Chmod(chmod::FileChmodArgs),
+    Edit(edit::FileEditArgs),
     List(list::FileListArgs),
     Search(search::FileSearchArgs),
     Show(show::FileShowArgs),
@@ -44,6 +46,7 @@ pub async fn cmd_file(
     match subcommand {
         FileCommand::Annotate(args) => annotate::cmd_file_annotate(ui, command, args).await,
         FileCommand::Chmod(args) => chmod::cmd_file_chmod(ui, command, args).await,
+        FileCommand::Edit(args) => edit::cmd_file_edit(ui, command, args).await,
         FileCommand::List(args) => list::cmd_file_list(ui, command, args).await,
         FileCommand::Search(args) => search::cmd_file_search(ui, command, args).await,
         FileCommand::Show(args) => show::cmd_file_show(ui, command, args).await,

--- a/cli/src/commands/file/mod.rs
+++ b/cli/src/commands/file/mod.rs
@@ -17,6 +17,7 @@ mod chmod;
 mod edit;
 mod list;
 mod search;
+mod set;
 mod show;
 mod track;
 mod untrack;
@@ -33,6 +34,7 @@ pub enum FileCommand {
     Edit(edit::FileEditArgs),
     List(list::FileListArgs),
     Search(search::FileSearchArgs),
+    Set(set::FileSetArgs),
     Show(show::FileShowArgs),
     Track(track::FileTrackArgs),
     Untrack(untrack::FileUntrackArgs),
@@ -49,6 +51,7 @@ pub async fn cmd_file(
         FileCommand::Edit(args) => edit::cmd_file_edit(ui, command, args).await,
         FileCommand::List(args) => list::cmd_file_list(ui, command, args).await,
         FileCommand::Search(args) => search::cmd_file_search(ui, command, args).await,
+        FileCommand::Set(args) => set::cmd_file_set(ui, command, args).await,
         FileCommand::Show(args) => show::cmd_file_show(ui, command, args).await,
         FileCommand::Track(args) => track::cmd_file_track(ui, command, args).await,
         FileCommand::Untrack(args) => untrack::cmd_file_untrack(ui, command, args).await,

--- a/cli/src/commands/file/set.rs
+++ b/cli/src/commands/file/set.rs
@@ -1,0 +1,169 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::io::Read as _;
+use std::io::Write as _;
+
+use clap_complete::ArgValueCompleter;
+use jj_lib::backend::CopyId;
+use jj_lib::backend::TreeValue;
+use jj_lib::conflicts::MaterializedTreeValue;
+use jj_lib::conflicts::materialize_tree_value;
+use jj_lib::merge::Merge;
+use jj_lib::merged_tree_builder::MergedTreeBuilder;
+use jj_lib::object_id::ObjectId as _;
+use jj_lib::repo::Repo as _;
+use tracing::instrument;
+
+use crate::cli_util::CommandHelper;
+use crate::cli_util::RevisionArg;
+use crate::command_error::CommandError;
+use crate::command_error::user_error;
+use crate::complete;
+use crate::ui::Ui;
+
+/// Update the contents of a file in the given revision
+///
+/// The new file contents must be provided via `--stdin`. In the future,
+/// additional content sources may be supported.
+///
+/// Descendants are rebased on top of the rewritten commit.
+///
+/// Example usage:
+///
+/// ```shell
+/// echo "new file contents" | jj file set --stdin -r xyz path/to/file.md
+/// ```
+#[derive(clap::Args, Clone, Debug)]
+pub(crate) struct FileSetArgs {
+    /// The revision to set the file in
+    #[arg(long, short, default_value = "@", value_name = "REVSET")]
+    #[arg(add = ArgValueCompleter::new(complete::revset_expression_mutable))]
+    revision: RevisionArg,
+
+    /// Read the new file contents from standard input
+    #[arg(long)]
+    stdin: bool,
+    /// The file to set
+    #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
+    #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
+    path: String,
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn cmd_file_set(
+    ui: &mut Ui,
+    command: &CommandHelper,
+    args: &FileSetArgs,
+) -> Result<(), CommandError> {
+    let mut workspace_command = command.workspace_helper(ui).await?;
+    let commit = workspace_command
+        .resolve_single_rev(ui, &args.revision)
+        .await?;
+    workspace_command.check_rewritable([commit.id()]).await?;
+
+    let repo_path = workspace_command.parse_file_path(&args.path)?;
+    let repo = workspace_command.repo().clone();
+    let tree = commit.tree();
+
+    // Read the path's current tree value to determine if it's a file and to
+    // preserve the executable bit and copy ID.
+    let value = tree.path_value(&repo_path).await?;
+    if value.is_tree() {
+        let ui_path = workspace_command.format_file_path(&repo_path);
+        return Err(user_error(format!("Path is a directory: {ui_path}")));
+    }
+
+    // Preserve metadata from the existing file entry if present.
+    let (executable, copy_id) = if value.is_absent() {
+        // New file: use defaults.
+        (false, CopyId::placeholder())
+    } else {
+        let materialized =
+            materialize_tree_value(repo.store(), &repo_path, value, tree.labels()).await?;
+        match materialized {
+            MaterializedTreeValue::File(file) => (file.executable, file.copy_id),
+            MaterializedTreeValue::FileConflict(file) => (
+                file.executable.unwrap_or(false),
+                file.copy_id.unwrap_or_else(CopyId::placeholder),
+            ),
+            MaterializedTreeValue::Symlink { .. } | MaterializedTreeValue::GitSubmodule(_) => {
+                let ui_path = workspace_command.format_file_path(&repo_path);
+                return Err(user_error(format!(
+                    "Path '{ui_path}' is not a regular file"
+                )));
+            }
+            MaterializedTreeValue::OtherConflict { .. } => (false, CopyId::placeholder()),
+            MaterializedTreeValue::AccessDenied(err) => {
+                let ui_path = workspace_command.format_file_path(&repo_path);
+                return Err(user_error(format!(
+                    "Path '{ui_path}' exists but access is denied: {err}"
+                )));
+            }
+            MaterializedTreeValue::Absent => {
+                panic!("absent value was already checked above")
+            }
+            MaterializedTreeValue::Tree(_) => {
+                panic!("tree value was already checked above")
+            }
+        }
+    };
+
+    if !args.stdin {
+        return Err(user_error(
+            "Pass `--stdin` to read the file contents from standard input",
+        ));
+    }
+    let mut new_bytes: Vec<u8> = Vec::new();
+    io::stdin().read_to_end(&mut new_bytes)?;
+
+    let ui_path = workspace_command.format_file_path(&repo_path);
+    let new_file_id = repo
+        .store()
+        .write_file(&repo_path, &mut new_bytes.as_slice())
+        .await?;
+    let new_tree_value = Merge::normal(TreeValue::File {
+        id: new_file_id,
+        executable,
+        copy_id,
+    });
+    let mut tree_builder = MergedTreeBuilder::new(commit.tree());
+    tree_builder.set_or_remove(repo_path.clone(), new_tree_value);
+    let new_tree = tree_builder.write_tree().await?;
+
+    if new_tree.tree_ids() == commit.tree().tree_ids() {
+        writeln!(ui.status(), "Nothing changed.")?;
+        return Ok(());
+    }
+
+    let mut tx = workspace_command.start_transaction();
+    tx.repo_mut()
+        .rewrite_commit(&commit)
+        .set_tree(new_tree)
+        .write()
+        .await?;
+    let num_rebased = tx.repo_mut().rebase_descendants().await?;
+    if let Some(mut formatter) = ui.status_formatter()
+        && num_rebased > 0
+    {
+        writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
+    }
+    tx.finish(
+        ui,
+        format!("set file {} in commit {}", ui_path, commit.id().hex()),
+    )
+    .await?;
+    Ok(())
+}

--- a/cli/src/commands/file/set.rs
+++ b/cli/src/commands/file/set.rs
@@ -56,6 +56,11 @@ pub(crate) struct FileSetArgs {
     /// Read the new file contents from standard input
     #[arg(long)]
     stdin: bool,
+
+    /// Preserve the content (not the diff) when rebasing descendants
+    #[arg(long)]
+    restore_descendants: bool,
+
     /// The file to set
     #[arg(value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
     #[arg(add = ArgValueCompleter::new(complete::all_revision_files))]
@@ -154,11 +159,21 @@ pub(crate) async fn cmd_file_set(
         .set_tree(new_tree)
         .write()
         .await?;
-    let num_rebased = tx.repo_mut().rebase_descendants().await?;
+    let (num_rebased, extra_msg) = if args.restore_descendants {
+        (
+            tx.repo_mut().reparent_descendants().await?,
+            " (while preserving their content)",
+        )
+    } else {
+        (tx.repo_mut().rebase_descendants().await?, "")
+    };
     if let Some(mut formatter) = ui.status_formatter()
         && num_rebased > 0
     {
-        writeln!(formatter, "Rebased {num_rebased} descendant commits")?;
+        writeln!(
+            formatter,
+            "Rebased {num_rebased} descendant commits{extra_msg}"
+        )?;
     }
     tx.finish(
         ui,

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -103,12 +103,33 @@ impl TextEditor {
         content: impl AsRef<[u8]>,
         suffix: Option<&str>,
     ) -> Result<String, TempTextEditError> {
+        self.edit(content, suffix, |p| fs::read_to_string(p))
+    }
+
+    /// Writes the given `content` to temporary file and opens it in editor.
+    pub fn edit_bytes(
+        &self,
+        content: impl AsRef<[u8]>,
+        suffix: Option<&str>,
+    ) -> Result<Vec<u8>, TempTextEditError> {
+        self.edit(content, suffix, |p| fs::read(p))
+    }
+
+    fn edit<R, F>(
+        &self,
+        content: impl AsRef<[u8]>,
+        suffix: Option<&str>,
+        read: F,
+    ) -> Result<R, TempTextEditError>
+    where
+        F: FnOnce(&PathBuf) -> io::Result<R>,
+    {
         let path = self
             .write_temp_file(content.as_ref(), suffix)
             .map_err(|err| TempTextEditError::new(err.into(), None))?;
         self.edit_file(&path)
             .map_err(|err| TempTextEditError::new(err.into(), Some(path.clone())))?;
-        let edited = fs::read_to_string(&path)
+        let edited = read(&path)
             .context(&path)
             .map_err(|err| TempTextEditError::new(err.into(), Some(path.clone())))?;
         // Delete the file only if everything went well.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1312,6 +1312,7 @@ Example usage:
 
   Default value: `@`
 * `--stdin` — Read the new file contents from standard input
+* `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1224,6 +1224,7 @@ Removes all files matched by the given filesets from the specified revision. Des
 * `-r`, `--revision <REVSET>` — The revision to delete the files in
 
   Default value: `@`
+* `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -45,6 +45,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj file`↴](#jj-file)
 * [`jj file annotate`↴](#jj-file-annotate)
 * [`jj file chmod`↴](#jj-file-chmod)
+* [`jj file edit`↴](#jj-file-edit)
 * [`jj file list`↴](#jj-file-list)
 * [`jj file search`↴](#jj-file-search)
 * [`jj file show`↴](#jj-file-show)
@@ -1138,6 +1139,7 @@ File operations
 
 * `annotate` — Show the source change for each line of the target file
 * `chmod` — Sets or removes the executable bit for paths in the repo
+* `edit` — Edit the contents of a file in a revision
 * `list` — List files in a revision
 * `search` — Search for content in files
 * `show` — Print contents of files in a revision
@@ -1196,6 +1198,30 @@ Unlike the POSIX `chmod`, `jj file chmod` also works on Windows, on conflicted f
 ###### **Options:**
 
 * `-r`, `--revision <REVSET>` — The revision to update
+
+  Default value: `@`
+
+
+
+## `jj file edit`
+
+Edit the contents of a file in a revision
+
+The file is opened with the contents from the given revision. After the editor exits, the file is saved back to the revision and descendants are rebased on top of the updated commit.
+
+If the file does not yet exist in the revision, a new file will be created.
+
+If the file is conflicted, the conflict markers are materialized in the editor. Editing the conflict markers can resolve the conflict.
+
+**Usage:** `jj file edit [OPTIONS] <FILE>`
+
+###### **Arguments:**
+
+* `<FILE>` — The file to edit
+
+###### **Options:**
+
+* `-r`, `--revision <REVSET>` — The revision to edit the file in
 
   Default value: `@`
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -45,6 +45,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj file`↴](#jj-file)
 * [`jj file annotate`↴](#jj-file-annotate)
 * [`jj file chmod`↴](#jj-file-chmod)
+* [`jj file delete`↴](#jj-file-delete)
 * [`jj file edit`↴](#jj-file-edit)
 * [`jj file list`↴](#jj-file-list)
 * [`jj file search`↴](#jj-file-search)
@@ -1140,6 +1141,7 @@ File operations
 
 * `annotate` — Show the source change for each line of the target file
 * `chmod` — Sets or removes the executable bit for paths in the repo
+* `delete` — Delete files from the given revision
 * `edit` — Edit the contents of a file in a revision
 * `list` — List files in a revision
 * `search` — Search for content in files
@@ -1200,6 +1202,26 @@ Unlike the POSIX `chmod`, `jj file chmod` also works on Windows, on conflicted f
 ###### **Options:**
 
 * `-r`, `--revision <REVSET>` — The revision to update
+
+  Default value: `@`
+
+
+
+## `jj file delete`
+
+Delete files from the given revision
+
+Removes all files matched by the given filesets from the specified revision. Descendants are rebased on top of the rewritten commit.
+
+**Usage:** `jj file delete [OPTIONS] <FILESETS>...`
+
+###### **Arguments:**
+
+* `<FILESETS>` — Files or directories to delete (filesets are accepted)
+
+###### **Options:**
+
+* `-r`, `--revision <REVSET>` — The revision to delete the files in
 
   Default value: `@`
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1224,6 +1224,7 @@ If the file is conflicted, the conflict markers are materialized in the editor. 
 * `-r`, `--revision <REVSET>` — The revision to edit the file in
 
   Default value: `@`
+* `--restore-descendants` — Preserve the content (not the diff) when rebasing descendants
 
 
 

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -48,6 +48,7 @@ This document contains the help content for the `jj` command-line program.
 * [`jj file edit`↴](#jj-file-edit)
 * [`jj file list`↴](#jj-file-list)
 * [`jj file search`↴](#jj-file-search)
+* [`jj file set`↴](#jj-file-set)
 * [`jj file show`↴](#jj-file-show)
 * [`jj file track`↴](#jj-file-track)
 * [`jj file untrack`↴](#jj-file-untrack)
@@ -1142,6 +1143,7 @@ File operations
 * `edit` — Edit the contents of a file in a revision
 * `list` — List files in a revision
 * `search` — Search for content in files
+* `set` — Update the contents of a file in the given revision
 * `show` — Print contents of files in a revision
 * `track` — Start tracking specified paths in the working copy
 * `untrack` — Stop tracking specified paths in the working copy
@@ -1283,6 +1285,33 @@ This is an early version of the command. It does not search files concurrently.
    [string pattern syntax]: https://docs.jj-vcs.dev/latest/revsets/#string-patterns
 * `--name-only` — Print only the paths of files that contain a match, not the matched lines
 * `-n`, `--line-number` — Prefix each matched line with its 1-based line number within the file
+
+
+
+## `jj file set`
+
+Update the contents of a file in the given revision
+
+The new file contents must be provided via `--stdin`. In the future, additional content sources may be supported.
+
+Descendants are rebased on top of the rewritten commit.
+
+Example usage:
+
+```shell echo "new file contents" | jj file set --stdin -r xyz path/to/file.md ```
+
+**Usage:** `jj file set [OPTIONS] <FILE>`
+
+###### **Arguments:**
+
+* `<FILE>` — The file to set
+
+###### **Options:**
+
+* `-r`, `--revision <REVSET>` — The revision to set the file in
+
+  Default value: `@`
+* `--stdin` — Read the new file contents from standard input
 
 
 

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -37,6 +37,7 @@ mod test_file_chmod_command;
 mod test_file_edit_command;
 mod test_file_list_command;
 mod test_file_search_command;
+mod test_file_set_command;
 mod test_file_show_command;
 mod test_file_track_untrack_commands;
 mod test_fileset_output;

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -34,6 +34,7 @@ mod test_edit_command;
 mod test_evolog_command;
 mod test_file_annotate_command;
 mod test_file_chmod_command;
+mod test_file_delete_command;
 mod test_file_edit_command;
 mod test_file_list_command;
 mod test_file_search_command;

--- a/cli/tests/runner.rs
+++ b/cli/tests/runner.rs
@@ -34,6 +34,7 @@ mod test_edit_command;
 mod test_evolog_command;
 mod test_file_annotate_command;
 mod test_file_chmod_command;
+mod test_file_edit_command;
 mod test_file_list_command;
 mod test_file_search_command;
 mod test_file_show_command;

--- a/cli/tests/test_file_delete_command.rs
+++ b/cli/tests/test_file_delete_command.rs
@@ -216,6 +216,40 @@ fn test_file_delete_rebases_descendants() {
 }
 
 #[test]
+fn test_file_delete_restore_descendants() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The child re-adds `file` with its own content. With --restore-descendants
+    // the child should keep that content even after we delete `file` from base.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "child", &["base"], &[("file", "child\n")]);
+
+    let output = work_dir.run_jj(["file", "delete", "-r=base", "--restore-descendants", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits (while preserving their content)
+    Working copy  (@) now at: zsuskuln afd5628e child | child
+    Parent commit (@-)      : rlvkpnrz e39fdc42 base | (empty) base
+    [EOF]
+    ");
+
+    // The file is gone from base.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=base", "file"]), @"
+    ------- stderr -------
+    Error: No such path: file
+    [EOF]
+    [exit status: 1]
+    ");
+    // The child preserved its own content because of --restore-descendants.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=child", "file"]), @"
+    child
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_file_delete_no_match() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_file_delete_command.rs
+++ b/cli/tests/test_file_delete_command.rs
@@ -1,0 +1,355 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+use crate::common::create_commit_with_files;
+
+#[test]
+fn test_file_delete() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file", "hello\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let output = work_dir.run_jj(["file", "delete", "-r=a", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 05587b47 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 73d7da45 a | (empty) a
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+
+    // The file is gone from the revision.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "file"]), @"
+    ------- stderr -------
+    Error: No such path: file
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_file_delete_multiple_paths() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(
+        &work_dir,
+        "a",
+        &[],
+        &[("file1", "one\n"), ("file2", "two\n"), ("keep", "keep\n")],
+    );
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let output = work_dir.run_jj(["file", "delete", "-r=a", "file1", "file2"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 381c0779 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 40dacdef a | a
+    Added 0 files, modified 0 files, removed 2 files
+    [EOF]
+    ");
+
+    // Both deleted files are gone; the third is still present.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "file1"]), @"
+    ------- stderr -------
+    Error: No such path: file1
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "file2"]), @"
+    ------- stderr -------
+    Error: No such path: file2
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "keep"]), @"
+    keep
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_file_delete_directory() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(
+        &work_dir,
+        "a",
+        &[],
+        &[("dir/a", "a\n"), ("dir/b", "b\n"), ("keep", "keep\n")],
+    );
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let output = work_dir.run_jj(["file", "delete", "-r=a", "dir"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 381c0779 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 40dacdef a | a
+    Added 0 files, modified 0 files, removed 2 files
+    [EOF]
+    ");
+
+    // All files under dir/ are gone.
+    insta::assert_snapshot!(
+        work_dir.run_jj(["file", "show", "-r=a", "dir/a"]).normalize_backslash(), @"
+    ------- stderr -------
+    Error: No such path: dir/a
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(
+        work_dir.run_jj(["file", "show", "-r=a", "dir/b"]).normalize_backslash(), @"
+    ------- stderr -------
+    Error: No such path: dir/b
+    [EOF]
+    [exit status: 1]
+    ");
+    // The file outside the directory is untouched.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "keep"]), @"
+    keep
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_file_delete_fileset() {
+    // A jj fileset expression (glob:) can be used as the path argument.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(
+        &work_dir,
+        "a",
+        &[],
+        &[
+            ("readme.md", "readme\n"),
+            ("notes.txt", "notes\n"),
+            ("data.txt", "data\n"),
+        ],
+    );
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let output = work_dir.run_jj(["file", "delete", "-r=a", "glob:*.txt"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 929a622c (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 2b863d10 a | a
+    Added 0 files, modified 0 files, removed 2 files
+    [EOF]
+    ");
+
+    // Only .txt files are deleted; the .md file is untouched.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "notes.txt"]), @"
+    ------- stderr -------
+    Error: No such path: notes.txt
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "data.txt"]), @"
+    ------- stderr -------
+    Error: No such path: data.txt
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "readme.md"]), @"
+    readme
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_file_delete_rebases_descendants() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The child commit only touches a different file so the rebase is clean.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "child", &["base"], &[("other", "child\n")]);
+
+    let output = work_dir.run_jj(["file", "delete", "-r=base", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 58951718 child | child
+    Parent commit (@-)      : rlvkpnrz e39fdc42 base | (empty) base
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+
+    // File is gone from both the rewritten base and the rebased child.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=base", "file"]), @"
+    ------- stderr -------
+    Error: No such path: file
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=child", "file"]), @"
+    ------- stderr -------
+    Error: No such path: file
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_file_delete_no_match() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file", "hello\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let op_log_before = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+
+    let output = work_dir.run_jj(["file", "delete", "-r=a", "nonexistent"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Warning: No matching entries for paths: nonexistent
+    Nothing changed.
+    [EOF]
+    ");
+
+    // No new operation was created.
+    let op_log_after = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+    assert_eq!(op_log_before, op_log_after);
+}
+
+#[test]
+fn test_file_delete_partial_match() {
+    // A warning is emitted for the unmatched path, but the matched path is
+    // still deleted — the warning is informational, not fatal.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file", "hello\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let output = work_dir.run_jj(["file", "delete", "-r=a", "file", "nonexistent"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Warning: No matching entries for paths: nonexistent
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 05587b47 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 73d7da45 a | (empty) a
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+
+    // The matched file was deleted.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "file"]), @"
+    ------- stderr -------
+    Error: No such path: file
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_file_delete_immutable() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmarks(main)""#);
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "main", &[], &[("file", "hello\n")]);
+
+    let output = work_dir.run_jj(["file", "delete", "-r=main", "file"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Commit b08080c83282 is immutable
+    Hint: Could not modify commit: rlvkpnrz b08080c8 main | main
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    let output = work_dir.run_jj(["--ignore-immutable", "file", "delete", "-r=main", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: kkmpptxz a43f66cc (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz f6eab8bc main | (empty) main
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=main", "file"]), @"
+    ------- stderr -------
+    Error: No such path: file
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_file_delete_conflict() {
+    // Deleting a conflicted file removes it cleanly regardless of how many
+    // conflict sides there are.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "left", &["base"], &[("file", "left\n")]);
+    create_commit_with_files(&work_dir, "right", &["base"], &[("file", "right\n")]);
+    create_commit_with_files(&work_dir, "conflict", &["left", "right"], &[]);
+    work_dir.run_jj(["new", "-r=conflict"]).success();
+
+    // Confirm the file is conflicted before deletion.
+    let show_before = work_dir
+        .run_jj(["file", "show", "-r=conflict", "file"])
+        .stdout
+        .into_raw();
+    assert!(
+        show_before.contains("<<<"),
+        "expected conflict markers, got: {show_before}"
+    );
+
+    let output = work_dir.run_jj(["file", "delete", "-r=conflict", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: znkkpsqq 068ccef1 (empty) (no description set)
+    Parent commit (@-)      : vruxwmqv 8dd54404 conflict | conflict
+    Added 0 files, modified 0 files, removed 1 files
+    [EOF]
+    ");
+
+    // The file is completely gone — no conflict entry remains.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=conflict", "file"]), @"
+    ------- stderr -------
+    Error: No such path: file
+    [EOF]
+    [exit status: 1]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["debug", "tree", "-r=conflict"]), @"");
+}

--- a/cli/tests/test_file_edit_command.rs
+++ b/cli/tests/test_file_edit_command.rs
@@ -1,0 +1,497 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use testutils::TestResult;
+
+use crate::common::TestEnvironment;
+use crate::common::create_commit_with_files;
+
+#[must_use]
+fn get_log_output(work_dir: &crate::common::TestWorkDir) -> crate::common::CommandOutput {
+    work_dir.run_jj(["log", "-T", "bookmarks"])
+}
+
+#[test]
+fn test_file_edit() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file.txt", "original\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    // Verify editor sees the original content, then overwrite it.
+    // \0 separates multiple instructions within a single editor invocation.
+    std::fs::write(&edit_script, "expect\noriginal\n\0write\nnew contents\n")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=a", "file.txt"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln c0a7b6ad (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 776d4585 a | a
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "file.txt"]), @"
+    new contents
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_at_working_copy() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file.txt", "original\n");
+
+    std::fs::write(&edit_script, "write\nedited\n")?;
+    let output = work_dir.run_jj(["file", "edit", "file.txt"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Working copy  (@) now at: qpvuntsm 317f7579 (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "file.txt"]), @"
+    edited
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_uses_file_name_being_edited() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(
+        &work_dir,
+        "a",
+        &[],
+        &[("foo.txt", "foo\n"), ("dir/bar.txt", "bar\n")],
+    );
+
+    std::fs::write(&edit_script, "dump-path path_dump")?;
+    work_dir
+        .run_jj(["file", "edit", "-r=a", "foo.txt"])
+        .success();
+    let path = std::fs::read_to_string(test_env.env_root().join("path_dump"))?.replace('\\', "/");
+    assert!(
+        path.ends_with("/foo.txt"),
+        "materialized path for foo.txt should end with /foo.txt, got: {path}"
+    );
+
+    std::fs::write(&edit_script, "dump-path path_dump")?;
+    work_dir
+        .run_jj(["file", "edit", "-r=a", "dir/bar.txt"])
+        .success();
+    let path = std::fs::read_to_string(test_env.env_root().join("path_dump"))?.replace('\\', "/");
+    assert!(
+        path.ends_with("/dir/bar.txt"),
+        "materialized path for dir/bar.txt should end with /dir/bar.txt, got: {path}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_rebases_descendants() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The child commit only adds a new file, so editing `file` in `base` does
+    // not produce a conflict on rebase.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "child", &["base"], &[("other", "child\n")]);
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  child
+    ○  base
+    ◆
+    [EOF]
+    ");
+
+    std::fs::write(&edit_script, "write\nmodified\n")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=base", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln aa7f70b8 child | child
+    Parent commit (@-)      : rlvkpnrz 221f1897 base | base
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // The parent revision has the edited content.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=base", "file"]), @"
+    modified
+    [EOF]
+    ");
+    // The child revision has the new parent's content for `file` since it didn't
+    // touch that file.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=child", "file"]), @"
+    modified
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_no_change() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file", "hello\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    // Editor leaves the file unchanged.
+    std::fs::write(&edit_script, "")?;
+    let op_log_before = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+
+    let output = work_dir.run_jj(["file", "edit", "-r=a", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+
+    // No new operation was created.
+    let op_log_after = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+    assert_eq!(op_log_before, op_log_after);
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_immutable() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmarks(main)""#);
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "main", &[], &[("file", "hello\n")]);
+
+    let output = work_dir.run_jj(["file", "edit", "-r=main", "file"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Commit b08080c83282 is immutable
+    Hint: Could not modify commit: rlvkpnrz b08080c8 main | main
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    std::fs::write(&edit_script, "write\nedited\n")?;
+    let output = work_dir.run_jj(["--ignore-immutable", "file", "edit", "-r=main", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: kkmpptxz 5936de99 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz be0f8891 main | main
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=main", "file"]), @"
+    edited
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_new_file() -> TestResult {
+    // Editing a path that doesn't exist in the revision opens with empty
+    // content and creates the file on save.
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("existing", "hello\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    std::fs::write(&edit_script, "write\nbrand new\n")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=a", "newfile"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 4af53614 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 05c2911c a | a
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "newfile"]), @"
+    brand new
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_directory() {
+    let mut test_env = TestEnvironment::default();
+    test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("dir/file", "hello\n")]);
+
+    let output = work_dir.run_jj(["file", "edit", "-r=a", "dir"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Path is a directory: dir
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+/// Set up a simple 2-sided conflict: base="base\n", left="left\n",
+/// right="right\n".
+fn set_up_conflict(work_dir: &crate::common::TestWorkDir) {
+    create_commit_with_files(work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(work_dir, "left", &["base"], &[("file", "left\n")]);
+    create_commit_with_files(work_dir, "right", &["base"], &[("file", "right\n")]);
+    create_commit_with_files(work_dir, "conflict", &["left", "right"], &[]);
+}
+
+#[test]
+fn test_file_edit_conflict_shows_markers() -> TestResult {
+    // The editor should receive the materialized conflict markers.
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    set_up_conflict(&work_dir);
+
+    // Dump what the editor sees into a file, leaving the conflict unchanged.
+    std::fs::write(&edit_script, "dump conflict_dump")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=conflict", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+
+    // Verify the editor saw conflict markers matching what `jj file show` emits.
+    let dumped = std::fs::read_to_string(test_env.env_root().join("conflict_dump"))?;
+    let shown = work_dir
+        .run_jj(["file", "show", "-r=conflict", "file"])
+        .stdout
+        .into_raw();
+    assert_eq!(dumped, shown);
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_conflict_resolve() -> TestResult {
+    // Editing a conflicted file and removing all conflict markers resolves it.
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    set_up_conflict(&work_dir);
+    work_dir.run_jj(["new", "-r=conflict"]).success();
+
+    std::fs::write(&edit_script, "write\nresolved\n")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=conflict", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: znkkpsqq 6e173dd9 (empty) (no description set)
+    Parent commit (@-)      : vruxwmqv 4a4c9232 conflict | conflict
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // The conflict should be resolved.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=conflict", "file"]), @"
+    resolved
+    [EOF]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["debug", "tree", "-r=conflict"]), @r#"
+    file: Ok(Resolved(Some(File { id: FileId("2ab19ae607aabda796309682e0448237aab03047"), executable: false, copy_id: CopyId("") })))
+    [EOF]
+    "#);
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_conflict_update() -> TestResult {
+    // Editing a conflicted file and keeping (modified) conflict markers keeps it
+    // conflicted but updates the sides.
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    set_up_conflict(&work_dir);
+
+    // First, dump what the editor sees so we know the exact marker format.
+    std::fs::write(&edit_script, "dump original_conflict")?;
+    work_dir
+        .run_jj(["file", "edit", "-r=conflict", "file"])
+        .success();
+    let original = std::fs::read_to_string(test_env.env_root().join("original_conflict"))?;
+
+    // Replace "left" with "new-left" in the conflict markers and write it back.
+    let modified = original.replace("left\n", "new-left\n");
+    std::fs::write(&edit_script, format!("write\n{modified}"))?;
+    let output = work_dir.run_jj(["file", "edit", "-r=conflict", "file"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Working copy  (@) now at: vruxwmqv ad5baaa3 conflict | (conflict) conflict
+    Parent commit (@-)      : zsuskuln c0778f46 left | left
+    Parent commit (@-)      : royxmykx 386edb4d right | right
+    Added 0 files, modified 1 files, removed 0 files
+    Warning: There are unresolved conflicts at these paths:
+    file    2-sided conflict
+    New conflicts appeared in 1 commits:
+      vruxwmqv ad5baaa3 conflict | (conflict) conflict
+    Hint: To resolve the conflicts, start by creating a commit on top of
+    the conflicted commit:
+      jj new vruxwmqv
+    Then use `jj resolve`, or edit the conflict markers in the file directly.
+    Once the conflicts are resolved, you can inspect the result with `jj diff`.
+    Then run `jj squash` to move the resolution into the conflicted commit.
+    [EOF]
+    ");
+
+    // The file should still be conflicted but with the updated side content.
+    let shown = work_dir
+        .run_jj(["file", "show", "-r=conflict", "file"])
+        .stdout
+        .into_raw();
+    assert!(
+        shown.contains("new-left"),
+        "expected new-left in conflict, got: {shown}"
+    );
+    assert!(
+        !shown.contains("left\n") || shown.contains("new-left"),
+        "expected old 'left' to be replaced"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_conflict_no_change() -> TestResult {
+    // If the editor makes no changes to a conflict, "Nothing changed." is printed.
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    set_up_conflict(&work_dir);
+
+    let op_log_before = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+
+    std::fs::write(&edit_script, "")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=conflict", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+
+    let op_log_after = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+    assert_eq!(op_log_before, op_log_after);
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_editor_fail() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file.txt", "hello\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    std::fs::write(&edit_script, "fail")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=a", "file.txt"]);
+    insta::with_settings!({
+        filters => [
+            (r"\bEditor '[^']*'", "Editor '<redacted>'"),
+            (r"in .*(jj-file-edit-)[^/]*(/wc/file\.txt)\b", "in <redacted>$1<redacted>$2"),
+            (r"exit code", "exit status"),
+        ]
+    }, {
+        insta::assert_snapshot!(&&output.normalize_backslash(), @r"
+        ------- stderr -------
+        Error: Failed to edit file
+        Caused by: Editor '<redacted>' exited with exit status: 1
+        Hint: Edited file is left in <redacted>jj-file-edit-<redacted>/wc/file.txt
+        [EOF]
+        [exit status: 1]
+        ");
+    });
+
+    // The commit was not modified.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "file.txt"]), @r"
+    hello
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
+fn test_file_edit_preserves_executable() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("script.sh", "#!/bin/sh\n")]);
+    work_dir
+        .run_jj(["file", "chmod", "x", "-r=a", "script.sh"])
+        .success();
+    let debug_before = work_dir.run_jj(["debug", "tree", "-r=a"]);
+    insta::assert_snapshot!(debug_before, @r#"
+    script.sh: Ok(Resolved(Some(File { id: FileId("1a2485251c33a70432394c93fb89330ef214bfc9"), executable: true, copy_id: CopyId("") })))
+    [EOF]
+    "#);
+
+    std::fs::write(&edit_script, "write\n#!/bin/sh\necho hello\n")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=a", "script.sh"]);
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Working copy  (@) now at: rlvkpnrz f276cfce a | a
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // The executable bit must still be set after the edit.
+    let debug_after = work_dir.run_jj(["debug", "tree", "-r=a"]);
+    insta::assert_snapshot!(debug_after, @r#"
+    script.sh: Ok(Resolved(Some(File { id: FileId("21ba682558a42264518f1e0ba55e8a5cd9d7db0a"), executable: true, copy_id: CopyId("") })))
+    [EOF]
+    "#);
+    Ok(())
+}

--- a/cli/tests/test_file_edit_command.rs
+++ b/cli/tests/test_file_edit_command.rs
@@ -158,6 +158,47 @@ fn test_file_edit_rebases_descendants() -> TestResult {
 }
 
 #[test]
+fn test_file_edit_restore_descendants() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The child explicitly modifies `file`, so with --restore-descendants it
+    // should keep "child\n" regardless of what happens in `base`.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "child", &["base"], &[("file", "child\n")]);
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  child
+    ○  base
+    ◆
+    [EOF]
+    ");
+
+    std::fs::write(&edit_script, "write\nmodified\n")?;
+    let output = work_dir.run_jj(["file", "edit", "-r=base", "--restore-descendants", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Rebased 1 descendant commits (while preserving their content)
+    Working copy  (@) now at: zsuskuln f8c05ab2 child | child
+    Parent commit (@-)      : rlvkpnrz 221f1897 base | base
+    [EOF]
+    ");
+
+    // The parent has the edited content.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=base", "file"]), @"
+    modified
+    [EOF]
+    ");
+    // The child preserved its own content because of --restore-descendants.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=child", "file"]), @"
+    child
+    [EOF]
+    ");
+    Ok(())
+}
+
+#[test]
 fn test_file_edit_no_change() -> TestResult {
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_editor();

--- a/cli/tests/test_file_set_command.rs
+++ b/cli/tests/test_file_set_command.rs
@@ -80,6 +80,48 @@ fn test_file_set_rebases_descendants() {
 }
 
 #[test]
+fn test_file_set_restore_descendants() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The child explicitly modifies `file`, so with --restore-descendants it
+    // should keep "child\n" regardless of what happens in `base`.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "child", &["base"], &[("file", "child\n")]);
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "file",
+            "set",
+            "--stdin",
+            "-r=base",
+            "--restore-descendants",
+            "file",
+        ])
+        .write_stdin("modified\n")
+    });
+    insta::assert_snapshot!(output, @r"
+     ------- stderr -------
+     Rebased 1 descendant commits (while preserving their content)
+     Working copy  (@) now at: zsuskuln ce938357 child | child
+     Parent commit (@-)      : rlvkpnrz 7c5ffc58 base | base
+     [EOF]
+     ");
+
+    // The parent has the new content.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=base", "file"]), @"
+     modified
+     [EOF]
+     ");
+    // The child preserved its own content because of --restore-descendants.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=child", "file"]), @"
+     child
+     [EOF]
+     ");
+}
+
+#[test]
 fn test_file_set_no_change() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_file_set_command.rs
+++ b/cli/tests/test_file_set_command.rs
@@ -1,0 +1,309 @@
+// Copyright 2026 The Jujutsu Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::TestEnvironment;
+use crate::common::create_commit_with_files;
+
+#[test]
+fn test_file_set() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file.txt", "original\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=a", "file.txt"])
+            .write_stdin("new contents\n")
+    });
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln c0a7b6ad (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 776d4585 a | a
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "file.txt"]), @"
+    new contents
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_file_set_rebases_descendants() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // The child commit only adds a new file, so editing `file` in `base` does
+    // not produce a conflict on rebase.
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "child", &["base"], &[("other", "child\n")]);
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=base", "file"])
+            .write_stdin("modified\n")
+    });
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 72a196e8 child | child
+    Parent commit (@-)      : rlvkpnrz 7c5ffc58 base | base
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // The parent revision has the new content.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=base", "file"]), @"
+    modified
+    [EOF]
+    ");
+    // The child revision inherits the new content since it didn't modify `file`.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=child", "file"]), @"
+    modified
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_file_set_no_change() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file", "hello\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let op_log_before = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=a", "file"])
+            .write_stdin("hello\n")
+    });
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+
+    // No new operation was created.
+    let op_log_after = work_dir.run_jj(["op", "log", "--no-graph", "-Tid.short()"]);
+    assert_eq!(op_log_before, op_log_after);
+}
+
+#[test]
+fn test_file_set_no_stdin() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("file", "hello\n")]);
+
+    let output = work_dir.run_jj(["file", "set", "-r=a", "file"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Pass `--stdin` to read the file contents from standard input
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_file_set_immutable() {
+    let test_env = TestEnvironment::default();
+    test_env.add_config(r#"revset-aliases."immutable_heads()" = "bookmarks(main)""#);
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "main", &[], &[("file", "hello\n")]);
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=main", "file"])
+            .write_stdin("content\n")
+    });
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Commit b08080c83282 is immutable
+    Hint: Could not modify commit: rlvkpnrz b08080c8 main | main
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    "#);
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args([
+            "--ignore-immutable",
+            "file",
+            "set",
+            "--stdin",
+            "-r=main",
+            "file",
+        ])
+        .write_stdin("content\n")
+    });
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: kkmpptxz 371bd7b1 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 0e505733 main | main
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=main", "file"]), @"
+    content
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_file_set_directory() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("dir/file", "hello\n")]);
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=a", "dir"])
+            .write_stdin("content\n")
+    });
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Error: Path is a directory: dir
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_file_set_new_file() {
+    // Setting a file that does not yet exist in the revision creates it.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("existing", "old\n")]);
+    work_dir.run_jj(["new", "-r=a"]).success();
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=a", "newfile"])
+            .write_stdin("brand new\n")
+    });
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: zsuskuln 702c5236 (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz 08838e71 a | a
+    Added 1 files, modified 0 files, removed 0 files
+    [EOF]
+    ");
+
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=a", "newfile"]), @"
+    brand new
+    [EOF]
+    ");
+}
+
+#[test]
+fn test_file_set_preserves_executable() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "a", &[], &[("script.sh", "#!/bin/sh\n")]);
+    work_dir
+        .run_jj(["file", "chmod", "x", "-r=a", "script.sh"])
+        .success();
+    let debug_before = work_dir.run_jj(["debug", "tree", "-r=a"]);
+    insta::assert_snapshot!(debug_before, @r#"
+    script.sh: Ok(Resolved(Some(File { id: FileId("1a2485251c33a70432394c93fb89330ef214bfc9"), executable: true, copy_id: CopyId("") })))
+    [EOF]
+    "#);
+
+    work_dir.run_jj(["new", "-r=a"]).success();
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=a", "script.sh"])
+            .write_stdin("#!/bin/sh\necho hello\n")
+    });
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: royxmykx 8ddf4d1e (empty) (no description set)
+    Parent commit (@-)      : rlvkpnrz b4f8233a a | a
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // The executable bit must still be set after the set.
+    let debug_after = work_dir.run_jj(["debug", "tree", "-r=a"]);
+    insta::assert_snapshot!(debug_after, @r#"
+    script.sh: Ok(Resolved(Some(File { id: FileId("21ba682558a42264518f1e0ba55e8a5cd9d7db0a"), executable: true, copy_id: CopyId("") })))
+    [EOF]
+    "#);
+}
+
+#[test]
+fn test_file_set_conflict() {
+    // Setting a conflicted file replaces it with the provided content,
+    // resolving the conflict.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    create_commit_with_files(&work_dir, "base", &[], &[("file", "base\n")]);
+    create_commit_with_files(&work_dir, "left", &["base"], &[("file", "left\n")]);
+    create_commit_with_files(&work_dir, "right", &["base"], &[("file", "right\n")]);
+    create_commit_with_files(&work_dir, "conflict", &["left", "right"], &[]);
+    work_dir.run_jj(["new", "-r=conflict"]).success();
+
+    // Confirm the file is indeed conflicted before we set it.
+    let show_before = work_dir
+        .run_jj(["file", "show", "-r=conflict", "file"])
+        .stdout
+        .into_raw();
+    assert!(
+        show_before.contains("<<<"),
+        "expected conflict markers, got: {show_before}"
+    );
+
+    let output = work_dir.run_jj_with(|cmd| {
+        cmd.args(["file", "set", "--stdin", "-r=conflict", "file"])
+            .write_stdin("resolved\n")
+    });
+    insta::assert_snapshot!(output, @r"
+    ------- stderr -------
+    Rebased 1 descendant commits
+    Working copy  (@) now at: znkkpsqq 9474ffad (empty) (no description set)
+    Parent commit (@-)      : vruxwmqv 0613e382 conflict | conflict
+    Added 0 files, modified 1 files, removed 0 files
+    [EOF]
+    ");
+
+    // The conflict is now resolved.
+    insta::assert_snapshot!(work_dir.run_jj(["file", "show", "-r=conflict", "file"]), @"
+    resolved
+    [EOF]
+    ");
+    insta::assert_snapshot!(work_dir.run_jj(["debug", "tree", "-r=conflict"]), @r#"
+    file: Ok(Resolved(Some(File { id: FileId("2ab19ae607aabda796309682e0448237aab03047"), executable: false, copy_id: CopyId("") })))
+    [EOF]
+    "#);
+}

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -470,6 +470,20 @@ fn test_rewrite_immutable_commands() {
     [EOF]
     [exit status: 1]
     "#);
+    // file set
+    let output = work_dir.run_jj(["file", "set", "-r=main", "file"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Commit 1ca17106e94f is immutable
+    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    "#);
     // metaedit
     let output = work_dir.run_jj(["metaedit", "-r=main"]);
     insta::assert_snapshot!(output, @r#"

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -456,6 +456,20 @@ fn test_rewrite_immutable_commands() {
     [EOF]
     [exit status: 1]
     "#);
+    // file delete
+    let output = work_dir.run_jj(["file", "delete", "-r=main", "file"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Commit 1ca17106e94f is immutable
+    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    "#);
     // file edit
     let output = work_dir.run_jj(["file", "edit", "-r=main", "file"]);
     insta::assert_snapshot!(output, @r#"

--- a/cli/tests/test_immutable_commits.rs
+++ b/cli/tests/test_immutable_commits.rs
@@ -456,6 +456,20 @@ fn test_rewrite_immutable_commands() {
     [EOF]
     [exit status: 1]
     "#);
+    // file edit
+    let output = work_dir.run_jj(["file", "edit", "-r=main", "file"]);
+    insta::assert_snapshot!(output, @r#"
+    ------- stderr -------
+    Error: Commit 1ca17106e94f is immutable
+    Hint: Could not modify commit: mzvwutvl 1ca17106 main | (conflict) merge
+    Hint: Immutable commits are used to protect shared history.
+    Hint: For more information, see:
+          - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+          - `jj help -k config`, "Set of immutable commits"
+    Hint: This operation would rewrite 1 immutable commits.
+    [EOF]
+    [exit status: 1]
+    "#);
     // metaedit
     let output = work_dir.run_jj(["metaedit", "-r=main"]);
     insta::assert_snapshot!(output, @r#"


### PR DESCRIPTION
Adds three new commands for updating files in arbitrary revisions without moving the working copy:

- `jj file edit`
- `jj file set`
- `jj file delete`

# Checklist

If applicable:

- [X] I have updated `CHANGELOG.md`
- [X] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [X] I have updated the config schema (`cli/src/config-schema.json`)
- [X] I have added/updated tests to cover my changes
- [X] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [X] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
