### PR TITLE
status: don't suggest `jj git fetch` when using non-Git backend

### DIFF
--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -241,7 +241,8 @@ pub(crate) async fn cmd_status(
         }
         writeln!(
             formatter.labeled("hint").with_heading("Hint: "),
-            "Use `jj bookmark list` to see details. Use `jj git fetch` to resolve."
+            "Use `jj bookmark list` to see details. Resolve by fetching an updated bookmark from \
+             the remote."
         )?;
     }
 

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -237,7 +237,7 @@ fn test_status_conflicted_bookmarks() {
     Hint: Use `jj bookmark list` to see details. Use `jj bookmark set <name> -r <rev>` to resolve.
     Warning: These remote bookmarks have conflicts:
       remote_bookmark@origin
-    Hint: Use `jj bookmark list` to see details. Use `jj git fetch` to resolve.
+    Hint: Use `jj bookmark list` to see details. Resolve by fetching an updated bookmark from the remote.
     [EOF]
     ------- stderr -------
     Concurrent modification detected, resolving automatically.


### PR DESCRIPTION
I made the code print a more generic message when using a non-Git backend. We could instead always use the more generic message, but the Git-specific one seems useful when using the Git backend.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
