### PR TITLE
Accept multiple revs in show and show -r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   extracted from the `.doc` field of the alias definition if it is a table
   with `.doc` and `.definition` properties.
 
+* `jj show` now accepts multiple revisions, showing all of them one after the
+  other, behaving closer to `git show`.
+
 ### Fixed bugs
 
 * `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no

--- a/cli/src/commands/show.rs
+++ b/cli/src/commands/show.rs
@@ -14,33 +14,35 @@
 
 use clap_complete::ArgValueCandidates;
 use clap_complete::ArgValueCompleter;
+use futures::TryStreamExt as _;
 use jj_lib::matchers::EverythingMatcher;
 use tracing::instrument;
 
 use crate::cli_util::CommandHelper;
 use crate::cli_util::RevisionArg;
+use crate::cli_util::merge_args_with;
 use crate::command_error::CommandError;
 use crate::complete;
 use crate::diff_util::DiffFormatArgs;
 use crate::ui::Ui;
 
-/// Show commit description and changes in a revision
+/// Show revision metadata and diff
 #[derive(clap::Args, Clone, Debug)]
 #[command(group(clap::ArgGroup::new("revision")))]
 #[command(mut_arg("ignore_all_space", |a| a.short('w')))]
 #[command(mut_arg("ignore_space_change", |a| a.short('b')))]
 pub(crate) struct ShowArgs {
-    /// Show changes in this revision, compared to its parent(s) [default: @]
-    /// [aliases: -r]
-    #[arg(group = "revision", value_name = "REVSET")]
+    /// Show changes in these revisions, compared to their parent(s)
+    /// [default: @] [aliases: -r]
+    #[arg(group = "revision", value_name = "REVSETS")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
-    revision_pos: Option<RevisionArg>,
+    revisions_pos: Option<Vec<RevisionArg>>,
 
-    #[arg(short = 'r', group = "revision", hide = true, value_name = "REVSET")]
+    #[arg(short = 'r', group = "revision", hide = true, value_name = "REVSETS")]
     #[arg(add = ArgValueCompleter::new(complete::revset_expression_all))]
-    revision_opt: Option<RevisionArg>,
+    revisions_opt: Option<Vec<RevisionArg>>,
 
-    /// Render a revision using the given template
+    /// Render each revision using the given template
     ///
     /// You can specify arbitrary template expressions using the
     /// [built-in keywords]. See [`jj help -k templates`] for more information.
@@ -69,14 +71,21 @@ pub(crate) async fn cmd_show(
     args: &ShowArgs,
 ) -> Result<(), CommandError> {
     let workspace_command = command.workspace_helper(ui).await?;
-    let revision_arg = args
-        .revision_pos
-        .as_ref()
-        .or(args.revision_opt.as_ref())
-        .unwrap_or(&RevisionArg::AT);
-    let commit = workspace_command
-        .resolve_single_rev(ui, revision_arg)
-        .await?;
+
+    let revision_args = match (&args.revisions_pos, &args.revisions_opt) {
+        (None, None) => Some(vec![RevisionArg::AT]),
+        (None, Some(args)) | (Some(args), None) => Some(args.clone()),
+        (Some(pos), Some(opt)) => Some(merge_args_with(
+            command.matches().subcommand_matches("new").unwrap(),
+            &[("revisions_pos", pos), ("revisions_opt", opt)],
+            |_id, value| value.clone(),
+        )),
+    };
+
+    let mut commits = workspace_command
+        .parse_union_revsets(ui, revision_args.as_deref().unwrap_or_default())?
+        .evaluate_to_commits()?;
+
     let template_string = match &args.template {
         Some(value) => value.clone(),
         None => workspace_command.settings().get_string("templates.show")?,
@@ -88,11 +97,15 @@ pub(crate) async fn cmd_show(
     ui.request_pager();
     let mut formatter = ui.stdout_formatter();
     let formatter = formatter.as_mut();
-    template.format(&commit, formatter)?;
-    if !args.no_patch {
-        diff_renderer
-            .show_patch(ui, formatter, &commit, &EverythingMatcher, ui.term_width())
-            .await?;
+
+    while let Some(commit) = commits.try_next().await? {
+        template.format(&commit, formatter)?;
+
+        if !args.no_patch {
+            diff_renderer
+                .show_patch(ui, formatter, &commit, &EverythingMatcher, ui.term_width())
+                .await?;
+        }
     }
     Ok(())
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -174,7 +174,7 @@ To get started, see the tutorial [`jj help -k tutorial`].
 * `restore` — Restore paths from another revision
 * `revert` — Apply the reverse of the given revision(s)
 * `root` — Show the current workspace root directory (shortcut for `jj workspace root`)
-* `show` — Show commit description and changes in a revision
+* `show` — Show revision metadata and diff
 * `sign` — Cryptographically sign a revision
 * `simplify-parents` — Simplify parent edges for the specified revision(s)
 * `sparse` — Manage which paths from the working-copy commit are present in the working copy
@@ -2931,17 +2931,17 @@ Show the current workspace root directory (shortcut for `jj workspace root`)
 
 ## `jj show`
 
-Show commit description and changes in a revision
+Show revision metadata and diff
 
-**Usage:** `jj show [OPTIONS] [REVSET]`
+**Usage:** `jj show [OPTIONS] [REVSETS]...`
 
 ###### **Arguments:**
 
-* `<REVSET>` — Show changes in this revision, compared to its parent(s) [default: @] [aliases: -r]
+* `<REVSETS>` — Show changes in these revisions, compared to their parent(s) [default: @] [aliases: -r]
 
 ###### **Options:**
 
-* `-T`, `--template <TEMPLATE>` — Render a revision using the given template
+* `-T`, `--template <TEMPLATE>` — Render each revision using the given template
 
    You can specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -53,9 +53,9 @@ fn test_show() {
     let output = work_dir.run_jj(["show", "@", "-r@-"]);
     insta::assert_snapshot!(output, @"
     ------- stderr -------
-    error: the argument '[REVSET]' cannot be used with '-r <REVSET>'
+    error: the argument '[REVSETS]...' cannot be used with '-r <REVSETS>'
 
-    Usage: jj show <REVSET>
+    Usage: jj show <REVSETS>...
 
     For more information, try '--help'.
     [EOF]
@@ -396,4 +396,165 @@ fn test_show_relative_timestamps() -> TestResult {
     [EOF]
     ");
     Ok(())
+}
+
+#[test]
+fn test_show_multiple_revisions() {
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    work_dir.write_file("file1", "a");
+    work_dir.run_jj(["commit", "-m", "add file1"]).success();
+
+    work_dir.write_file("file2", "b");
+    work_dir.run_jj(["commit", "-m", "add file2"]).success();
+
+    work_dir.write_file("file1", "c");
+    work_dir
+        .run_jj(["describe", "-m", "modify file1"])
+        .success();
+
+    let output = work_dir.run_jj(["show", "root()..@"]);
+    let output = output.normalize_stdout_with(|s| {
+        s.split_inclusive('\n')
+            .filter(|line| !line.starts_with("Change ID") && !line.starts_with("Commit ID"))
+            .collect()
+    });
+
+    insta::assert_snapshot!(output, @"
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:10)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:10)
+
+        modify file1
+
+    Modified regular file file1:
+       1    1: ac
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
+
+        add file2
+
+    Added regular file file2:
+            1: b
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
+
+        add file1
+
+    Added regular file file1:
+            1: a
+    [EOF]
+    ");
+
+    // Specify revision with -r
+    let output = work_dir.run_jj(["show", "-r", "root()..@"]);
+    let output = output.normalize_stdout_with(|s| {
+        s.split_inclusive('\n')
+            .filter(|line| !line.starts_with("Change ID") && !line.starts_with("Commit ID"))
+            .collect()
+    });
+
+    insta::assert_snapshot!(output, @"
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:10)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:10)
+
+        modify file1
+
+    Modified regular file file1:
+       1    1: ac
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
+
+        add file2
+
+    Added regular file file2:
+            1: b
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
+
+        add file1
+
+    Added regular file file1:
+            1: a
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["show", "--no-patch", "root()..@"]);
+    let output = output.normalize_stdout_with(|s| {
+        s.split_inclusive('\n')
+            .filter(|line| !line.starts_with("Change ID") && !line.starts_with("Commit ID"))
+            .collect()
+    });
+
+    insta::assert_snapshot!(output, @"
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:10)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:10)
+
+        modify file1
+
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
+
+        add file2
+
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
+
+        add file1
+
+    [EOF]
+    ");
+
+    let output = work_dir.run_jj(["show", "--git", "root()..@"]);
+    let output = output.normalize_stdout_with(|s| {
+        s.split_inclusive('\n')
+            .filter(|line| {
+                !line.starts_with("Change ID")
+                    && !line.starts_with("Commit ID")
+                    && !line.starts_with("index")
+            })
+            .collect()
+    });
+
+    insta::assert_snapshot!(output, @"
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:10)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:10)
+
+        modify file1
+
+    diff --git a/file1 b/file1
+    --- a/file1
+    +++ b/file1
+    @@ -1,1 +1,1 @@
+    -a
+    \\ No newline at end of file
+    +c
+    \\ No newline at end of file
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
+
+        add file2
+
+    diff --git a/file2 b/file2
+    new file mode 100644
+    --- /dev/null
+    +++ b/file2
+    @@ -0,0 +1,1 @@
+    +b
+    \\ No newline at end of file
+    Author   : Test User <test.user@example.com> (2001-02-03 08:05:08)
+    Committer: Test User <test.user@example.com> (2001-02-03 08:05:08)
+
+        add file1
+
+    diff --git a/file1 b/file1
+    new file mode 100644
+    --- /dev/null
+    +++ b/file1
+    @@ -0,0 +1,1 @@
+    +a
+    \\ No newline at end of file
+    [EOF]
+    ");
 }


### PR DESCRIPTION
I took a crack at implementing the feature I'm missing that I reported in #9513.

It's still not ideal but I thought I'd rather share my attempt and get some feedback than struggle by myself.

I used "new" command implementation as reference for accepting multiple revsets and "git push" command as reference for resolving multiple commit IDs into commits.

I haven't done anything from the checklist yet but I will if/when the PR passes initial review.

Thanks!

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
