### PR TITLE
docs: add author date / committer date entries to glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -8,6 +8,16 @@ Jujutsu keeps commits on anonymous branches around until they are explicitly
 abandoned. Visible anonymous branches are tracked by the [view](#view), which
 stores a list of [heads](#head) of such branches.
 
+## Author date
+
+The author date of a [commit](#commit) records when the commit's changes were
+originally authored. It is set when the commit is first authored and usually
+stays the same when the commit is [rewritten](#rewrite). For a newly-created
+commit, the author date and [committer date](#committer-date) are usually the
+same, but they can differ after history-editing commands such as `jj rebase`,
+`jj describe`, or `jj squash`. When using the Git [backend](#backend), this is
+stored as Git's native author date field.
+
 ## Backend
 
 A backend is an implementation of the storage layer. There is currently only one
@@ -67,8 +77,9 @@ instance, the most recent commit with change ID `xyz` could be referred to as
 
 A snapshot of the files in the repository at a given point in time (technically
 a [tree object](#tree)), together with some metadata. The metadata includes the
-author, the date, and pointers to the commit's parents. Through the pointers to
-the parents, the commits form a
+author, the committer, the [author date](#author-date), the
+[committer date](#committer-date), and pointers to the commit's parents. Through
+the pointers to the parents, the commits form a
 [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph)
 .
 
@@ -87,6 +98,16 @@ A commit ID is a unique identifier for a [commit](#commit). They are 20 bytes
 long when using the Git backend. They are presented in regular hexadecimal
 format at the end of the line in `jj log`, using 12 hexadecimal digits by
 default. When using the Git backend, the commit ID is the Git commit ID.
+
+## Committer date
+
+The committer date of a [commit](#commit) records when that particular commit
+object was created. It is set for a new commit and updated whenever `jj`
+[rewrites](#rewrite) the commit, such as when rebasing, describing, or squashing
+it. For a newly-created commit, the committer date and
+[author date](#author-date) are usually the same, but they can differ after the
+commit has been rewritten. When using the Git [backend](#backend), this is
+stored as Git's native committer date field.
 
 ## <a name="colocated-repos"></a>Colocated workspaces
 

--- a/docs/revsets.md
+++ b/docs/revsets.md
@@ -391,8 +391,8 @@ revsets (expressions) as arguments.
 * `author_email(pattern)`: Commits with the author's email matching the given
   [string pattern](#string-patterns).
 
-* `author_date(pattern)`: Commits with author dates matching the specified [date
-  pattern](#date-patterns).
+* `author_date(pattern)`: Commits with [author dates](glossary.md#author-date)
+  matching the specified [date pattern](#date-patterns).
 
 * `mine()`: Commits where the author's email matches the email of the current
   user. Equivalent to `author_email(exact-i:<user-email>)`
@@ -407,8 +407,9 @@ revsets (expressions) as arguments.
 * `committer_email(pattern)`: Commits with the committer's email matching the
   given [string pattern](#string-patterns).
 
-* `committer_date(pattern)`: Commits with committer dates matching the specified
-  [date pattern](#date-patterns).
+* `committer_date(pattern)`: Commits with
+  [committer dates](glossary.md#committer-date) matching the specified [date
+  pattern](#date-patterns).
 
 * `signed()`: Commits that are cryptographically signed.
 


### PR DESCRIPTION
## Summary

Adds glossary entries for "author date" and "committer date", plus a one-line cross-reference from `revsets.md` where these terms first show up. #9469 flagged that the docs assume the reader knows the Git distinction; this fills the gap without restructuring anything.

## Why this matters

The difference matters for jj specifically because rebase / squash / abandon all preserve author date while committer date floats forward, and revset filters and templates that surface "committer_date" surprise users who expected "the date the commit was created."

## Changes

- `docs/glossary.md` - add `author date` and `committer date` entries with the jj-specific behavior callouts.
- `docs/revsets.md` - link to the new glossary entries from the first mention of these terms.

## Testing

Docs-only change. No code paths affected.

## CLA

Google CLA required. I'll sign on the PR.

Fixes #9469
