### PR TITLE
docs: make builtin_log_redacted templates more discoverable

### DIFF
--- a/cli/src/commands/log.rs
+++ b/cli/src/commands/log.rs
@@ -104,6 +104,8 @@ pub(crate) struct LogArgs {
     ///
     /// Run `jj log -T` to list the built-in templates.
     ///
+    /// For shareable bug reports, use `jj log -T builtin_log_redacted`.
+    ///
     /// You can also specify arbitrary template expressions using the
     /// [built-in keywords]. See [`jj help -k templates`] for more
     /// information.

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -2024,6 +2024,8 @@ The working-copy commit is indicated by a `@` symbol in the graph. [Immutable re
 
    Run `jj log -T` to list the built-in templates.
 
+   For shareable bug reports, use `jj log -T builtin_log_redacted`.
+
    You can also specify arbitrary template expressions using the [built-in keywords]. See [`jj help -k templates`] for more information.
 
    If not specified, this defaults to the `templates.log` setting.

--- a/docs/operation-log.md
+++ b/docs/operation-log.md
@@ -17,6 +17,9 @@ revert a specific one which isn't the most recent operation (`jj op revert`). It
 also lets you restore the entire repo to the way it looked at an earlier point
 (`jj op restore`).
 
+If you need to share operation-log output in a bug report, see
+[redacted log output for bug reports](templates.md#redacted-log-output-for-bug-reports).
+
 When referring to operations, you can use `@` to represent the current
 operation.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -790,6 +790,26 @@ The following methods are defined.
 * `.target() -> Commit`: Returns the working-copy commit of this workspace.
 * `.root() -> Template`: Returns the absolute path to the workspace root.
 
+## Redacted log output for bug reports
+
+Two built-in templates are useful for sharing log output in bug reports or
+support requests:
+
+```sh
+jj log -T builtin_log_redacted -r ::@
+jj op log -T builtin_op_log_redacted
+```
+
+`builtin_log_redacted` keeps the commit graph, change IDs, commit IDs,
+timestamps, and structural labels such as empty, immutable, or conflicted, but
+replaces commit descriptions with `(redacted)`. User, bookmark, tag, and
+workspace names are replaced with stable hashed labels such as `user-0a1b` or
+`workspace-0a1b@`.
+
+`builtin_op_log_redacted` keeps the operation graph, operation IDs, operation
+descriptions, and timestamps. User and workspace names are replaced with stable
+hashed labels, and operation attributes are replaced with `(redacted)`.
+
 ## Color labels
 
 You can [customize the output colors][config-colors] by using color labels. `jj`


### PR DESCRIPTION
## Summary

Surfaces the `builtin_log_redacted` and `builtin_op_log_redacted` templates so users filing bug reports can find them without digging through source. Adds a one-line pointer in `jj log -T` help, a templates.md section listing the redacted variants, and a brief note in operation-log.md.

## Why this matters

#9372 specifically asked for the redacted templates to be discoverable from the bug-report flow. Today the only way a reporter learns about them is from someone replying to their issue with the template name.

## Changes

- `cli/src/commands/log.rs` - add a sentence in the `-T` help pointing at `builtin_log_redacted`.
- `docs/templates.md` - add a "Redacted templates" section.
- `docs/operation-log.md` - note that `builtin_op_log_redacted` exists for sharing op log output.

## Testing

Docs and help text only. Help text was reviewed by running `cargo run -- log --help` locally and confirming the new line renders inline.

## CLA

Google CLA required. I'll sign on the PR.

Fixes #9372
