### PR TITLE
docs: add jj-hunk to community tools

### DIFF
--- a/docs/community_tools.md
+++ b/docs/community_tools.md
@@ -36,6 +36,14 @@ commonly used `jj` operations from rebase to undo, and helps with divergent comm
 
 Find it [here][jj-fzf].
 
+## jj-hunk
+
+jj-hunk is a command-line tool for programmatic hunk selection. It can split,
+commit, and squash selected hunks without opening an interactive diff editor,
+which is useful for scripts and AI coding agents.
+
+Find it [here][jj-hunk].
+
 ## JJ TUI
 
 This is TUI for Jujutsu built in Ocaml, it is unopiniated and its creator is
@@ -100,6 +108,7 @@ You can find other community contributed tools and integrations in our
 [gg]: https://github.com/gulbanana/gg
 [hunk.nvim]: https://github.com/julienvincent/hunk.nvim
 [jj-fzf]: https://github.com/tim-janik/jj-fzf
+[jj-hunk]: https://github.com/laulauland/jj-hunk
 [jj_tui]: https://github.com/faldor20/jj_tui
 [jjk]: https://github.com/keanemind/jjk
 [jjui]: https://github.com/idursun/jjui


### PR DESCRIPTION
I built jj-hunk as a small companion tool for programmatic hunk selection in Jujutsu. It can drive `split`, `commit`, and `squash` without opening an interactive diff editor, which has been useful for scripts and AI coding-agent workflows.

This came out of the use case discussed in [#8218](https://github.com/jj-vcs/jj/issues/8218). Until something like native programmatic hunk selection exists in jj itself, jj-hunk is one external-tool approach people can try today.

Since the community tools page already collects related integrations and diff-editor-adjacent tools, this adds a short entry so people looking for non-interactive hunk selection can discover it.

Docs-only change; I did not run tests.