### PR TITLE
git push: give an actionable hint when a commit is missing a description or identity

### DIFF
--- a/cli/src/commands/git/push.rs
+++ b/cli/src/commands/git/push.rs
@@ -749,6 +749,11 @@ impl<'repo> CommitsValidator<'repo> {
             let mut hint = None;
             if commit.description().is_empty() && !self.allow_empty_description {
                 reasons.push("has no description");
+                hint = Some(format!(
+                    "Run `jj describe {id}` to add a description, or pass \
+                     --allow-empty-description.",
+                    id = short_commit_hash(commit.id()),
+                ));
             }
             if commit.author().name.is_empty()
                 || commit.author().email.is_empty()
@@ -756,6 +761,11 @@ impl<'repo> CommitsValidator<'repo> {
                 || commit.committer().email.is_empty()
             {
                 reasons.push("has no author and/or committer set");
+                hint = Some(format!(
+                    "Run `jj metaedit --update-author {id}` to re-stamp the \
+                     commit with your current jj user.name and user.email.",
+                    id = short_commit_hash(commit.id()),
+                ));
             }
             if commit.has_conflict() {
                 reasons.push("has conflicts");

--- a/cli/tests/test_git_push.rs
+++ b/cli/tests/test_git_push.rs
@@ -1879,6 +1879,7 @@ fn test_git_push_no_description() {
     ------- stderr -------
     Error: Won't push commit 8d23abddc924 since it has no description
     Hint: Rejected commit: yqosqzyt 8d23abdd my-bookmark* | (empty) (no description set)
+    Hint: Run `jj describe 8d23abddc924` to add a description, or pass --allow-empty-description.
     [EOF]
     [exit status: 1]
     ");
@@ -1914,6 +1915,7 @@ fn test_git_push_no_description_in_immutable() {
     ------- stderr -------
     Error: Won't push commit 8d23abddc924 since it has no description
     Hint: Rejected commit: yqosqzyt 8d23abdd imm* | (empty) (no description set)
+    Hint: Run `jj describe 8d23abddc924` to add a description, or pass --allow-empty-description.
     [EOF]
     [exit status: 1]
     ");
@@ -1947,6 +1949,7 @@ fn test_git_push_missing_author() {
     ------- stderr -------
     Error: Won't push commit 613adaba9d49 since it has no author and/or committer set
     Hint: Rejected commit: vruxwmqv 613adaba missing-name* | (empty) initial
+    Hint: Run `jj metaedit --update-author 613adaba9d49` to re-stamp the commit with your current jj user.name and user.email.
     [EOF]
     [exit status: 1]
     ");
@@ -1957,6 +1960,7 @@ fn test_git_push_missing_author() {
     ------- stderr -------
     Error: Won't push commit bb4ea60fc9ba since it has no author and/or committer set
     Hint: Rejected commit: kpqxywon bb4ea60f missing-email* | (empty) initial
+    Hint: Run `jj metaedit --update-author bb4ea60fc9ba` to re-stamp the commit with your current jj user.name and user.email.
     [EOF]
     [exit status: 1]
     ");
@@ -1989,6 +1993,7 @@ fn test_git_push_missing_author_in_immutable() {
     ------- stderr -------
     Error: Won't push commit 5c3cc711907f since it has no author and/or committer set
     Hint: Rejected commit: yostqsxw 5c3cc711 imm* | (empty) no author email
+    Hint: Run `jj metaedit --update-author 5c3cc711907f` to re-stamp the commit with your current jj user.name and user.email.
     [EOF]
     [exit status: 1]
     ");
@@ -2024,6 +2029,7 @@ fn test_git_push_missing_committer() {
     ------- stderr -------
     Error: Won't push commit e8a77cb24da9 since it has no author and/or committer set
     Hint: Rejected commit: yqosqzyt e8a77cb2 missing-name* | (empty) no committer name
+    Hint: Run `jj metaedit --update-author e8a77cb24da9` to re-stamp the commit with your current jj user.name and user.email.
     [EOF]
     [exit status: 1]
     ");
@@ -2037,6 +2043,7 @@ fn test_git_push_missing_committer() {
     ------- stderr -------
     Error: Won't push commit 971c50fd8d1d since it has no author and/or committer set
     Hint: Rejected commit: kpqxywon 971c50fd missing-email* | (empty) no committer email
+    Hint: Run `jj metaedit --update-author 971c50fd8d1d` to re-stamp the commit with your current jj user.name and user.email.
     [EOF]
     [exit status: 1]
     ");
@@ -2049,6 +2056,7 @@ fn test_git_push_missing_committer() {
     ------- stderr -------
     Error: Won't push commit 4bd3b55c7759 since it has no description and has no author and/or committer set
     Hint: Rejected commit: kpqxywon 4bd3b55c missing-email* | (empty) (no description set)
+    Hint: Run `jj metaedit --update-author 4bd3b55c7759` to re-stamp the commit with your current jj user.name and user.email.
     [EOF]
     [exit status: 1]
     ");
@@ -2082,6 +2090,7 @@ fn test_git_push_missing_committer_in_immutable() {
     ------- stderr -------
     Error: Won't push commit ab230f98c812 since it has no author and/or committer set
     Hint: Rejected commit: yostqsxw ab230f98 imm* | (empty) no committer email
+    Hint: Run `jj metaedit --update-author ab230f98c812` to re-stamp the commit with your current jj user.name and user.email.
     [EOF]
     [exit status: 1]
     ");
@@ -2613,6 +2622,7 @@ fn test_git_push_commits_not_ready() {
     ------- stderr -------
     Warning: Won't push bookmark bookmark2: commit b63db0e60f60 has no author and/or committer set
       vruxwmqv b63db0e6 bookmark2* | (empty) commit not suitable
+    Hint: Run `jj metaedit --update-author b63db0e60f60` to re-stamp the commit with your current jj user.name and user.email.
     Nothing changed.
     [EOF]
     ");
@@ -2640,6 +2650,7 @@ fn test_git_push_commits_not_ready() {
     ------- stderr -------
     Warning: Won't push bookmark bookmark2: commit b63db0e60f60 has no author and/or committer set
       vruxwmqv b63db0e6 bookmark2* | (empty) commit not suitable
+    Hint: Run `jj metaedit --update-author b63db0e60f60` to re-stamp the commit with your current jj user.name and user.email.
     Nothing changed.
     [EOF]
     ");


### PR DESCRIPTION
Closes #9520.

The Hint that followed *Won't push commit ... since it has no description* just repeated the rejected commit summary, so the user had no signal about how to fix it. Surface a concrete next step:

```
Hint: Run \`jj describe <id>\` to add a description, or pass --allow-empty-description.
```

Same treatment for the missing-author/committer case: point users at `jj config set --user user.name '...'`.