### PR TITLE
diff: avoid word inlining without color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed bugs
 
+* Color-words diffs are now shown as separate before and after lines when color
+  output is disabled, making piped or redirected diffs readable.
+  [#5894](https://github.com/jj-vcs/jj/issues/5894)
+
 * `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no
   local bookmarks were actually forgotten (e.g. when only an untracked remote
   bookmark matched). [#9181](https://github.com/jj-vcs/jj/issues/9181).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,6 +2516,7 @@ name = "jj-cli"
 version = "0.41.0"
 dependencies = [
  "ansi-to-tui",
+ "anstream",
  "assert_cmd",
  "assert_matches",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["VCS", "DVCS", "SCM", "Git", "Mercurial"]
 
 [workspace.dependencies]
 ansi-to-tui = "8.0.1"
+anstream = "1.0.0"
 assert_cmd = "2.2.2"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -119,6 +119,7 @@ libc = { workspace = true }
 nix = { workspace = true, features = [ "signal" ] }
 
 [dev-dependencies]
+anstream = { workspace = true }
 assert_cmd = { workspace = true }
 assert_matches = { workspace = true }
 async-trait = { workspace = true }

--- a/cli/src/diff_util.rs
+++ b/cli/src/diff_util.rs
@@ -1101,13 +1101,19 @@ fn show_color_words_diff_lines(
     let word_diff_hunks = ContentDiff::by_word(contents.into_array())
         .hunks()
         .collect_vec();
-    let can_inline = match options.max_inline_alternation {
-        None => true,     // unlimited
-        Some(0) => false, // no need to count alternation
-        Some(max_num) => {
-            let groups = split_diff_hunks_by_matching_newline(&word_diff_hunks);
-            groups.map(count_diff_alternation).max().unwrap_or(0) <= max_num
+    let can_inline = if formatter.maybe_color() {
+        match options.max_inline_alternation {
+            None => true,     // unlimited
+            Some(0) => false, // no need to count alternation
+            Some(max_num) => {
+                let groups = split_diff_hunks_by_matching_newline(&word_diff_hunks);
+                groups.map(count_diff_alternation).max().unwrap_or(0) <= max_num
+            }
         }
+    } else {
+        // Inline word hunks rely on color labels to distinguish sides. Without
+        // color support, show separate before/after lines instead.
+        false
     };
     if can_inline {
         let mut diff_line_iter =

--- a/cli/tests/test_acls.rs
+++ b/cli/tests/test_acls.rs
@@ -41,13 +41,15 @@ fn test_diff() {
     let output = work_dir.run_jj(["diff", "--color-words"]);
     insta::assert_snapshot!(output.normalize_backslash(), @"
     Modified regular file a-first:
-       1    1: foobar
+       1     : foo
+            1: bar
     Access denied to added-secret: No access
     Access denied to deleted-secret: No access
     Access denied to dir/secret: No access
     Access denied to modified-secret: No access
     Modified regular file z-last:
-       1    1: foobar
+       1     : foo
+            1: bar
     [EOF]
     ");
     let output = work_dir.run_jj(["diff", "--summary"]);

--- a/cli/tests/test_commit_template.rs
+++ b/cli/tests/test_commit_template.rs
@@ -1239,7 +1239,8 @@ fn test_log_diff_predefined_formats() -> TestResult {
        2    2: b
             3: c
     Modified regular file repo/file2:
-       1    1: ab
+       1     : a
+            1: b
             2: c
     Modified regular file repo/rename-target (repo/rename-source => repo/rename-target):
     === git ===

--- a/cli/tests/test_diff_command.rs
+++ b/cli/tests/test_diff_command.rs
@@ -24,6 +24,10 @@ use crate::common::create_commit_with_files;
 use crate::common::fake_diff_editor_path;
 use crate::common::to_toml_value;
 
+fn strip_ansi_escape_codes(output: String) -> String {
+    anstream::adapter::strip_str(&output).to_string()
+}
+
 #[test]
 fn test_diff_basic() {
     let test_env = TestEnvironment::default();
@@ -42,7 +46,8 @@ fn test_diff_basic() {
     insta::assert_snapshot!(output, @"
     Modified regular file file2:
        1    1: 1
-       2    2: 25
+       2     : 2
+            2: 5
        3    3: 3
        4     : 4
     Modified regular file file3 (file1 => file3):
@@ -54,7 +59,8 @@ fn test_diff_basic() {
     insta::assert_snapshot!(output, @"
     Modified regular file file2:
        1    1: 1
-       2    2: 25
+       2     : 2
+            2: 5
        3    3: 3
        4     : 4
     Modified regular file file3 (file1 => file3):
@@ -304,7 +310,8 @@ fn test_diff_basic() {
     M file2
     Modified regular file file2:
        1    1: 1
-       2    2: 25
+       2     : 2
+            2: 5
        3    3: 3
        4     : 4
     [EOF]
@@ -485,7 +492,8 @@ fn test_diff_file_mode() {
             1: 2
     Executable file became non-executable at file2:
     Non-executable file became executable at file3:
-       1    1: 12
+       1     : 1
+            1: 2
     Non-executable file became executable at file4:
     [EOF]
     ");
@@ -781,25 +789,33 @@ fn test_diff_relative_paths() {
     #[cfg(unix)]
     insta::assert_snapshot!(output, @"
     Modified regular file file2:
-       1    1: foo2bar2
+       1     : foo2
+            1: bar2
     Modified regular file subdir1/file3:
-       1    1: foo3bar3
+       1     : foo3
+            1: bar3
     Modified regular file ../dir2/file4:
-       1    1: foo4bar4
+       1     : foo4
+            1: bar4
     Modified regular file ../file1:
-       1    1: foo1bar1
+       1     : foo1
+            1: bar1
     [EOF]
     ");
     #[cfg(windows)]
     insta::assert_snapshot!(output, @r"
     Modified regular file file2:
-       1    1: foo2bar2
+       1     : foo2
+            1: bar2
     Modified regular file subdir1\file3:
-       1    1: foo3bar3
+       1     : foo3
+            1: bar3
     Modified regular file ..\dir2\file4:
-       1    1: foo4bar4
+       1     : foo4
+            1: bar4
     Modified regular file ..\file1:
-       1    1: foo1bar1
+       1     : foo1
+            1: bar1
     [EOF]
     ");
 
@@ -917,8 +933,9 @@ fn test_diff_hunks() {
        1     : foo
     Modified regular file file3:
        1    1: foo
+       2     : baz qux blah blah
             2: bar
-       2    3: baz quxquux blah blah
+            3: baz quux blah blah
     [EOF]
     ");
 
@@ -997,6 +1014,10 @@ fn test_diff_color_words_inlining_threshold() {
     let render_diff = |max_alternation: i32, args: &[&str]| {
         let config = format!("diff.color-words.max-inline-alternation={max_alternation}");
         work_dir.run_jj_with(|cmd| cmd.args(["diff", "--config", &config]).args(args))
+    };
+    let render_color_diff = |max_alternation| {
+        render_diff(max_alternation, &["--color=always"])
+            .normalize_stdout_with(strip_ansi_escape_codes)
     };
 
     let file1_path = "file1-single-line";
@@ -1097,7 +1118,9 @@ fn test_diff_color_words_inlining_threshold() {
     );
 
     // default
-    let output = work_dir.run_jj(["diff"]);
+    let output = work_dir
+        .run_jj(["diff", "--color=always"])
+        .normalize_stdout_with(strip_ansi_escape_codes);
     insta::assert_snapshot!(output, @"
     Modified regular file file1-single-line:
        1    1: == adds ==
@@ -1145,7 +1168,7 @@ fn test_diff_color_words_inlining_threshold() {
     ");
 
     // -1: inline all
-    insta::assert_snapshot!(render_diff(-1, &[]), @"
+    insta::assert_snapshot!(render_color_diff(-1), @"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1188,7 +1211,7 @@ fn test_diff_color_words_inlining_threshold() {
     ");
 
     // 0: no inlining
-    insta::assert_snapshot!(render_diff(0, &[]), @"
+    insta::assert_snapshot!(render_color_diff(0), @"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2     : a b c
@@ -1246,7 +1269,7 @@ fn test_diff_color_words_inlining_threshold() {
     ");
 
     // 1: inline adds-only or removes-only lines
-    insta::assert_snapshot!(render_diff(1, &[]), @"
+    insta::assert_snapshot!(render_color_diff(1), @"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1300,7 +1323,7 @@ fn test_diff_color_words_inlining_threshold() {
     ");
 
     // 2: inline up to adds + removes lines
-    insta::assert_snapshot!(render_diff(2, &[]), @"
+    insta::assert_snapshot!(render_color_diff(2), @"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1349,7 +1372,7 @@ fn test_diff_color_words_inlining_threshold() {
     ");
 
     // 3: inline up to adds + removes + adds lines
-    insta::assert_snapshot!(render_diff(3, &[]), @"
+    insta::assert_snapshot!(render_color_diff(3), @"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1396,7 +1419,7 @@ fn test_diff_color_words_inlining_threshold() {
     ");
 
     // 4: inline up to adds + removes + adds + removes lines
-    insta::assert_snapshot!(render_diff(4, &[]), @"
+    insta::assert_snapshot!(render_color_diff(4), @"
     Modified regular file file1-single-line:
        1    1: == adds ==
        2    2: a X b Y Z c
@@ -1596,7 +1619,9 @@ fn test_diff_color_words_omit_blank_right_line() {
         "},
     );
 
-    let output = work_dir.run_jj(["diff"]);
+    let output = work_dir
+        .run_jj(["diff", "--color=always"])
+        .normalize_stdout_with(strip_ansi_escape_codes);
     insta::assert_snapshot!(output, @"
     Modified regular file file1:
        1    1: a x
@@ -1631,11 +1656,13 @@ fn test_diff_missing_newline() {
     let output = work_dir.run_jj(["diff"]);
     insta::assert_snapshot!(output, @"
     Modified regular file file1:
-       1    1: foo
+       1     : foo
+            1: foo
             2: bar
     Modified regular file file2:
-       1    1: foo
+       1     : foo
        2     : bar
+            1: foo
     [EOF]
     ");
 
@@ -1708,13 +1735,16 @@ fn test_color_words_diff_missing_newline() {
     work_dir.write_file("file1", "");
     work_dir.run_jj(["commit", "-m", "=== Empty"]).success();
 
-    let output = work_dir.run_jj([
-        "log",
-        "-Tdescription",
-        "-pr::@-",
-        "--no-graph",
-        "--reversed",
-    ]);
+    let output = work_dir
+        .run_jj([
+            "log",
+            "-Tdescription",
+            "-pr::@-",
+            "--no-graph",
+            "--reversed",
+            "--color=always",
+        ])
+        .normalize_stdout_with(strip_ansi_escape_codes);
     insta::assert_snapshot!(output, @"
     === Empty
     Added regular file file1:
@@ -1783,14 +1813,17 @@ fn test_color_words_diff_missing_newline() {
     [EOF]
     ");
 
-    let output = work_dir.run_jj([
-        "log",
-        "--config=diff.color-words.max-inline-alternation=0",
-        "-Tdescription",
-        "-pr::@-",
-        "--no-graph",
-        "--reversed",
-    ]);
+    let output = work_dir
+        .run_jj([
+            "log",
+            "--config=diff.color-words.max-inline-alternation=0",
+            "-Tdescription",
+            "-pr::@-",
+            "--no-graph",
+            "--reversed",
+            "--color=always",
+        ])
+        .normalize_stdout_with(strip_ansi_escape_codes);
     insta::assert_snapshot!(output, @"
     === Empty
     Added regular file file1:
@@ -2055,7 +2088,8 @@ fn test_diff_skipped_context() {
            10: j
     === Must skip 2 lines
     Modified regular file file1:
-       1    1: aA
+       1     : a
+            1: A
        2    2: b
        3    3: c
        4    4: d
@@ -2063,10 +2097,12 @@ fn test_diff_skipped_context() {
        7    7: g
        8    8: h
        9    9: i
-      10   10: jJ
+      10     : j
+           10: J
     === Don't skip 1 line
     Modified regular file file1:
-       1    1: aA
+       1     : a
+            1: A
        2    2: b
        3    3: c
        4    4: d
@@ -2074,31 +2110,36 @@ fn test_diff_skipped_context() {
        6    6: f
        7    7: g
        8    8: h
-       9    9: iI
+       9     : i
+            9: I
       10   10: j
     === No gap to skip
     Modified regular file file1:
        1    1: a
-       2    2: bB
+       2     : b
+            2: B
        3    3: c
        4    4: d
        5    5: e
        6    6: f
        7    7: g
        8    8: h
-       9    9: iI
+       9     : i
+            9: I
       10   10: j
     === No gap to skip
     Modified regular file file1:
        1    1: a
        2    2: b
-       3    3: cC
+       3     : c
+            3: C
        4    4: d
        5    5: e
        6    6: f
        7    7: g
        8    8: h
-       9    9: iI
+       9     : i
+            9: I
       10   10: j
     === 1 line at start
     Modified regular file file1:
@@ -2106,7 +2147,8 @@ fn test_diff_skipped_context() {
        2    2: b
        3    3: c
        4    4: d
-       5    5: eE
+       5     : e
+            5: E
        6    6: f
        7    7: g
        8    8: h
@@ -2117,7 +2159,8 @@ fn test_diff_skipped_context() {
        3    3: c
        4    4: d
        5    5: e
-       6    6: fF
+       6     : f
+            6: F
        7    7: g
        8    8: h
        9    9: i
@@ -2149,7 +2192,16 @@ context = 0
         .success();
     work_dir.write_file("file1", "a\nb\nC\nd\ne");
 
-    let output = work_dir.run_jj(["log", "-Tdescription", "-p", "--no-graph", "--reversed"]);
+    let output = work_dir
+        .run_jj([
+            "log",
+            "-Tdescription",
+            "-p",
+            "--no-graph",
+            "--reversed",
+            "--color=always",
+        ])
+        .normalize_stdout_with(strip_ansi_escape_codes);
     insta::assert_snapshot!(output, @"
     === First commit
     Added regular file file1:
@@ -2273,30 +2325,38 @@ fn test_diff_skipped_context_nondefault() {
             4: d
     === Must skip 2 lines
     Modified regular file file1:
-       1    1: aA
+       1     : a
+            1: A
         ...
-       4    4: dD
+       4     : d
+            4: D
     === Don't skip 1 line
     Modified regular file file1:
-       1    1: aA
+       1     : a
+            1: A
        2    2: b
-       3    3: cC
+       3     : c
+            3: C
        4    4: d
     === No gap to skip
     Modified regular file file1:
        1    1: a
-       2    2: bB
-       3    3: cC
+       2     : b
+       3     : c
+            2: B
+            3: C
        4    4: d
     === 1 line at start
     Modified regular file file1:
        1    1: a
-       2    2: bB
+       2     : b
+            2: B
         ...
     === 1 line at end
     Modified regular file file1:
         ...
-       3    3: cC
+       3     : c
+            3: C
        4    4: d
     [EOF]
     ");

--- a/cli/tests/test_evolog_command.rs
+++ b/cli/tests/test_evolog_command.rs
@@ -80,7 +80,8 @@ fn test_evolog_with_or_without_diff() {
     │     5     : +++++++ rlvkpnrz 51e08f95 "my description" (rebased revision)
     │     6     : foo
     │     7     : bar
-    │     8    1: >>>>>>> conflict 1 of 1 endsresolved
+    │     8     : >>>>>>> conflict 1 of 1 ends
+    │          1: resolved
     ×  rlvkpnrz/1 test.user@example.com 2001-02-03 08:05:09 cdf175ef (hidden) (conflict)
     │  my description
     │  -- operation 449a03ec4824 rebase commit 51e08f95160c897080d035d330aead3ee6ed5588
@@ -422,14 +423,15 @@ fn test_evolog_squash() {
     │ │ │  Modified commit description:
     │ │ │     1     : <<<<<<< conflict 1 of 1
     │ │ │     2     : +++++++ side #1
-    │ │ │     3    1: squashed 2
+    │ │ │     3     : squashed 2
     │ │ │     4     : %%%%%%% diff from: base #1
     │ │ │     5     : \\\\\\\        to: side #2
     │ │ │     6     : +fourth
     │ │ │     7     : %%%%%%% diff from: base #2
-    │ │ │     8    1: \\\\\\\        to: side #3
+    │ │ │     8     : \\\\\\\        to: side #3
     │ │ │     9     : +fifth
     │ │ │    10     : >>>>>>> conflict 1 of 1 ends
+    │ │ │          1: squashed 3
     │ │ ○  vruxwmqv/0 test.user@example.com 2001-02-03 08:05:15 770795d0 (hidden)
     │ │ │  fifth
     │ │ │  -- operation d727647433c1 snapshot working copy
@@ -456,11 +458,12 @@ fn test_evolog_squash() {
     │ │  Modified commit description:
     │ │     1     : <<<<<<< conflict 1 of 1
     │ │     2     : +++++++ side #1
-    │ │     3    1: squashed 1
+    │ │     3     : squashed 1
     │ │     4     : %%%%%%% diff from: base
-    │ │     5    1: \\\\\\\        to: side #2
+    │ │     5     : \\\\\\\        to: side #2
     │ │     6     : +third
     │ │     7     : >>>>>>> conflict 1 of 1 ends
+    │ │          1: squashed 2
     │ │  Removed regular file file2:
     │ │     1     : foo2
     │ │  Removed regular file file3:

--- a/cli/tests/test_interdiff_command.rs
+++ b/cli/tests/test_interdiff_command.rs
@@ -40,7 +40,8 @@ fn test_interdiff_basic() {
     let output = work_dir.run_jj(["interdiff", "--from", "left"]);
     insta::assert_snapshot!(output, @"
     Modified commit description:
-       1    1: add file2 leftright
+       1     : add file2 left
+            1: add file2 right
     Modified regular file file2:
        1    1: foo
             2: bar
@@ -52,7 +53,8 @@ fn test_interdiff_basic() {
     let output = work_dir.run_jj(["interdiff", "--from", "left", "--to", "right"]);
     insta::assert_snapshot!(output, @"
     Modified commit description:
-       1    1: add file2 leftright
+       1     : add file2 left
+            1: add file2 right
     Modified regular file file2:
        1    1: foo
             2: bar
@@ -114,7 +116,8 @@ fn test_interdiff_paths() {
     let output = work_dir.run_jj(["interdiff", "--from", "left", "--to", "right", "file1"]);
     insta::assert_snapshot!(output, @"
     Modified regular file file1:
-       1    1: barbaz
+       1     : bar
+            1: baz
     [EOF]
     ");
 
@@ -130,9 +133,11 @@ fn test_interdiff_paths() {
     ]);
     insta::assert_snapshot!(output, @"
     Modified regular file file1:
-       1    1: barbaz
+       1     : bar
+            1: baz
     Modified regular file file2:
-       1    1: barbaz
+       1     : bar
+            1: baz
     [EOF]
     ------- stderr -------
     Warning: No matching entries for paths: nonexistent
@@ -157,7 +162,8 @@ fn test_interdiff_paths() {
     Removed regular file file1:
        1     : bar
     Modified regular file file2:
-       1    1: barbaz
+       1     : bar
+            1: baz
     [EOF]
     ");
 }

--- a/cli/tests/test_metaedit_command.rs
+++ b/cli/tests/test_metaedit_command.rs
@@ -347,7 +347,8 @@ fn test_metaedit() {
         (no description set)
 
     Modified regular file file1:
-       1    1: bc
+       1     : b
+            1: c
     [EOF]
     ");
 

--- a/cli/tests/test_show_command.rs
+++ b/cli/tests/test_show_command.rs
@@ -98,8 +98,9 @@ fn test_show_basic() {
 
     Modified regular file file2:
        1    1: foo
+       2     : baz qux
             2: bar
-       2    3: baz quxquux
+            3: baz quux
     Modified regular file file3 (file1 => file3):
     [EOF]
     ");
@@ -115,8 +116,9 @@ fn test_show_basic() {
 
     Modified regular file file2:
        1    1: foo
+       2     : baz qux
             2: bar
-       2    3: baz quxquux
+            3: baz quux
     Modified regular file file3 (file1 => file3):
     [EOF]
     ");
@@ -440,7 +442,8 @@ fn test_show_multiple_revisions() {
         modify file1
 
     Modified regular file file1:
-       1    1: ac
+       1     : a
+            1: c
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 
@@ -473,7 +476,8 @@ fn test_show_multiple_revisions() {
         modify file1
 
     Modified regular file file1:
-       1    1: ac
+       1     : a
+            1: c
     Author   : Test User <test.user@example.com> (2001-02-03 08:05:09)
     Committer: Test User <test.user@example.com> (2001-02-03 08:05:09)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -435,10 +435,13 @@ diff-formatter = ":git"
 
 #### Color-words diff options
 
-In color-words diffs, changed words are displayed inline by default. Because
-it's difficult to read a diff line with many removed/added words, there's a
-threshold to switch to traditional separate-line format. You can also change
-the default number of lines of context shown.
+In color-words diffs, changed words are displayed inline by default when color
+is enabled. When the formatter cannot emit color, changed words are always shown
+on separate lines because inline changes would not be distinguishable.
+
+Because it's difficult to read a diff line with many removed/added words, there's
+a threshold to switch to traditional separate-line format in colorized output.
+You can also change the default number of lines of context shown.
 
 * `max-inline-alternation`: Maximum number of removed/added word alternation to
   inline. For example, `<added> ... <added>` sequence has 1 alternation, so the


### PR DESCRIPTION
Color-words diffs use formatter labels to distinguish removed and added tokens. When color is disabled, those labels are invisible, so inline word changes can collapse into unreadable text when stdout is not a TTY.

Render color-words hunks as separate before and after lines whenever the formatter cannot emit color. This keeps the default diff format stable while making piped or redirected output readable.

The color-words threshold tests force color output because the threshold matrix is only meaningful when color is available. Without it, all threshold values take the same separate-line path, making the coverage identical regardless of the setting. ANSI sequences are stripped before snapshotting to keep the snapshots readable.

This does not make redirected diffs into git-format patches. Users still need --git for patch exchange or tools that require unified diff input.

Fixes #5894.
Related to #6972.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
