### PR TITLE
description: `ui.add-description-comment-hint` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,11 @@ Thanks to the people who made this release happen!
 * `JJ_PAGER` can now override the `ui.pager` config, matching `JJ_EDITOR` for
   callers that need a jj-specific environment override.
 
+* New `ui.add-description-comment-hint` configuration option (default `true`)
+  which, when set to `false`, omits the comment hint appended to description
+  editor buffers: `JJ: Lines starting with "JJ:" (like this one) will be
+  removed.`.
+
 ### Fixed bugs
 
 * Improving consistency with `git` handling of `.gitignore`, including `/`

--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -1720,6 +1720,12 @@ to the current parents may contain changes from multiple commits.
         TextEditor::from_settings(self.settings())
     }
 
+    /// Whether to add a comment hint to `jjdescription` buffers describing how
+    /// lines beginning with "JJ:" will be removed. Defaults to `true`.
+    pub fn should_add_description_comment_hint(&self) -> Result<bool, ConfigGetError> {
+        self.settings().get_bool("ui.add-description-comment-hint")
+    }
+
     pub fn resolve_single_op(&self, op_str: &str) -> Result<Operation, OpsetEvaluationError> {
         op_walk::resolve_op_with_repo(self.repo(), op_str).block_on()
     }

--- a/cli/src/commands/commit.rs
+++ b/cli/src/commands/commit.rs
@@ -103,6 +103,7 @@ pub(crate) async fn cmd_commit(
     let diff_selector =
         workspace_command.diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let text_editor = workspace_command.text_editor()?;
+    let add_comment_hint = workspace_command.should_add_description_comment_hint()?;
     let mut tx = workspace_command.start_transaction();
     let base_tree = commit.parent_tree(tx.repo()).await?;
     let format_instructions = || {
@@ -160,7 +161,7 @@ new working-copy commit.
         let temp_commit = commit_builder.write_hidden().await?;
         let intro = "";
         let description = description_template(ui, &tx, intro, &temp_commit)?;
-        let description = edit_description(&text_editor, &description)?;
+        let description = edit_description(&text_editor, &description, add_comment_hint)?;
         if description.is_empty() {
             writedoc!(
                 ui.hint_default(),

--- a/cli/src/commands/describe.rs
+++ b/cli/src/commands/describe.rs
@@ -111,6 +111,7 @@ pub(crate) async fn cmd_describe(
         return Ok(());
     }
     let text_editor = workspace_command.text_editor()?;
+    let add_comment_hint = workspace_command.should_add_description_comment_hint()?;
 
     let mut tx = workspace_command.start_transaction();
     let tx_description = match commits.as_slice() {
@@ -179,7 +180,7 @@ pub(crate) async fn cmd_describe(
         if let [(_, temp_commit)] = &*temp_commits {
             let intro = "";
             let template = description_template(ui, &tx, intro, temp_commit)?;
-            let description = edit_description(&text_editor, &template)?;
+            let description = edit_description(&text_editor, &template, add_comment_hint)?;
             commit_builders[0].set_description(description);
         } else {
             let ParsedBulkEditMessage {
@@ -187,7 +188,7 @@ pub(crate) async fn cmd_describe(
                 missing,
                 duplicates,
                 unexpected,
-            } = edit_multiple_descriptions(ui, &text_editor, &tx, &temp_commits)?;
+            } = edit_multiple_descriptions(ui, &text_editor, &tx, &temp_commits, add_comment_hint)?;
             if !missing.is_empty() {
                 return Err(user_error(format!(
                     "The description for the following commits were not found in the edited \

--- a/cli/src/commands/split.rs
+++ b/cli/src/commands/split.rs
@@ -287,6 +287,7 @@ pub(crate) async fn cmd_split(
         new_child_ids,
     } = args.resolve(ui, &workspace_command).await?;
     let text_editor = workspace_command.text_editor()?;
+    let add_comment_hint = workspace_command.should_add_description_comment_hint()?;
     let mut tx = workspace_command.start_transaction();
 
     // Prompt the user to select the changes they want for the first commit.
@@ -323,7 +324,7 @@ pub(crate) async fn cmd_split(
             let temp_commit = commit_builder.write_hidden().await?;
             let intro = "Enter a description for the selected changes.";
             let template = description_template(ui, &tx, intro, &temp_commit)?;
-            edit_description(&text_editor, &template)?
+            edit_description(&text_editor, &template, add_comment_hint)?
         } else {
             description
         };
@@ -386,7 +387,7 @@ pub(crate) async fn cmd_split(
             let temp_commit = commit_builder.write_hidden().await?;
             let intro = "Enter a description for the remaining changes.";
             let template = description_template(ui, &tx, intro, &temp_commit)?;
-            edit_description(&text_editor, &template)?
+            edit_description(&text_editor, &template, add_comment_hint)?
         } else {
             description
         };

--- a/cli/src/commands/squash.rs
+++ b/cli/src/commands/squash.rs
@@ -315,6 +315,9 @@ pub(crate) async fn cmd_squash(
         tx.base_workspace_helper()
             .diff_selector(ui, args.tool.as_deref(), args.interactive)?;
     let text_editor = tx.base_workspace_helper().text_editor()?;
+    let add_comment_hint = tx
+        .base_workspace_helper()
+        .should_add_description_comment_hint()?;
     let squashed_description = SquashedDescription::from_args(args);
 
     let source_commits =
@@ -355,7 +358,7 @@ pub(crate) async fn cmd_squash(
                     let temp_commit = commit_builder.write_hidden().await?;
                     let intro = "";
                     let template = description_template(ui, &tx, intro, &temp_commit)?;
-                    edit_description(&text_editor, &template)?
+                    edit_description(&text_editor, &template, add_comment_hint)?
                 } else {
                     description_with_trailers
                 }
@@ -376,7 +379,7 @@ pub(crate) async fn cmd_squash(
             let temp_commit = commit_builder.write_hidden().await?;
             let intro = "Enter a description for the combined commit.";
             let template = description_template(ui, &tx, intro, &temp_commit)?;
-            edit_description(&text_editor, &template)?
+            edit_description(&text_editor, &template, add_comment_hint)?
         };
         commit_builder.set_description(description);
         if insert_destination_commit {

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -295,6 +295,11 @@
                             "committer-date-"
                         ]
                     }
+                },
+                "add-description-comment-hint": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to add the comment hint to description editor buffers: `JJ: Lines starting with \"JJ:\" (like this one) will be removed.`"
                 }
             }
         },

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -46,6 +46,7 @@ conflict-marker-style = "diff"
 show-cryptographic-signatures = false
 bookmark-list-sort-keys = ["name"]
 tag-list-sort-keys = ["name"]
+add-description-comment-hint = true
 
 [ui.movement]
 edit = false

--- a/cli/src/description_util.rs
+++ b/cli/src/description_util.rs
@@ -166,10 +166,17 @@ where
     text_util::complete_newline(description.trim_matches('\n'))
 }
 
-pub fn edit_description(editor: &TextEditor, description: &str) -> Result<String, CommandError> {
+pub fn edit_description(
+    editor: &TextEditor,
+    description: &str,
+    add_comment_hint: bool,
+) -> Result<String, CommandError> {
     let mut description = description.to_owned();
-    append_blank_line(&mut description);
-    description.push_str("JJ: Lines starting with \"JJ:\" (like this one) will be removed.\n");
+
+    if add_comment_hint {
+        append_blank_line(&mut description);
+        description.push_str("JJ: Lines starting with \"JJ:\" (like this one) will be removed.\n");
+    }
 
     let description = editor
         .edit_str(description, Some(".jjdescription"))
@@ -184,6 +191,7 @@ pub fn edit_multiple_descriptions(
     editor: &TextEditor,
     tx: &WorkspaceCommandTransaction,
     commits: &[(&CommitId, Commit)],
+    add_comment_hint: bool,
 ) -> Result<ParsedBulkEditMessage<CommitId>, CommandError> {
     let mut commits_map = IndexMap::new();
     let mut bulk_message = String::new();
@@ -195,7 +203,10 @@ pub fn edit_multiple_descriptions(
         JJ: - The syntax of the separator lines may change in the future.
         JJ:
     "#});
-    for (commit_id, temp_commit) in commits {
+    for (i, (commit_id, temp_commit)) in commits.iter().enumerate() {
+        if i > 0 {
+            append_blank_line(&mut bulk_message);
+        }
         let commit_hash = short_commit_hash(commit_id);
         bulk_message.push_str("JJ: describe ");
         bulk_message.push_str(&commit_hash);
@@ -204,9 +215,12 @@ pub fn edit_multiple_descriptions(
         let intro = "";
         let template = description_template(ui, tx, intro, temp_commit)?;
         bulk_message.push_str(&template);
-        append_blank_line(&mut bulk_message);
     }
-    bulk_message.push_str("JJ: Lines starting with \"JJ:\" (like this one) will be removed.\n");
+
+    if add_comment_hint {
+        append_blank_line(&mut bulk_message);
+        bulk_message.push_str("JJ: Lines starting with \"JJ:\" (like this one) will be removed.\n");
+    }
 
     let bulk_message = editor
         .edit_str(bulk_message, Some(".jjdescription"))

--- a/cli/tests/test_describe_command.rs
+++ b/cli/tests/test_describe_command.rs
@@ -550,6 +550,143 @@ fn test_describe_multiple_commits() -> TestResult {
 }
 
 #[test]
+fn test_describe_without_comment_hint() {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Initial setup
+    work_dir.write_file("a.txt", "aaaa\nbbbb\ncccc\n");
+    work_dir.run_jj(["commit", "-m=first"]).success();
+    work_dir.write_file("a.txt", b"aaaa\ncccc\ndddd\n\xff\n");
+    work_dir.run_jj(["describe", "-m=second"]).success();
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  c43cce883e27 second
+    ○  8620a92b036c first
+    ◆  000000000000
+    [EOF]
+    ");
+
+    // Dump the default commit description template
+    std::fs::write(&edit_script, "dump editor0").unwrap();
+    let output = work_dir.run_jj(["describe", "--config=ui.add-description-comment-hint=false"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
+    second
+
+    JJ: Change ID: rlvkpnrz
+    JJ: This commit contains the following changes:
+    JJ:     M a.txt
+    "#);
+
+    // Builtin template with diff content
+    std::fs::write(&edit_script, "dump editor0").unwrap();
+    let output = work_dir.run_jj([
+        "describe",
+        "--config=ui.add-description-comment-hint=false",
+        "--config=templates.draft_commit_description=builtin_draft_commit_description_with_diff",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.env_root().join("editor0")).unwrap(), @r#"
+    second
+
+    JJ: Change ID: rlvkpnrz
+    JJ: This commit contains the following changes:
+    JJ:     M a.txt
+
+    JJ: ignore-rest
+    diff --git a/a.txt b/a.txt
+    index edd13ee535..12e5763da1 100644
+    --- a/a.txt
+    +++ b/a.txt
+    @@ -1,3 +1,4 @@
+     aaaa
+    -bbbb
+     cccc
+    +dddd
+    +�
+    "#);
+
+    // Fails with invalid value
+    std::fs::write(&edit_script, "dump editor0").unwrap();
+    let output = work_dir.run_jj([
+        "describe",
+        "--config=ui.add-description-comment-hint='abcd'",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Config error: Invalid type or value for ui.add-description-comment-hint
+    Caused by: invalid type: string \"abcd\", expected a boolean
+
+    For help, see https://docs.jj-vcs.dev/latest/config/ or use `jj help -k config`.
+    [EOF]
+    [exit status: 1]
+    ");
+}
+
+#[test]
+fn test_describe_multiple_commits_without_comment_hint() -> TestResult {
+    let mut test_env = TestEnvironment::default();
+    let edit_script = test_env.set_up_fake_editor();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+
+    // Initial setup
+    work_dir.run_jj(["new"]).success();
+    work_dir.run_jj(["new"]).success();
+    insta::assert_snapshot!(get_log_output(&work_dir), @"
+    @  3cd3b246e098
+    ○  43444d88b009
+    ○  e8849ae12c70
+    ◆  000000000000
+    [EOF]
+    ");
+
+    // No comment hint after multiple commits
+    std::fs::write(&edit_script, "dump editor0")?;
+    let output = work_dir.run_jj([
+        "describe",
+        "--config=ui.add-description-comment-hint=false",
+        "-r@",
+        "@-",
+    ]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    Nothing changed.
+    [EOF]
+    ");
+    insta::assert_snapshot!(
+        std::fs::read_to_string(test_env.env_root().join("editor0"))?, @r#"
+    JJ: Enter or edit commit descriptions after the `JJ: describe` lines.
+    JJ: Warning:
+    JJ: - The text you enter will be lost on a syntax error.
+    JJ: - The syntax of the separator lines may change in the future.
+    JJ:
+    JJ: describe 43444d88b009 -------
+
+
+    JJ: Change ID: rlvkpnrz
+    JJ:
+    JJ: describe 3cd3b246e098 -------
+
+
+    JJ: Change ID: kkmpptxz
+    "#);
+    Ok(())
+}
+
+#[test]
 fn test_describe_with_draft_template() {
     let mut test_env = TestEnvironment::default();
     let edit_script = test_env.set_up_fake_editor();

--- a/docs/config.md
+++ b/docs/config.md
@@ -386,6 +386,29 @@ Some ready-to-use trailer templates are available for frequently used trailers:
 
 Existing trailers are also accessible via `commit.trailers()`.
 
+### Commit description comment hint
+
+By default, when opening an editor to write a commit description (e.g. with `jj
+describe`), `jj` will append a blank line followed by the following comment
+hint:
+
+```
+JJ: Lines starting with "JJ:" (like this one) will be removed.
+```
+
+This line can be omitted by setting `ui.add-description-comment-hint` to `false`:
+
+```toml
+[ui]
+add-description-comment-hint = false
+```
+
+This is useful when setting `templates.draft_commit_description =
+'builtin_draft_commit_description_with_diff'`, which appends the commit diff at
+the bottom of the description buffer. Removing the final `JJ:` comment can make
+the diff easier to parse (for you, or your editor which may attempt to highlight
+it!).
+
 ### Diff colors and styles
 
 In color-words and git diffs, word-level hunks are rendered with underline. You


### PR DESCRIPTION
## Problem

No way to remove the placeholder comment appended to all description editor buffers: `JJ: Lines starting with "JJ:" (like this one) will be removed.`. This can cause confusion / highlighting incongruities when using `JJ: ignore-rest` to append the commit diff to the description buffer. This is because it appears as though it should be part of the commit diff output.

## Solution

Add the `ui.add-description-placeholder-comment` configuration option (default `true`) to control the addition of the blank line and placeholder comment.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
