### PR TITLE
cargo: sort dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ clap = { version = "4.6.1", features = [
     "wrap_help",
     "string",
 ] }
-clap_complete = { version = "4.6.5", features = ["unstable-dynamic"] }
-clap_complete_nushell = "4.6.0"
 # Update clap-markdown manually since test_generate_md_cli_help snapshot
 # will need regenerating.
 clap-markdown = "=0.1.5"
+clap_complete = { version = "4.6.5", features = ["unstable-dynamic"] }
+clap_complete_nushell = "4.6.0"
 clap_mangen = "0.3.0"
 clru = "0.6.3"
 criterion = "0.8.2"
@@ -48,8 +48,8 @@ digest = "0.10.7"
 dunce = "1.0.5"
 either = "1.15.0"
 erased-serde = "0.4.10"
-eyre = "0.6"
 etcetera = "0.11.0"
+eyre = "0.6"
 futures = "0.3.32"
 gix = { version = "0.83.0", default-features = false, features = [
     "attributes",
@@ -94,6 +94,7 @@ ref-cast = "1.0.25"
 regex = "1.12.3"
 rpassword = "7.5.2"
 rustix = { version = "1.1.4", features = ["fs"] }
+rustversion = "1.0.22"
 same-file = "1.0.6"
 sapling-renderdag = "0.1.0"
 sapling-streampager = "0.12.0"
@@ -110,7 +111,6 @@ smallvec = { version = "1.15.1", features = [
 ] }
 strsim = "0.11.1"
 syn = "2.0.111"
-rustversion = "1.0.22"
 tempfile = "3.27.0"
 test-case = "3.3.1"
 textwrap = "0.16.2"
@@ -134,7 +134,6 @@ winreg = "0.56"
 
 # put all inter-workspace libraries, i.e. those that use 'path = ...' here in
 # their own (alphabetically sorted) block
-
 jj-lib = { path = "lib", version = "0.41.0", default-features = false }
 jj-lib-proc-macros = { path = "lib/proc-macros", version = "0.41.0" }
 testutils = { path = "lib/testutils" }


### PR DESCRIPTION
Sort with `cargo-sort` using the following command to ensure the inter-workspace libraries are kept at the bottom of the list:

```console
$ cargo sort --grouped
```

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
