### PR TITLE
git: look for predecessors also in locally reachable commits

### DIFF
--- a/cli/src/git_util.rs
+++ b/cli/src/git_util.rs
@@ -259,6 +259,13 @@ fn print_imported_changes(
         let template = tx.commit_summary_template();
         print_updated_commits(formatter, &template, &stats.abandoned_commits)?;
     }
+    if !stats.rewritten_commit_ids.is_empty() {
+        writeln!(
+            formatter,
+            "Updated {} rewritten commits.",
+            stats.rewritten_commit_ids.len()
+        )?;
+    }
 
     Ok(())
 }
@@ -293,14 +300,21 @@ fn print_failed_git_import(ui: &Ui, stats: &GitImportStats) -> Result<(), Comman
 /// Prints only the summary of git import stats (abandoned count, failed refs).
 /// Use this when a WorkspaceCommandTransaction is not available.
 pub fn print_git_import_stats_summary(ui: &Ui, stats: &GitImportStats) -> Result<(), CommandError> {
-    if !stats.abandoned_commits.is_empty()
-        && let Some(mut formatter) = ui.status_formatter()
-    {
-        writeln!(
-            formatter,
-            "Abandoned {} commits that are no longer reachable.",
-            stats.abandoned_commits.len()
-        )?;
+    if let Some(mut formatter) = ui.status_formatter() {
+        if !stats.abandoned_commits.is_empty() {
+            writeln!(
+                formatter,
+                "Abandoned {} commits that are no longer reachable.",
+                stats.abandoned_commits.len()
+            )?;
+        }
+        if !stats.rewritten_commit_ids.is_empty() {
+            writeln!(
+                formatter,
+                "Updated {} rewritten commits.",
+                stats.rewritten_commit_ids.len()
+            )?;
+        }
     }
     print_failed_git_import(ui, stats)?;
     Ok(())

--- a/cli/tests/test_git_colocated.rs
+++ b/cli/tests/test_git_colocated.rs
@@ -739,9 +739,9 @@ fn test_git_colocated_fetch_deleted_or_moved_bookmark() -> TestResult {
     ------- stderr -------
     bookmark: B_to_delete@origin [deleted] untracked
     bookmark: C_to_move@origin   [updated] tracked
-    Abandoned 2 commits that are no longer reachable:
-      royxmykx/1 dd905bab C_to_move@git | (divergent) (empty) original C
+    Abandoned 1 commits that are no longer reachable:
       zsuskuln b2ea51c0 B_to_delete@git | (empty) B_to_delete
+    Updated 1 rewritten commits.
     [EOF]
     ");
     // "original C" and "B_to_delete" are abandoned, as the corresponding bookmarks

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -2235,6 +2235,91 @@ fn test_git_fetch_remotely_rewritten_no_synthetic_predecessors() {
 }
 
 #[test]
+fn test_git_fetch_remotely_rewritten_descendants() {
+    let test_env = TestEnvironment::default();
+
+    // Add bookmarked branches to the remote repo
+    test_env
+        .run_jj_in(".", ["git", "init", "remote", "--colocate"])
+        .success();
+    let remote_dir = test_env.work_dir("remote");
+    remote_dir.run_jj(["describe", "-moriginal"]).success();
+    remote_dir.run_jj(["new", "-mbookmarked 1"]).success();
+    remote_dir.run_jj(["bookmark", "set", "book1"]).success();
+    remote_dir.run_jj(["new", "@-", "-mbookmarked 2"]).success();
+    remote_dir.run_jj(["bookmark", "set", "book2"]).success();
+
+    // Check out the base revision
+    test_env
+        .run_jj_in(".", ["git", "clone", "remote", "local"])
+        .success();
+    let local_dir = test_env.work_dir("local");
+    local_dir
+        .run_jj(["new", "subject(original)", "-mlocal"])
+        .success();
+    insta::assert_snapshot!(get_log_output(&local_dir), @r#"
+    @  b4adc7786cf0 "local"
+    │ ◆  cce448c253e0 "bookmarked 2" book2@origin
+    ├─╯
+    │ ◆  2a6bbeb458de "bookmarked 1" book1@origin
+    ├─╯
+    ◆  97604bbedb48 "original"
+    ◆  000000000000 ""
+    [EOF]
+    "#);
+
+    // Rewrite the base revision and descendants remotely
+    remote_dir
+        .run_jj(["describe", "-r@-", "-mmodified"])
+        .success();
+
+    // Fetch one of the rewritten branches
+    let output = local_dir.run_jj(["git", "fetch", "--branch=book1"]);
+    insta::assert_snapshot!(output, @"
+    ------- stderr -------
+    bookmark: book1@origin [updated] untracked
+    Updated 2 rewritten commits.
+    Rebased 2 descendant commits
+    Working copy  (@) now at: vruxwmqv a1d01244 (empty) local
+    Parent commit (@-)      : qpvuntsm a843bfad (empty) modified
+    [EOF]
+    ");
+
+    // The working copy should be rebased onto the modified revision
+    // FIXME: the other remote branch shouldn't be rebased
+    insta::assert_snapshot!(get_log_output(&local_dir), @r#"
+    @  a1d01244a4ec "local"
+    │ ○  8e6c17fa9e2e "bookmarked 2"
+    ├─╯
+    │ ◆  ad5c5f3c59a7 "bookmarked 1" book1@origin
+    ├─╯
+    ◆  a843bfad2abb "modified"
+    ◆  000000000000 ""
+    [EOF]
+    "#);
+
+    // Evolution history should point to the "git fetch" operation
+    let output = local_dir.run_jj(["evolog", "-r..remote_bookmarks()"]);
+    insta::assert_snapshot!(output, @"
+    ◆  kkmpptxz test.user@example.com 2001-02-03 08:05:16 book1@origin ad5c5f3c
+    │  (empty) bookmarked 1
+    │  -- operation ac34b601b3a2 fetch from git remote(s) origin
+    ○  kkmpptxz/1 test.user@example.com 2001-02-03 08:05:09 2a6bbeb4 (hidden)
+       (empty) bookmarked 1
+    ◆  qpvuntsm test.user@example.com 2001-02-03 08:05:16 a843bfad
+    │  (empty) modified
+    │  -- operation ac34b601b3a2 fetch from git remote(s) origin
+    ◆  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
+       (empty) original
+    ◆  mzvwutvl/1 test.user@example.com 2001-02-03 08:05:11 book2@origin cce448c2 (hidden)
+       (empty) bookmarked 2
+    ◆  qpvuntsm/1 test.user@example.com 2001-02-03 08:05:08 97604bbe (hidden)
+       (empty) original
+    [EOF]
+    ");
+}
+
+#[test]
 fn test_git_fetch_tracked() {
     let test_env = TestEnvironment::default();
     test_env.add_config("remotes.origin.auto-track-bookmarks = '*'");

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1020,9 +1020,7 @@ fn test_git_fetch_all() {
     bookmark: a2@origin     [updated] tracked
     bookmark: b@origin      [updated] tracked
     bookmark: trunk2@origin [new] tracked
-    Abandoned 2 commits that are no longer reachable:
-      yqosqzyt/1 d4d535f1 (divergent) a2
-      mzvwutvl/1 c8303692 (divergent) a1
+    Updated 2 rewritten commits.
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
@@ -1210,8 +1208,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     ------- stderr -------
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
-    Abandoned 1 commits that are no longer reachable:
-      mzvwutvl/1 c8303692 (divergent) a1
+    Updated 1 rewritten commits.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -1249,8 +1246,7 @@ fn test_git_fetch_some_of_many_bookmarks() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     bookmark: a2@origin [updated] tracked
-    Abandoned 1 commits that are no longer reachable:
-      yqosqzyt/1 d4d535f1 (divergent) a2
+    Updated 1 rewritten commits.
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"
@@ -2098,9 +2094,7 @@ fn test_git_fetch_remotely_rewritten() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     bookmark: book@origin [updated] untracked
-    Abandoned 2 commits that are no longer reachable:
-      kkmpptxz/1 eedc2709 (divergent) (empty) bookmarked
-      qpvuntsm/1 97604bbe (divergent) (empty) original
+    Updated 2 rewritten commits.
     Rebased 1 descendant commits
     Working copy  (@) now at: royxmykx 0818b176 (empty) (no description set)
     Parent commit (@-)      : kkmpptxz 3ee37bc8 book@origin | (empty) bookmarked
@@ -2138,9 +2132,7 @@ fn test_git_fetch_remotely_rewritten() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     bookmark: book@origin [updated] untracked
-    Abandoned 2 commits that are no longer reachable:
-      kkmpptxz/1 eedc2709 (divergent) (empty) bookmarked
-      qpvuntsm/1 97604bbe (divergent) (empty) original
+    Updated 2 rewritten commits.
     Rebased 1 descendant commits
     Working copy  (@) now at: royxmykx 3eb3f040 (empty) (no description set)
     Parent commit (@-)      : kkmpptxz 3ee37bc8 book@origin | (empty) bookmarked

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -526,8 +526,10 @@ pub struct GitImportOptions {
 /// Describes changes made by `import_refs()` or `fetch()`.
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct GitImportStats {
-    /// Commits superseded by newly imported commits.
+    /// Commits that are no longer reachable nor rewritten to the new commits.
     pub abandoned_commits: Vec<Commit>,
+    /// Commits that have been rewritten to the new commits.
+    pub rewritten_commit_ids: HashSet<CommitId>,
     /// Remote bookmark `(symbol, (old_remote_ref, new_target))`s to be merged
     /// in to the local bookmarks, sorted by `symbol`.
     pub changed_remote_bookmarks: Vec<(RemoteRefSymbolBuf, (RemoteRef, RefTarget))>,
@@ -705,12 +707,12 @@ async fn import_refs_inner(
         mut_repo.set_remote_tag(symbol, new_remote_ref);
     }
 
-    let abandoned_commits = if options.abandon_unreachable_commits {
+    let mut abandoned_commits = if options.abandon_unreachable_commits {
         abandon_unreachable_commits(mut_repo, old_referenced_heads).await?
     } else {
         vec![]
     };
-    if options.record_synthetic_predecessors {
+    let rewritten_commit_ids = if options.record_synthetic_predecessors {
         record_synthetic_predecessors(
             mut_repo,
             old_visible_heads,
@@ -718,10 +720,14 @@ async fn import_refs_inner(
             &abandoned_commits,
             &imported_commits,
         )
-        .await?;
-    }
+        .await?
+    } else {
+        HashSet::new()
+    };
+    abandoned_commits.retain(|commit| !rewritten_commit_ids.contains(commit.id()));
     let stats = GitImportStats {
         abandoned_commits,
+        rewritten_commit_ids,
         changed_remote_bookmarks,
         changed_remote_tags,
         failed_ref_names,
@@ -767,15 +773,17 @@ async fn abandon_unreachable_commits(
 ///
 /// The `imported_commits` should exclude any pre-existing commits, including
 /// those that were previously hidden.
+///
+/// Returns old commit IDs that have been mapped to the new commits.
 async fn record_synthetic_predecessors(
     mut_repo: &mut MutableRepo,
     old_visible_heads: Vec<CommitId>,
     new_referenced_heads: Vec<CommitId>,
     abandoned_commits: &[Commit],
     imported_commits: &[Commit],
-) -> Result<(), GitImportError> {
+) -> Result<HashSet<CommitId>, GitImportError> {
     if new_referenced_heads.is_empty() {
-        return Ok(());
+        return Ok(HashSet::new());
     }
 
     let new_referenced_change_to_commit_ids = {
@@ -810,6 +818,7 @@ async fn record_synthetic_predecessors(
         "new referenced commits should never be reachable from old refs"
     );
 
+    let mut rewritten_commit_ids = HashSet::new();
     for (change_id, new_commit_ids) in &new_referenced_change_to_commit_ids {
         let predecessor_id: Option<CommitId>;
         let rewrite_source_ids: &[&CommitId];
@@ -843,9 +852,10 @@ async fn record_synthetic_predecessors(
                     .set_divergent_rewrite(old_commit_id.clone(), new_commit_ids.iter().cloned());
             }
         }
+        rewritten_commit_ids.extend(rewrite_source_ids.iter().map(|&id| id.clone()));
     }
 
-    Ok(())
+    Ok(rewritten_commit_ids)
 }
 
 /// Calculates diff of git refs to be imported.

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -70,6 +70,7 @@ use crate::ref_name::RemoteRefSymbolBuf;
 use crate::repo::MutableRepo;
 use crate::repo::Repo;
 use crate::repo_path::RepoPath;
+use crate::revset::ResolvedRevsetExpression;
 use crate::revset::RevsetEvaluationError;
 use crate::revset::RevsetExpression;
 use crate::revset::RevsetStreamExt as _;
@@ -707,16 +708,21 @@ async fn import_refs_inner(
         mut_repo.set_remote_tag(symbol, new_remote_ref);
     }
 
-    let mut abandoned_commits = if options.abandon_unreachable_commits {
-        abandon_unreachable_commits(mut_repo, old_referenced_heads).await?
+    let any_old_referenced = !old_referenced_heads.is_empty();
+    let any_new_referenced = !new_referenced_heads.is_empty();
+    let old_visible_heads = RevsetExpression::commits(old_visible_heads);
+    let old_referenced_heads = RevsetExpression::commits(old_referenced_heads);
+    let new_referenced_heads = RevsetExpression::commits(new_referenced_heads);
+    let mut abandoned_commits = if options.abandon_unreachable_commits && any_old_referenced {
+        abandon_unreachable_commits(mut_repo, &old_referenced_heads).await?
     } else {
         vec![]
     };
-    let rewritten_commit_ids = if options.record_synthetic_predecessors {
+    let rewritten_commit_ids = if options.record_synthetic_predecessors && any_new_referenced {
         record_synthetic_predecessors(
             mut_repo,
-            old_visible_heads,
-            new_referenced_heads,
+            &old_visible_heads,
+            &new_referenced_heads,
             &abandoned_commits,
             &imported_commits,
         )
@@ -739,11 +745,8 @@ async fn import_refs_inner(
 /// Those commits will be recorded as abandoned in the `MutableRepo`.
 async fn abandon_unreachable_commits(
     mut_repo: &mut MutableRepo,
-    hidable_git_heads: Vec<CommitId>,
+    hidable_git_heads: &Arc<ResolvedRevsetExpression>,
 ) -> Result<Vec<Commit>, GitImportError> {
-    if hidable_git_heads.is_empty() {
-        return Ok(vec![]);
-    }
     let pinned_expression = RevsetExpression::union_all(&[
         // Local refs are usually visible, no need to filter out hidden
         RevsetExpression::commits(pinned_commit_ids(mut_repo.view())),
@@ -753,7 +756,7 @@ async fn abandon_unreachable_commits(
         RevsetExpression::root(),
     ]);
     let abandoned_expression = pinned_expression
-        .range(&RevsetExpression::commits(hidable_git_heads))
+        .range(hidable_git_heads)
         // Don't include already-abandoned commits in GitImportStats
         .intersection(&RevsetExpression::visible_heads().ancestors());
     let abandoned_commits: Vec<_> = abandoned_expression
@@ -777,19 +780,15 @@ async fn abandon_unreachable_commits(
 /// Returns old commit IDs that have been mapped to the new commits.
 async fn record_synthetic_predecessors(
     mut_repo: &mut MutableRepo,
-    old_visible_heads: Vec<CommitId>,
-    new_referenced_heads: Vec<CommitId>,
+    old_visible_heads: &Arc<ResolvedRevsetExpression>,
+    new_referenced_heads: &Arc<ResolvedRevsetExpression>,
     abandoned_commits: &[Commit],
     imported_commits: &[Commit],
 ) -> Result<HashSet<CommitId>, GitImportError> {
-    if new_referenced_heads.is_empty() {
-        return Ok(HashSet::new());
-    }
-
     let new_referenced_change_to_commit_ids = {
         let mut change_to_commit_ids: HashMap<ChangeId, Vec<CommitId>> = HashMap::new();
-        let mut stream = RevsetExpression::commits(old_visible_heads)
-            .range(&RevsetExpression::commits(new_referenced_heads))
+        let mut stream = old_visible_heads
+            .range(new_referenced_heads)
             .evaluate(mut_repo)?
             .commit_change_ids();
         while let Some((commit_id, change_id)) = stream.try_next().await? {

--- a/lib/src/git.rs
+++ b/lib/src/git.rs
@@ -722,9 +722,11 @@ async fn import_refs_inner(
         record_synthetic_predecessors(
             mut_repo,
             &old_visible_heads,
-            &new_referenced_heads,
-            &abandoned_commits,
+            Diff::new(&old_referenced_heads, &new_referenced_heads),
             &imported_commits,
+            // TODO: Maybe enable rewriting unconditionally? This should be more
+            // reliable than reachability-based heuristic.
+            options.abandon_unreachable_commits,
         )
         .await?
     } else {
@@ -781,47 +783,49 @@ async fn abandon_unreachable_commits(
 async fn record_synthetic_predecessors(
     mut_repo: &mut MutableRepo,
     old_visible_heads: &Arc<ResolvedRevsetExpression>,
-    new_referenced_heads: &Arc<ResolvedRevsetExpression>,
-    abandoned_commits: &[Commit],
+    Diff {
+        before: old_referenced_heads,
+        after: new_referenced_heads,
+    }: Diff<&Arc<ResolvedRevsetExpression>>,
     imported_commits: &[Commit],
+    rewrite_commits: bool,
 ) -> Result<HashSet<CommitId>, GitImportError> {
-    let new_referenced_change_to_commit_ids = {
+    let build_change_to_commit_ids_map = async |expr: Arc<ResolvedRevsetExpression>| {
         let mut change_to_commit_ids: HashMap<ChangeId, Vec<CommitId>> = HashMap::new();
-        let mut stream = old_visible_heads
-            .range(new_referenced_heads)
-            .evaluate(mut_repo)?
-            .commit_change_ids();
+        let mut stream = expr.evaluate(mut_repo)?.commit_change_ids();
         while let Some((commit_id, change_id)) = stream.try_next().await? {
             let commit_ids = change_to_commit_ids.entry(change_id).or_default();
             commit_ids.push(commit_id);
         }
-        change_to_commit_ids
+        Ok::<_, GitImportError>(change_to_commit_ids)
     };
-    // TODO: Maybe we can use new_referenced_heads..old_referenced_heads as
-    // predecessor candidates. If abandon_unreachable_commits is set, we can
-    // mark them as "rewritten" in addition to the current abandoned commits.
-    let abandoned_change_to_commit_ids = {
-        let mut change_to_commit_ids: HashMap<&ChangeId, Vec<&CommitId>> = HashMap::new();
-        for commit in abandoned_commits {
-            let commit_ids = change_to_commit_ids.entry(commit.change_id()).or_default();
-            commit_ids.push(commit.id());
-        }
-        change_to_commit_ids
-    };
+    // TODO: Commits within new_referenced_heads..old_referenced_heads may have
+    // both mutable and immutable descendants. Rebasing the immutable
+    // descendants onto the new parents would be unexpected.
+    let old_referenced_change_to_commit_ids =
+        build_change_to_commit_ids_map(new_referenced_heads.range(old_referenced_heads)).await?;
+    let new_referenced_change_to_commit_ids =
+        build_change_to_commit_ids_map(old_visible_heads.range(new_referenced_heads)).await?;
     let imported_commit_ids: HashSet<_> = imported_commits.iter().map(Commit::id).collect();
-    debug_assert!(
-        new_referenced_change_to_commit_ids
-            .values()
-            .flatten()
-            .all(|new_id| abandoned_commits.iter().all(|old| old.id() != new_id)),
-        "new referenced commits should never be reachable from old refs"
-    );
+    let rewritable_commit_ids: HashSet<_> = if rewrite_commits {
+        // Similar to old_referenced_change_to_commit_ids, but doesn't include
+        // previously abandoned commits, which shouldn't be rewritten again.
+        new_referenced_heads
+            .range(old_referenced_heads)
+            .intersection(&old_visible_heads.ancestors())
+            .evaluate(mut_repo)?
+            .stream()
+            .try_collect()
+            .await?
+    } else {
+        HashSet::new()
+    };
 
     let mut rewritten_commit_ids = HashSet::new();
     for (change_id, new_commit_ids) in &new_referenced_change_to_commit_ids {
         let predecessor_id: Option<CommitId>;
-        let rewrite_source_ids: &[&CommitId];
-        if let Some(old_commit_ids) = abandoned_change_to_commit_ids.get(change_id) {
+        let rewrite_source_ids: &[CommitId];
+        if let Some(old_commit_ids) = old_referenced_change_to_commit_ids.get(change_id) {
             // Pick the latest one if previously diverged. Divergence isn't
             // usually resolved by "squashing" the commits.
             predecessor_id = Some(old_commit_ids[0].clone());
@@ -841,17 +845,21 @@ async fn record_synthetic_predecessors(
         {
             mut_repo.set_predecessors(new_commit_id.clone(), predecessor_id.as_slice().to_vec());
         }
+        let rewrite_source_ids = rewrite_source_ids
+            .iter()
+            .filter(|id| rewritable_commit_ids.contains(id));
         if let [new_commit_id] = &**new_commit_ids {
-            for &old_commit_id in rewrite_source_ids {
+            for old_commit_id in rewrite_source_ids {
                 mut_repo.set_rewritten_commit(old_commit_id.clone(), new_commit_id.clone());
+                rewritten_commit_ids.insert(old_commit_id.clone());
             }
         } else {
-            for &old_commit_id in rewrite_source_ids {
+            for old_commit_id in rewrite_source_ids {
                 mut_repo
                     .set_divergent_rewrite(old_commit_id.clone(), new_commit_ids.iter().cloned());
+                rewritten_commit_ids.insert(old_commit_id.clone());
             }
         }
-        rewritten_commit_ids.extend(rewrite_source_ids.iter().map(|&id| id.clone()));
     }
 
     Ok(rewritten_commit_ids)

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -1664,6 +1664,287 @@ fn test_import_refs_synthetic_predecessors_multiple_descendants() -> TestResult 
     Ok(())
 }
 
+#[test_case(true, false; "without synthetic predecessors")]
+#[test_case(false, true; "with synthetic predecessors but no rewriting")]
+#[test_case(true, true; "with synthetic predecessors")]
+fn test_import_refs_synthetic_predecessors_bookmarked_simple(
+    abandon_unreachable_commits: bool,
+    record_synthetic_predecessors: bool,
+) -> TestResult {
+    let synthetic_rewrite_commits = abandon_unreachable_commits && record_synthetic_predecessors;
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let main_repo = &test_repo.repo;
+    let ext_repo = init_external_git_repo(&test_repo, "ext-repo".as_ref())?;
+    let ext_store = ext_repo.store().clone();
+    let import_options = GitImportOptions {
+        abandon_unreachable_commits,
+        record_synthetic_predecessors,
+        ..default_import_options()
+    };
+
+    // Main:
+    // 2A
+    //  |
+    // 1A*
+    let mut tx = main_repo.start_transaction();
+    let commit1a = write_random_commit(tx.repo_mut());
+    let commit2a = write_random_commit_with_parents(tx.repo_mut(), &[&commit1a]);
+    tx.repo_mut()
+        .set_local_bookmark_target("1A".as_ref(), RefTarget::normal(commit1a.id().clone()));
+    git::export_refs(tx.repo_mut())?;
+    let main_repo = tx.commit("test").block_on()?;
+
+    // Ext: Rewrite 1A* -> 1B*
+    let mut tx = ext_repo.start_transaction();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
+    assert_eq!(stats.changed_remote_bookmarks.len(), 1);
+    let commit1b = rewrite_commit(tx.repo_mut(), &ext_store.get_commit(commit1a.id())?, "1B");
+    let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
+    assert_eq!(num_rebased, 0);
+    git::export_refs(tx.repo_mut())?;
+
+    // Main: Set bookmark 2A* (without importing)
+    let mut tx = main_repo.start_transaction();
+    tx.repo_mut()
+        .set_local_bookmark_target("2A".as_ref(), RefTarget::normal(commit2a.id().clone()));
+    git::export_refs(tx.repo_mut())?;
+
+    // Main: Import changes
+    //
+    // (synthetic_rewrite_commits = true)
+    // 2C*
+    //  |
+    // 1B*
+    //
+    // (synthetic_rewrite_commits = false)
+    // 2A
+    //  |
+    // 1A* 1B*
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(
+        stats.rewritten_commit_ids.len(),
+        if synthetic_rewrite_commits { 1 } else { 0 }
+    );
+    assert_eq!(stats.changed_remote_bookmarks.len(), 1);
+    let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
+    assert_eq!(num_rebased, if synthetic_rewrite_commits { 1 } else { 0 });
+    let main_repo = tx.commit("test").block_on()?;
+
+    if synthetic_rewrite_commits {
+        let commit2c = find_unique_successor(&main_repo, commit2a.id()).unwrap();
+
+        // Sanity check for the new graph
+        assert_eq!(
+            *main_repo.view().heads(),
+            HashSet::from([&commit2c].map(|c| c.id().clone()))
+        );
+
+        // Synthetic predecessors should be recorded
+        assert_eq!(
+            main_repo.operation().predecessors_for_commit(commit1b.id()),
+            Some(slice::from_ref(commit1a.id()))
+        );
+        // Descendants should be rebased onto 1B
+        assert_eq!(commit2c.parent_ids(), slice::from_ref(commit1b.id()));
+    } else if record_synthetic_predecessors {
+        assert!(!abandon_unreachable_commits);
+        // Sanity check for the new graph
+        assert_eq!(
+            *main_repo.view().heads(),
+            HashSet::from([&commit2a, &commit1b].map(|c| c.id().clone()))
+        );
+
+        // Synthetic predecessors should be recorded
+        assert_eq!(
+            main_repo.operation().predecessors_for_commit(commit1b.id()),
+            Some(slice::from_ref(commit1a.id()))
+        );
+    } else {
+        // Sanity check for the new graph
+        assert_eq!(
+            *main_repo.view().heads(),
+            HashSet::from([&commit2a, &commit1b].map(|c| c.id().clone()))
+        );
+
+        // Synthetic predecessors shouldn't be recorded
+        assert_eq!(
+            main_repo.operation().predecessors_for_commit(commit1b.id()),
+            None
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_synthetic_predecessors_some_bookmarked_descendants() -> TestResult {
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let main_repo = &test_repo.repo;
+    let ext_repo = init_external_git_repo(&test_repo, "ext-repo".as_ref())?;
+    let ext_store = ext_repo.store().clone();
+    let import_options = default_import_options();
+
+    // Main:
+    // 3A  5A
+    //  | /
+    // 2A* 4A
+    //  | /
+    // 1A
+    let mut tx = main_repo.start_transaction();
+    let commit1a = write_random_commit(tx.repo_mut());
+    let commit2a = write_random_commit_with_parents(tx.repo_mut(), &[&commit1a]);
+    let commit3a = write_random_commit_with_parents(tx.repo_mut(), &[&commit2a]);
+    let commit4a = write_random_commit_with_parents(tx.repo_mut(), &[&commit1a]);
+    let commit5a = write_random_commit_with_parents(tx.repo_mut(), &[&commit2a]);
+    tx.repo_mut()
+        .set_local_bookmark_target("2A".as_ref(), RefTarget::normal(commit2a.id().clone()));
+    git::export_refs(tx.repo_mut())?;
+    let main_repo = tx.commit("test").block_on()?;
+
+    // Ext: Rewrite 1A -> 1B, 2A* -> 2B*
+    let mut tx = ext_repo.start_transaction();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
+    assert_eq!(stats.changed_remote_bookmarks.len(), 1);
+    let commit1b = rewrite_commit(tx.repo_mut(), &ext_store.get_commit(commit1a.id())?, "1B");
+    let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
+    assert_eq!(num_rebased, 1);
+    git::export_refs(tx.repo_mut())?;
+    let ext_repo = tx.commit("test").block_on()?;
+    let commit2b = find_unique_successor(&ext_repo, commit2a.id()).unwrap();
+
+    // Main: Set bookmark 3A* (without importing)
+    let mut tx = main_repo.start_transaction();
+    tx.repo_mut()
+        .set_local_bookmark_target("3A".as_ref(), RefTarget::normal(commit3a.id().clone()));
+    git::export_refs(tx.repo_mut())?;
+
+    // Main: Import changes
+    // 3C* 5C
+    //  | /
+    // 2B* 4C
+    //  | /
+    // 1B
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(stats.rewritten_commit_ids.len(), 2);
+    assert_eq!(stats.changed_remote_bookmarks.len(), 1);
+    let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
+    assert_eq!(num_rebased, 3);
+    let main_repo = tx.commit("test").block_on()?;
+    let commit3c = find_unique_successor(&main_repo, commit3a.id()).unwrap();
+    let commit4c = find_unique_successor(&main_repo, commit4a.id()).unwrap();
+    let commit5c = find_unique_successor(&main_repo, commit5a.id()).unwrap();
+
+    // Sanity check for the new graph
+    assert_eq!(
+        *main_repo.view().heads(),
+        HashSet::from([&commit3c, &commit4c, &commit5c].map(|c| c.id().clone()))
+    );
+
+    // Synthetic predecessors should be recorded
+    assert_eq!(
+        main_repo.operation().predecessors_for_commit(commit1b.id()),
+        Some(slice::from_ref(commit1a.id()))
+    );
+    assert_eq!(
+        main_repo.operation().predecessors_for_commit(commit2b.id()),
+        Some(slice::from_ref(commit2a.id()))
+    );
+    // Descendants should be rebased onto 2B
+    assert_eq!(commit3c.parent_ids(), slice::from_ref(commit2b.id()));
+    assert_eq!(commit4c.parent_ids(), slice::from_ref(commit1b.id()));
+    assert_eq!(commit5c.parent_ids(), slice::from_ref(commit2b.id()));
+
+    Ok(())
+}
+
+#[test]
+fn test_import_refs_synthetic_predecessors_rewritten_bookmarked_descendants() -> TestResult {
+    let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);
+    let main_repo = &test_repo.repo;
+    let ext_repo = init_external_git_repo(&test_repo, "ext-repo".as_ref())?;
+    let ext_store = ext_repo.store().clone();
+    let import_options = default_import_options();
+
+    // Main:
+    // 2A*
+    //  |
+    // 1A*
+    let mut tx = main_repo.start_transaction();
+    let commit1a = write_random_commit(tx.repo_mut());
+    let commit2a = write_random_commit_with_parents(tx.repo_mut(), &[&commit1a]);
+    tx.repo_mut()
+        .set_local_bookmark_target("1A".as_ref(), RefTarget::normal(commit1a.id().clone()));
+    tx.repo_mut()
+        .set_local_bookmark_target("2A".as_ref(), RefTarget::normal(commit2a.id().clone()));
+    git::export_refs(tx.repo_mut())?;
+    let main_repo = tx.commit("test").block_on()?;
+
+    // Ext: Rewrite 1A* -> 1B*, 2A* -> 2B*
+    let mut tx = ext_repo.start_transaction();
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
+    assert_eq!(stats.changed_remote_bookmarks.len(), 2);
+    let commit1b = rewrite_commit(tx.repo_mut(), &ext_store.get_commit(commit1a.id())?, "1B");
+    let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
+    assert_eq!(num_rebased, 1);
+    git::export_refs(tx.repo_mut())?;
+    let ext_repo = tx.commit("test").block_on()?;
+    let commit2b = find_unique_successor(&ext_repo, commit2a.id()).unwrap();
+
+    // Main: Rewrite 2A* -> 2C*, Add 3C* (without importing)
+    // 2C* 3C*
+    //  | /
+    // 1A*
+    let mut tx = main_repo.start_transaction();
+    let commit2c = rewrite_commit(tx.repo_mut(), &commit2a, "2C");
+    let commit3c = write_random_commit_with_parents(tx.repo_mut(), &[&commit1a]);
+    tx.repo_mut()
+        .set_local_bookmark_target("2C".as_ref(), RefTarget::normal(commit2c.id().clone()));
+    tx.repo_mut()
+        .set_local_bookmark_target("3C".as_ref(), RefTarget::normal(commit3c.id().clone()));
+    let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
+    assert_eq!(num_rebased, 0);
+
+    // Main: Import changes
+    // 2D* 3D* 2B*
+    //    \ | /
+    //     1B*
+    let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(
+        stats.rewritten_commit_ids.len(),
+        1 // 2B/2C isn't included because it has already been rewritten locally
+    );
+    assert_eq!(stats.changed_remote_bookmarks.len(), 2);
+    let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
+    assert_eq!(num_rebased, 2);
+    let main_repo = tx.commit("test").block_on()?;
+    let commit2d = find_unique_successor(&main_repo, commit2c.id()).unwrap();
+    let commit3d = find_unique_successor(&main_repo, commit3c.id()).unwrap();
+
+    // Sanity check for the new graph
+    assert_eq!(
+        *main_repo.view().heads(),
+        HashSet::from([&commit2d, &commit3d, &commit2b].map(|c| c.id().clone()))
+    );
+
+    // Synthetic predecessors should be recorded
+    assert_eq!(
+        main_repo.operation().predecessors_for_commit(commit1b.id()),
+        Some(slice::from_ref(commit1a.id()))
+    );
+    assert_eq!(
+        main_repo.operation().predecessors_for_commit(commit2b.id()),
+        Some(slice::from_ref(commit2a.id()))
+    );
+    // Descendants should be rebased onto 1B
+    assert_eq!(commit2d.parent_ids(), slice::from_ref(commit1b.id()));
+    assert_eq!(commit3d.parent_ids(), slice::from_ref(commit1b.id()));
+
+    Ok(())
+}
+
 #[test]
 fn test_import_refs_synthetic_predecessors_old_divergent() -> TestResult {
     let test_repo = TestRepo::init_with_backend(TestRepoBackend::Git);

--- a/lib/tests/test_git.rs
+++ b/lib/tests/test_git.rs
@@ -313,6 +313,7 @@ fn test_import_refs() -> TestResult {
     let view = repo.view();
 
     assert!(stats.abandoned_commits.is_empty());
+    assert!(stats.rewritten_commit_ids.is_empty());
     let expected_heads = hashset! {
         jj_id(commit3),
         jj_id(commit4),
@@ -453,6 +454,7 @@ fn test_import_refs_reimport() -> TestResult {
     let repo = tx.commit("test").block_on()?;
 
     assert!(stats.abandoned_commits.is_empty());
+    assert!(stats.rewritten_commit_ids.is_empty());
     let expected_heads = hashset! {
             jj_id(commit3),
             jj_id(commit4),
@@ -484,6 +486,7 @@ fn test_import_refs_reimport() -> TestResult {
         HashSet::from_iter(stats.abandoned_commits.iter().map(Commit::id)),
         HashSet::from([&jj_id(commit4), &jj_id(commit3)]),
     );
+    assert!(stats.rewritten_commit_ids.is_empty());
     let view = repo.view();
     let expected_heads = hashset! {
             jj_id(commit5),
@@ -1531,7 +1534,14 @@ fn test_import_refs_synthetic_predecessors_simple(
     // 2C  1B*
     let mut tx = main_repo.start_transaction();
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
-    assert_eq!(stats.abandoned_commits.len(), 1);
+    assert_eq!(
+        stats.abandoned_commits.len(),
+        if record_synthetic_predecessors { 0 } else { 1 }
+    );
+    assert_eq!(
+        stats.rewritten_commit_ids.len(),
+        if record_synthetic_predecessors { 1 } else { 0 }
+    );
     assert_eq!(stats.changed_remote_bookmarks.len(), 2);
     let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(num_rebased, 1);
@@ -1620,7 +1630,8 @@ fn test_import_refs_synthetic_predecessors_multiple_descendants() -> TestResult 
     // 1B
     let mut tx = main_repo.start_transaction();
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
-    assert_eq!(stats.abandoned_commits.len(), 2);
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(stats.rewritten_commit_ids.len(), 2);
     assert_eq!(stats.changed_remote_bookmarks.len(), 1);
     let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(num_rebased, 3);
@@ -1702,7 +1713,8 @@ fn test_import_refs_synthetic_predecessors_old_divergent() -> TestResult {
     // 1A      1C  1E*
     let mut tx = main_repo.start_transaction();
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
-    assert_eq!(stats.abandoned_commits.len(), 2);
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(stats.rewritten_commit_ids.len(), 2);
     assert_eq!(stats.changed_remote_bookmarks.len(), 2);
     let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(num_rebased, 2);
@@ -1770,7 +1782,8 @@ fn test_import_refs_synthetic_predecessors_new_divergent() -> TestResult {
     // 1A  3A  3B* 3C*
     let mut tx = main_repo.start_transaction();
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
-    assert_eq!(stats.abandoned_commits.len(), 1);
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(stats.rewritten_commit_ids.len(), 1);
     assert_eq!(stats.changed_remote_bookmarks.len(), 3);
     let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(num_rebased, 0);
@@ -1831,7 +1844,8 @@ fn test_import_refs_synthetic_predecessors_reimport_same_commits() -> TestResult
     // 1B*
     let mut tx = main_repo.start_transaction();
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
-    assert_eq!(stats.abandoned_commits.len(), 1);
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(stats.rewritten_commit_ids.len(), 1);
     assert_eq!(stats.changed_remote_bookmarks.len(), 1);
     let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(num_rebased, 1);
@@ -1866,7 +1880,8 @@ fn test_import_refs_synthetic_predecessors_reimport_same_commits() -> TestResult
     // hash than 2C. We can't rely on low-resolution committer timestamp here.
     let commit2d = rewrite_commit(tx.repo_mut(), &ext_store.get_commit(commit2a.id())?, "2D");
     let stats = git::import_refs(tx.repo_mut(), &import_options).block_on()?;
-    assert_eq!(stats.abandoned_commits.len(), 1);
+    assert_eq!(stats.abandoned_commits.len(), 0);
+    assert_eq!(stats.rewritten_commit_ids.len(), 1);
     assert_eq!(stats.changed_remote_bookmarks.len(), 1);
     let num_rebased = tx.repo_mut().rebase_descendants().block_on()?;
     assert_eq!(num_rebased, 1);
@@ -3736,6 +3751,7 @@ fn test_fetch_empty_repo() -> TestResult {
     // No default bookmark and no refs
     assert_eq!(default_branch, None);
     assert!(stats.abandoned_commits.is_empty());
+    assert!(stats.rewritten_commit_ids.is_empty());
     assert_eq!(*tx.repo().view().git_refs(), btreemap! {});
     assert_eq!(tx.repo().view().bookmarks().count(), 0);
     Ok(())
@@ -3756,6 +3772,7 @@ fn test_fetch_initial_commit_head_is_not_set() -> TestResult {
     // No default bookmark because the origin repo's HEAD wasn't set
     assert_eq!(default_branch, None);
     assert!(stats.abandoned_commits.is_empty());
+    assert!(stats.rewritten_commit_ids.is_empty());
     let repo = tx.commit("test").block_on()?;
     // The initial commit is visible after git_fetch().
     let view = repo.view();
@@ -3812,6 +3829,7 @@ fn test_fetch_initial_commit_head_is_set() -> TestResult {
 
     assert_eq!(default_branch, Some("main".into()));
     assert!(stats.abandoned_commits.is_empty());
+    assert!(stats.rewritten_commit_ids.is_empty());
     Ok(())
 }
 
@@ -3849,6 +3867,7 @@ fn test_fetch_success() -> TestResult {
     // The default bookmark is "main"
     assert_eq!(default_branch, Some("main".into()));
     assert!(stats.abandoned_commits.is_empty());
+    assert!(stats.rewritten_commit_ids.is_empty());
     let repo = tx.commit("test").block_on()?;
     // The new commit is visible after we fetch again
     let view = repo.view();
@@ -3914,6 +3933,7 @@ fn test_fetch_prune_deleted_ref() -> TestResult {
         stats.abandoned_commits.iter().map(Commit::id).collect_vec(),
         vec![&jj_id(commit)]
     );
+    assert!(stats.rewritten_commit_ids.is_empty());
     assert!(tx.repo().get_local_bookmark("main".as_ref()).is_absent());
     assert_eq!(
         tx.repo_mut()


### PR DESCRIPTION
There is a known issue where immutable descendants can accidentally be rebased
onto rewritten immutable parents. For example, suppose we have the history
`A@origin <- B@origin` and `A@origin` is rewritten remotely. If we fetch only
`A'@origin`, `B@origin` ends up being rebased onto `A'@origin`. Because remote
bookmarks do not move locally, this process creates a new, anonymous `B` revision.
One way to fix this would be to implement `rebase_descendants()` that leaves
immutable descendants untouched, while still allowing mutable descendants to be
rebased onto `A'@origin`.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
