### PR TITLE
duplicate: document placement with graphs

### DIFF
--- a/cli/src/commands/duplicate.rs
+++ b/cli/src/commands/duplicate.rs
@@ -40,18 +40,64 @@ use crate::ui::Ui;
 ///
 /// When none of the `--onto`, `--insert-after`, or `--insert-before` arguments
 /// are provided, commits will be duplicated onto their existing parents or onto
-/// other newly duplicated commits.
+/// other newly duplicated commits. For example, `jj duplicate B`:
 ///
-/// When any of the `--onto`, `--insert-after`, or `--insert-before` arguments
-/// are provided, the roots of the specified commits will be duplicated onto the
-/// destination indicated by the arguments. Other specified commits will be
-/// duplicated onto these newly duplicated commits. If the `--insert-after` or
-/// `--insert-before` arguments are provided, the new children indicated by the
-/// arguments will be rebased onto the heads of the specified commits.
+/// ```text
+/// C            C
+/// |            |
+/// B    =>      B   B'
+/// |            |  /
+/// A            A
+/// ```
+///
+/// With `--onto/-o`, the roots of the duplicated set are placed on the
+/// destination, and existing descendants of the destination are not affected.
+/// This is the closest equivalent to `git cherry-pick`. For example,
+/// `jj duplicate B --onto C`:
+///
+/// ```text
+/// D            D   B'
+/// |            |  /
+/// C   B   =>   C   B
+///  \ /          \ /
+///   A            A
+/// ```
+///
+/// With `--insert-after/-A`, the roots of the duplicated set are placed on the
+/// destination, and the destination's existing descendants are rebased onto the
+/// heads of the duplicates. For example, `jj duplicate B --insert-after C`:
+///
+/// ```text
+/// D            D'
+/// |            |
+/// C   B   =>   B'
+///  \ /         |
+///   A          C   B
+///               \ /
+///                A
+/// ```
+///
+/// With `--insert-before/-B`, the roots of the duplicated set are placed on the
+/// target's parents, and the target and its descendants are rebased onto the
+/// heads of the duplicates. For example, `jj duplicate B --insert-before C`:
+///
+/// ```text
+/// D            D'
+/// |            |
+/// C   B   =>   C'
+///  \ /         |
+///   A          B'  B
+///               \ /
+///                A
+/// ```
+///
+/// When duplicating multiple commits, dependencies among the selected commits
+/// are preserved in the duplicated subgraph.
 ///
 /// By default, the duplicated commits retain the descriptions of the originals.
 /// This can be customized with the `templates.duplicate_description` setting.
 #[derive(clap::Args, Clone, Debug)]
+#[command(verbatim_doc_comment)]
 pub(crate) struct DuplicateArgs {
     /// The revision(s) to duplicate (default: @) [aliases: -r]
     #[arg(value_name = "REVSETS")]

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -1012,11 +1012,64 @@ See `jj restore` if you want to move entire files from one revision to another. 
 
 Create new changes with the same content as existing ones
 
-When none of the `--onto`, `--insert-after`, or `--insert-before` arguments are provided, commits will be duplicated onto their existing parents or onto other newly duplicated commits.
+When none of the `--onto`, `--insert-after`, or `--insert-before` arguments
+are provided, commits will be duplicated onto their existing parents or onto
+other newly duplicated commits. For example, `jj duplicate B`:
 
-When any of the `--onto`, `--insert-after`, or `--insert-before` arguments are provided, the roots of the specified commits will be duplicated onto the destination indicated by the arguments. Other specified commits will be duplicated onto these newly duplicated commits. If the `--insert-after` or `--insert-before` arguments are provided, the new children indicated by the arguments will be rebased onto the heads of the specified commits.
+```text
+C            C
+|            |
+B    =>      B   B'
+|            |  /
+A            A
+```
 
-By default, the duplicated commits retain the descriptions of the originals. This can be customized with the `templates.duplicate_description` setting.
+With `--onto/-o`, the roots of the duplicated set are placed on the
+destination, and existing descendants of the destination are not affected.
+This is the closest equivalent to `git cherry-pick`. For example,
+`jj duplicate B --onto C`:
+
+```text
+D            D   B'
+|            |  /
+C   B   =>   C   B
+ \ /          \ /
+  A            A
+```
+
+With `--insert-after/-A`, the roots of the duplicated set are placed on the
+destination, and the destination's existing descendants are rebased onto the
+heads of the duplicates. For example, `jj duplicate B --insert-after C`:
+
+```text
+D            D'
+|            |
+C   B   =>   B'
+ \ /         |
+  A          C   B
+              \ /
+               A
+```
+
+With `--insert-before/-B`, the roots of the duplicated set are placed on the
+target's parents, and the target and its descendants are rebased onto the
+heads of the duplicates. For example, `jj duplicate B --insert-before C`:
+
+```text
+D            D'
+|            |
+C   B   =>   C'
+ \ /         |
+  A          B'  B
+              \ /
+               A
+```
+
+When duplicating multiple commits, dependencies among the selected commits
+are preserved in the duplicated subgraph.
+
+By default, the duplicated commits retain the descriptions of the originals.
+This can be customized with the `templates.duplicate_description` setting.
 
 **Usage:** `jj duplicate [OPTIONS] [REVSETS]...`
 


### PR DESCRIPTION
The plain description of the behavior can be parsed correctly but I find things much easier to understand if some examples are provided so I figured I'd take a stab at it.

Following the lead of some other commands I added ASCII trees too.

Mentioning "git cherry-pick" by name to help with finding things if someone explicitly looks for cherry-pick.

I switched verbatim_doc_comment on so that the generated help preserves the trees correctly.

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
