### PR TITLE
status: Report divergent changes

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -2385,9 +2385,12 @@ to the current parents may contain changes from multiple commits.
         // `jj new <conflicted commit>` doesn't result in a message about new conflicts.
         let conflicts = RevsetExpression::filter(RevsetFilterPredicate::HasConflict)
             .filtered(RevsetFilterPredicate::File(FilesetExpression::all()));
+        let divergents = RevsetExpression::divergent();
         let removed_conflicts_expr = new_heads.range(&old_heads).intersection(&conflicts);
         let added_conflicts_expr = old_heads.range(&new_heads).intersection(&conflicts);
 
+        let removed_divergents_expr = new_heads.range(&old_heads).intersection(&divergents);
+        let added_divergents_expr = old_heads.range(&new_heads).intersection(&divergents);
         let get_commits =
             async |expr: Arc<ResolvedRevsetExpression>| -> Result<Vec<Commit>, CommandError> {
                 let commits = expr
@@ -2400,6 +2403,8 @@ to the current parents may contain changes from multiple commits.
             };
         let removed_conflict_commits = get_commits(removed_conflicts_expr).await?;
         let added_conflict_commits = get_commits(added_conflicts_expr).await?;
+        let removed_divergent_commits = get_commits(removed_divergents_expr).await?;
+        let added_divergent_commits = get_commits(added_divergents_expr).await?;
 
         fn commits_by_change_id(commits: &[Commit]) -> IndexMap<&ChangeId, Vec<&Commit>> {
             let mut result: IndexMap<&ChangeId, Vec<&Commit>> = IndexMap::new();
@@ -2416,8 +2421,23 @@ to the current parents may contain changes from multiple commits.
         let mut new_conflicts_by_change_id = added_conflicts_by_change_id.clone();
         new_conflicts_by_change_id
             .retain(|change_id, _commits| !removed_conflicts_by_change_id.contains_key(change_id));
+        let solved_divergence_by_change_id = commits_by_change_id(&removed_divergent_commits);
+        let unresolved_divergence_by_change_id = commits_by_change_id(&added_divergent_commits);
+        let mut new_divergents_by_change_id = solved_divergence_by_change_id.clone();
 
-        // TODO: Also report new divergence and maybe resolved divergence
+        new_divergents_by_change_id
+            .retain(|change_id, _commits| !solved_divergence_by_change_id.contains_key(change_id));
+
+        if !solved_divergence_by_change_id.is_empty() {
+            let num_resolved: usize = solved_divergence_by_change_id
+                .values()
+                .map(|commits| commits.len())
+                .sum();
+            writeln!(
+                fmt,
+                "Divergence were solved or abandoned from {num_resolved} commits."
+            )?;
+        }
         if !resolved_conflicts_by_change_id.is_empty() {
             // TODO: Report resolved and abandoned numbers separately. However,
             // that involves resolving the change_id among the visible commits in the new
@@ -2443,7 +2463,20 @@ to the current parents may contain changes from multiple commits.
                 new_conflicts_by_change_id.values().flatten().copied(),
             )?;
         }
+        if !unresolved_divergence_by_change_id.is_empty() {
+            let num_divergent: usize = new_divergents_by_change_id
+                .values()
+                .map(|commits| commits.len())
+                .sum();
+            writeln!(fmt, "New divergence appeared in {num_divergent} commits:")?;
+            print_updated_commits(
+                fmt.as_mut(),
+                &self.commit_summary_template(),
+                new_divergents_by_change_id.values().flatten().copied(),
+            )?;
+        }
 
+        // TODO: Also have a similar hint for divergence when jj converge lands.
         // Hint that the user might want to `jj new` to the first conflict commit to
         // resolve conflicts. Only show the hints if there were any new or resolved
         // conflicts, and only if there are still some conflicts.

--- a/cli/tests/test_bisect_command.rs
+++ b/cli/tests/test_bisect_command.rs
@@ -531,7 +531,7 @@ fn test_bisect_run_jj_command() -> TestResult {
     create_commit(&work_dir, "e", &["d"]);
 
     std::fs::write(&bisection_script, ["jj new -mtesting", "fail"].join("\0"))?;
-    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["bisect", "run", "--range=..", &bisector_path]), @r"
     Bisecting: 4 revisions left to test after this (roughly 3 steps)
     Now evaluating: zsuskuln 123b4d91 b | b
     fake-bisector testing commit 123b4d91f6e5e39bfed39bae3bacf9380dc79078
@@ -552,11 +552,13 @@ fn test_bisect_run_jj_command() -> TestResult {
     Added 0 files, modified 0 files, removed 3 files
     Working copy  (@) now at: kmkuslsw/0 55b3b4a8 (divergent) (empty) testing
     Parent commit (@-)      : kmkuslsw/1 17e2a972 (divergent) (empty) (no description set)
+    New divergence appeared in 0 commits:
     Working copy  (@) now at: msksykpx 2f6e298d (empty) (no description set)
     Parent commit (@-)      : rlvkpnrz 7d980be7 a | a
     Added 0 files, modified 0 files, removed 1 files
     Working copy  (@) now at: kmkuslsw/0 2f80658c (divergent) (empty) testing
     Parent commit (@-)      : msksykpx 2f6e298d (empty) (no description set)
+    New divergence appeared in 0 commits:
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&work_dir), @"

--- a/cli/tests/test_bookmark_command.rs
+++ b/cli/tests/test_bookmark_command.rs
@@ -1889,9 +1889,10 @@ fn test_bookmark_track_conflict() {
         .run_jj(["bookmark", "untrack", "main", "--remote=origin"])
         .success();
     let output = work_dir.run_jj(["bookmark", "track", "main", "--remote=origin"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Started tracking 1 remote bookmarks.
+    New divergence appeared in 0 commits:
     main (conflicted):
       + qpvuntsm/0 467e027c (divergent) (empty) c
       + qpvuntsm/2 48ded843 (divergent) (empty) a
@@ -1915,9 +1916,10 @@ fn test_bookmark_track_conflict() {
         .run_jj(["bookmark", "untrack", "main", "--remote=origin2"])
         .success();
     let output = work_dir.run_jj(["bookmark", "track", "main", "--remote=origin2"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Started tracking 1 remote bookmarks.
+    New divergence appeared in 0 commits:
     main (conflicted):
       + qpvuntsm/0 467e027c (divergent) (empty) c
       + qpvuntsm/2 48ded843 (divergent) (empty) a

--- a/cli/tests/test_git_fetch.rs
+++ b/cli/tests/test_git_fetch.rs
@@ -1014,7 +1014,7 @@ fn test_git_fetch_all() {
     [EOF]
     ");
     let output = target_dir.run_jj(["git", "fetch"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin     [updated] tracked
     bookmark: a2@origin     [updated] tracked
@@ -1023,6 +1023,7 @@ fn test_git_fetch_all() {
     Abandoned 2 commits that are no longer reachable:
       yqosqzyt/1 d4d535f1 (divergent) a2
       mzvwutvl/1 c8303692 (divergent) a1
+    New divergence appeared in 0 commits:
     [EOF]
     ");
     insta::assert_snapshot!(get_bookmark_output(&target_dir), @"
@@ -1206,12 +1207,13 @@ fn test_git_fetch_some_of_many_bookmarks() {
     [EOF]
     "#);
     let output = target_dir.run_jj(["git", "fetch", "--branch=~(a2 | trunk*)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     bookmark: a1@origin [updated] tracked
     bookmark: b@origin  [updated] tracked
     Abandoned 1 commits that are no longer reachable:
       mzvwutvl/1 c8303692 (divergent) a1
+    New divergence appeared in 0 commits:
     [EOF]
     ");
     insta::assert_snapshot!(get_log_output(&target_dir), @r#"

--- a/cli/tests/test_rebase_command.rs
+++ b/cli/tests/test_rebase_command.rs
@@ -2987,9 +2987,11 @@ fn test_rebase_skip_duplicate_divergent() {
 
     // Rebase with "--keep-divergent" shouldn't skip any duplicates
     work_dir.run_jj(["op", "restore", &setup_opid]).success();
-    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "c", "-o", "d", "--keep-divergent"]), @"
+    insta::assert_snapshot!(work_dir.run_jj(["rebase", "-s", "c", "-o", "d", "--keep-divergent"]), @r"
     ------- stderr -------
     Rebased 2 commits to destination
+    Divergence were solved or abandoned from 1 commits.
+    New divergence appeared in 0 commits:
     [EOF]
     ");
     insta::assert_snapshot!(get_long_log_output(&work_dir), @"

--- a/cli/tests/test_repo_change_report.rs
+++ b/cli/tests/test_repo_change_report.rs
@@ -123,7 +123,7 @@ fn test_report_conflicts_with_divergent_commits() {
         .success();
 
     let output = work_dir.run_jj(["rebase", "-s=subject(B)", "-d=root()"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 3 commits to destination
@@ -132,10 +132,12 @@ fn test_report_conflicts_with_divergent_commits() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
+    Divergence were solved or abandoned from 2 commits.
     New conflicts appeared in 3 commits:
       zsuskuln/0 9432879f (divergent) (conflict) C3
       zsuskuln/1 f3e2e0a2 (divergent) (conflict) C2
       kkmpptxz c6237d2f (conflict) B
+    New divergence appeared in 0 commits:
     Hint: To resolve the conflicts, start by creating a commit on top of
     the first conflicted commit:
       jj new kkmpptxz
@@ -146,19 +148,21 @@ fn test_report_conflicts_with_divergent_commits() {
     ");
 
     let output = work_dir.run_jj(["rebase", "-d=subject(A)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 3 commits to destination
     Working copy  (@) now at: zsuskuln/1 27ef05d9 (divergent) C2
     Parent commit (@-)      : kkmpptxz 9039ed49 B
     Added 0 files, modified 1 files, removed 0 files
+    Divergence were solved or abandoned from 2 commits.
     Existing conflicts were resolved or abandoned from 3 commits.
+    New divergence appeared in 0 commits:
     [EOF]
     ");
 
     // Same thing when rebasing the divergent commits one at a time
     let output = work_dir.run_jj(["rebase", "-s=subject(C2)", "-d=root()"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     Working copy  (@) now at: zsuskuln/0 aa95f2b1 (divergent) (conflict) C2
@@ -166,8 +170,10 @@ fn test_report_conflicts_with_divergent_commits() {
     Added 0 files, modified 1 files, removed 0 files
     Warning: There are unresolved conflicts at these paths:
     file    2-sided conflict including 1 deletion
+    Divergence were solved or abandoned from 1 commits.
     New conflicts appeared in 1 commits:
       zsuskuln/0 aa95f2b1 (divergent) (conflict) C2
+    New divergence appeared in 0 commits:
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new zsuskuln/0
@@ -178,11 +184,13 @@ fn test_report_conflicts_with_divergent_commits() {
     ");
 
     let output = work_dir.run_jj(["rebase", "-s=subject(C3)", "-d=root()"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
+    Divergence were solved or abandoned from 1 commits.
     New conflicts appeared in 1 commits:
       zsuskuln/0 733a79ca (divergent) (conflict) C3
+    New divergence appeared in 0 commits:
     Hint: To resolve the conflicts, start by creating a commit on top of
     the conflicted commit:
       jj new zsuskuln/0
@@ -193,21 +201,25 @@ fn test_report_conflicts_with_divergent_commits() {
     ");
 
     let output = work_dir.run_jj(["rebase", "-s=subject(C2)", "-d=subject(B)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
     Working copy  (@) now at: zsuskuln/0 3fcf2fd2 (divergent) C2
     Parent commit (@-)      : kkmpptxz 9039ed49 B
     Added 0 files, modified 1 files, removed 0 files
+    Divergence were solved or abandoned from 1 commits.
     Existing conflicts were resolved or abandoned from 1 commits.
+    New divergence appeared in 0 commits:
     [EOF]
     ");
 
     let output = work_dir.run_jj(["rebase", "-s=subject(C3)", "-d=subject(B)"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Rebased 1 commits to destination
+    Divergence were solved or abandoned from 1 commits.
     Existing conflicts were resolved or abandoned from 1 commits.
+    New divergence appeared in 0 commits:
     [EOF]
     ");
 }

--- a/cli/tests/test_status_command.rs
+++ b/cli/tests/test_status_command.rs
@@ -694,6 +694,22 @@ fn test_status_filtered_untracked() {
 }
 
 #[test]
+fn test_status_reports_divergence() {
+    // Shows that status can show divergence and solved divergence.
+    let test_env = TestEnvironment::default();
+    test_env.run_jj_in(".", ["git", "init", "repo"]).success();
+    let work_dir = test_env.work_dir("repo");
+    work_dir.run_jj(["new -m=aa"]).success();
+    work_dir.run_jj(["new -m=bb"]).success();
+    // use `jj desc --at-op` to create divergence in "aa"
+    work_dir
+        .run_jj(["jj", "desc -m=aaa", "--at-op=@-"])
+        .success();
+    // The divergence should now be reported in status.
+    insta::assert_snapshot!(work_dir.run_jj(["status"]), @"");
+}
+
+#[test]
 fn test_status_no_working_copy() {
     let test_env = TestEnvironment::default();
     test_env.run_jj_in(".", ["git", "init", "repo"]).success();

--- a/cli/tests/test_workspaces.rs
+++ b/cli/tests/test_workspaces.rs
@@ -990,7 +990,7 @@ fn test_workspaces_updated_by_other_with_changes_in_working_copy_automatic() {
     // The first working copy gets automatically updated.
     secondary_dir.write_file("file", "modified contents\n");
     let output = secondary_dir.run_jj(["describe", "-m", "modified"]);
-    insta::assert_snapshot!(output, @"
+    insta::assert_snapshot!(output, @r"
     ------- stderr -------
     Concurrent modification detected, resolving automatically.
     Rebased 1 descendant commits onto commits rewritten by other operation
@@ -1000,6 +1000,8 @@ fn test_workspaces_updated_by_other_with_changes_in_working_copy_automatic() {
     Updated working copy to fresh commit 90f3d42e0bff
     Working copy  (@) now at: pmmvwywv/0 c38323e3 (divergent) (empty) modified
     Parent commit (@-)      : qpvuntsm b853f7c8 (no description set)
+    Divergence were solved or abandoned from 1 commits.
+    New divergence appeared in 0 commits:
     [EOF]
     ");
 


### PR DESCRIPTION
This is something which was made possible a while ago when the `divergent()` revset was added, it just never was plumbed in. Its something which also falls out of my work to extract core parts of `cli_util.rs` to the library.

While `jj converge` hasn't landed yet, it is useful to report divergence. 

TODO: tests

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [ ] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
