### PR TITLE
templates: Add `ui.redacted` as an explicit config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added `jj util backend name` command that prints the backend being used in the
   current repo.
 
+* Added `ui.redacted` boolean config which will redirect to redacted templates
+  in `templates.*` if set. If you have overridden any of these values yourself
+  (such as `templates.log`), you can add your own
+  `if(config("ui.redacted").as_boolean(), ..., ...)` conditionals.
+
 ### Fixed bugs
 
 * `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -175,6 +175,11 @@
                         }
                     }
                 },
+                "redacted": {
+                    "type": "boolean",
+                    "description": "Whether to redact information such as users, descriptions, bookmark names, etc.",
+                    "default": false
+                },
                 "log-word-wrap": {
                     "type": "boolean",
                     "description": "Whether to wrap log template output",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -36,6 +36,7 @@ color = "auto"
 diff-formatter = ":color-words"
 diff-instructions = true
 graph.style = "curved"
+redacted = false
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 paginate = "auto"
 progress-indicator = true

--- a/cli/src/config/templates.toml
+++ b/cli/src/config/templates.toml
@@ -29,10 +29,34 @@ file_show = ''
 
 git_push_bookmark = '"push-" ++ change_id.short()'
 
-log = 'builtin_log_compact'
-show = 'builtin_log_detailed'
-op_log = 'builtin_op_log_compact'
-op_show = 'builtin_op_log_compact'
+log = '''
+if(
+  config("ui.redacted").as_boolean(),
+  builtin_log_redacted(self),
+  builtin_log_compact(self)
+)
+'''
+show = '''
+if(
+  config("ui.redacted").as_boolean(),
+  builtin_log_detailed_redacted(self),
+  builtin_log_detailed(self)
+)
+'''
+op_log = '''
+if(
+  config("ui.redacted").as_boolean(),
+  builtin_op_log_redacted(self),
+  builtin_op_log_compact(self)
+)
+'''
+op_show = '''
+if(
+  config("ui.redacted").as_boolean(),
+  builtin_op_log_redacted(self),
+  builtin_op_log_compact(self)
+)
+'''
 
 revert_description = '''
 concat(
@@ -133,6 +157,14 @@ concat(
     ) ++ "\n",
   ),
 )
+'''
+
+# TODO: Possibly add some kind of repo-unique salt to the hash methods, if it
+# makes users feel more secure (e.g., right now, `main` will always be
+# `bookmark-5abd` for every repo).
+'format_redacted(value)' = 'hash(value).substr(0, 4)'
+'format_redacted(value_label, value)' = '''
+concat(value_label ++ "-" ++ format_redacted(value))
 '''
 
 builtin_log_oneline = 'builtin_log_oneline(self)'
@@ -268,6 +300,35 @@ concat(
   "\n",
 )
 '''
+'builtin_log_detailed_redacted(commit)' = '''
+concat(
+  "Commit ID: " ++ commit.commit_id() ++ "\n",
+  "Change ID: " ++ commit.change_id() ++ "\n",
+  surround("Bookmarks: ", "\n", separate(" ",
+    commit.local_bookmarks().map(|b| format_bookmark_redacted(b)),
+    commit.remote_bookmarks().map(|b| format_bookmark_redacted(b)),
+  )),
+  surround("Tags     : ", "\n", commit.tags().map(|t| format_tag_redacted(t))),
+  concat(
+    "Author   : ",
+    format_detailed_signature_redacted("author", commit.author()),
+  ) ++ "\n",
+  concat(
+    "Committer: ",
+    format_detailed_signature_redacted("committer", commit.committer()),
+  ) ++ "\n",
+  if(config("ui.show-cryptographic-signatures").as_boolean(),
+    concat(
+      "Signature: ",
+      format_detailed_cryptographic_signature(commit.signature()),
+      "\n",
+    )
+  ),
+  "\n",
+  "    " ++ label("description", "(redacted)") ++ "\n",
+  "\n",
+)
+'''
 
 builtin_op_log_compact = 'builtin_op_log_compact(self)'
 'builtin_op_log_compact(op)' = '''
@@ -329,6 +390,12 @@ coalesce(signature.email().local(), email_placeholder)
 join(" ",
   coalesce(signature.name(), name_placeholder),
   "<" ++ coalesce(signature.email(), email_placeholder) ++ ">",
+  "(" ++ format_timestamp(signature.timestamp()) ++ ")",
+)
+'''
+'format_detailed_signature_redacted(signature_type, signature)' = '''
+join(" ",
+  format_user_redacted(signature_type, signature),
   "(" ++ format_timestamp(signature.timestamp()) ++ ")",
 )
 '''
@@ -445,16 +512,16 @@ concat(
 concat(
   separate(" ",
     format_short_operation_id(op.id()),
-    format_user_redacted(op.user()),
+    format_user_redacted("user", op.user()),
     format_workspace_redacted(op.workspace_name()),
     format_time_range(op.time()),
   ), "\n",
   op.description().first_line(), "\n",
-  if(op.attributes(), "(redacted)\n"),
+  if(op.attributes(), label("attributes", "(redacted)\n")),
 )
 '''
 'format_workspace_redacted(workspace)' = '''
-label("workspace", concat("workspace-", hash(workspace).substr(0, 4), "@"))
+label("workspace_name", format_redacted("workspace", workspace) ++ "@")
 '''
 'format_snapshot_operation(op)' = 'format_operation(op)'
 'format_snapshot_operation_redacted(op)' = 'format_operation_redacted(op)'
@@ -517,22 +584,13 @@ separate(" ",
 )
 '''
 
-# TODO: Possibly add some kind of repo-unique salt to the hash methods, if it
-# makes users feel more secure (right now, `main` will always be `branch-c8c7a`
-# for every repo)
 'format_short_commit_header_redacted(commit)' = '''
 separate(" ",
   format_short_change_id_with_change_offset(commit),
-  label("author", format_user_redacted(commit.author())),
+  label("author", format_user_redacted("author", commit.author())),
   format_timestamp(commit_timestamp(commit)),
-  commit.bookmarks().map(|bookmark| concat(
-    "bookmark-", hash(bookmark.name()).substr(0, 4),
-    if(bookmark.remote(),
-      "@remote-" ++ hash(bookmark.remote()).substr(0, 4),
-      if(!bookmark.synced(), "*")
-    )
-  )),
-  commit.tags().map(|tag| concat("tag-", hash(tag.name()).substr(0, 4))),
+  commit.bookmarks().map(|bookmark| format_bookmark_redacted(bookmark)),
+  commit.tags().map(|tag| format_tag_redacted(tag)),
   commit.working_copies().map(|workspace| format_workspace_redacted(workspace)),
   format_short_commit_id(commit.commit_id()),
   format_commit_labels(commit),
@@ -566,8 +624,22 @@ if(signature,
 )
 '''
 
-'format_user_redacted(user)' = '''
-label("user", concat("user-", hash(user).substr(0, 4)))
+'format_user_redacted(user_label, user)' = '''
+label(user_label, format_redacted(user_label, format_redacted(user)))
+'''
+
+'format_bookmark_redacted(bookmark)' = '''
+label("bookmark", concat(
+  format_redacted("bookmark", bookmark.name()),
+  if(bookmark.remote(),
+    "@" ++ format_redacted("remote", bookmark.remote()),
+    if(!bookmark.synced(), "*")
+  ),
+))
+'''
+
+'format_tag_redacted(tag)' = '''
+label("tag", format_redacted("tag", tag.name()))
 '''
 
 builtin_log_node = '''

--- a/cli/tests/test_log_command.rs
+++ b/cli/tests/test_log_command.rs
@@ -1815,10 +1815,10 @@ fn test_log_anonymize() {
     work_dir.run_jj(["bookmark", "move", "b1", "-t@"]).success();
 
     let output = work_dir.run_jj(["log", "-r::", "-Tbuiltin_log_redacted"]);
-    insta::assert_snapshot!(output, @"
-    @  yqosqzyt user-78cd 2001-02-03 08:05:13 bookmark-dc8b* de3c47af
+    insta::assert_snapshot!(output, @r"
+    @  yqosqzyt author-b3f5 2001-02-03 08:05:13 bookmark-dc8b* de3c47af
     │  (empty) (redacted)
-    ◆  qpvuntsm user-78cd 2001-02-03 08:05:08 bookmark-dc8b@remote-86e9 bookmark-56f1 bookmark-ff9e@remote-86e9 37b69cda
+    ◆  qpvuntsm author-b3f5 2001-02-03 08:05:08 bookmark-dc8b@remote-86e9 bookmark-56f1 bookmark-ff9e@remote-86e9 37b69cda
     │  (empty) (redacted)
     ◆  zzzzzzzz root() 00000000
     [EOF]

--- a/cli/tests/test_operations.rs
+++ b/cli/tests/test_operations.rs
@@ -3127,11 +3127,11 @@ fn test_op_log_anonymize() {
         .success();
 
     let output = work_dir.run_jj(["op", "log", "-Tbuiltin_op_log_redacted"]);
-    insta::assert_snapshot!(output, @"
-    @  8501e29d2d94 user-5910 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
+    insta::assert_snapshot!(output, @r"
+    @  8501e29d2d94 user-1df1 workspace-ab88@ 2001-02-03 04:05:08.000 +07:00 - 2001-02-03 04:05:08.000 +07:00
     │  describe commit e8849ae12c709f2321908879bc724fdb2ab8a781
     │  (redacted)
-    ○  90267f31f904 user-5910 workspace-482a@ 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
+    ○  90267f31f904 user-1df1 workspace-482a@ 2001-02-03 04:05:07.000 +07:00 - 2001-02-03 04:05:07.000 +07:00
     │  add workspace 'default'
     ○  000000000000 root()
     [EOF]


### PR DESCRIPTION
This allows users to use `--config ui.redacted=true` rather than `--template i_remember_what_the_redacted_template_alias_is`. (See commit description for more details.)

For potential discussion: A caveat of this approach is, as mentioned in the changelog, that the config value doesn't automatically redact all values, but as of now merely redirects the default `templates.*` values to a redacted version. So if you've customized your `templates.log`, then `jj --config ui.redacted=true log` won't change anything for you. I thought about detecting `ui.redacted` in the `template_builder.rs` instead, which would make redaction an actual, full-supported feature, but I'm not sure if that's desired. I also thought about making a global `format_value(value)` alias that checks `config("ui.redacted")` inside that instead, but that is way too overkill and also doesn't work if anyone has customized anything.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [x] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
