### PR TITLE
util snapshot: Add examples

### DIFF
--- a/cli/src/commands/util/snapshot.rs
+++ b/cli/src/commands/util/snapshot.rs
@@ -26,7 +26,58 @@ use crate::ui::Ui;
 /// If you want to see the ID of the current operation after this command, run
 /// `jj operation log --limit 1`. However, since that command also snapshots the
 /// working copy, there would be no need to run `jj util snapshot` first.
+///
+/// ### Example of programmatic snapshotting
+///
+/// Consider the following:
+///
+/// ```bash
+/// $ echo content > new-file.txt
+/// # At this point, `jj` does not know about `new-file.txt`.
+/// $ ./my-script-that-runs-jj-commands
+/// # Since the script ran `jj` commands, the changes to `new-file.txt` have
+/// # been snapshotted in an operation, which you can see with:
+/// $ jj operation log --patch
+/// ```
+///
+/// If `my-script-that-runs-jj-commands` has a "sandwich" of `jj util snapshot`
+/// at the beginning and end of the script, then the operation that captures
+/// `new-file.txt` will be distinct from the operations created by the `jj`
+/// commands in that script. In addition, the `jj operation log --patch` that
+/// you ran on the command-line after the script would also have its own
+/// operation if needed. However, without `jj util snapshot`, these operations
+/// will be mixed together in the operation log. If this is important to you,
+/// then `jj util snapshot` is useful here to explicitly trigger a snapshot.
+///
+/// ### Checking if the operation ID changed
+///
+/// If you want to compare "before and after" operation IDs, it may be better to
+/// use `jj operation log --no-graph --limit 1 -T id` to query for operation
+/// information, which you can store in a variable in a script. You can then
+/// compare these values as needed to figure out if anything changed during a
+/// `jj` command, such as:
+///
+/// ```bash
+/// start_op_id="$(jj op log -G -n 1 -T id)"
+/// jj git fetch || exit
+/// fetch_op_id="$(jj op log -G -n 1 -T id)"
+/// if [[ "${start_op_id}" == "${fetch_op_id}" ]]; then
+///   # Nothing was fetched.
+///   exit 0
+/// fi
+/// jj rebase -r 'mutable()' -o 'trunk()'
+/// rebase_op_id="$(jj op log -G -n 1 -T id)"
+/// if [[ "${fetch_op_id}" == "${rebase_op_id}" ]]; then
+///   # Nothing was rebased.
+///   exit 0
+/// fi
+/// echo "Fetched and rebased!"
+/// ```
+///
+/// Note that `jj util snapshot` does not output an operation ID, so it is not
+/// suitable for checks such as these.
 #[derive(clap::Args, Clone, Debug)]
+#[command(verbatim_doc_comment)]
 pub struct UtilSnapshotArgs {}
 
 pub async fn cmd_util_snapshot(

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3550,9 +3550,64 @@ Print the CLI help for all subcommands in Markdown
 
 Snapshot the working copy if needed
 
-Snapshots the working copy and updates the working-copy commit if the working copy has changed since the last snapshot. Since almost every command snapshots the working copy, there is very little reason to run this command as a human; it is mostly meant for scripts.
+Snapshots the working copy and updates the working-copy commit if the
+working copy has changed since the last snapshot. Since almost every command
+snapshots the working copy, there is very little reason to run this command
+as a human; it is mostly meant for scripts.
 
-If you want to see the ID of the current operation after this command, run `jj operation log --limit 1`. However, since that command also snapshots the working copy, there would be no need to run `jj util snapshot` first.
+If you want to see the ID of the current operation after this command, run
+`jj operation log --limit 1`. However, since that command also snapshots the
+working copy, there would be no need to run `jj util snapshot` first.
+
+### Example of programmatic snapshotting
+
+Consider the following:
+
+```bash
+$ echo content > new-file.txt
+# At this point, `jj` does not know about `new-file.txt`.
+$ ./my-script-that-runs-jj-commands
+# Since the script ran `jj` commands, the changes to `new-file.txt` have
+# been snapshotted in an operation, which you can see with:
+$ jj operation log --patch
+```
+
+If `my-script-that-runs-jj-commands` has a "sandwich" of `jj util snapshot`
+at the beginning and end of the script, then the operation that captures
+`new-file.txt` will be distinct from the operations created by the `jj`
+commands in that script. In addition, the `jj operation log --patch` that
+you ran on the command-line after the script would also have its own
+operation if needed. However, without `jj util snapshot`, these operations
+will be mixed together in the operation log. If this is important to you,
+then `jj util snapshot` is useful here to explicitly trigger a snapshot.
+
+### Checking if the operation ID changed
+
+If you want to compare "before and after" operation IDs, it may be better to
+use `jj operation log --no-graph --limit 1 -T id` to query for operation
+information, which you can store in a variable in a script. You can then
+compare these values as needed to figure out if anything changed during a
+`jj` command, such as:
+
+```bash
+start_op_id="$(jj op log -G -n 1 -T id)"
+jj git fetch || exit
+fetch_op_id="$(jj op log -G -n 1 -T id)"
+if [[ "${start_op_id}" == "${fetch_op_id}" ]]; then
+  # Nothing was fetched.
+  exit 0
+fi
+jj rebase -r 'mutable()' -o 'trunk()'
+rebase_op_id="$(jj op log -G -n 1 -T id)"
+if [[ "${fetch_op_id}" == "${rebase_op_id}" ]]; then
+  # Nothing was rebased.
+  exit 0
+fi
+echo "Fetched and rebased!"
+```
+
+Note that `jj util snapshot` does not output an operation ID, so it is not
+suitable for checks such as these.
 
 **Usage:** `jj util snapshot`
 


### PR DESCRIPTION
A discussion came up [in Discord][thread] about why `jj util snapshot` does not output the operation ID. It serves a different purpose than `jj op log -G -n 1 -T id`, so this commit adds some more examples of when `jj util snapshot` is useful vs. when `jj op log` is useful.

[thread]:
  https://discord.com/channels/968932220549103686/969291218347524238/1508659644682207374

Very much open to suggestions on the examples or wording. I think this might honestly be pretty confusing, but opening this PR to get some more eyes on this.

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [ ] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
