### PR TITLE
util snapshot: report resulting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added `jj util backend name` command that prints the backend being used in the
   current repo.
 
+* `jj util snapshot` now reports the resulting working-copy state together with
+  the current operation summary.
+
 ### Fixed bugs
 
 * `jj bookmark forget` no longer prints `Forgot N local bookmarks.` when no

--- a/cli/src/commands/util/snapshot.rs
+++ b/cli/src/commands/util/snapshot.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use jj_lib::repo::Repo as _;
+
 use crate::cli_util::CommandHelper;
 use crate::command_error::CommandError;
 use crate::ui::Ui;
@@ -21,11 +23,12 @@ use crate::ui::Ui;
 /// Snapshots the working copy and updates the working-copy commit if the
 /// working copy has changed since the last snapshot. Since almost every command
 /// snapshots the working copy, there is very little reason to run this command
-/// as a human; it is mostly meant for scripts.
+/// as a human; it is mostly meant for scripts. It prints the resulting
+/// working-copy state together with the current operation summary.
 ///
-/// If you want to see the ID of the current operation after this command, run
+/// If you want to query the current operation ID directly, run
 /// `jj operation log --limit 1`. However, since that command also snapshots the
-/// working copy, there would be no need to run `jj util snapshot` first.
+/// working copy, there would often be no need to run `jj util snapshot` first.
 #[derive(clap::Args, Clone, Debug)]
 pub struct UtilSnapshotArgs {}
 
@@ -35,14 +38,54 @@ pub async fn cmd_util_snapshot(
     _args: &UtilSnapshotArgs,
 ) -> Result<(), CommandError> {
     let mut workspace_command = command.workspace_helper_no_snapshot(ui).await?;
+    let old_wc_commit_id = workspace_command.get_wc_commit_id().cloned();
 
     // Trigger the snapshot if needed.
-    let was_snapshot_taken = workspace_command.maybe_snapshot(ui).await?;
-    if was_snapshot_taken {
-        writeln!(ui.status(), "Snapshot complete.")?;
+    let did_operation_change = workspace_command.maybe_snapshot(ui).await?;
+    let Some(mut formatter) = ui.status_formatter() else {
+        return Ok(());
+    };
+    let status = if did_operation_change {
+        "Snapshot complete."
     } else {
-        writeln!(ui.status(), "No snapshot needed.")?;
+        "No snapshot needed."
+    };
+
+    writeln!(formatter, "{status}")?;
+
+    if let Some(commit_id) = workspace_command.get_wc_commit_id() {
+        let commit = workspace_command
+            .repo()
+            .store()
+            .get_commit_async(commit_id)
+            .await?;
+        if Some(commit.id()) != old_wc_commit_id.as_ref() {
+            write!(formatter, "Working copy  (@) now at: ")?;
+            workspace_command
+                .commit_summary_template()
+                .format(&commit, formatter.as_mut())?;
+            writeln!(formatter)?;
+            for parent in commit.parents().await? {
+                write!(formatter, "Parent commit (@-)      : ")?;
+                workspace_command
+                    .commit_summary_template()
+                    .format(&parent, formatter.as_mut())?;
+                writeln!(formatter)?;
+            }
+        } else {
+            write!(formatter, "Working copy change (@): ")?;
+            workspace_command
+                .short_change_id_template()
+                .format(&commit, formatter.as_mut())?;
+            writeln!(formatter)?;
+        }
     }
+
+    write!(formatter, "Current operation: ")?;
+    workspace_command
+        .operation_summary_template()
+        .format(workspace_command.repo().operation(), formatter.as_mut())?;
+    writeln!(formatter)?;
 
     Ok(())
 }

--- a/cli/tests/cli-reference@.md.snap
+++ b/cli/tests/cli-reference@.md.snap
@@ -3550,9 +3550,9 @@ Print the CLI help for all subcommands in Markdown
 
 Snapshot the working copy if needed
 
-Snapshots the working copy and updates the working-copy commit if the working copy has changed since the last snapshot. Since almost every command snapshots the working copy, there is very little reason to run this command as a human; it is mostly meant for scripts.
+Snapshots the working copy and updates the working-copy commit if the working copy has changed since the last snapshot. Since almost every command snapshots the working copy, there is very little reason to run this command as a human; it is mostly meant for scripts. It prints the resulting working-copy state together with the current operation summary.
 
-If you want to see the ID of the current operation after this command, run `jj operation log --limit 1`. However, since that command also snapshots the working copy, there would be no need to run `jj util snapshot` first.
+If you want to query the current operation ID directly, run `jj operation log --limit 1`. However, since that command also snapshots the working copy, there would often be no need to run `jj util snapshot` first.
 
 **Usage:** `jj util snapshot`
 

--- a/cli/tests/test_util_command.rs
+++ b/cli/tests/test_util_command.rs
@@ -289,6 +289,9 @@ fn test_util_snapshot() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     Snapshot complete.
+    Working copy  (@) now at: qpvuntsm 0f7e5910 (no description set)
+    Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+    Current operation: 400986d31c96 (2001-02-03 08:05:08) snapshot working copy
     [EOF]
     ");
 }
@@ -303,6 +306,8 @@ fn test_util_snapshot_nothing_changed() {
     insta::assert_snapshot!(output, @"
     ------- stderr -------
     No snapshot needed.
+    Working copy change (@): qpvuntsm
+    Current operation: 90267f31f904 (2001-02-03 08:05:07) add workspace 'default'
     [EOF]
     ");
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -613,8 +613,8 @@ likely most useful for scripting rather than for running on the command line by
 a human.
 
 If you want to see the ID of the current operation after this command, it would
-be simpler to run `jj operation log --limit 1` directly, since that command also
-takes a snapshot if needed.
+be simpler to run `jj operation log --limit 1` directly, since that command
+already takes a snapshot if needed.
 
 ### I want to write a tool which integrates with Jujutsu. Should I use the library or parse the CLI?
 


### PR DESCRIPTION
This makes `jj util snapshot` print a small receipt of the resulting state using
existing JJ formatting conventions.

Specifically, it now:

- prints the working-copy commit summary if `@` changed
- otherwise prints the current working-copy change id
- prints the current operation summary if the command advanced the repo state

This keeps `jj util snapshot` lightweight while making it easier for humans and
tools to see what state it left the repo in.

# Checklist

If applicable:

- [x] I have updated `CHANGELOG.md`
- [x] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [x] I have added/updated tests to cover my changes
- [x] I fully understand the code that I am submitting (what it does,
      how it works, how it's organized), including any code drafted by an LLM.
- [x] For any prose generated by an LLM, I have proof-read and copy-edited with
      an eye towards deleting anything that is irrelevant, clarifying anything
      that is confusing, and adding details that are relevant. This includes,
      for example, commit descriptions, PR descriptions, and code comments.
